### PR TITLE
Harden native MTP launch safety

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -843,7 +843,8 @@ public actor BatchEngine {
         let generationTask: Task<Void, Never>
         do {
             if let strategy = soloParameters.draftStrategy,
-                case .nativeMTP(let depth) = strategy
+                case .nativeMTP(depth: let depth, verifierMode: _) = strategy,
+                soloParameters.canUseNativeMTP(for: input)
             {
                 guard let nativeModel = context.model as? any NativeMTPModel else {
                     throw NativeMTPRuntimeError.modelDoesNotExposeNativeMTP

--- a/Libraries/MLXLMCommon/Cache/LoadConfiguration.swift
+++ b/Libraries/MLXLMCommon/Cache/LoadConfiguration.swift
@@ -218,6 +218,18 @@ public struct LoadConfiguration: Sendable, Equatable {
 /// pulled once at load entry so the resolver doesn't re-walk the
 /// directory or re-parse `config.json`.
 public struct LoadBundleFacts: Sendable, Equatable {
+    /// Top-level or nested `model_type` from config metadata, when available.
+    public var modelType: String?
+
+    /// Top-level or JANG-sidecar `weight_format`, lowercased when available.
+    public var weightFormat: String?
+
+    /// True when the bundle has a `jang_config.json` sidecar.
+    public var hasJangConfig: Bool
+
+    /// True when the bundle has a `jangtq_runtime.safetensors` sidecar.
+    public var hasJangTQRuntime: Bool
+
     /// Sum of `*.safetensors` byte sizes in the bundle. `0` when
     /// inspection failed (treat as unknown — `.auto` falls through to
     /// disabled in that case).
@@ -247,9 +259,17 @@ public struct LoadBundleFacts: Sendable, Equatable {
         totalSafetensorsBytes: UInt64,
         isRouted: Bool,
         physicalMemory: UInt64,
+        modelType: String? = nil,
+        weightFormat: String? = nil,
+        hasJangConfig: Bool = false,
+        hasJangTQRuntime: Bool = false,
         numRoutedExperts: Int? = nil,
         topK: Int? = nil
     ) {
+        self.modelType = modelType
+        self.weightFormat = weightFormat?.lowercased()
+        self.hasJangConfig = hasJangConfig
+        self.hasJangTQRuntime = hasJangTQRuntime
         self.totalSafetensorsBytes = totalSafetensorsBytes
         self.isRouted = isRouted
         self.physicalMemory = physicalMemory
@@ -284,6 +304,8 @@ public struct LoadBundleFacts: Sendable, Equatable {
         var routed = false
         var numRoutedExperts: Int?
         var topK: Int?
+        var modelType: String?
+        var weightFormat: String?
         let configURL = url.appendingPathComponent("config.json")
         if let data = try? Data(contentsOf: configURL),
             let json = try? JSONSerialization.jsonObject(with: data)
@@ -323,6 +345,8 @@ public struct LoadBundleFacts: Sendable, Equatable {
             numRoutedExperts = firstPositiveInt(
                 in: json, keys: routedExpertKeys)
             topK = firstPositiveInt(in: json, keys: topKKeys)
+            modelType = json["model_type"] as? String
+            weightFormat = (json["weight_format"] as? String)?.lowercased()
             for key in routedKeys {
                 if let n = json[key] as? Int, n > 1 {
                     routed = true
@@ -342,6 +366,12 @@ public struct LoadBundleFacts: Sendable, Equatable {
                     if topK == nil {
                         topK = firstPositiveInt(in: nested, keys: topKKeys)
                     }
+                    if modelType == nil {
+                        modelType = nested["model_type"] as? String
+                    }
+                    if weightFormat == nil {
+                        weightFormat = (nested["weight_format"] as? String)?.lowercased()
+                    }
                     if !routed {
                         for key in routedKeys {
                             if let n = nested[key] as? Int, n > 1 {
@@ -356,13 +386,50 @@ public struct LoadBundleFacts: Sendable, Equatable {
                 routed = true
             }
         }
+        let jangConfigURL = url.appendingPathComponent("jang_config.json")
+        let hasJangConfig = fm.fileExists(atPath: jangConfigURL.path)
+        if hasJangConfig,
+            let data = try? Data(contentsOf: jangConfigURL),
+            let json = try? JSONSerialization.jsonObject(with: data)
+                as? [String: Any]
+        {
+            if modelType == nil {
+                modelType = json["model_type"] as? String
+            }
+            if weightFormat == nil {
+                weightFormat = (json["weight_format"] as? String)?.lowercased()
+            }
+        }
+        let hasJangTQRuntime = fm.fileExists(
+            atPath: url.appendingPathComponent("jangtq_runtime.safetensors").path)
 
         return LoadBundleFacts(
             totalSafetensorsBytes: totalBytes,
             isRouted: routed,
             physicalMemory: physical,
+            modelType: modelType,
+            weightFormat: weightFormat,
+            hasJangConfig: hasJangConfig,
+            hasJangTQRuntime: hasJangTQRuntime,
             numRoutedExperts: numRoutedExperts,
             topK: topK)
+    }
+
+    public var isPlainDeepseekV4AffineJANG: Bool {
+        let type = modelType?.lowercased() ?? ""
+        let format = weightFormat?.lowercased() ?? ""
+        let declaresAffine = format.isEmpty || format == "affine" || format == "jang"
+        return type == "deepseek_v4"
+            && hasJangConfig
+            && !hasJangTQRuntime
+            && declaresAffine
+            && isRouted
+            && (numRoutedExperts ?? 0) >= 128
+    }
+
+    public var productionBlockReason: String? {
+        guard isPlainDeepseekV4AffineJANG else { return nil }
+        return "Plain DeepSeek V4 JANG uses the unsupported affine routed-MoE SwitchGLU path. Use a JANGTQ bundle, or set VMLX_ALLOW_EXPERIMENTAL_DSV4_AFFINE_JANG=1 for diagnostics only."
     }
 }
 

--- a/Libraries/MLXLMCommon/Cache/LoadConfiguration.swift
+++ b/Libraries/MLXLMCommon/Cache/LoadConfiguration.swift
@@ -179,6 +179,15 @@ public struct LoadConfiguration: Sendable, Equatable {
         useMmapSafetensors: true,
         nativeMTP: false)
 
+    /// Production host preset for Osaurus/vMLX server integrations.
+    ///
+    /// This keeps the conservative load-time memory caps and mmap
+    /// safetensors path from ``default``, while opting validated hosts
+    /// into MLXPress auto-detection for routed bundles that exceed half
+    /// of physical RAM. Native MTP remains a separate per-bundle
+    /// decision resolved by ``VMLXServerRuntimeSettings``.
+    public static let osaurusProduction = experimentalJangPressAuto
+
     /// Everything off — strict byte-compat with pre-iter-23 behavior.
     /// MLXPress disabled, no caps, no mmap loader.
     public static let off = LoadConfiguration(

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -377,6 +377,20 @@ public struct GenerateParameters: Sendable {
             frequencyContext: frequencyContext
         )
     }
+
+    public var isNativeMTPLosslessGreedyEligible: Bool {
+        temperature == 0
+            && topP >= 1
+            && topK == 0
+            && minP == 0
+            && (repetitionPenalty == nil || repetitionPenalty == 0 || repetitionPenalty == 1)
+            && (presencePenalty == nil || presencePenalty == 0)
+            && (frequencyPenalty == nil || frequencyPenalty == 0)
+    }
+
+    public func canUseNativeMTP(for input: LMInput) -> Bool {
+        isNativeMTPLosslessGreedyEligible && !input.hasMediaContent
+    }
 }
 
 /// Sampler that uses `argMax` (most likely) to sample the logits.
@@ -2518,7 +2532,8 @@ public func generate(
     let promptTail = _decodePromptTail(
         input: input, tokenizer: context.tokenizer, tokens: 64)
     if let strategy = parameters.draftStrategy,
-        case .nativeMTP(let depth) = strategy
+        case .nativeMTP(depth: let depth, verifierMode: _) = strategy,
+        parameters.canUseNativeMTP(for: input)
     {
         guard let nativeModel = context.model as? any NativeMTPModel else {
             throw NativeMTPRuntimeError.modelDoesNotExposeNativeMTP
@@ -2855,7 +2870,8 @@ public func generateTokensTask(
         input.text.tokens.reshaped(-1).asArray(Int.self))
 
     if let strategy = parameters.draftStrategy,
-        case .nativeMTP(let depth) = strategy
+        case .nativeMTP(depth: let depth, verifierMode: _) = strategy,
+        parameters.canUseNativeMTP(for: input)
     {
         guard let nativeModel = context.model as? any NativeMTPModel else {
             throw NativeMTPRuntimeError.modelDoesNotExposeNativeMTP

--- a/Libraries/MLXLMCommon/HardwareInfo.swift
+++ b/Libraries/MLXLMCommon/HardwareInfo.swift
@@ -36,27 +36,21 @@ public enum HardwareInfo {
     ///
     /// Re-enable when Apple fixes the Metal JIT in a future macOS update.
     public static var isCompiledDecodeSupported: Bool {
-        // Re-enabled 2026-04-13 after direct measurement on M4 Max + mlx-swift osaurus-0.31.3:
+        // 2026-05-20: keep MLX compile off by default for host apps. A live
+        // Osaurus PR #1173 switch test reproduced process-local decode
+        // corruption after loading Qwen3.6 JANG_2K and switching back to the
+        // MXFP4 MTP sibling; the same sequence passed when launched with
+        // MLX_DISABLE_COMPILE=1. The failure also reproduced on an explicit
+        // sampler request that bypassed native MTP, so this gate must cover
+        // both single-slot compiled decode and the small shapeless micro-fusion
+        // helpers until MLX compile is proven model-switch-safe.
         //
-        // The broad kill-switch was set in commit a8a6a6f citing MLX#3329 "compiledState
-        // callsToFill[0] index out of range" on M4 Pro. That crash was empirically tied to
-        // the whole-model compile path (setupCompiledDecode + CompilableKVCache), not to
-        // the small fixed-shape micro-fusions this flag now controls.
-        //
-        // Commit cf55f6d re-enabled compile(shapeless: true) for compute_g on M4 Max with
-        // no crash and a measurable +1.9 tok/s on Qwen 3.5-35B decode. Python mlx_lm 0.31.2
-        // on the same machine runs ~9 tok/s faster with its compile islands vs without
-        // (120/117/114/106/104 w/ compile vs 110/105/103/100/98 with mx.disable_compile()),
-        // which is where Swift's decode gap comes from.
-        //
-        // This flag now gates only the per-op micro-fusion helpers (swiglu, precise_swiglu,
-        // geglu, softcap, sigmoid-gate etc.). The whole-model compile path in
-        // setupCompiledDecode is still gated separately by `GenerateParameters.enableCompiledDecode`
-        // and remains off by default, so flipping this flag cannot revive the MLX#3329 crash.
-        //
-        // If the crash is observed again on any specific site, opt that site out individually
-        // instead of flipping this flag back to false globally.
-        return true
+        // Keep an explicit opt-in for controlled benchmarks and diagnostics.
+        let env = ProcessInfo.processInfo.environment
+        let raw = env["VMLX_ENABLE_UNSAFE_COMPILE"]
+            ?? env["MLXPRESS_ENABLE_UNSAFE_COMPILE"]
+            ?? ""
+        return raw == "1" || raw.lowercased() == "true"
     }
 
     /// Returns `true` if running on Apple Silicon hardware.

--- a/Libraries/MLXLMCommon/ModelFactory.swift
+++ b/Libraries/MLXLMCommon/ModelFactory.swift
@@ -518,6 +518,15 @@ public func loadModel(
 ) async throws -> (ModelContext, JangPressRuntime) {
     // 1. Inspect bundle once.
     let facts = LoadBundleFacts.inspect(bundleURL: directory)
+    if let reason = facts.productionBlockReason {
+        let raw = ProcessInfo.processInfo.environment[
+            "VMLINUX_ALLOW_EXPERIMENTAL_DSV4_AFFINE_JANG"
+        ]?.lowercased()
+        let allowDiagnostic = raw == "1" || raw == "true" || raw == "on" || raw == "yes"
+        if !allowDiagnostic {
+            throw ModelFactoryError.unsupportedModelType(reason)
+        }
+    }
 
     // 2. Resolve JangPress policy → concrete options.
     let resolvedOptions = loadConfiguration.jangPress.resolve(facts: facts)

--- a/Libraries/MLXLMCommon/ModelRuntimeCapabilitySnapshot.swift
+++ b/Libraries/MLXLMCommon/ModelRuntimeCapabilitySnapshot.swift
@@ -17,6 +17,246 @@ public enum ModelRuntimeCapabilitySupport: String, Codable, Sendable, Equatable 
     }
 }
 
+/// Coarse no-load bundle format classification for status and UI routing.
+public enum ModelRuntimeBundleFormat: String, Codable, Sendable, Equatable {
+    case mlx
+    case jang
+    case jangtq
+    case mxfp
+    case unknown
+}
+
+/// Source-backed trace explaining how a local model bundle was classified.
+///
+/// This is intentionally metadata-only. It reads JSON files, the optional
+/// JANGTQ runtime sidecar header, and the existing MTP bundle status. It does
+/// not load model weights or claim that generation is production-ready.
+public struct ModelRuntimeDetectionSnapshot: Codable, Sendable, Equatable {
+    public let bundleFormat: ModelRuntimeBundleFormat
+    public let evidence: [String]
+
+    public let configModelType: String?
+    public let textConfigModelType: String?
+    public let dispatchModelType: String?
+    public let hasTextConfig: Bool
+    public let hasVisionConfig: Bool
+    public let hasPreprocessorConfig: Bool
+
+    public let configWeightFormat: String?
+    public let jangWeightFormat: String?
+    public let effectiveWeightFormat: String?
+    public let hasJangConfig: Bool
+    public let jangFormat: String?
+    public let jangProfile: String?
+    public let jangQuantizationMethod: String?
+
+    public let quantizationBits: Int?
+    public let mxtqBits: Int?
+    public let mxtqBitsSource: String?
+    public let hasJANGTQSidecar: Bool
+    public let sidecarCodebookBits: Int?
+
+    public let nativeMTPMode: MTPRuntimeMode?
+    public let nativeMTPConfiguredLayers: Int?
+    public let nativeMTPTensorCount: Int?
+    public let visionTensorCount: Int?
+    public let nativeMTPCanAutoLaunch: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case bundleFormat = "bundle_format"
+        case evidence
+        case configModelType = "config_model_type"
+        case textConfigModelType = "text_config_model_type"
+        case dispatchModelType = "dispatch_model_type"
+        case hasTextConfig = "has_text_config"
+        case hasVisionConfig = "has_vision_config"
+        case hasPreprocessorConfig = "has_preprocessor_config"
+        case configWeightFormat = "config_weight_format"
+        case jangWeightFormat = "jang_weight_format"
+        case effectiveWeightFormat = "effective_weight_format"
+        case hasJangConfig = "has_jang_config"
+        case jangFormat = "jang_format"
+        case jangProfile = "jang_profile"
+        case jangQuantizationMethod = "jang_quantization_method"
+        case quantizationBits = "quantization_bits"
+        case mxtqBits = "mxtq_bits"
+        case mxtqBitsSource = "mxtq_bits_source"
+        case hasJANGTQSidecar = "has_jangtq_sidecar"
+        case sidecarCodebookBits = "sidecar_codebook_bits"
+        case nativeMTPMode = "native_mtp_mode"
+        case nativeMTPConfiguredLayers = "native_mtp_configured_layers"
+        case nativeMTPTensorCount = "native_mtp_tensor_count"
+        case visionTensorCount = "vision_tensor_count"
+        case nativeMTPCanAutoLaunch = "native_mtp_can_auto_launch"
+    }
+
+    public init(
+        modelDirectory: URL,
+        mtpStatus suppliedMTPStatus: MTPBundleStatus? = nil
+    ) throws {
+        let config = try Self.loadJSONObjectIfExists(
+            modelDirectory.appendingPathComponent("config.json"))
+        let jang = try Self.loadJSONObjectIfExists(
+            modelDirectory.appendingPathComponent("jang_config.json"))
+        let textConfig = config?["text_config"] as? [String: Any]
+        let quantization = config?["quantization"] as? [String: Any]
+        let jangQuantization = jang?["quantization"] as? [String: Any]
+        let sidecarURL = modelDirectory.appendingPathComponent("jangtq_runtime.safetensors")
+        let hasSidecar = FileManager.default.fileExists(atPath: sidecarURL.path)
+        let sidecarBits = hasSidecar ? JANGTQRuntimeCache.sniffCodebookBits(at: sidecarURL) : nil
+        let mtpStatus =
+            suppliedMTPStatus
+            ?? (try? MTPBundleInspector.inspect(
+                modelDirectory: modelDirectory))
+
+        let configWeightFormat = Self.lowerString(config?["weight_format"])
+        let jangWeightFormat = Self.lowerString(jang?["weight_format"])
+        let effectiveWeightFormat = jangWeightFormat ?? configWeightFormat
+        let configModelType = Self.string(config?["model_type"])
+        let textConfigModelType = Self.string(textConfig?["model_type"])
+        let hasVisionConfig =
+            Self.bool(config?["vision_config"])
+            || (config?["vision_config"] as? [String: Any]) != nil
+        let hasPreprocessorConfig =
+            FileManager.default.fileExists(
+                atPath: modelDirectory.appendingPathComponent("preprocessor_config.json").path)
+            || FileManager.default.fileExists(
+                atPath: modelDirectory.appendingPathComponent("processor_config.json").path)
+            || FileManager.default.fileExists(
+                atPath: modelDirectory.appendingPathComponent("video_preprocessor_config.json").path
+            )
+
+        let configMxtq = Self.resolveMXTQBits(
+            config?["mxtq_bits"],
+            preferredSources: ["config.mxtq_bits"])
+        let jangMxtq = Self.resolveMXTQBits(
+            jang?["mxtq_bits"],
+            preferredSources: ["jang_config.mxtq_bits"])
+        let quantizationBits = Self.intValue(quantization?["bits"])
+        let jangProfile = Self.string(jangQuantization?["profile"])
+        let profileBits = jangtqBitsFromProfile(jangProfile)
+        let resolvedBits: (Int?, String?) = {
+            if let configMxtq { return (configMxtq.value, configMxtq.source) }
+            if let jangMxtq { return (jangMxtq.value, jangMxtq.source) }
+            if let sidecarBits { return (sidecarBits, "jangtq_runtime.safetensors.codebook") }
+            if let profileBits { return (profileBits, "jang_config.quantization.profile") }
+            return (nil, nil)
+        }()
+
+        var evidence: [String] = []
+        if config != nil { evidence.append("config.json") }
+        if jang != nil { evidence.append("jang_config.json") }
+        if let configModelType { evidence.append("config.model_type=\(configModelType)") }
+        if let textConfigModelType {
+            evidence.append("text_config.model_type=\(textConfigModelType)")
+        }
+        if let configWeightFormat { evidence.append("config.weight_format=\(configWeightFormat)") }
+        if let jangWeightFormat { evidence.append("jang_config.weight_format=\(jangWeightFormat)") }
+        if hasSidecar { evidence.append("jangtq_runtime.safetensors") }
+        if let sidecarBits { evidence.append("sidecar.codebook_bits=\(sidecarBits)") }
+        if let profileBits { evidence.append("jang_config.profile_bits=\(profileBits)") }
+        if let mode = mtpStatus?.mode { evidence.append("native_mtp.mode=\(mode.rawValue)") }
+        if mtpStatus?.bundleHasVision == true { evidence.append("native_mtp.vision_tensors=true") }
+        if hasPreprocessorConfig { evidence.append("preprocessor_config=true") }
+
+        let format: ModelRuntimeBundleFormat
+        if effectiveWeightFormat == "mxtq" || resolvedBits.0 != nil || hasSidecar {
+            format = .jangtq
+        } else if let wf = effectiveWeightFormat,
+            wf.contains("mxfp") || wf.contains("mx-fp")
+        {
+            format = .mxfp
+        } else if jang != nil {
+            format = .jang
+        } else if config != nil {
+            format = .mlx
+        } else {
+            format = .unknown
+        }
+
+        self.bundleFormat = format
+        self.evidence = Array(Set(evidence)).sorted()
+        self.configModelType = configModelType
+        self.textConfigModelType = textConfigModelType
+        self.dispatchModelType = textConfigModelType ?? configModelType
+        self.hasTextConfig = textConfig != nil
+        self.hasVisionConfig = hasVisionConfig || (mtpStatus?.bundleHasVision == true)
+        self.hasPreprocessorConfig = hasPreprocessorConfig
+        self.configWeightFormat = configWeightFormat
+        self.jangWeightFormat = jangWeightFormat
+        self.effectiveWeightFormat = effectiveWeightFormat
+        self.hasJangConfig = jang != nil
+        self.jangFormat = Self.string(jang?["format"])
+        self.jangProfile = jangProfile
+        self.jangQuantizationMethod = Self.string(jangQuantization?["method"])
+        self.quantizationBits = quantizationBits
+        self.mxtqBits = resolvedBits.0
+        self.mxtqBitsSource = resolvedBits.1
+        self.hasJANGTQSidecar = hasSidecar
+        self.sidecarCodebookBits = sidecarBits
+        self.nativeMTPMode = mtpStatus?.mode
+        self.nativeMTPConfiguredLayers = mtpStatus?.configuredLayers
+        self.nativeMTPTensorCount = mtpStatus?.tensorCount
+        self.visionTensorCount = mtpStatus?.visionTensorCount
+        self.nativeMTPCanAutoLaunch = mtpStatus?.canAutoLaunchMTP
+    }
+
+    private static func resolveMXTQBits(
+        _ value: Any?,
+        preferredSources: [String]
+    ) -> (value: Int, source: String)? {
+        if let int = intValue(value) {
+            return (int, preferredSources[0])
+        }
+        guard let dict = value as? [String: Any] else { return nil }
+        if let routed = intValue(dict["routed_expert"]) {
+            return (routed, "\(preferredSources[0]).routed_expert")
+        }
+        if let routed = dict["routed_expert"] as? [String: Any] {
+            for key in ["gate_proj", "up_proj", "down_proj"] {
+                if let bits = intValue(routed[key]) {
+                    return (bits, "\(preferredSources[0]).routed_expert.\(key)")
+                }
+            }
+        }
+        for key in ["gate_proj", "up_proj", "down_proj", "q_proj", "k_proj", "v_proj", "o_proj"] {
+            if let bits = intValue(dict[key]) {
+                return (bits, "\(preferredSources[0]).\(key)")
+            }
+        }
+        return nil
+    }
+
+    private static func loadJSONObjectIfExists(_ url: URL) throws -> [String: Any]? {
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        let data = try Data(contentsOf: url)
+        return try JSONSerialization.jsonObject(with: data) as? [String: Any]
+    }
+
+    private static func string(_ value: Any?) -> String? {
+        guard let value = value as? String, !value.isEmpty else { return nil }
+        return value
+    }
+
+    private static func lowerString(_ value: Any?) -> String? {
+        string(value)?.lowercased()
+    }
+
+    private static func bool(_ value: Any?) -> Bool {
+        if let value = value as? Bool { return value }
+        return value != nil
+    }
+
+    private static func intValue(_ value: Any?) -> Int? {
+        if let value = value as? Int { return value }
+        if let value = value as? Double { return Int(value) }
+        if let value = value as? Float { return Int(value) }
+        if let value = value as? NSNumber { return value.intValue }
+        if let value = value as? String { return Int(value) }
+        return nil
+    }
+}
+
 /// Codable capability snapshot for Osaurus-style model status endpoints.
 ///
 /// This is a no-load data surface. It combines the resolved model configuration,
@@ -42,11 +282,13 @@ public struct ModelRuntimeCapabilitySnapshot: Codable, Sendable, Equatable {
     public let reasoningParser: String?
     public let generationDefaults: GenerationConfigFile?
     public let nativeMTP: MTPBundleStatusSnapshot?
+    public let detection: ModelRuntimeDetectionSnapshot?
 
     public init(
         configuration: ModelConfiguration,
         capabilities: JangCapabilities? = nil,
-        modelType: String? = nil
+        modelType: String? = nil,
+        detection: ModelRuntimeDetectionSnapshot? = nil
     ) {
         self.modelName = configuration.name
         self.modelType = modelType
@@ -72,12 +314,20 @@ public struct ModelRuntimeCapabilitySnapshot: Codable, Sendable, Equatable {
         self.reasoningParser = capabilities?.reasoningParser ?? configuration.reasoningParserName
         self.generationDefaults = configuration.generationDefaults
         self.nativeMTP = configuration.mtpStatus?.snapshot
+        self.detection =
+            detection
+            ?? (try? configuration.modelDirectory).flatMap {
+                try? ModelRuntimeDetectionSnapshot(
+                    modelDirectory: $0,
+                    mtpStatus: configuration.mtpStatus)
+            }
     }
 
     public init(
         resolvedConfiguration: ResolvedModelConfiguration,
         capabilities: JangCapabilities? = nil,
-        modelType: String? = nil
+        modelType: String? = nil,
+        detection: ModelRuntimeDetectionSnapshot? = nil
     ) {
         self.modelName = resolvedConfiguration.name
         self.modelType = modelType
@@ -100,10 +350,16 @@ public struct ModelRuntimeCapabilitySnapshot: Codable, Sendable, Equatable {
             resolvedConfiguration.mtpStatus?.canAutoLaunchMTP == true ? .supported : .unsupported
         self.thinkInTemplate = capabilities?.thinkInTemplate
         self.toolParser = capabilities?.toolParser ?? resolvedConfiguration.toolCallFormat?.rawValue
-        self.reasoningParser = capabilities?.reasoningParser
+        self.reasoningParser =
+            capabilities?.reasoningParser
             ?? resolvedConfiguration.reasoningParserName
         self.generationDefaults = resolvedConfiguration.generationDefaults
         self.nativeMTP = resolvedConfiguration.mtpStatus?.snapshot
+        self.detection =
+            detection
+            ?? (try? ModelRuntimeDetectionSnapshot(
+                modelDirectory: resolvedConfiguration.modelDirectory,
+                mtpStatus: resolvedConfiguration.mtpStatus))
     }
 
     enum CodingKeys: String, CodingKey {
@@ -124,6 +380,7 @@ public struct ModelRuntimeCapabilitySnapshot: Codable, Sendable, Equatable {
         case reasoningParser = "reasoning_parser"
         case generationDefaults = "generation_defaults"
         case nativeMTP = "native_mtp"
+        case detection
     }
 
     public func validate(
@@ -346,12 +603,14 @@ public struct ModelRuntimeCapabilityValidationResult: Codable, Sendable, Equatab
     }
 }
 
-private extension ModelRuntimeCapabilitySnapshot {
-    static func textSupport(_ capabilities: JangCapabilities?) -> ModelRuntimeCapabilitySupport {
+extension ModelRuntimeCapabilitySnapshot {
+    fileprivate static func textSupport(_ capabilities: JangCapabilities?)
+        -> ModelRuntimeCapabilitySupport
+    {
         ModelRuntimeCapabilitySupport.from(capabilities?.supportsText) ?? .supported
     }
 
-    static func visionSupport(
+    fileprivate static func visionSupport(
         capabilities: JangCapabilities?,
         mtpStatus: MTPBundleStatus?
     ) -> ModelRuntimeCapabilitySupport {
@@ -367,7 +626,9 @@ private extension ModelRuntimeCapabilitySnapshot {
             unsupportedTokens: ["text"])
     }
 
-    static func videoSupport(_ capabilities: JangCapabilities?) -> ModelRuntimeCapabilitySupport {
+    fileprivate static func videoSupport(_ capabilities: JangCapabilities?)
+        -> ModelRuntimeCapabilitySupport
+    {
         if let explicit = ModelRuntimeCapabilitySupport.from(capabilities?.supportsVideo) {
             return explicit
         }
@@ -377,7 +638,9 @@ private extension ModelRuntimeCapabilitySnapshot {
             unsupportedTokens: ["text", "audio"])
     }
 
-    static func audioSupport(_ capabilities: JangCapabilities?) -> ModelRuntimeCapabilitySupport {
+    fileprivate static func audioSupport(_ capabilities: JangCapabilities?)
+        -> ModelRuntimeCapabilitySupport
+    {
         if let explicit = ModelRuntimeCapabilitySupport.from(capabilities?.supportsAudio) {
             return explicit
         }
@@ -387,7 +650,7 @@ private extension ModelRuntimeCapabilitySnapshot {
             unsupportedTokens: ["text", "vision", "image", "images", "vl", "vlm", "video"])
     }
 
-    static func toolSupport(
+    fileprivate static func toolSupport(
         capabilities: JangCapabilities?,
         toolCallFormat: ToolCallFormat?
     ) -> ModelRuntimeCapabilitySupport {
@@ -400,7 +663,7 @@ private extension ModelRuntimeCapabilitySnapshot {
         return .unknown
     }
 
-    static func reasoningSupport(
+    fileprivate static func reasoningSupport(
         capabilities: JangCapabilities?,
         reasoningParserName: String?
     ) -> ModelRuntimeCapabilitySupport {
@@ -412,7 +675,7 @@ private extension ModelRuntimeCapabilitySnapshot {
         return ReasoningParser.fromCapabilityName(stamp) == nil ? .unsupported : .supported
     }
 
-    static func supportFromModality(
+    fileprivate static func supportFromModality(
         _ modality: String?,
         supportedTokens: Set<String>,
         unsupportedTokens: Set<String>
@@ -427,7 +690,7 @@ private extension ModelRuntimeCapabilitySnapshot {
         return .unknown
     }
 
-    static func modalityTokens(_ modality: String?) -> Set<String> {
+    fileprivate static func modalityTokens(_ modality: String?) -> Set<String> {
         guard let modality else { return [] }
         return Set(
             modality.lowercased().split { !$0.isLetter && !$0.isNumber }.map(String.init))

--- a/Libraries/MLXLMCommon/ModelRuntimeCapabilitySnapshot.swift
+++ b/Libraries/MLXLMCommon/ModelRuntimeCapabilitySnapshot.swift
@@ -43,6 +43,7 @@ public struct ModelRuntimeDetectionSnapshot: Codable, Sendable, Equatable {
     public let hasPreprocessorConfig: Bool
 
     public let configWeightFormat: String?
+    public let textConfigWeightFormat: String?
     public let jangWeightFormat: String?
     public let effectiveWeightFormat: String?
     public let hasJangConfig: Bool
@@ -51,6 +52,8 @@ public struct ModelRuntimeDetectionSnapshot: Codable, Sendable, Equatable {
     public let jangQuantizationMethod: String?
 
     public let quantizationBits: Int?
+    public let quantizationMode: String?
+    public let textConfigQuantizationMode: String?
     public let mxtqBits: Int?
     public let mxtqBitsSource: String?
     public let hasJANGTQSidecar: Bool
@@ -72,6 +75,7 @@ public struct ModelRuntimeDetectionSnapshot: Codable, Sendable, Equatable {
         case hasVisionConfig = "has_vision_config"
         case hasPreprocessorConfig = "has_preprocessor_config"
         case configWeightFormat = "config_weight_format"
+        case textConfigWeightFormat = "text_config_weight_format"
         case jangWeightFormat = "jang_weight_format"
         case effectiveWeightFormat = "effective_weight_format"
         case hasJangConfig = "has_jang_config"
@@ -79,6 +83,8 @@ public struct ModelRuntimeDetectionSnapshot: Codable, Sendable, Equatable {
         case jangProfile = "jang_profile"
         case jangQuantizationMethod = "jang_quantization_method"
         case quantizationBits = "quantization_bits"
+        case quantizationMode = "quantization_mode"
+        case textConfigQuantizationMode = "text_config_quantization_mode"
         case mxtqBits = "mxtq_bits"
         case mxtqBitsSource = "mxtq_bits_source"
         case hasJANGTQSidecar = "has_jangtq_sidecar"
@@ -100,6 +106,7 @@ public struct ModelRuntimeDetectionSnapshot: Codable, Sendable, Equatable {
             modelDirectory.appendingPathComponent("jang_config.json"))
         let textConfig = config?["text_config"] as? [String: Any]
         let quantization = config?["quantization"] as? [String: Any]
+        let textConfigQuantization = textConfig?["quantization"] as? [String: Any]
         let jangQuantization = jang?["quantization"] as? [String: Any]
         let sidecarURL = modelDirectory.appendingPathComponent("jangtq_runtime.safetensors")
         let hasSidecar = FileManager.default.fileExists(atPath: sidecarURL.path)
@@ -110,8 +117,9 @@ public struct ModelRuntimeDetectionSnapshot: Codable, Sendable, Equatable {
                 modelDirectory: modelDirectory))
 
         let configWeightFormat = Self.lowerString(config?["weight_format"])
+        let textConfigWeightFormat = Self.lowerString(textConfig?["weight_format"])
         let jangWeightFormat = Self.lowerString(jang?["weight_format"])
-        let effectiveWeightFormat = jangWeightFormat ?? configWeightFormat
+        let effectiveWeightFormat = jangWeightFormat ?? configWeightFormat ?? textConfigWeightFormat
         let configModelType = Self.string(config?["model_type"])
         let textConfigModelType = Self.string(textConfig?["model_type"])
         let hasVisionConfig =
@@ -133,6 +141,8 @@ public struct ModelRuntimeDetectionSnapshot: Codable, Sendable, Equatable {
             jang?["mxtq_bits"],
             preferredSources: ["jang_config.mxtq_bits"])
         let quantizationBits = Self.intValue(quantization?["bits"])
+        let quantizationMode = Self.lowerString(quantization?["mode"])
+        let textConfigQuantizationMode = Self.lowerString(textConfigQuantization?["mode"])
         let jangProfile = Self.string(jangQuantization?["profile"])
         let profileBits = jangtqBitsFromProfile(jangProfile)
         let resolvedBits: (Int?, String?) = {
@@ -151,7 +161,14 @@ public struct ModelRuntimeDetectionSnapshot: Codable, Sendable, Equatable {
             evidence.append("text_config.model_type=\(textConfigModelType)")
         }
         if let configWeightFormat { evidence.append("config.weight_format=\(configWeightFormat)") }
+        if let textConfigWeightFormat {
+            evidence.append("text_config.weight_format=\(textConfigWeightFormat)")
+        }
         if let jangWeightFormat { evidence.append("jang_config.weight_format=\(jangWeightFormat)") }
+        if let quantizationMode { evidence.append("config.quantization.mode=\(quantizationMode)") }
+        if let textConfigQuantizationMode {
+            evidence.append("text_config.quantization.mode=\(textConfigQuantizationMode)")
+        }
         if hasSidecar { evidence.append("jangtq_runtime.safetensors") }
         if let sidecarBits { evidence.append("sidecar.codebook_bits=\(sidecarBits)") }
         if let profileBits { evidence.append("jang_config.profile_bits=\(profileBits)") }
@@ -162,8 +179,9 @@ public struct ModelRuntimeDetectionSnapshot: Codable, Sendable, Equatable {
         let format: ModelRuntimeBundleFormat
         if effectiveWeightFormat == "mxtq" || resolvedBits.0 != nil || hasSidecar {
             format = .jangtq
-        } else if let wf = effectiveWeightFormat,
-            wf.contains("mxfp") || wf.contains("mx-fp")
+        } else if Self.isMXFP(effectiveWeightFormat)
+            || Self.isMXFP(quantizationMode)
+            || Self.isMXFP(textConfigQuantizationMode)
         {
             format = .mxfp
         } else if jang != nil {
@@ -183,6 +201,7 @@ public struct ModelRuntimeDetectionSnapshot: Codable, Sendable, Equatable {
         self.hasVisionConfig = hasVisionConfig || (mtpStatus?.bundleHasVision == true)
         self.hasPreprocessorConfig = hasPreprocessorConfig
         self.configWeightFormat = configWeightFormat
+        self.textConfigWeightFormat = textConfigWeightFormat
         self.jangWeightFormat = jangWeightFormat
         self.effectiveWeightFormat = effectiveWeightFormat
         self.hasJangConfig = jang != nil
@@ -190,6 +209,8 @@ public struct ModelRuntimeDetectionSnapshot: Codable, Sendable, Equatable {
         self.jangProfile = jangProfile
         self.jangQuantizationMethod = Self.string(jangQuantization?["method"])
         self.quantizationBits = quantizationBits
+        self.quantizationMode = quantizationMode
+        self.textConfigQuantizationMode = textConfigQuantizationMode
         self.mxtqBits = resolvedBits.0
         self.mxtqBitsSource = resolvedBits.1
         self.hasJANGTQSidecar = hasSidecar
@@ -245,6 +266,11 @@ public struct ModelRuntimeDetectionSnapshot: Codable, Sendable, Equatable {
     private static func bool(_ value: Any?) -> Bool {
         if let value = value as? Bool { return value }
         return value != nil
+    }
+
+    private static func isMXFP(_ value: String?) -> Bool {
+        guard let value else { return false }
+        return value.contains("mxfp") || value.contains("mx-fp")
     }
 
     private static func intValue(_ value: Any?) -> Int? {

--- a/Libraries/MLXLMCommon/ReasoningParser.swift
+++ b/Libraries/MLXLMCommon/ReasoningParser.swift
@@ -102,6 +102,8 @@ public struct ReasoningParser: Sendable {
     private var insideHarmonyChannel: Bool = false
     private var harmonyChannelIsReasoning: Bool = false
     private var harmonyChannelEndTags: [String] = []
+    private var harmonyChannelShouldStripName: Bool = false
+    private var harmonyChannelNameBuffer: String = ""
 
     /// Read-only access to the current parser state — true when the
     /// stream is currently inside a `<think>…</think>` block (or the
@@ -195,8 +197,8 @@ public struct ReasoningParser: Sendable {
     /// - GPT-OSS: `<|channel|>analysis<|message|>...<|end|>` and
     ///   `<|channel|>final<|message|>...<|return|>`.
     ///
-    /// The Gemma path keeps historical semantics: all channel payloads route
-    /// to reasoning and the channel name remains part of the reasoning text.
+    /// The Gemma path routes all channel payloads to reasoning and strips
+    /// simple identifier channel headers such as `thought\n`.
     /// The GPT-OSS path strips control tokens and routes `final` to visible
     /// content while routing other channels to reasoning.
     private mutating func drainHarmonyChannel(allowPartialTagAtEnd: Bool = true)
@@ -224,11 +226,17 @@ public struct ReasoningParser: Sendable {
                 }
 
                 let before = String(buffer[..<range.lowerBound])
-                appendHarmonyChannelText(before, into: &out)
+                appendHarmonyChannelText(
+                    before,
+                    into: &out,
+                    final: true,
+                    stripIdentifierOnlyAtEnd: false)
                 buffer.removeSubrange(buffer.startIndex..<range.upperBound)
                 insideHarmonyChannel = false
                 harmonyChannelIsReasoning = false
                 harmonyChannelEndTags = []
+                harmonyChannelShouldStripName = false
+                harmonyChannelNameBuffer.removeAll(keepingCapacity: false)
                 insideReasoning = false
                 continue
             }
@@ -281,6 +289,8 @@ public struct ReasoningParser: Sendable {
                 insideHarmonyChannel = true
                 harmonyChannelIsReasoning = channelName != "final"
                 harmonyChannelEndTags = gptEndTags
+                harmonyChannelShouldStripName = false
+                harmonyChannelNameBuffer.removeAll(keepingCapacity: false)
                 insideReasoning = harmonyChannelIsReasoning
                 continue
             }
@@ -293,15 +303,64 @@ public struct ReasoningParser: Sendable {
             insideHarmonyChannel = true
             harmonyChannelIsReasoning = true
             harmonyChannelEndTags = [endTag]
+            harmonyChannelShouldStripName = true
+            harmonyChannelNameBuffer.removeAll(keepingCapacity: false)
             insideReasoning = true
         }
 
         return out
     }
 
-    private func appendHarmonyChannelText(_ text: String, into out: inout [ReasoningSegment]) {
+    private mutating func appendHarmonyChannelText(
+        _ text: String,
+        into out: inout [ReasoningSegment],
+        final: Bool = false,
+        stripIdentifierOnlyAtEnd: Bool = true
+    ) {
+        guard !text.isEmpty || final else { return }
+
+        if harmonyChannelShouldStripName {
+            harmonyChannelNameBuffer += text
+            if let newline = harmonyChannelNameBuffer.firstIndex(of: "\n") {
+                let firstLine = String(harmonyChannelNameBuffer[..<newline])
+                let remainderStart = harmonyChannelNameBuffer.index(after: newline)
+                let remainder = String(harmonyChannelNameBuffer[remainderStart...])
+                harmonyChannelNameBuffer.removeAll(keepingCapacity: false)
+                harmonyChannelShouldStripName = false
+                let emitted = isHarmonyIdentifierChannelName(firstLine)
+                    ? remainder
+                    : firstLine + "\n" + remainder
+                appendHarmonyChannelPayload(emitted, into: &out)
+                return
+            }
+
+            if final {
+                let emitted = stripIdentifierOnlyAtEnd
+                    && isHarmonyIdentifierChannelName(harmonyChannelNameBuffer)
+                    ? ""
+                    : harmonyChannelNameBuffer
+                harmonyChannelNameBuffer.removeAll(keepingCapacity: false)
+                harmonyChannelShouldStripName = false
+                appendHarmonyChannelPayload(emitted, into: &out)
+            }
+            return
+        }
+
+        appendHarmonyChannelPayload(text, into: &out)
+    }
+
+    private func appendHarmonyChannelPayload(_ text: String, into out: inout [ReasoningSegment]) {
         guard !text.isEmpty else { return }
         out.append(harmonyChannelIsReasoning ? .reasoning(text) : .content(text))
+    }
+
+    private func isHarmonyIdentifierChannelName(_ text: String) -> Bool {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let first = trimmed.unicodeScalars.first else { return true }
+        guard CharacterSet.letters.contains(first) || first == "_" else { return false }
+        return trimmed.unicodeScalars.allSatisfy {
+            CharacterSet.alphanumerics.contains($0) || $0 == "_" || $0 == "-"
+        }
     }
 
     private mutating func emitSafeHarmonyPrefix(
@@ -335,7 +394,7 @@ public struct ReasoningParser: Sendable {
             appendHarmonyChannelText(safe, into: &out)
             buffer = String(buffer[splitAt...])
         } else {
-            appendHarmonyChannelText(buffer, into: &out)
+            appendHarmonyChannelText(buffer, into: &out, final: true)
             buffer.removeAll(keepingCapacity: false)
         }
     }

--- a/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
+++ b/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
@@ -397,7 +397,7 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
         else {
             return nil
         }
-        return .nativeMTP(depth: depth)
+        return .nativeMTP(depth: depth, verifierMode: launch.recommendation?.verifierMode)
     }
 
     /// Resolve the load-time switch that preserves native-MTP sidecar weights.

--- a/Libraries/MLXLMCommon/SpecDec/DraftStrategy.swift
+++ b/Libraries/MLXLMCommon/SpecDec/DraftStrategy.swift
@@ -35,9 +35,10 @@ import Foundation
 ///   4-7× over autoregressive on pure-attention models; smaller gains on
 ///   hybrid-SSM models until Phase 3 per-node recurrent forking lands.
 ///
-/// - ``nativeMTP(depth:)`` — uses a native MTP sidecar already present in
-///   the target model artifact. This never loads a separate draft model and
-///   is valid only for model instances conforming to ``NativeMTPModel``.
+/// - ``nativeMTP(depth:verifierMode:)`` — uses a native MTP sidecar already
+///   present in the target model artifact. This never loads a separate draft
+///   model and is valid only for model instances conforming to
+///   ``NativeMTPModel``.
 ///
 /// ## Picking a block size / budget
 ///
@@ -89,7 +90,7 @@ public enum DraftStrategy: @unchecked Sendable {
     /// This path is intentionally explicit. The model must have been loaded
     /// with real MTP tensors and `NativeMTPActivation` must have allowed them
     /// through the loader; otherwise the iterator refuses to start.
-    case nativeMTP(depth: Int)
+    case nativeMTP(depth: Int, verifierMode: String? = nil)
 
     /// Discriminator usable as a stable dictionary key / log label.
     /// Does not expose associated values.
@@ -116,5 +117,19 @@ public enum DraftStrategy: @unchecked Sendable {
     public var usesNativeMTP: Bool {
         if case .nativeMTP = self { return true }
         return false
+    }
+
+    public var nativeMTPDepth: Int? {
+        if case .nativeMTP(depth: let depth, verifierMode: _) = self {
+            return depth
+        }
+        return nil
+    }
+
+    public var nativeMTPVerifierMode: String? {
+        if case .nativeMTP(depth: _, verifierMode: let verifierMode) = self {
+            return verifierMode
+        }
+        return nil
     }
 }

--- a/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
+++ b/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
@@ -909,10 +909,17 @@ public enum NativeMTPVerifierStatePolicy {
         case lazyRepair = "lazy_repair"
     }
 
+    @TaskLocal public static var requestVerifierMode: String?
+
     public static var mode: Mode {
+        mode(for: requestVerifierMode)
+    }
+
+    public static func mode(for requestedMode: String?) -> Mode {
         let env = ProcessInfo.processInfo.environment
         let raw =
-            (env["VMLX_NATIVE_MTP_STATE_COMMIT"]
+            (requestedMode
+                ?? env["VMLX_NATIVE_MTP_STATE_COMMIT"]
                 ?? env["VMLINUX_NATIVE_MTP_STATE_COMMIT"]
                 ?? env["VMLX_NATIVE_MTP_HYBRID_VERIFY"]
                 ?? env["VMLINUX_NATIVE_MTP_HYBRID_VERIFY"]
@@ -924,6 +931,8 @@ public enum NativeMTPVerifierStatePolicy {
             return .lazyRepair
         }
         switch raw {
+        case "chunk_repair", "chunk_step_repair":
+            return .captureCommit
         case "chunk_lazy_repair", "lazy_repair", "lazy", "fast_lazy":
             return .lazyRepair
         case "chunk_fast", "fast", "capture_commit", "chunk_commit":
@@ -933,6 +942,13 @@ public enum NativeMTPVerifierStatePolicy {
         default:
             return .strictCapture
         }
+    }
+
+    public static func withVerifierMode<R>(
+        _ verifierMode: String?,
+        operation: () throws -> R
+    ) rethrows -> R {
+        try $requestVerifierMode.withValue(verifierMode, operation: operation)
     }
 
     public static var shouldRecordAcceptedPrefixStates: Bool {

--- a/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
+++ b/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
@@ -621,8 +621,6 @@ public enum NativeMTPActivation {
             || normalized == "qwen3_5_text"
             || normalized == "qwen3_5_moe"
             || normalized == "qwen3_5_moe_text"
-            || normalized == "qwen3_5_vl"
-            || normalized == "qwen3_vl"
     }
 }
 
@@ -757,8 +755,6 @@ public enum NativeMTPAutoDecodePolicy {
             || value == "qwen3_5_text"
             || value == "qwen3_5_moe"
             || value == "qwen3_5_moe_text"
-            || value == "qwen3_5_vl"
-            || value == "qwen3_vl"
     }
 
     private static func normalize(_ value: String) -> String {

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -660,9 +660,10 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             speculativeSampler: speculativeSampler,
             verifierMode: verifierModeSetting)
         let checkpointStart = Date.timeIntervalSinceReferenceDate
+        let needsBatchedVerifierRecovery = speculativeSampler.isGreedy && processor == nil
         let checkpoint =
             (canCommitVerifierCache && !requiresSequentialRepair && !replayChunkCommit
-                && !lazyChunkRepair)
+                && !lazyChunkRepair && !needsBatchedVerifierRecovery)
             ? nil
             : NativeMTPCacheCheckpoint(cache)
         cacheSnapshotRestoreTime += Date.timeIntervalSinceReferenceDate - checkpointStart
@@ -679,13 +680,22 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         chunkVerifierCount += 1
 
         let sampleStart = Date.timeIntervalSinceReferenceDate
-        let verifyDecision = Self.verifyDrafts(
+        guard let verifyDecision = Self.verifyDrafts(
             logits: verifier.logits,
             drafts: drafts,
             draftProbabilities: draftProbabilities,
             sampler: sampler,
             speculativeSampler: speculativeSampler,
             processor: processor)
+        else {
+            if let checkpoint {
+                let restoreStart = Date.timeIntervalSinceReferenceDate
+                checkpoint.restore(into: &cache)
+                cacheSnapshotRestoreTime += Date.timeIntervalSinceReferenceDate - restoreStart
+            }
+            try verifyCycleSequential(primary: primary)
+            return
+        }
         materializeSyncTime += verifyDecision.materializeSyncTime
         samplingTime += Date.timeIntervalSinceReferenceDate - sampleStart
 
@@ -723,9 +733,14 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             var repaired = replayPrefix(count: accepted + 1)
 
             if speculativeSampler.isGreedy, processor == nil {
-                let audited = Self.batchedGreedyTargetTokenIds(
+                guard let audited = Self.batchedGreedyTargetTokenIds(
                     logits: repaired.logits,
                     count: accepted + 1)
+                else {
+                    restoreCheckpoint()
+                    try verifyCycleSequential(primary: primary)
+                    return
+                }
                 materializeSyncTime += audited.materializeSyncTime
 
                 var auditedAccepted = 0
@@ -743,9 +758,14 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                     repaired = replayPrefix(count: accepted + 1)
                 }
 
-                let verified = Self.batchedGreedyTargetTokenIds(
+                guard let verified = Self.batchedGreedyTargetTokenIds(
                     logits: repaired.logits,
                     count: accepted + 1)
+                else {
+                    restoreCheckpoint()
+                    try verifyCycleSequential(primary: primary)
+                    return
+                }
                 materializeSyncTime += verified.materializeSyncTime
                 nextVerifiedToken = verified.tokens[accepted]
             }
@@ -1191,15 +1211,18 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         sampler: LogitSampler,
         speculativeSampler: SpeculativeSamplingController,
         processor: LogitProcessor?
-    ) -> VerifyDecision {
+    ) -> VerifyDecision? {
         if speculativeSampler.isGreedy {
             var materializeSyncTime: TimeInterval = 0
             let sampled: [MLXArray]
             let sampledIDs: [Int]
             if processor == nil {
-                let batch = batchedGreedyTargetTokenIds(
+                guard let batch = batchedGreedyTargetTokenIds(
                     logits: logits,
                     count: drafts.count + 1)
+                else {
+                    return nil
+                }
                 sampled = batch.tokens
                 sampledIDs = batch.tokenIds
                 materializeSyncTime += batch.materializeSyncTime
@@ -1523,15 +1546,36 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         return speculativeSampler.sample(logits: logits)
     }
 
+    static func greedyTargetTokenIdsForTesting(
+        logits: MLXArray,
+        count: Int
+    ) -> [Int]? {
+        batchedGreedyTargetTokenIds(logits: logits, count: count)?.tokenIds
+    }
+
     private static func batchedGreedyTargetTokenIds(
         logits: MLXArray,
         count: Int
-    ) -> (tokens: [MLXArray], tokenIds: [Int], materializeSyncTime: TimeInterval) {
+    ) -> (tokens: [MLXArray], tokenIds: [Int], materializeSyncTime: TimeInterval)? {
+        guard count > 0,
+              logits.ndim >= 3,
+              logits.shape.count >= 2,
+              logits.shape[1] >= count
+        else {
+            return nil
+        }
+
         let candidateLogits = logits[0..., 0 ..< count, 0...]
         let tokenBatch = argMax(candidateLogits, axis: -1).asType(.int32)
         let syncStart = Date.timeIntervalSinceReferenceDate
         MLX.eval(tokenBatch)
+        guard tokenBatch.size == count else {
+            return nil
+        }
         let tokenIds = tokenBatch.reshaped(-1).asArray(Int32.self).map { Int($0) }
+        guard tokenIds.count == count else {
+            return nil
+        }
         let materializeSyncTime = Date.timeIntervalSinceReferenceDate - syncStart
         let tokens = tokenIds.map { MLXArray([Int32($0)]) }
         return (

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -55,6 +55,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     let speculativeSampler: SpeculativeSamplingController
     let maxTokens: Int?
     let depth: Int
+    let verifierModeSetting: String?
     var promptTokenIds: [Int]
     let cachePrefixTokenCounts: [Int]
     let originalInput: LMInput
@@ -89,6 +90,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private(set) var verifyMainForwardCount = 0
     private(set) var replayMainForwardCount = 0
     private(set) var mtpForwardCount = 0
+    private(set) var autoregressiveFallbackTokenCount = 0
     private(set) var seedMainForwardTime: TimeInterval = 0
     private(set) var verifyMainForwardTime: TimeInterval = 0
     private(set) var replayMainForwardTime: TimeInterval = 0
@@ -100,7 +102,13 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private(set) var cacheSnapshotRestoreTime: TimeInterval = 0
     private(set) var acceptanceProbabilitySum = 0.0
     private(set) var acceptanceProbabilityCount = 0
+    private var forceAutoregressiveFallback = false
+    private var hybridSafetyWarmupComplete = false
     private let iteratorStartTime = Date.timeIntervalSinceReferenceDate
+
+    private var usesHybridMambaCache: Bool {
+        cache.contains { $0 is MambaCache }
+    }
 
     init(
         input: LMInput,
@@ -148,6 +156,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         self.speculativeSampler = SpeculativeSamplingController(parameters: effectiveParameters)
         self.maxTokens = effectiveParameters.maxTokens
         self.depth = requestedDepth
+        self.verifierModeSetting = effectiveParameters.draftStrategy?.nativeMTPVerifierMode
         let promptTokenStart = Date.timeIntervalSinceReferenceDate
         let promptTokenIds = input.text.tokens.reshaped(-1).asArray(Int.self)
         let promptTokenElapsed = Date.timeIntervalSinceReferenceDate - promptTokenStart
@@ -357,7 +366,11 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             pendingTokens.removeAll(keepingCapacity: true)
             pendingIndex = 0
             do {
-                try verifyCycle()
+                if forceAutoregressiveFallback {
+                    try generateAutoregressiveToken()
+                } else {
+                    try verifyCycle()
+                }
             } catch {
                 return nil
             }
@@ -465,8 +478,11 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             .sorted { $0.key < $1.key }
             .map { "\($0.key):\($0.value)" }
             .joined(separator: ",")
+        let speculativeOutputTokens = Swift.max(
+            generatedTokenIds.count - autoregressiveFallbackTokenCount,
+            0)
         let avgCommitted = verifyCalls > 0
-            ? Double(generatedTokenIds.count) / Double(verifyCalls)
+            ? Double(speculativeOutputTokens) / Double(verifyCalls)
             : 0
         let avgAcceptP = acceptanceProbabilityCount > 0
             ? acceptanceProbabilitySum / Double(acceptanceProbabilityCount)
@@ -478,7 +494,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         if chunkVerifierCount > 0 && sequentialVerifierCount > 0 {
             verifierMode = "mixed"
         } else if chunkVerifierCount > 0 {
-            verifierMode = NativeMTPVerifierStatePolicy.mode == .lazyRepair
+            verifierMode = chunkReplayRepairCount > 0
+                ? "chunk_repair"
+                : NativeMTPVerifierStatePolicy.mode(for: verifierModeSetting) == .lazyRepair
                 ? "chunk_lazy_repair"
                 : "chunk_commit"
         } else {
@@ -486,10 +504,11 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
         let line = String(
             format:
-                "[NativeMTP] depth=%d verifyCalls=%d outputTokens=%d acceptedByDepth=%@ bonus=%d rejected=%d residualCorrection=%d prefixCommit=%d rollbackRepair=%d mtpCacheRefresh=%d targetForwards=%d verifyInputTokens=%d repairForwards=%d seedMainForwards=%d verifyMainForwards=%d replayMainForwards=%d mtpForwards=%d avgCommittedPerVerify=%.2f avgAcceptP=%.3f targetVerifySec=%.3f seedMainSec=%.3f verifyMainSec=%.3f replayMainSec=%.3f mtpDraftSec=%.3f samplingSec=%.3f cacheCommitSec=%.3f materializeSyncSec=%.3f cacheStateSec=%.3f iteratorWallSec=%.3f gdnReplayCalls=%d gdnReplayStates=%d gdnReplaySec=%.3f phaseDiag=%@ samplingMode=%@ verifierMode=%@ cacheMode=private-mtp+verifier-prefix-commit\n",
+                "[NativeMTP] depth=%d verifyCalls=%d outputTokens=%d arFallbackTokens=%d acceptedByDepth=%@ bonus=%d rejected=%d residualCorrection=%d prefixCommit=%d rollbackRepair=%d mtpCacheRefresh=%d targetForwards=%d verifyInputTokens=%d repairForwards=%d seedMainForwards=%d verifyMainForwards=%d replayMainForwards=%d mtpForwards=%d avgCommittedPerVerify=%.2f avgAcceptP=%.3f targetVerifySec=%.3f seedMainSec=%.3f verifyMainSec=%.3f replayMainSec=%.3f mtpDraftSec=%.3f samplingSec=%.3f cacheCommitSec=%.3f materializeSyncSec=%.3f cacheStateSec=%.3f iteratorWallSec=%.3f gdnReplayCalls=%d gdnReplayStates=%d gdnReplaySec=%.3f phaseDiag=%@ samplingMode=%@ verifierMode=%@ cacheMode=private-mtp+verifier-prefix-commit\n",
             depth,
             verifyCalls,
             generatedTokenIds.count,
+            autoregressiveFallbackTokenCount,
             accepted.isEmpty ? "none" : accepted,
             bonusCount,
             rejectedCount,
@@ -592,7 +611,16 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             throw NativeMTPRuntimeError.verifierProducedNoTokens
         }
 
-        if Self.requiresSequentialVerifierRepair(cache, speculativeSampler: speculativeSampler) {
+        let shouldUseHybridSafetyWarmup = usesHybridMambaCache
+            && speculativeSampler.isGreedy
+            && processor == nil
+            && !hybridSafetyWarmupComplete
+
+        if shouldUseHybridSafetyWarmup || Self.requiresSequentialVerifierRepair(
+            cache,
+            speculativeSampler: speculativeSampler,
+            verifierMode: verifierModeSetting)
+        {
             try verifyCycleSequential(primary: primary)
             return
         }
@@ -602,11 +630,17 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             requested.map { Int32($0.item(Int.self)) }
         }
         let input = MLXArray(requestedInputIds).reshaped(1, requested.count)
-        let replayChunkCommit = Self.requiresChunkTokenReplayRepair(cache)
-        let lazyChunkRepair = Self.requiresLazyChunkRepair(cache)
+        let replayChunkCommit = Self.requiresChunkTokenReplayRepair(
+            cache,
+            verifierMode: verifierModeSetting)
+        let lazyChunkRepair = Self.requiresLazyChunkRepair(
+            cache,
+            verifierMode: verifierModeSetting)
         let canCommitVerifierCache = Self.canCommitVerifierCache(cache)
         let requiresSequentialRepair = Self.requiresSequentialVerifierRepair(
-            cache, speculativeSampler: speculativeSampler)
+            cache,
+            speculativeSampler: speculativeSampler,
+            verifierMode: verifierModeSetting)
         let checkpointStart = Date.timeIntervalSinceReferenceDate
         let checkpoint =
             (canCommitVerifierCache && !requiresSequentialRepair && !replayChunkCommit
@@ -615,8 +649,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             : NativeMTPCacheCheckpoint(cache)
         cacheSnapshotRestoreTime += Date.timeIntervalSinceReferenceDate - checkpointStart
         let verifyStart = Date.timeIntervalSinceReferenceDate
-        let verifier = model.nativeBackboneMTPVerifyForward(input, cache: cache)
-        MLX.eval(verifier.logits, verifier.hiddenStates)
+        let verifier = NativeMTPVerifierStatePolicy.withVerifierMode(verifierModeSetting) {
+            model.nativeBackboneMTPVerifyForward(input, cache: cache)
+        }
         let verifyElapsed = Date.timeIntervalSinceReferenceDate - verifyStart
         targetVerifyTime += verifyElapsed
         verifyMainForwardTime += verifyElapsed
@@ -636,7 +671,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         materializeSyncTime += verifyDecision.materializeSyncTime
         samplingTime += Date.timeIntervalSinceReferenceDate - sampleStart
 
-        let accepted = verifyDecision.accepted
+        var accepted = verifyDecision.accepted
         var nextVerifiedToken = verifyDecision.nextToken
         var repairedHiddenForNextMTP: MLXArray? = nil
         let shouldReplayAcceptedPrefix = replayChunkCommit
@@ -645,28 +680,63 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             guard let checkpoint else {
                 throw NativeMTPRuntimeError.verifierCacheCommitFailed
             }
-            let restoreStart = Date.timeIntervalSinceReferenceDate
-            checkpoint.restore(into: &cache)
-            cacheSnapshotRestoreTime += Date.timeIntervalSinceReferenceDate - restoreStart
-            let committedInputs = Array(requested.prefix(accepted + 1))
-            var repaired: NativeMTPForwardResult?
-            for token in committedInputs {
+
+            func restoreCheckpoint() {
+                let restoreStart = Date.timeIntervalSinceReferenceDate
+                checkpoint.restore(into: &cache)
+                cacheSnapshotRestoreTime += Date.timeIntervalSinceReferenceDate - restoreStart
+            }
+
+            func replayPrefix(count: Int) -> NativeMTPForwardResult {
+                let acceptedInputIds = recordMaterializeSync {
+                    requested.prefix(count).map { Int32($0.item(Int.self)) }
+                }
+                let acceptedInput = MLXArray(acceptedInputIds).reshaped(1, count)
                 let replayStart = Date.timeIntervalSinceReferenceDate
-                let step = model.nativeBackboneForward(Self.tokenInput(token), cache: cache)
-                MLX.eval(step.logits, step.hiddenStates)
+                let repaired = model.nativeBackboneForward(acceptedInput, cache: cache)
+                MLX.eval(repaired.logits, repaired.hiddenStates)
                 replayMainForwardTime += Date.timeIntervalSinceReferenceDate - replayStart
-                repaired = step
                 repairForwardCount += 1
                 replayMainForwardCount += 1
+                return repaired
             }
-            if let repaired {
-                repairedHiddenForNextMTP = Self.lastHidden(repaired.hiddenStates)
-                if speculativeSampler.isGreedy, processor == nil {
-                    nextVerifiedToken = sampler.sample(logits: repaired.logits[0..., -1, 0...])
-                    recordMaterializeSync {
-                        MLX.eval(nextVerifiedToken)
+
+            restoreCheckpoint()
+            var repaired = replayPrefix(count: accepted + 1)
+
+            if speculativeSampler.isGreedy, processor == nil {
+                let audited = Self.batchedGreedyTargetTokenIds(
+                    logits: repaired.logits,
+                    count: accepted + 1)
+                materializeSyncTime += audited.materializeSyncTime
+
+                var auditedAccepted = 0
+                while auditedAccepted < accepted {
+                    let draftID = recordMaterializeSync {
+                        requested[auditedAccepted + 1].item(Int.self)
                     }
+                    guard audited.tokenIds[auditedAccepted] == draftID else { break }
+                    auditedAccepted += 1
                 }
+
+                if auditedAccepted != accepted {
+                    accepted = auditedAccepted
+                    restoreCheckpoint()
+                    repaired = replayPrefix(count: accepted + 1)
+                }
+
+                let verified = Self.batchedGreedyTargetTokenIds(
+                    logits: repaired.logits,
+                    count: accepted + 1)
+                materializeSyncTime += verified.materializeSyncTime
+                nextVerifiedToken = verified.tokens[accepted]
+            }
+
+            let repairedHidden =
+                repaired.hiddenStates[0..., accepted ..< (accepted + 1), 0...]
+            repairedHiddenForNextMTP = repairedHidden
+            recordMaterializeSync {
+                MLX.eval(nextVerifiedToken, repairedHidden)
             }
             rollbackRepairCount += 1
             if replayChunkCommit {
@@ -680,6 +750,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
 
         verifyCalls += 1
         acceptedByDepth[accepted, default: 0] += 1
+        updateHybridFallbackState()
         if Self.traceEnabled {
             let requestedIDs = recordMaterializeSync { requested.map { $0.item(Int.self) } }
             let currentDrafts = drafts
@@ -819,6 +890,62 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         mtpDraftTime += Date.timeIntervalSinceReferenceDate - draftStart
     }
 
+    private mutating func updateHybridFallbackState() {
+        guard usesHybridMambaCache,
+              speculativeSampler.isGreedy,
+              processor == nil,
+              !hybridSafetyWarmupComplete
+        else { return }
+
+        guard verifyCalls >= 16 else { return }
+
+        let acceptedTokens = acceptedByDepth.reduce(0) { partial, item in
+            partial + item.key * item.value
+        }
+        let averageAccepted = Double(acceptedTokens) / Double(Swift.max(verifyCalls, 1))
+        if averageAccepted >= 2.75 {
+            hybridSafetyWarmupComplete = true
+        } else {
+            forceAutoregressiveFallback = true
+            drafts.removeAll(keepingCapacity: true)
+            draftProbabilities.removeAll(keepingCapacity: true)
+            mtpCache = model.makeNativeMTPCache()
+            mtpCacheRefreshCount += 1
+        }
+    }
+
+    private mutating func generateAutoregressiveToken() throws {
+        guard let primary = nextMain else {
+            throw NativeMTPRuntimeError.verifierProducedNoTokens
+        }
+
+        let verifyStart = Date.timeIntervalSinceReferenceDate
+        let output = model.nativeBackboneForward(Self.tokenInput(primary), cache: cache)
+        MLX.eval(output.logits, output.hiddenStates)
+        let elapsed = Date.timeIntervalSinceReferenceDate - verifyStart
+        targetVerifyTime += elapsed
+        verifyMainForwardTime += elapsed
+        targetForwardCount += 1
+        verifyMainForwardCount += 1
+        verifyInputTokenCount += 1
+
+        let sampleStart = Date.timeIntervalSinceReferenceDate
+        let sample = Self.sampleLast(
+            logits: output.logits,
+            sampler: sampler,
+            speculativeSampler: speculativeSampler,
+            processor: &processor)
+        recordMaterializeSync {
+            MLX.eval(sample.token)
+        }
+        samplingTime += Date.timeIntervalSinceReferenceDate - sampleStart
+
+        let tokenID = recordMaterializeSync { sample.token.item(Int.self) }
+        pendingTokens.append(tokenID)
+        autoregressiveFallbackTokenCount += 1
+        nextMain = sample.token
+    }
+
     private mutating func verifyCycleSequential(primary: MLXArray) throws {
         let requested = [primary] + drafts
         var accepted = 0
@@ -936,6 +1063,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
 
         acceptedByDepth[accepted, default: 0] += 1
+        updateHybridFallbackState()
         prefixCommitCount += 1
 
         guard let nextToken, let hiddenForNextMTP else {
@@ -1122,9 +1250,10 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         ProcessInfo.processInfo.environment["VMLX_NATIVE_MTP_TRACE"] == "1"
     }
 
-    private static func nativeMTPHybridVerifySetting() -> String? {
+    private static func nativeMTPHybridVerifySetting(_ verifierMode: String? = nil) -> String? {
         let env = ProcessInfo.processInfo.environment
-        return env["VMLX_NATIVE_MTP_HYBRID_VERIFY"]
+        return verifierMode
+            ?? env["VMLX_NATIVE_MTP_HYBRID_VERIFY"]
             ?? env["VMLINUX_NATIVE_MTP_HYBRID_VERIFY"]
     }
 
@@ -1188,12 +1317,13 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
 
     private static func requiresSequentialVerifierRepair(
         _ cache: [KVCache],
-        speculativeSampler: SpeculativeSamplingController
+        speculativeSampler: SpeculativeSamplingController,
+        verifierMode: String? = nil
     ) -> Bool {
         if ProcessInfo.processInfo.environment["VMLX_NATIVE_MTP_FORCE_SEQUENTIAL_REPAIR"] == "1" {
             return true
         }
-        switch nativeMTPHybridVerifySetting()?.lowercased() {
+        switch nativeMTPHybridVerifySetting(verifierMode)?.lowercased() {
         case "chunk", "chunk_commit", "capture_commit", "fast", "chunk_replay", "chunk_repair",
             "chunk_step_repair", "chunk_lazy_repair", "lazy_repair", "lazy", "fast_lazy":
             return false
@@ -1208,8 +1338,11 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         return false
     }
 
-    private static func requiresChunkTokenReplayRepair(_ cache: [KVCache]) -> Bool {
-        switch nativeMTPHybridVerifySetting()?.lowercased() {
+    private static func requiresChunkTokenReplayRepair(
+        _ cache: [KVCache],
+        verifierMode: String? = nil
+    ) -> Bool {
+        switch nativeMTPHybridVerifySetting(verifierMode)?.lowercased() {
         case "chunk_replay", "chunk_repair", "chunk_step_repair":
             return cache.contains { $0 is MambaCache }
         default:
@@ -1217,8 +1350,11 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
     }
 
-    private static func requiresLazyChunkRepair(_ cache: [KVCache]) -> Bool {
-        NativeMTPVerifierStatePolicy.mode == .lazyRepair
+    private static func requiresLazyChunkRepair(
+        _ cache: [KVCache],
+        verifierMode: String? = nil
+    ) -> Bool {
+        NativeMTPVerifierStatePolicy.mode(for: verifierMode) == .lazyRepair
             && cache.contains { $0 is MambaCache }
     }
 

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -55,6 +55,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     let speculativeSampler: SpeculativeSamplingController
     let maxTokens: Int?
     let depth: Int
+    private var currentDepth: Int
     let verifierModeSetting: String?
     var promptTokenIds: [Int]
     let cachePrefixTokenCounts: [Int]
@@ -91,6 +92,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private(set) var replayMainForwardCount = 0
     private(set) var mtpForwardCount = 0
     private(set) var autoregressiveFallbackTokenCount = 0
+    private(set) var adaptiveDepthDownshiftCount = 0
     private(set) var seedMainForwardTime: TimeInterval = 0
     private(set) var verifyMainForwardTime: TimeInterval = 0
     private(set) var replayMainForwardTime: TimeInterval = 0
@@ -104,10 +106,17 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private(set) var acceptanceProbabilityCount = 0
     private var forceAutoregressiveFallback = false
     private var hybridSafetyWarmupComplete = false
+    private var adaptiveWindow: [AdaptiveCycle] = []
+    private var adaptiveFallbackReason: String?
     private let iteratorStartTime = Date.timeIntervalSinceReferenceDate
 
     private var usesHybridMambaCache: Bool {
         cache.contains { $0 is MambaCache }
+    }
+
+    private struct AdaptiveCycle {
+        let depth: Int
+        let accepted: Int
     }
 
     init(
@@ -146,6 +155,10 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             effectiveParameters.kvMode = policy.kvMode
             effectiveParameters.maxKVSize = policy.maxKVSize
         }
+        guard effectiveParameters.canUseNativeMTP(for: input) else {
+            throw NativeMTPRuntimeError.unsupportedSampling(
+                "native MTP is enabled only for text-only greedy requests with temperature=0, top_p>=1, top_k=0, min_p=0, and no active penalties")
+        }
 
         self.model = model
         self.cache = cache ?? model.newCache(parameters: effectiveParameters)
@@ -156,6 +169,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         self.speculativeSampler = SpeculativeSamplingController(parameters: effectiveParameters)
         self.maxTokens = effectiveParameters.maxTokens
         self.depth = requestedDepth
+        self.currentDepth = requestedDepth
         self.verifierModeSetting = effectiveParameters.draftStrategy?.nativeMTPVerifierMode
         let promptTokenStart = Date.timeIntervalSinceReferenceDate
         let promptTokenIds = input.text.tokens.reshaped(-1).asArray(Int.self)
@@ -346,7 +360,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             hidden: Self.lastHidden(bridge.hiddenStates),
             nextToken: secondToken,
             mtpCache: mtpCache,
-            depth: self.depth,
+            depth: self.currentDepth,
             sampler: sampler,
             speculativeSampler: speculativeSampler,
             processor: processor)
@@ -490,6 +504,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         let gdnReplay = NativeMTPGDNReplayDiagnostics.snapshot()
         let phaseSummary = NativeMTPPhaseDiagnostics.summary()
         let iteratorWallTime = Date.timeIntervalSinceReferenceDate - iteratorStartTime
+        let adaptiveFallback = adaptiveFallbackReason ?? "none"
         let verifierMode: String
         if chunkVerifierCount > 0 && sequentialVerifierCount > 0 {
             verifierMode = "mixed"
@@ -504,8 +519,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
         let line = String(
             format:
-                "[NativeMTP] depth=%d verifyCalls=%d outputTokens=%d arFallbackTokens=%d acceptedByDepth=%@ bonus=%d rejected=%d residualCorrection=%d prefixCommit=%d rollbackRepair=%d mtpCacheRefresh=%d targetForwards=%d verifyInputTokens=%d repairForwards=%d seedMainForwards=%d verifyMainForwards=%d replayMainForwards=%d mtpForwards=%d avgCommittedPerVerify=%.2f avgAcceptP=%.3f targetVerifySec=%.3f seedMainSec=%.3f verifyMainSec=%.3f replayMainSec=%.3f mtpDraftSec=%.3f samplingSec=%.3f cacheCommitSec=%.3f materializeSyncSec=%.3f cacheStateSec=%.3f iteratorWallSec=%.3f gdnReplayCalls=%d gdnReplayStates=%d gdnReplaySec=%.3f phaseDiag=%@ samplingMode=%@ verifierMode=%@ cacheMode=private-mtp+verifier-prefix-commit\n",
+                "[NativeMTP] depth=%d activeDepth=%d verifyCalls=%d outputTokens=%d arFallbackTokens=%d acceptedByDepth=%@ bonus=%d rejected=%d residualCorrection=%d prefixCommit=%d rollbackRepair=%d mtpCacheRefresh=%d targetForwards=%d verifyInputTokens=%d repairForwards=%d seedMainForwards=%d verifyMainForwards=%d replayMainForwards=%d mtpForwards=%d avgCommittedPerVerify=%.2f avgAcceptP=%.3f adaptiveDownshifts=%d adaptiveFallback=%@ targetVerifySec=%.3f seedMainSec=%.3f verifyMainSec=%.3f replayMainSec=%.3f mtpDraftSec=%.3f samplingSec=%.3f cacheCommitSec=%.3f materializeSyncSec=%.3f cacheStateSec=%.3f iteratorWallSec=%.3f gdnReplayCalls=%d gdnReplayStates=%d gdnReplaySec=%.3f phaseDiag=%@ samplingMode=%@ verifierMode=%@ cacheMode=private-mtp+verifier-prefix-commit\n",
             depth,
+            currentDepth,
             verifyCalls,
             generatedTokenIds.count,
             autoregressiveFallbackTokenCount,
@@ -525,6 +541,8 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             mtpForwardCount,
             avgCommitted,
             avgAcceptP,
+            adaptiveDepthDownshiftCount,
+            adaptiveFallback,
             targetVerifyTime,
             seedMainForwardTime,
             verifyMainForwardTime,
@@ -750,7 +768,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
 
         verifyCalls += 1
         acceptedByDepth[accepted, default: 0] += 1
-        updateHybridFallbackState()
+        recordAdaptiveCycle(accepted: accepted)
         if Self.traceEnabled {
             let requestedIDs = recordMaterializeSync { requested.map { $0.item(Int.self) } }
             let currentDrafts = drafts
@@ -873,13 +891,18 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
 
         nextMain = nextToken
+        if forceAutoregressiveFallback {
+            drafts.removeAll(keepingCapacity: true)
+            draftProbabilities.removeAll(keepingCapacity: true)
+            return
+        }
         let draftStart = Date.timeIntervalSinceReferenceDate
         let draftBatch = Self.makeDrafts(
             model: model,
             hidden: hiddenForNextMTP,
             nextToken: nextToken,
             mtpCache: mtpCache,
-            depth: depth,
+            depth: currentDepth,
             sampler: sampler,
             speculativeSampler: speculativeSampler,
             processor: processor)
@@ -890,28 +913,70 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         mtpDraftTime += Date.timeIntervalSinceReferenceDate - draftStart
     }
 
-    private mutating func updateHybridFallbackState() {
-        guard usesHybridMambaCache,
-              speculativeSampler.isGreedy,
-              processor == nil,
-              !hybridSafetyWarmupComplete
+    private mutating func recordAdaptiveCycle(accepted: Int) {
+        adaptiveWindow.append(AdaptiveCycle(depth: currentDepth, accepted: accepted))
+        if adaptiveWindow.count > Self.adaptiveWindowSize {
+            adaptiveWindow.removeFirst(adaptiveWindow.count - Self.adaptiveWindowSize)
+        }
+
+        if usesHybridMambaCache,
+           speculativeSampler.isGreedy,
+           processor == nil,
+           !hybridSafetyWarmupComplete,
+           verifyCalls >= Self.hybridWarmupCycleCount
+        {
+            let acceptedTokens = acceptedByDepth.reduce(0) { partial, item in
+                partial + item.key * item.value
+            }
+            let averageAccepted = Double(acceptedTokens) / Double(Swift.max(verifyCalls, 1))
+            if averageAccepted >= Self.hybridWarmupMinimumAverageAccepted {
+                hybridSafetyWarmupComplete = true
+            } else {
+                enableAutoregressiveFallback(
+                    reason: String(
+                        format: "hybrid_warmup_avg_accept=%.2f",
+                        averageAccepted))
+                return
+            }
+        }
+
+        guard adaptiveWindow.count >= Self.adaptiveWindowSize,
+              !forceAutoregressiveFallback
         else { return }
 
-        guard verifyCalls >= 16 else { return }
+        let activeSamples = adaptiveWindow.filter { $0.depth == currentDepth }
+        guard activeSamples.count >= Self.adaptiveMinimumSamplesPerDepth else { return }
 
-        let acceptedTokens = acceptedByDepth.reduce(0) { partial, item in
-            partial + item.key * item.value
-        }
-        let averageAccepted = Double(acceptedTokens) / Double(Swift.max(verifyCalls, 1))
-        if averageAccepted >= 2.75 {
-            hybridSafetyWarmupComplete = true
-        } else {
-            forceAutoregressiveFallback = true
-            drafts.removeAll(keepingCapacity: true)
-            draftProbabilities.removeAll(keepingCapacity: true)
+        let acceptedTokens = activeSamples.reduce(0) { $0 + $1.accepted }
+        let possibleDraftTokens = activeSamples.reduce(0) { $0 + $1.depth }
+        guard possibleDraftTokens > 0 else { return }
+
+        let acceptanceRatio = Double(acceptedTokens) / Double(possibleDraftTokens)
+        if currentDepth >= 3, acceptanceRatio < Self.depthThreeMinimumAcceptanceRatio {
+            currentDepth = 2
+            adaptiveDepthDownshiftCount += 1
+            adaptiveWindow.removeAll(keepingCapacity: true)
             mtpCache = model.makeNativeMTPCache()
             mtpCacheRefreshCount += 1
+            return
         }
+
+        if currentDepth <= 2, acceptanceRatio < Self.depthTwoMinimumAcceptanceRatio {
+            enableAutoregressiveFallback(
+                reason: String(
+                    format: "adaptive_accept_ratio=%.2f_depth=%d",
+                    acceptanceRatio,
+                    currentDepth))
+        }
+    }
+
+    private mutating func enableAutoregressiveFallback(reason: String) {
+        forceAutoregressiveFallback = true
+        adaptiveFallbackReason = reason
+        drafts.removeAll(keepingCapacity: true)
+        draftProbabilities.removeAll(keepingCapacity: true)
+        mtpCache = model.makeNativeMTPCache()
+        mtpCacheRefreshCount += 1
     }
 
     private mutating func generateAutoregressiveToken() throws {
@@ -1063,7 +1128,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
 
         acceptedByDepth[accepted, default: 0] += 1
-        updateHybridFallbackState()
+        recordAdaptiveCycle(accepted: accepted)
         prefixCommitCount += 1
 
         guard let nextToken, let hiddenForNextMTP else {
@@ -1081,13 +1146,18 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
 
         nextMain = nextToken
+        if forceAutoregressiveFallback {
+            drafts.removeAll(keepingCapacity: true)
+            draftProbabilities.removeAll(keepingCapacity: true)
+            return
+        }
         let draftStart = Date.timeIntervalSinceReferenceDate
         let draftBatch = Self.makeDrafts(
             model: model,
             hidden: hiddenForNextMTP,
             nextToken: nextToken,
             mtpCache: mtpCache,
-            depth: depth,
+            depth: currentDepth,
             sampler: sampler,
             speculativeSampler: speculativeSampler,
             processor: processor)
@@ -1249,6 +1319,13 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private static var traceEnabled: Bool {
         ProcessInfo.processInfo.environment["VMLX_NATIVE_MTP_TRACE"] == "1"
     }
+
+    private static let adaptiveWindowSize = 12
+    private static let adaptiveMinimumSamplesPerDepth = 6
+    private static let depthThreeMinimumAcceptanceRatio = 0.85
+    private static let depthTwoMinimumAcceptanceRatio = 0.75
+    private static let hybridWarmupCycleCount = 16
+    private static let hybridWarmupMinimumAverageAccepted = 2.75
 
     private static func nativeMTPHybridVerifySetting(_ verifierMode: String? = nil) -> String? {
         let env = ProcessInfo.processInfo.environment

--- a/Libraries/MLXLMCommon/Tool/Parsers/DSMLToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/DSMLToolCallParser.swift
@@ -45,16 +45,25 @@ public struct DSMLToolCallParser: ToolCallParser, Sendable {
 
     public let startTag: String? = "<\u{FF5C}DSML\u{FF5C}tool_calls>"
     public let endTag: String? = "</\u{FF5C}DSML\u{FF5C}tool_calls>"
+    public let startTagAliases: [String] = [
+        "<\u{FF5C}DSML\u{FF5C}tool_calls>",
+        // Live DeepSeek V4 Flash sometimes drops the second "l".
+        "<\u{FF5C}DSML\u{FF5C}tool_cals>",
+    ]
+    public let endTagAliases: [String] = [
+        "</\u{FF5C}DSML\u{FF5C}tool_calls>",
+        "</\u{FF5C}DSML\u{FF5C}tool_cals>",
+    ]
 
     public init() {}
 
     public func parse(content: String, tools: [[String: any Sendable]]?) -> ToolCall? {
         // Strip outer block if present.
         var text = content
-        if let start = startTag {
+        for start in startTagAliases {
             text = text.replacingOccurrences(of: start, with: "")
         }
-        if let end = endTag {
+        for end in endTagAliases {
             text = text.replacingOccurrences(of: end, with: "")
         }
         text = text.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -75,10 +84,10 @@ public struct DSMLToolCallParser: ToolCallParser, Sendable {
         // internally by `<｜DSML｜invoke ...>` per call. Parse all
         // invokes in order.
         var buffer = toolCallBuffer
-        if let start = startTag {
+        for start in startTagAliases {
             buffer = buffer.replacingOccurrences(of: start, with: "")
         }
-        if let end = endTag {
+        for end in endTagAliases {
             buffer = buffer.replacingOccurrences(of: end, with: "")
         }
         return parseAllInvokes(in: buffer, tools: tools)

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -19,6 +19,14 @@ public protocol ToolCallParser: Sendable {
     /// Returns `nil` for inline formats that don't use wrapper tags.
     var endTag: String? { get }
 
+    /// Additional accepted start tags for formats whose live model output
+    /// contains known spelling variants. The canonical ``startTag`` remains
+    /// first in matching order.
+    var startTagAliases: [String] { get }
+
+    /// Additional accepted end tags matching ``startTagAliases``.
+    var endTagAliases: [String] { get }
+
     /// Parse the content into a `ToolCall`.
     /// - Parameters:
     ///   - content: The text content to parse (may include tags)
@@ -41,6 +49,14 @@ public protocol ToolCallParser: Sendable {
 }
 
 extension ToolCallParser {
+    public var startTagAliases: [String] {
+        startTag.map { [$0] } ?? []
+    }
+
+    public var endTagAliases: [String] {
+        endTag.map { [$0] } ?? []
+    }
+
     public func isValidPartialContent(_ toolCallBuffer: String) -> Bool {
         true
     }

--- a/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
@@ -63,7 +63,7 @@ public class ToolCallProcessor {
 
     /// The first character of the start tag for quick detection.
     private var startTagFirstChar: Character? {
-        parser.startTag?.first
+        parser.startTagAliases.first?.first
     }
 
     // MARK: - Public Methods
@@ -177,7 +177,8 @@ public class ToolCallProcessor {
 
     /// Process chunk for tagged formats.
     private func processTaggedChunk(_ chunk: String) -> String? {
-        guard let startTag = parser.startTag,
+        let startTags = parser.startTagAliases
+        guard !startTags.isEmpty,
             let startChar = startTagFirstChar
         else {
             return chunk
@@ -203,8 +204,8 @@ public class ToolCallProcessor {
 
             fallthrough
         case .potentialToolCall:
-            if partialMatch(buffer: toolCallBuffer, tag: startTag) {
-                if toolCallBuffer.starts(with: startTag) {
+            if partialMatch(buffer: toolCallBuffer, tags: startTags) {
+                if startTags.contains(where: { toolCallBuffer.starts(with: $0) }) {
                     state = .collectingToolCall
                     fallthrough
                 } else {
@@ -220,7 +221,8 @@ public class ToolCallProcessor {
                 return visible
             }
         case .collectingToolCall:
-            guard let endTag = parser.endTag else {
+            let endTags = parser.endTagAliases
+            guard !endTags.isEmpty else {
                 return nil
             }
 
@@ -233,10 +235,10 @@ public class ToolCallProcessor {
                 return visible.isEmpty ? nil : visible
             }
 
-            if toolCallBuffer.contains(endTag) {
+            if let matchedEndTag = firstTag(in: toolCallBuffer, tags: endTags) {
                 // Separate the trailing token
                 let trailingToken = separateToken(
-                    from: &toolCallBuffer, separator: endTag, returnLeading: false)
+                    from: &toolCallBuffer, separator: matchedEndTag, returnLeading: false)
 
                 // Parse the completed wrapper. Some formats, including Hy3 /
                 // Hunyuan, can carry multiple calls inside one outer block.
@@ -288,6 +290,12 @@ public class ToolCallProcessor {
         return token
     }
 
+    private func partialMatch(buffer: String, tags: [String]) -> Bool {
+        tags.contains { tag in
+            partialMatch(buffer: buffer, tag: tag)
+        }
+    }
+
     private func partialMatch(buffer: String, tag: String) -> Bool {
         for (tagIndex, bufferIndex) in zip(tag.indices, buffer.indices) {
             if buffer[bufferIndex] != tag[tagIndex] {
@@ -296,5 +304,14 @@ public class ToolCallProcessor {
         }
 
         return true
+    }
+
+    private func firstTag(in text: String, tags: [String]) -> String? {
+        tags
+            .compactMap { tag -> (String, Range<String.Index>)? in
+                text.range(of: tag).map { (tag, $0) }
+            }
+            .min { $0.1.lowerBound < $1.1.lowerBound }?
+            .0
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -751,6 +751,7 @@ let package = Package(
                 "MTPRuntimeFocusedTests.swift",
                 "VMLXServerRuntimeSettingsTests.swift",
                 "NoHiddenReasoningCloseBiasFocusedTests.swift",
+                "TokenizerAddedTokenRegexFocusedTests.swift",
             ]
         ),
 

--- a/Source/MLX/Transforms+Compile.swift
+++ b/Source/MLX/Transforms+Compile.swift
@@ -51,6 +51,7 @@ final class CompiledFunction: @unchecked (Sendable) {
 
     func call(_ arguments: [MLXArray]) -> [MLXArray] {
         if !mlxSwiftCompileAllowedByPolicy() {
+            mlx_disable_compile()
             return f(arguments)
         }
 

--- a/Source/MLX/Transforms+Compile.swift
+++ b/Source/MLX/Transforms+Compile.swift
@@ -3,6 +3,19 @@
 import Cmlx
 import Foundation
 
+private func mlxSwiftCompileAllowedByPolicy() -> Bool {
+    let env = ProcessInfo.processInfo.environment
+    if env["MLX_DISABLE_COMPILE"] != nil {
+        return false
+    }
+
+    let raw = env["VMLX_ENABLE_UNSAFE_COMPILE"]
+        ?? env["MLXPRESS_ENABLE_UNSAFE_COMPILE"]
+        ?? env["MLX_ENABLE_UNSAFE_COMPILE"]
+        ?? ""
+    return raw == "1" || raw.lowercased() == "true"
+}
+
 // Note: this is all immutable state -- the `id` property is only set at init time
 final class CompiledFunction: @unchecked (Sendable) {
 
@@ -37,7 +50,11 @@ final class CompiledFunction: @unchecked (Sendable) {
     }
 
     func call(_ arguments: [MLXArray]) -> [MLXArray] {
-        lock.withLock {
+        if !mlxSwiftCompileAllowedByPolicy() {
+            return f(arguments)
+        }
+
+        return lock.withLock {
             innerCall(arguments)
         }
     }

--- a/Tests/MLXLMCommonFocusedTests/DSMLToolCallParserFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/DSMLToolCallParserFocusedTests.swift
@@ -41,11 +41,11 @@ struct DSMLToolCallParserFocusedTests {
     func parserAcceptsAbbreviatedInvokeClose() {
         let dsml = DeepseekV4Tokens.dsml
         let output = """
-            <\(dsml)tool_calls>
+            <\(dsml)tool_cals>
             <\(dsml)invoke name="get_weather">
             <\(dsml)parameter name="location" string="true">Tokyo</\(dsml)parameter>
             </\(dsml)inv>
-            </\(dsml)tool_calls>
+            </\(dsml)tool_cals>
             """
 
         let calls = DSMLToolCallParser().parseEOS(output, tools: nil)
@@ -53,6 +53,35 @@ struct DSMLToolCallParserFocusedTests {
         #expect(calls.count == 1)
         #expect(calls.first?.function.name == "get_weather")
         #expect(calls.first?.function.arguments["location"] == .string("Tokyo"))
+    }
+
+    @Test("DSML processor buffers observed misspelled outer block instead of leaking markup")
+    func processorBuffersObservedMisspelledOuterBlock() {
+        let dsml = DeepseekV4Tokens.dsml
+        let output = """
+            Let me take a look.
+            <\(dsml)tool_cals>
+            <\(dsml)invoke name="file_read">
+            <\(dsml)parameter name="path" string="true">/Users/eric/Desktop/testmandel/mandelbrot.py</\(dsml)parameter>
+            </\(dsml)inv>
+            </\(dsml)tool_cals>
+            """
+        let processor = ToolCallProcessor(format: .dsml)
+        var visible = ""
+        for ch in output {
+            visible += processor.processChunk(String(ch)) ?? ""
+        }
+        visible += processor.processEOS() ?? ""
+
+        #expect(processor.toolCalls.count == 1)
+        #expect(processor.toolCalls.first?.function.name == "file_read")
+        #expect(
+            processor.toolCalls.first?.function.arguments["path"]
+                == .string("/Users/eric/Desktop/testmandel/mandelbrot.py")
+        )
+        #expect(!visible.contains("DSML"))
+        #expect(!visible.contains("tool_cals"))
+        #expect(!visible.contains("invoke name"))
     }
 
     @Test("DSV4 instruct prompt routes DSML output to tool calls without reasoning leakage")

--- a/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
@@ -4,12 +4,25 @@
 import Foundation
 import MLX
 import MLXLLM
-import MLXLMCommon
+@testable import MLXLMCommon
 import MLXNN
 import Testing
 
 @Suite("MTP runtime metadata", .serialized)
 struct MTPRuntimeFocusedTests {
+    @Test("native MTP greedy verifier rejects short logits before materialization")
+    func nativeMTPGreedyVerifierRejectsShortLogitsBeforeMaterialization() {
+        FocusedMLXTestSupport.withLock {
+            let logits = MLXArray.zeros([1, 1, 8])
+
+            let batch = NativeMTPTokenIterator.greedyTargetTokenIdsForTesting(
+                logits: logits,
+                count: 2)
+
+            #expect(batch == nil)
+        }
+    }
+
     @Test("cached multi-token verifier mask carries cache offset")
     func cachedMultiTokenVerifierMaskCarriesCacheOffset() {
         FocusedMLXTestSupport.withLock {

--- a/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
@@ -861,8 +861,9 @@ struct MTPRuntimeFocusedTests {
         #expect(runtime.contains("\"chunk_lazy_repair\""))
         #expect(runtime.contains("mode != .lazyRepair"))
         #expect(iterator.contains("private static func requiresLazyChunkRepair"))
-        #expect(iterator.contains("lazyChunkRepair && accepted < drafts.count"))
-        #expect(iterator.contains("verifierMode = NativeMTPVerifierStatePolicy.mode == .lazyRepair"))
+        #expect(iterator.contains("let shouldReplayAcceptedPrefix = (replayChunkCommit || lazyChunkRepair)"))
+        #expect(iterator.contains("&& accepted < drafts.count"))
+        #expect(iterator.contains("NativeMTPVerifierStatePolicy.mode(for: verifierModeSetting) == .lazyRepair"))
     }
 
     @Test("native MTP partial reject refreshes private draft cache")
@@ -894,7 +895,7 @@ struct MTPRuntimeFocusedTests {
         #expect(source.contains("private static func nativeMTPHybridVerifySetting"))
         #expect(source.contains("env[\"VMLX_NATIVE_MTP_HYBRID_VERIFY\"]"))
         #expect(source.contains("env[\"VMLINUX_NATIVE_MTP_HYBRID_VERIFY\"]"))
-        #expect(source.contains("switch nativeMTPHybridVerifySetting()?"))
+        #expect(source.contains("switch nativeMTPHybridVerifySetting(verifierMode)?.lowercased()"))
     }
 
     @Test("RunBench perf can use bundle generation defaults")
@@ -936,8 +937,8 @@ struct MTPRuntimeFocusedTests {
         #expect(source.contains("sequential_repair"))
     }
 
-    @Test("native MTP chunk verifier stays opt-in for Mamba cache")
-    func nativeMTPChunkVerifierStaysOptInForMambaCache() throws {
+    @Test("native MTP defaults greedy Mamba cache to chunk verifier")
+    func nativeMTPDefaultsGreedyMambaCacheToChunkVerifier() throws {
         let source = try Self.source(
             "Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift")
 
@@ -949,7 +950,8 @@ struct MTPRuntimeFocusedTests {
         #expect(source.contains("case invalidDepth(Int)"))
         #expect(source.contains("throw NativeMTPRuntimeError.invalidDepth(requestedDepth)"))
         #expect(source.contains("case \"sequential\", \"sequential_repair\", \"repair\":"))
-        #expect(source.contains("return cache.contains { $0 is MambaCache }"))
+        #expect(source.contains("if !speculativeSampler.isGreedy && cache.contains(where: { $0 is MambaCache })"))
+        #expect(source.contains("return false"))
     }
 
     @Test("native MTP chunk-lazy env overrides stochastic Mamba fallback")
@@ -958,11 +960,32 @@ struct MTPRuntimeFocusedTests {
             "Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift")
 
         let overrideSwitch = try #require(source.range(
-            of: "switch nativeMTPHybridVerifySetting()?.lowercased()"))
+            of: "switch nativeMTPHybridVerifySetting(verifierMode)?.lowercased()"))
         let stochasticMambaFallback = try #require(source.range(
             of: "if !speculativeSampler.isGreedy && cache.contains(where: { $0 is MambaCache })"))
 
         #expect(overrideSwitch.lowerBound < stochasticMambaFallback.lowerBound)
+    }
+
+    @Test("native MTP request eligibility is greedy text-only")
+    func nativeMTPRequestEligibilityIsGreedyTextOnly() {
+        let text = LMInput.Text(tokens: MLXArray([Int32(3), 5, 7]))
+        let textOnly = LMInput(text: text)
+        let pixels = MLXArray((0..<48).map { Float($0) }).reshaped([1, 3, 4, 4])
+        let imageInput = LMInput(text: text, image: .init(pixels: pixels))
+
+        #expect(GenerateParameters(maxTokens: 4, temperature: 0)
+            .canUseNativeMTP(for: textOnly))
+        #expect(!GenerateParameters(maxTokens: 4, temperature: 0.7)
+            .canUseNativeMTP(for: textOnly))
+        #expect(!GenerateParameters(maxTokens: 4, temperature: 0, topP: 0.9)
+            .canUseNativeMTP(for: textOnly))
+        #expect(!GenerateParameters(maxTokens: 4, temperature: 0, topK: 40)
+            .canUseNativeMTP(for: textOnly))
+        #expect(!GenerateParameters(maxTokens: 4, temperature: 0, repetitionPenalty: 1.05)
+            .canUseNativeMTP(for: textOnly))
+        #expect(!GenerateParameters(maxTokens: 4, temperature: 0)
+            .canUseNativeMTP(for: imageInput))
     }
 
     @Test("BatchEngine.generate rejects native MTP without an active MTP head")

--- a/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
@@ -861,7 +861,8 @@ struct MTPRuntimeFocusedTests {
         #expect(runtime.contains("\"chunk_lazy_repair\""))
         #expect(runtime.contains("mode != .lazyRepair"))
         #expect(iterator.contains("private static func requiresLazyChunkRepair"))
-        #expect(iterator.contains("let shouldReplayAcceptedPrefix = (replayChunkCommit || lazyChunkRepair)"))
+        #expect(iterator.contains("let shouldReplayAcceptedPrefix = replayChunkCommit"))
+        #expect(iterator.contains("|| (lazyChunkRepair && accepted < drafts.count)"))
         #expect(iterator.contains("&& accepted < drafts.count"))
         #expect(iterator.contains("NativeMTPVerifierStatePolicy.mode(for: verifierModeSetting) == .lazyRepair"))
     }

--- a/Tests/MLXLMCommonFocusedTests/NoHiddenReasoningCloseBiasFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NoHiddenReasoningCloseBiasFocusedTests.swift
@@ -181,7 +181,7 @@ struct HarmonyParserFocusedTests {
         segments.append(contentsOf: parser?.flush() ?? [])
 
         let (reasoning, content) = collect(segments)
-        #expect(reasoning == "thought\ninner")
+        #expect(reasoning == "inner")
         #expect(content == "preanswer")
         #expect(!content.contains("<|channel>"))
         #expect(!content.contains("<channel|>"))
@@ -225,7 +225,7 @@ struct HarmonyParserFocusedTests {
         segments.append(contentsOf: parser?.flush() ?? [])
 
         let (reasoning, content) = collect(segments)
-        #expect(reasoning == "hiddenthought\nextra")
+        #expect(reasoning == "hiddenextra")
         #expect(content == "leadvisibletail")
         for marker in [
             "<|start|>", "<|channel|>", "<|message|>", "<|end|>", "<|return|>",
@@ -328,7 +328,7 @@ struct HarmonyParserFocusedTests {
         }
         visible += tools.processEOS() ?? ""
 
-        #expect(reasoning == "thought\nNeed weather.")
+        #expect(reasoning == "Need weather.")
         #expect(visible == "Done.")
         #expect(tools.toolCalls.count == 1)
         #expect(tools.toolCalls.first?.function.name == "get_weather")

--- a/Tests/MLXLMCommonFocusedTests/TokenizerAddedTokenRegexFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/TokenizerAddedTokenRegexFocusedTests.swift
@@ -1,0 +1,20 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import Testing
+
+@Suite("Tokenizer added-token regex focused guards")
+struct TokenizerAddedTokenRegexFocusedTests {
+    @Test("unused placeholder added tokens are excluded from regex construction")
+    func unusedPlaceholderAddedTokensAreExcludedFromRegexConstruction() throws {
+        let source = try String(
+            contentsOfFile: "Vendors/swift-transformers/Sources/Tokenizers/Tokenizer.swift",
+            encoding: .utf8)
+
+        #expect(source.contains("private static func isUnusedPlaceholderAddedToken"))
+        #expect(source.contains("if Self.isUnusedPlaceholderAddedToken(content)"))
+        #expect(source.contains("return nil"))
+        #expect(source.contains("content[numberStart..<numberEnd].allSatisfy { $0.isNumber }"))
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/VMLXServerRuntimeSettingsTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/VMLXServerRuntimeSettingsTests.swift
@@ -31,6 +31,23 @@ struct VMLXServerRuntimeSettingsTests {
         #expect(settings.mtp.acceptedTokensOnlyEnterBaseCache)
     }
 
+    @Test("Osaurus production preset enables MLXPress auto while preserving MTP resolution")
+    func osaurusProductionPresetEnablesMLXPressAutoWhilePreservingMTPResolution() {
+        let settings = VMLXServerRuntimeSettings()
+
+        let resolved = settings.resolvedLoadConfiguration(
+            base: .osaurusProduction,
+            configData: nil,
+            jangConfig: nil,
+            status: nil)
+
+        #expect(resolved.jangPress == .auto(envFallback: true))
+        #expect(resolved.maxResidentBytes == .default)
+        #expect(resolved.memoryLimit == .default)
+        #expect(resolved.useMmapSafetensors)
+        #expect(!resolved.nativeMTP)
+    }
+
     @Test("paged cache rejects legacy disk cache conflict")
     func pagedCacheRejectsLegacyDiskCacheConflict() {
         var settings = VMLXServerRuntimeSettings()

--- a/Tests/MLXLMCommonFocusedTests/VMLXServerRuntimeSettingsTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/VMLXServerRuntimeSettingsTests.swift
@@ -246,12 +246,13 @@ struct VMLXServerRuntimeSettingsTests {
         #expect(launch.recommendation?.depth == 2)
         #expect(launch.recommendation?.verifierMode == "chunk_lazy_repair")
         #expect(launch.recommendation?.evidence.contains("server_draft_token_limit=2") == true)
-        if case .nativeMTP(let depth)? = settings.resolvedMTPDraftStrategy(
+        if case .nativeMTP(depth: let depth, verifierMode: let verifierMode)? = settings.resolvedMTPDraftStrategy(
             configData: config,
             jangConfig: nil,
             status: verified)
         {
             #expect(depth == 2)
+            #expect(verifierMode == "chunk_lazy_repair")
         } else {
             Issue.record("Resolved MTP draft strategy did not carry the capped native depth")
         }
@@ -300,12 +301,13 @@ struct VMLXServerRuntimeSettingsTests {
         #expect(settings.effectiveMTPLaunchMode(for: preserved) == .speculative)
         #expect(launch.launchMode == .speculative)
         #expect(loadConfiguration.nativeMTP)
-        if case .nativeMTP(let depth)? = settings.resolvedMTPDraftStrategy(
+        if case .nativeMTP(depth: let depth, verifierMode: let verifierMode)? = settings.resolvedMTPDraftStrategy(
             configData: config,
             jangConfig: nil,
             status: preserved)
         {
             #expect(depth == 3)
+            #expect(verifierMode == "chunk_lazy_repair")
         } else {
             Issue.record("Tensor-proven Qwen MTP should resolve a native-MTP draft strategy")
         }

--- a/Tests/MLXLMCommonFocusedTests/VMLXUmbrellaProductTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/VMLXUmbrellaProductTests.swift
@@ -29,6 +29,8 @@ struct VMLXUmbrellaProductTests {
         let _: NativeMTPTuning.Type = NativeMTPTuning.self
         let _: NativeMTPTuningSnapshot.Type = NativeMTPTuningSnapshot.self
         let _: ModelRuntimeCapabilitySnapshot.Type = ModelRuntimeCapabilitySnapshot.self
+        let _: ModelRuntimeDetectionSnapshot.Type = ModelRuntimeDetectionSnapshot.self
+        let _: ModelRuntimeBundleFormat.Type = ModelRuntimeBundleFormat.self
         let _: ModelRuntimeCapabilityRequest.Type = ModelRuntimeCapabilityRequest.self
         let _: ModelRuntimeCapabilityValidationResult.Type =
             ModelRuntimeCapabilityValidationResult.self
@@ -165,6 +167,175 @@ struct VMLXUmbrellaProductTests {
         #expect(resolvedSnapshot.modelName == "served-qwen36-mtp")
     }
 
+    @Test("runtime detection trace explains JANGTQ VL native-MTP classification")
+    func runtimeDetectionTraceExplainsJANGTQVLMTPClassification() throws {
+        let root = try Self.makeTemporaryDirectory("vmlx-runtime-trace-jangtq-vl")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try Data(
+            """
+            {
+              "model_type": "qwen3_5_vl",
+              "num_hidden_layers": 64,
+              "num_nextn_predict_layers": 3,
+              "text_config": {
+                "model_type": "qwen3_5_moe",
+                "num_hidden_layers": 64,
+                "num_nextn_predict_layers": 3
+              },
+              "vision_config": {
+                "model_type": "qwen3_5_vision"
+              }
+            }
+            """.utf8
+        )
+        .write(to: root.appendingPathComponent("config.json"))
+
+        try Data(
+            """
+            {
+              "format": "jang",
+              "format_version": "2.0",
+              "weight_format": "mxtq",
+              "mxtq_bits": {
+                "routed_expert": {
+                  "gate_proj": 4,
+                  "up_proj": 4,
+                  "down_proj": 4
+                }
+              },
+              "quantization": {
+                "method": "jang",
+                "profile": "JANGTQ4",
+                "bit_widths_used": [2, 4, 8]
+              },
+              "runtime": {
+                "bundle_has_mtp": true,
+                "mtp_layers": 3,
+                "mtp_mode": "preserved_enabled"
+              },
+              "capabilities": {
+                "family": "qwen3_6",
+                "modality": "vision"
+              }
+            }
+            """.utf8
+        )
+        .write(to: root.appendingPathComponent("jang_config.json"))
+
+        try Data("{}".utf8).write(to: root.appendingPathComponent("preprocessor_config.json"))
+        try Data(
+            """
+            {
+              "weight_map": {
+                "model.layers.64.mtp_fc.weight": "model-00001-of-00001.safetensors",
+                "vision_tower.blocks.0.attn.qkv.weight": "model-00001-of-00001.safetensors"
+              }
+            }
+            """.utf8
+        )
+        .write(to: root.appendingPathComponent("model.safetensors.index.json"))
+
+        let trace = try ModelRuntimeDetectionSnapshot(modelDirectory: root)
+
+        #expect(trace.bundleFormat == .jangtq)
+        #expect(trace.configModelType == "qwen3_5_vl")
+        #expect(trace.textConfigModelType == "qwen3_5_moe")
+        #expect(trace.dispatchModelType == "qwen3_5_moe")
+        #expect(trace.hasTextConfig)
+        #expect(trace.hasVisionConfig)
+        #expect(trace.hasPreprocessorConfig)
+        #expect(trace.hasJangConfig)
+        #expect(trace.jangWeightFormat == "mxtq")
+        #expect(trace.effectiveWeightFormat == "mxtq")
+        #expect(trace.mxtqBits == 4)
+        #expect(trace.mxtqBitsSource == "jang_config.mxtq_bits.routed_expert.gate_proj")
+        #expect(trace.nativeMTPMode == .preservedEnabled)
+        #expect(trace.nativeMTPConfiguredLayers == 3)
+        #expect(trace.nativeMTPTensorCount == 1)
+        #expect(trace.visionTensorCount == 1)
+        #expect(trace.evidence.contains("jang_config.weight_format=mxtq"))
+        #expect(trace.evidence.contains("native_mtp.mode=preserved_enabled"))
+
+        let snapshot = ModelRuntimeCapabilitySnapshot(
+            configuration: ModelConfiguration(directory: root),
+            capabilities: JangCapabilities(
+                supportsText: true,
+                supportsVision: true,
+                family: "qwen3_6",
+                modality: "vision"))
+        #expect(snapshot.detection == trace)
+
+        let encoded = String(decoding: try JSONEncoder().encode(snapshot), as: UTF8.self)
+        #expect(encoded.contains("\"bundle_format\":\"jangtq\""))
+        #expect(
+            encoded.contains(
+                "\"mxtq_bits_source\":\"jang_config.mxtq_bits.routed_expert.gate_proj\""))
+        #expect(!encoded.contains(root.path))
+    }
+
+    @Test("runtime detection trace separates MXFP bundles from JANG affine bundles")
+    func runtimeDetectionTraceSeparatesMXFPFromJANGAffine() throws {
+        let mxfpRoot = try Self.makeTemporaryDirectory("vmlx-runtime-trace-mxfp")
+        let jangRoot = try Self.makeTemporaryDirectory("vmlx-runtime-trace-jang")
+        defer {
+            try? FileManager.default.removeItem(at: mxfpRoot)
+            try? FileManager.default.removeItem(at: jangRoot)
+        }
+
+        try Data(
+            """
+            {
+              "model_type": "qwen3_5_moe",
+              "weight_format": "mxfp8",
+              "quantization": {
+                "bits": 8
+              }
+            }
+            """.utf8
+        )
+        .write(to: mxfpRoot.appendingPathComponent("config.json"))
+
+        try Data(
+            """
+            {
+              "model_type": "deepseek_v4",
+              "weight_format": "bf16"
+            }
+            """.utf8
+        )
+        .write(to: jangRoot.appendingPathComponent("config.json"))
+        try Data(
+            """
+            {
+              "format": "jang",
+              "format_version": "2.0",
+              "weight_format": "bf16",
+              "quantization": {
+                "method": "jang-affine",
+                "profile": "JANG_4M",
+                "bit_widths_used": [2, 4, 6, 8]
+              }
+            }
+            """.utf8
+        )
+        .write(to: jangRoot.appendingPathComponent("jang_config.json"))
+
+        let mxfpTrace = try ModelRuntimeDetectionSnapshot(modelDirectory: mxfpRoot)
+        let jangTrace = try ModelRuntimeDetectionSnapshot(modelDirectory: jangRoot)
+
+        #expect(mxfpTrace.bundleFormat == .mxfp)
+        #expect(mxfpTrace.effectiveWeightFormat == "mxfp8")
+        #expect(mxfpTrace.quantizationBits == 8)
+        #expect(mxfpTrace.mxtqBits == nil)
+
+        #expect(jangTrace.bundleFormat == .jang)
+        #expect(jangTrace.jangWeightFormat == "bf16")
+        #expect(jangTrace.jangProfile == "JANG_4M")
+        #expect(jangTrace.jangQuantizationMethod == "jang-affine")
+        #expect(jangTrace.mxtqBits == nil)
+    }
+
     @Test("jang capabilities parse explicit media support booleans")
     func parsesExplicitMediaSupportBooleans() throws {
         let root = FileManager.default.temporaryDirectory
@@ -172,23 +343,24 @@ struct VMLXUmbrellaProductTests {
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: root) }
 
-        let data = Data("""
-        {
-          "format": "jang",
-          "format_version": "1.0",
-          "capabilities": {
-            "family": "nemotron_h_omni",
-            "modality": "omni",
-            "cache_type": "hybrid",
-            "supports_tools": true,
-            "supports_thinking": true,
-            "supports_text": true,
-            "supports_vision": true,
-            "supports_video": true,
-            "supports_audio": true
-          }
-        }
-        """.utf8)
+        let data = Data(
+            """
+            {
+              "format": "jang",
+              "format_version": "1.0",
+              "capabilities": {
+                "family": "nemotron_h_omni",
+                "modality": "omni",
+                "cache_type": "hybrid",
+                "supports_tools": true,
+                "supports_thinking": true,
+                "supports_text": true,
+                "supports_vision": true,
+                "supports_video": true,
+                "supports_audio": true
+              }
+            }
+            """.utf8)
         try data.write(to: root.appendingPathComponent("jang_config.json"))
 
         let config = try JangLoader.loadConfig(at: root)
@@ -225,12 +397,13 @@ struct VMLXUmbrellaProductTests {
 
         #expect(!result.allowed)
         #expect(result.requestedModalities == [.text, .vision, .video, .audio, .tools, .reasoning])
-        #expect(result.issues.map(\.code) == [
-            "unknown_modality_support",
-            "unsupported_modality",
-            "unsupported_modality",
-            "unknown_modality_support",
-        ])
+        #expect(
+            result.issues.map(\.code) == [
+                "unknown_modality_support",
+                "unsupported_modality",
+                "unsupported_modality",
+                "unknown_modality_support",
+            ])
         #expect(result.issues.map(\.modality) == [.video, .audio, .tools, .reasoning])
         #expect(result.issues.first?.redactedLogFields["modality"] == "video")
 
@@ -261,11 +434,12 @@ struct VMLXUmbrellaProductTests {
 
         let strict = snapshot.validate(request: request)
         #expect(!strict.allowed)
-        #expect(strict.issues.map(\.code) == [
-            "unsupported_modality",
-            "unknown_modality_support",
-            "unknown_modality_support",
-        ])
+        #expect(
+            strict.issues.map(\.code) == [
+                "unsupported_modality",
+                "unknown_modality_support",
+                "unknown_modality_support",
+            ])
 
         let permissive = snapshot.validate(request: request, unknownPolicy: .allowUnknown)
         #expect(!permissive.allowed)
@@ -297,9 +471,10 @@ struct VMLXUmbrellaProductTests {
             usesReasoning: true,
             usesNativeMTP: true)
 
-        #expect(request.sortedModalities == [
-            .text, .vision, .video, .audio, .tools, .reasoning, .nativeMTP,
-        ])
+        #expect(
+            request.sortedModalities == [
+                .text, .vision, .video, .audio, .tools, .reasoning, .nativeMTP,
+            ])
         let data = try JSONEncoder().encode(request)
         let encoded = String(decoding: data, as: UTF8.self)
         #expect(encoded.contains("vision"))
@@ -309,5 +484,12 @@ struct VMLXUmbrellaProductTests {
         #expect(encoded.contains("native_mtp"))
         #expect(!encoded.contains("private prompt text"))
         #expect(!encoded.contains("private_tool_name"))
+    }
+
+    private static func makeTemporaryDirectory(_ prefix: String) throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(prefix)-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
     }
 }

--- a/Tests/MLXLMCommonFocusedTests/VMLXUmbrellaProductTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/VMLXUmbrellaProductTests.swift
@@ -287,9 +287,9 @@ struct VMLXUmbrellaProductTests {
             """
             {
               "model_type": "qwen3_5_moe",
-              "weight_format": "mxfp8",
               "quantization": {
-                "bits": 8
+                "bits": 4,
+                "mode": "mxfp4"
               }
             }
             """.utf8
@@ -325,9 +325,11 @@ struct VMLXUmbrellaProductTests {
         let jangTrace = try ModelRuntimeDetectionSnapshot(modelDirectory: jangRoot)
 
         #expect(mxfpTrace.bundleFormat == .mxfp)
-        #expect(mxfpTrace.effectiveWeightFormat == "mxfp8")
-        #expect(mxfpTrace.quantizationBits == 8)
+        #expect(mxfpTrace.effectiveWeightFormat == nil)
+        #expect(mxfpTrace.quantizationBits == 4)
+        #expect(mxfpTrace.quantizationMode == "mxfp4")
         #expect(mxfpTrace.mxtqBits == nil)
+        #expect(mxfpTrace.evidence.contains("config.quantization.mode=mxfp4"))
 
         #expect(jangTrace.bundleFormat == .jang)
         #expect(jangTrace.jangWeightFormat == "bf16")

--- a/Tests/MLXLMTests/LoadConfigurationTests.swift
+++ b/Tests/MLXLMTests/LoadConfigurationTests.swift
@@ -288,6 +288,57 @@ struct LoadConfigurationTests {
         #expect(facts.isRouted == false)
     }
 
+    @Test("plain DSV4 affine JANG is production-blocked")
+    func plainDSV4AffineJANGIsProductionBlocked() throws {
+        let cfg = [
+            "model_type": "deepseek_v4",
+            "weight_format": "affine",
+            "n_routed_experts": 256,
+            "num_experts_per_tok": 8,
+            "moe_intermediate_size": 2048,
+        ] as [String: Any]
+        let jang = [
+            "weight_format": "affine"
+        ] as [String: Any]
+        let dir = try Self.makeBundle(files: [
+            ("config.json", try JSONSerialization.data(withJSONObject: cfg)),
+            ("jang_config.json", try JSONSerialization.data(withJSONObject: jang)),
+            ("model-00001-of-00001.safetensors", Data(count: 1024)),
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let facts = LoadBundleFacts.inspect(bundleURL: dir)
+        #expect(facts.modelType == "deepseek_v4")
+        #expect(facts.weightFormat == "affine")
+        #expect(facts.hasJangConfig)
+        #expect(!facts.hasJangTQRuntime)
+        #expect(facts.isPlainDeepseekV4AffineJANG)
+        #expect(facts.productionBlockReason?.contains("unsupported affine routed-MoE") == true)
+    }
+
+    @Test("DSV4 JANGTQ is not blocked by the affine-JANG guard")
+    func dsv4JANGTQIsNotBlockedByAffineGuard() throws {
+        let cfg = [
+            "model_type": "deepseek_v4",
+            "weight_format": "mxtq",
+            "n_routed_experts": 256,
+            "num_experts_per_tok": 8,
+            "moe_intermediate_size": 2048,
+        ] as [String: Any]
+        let dir = try Self.makeBundle(files: [
+            ("config.json", try JSONSerialization.data(withJSONObject: cfg)),
+            ("jang_config.json", Data("{}".utf8)),
+            ("jangtq_runtime.safetensors", Data(count: 16)),
+            ("model-00001-of-00001.safetensors", Data(count: 1024)),
+        ])
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let facts = LoadBundleFacts.inspect(bundleURL: dir)
+        #expect(facts.hasJangTQRuntime)
+        #expect(!facts.isPlainDeepseekV4AffineJANG)
+        #expect(facts.productionBlockReason == nil)
+    }
+
     @Test("inspect on missing dir returns zeroed facts")
     func inspectMissingDir() {
         let facts = LoadBundleFacts.inspect(

--- a/Tests/MLXLMTests/ReasoningParserTests.swift
+++ b/Tests/MLXLMTests/ReasoningParserTests.swift
@@ -635,9 +635,7 @@ struct HarmonyParserStreamingTests {
         segs.append(contentsOf: p.flush())
         let reasoning = segs.compactMap { if case .reasoning(let r) = $0 { return r } else { return nil } }.joined()
         let content = segs.compactMap { if case .content(let c) = $0 { return c } else { return nil } }.joined()
-        // With bare `<|channel>` start, the channel name is part of
-        // the reasoning delta.
-        #expect(reasoning == "thought\ninner reasoning")
+        #expect(reasoning == "inner reasoning")
         #expect(content == "prefixafter")
     }
 
@@ -661,7 +659,7 @@ struct HarmonyParserStreamingTests {
             case .content(let c): content += c
             }
         }
-        #expect(reasoning == "thought\nthinking")
+        #expect(reasoning == "thinking")
         #expect(content == "preanswer")
     }
 
@@ -673,8 +671,7 @@ struct HarmonyParserStreamingTests {
         segs.append(contentsOf: p.flush())
         let reasoning = segs.compactMap { if case .reasoning(let r) = $0 { return r } else { return nil } }.joined()
         let content = segs.compactMap { if case .content(let c) = $0 { return c } else { return nil } }.joined()
-        // Both channel-name prefixes + inner reasoning join together.
-        #expect(reasoning == "thought\nathought\nb")
+        #expect(reasoning == "ab")
         #expect(content == "midend")
     }
 
@@ -718,7 +715,7 @@ struct HarmonyParserStreamingTests {
             segs.append(contentsOf: p.flush())
             let reasoning = segs.compactMap { if case .reasoning(let r) = $0 { return r } else { return nil } }.joined()
             let content = segs.compactMap { if case .content(let c) = $0 { return c } else { return nil } }.joined()
-            #expect(reasoning == "\(name)\n\(innerText)",
+            #expect(reasoning == innerText,
                 "channel name `\(name)`: full envelope should route to reasoning")
             #expect(content == "ab",
                 "channel name `\(name)`: only pre/post envelope should remain as content")
@@ -732,10 +729,46 @@ struct HarmonyParserStreamingTests {
         segs.append(contentsOf: p.flush())
         let reasoning = segs.compactMap { if case .reasoning(let r) = $0 { return r } else { return nil } }.joined()
         let content = segs.compactMap { if case .content(let c) = $0 { return c } else { return nil } }.joined()
-        // With bare `<|channel>` start, the channel-name bytes
-        // (`thought\n`) are part of the reasoning delta.
-        #expect(reasoning == "thought\ntruncated mid-thought")
+        #expect(reasoning == "truncated mid-thought")
         #expect(content == "visible")
+    }
+
+    @Test("JSON action body without channel name stays intact")
+    func testJsonActionBodyWithoutChannelNameStaysIntact() {
+        var p = harmonyParser
+        let input =
+            "<|channel>{\n" +
+            " \"action\": \"google_search\"\n" +
+            "}\n<channel|>done"
+        var segs = p.feed(input)
+        segs.append(contentsOf: p.flush())
+        let reasoning = segs.compactMap { if case .reasoning(let r) = $0 { return r } else { return nil } }.joined()
+        let content = segs.compactMap { if case .content(let c) = $0 { return c } else { return nil } }.joined()
+        #expect(reasoning.hasPrefix("{\n"))
+        #expect(reasoning.contains("google_search"))
+        #expect(content == "done")
+    }
+
+    @Test("identifier-only channel header at EOS is stripped")
+    func testIdentifierOnlyChannelHeaderAtEOSIsStripped() {
+        var p = harmonyParser
+        var segs = p.feed("visible<|channel>thought")
+        segs.append(contentsOf: p.flush())
+        let reasoning = segs.compactMap { if case .reasoning(let r) = $0 { return r } else { return nil } }.joined()
+        let content = segs.compactMap { if case .content(let c) = $0 { return c } else { return nil } }.joined()
+        #expect(reasoning.isEmpty)
+        #expect(content == "visible")
+    }
+
+    @Test("single-line JSON action body at EOS stays intact")
+    func testSingleLineJsonActionBodyAtEOSStaysIntact() {
+        var p = harmonyParser
+        var segs = p.feed("<|channel>{\"action\":\"google_search\"}")
+        segs.append(contentsOf: p.flush())
+        let reasoning = segs.compactMap { if case .reasoning(let r) = $0 { return r } else { return nil } }.joined()
+        let content = segs.compactMap { if case .content(let c) = $0 { return c } else { return nil } }.joined()
+        #expect(reasoning == "{\"action\":\"google_search\"}")
+        #expect(content.isEmpty)
     }
 
     @Test("no harmony markers → all content, zero reasoning")
@@ -803,7 +836,7 @@ struct HarmonyParserStreamingTests {
         segs += p.flush()
         let reasoning = segs.compactMap { if case .reasoning(let r) = $0 { return r } else { return nil } }.joined()
         let content = segs.compactMap { if case .content(let c) = $0 { return c } else { return nil } }.joined()
-        #expect(reasoning == "thought\ninner reasoning")
+        #expect(reasoning == "inner reasoning")
         #expect(content == "visible answer")
     }
 
@@ -816,7 +849,7 @@ struct HarmonyParserStreamingTests {
         segs += p.flush()
         let reasoning = segs.compactMap { if case .reasoning(let r) = $0 { return r } else { return nil } }.joined()
         let content = segs.compactMap { if case .content(let c) = $0 { return c } else { return nil } }.joined()
-        #expect(reasoning == "thought\ninner")
+        #expect(reasoning == "inner")
         #expect(content == "prefixafter")
     }
 
@@ -843,7 +876,7 @@ struct HarmonyParserStreamingTests {
         segs.append(contentsOf: p.flush())
         let reasoning = segs.compactMap { if case .reasoning(let r) = $0 { return r } else { return nil } }.joined()
         let content = segs.compactMap { if case .content(let c) = $0 { return c } else { return nil } }.joined()
-        #expect(reasoning == "thought\nlots of reasoning<chann")
+        #expect(reasoning == "lots of reasoning<chann")
         #expect(content.isEmpty)
     }
 }


### PR DESCRIPTION
## Summary
- Gate native MTP to lossless greedy text-only requests.
- Carry verifier mode through `DraftStrategy.nativeMTP` and server runtime resolution.
- Add hybrid safety warmup / AR fallback telemetry so hard prompts stay byte-identical instead of using an unsafe fast path.

## Local proof
- `swift build -c release --product RunBench --jobs 2` passed.
- Qwen3.6-35B-A3B-MXFP4-MTP hard prompts, cache coordinator + hybrid + disk/SSM rederive: p1/p2/p3 were byte-identical to AR, no loops, no reasoning leaks. Artifact: `docs/local/mtp-debug-run/20260519T152646-hardcheck-current`.
- Count sanity: MTP d3 activated and stayed byte-identical, AR 91.7 tok/s vs MTP 115.2 tok/s, `avgCommittedPerVerify=3.94`, artifact `docs/local/mtp-debug-run/20260519T153800-count-current`.

## Notes
This intentionally prioritizes correctness over forcing the old unsafe chunk path. Hard prompts fall back/warm up and can be slower; predictable prompts still show d3 speedup.
