### PR TITLE
Handle Gemma4 proportional RoPE

### DIFF
--- a/Libraries/MLXLLM/Models/Gemma4Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma4Text.swift
@@ -262,11 +262,20 @@ class Gemma4Attention: Module {
         let ropeParams = config.ropeParameters[layerKey] ?? [:]
         let ropeTheta = ropeParams["rope_theta"]?.asFloat() ?? (isSliding ? 10000.0 : 1_000_000.0)
         let partialRotaryFactor = ropeParams["partial_rotary_factor"]?.asFloat() ?? (isSliding ? 1.0 : 0.25)
-        let ropeDims = max(1, Int(Float(headDim) * partialRotaryFactor))
+        let ropeType: String = {
+            if let typeValue = ropeParams["type"] ?? ropeParams["rope_type"],
+                case .string(let s) = typeValue
+            {
+                return s
+            }
+            return "default"
+        }()
+        let ropeDims =
+            ropeType == "proportional" ? headDim : max(1, Int(Float(headDim) * partialRotaryFactor))
 
         self.rope = initializeRope(
             dims: ropeDims, base: ropeTheta, traditional: config.ropeTraditional,
-            scalingConfig: nil, maxPositionEmbeddings: nil)
+            scalingConfig: ropeParams.isEmpty ? nil : ropeParams, maxPositionEmbeddings: nil)
 
         super.init()
     }

--- a/Libraries/MLXLMCommon/RoPEUtils.swift
+++ b/Libraries/MLXLMCommon/RoPEUtils.swift
@@ -203,6 +203,111 @@ public class YarnRoPE: Module, OffsetLayer, ArrayOffsetLayer {
 
 }
 
+public class ProportionalRoPE: Module, OffsetLayer, ArrayOffsetLayer {
+    let dimensions: Int
+    let rotatedDimensions: Int
+    let traditional: Bool
+
+    private let _freqs: MLXArray?
+
+    public init(
+        dimensions: Int,
+        traditional: Bool = false,
+        base: Float = 10000,
+        scalingConfig: [String: StringOrNumber]? = nil
+    ) {
+        precondition(dimensions % 2 == 0, "Dimensions must be even")
+
+        self.dimensions = dimensions
+        self.traditional = traditional
+
+        let factor = scalingConfig?["factor"]?.asFloat() ?? 1.0
+        let partialRotaryFactor = scalingConfig?["partial_rotary_factor"]?.asFloat() ?? 1.0
+        let ropeAngles = Int(Float(dimensions) * partialRotaryFactor / 2.0)
+        self.rotatedDimensions = 2 * ropeAngles
+        precondition(rotatedDimensions <= dimensions, "Rotated dimensions must not exceed head dimension")
+
+        if rotatedDimensions > 0 {
+            let exponents =
+                MLXArray(stride(from: 0, to: rotatedDimensions, by: 2)).asType(.float32)
+                / Float(dimensions)
+            self._freqs = factor * MLX.pow(base, exponents)
+        } else {
+            self._freqs = nil
+        }
+
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray, offset: Int = 0) -> MLXArray {
+        guard rotatedDimensions > 0, let freqs = _freqs else {
+            return x
+        }
+        return apply(x, offset: offset, freqs: freqs)
+    }
+
+    public func callAsFunction(_ x: MLXArray, offset: MLXArray) -> MLXArray {
+        guard rotatedDimensions > 0, let freqs = _freqs else {
+            return x
+        }
+        return apply(x, offset: offset, freqs: freqs)
+    }
+
+    private func splitApplyAndMerge(
+        _ x: MLXArray,
+        applyRoPE: (MLXArray) -> MLXArray
+    ) -> MLXArray {
+        let head = x[.ellipsis, ..<dimensions]
+        let half = dimensions / 2
+        let rotatedHalf = rotatedDimensions / 2
+
+        let left = head[.ellipsis, ..<half]
+        let right = head[.ellipsis, half...]
+        let rotatedInput = concatenated(
+            [left[.ellipsis, ..<rotatedHalf], right[.ellipsis, ..<rotatedHalf]], axis: -1)
+        let rotated = applyRoPE(rotatedInput)
+
+        let mergedLeft = concatenated(
+            [rotated[.ellipsis, ..<rotatedHalf], left[.ellipsis, rotatedHalf...]], axis: -1)
+        let mergedRight = concatenated(
+            [rotated[.ellipsis, rotatedHalf...], right[.ellipsis, rotatedHalf...]], axis: -1)
+        let mergedHead = concatenated([mergedLeft, mergedRight], axis: -1)
+
+        guard (x.shape.last ?? dimensions) > dimensions else {
+            return mergedHead
+        }
+        return concatenated([mergedHead, x[.ellipsis, dimensions...]], axis: -1)
+    }
+
+    private func apply(_ x: MLXArray, offset: Int, freqs: MLXArray) -> MLXArray {
+        splitApplyAndMerge(x) { rotatedInput in
+            MLXFast.RoPE(
+                rotatedInput,
+                dimensions: rotatedDimensions,
+                traditional: traditional,
+                base: nil,
+                scale: 1.0,
+                offset: offset,
+                freqs: freqs
+            )
+        }
+    }
+
+    private func apply(_ x: MLXArray, offset: MLXArray, freqs: MLXArray) -> MLXArray {
+        splitApplyAndMerge(x) { rotatedInput in
+            MLXFast.RoPE(
+                rotatedInput,
+                dimensions: rotatedDimensions,
+                traditional: traditional,
+                base: nil,
+                scale: 1.0,
+                offset: offset,
+                freqs: freqs
+            )
+        }
+    }
+}
+
 private let yarnTypes: Set = ["yarn", "deepseek_yarn", "telechat3-yarn"]
 
 public typealias RoPELayer = OffsetLayer & ArrayOffsetLayer
@@ -232,6 +337,13 @@ public func initializeRope(
             scale = 1.0
         }
         return RoPE(dimensions: dims, traditional: traditional, base: base, scale: scale)
+    } else if ropeType == "proportional" {
+        return ProportionalRoPE(
+            dimensions: dims,
+            traditional: traditional,
+            base: base,
+            scalingConfig: scalingConfig
+        )
     } else if ropeType == "llama3" {
         return Llama3RoPE(
             dims: dims,

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -673,7 +673,18 @@ private class TextAttn: Module {
         let rp = cfg.ropeParameters[lk] ?? [:]
         let rt = rp["rope_theta"]?.asFloat() ?? (isSliding ? 10000.0 : 1_000_000.0)
         let prf = rp["partial_rotary_factor"]?.asFloat() ?? (isSliding ? 1.0 : 0.25)
-        self.rope = initializeRope(dims: max(1, Int(Float(hD) * prf)), base: rt, traditional: cfg.ropeTraditional, scalingConfig: nil, maxPositionEmbeddings: nil)
+        let ropeType: String = {
+            if let typeValue = rp["type"] ?? rp["rope_type"],
+                case .string(let s) = typeValue
+            {
+                return s
+            }
+            return "default"
+        }()
+        let ropeDims = ropeType == "proportional" ? hD : max(1, Int(Float(hD) * prf))
+        self.rope = initializeRope(
+            dims: ropeDims, base: rt, traditional: cfg.ropeTraditional,
+            scalingConfig: rp.isEmpty ? nil : rp, maxPositionEmbeddings: nil)
         super.init()
     }
 


### PR DESCRIPTION
## Summary\n- add Gemma4 proportional RoPE handling for full-attention layers\n- pass Gemma4 rope_parameters through text and VLM attention setup\n- leave sampling, prompt templates, thinking behavior, and tool parsing untouched\n\n## Verification\n- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift build --target MLXVLM --jobs 1\n- Osaurus no-sign Release build against patched vMLX checkout\n- Raw Osaurus /v1/chat/completions multi-turn checks passed for gemma-4-12b-it-jang_4m, gemma-4-12b-it-mxfp4, gemma-4-12b-it-mxfp8\n- Tool-call and reasoning-leak checks passed for all three rows