### PR TITLE
Strip repeated Gemma4 thought channel header

### DIFF
--- a/Libraries/MLXLMCommon/ReasoningParser.swift
+++ b/Libraries/MLXLMCommon/ReasoningParser.swift
@@ -357,8 +357,9 @@ public struct ReasoningParser: Sendable {
             }
 
             if final {
-                let emitted = stripIdentifierOnlyAtEnd
-                    && isHarmonyIdentifierChannelName(harmonyChannelNameBuffer)
+                let emitted = isHarmonyThoughtChannelName(harmonyChannelNameBuffer)
+                    || (stripIdentifierOnlyAtEnd
+                        && isHarmonyIdentifierChannelName(harmonyChannelNameBuffer))
                     ? ""
                     : harmonyChannelNameBuffer
                 harmonyChannelNameBuffer.removeAll(keepingCapacity: false)
@@ -383,6 +384,11 @@ public struct ReasoningParser: Sendable {
         return trimmed.unicodeScalars.allSatisfy {
             CharacterSet.alphanumerics.contains($0) || $0 == "_" || $0 == "-"
         }
+    }
+
+    private func isHarmonyThoughtChannelName(_ text: String) -> Bool {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return trimmed == "thought" || trimmed == "thinking"
     }
 
     private mutating func emitSafeHarmonyPrefix(
@@ -809,9 +815,15 @@ extension ReasoningParser {
             parser.insideReasoning = true
             if let lastOpener {
                 let promptChannelTail = String(promptTail[lastOpener.upperBound...])
-                if !promptChannelTail.contains("\n") {
+                if !promptChannelTail.contains("\n")
+                    || promptChannelTail
+                        .split(separator: "\n", maxSplits: 1, omittingEmptySubsequences: false)
+                        .first
+                        .map({ parser.isHarmonyThoughtChannelName(String($0)) }) == true
+                {
                     parser.harmonyChannelShouldStripName = true
-                    parser.harmonyChannelNameBuffer = promptChannelTail
+                    parser.harmonyChannelNameBuffer =
+                        promptChannelTail.contains("\n") ? "" : promptChannelTail
                 }
             }
         }

--- a/Tests/MLXLMCommonFocusedTests/Gemma4ThoughtChannelParserFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/Gemma4ThoughtChannelParserFocusedTests.swift
@@ -34,6 +34,19 @@ struct Gemma4ThoughtChannelParserFocusedTests {
         }
     }
 
+    @Test("prompt-tail open thought channel strips repeated thought header")
+    func promptTailOpenThoughtChannelStripsRepeatedThoughtHeader() {
+        var parser = ReasoningParser.forPrompt(
+            stampName: "gemma4",
+            promptTail: "<start_of_turn>model\n<|channel>thought\n")
+        let segments = feed("thought\nK7Q: yellow\nR9Z: purple<channel|>", into: &parser, chunkSize: 4)
+
+        let (reasoning, content) = collect(segments)
+        #expect(reasoning == "K7Q: yellow\nR9Z: purple")
+        #expect(content.isEmpty)
+        #expect(!reasoning.hasPrefix("thought"))
+    }
+
     private func feed(
         _ text: String,
         into parser: inout ReasoningParser?,


### PR DESCRIPTION
## Summary

Fix Gemma4 harmony-channel parsing when generation starts inside a prompt-prefilled `thought` channel and the model repeats the `thought\n` channel header as its first streamed bytes.

Also preserves the existing empty `<|channel>thought<channel|>` contract so the channel name itself is not emitted as hidden reasoning.

## Validation

- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter Gemma4ThoughtChannelParserFocusedTests --jobs 1 --no-parallel`
