### PR TITLE
Drop empty Gemma4 thought channel headers

### DIFF
--- a/Libraries/MLXLMCommon/ReasoningParser.swift
+++ b/Libraries/MLXLMCommon/ReasoningParser.swift
@@ -162,8 +162,10 @@ public struct ReasoningParser: Sendable {
             var out = drainHarmonyChannel(allowPartialTagAtEnd: false)
             if !buffer.isEmpty {
                 let text = insideHarmonyChannel ? buffer : stripHarmonyControlText(buffer)
-                if !text.isEmpty {
-                    out.append(harmonyChannelIsReasoning ? .reasoning(text) : .content(text))
+                if insideHarmonyChannel {
+                    appendHarmonyChannelPayload(text, into: &out)
+                } else if !text.isEmpty {
+                    out.append(.content(text))
                 }
                 buffer.removeAll(keepingCapacity: false)
             }
@@ -374,6 +376,7 @@ public struct ReasoningParser: Sendable {
 
     private func appendHarmonyChannelPayload(_ text: String, into out: inout [ReasoningSegment]) {
         guard !text.isEmpty else { return }
+        guard !isHarmonyThoughtChannelName(text) else { return }
         out.append(harmonyChannelIsReasoning ? .reasoning(text) : .content(text))
     }
 

--- a/Tests/MLXLMCommonFocusedTests/Gemma4ThoughtChannelParserFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/Gemma4ThoughtChannelParserFocusedTests.swift
@@ -47,6 +47,30 @@ struct Gemma4ThoughtChannelParserFocusedTests {
         #expect(!reasoning.hasPrefix("thought"))
     }
 
+    @Test("prompt-tail open thought channel drops repeated empty thought header before visible content")
+    func promptTailOpenThoughtChannelDropsRepeatedEmptyThoughtHeaderBeforeVisibleContent() {
+        var parser = ReasoningParser.forPrompt(
+            stampName: "gemma4",
+            promptTail: "<start_of_turn>model\n<|channel>thought\n")
+        let segments = feed("thought\n<channel|>NO_IMAGE_VISIBLE", into: &parser, chunkSize: 4)
+
+        let (reasoning, content) = collect(segments)
+        #expect(reasoning.isEmpty)
+        #expect(content == "NO_IMAGE_VISIBLE")
+    }
+
+    @Test("prompt-tail open thought channel drops repeated empty thought header at stream end")
+    func promptTailOpenThoughtChannelDropsRepeatedEmptyThoughtHeaderAtStreamEnd() {
+        var parser = ReasoningParser.forPrompt(
+            stampName: "gemma4",
+            promptTail: "<start_of_turn>model\n<|channel>thought\n")
+        let segments = feed("thought\n", into: &parser, chunkSize: 4)
+
+        let (reasoning, content) = collect(segments)
+        #expect(reasoning.isEmpty)
+        #expect(content.isEmpty)
+    }
+
     private func feed(
         _ text: String,
         into parser: inout ReasoningParser?,


### PR DESCRIPTION
## Summary
- Route harmony channel flush leftovers through the same payload helper used during normal streaming.
- Drop standalone Gemma4 `thought`/`thinking` channel-name payloads so empty duplicate thought headers do not leak as reasoning deltas.
- Add focused Gemma4 parser contracts for close-then-visible and stream-end duplicate thought headers.

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter Gemma4ThoughtChannelParserFocusedTests --jobs 1 --no-parallel`