### PR TITLE
Fix Gemma4 quoted tool argument keys

### DIFF
--- a/Libraries/MLXLMCommon/Tool/Parsers/GemmaFunctionParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/GemmaFunctionParser.swift
@@ -64,8 +64,9 @@ public struct GemmaFunctionParser: ToolCallParser, Sendable {
 
             // Find the key (everything before :)
             guard let colonIdx = argsStr.firstIndex(of: ":") else { break }
-            let key = String(argsStr[..<colonIdx])
-                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let key = normalizeArgumentKey(
+                String(argsStr[..<colonIdx])
+                    .trimmingCharacters(in: .whitespacesAndNewlines))
             argsStr = String(argsStr[argsStr.index(after: colonIdx)...])
 
             guard let value = parseValue(from: &argsStr) else { break }
@@ -178,6 +179,22 @@ public struct GemmaFunctionParser: ToolCallParser, Sendable {
             return decodeQuotedStringLiteral(value)
         }
         return decodeBackslashEscapedString(value)
+    }
+
+    private func normalizeArgumentKey(_ key: String) -> String {
+        guard key.count >= 2 else { return key }
+        if key.hasPrefix("\""), key.hasSuffix("\"") {
+            if let data = key.data(using: .utf8),
+                let decoded = try? JSONDecoder().decode(String.self, from: data)
+            {
+                return decoded
+            }
+            return decodeQuotedStringLiteral(key)
+        }
+        if key.hasPrefix("'"), key.hasSuffix("'") {
+            return String(key.dropFirst().dropLast())
+        }
+        return key
     }
 
     private func decodeBackslashEscapedString(_ value: String) -> String {

--- a/Package.swift
+++ b/Package.swift
@@ -760,6 +760,11 @@ let package = Package(
                 "TokenizerAddedTokenRegexFocusedTests.swift",
             ]
         ),
+        .testTarget(
+            name: "MLXLMCommonToolParserFocusedTests",
+            dependencies: ["MLXLMCommon"],
+            path: "Tests/MLXLMCommonToolParserFocusedTests"
+        ),
 
         // ------
         // Example programs

--- a/Tests/MLXLMCommonToolParserFocusedTests/Gemma4ToolCallParserFocusedTests.swift
+++ b/Tests/MLXLMCommonToolParserFocusedTests/Gemma4ToolCallParserFocusedTests.swift
@@ -1,0 +1,40 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import MLXLMCommon
+import Testing
+
+@Suite("Gemma4 tool parser focused contracts")
+struct Gemma4ToolCallParserFocusedTests {
+    @Test("Gemma4 parser normalizes JSON-style quoted argument keys")
+    func parserNormalizesJSONStyleQuotedArgumentKeys() throws {
+        let parser = GemmaFunctionParser(
+            startTag: "<|tool_call>", endTag: "<tool_call|>", escapeMarker: "<|\"|>")
+        let content =
+            #"<|tool_call>call:browser_navigate{"url":"https://www.amazon.com/gp/cssb","wait_until":"networkidle"}<tool_call|>"#
+
+        let toolCall = try #require(parser.parse(content: content, tools: nil))
+
+        #expect(toolCall.function.name == "browser_navigate")
+        #expect(toolCall.function.arguments["url"] == .string("https://www.amazon.com/gp/cssb"))
+        #expect(toolCall.function.arguments["wait_until"] == .string("networkidle"))
+        #expect(toolCall.function.arguments[#""url""#] == nil)
+        #expect(toolCall.function.arguments[#""wait_until""#] == nil)
+    }
+
+    @Test("Gemma4 processor keeps quoted keys schema-addressable")
+    func processorKeepsQuotedKeysSchemaAddressable() throws {
+        let processor = ToolCallProcessor(format: .gemma4)
+        _ = processor.processChunk(
+            #"<|tool_call>call:browser_navigate{"url":"https://www.amazon.com/gp/cssb","wait_until":"networkidle"}<tool_call|>"#
+        )
+
+        #expect(processor.toolCalls.count == 1)
+        let toolCall = try #require(processor.toolCalls.first)
+        #expect(toolCall.function.name == "browser_navigate")
+        #expect(toolCall.function.arguments["url"] == .string("https://www.amazon.com/gp/cssb"))
+        #expect(toolCall.function.arguments["wait_until"] == .string("networkidle"))
+        #expect(toolCall.function.arguments[#""url""#] == nil)
+    }
+}


### PR DESCRIPTION
## Summary
- normalize JSON-style quoted Gemma4 tool argument keys before storing parsed arguments
- keep existing value decoding behavior unchanged
- add a narrow MLXLMCommon tool parser focused test target covering direct parser and ToolCallProcessor paths

## Validation
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift build --target MLXLMCommonToolParserFocusedTests --jobs 1`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter 'MLXLMCommonToolParserFocusedTests.Gemma4ToolCallParserFocusedTests' --jobs 1 --no-parallel`\n\n## Notes\n- This fixes the observed Gemma4 browser tool call shape like `call:browser_navigate{"url":"...","wait_until":"networkidle"}` where the parser previously preserved literal keys `"url"` and `"wait_until"`, causing required schema validation to report missing `url`.\n