### PR TITLE
Fix Gemma4 nullable tool schemas

### DIFF
--- a/Libraries/MLXLMCommon/Tool/Tool.swift
+++ b/Libraries/MLXLMCommon/Tool/Tool.swift
@@ -18,6 +18,7 @@ private func normalizeChatTemplateValue(_ value: any Sendable) -> any Sendable {
             object[key] = normalizeChatTemplateValue(child)
         }
         normalizeNullableTypeUnion(&object)
+        normalizeNullableEnum(&object)
         return object
     }
 
@@ -48,6 +49,19 @@ private func normalizeNullableTypeUnion(_ object: inout [String: any Sendable]) 
     if hasNull {
         object["nullable"] = true
     }
+}
+
+private func normalizeNullableEnum(_ object: inout [String: any Sendable]) {
+    guard object["nullable"] as? Bool == true,
+          let entries = object["enum"] as? [any Sendable]
+    else { return }
+
+    let filtered = entries.filter { entry in
+        if entry is NSNull { return false }
+        if let string = entry as? String, string == "null" { return false }
+        return true
+    }
+    object["enum"] = filtered
 }
 
 private func stringTypeArray(_ value: (any Sendable)?) -> [String]? {

--- a/Package.swift
+++ b/Package.swift
@@ -762,7 +762,7 @@ let package = Package(
         ),
         .testTarget(
             name: "MLXLMCommonToolParserFocusedTests",
-            dependencies: ["MLXLMCommon"],
+            dependencies: ["MLXLMCommon", "VMLXJinja"],
             path: "Tests/MLXLMCommonToolParserFocusedTests"
         ),
 

--- a/Tests/MLXLMCommonToolParserFocusedTests/Gemma4ToolCallParserFocusedTests.swift
+++ b/Tests/MLXLMCommonToolParserFocusedTests/Gemma4ToolCallParserFocusedTests.swift
@@ -4,6 +4,15 @@
 import Foundation
 import MLXLMCommon
 import Testing
+import VMLXJinja
+
+private func renderGemma4(_ context: [String: any Sendable]) throws -> String {
+    var values: [String: Value] = [:]
+    for (key, value) in context {
+        values[key] = try Value(any: value)
+    }
+    return try Template(ChatTemplateFallbacks.gemma4WithTools).render(values)
+}
 
 @Suite("Gemma4 tool parser focused contracts")
 struct Gemma4ToolCallParserFocusedTests {
@@ -36,5 +45,63 @@ struct Gemma4ToolCallParserFocusedTests {
         #expect(toolCall.function.arguments["url"] == .string("https://www.amazon.com/gp/cssb"))
         #expect(toolCall.function.arguments["wait_until"] == .string("networkidle"))
         #expect(toolCall.function.arguments[#""url""#] == nil)
+    }
+
+    @Test("Gemma4 tool template renders browser schema with nullable enum")
+    func gemma4ToolTemplateRendersBrowserSchemaWithNullableEnum() throws {
+        let tool: ToolSpec = [
+            "type": "function",
+            "function": [
+                "name": "browser_navigate",
+                "description": "Navigate a browser page.",
+                "parameters": [
+                    "type": "object",
+                    "properties": [
+                        "url": [
+                            "type": "string",
+                            "description": "URL to navigate to.",
+                        ] as [String: any Sendable],
+                        "wait_until": [
+                            "type": ["string", "null"] as [any Sendable],
+                            "description": "Optional load state.",
+                            "enum": ["load", "domcontentloaded", "networkidle", NSNull()] as [any Sendable],
+                        ] as [String: any Sendable],
+                    ] as [String: any Sendable],
+                    "required": ["url"],
+                    "additionalProperties": false,
+                ] as [String: any Sendable],
+            ] as [String: any Sendable],
+        ]
+
+        let normalized = try #require(normalizedToolsForChatTemplate([tool])?.first)
+        let function = try #require(normalized["function"] as? [String: any Sendable])
+        let parameters = try #require(function["parameters"] as? [String: any Sendable])
+        let properties = try #require(parameters["properties"] as? [String: any Sendable])
+        let waitUntil = try #require(properties["wait_until"] as? [String: any Sendable])
+        #expect(waitUntil["type"] as? String == "string")
+        #expect(waitUntil["nullable"] as? Bool == true)
+        let enumValues = try #require(waitUntil["enum"] as? [any Sendable])
+        #expect(enumValues.count == 3)
+        #expect(!enumValues.contains { $0 is NSNull })
+
+        let rendered = try renderGemma4([
+            "messages": [
+                [
+                    "role": "user",
+                    "content": "Download https://www.youtube.com/watch?v=e5DF8CxhyAE",
+                ] as [String: any Sendable],
+            ] as [any Sendable],
+            "tools": [normalized] as [any Sendable],
+            "tool_choice": "required",
+            "add_generation_prompt": true,
+            "enable_thinking": false,
+            "bos_token": "<bos>",
+        ])
+
+        #expect(rendered.contains("declaration:browser_navigate"))
+        #expect(rendered.contains("wait_until"))
+        #expect(rendered.contains(#"type:<|"|>string<|"|>"#))
+        #expect(!rendered.contains("upper filter requires string"))
+        #expect(!rendered.contains("Cannot convert value of type Optional<Any> to Jinja Value"))
     }
 }

--- a/Tests/MLXLMTests/Gemma4ChatTemplateProbeTests.swift
+++ b/Tests/MLXLMTests/Gemma4ChatTemplateProbeTests.swift
@@ -222,6 +222,7 @@ final class Gemma4ChatTemplateProbeTests: XCTestCase {
                         "label": [
                             "type": ["string", "null"],
                             "description": "Optional label.",
+                            "enum": ["fast", "slow", NSNull()] as [any Sendable],
                         ] as [String: any Sendable],
                     ] as [String: any Sendable],
                     "required": ["label"],
@@ -244,9 +245,18 @@ final class Gemma4ChatTemplateProbeTests: XCTestCase {
         XCTAssertThrowsError(try template.renderAny(context(rawTools)))
 
         let normalizedTools = try XCTUnwrap(normalizedToolsForChatTemplate(rawTools))
+        let normalizedFunction = try XCTUnwrap(normalizedTools.first?["function"] as? [String: any Sendable])
+        let normalizedParameters = try XCTUnwrap(normalizedFunction["parameters"] as? [String: any Sendable])
+        let normalizedProperties = try XCTUnwrap(normalizedParameters["properties"] as? [String: any Sendable])
+        let normalizedLabel = try XCTUnwrap(normalizedProperties["label"] as? [String: any Sendable])
+        let normalizedEnum = try XCTUnwrap(normalizedLabel["enum"] as? [any Sendable])
+        XCTAssertEqual(normalizedEnum.count, 2)
+        XCTAssertFalse(normalizedEnum.contains { $0 is NSNull })
+
         let rendered = try template.renderAny(context(normalizedTools))
         XCTAssertTrue(rendered.contains("nullable:true"))
         XCTAssertTrue(rendered.contains("type:<|\"|>STRING<|\"|>"))
+        XCTAssertTrue(rendered.contains("enum:[<|\"|>fast<|\"|>,<|\"|>slow<|\"|>]"))
     }
 
     /// Iter 52: the minimal template must emit image / video placeholder

--- a/Vendors/Jinja/Sources/Jinja/Value.swift
+++ b/Vendors/Jinja/Sources/Jinja/Value.swift
@@ -50,6 +50,8 @@ public enum Value: Sendable {
             self = .double(Double(float))
         case let bool as Bool:
             self = .boolean(bool)
+        case is NSNull:
+            self = .null
         case let array as [Any?]:
             let values = try array.map { try Value(any: $0) }
             self = .array(values)


### PR DESCRIPTION
## Summary
- Normalize nullable enum schemas before Gemma4 chat-template rendering so `enum: [..., null]` does not leak into Jinja.
- Teach the vendored Jinja value bridge to accept `NSNull` as `.null` instead of throwing during tool-schema conversion.
- Add focused Gemma4 browser/tool schema coverage for nullable type unions and nullable enum values.

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter 'MLXLMCommonToolParserFocusedTests.Gemma4ToolCallParserFocusedTests' --jobs 1 --no-parallel`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter 'Gemma4ChatTemplateProbeTests/testGemma4TemplateRendersNullableToolSchemaAfterNormalization' --jobs 1 --no-parallel` (passes with the local-template test skipped when the repo-relative Gemma template fixture is unavailable)
- `git diff --check`
