### PR TITLE
Register Gemma4 unified text alias

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -34,6 +34,7 @@ public enum LLMTypeRegistry {
             "gemma3n": create(Gemma3nTextConfiguration.self, Gemma3nTextModel.init),
             "gemma4": create(Gemma4TextConfiguration.self, Gemma4TextModel.init),
             "gemma4_text": create(Gemma4TextConfiguration.self, Gemma4TextModel.init),
+            "gemma4_unified": create(Gemma4TextConfiguration.self, Gemma4TextModel.init),
             "gemma4_unified_text": create(Gemma4TextConfiguration.self, Gemma4TextModel.init),
             "qwen2": create(Qwen2Configuration.self, Qwen2Model.init),
             "qwen3": create(Qwen3Configuration.self, Qwen3Model.init),

--- a/Tests/MLXLMCommonFocusedTests/NoHiddenReasoningCloseBiasFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NoHiddenReasoningCloseBiasFocusedTests.swift
@@ -1731,6 +1731,7 @@ struct Gemma4VLMFocusedSourceContractsTests {
 
         #expect(vlmFactory.contains(#""gemma4_unified": create(Gemma4Configuration.self, Gemma4.init)"#))
         #expect(vlmFactory.contains(#""Gemma4UnifiedProcessor": create("#))
+        #expect(llmFactory.contains(#""gemma4_unified": create(Gemma4TextConfiguration.self, Gemma4TextModel.init)"#))
         #expect(llmFactory.contains(#""gemma4_unified_text": create(Gemma4TextConfiguration.self, Gemma4TextModel.init)"#))
         #expect(source.contains("@ModuleInfo(key: \"vision_embedder\")"))
         #expect(source.contains("UnifiedVisionEmbedder"))


### PR DESCRIPTION
## Summary
- Register `model_type: gemma4_unified` in `LLMModelFactory` as `Gemma4TextModel`.
- Keep the existing VLM `gemma4_unified` route intact.
- Extend the Gemma4 unified source guard so this exact unsupported-model regression is covered.

## Validation
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter 'NoHiddenReasoningCloseBiasFocusedTests/gemma4UnifiedRegistryAndEmbedderPathsAreWired' --jobs 1 --no-parallel` is running on the clean worktree; result will be posted before Osaurus live promotion.
