### PR TITLE
Support Nemotron 3 Ultra JANGTQ metadata

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -363,14 +363,67 @@ public enum LLMTypeRegistry {
     }
 
     private static func dispatchNemotronH(data: Data) throws -> any LanguageModel {
-        struct Probe: Codable {
+        enum ProbeBits: Decodable {
+            case int(Int)
+            case routed(up: Int?, down: Int?)
+
+            init(from decoder: Decoder) throws {
+                let container = try decoder.singleValueContainer()
+                if let value = try? container.decode(Int.self) {
+                    self = .int(value)
+                    return
+                }
+                let keyed = try decoder.container(keyedBy: CodingKeys.self)
+                if let routed = try keyed.decodeIfPresent(
+                    RoutedExpert.self, forKey: .routedExpert)
+                {
+                    self = .routed(up: routed.upProj ?? routed.gateProj, down: routed.downProj)
+                } else {
+                    throw DecodingError.dataCorruptedError(
+                        in: container,
+                        debugDescription: "mxtq_bits must be an Int or contain routed_expert projection bits")
+                }
+            }
+
+            var uniformBits: Int? {
+                switch self {
+                case .int(let value):
+                    return value
+                case .routed(let up, let down):
+                    if let up, let down, up != down {
+                        return nil
+                    }
+                    return up ?? down
+                }
+            }
+
+            private enum CodingKeys: String, CodingKey {
+                case routedExpert = "routed_expert"
+            }
+
+            private struct RoutedExpert: Decodable {
+                let gateProj: Int?
+                let upProj: Int?
+                let downProj: Int?
+
+                enum CodingKeys: String, CodingKey {
+                    case gateProj = "gate_proj"
+                    case upProj = "up_proj"
+                    case downProj = "down_proj"
+                }
+            }
+        }
+
+        struct Probe: Decodable {
             let weightFormat: String?
-            let mxtqBits: Int?
+            let format: String?
+            let mxtqBits: ProbeBits?
             let routedExpertBits: Int?
             let mxtqSeed: Int?
 
             enum CodingKeys: String, CodingKey {
                 case weightFormat = "weight_format"
+                case format
                 case mxtqBits = "mxtq_bits"
                 case routedExpertBits = "routed_expert_bits"
                 case mxtqSeed = "mxtq_seed"
@@ -380,20 +433,30 @@ public enum LLMTypeRegistry {
         let config = try JSONDecoder.json5().decode(NemotronHConfiguration.self, from: data)
         let probe = try? JSONDecoder.json5().decode(Probe.self, from: data)
         let weightFormat = probe?.weightFormat?.lowercased()
+        let jangFormat = probe?.format?.lowercased()
+        let mxtqBits = probe?.mxtqBits?.uniformBits
         let isJANGTQ =
             weightFormat == "mxtq"
+            || jangFormat?.contains("jangtq") == true
             || weightFormat == "jangtq2"
             || weightFormat == "jangtq4"
-            || probe?.mxtqBits != nil
+            || mxtqBits != nil
             || probe?.routedExpertBits != nil
 
         guard isJANGTQ else {
             return NemotronHModel(config)
         }
 
+        guard let bits = mxtqBits ?? probe?.routedExpertBits else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: [],
+                    debugDescription: "NemotronH JANGTQ requires uniform routed expert bits for fc1/fc2"))
+        }
+
         return NemotronHModel(
             jangtqContext: NemotronHJANGTQContext(
-                bits: probe?.mxtqBits ?? probe?.routedExpertBits ?? 2,
+                bits: bits,
                 mxtqSeed: probe?.mxtqSeed ?? 42),
             configuration: config)
     }

--- a/Libraries/MLXLLM/Models/NemotronH.swift
+++ b/Libraries/MLXLLM/Models/NemotronH.swift
@@ -794,6 +794,7 @@ public class NemotronHModel: Module, LLMModel, KVCacheDimensionProvider, LoRAMod
 
     @ModuleInfo(key: "backbone") private var backbone: NemotronHBackbone
     public let configuration: NemotronHConfiguration
+    public let jangtqContext: NemotronHJANGTQContext?
 
     @ModuleInfo(key: "lm_head") var lmHead: Linear?
 
@@ -803,6 +804,7 @@ public class NemotronHModel: Module, LLMModel, KVCacheDimensionProvider, LoRAMod
 
     public init(_ args: NemotronHConfiguration) {
         self.configuration = args
+        self.jangtqContext = nil
         self.vocabularySize = args.vocabSize
 
         // kvHeads array: non-zero for attention layers, zero for others
@@ -829,6 +831,7 @@ public class NemotronHModel: Module, LLMModel, KVCacheDimensionProvider, LoRAMod
     /// `jang_config.weight_format == "mxtq"` and dispatches here.
     public init(jangtqContext: NemotronHJANGTQContext, configuration args: NemotronHConfiguration) {
         self.configuration = args
+        self.jangtqContext = jangtqContext
         self.vocabularySize = args.vocabSize
         let pattern = Array(args.hybridOverridePattern)
         self.kvHeads = pattern.compactMap { char -> Int? in
@@ -1117,6 +1120,7 @@ public struct NemotronHConfiguration: Codable, Sendable {
 
     private enum RawCodingKeys: String, CodingKey {
         case timeStepLimit = "time_step_limit"
+        case layersBlockType = "layers_block_type"
     }
 
     public init(from decoder: Decoder) throws {
@@ -1126,7 +1130,6 @@ public struct NemotronHConfiguration: Codable, Sendable {
         modelType = try container.decodeIfPresent(String.self, forKey: .modelType) ?? "nemotron_h"
         vocabSize = try container.decode(Int.self, forKey: .vocabSize)
         hiddenSize = try container.decode(Int.self, forKey: .hiddenSize)
-        numHiddenLayers = try container.decode(Int.self, forKey: .numHiddenLayers)
         numAttentionHeads = try container.decode(Int.self, forKey: .numAttentionHeads)
         numKeyValueHeads = try container.decode(Int.self, forKey: .numKeyValueHeads)
         attentionBias = try container.decodeIfPresent(Bool.self, forKey: .attentionBias) ?? false
@@ -1162,18 +1165,25 @@ public struct NemotronHConfiguration: Codable, Sendable {
         routedScalingFactor =
             try container.decodeIfPresent(Float.self, forKey: .routedScalingFactor) ?? 1.0
 
-        // Handle hybrid_override_pattern - can be string or array of strings
+        // Handle hybrid_override_pattern - can be string or array of strings.
+        // Nemotron 3 Ultra instead ships mlx-lm's `layers_block_type`
+        // string array: mamba / attention / moe / mlp.
         if let patternString = try? container.decode(String.self, forKey: .hybridOverridePattern) {
             hybridOverridePattern = patternString
         } else if let patternArray = try? container.decode(
             [String].self, forKey: .hybridOverridePattern)
         {
             hybridOverridePattern = patternArray.joined()
+        } else if let layerTypes = try? rawContainer.decode([String].self, forKey: .layersBlockType) {
+            hybridOverridePattern = try Self.pattern(fromLayerBlockTypes: layerTypes)
         } else {
             throw DecodingError.dataCorruptedError(
                 forKey: .hybridOverridePattern, in: container,
-                debugDescription: "hybrid_override_pattern must be string or array of strings")
+                debugDescription: "hybrid_override_pattern must be string/array, or layers_block_type must be present")
         }
+        numHiddenLayers =
+            try container.decodeIfPresent(Int.self, forKey: .numHiddenLayers)
+            ?? hybridOverridePattern.count
 
         // mlx-lm stores Nemotron-H as `time_step_limit: [min, max]`.
         // A lower bound of 0.0 is normalized to 0.001 upstream before the
@@ -1190,6 +1200,22 @@ public struct NemotronHConfiguration: Codable, Sendable {
                 try container.decodeIfPresent(Float.self, forKey: .timeStepLimitMax)
                 ?? Float.infinity
         }
+    }
+
+    private static func pattern(fromLayerBlockTypes layerTypes: [String]) throws -> String {
+        try layerTypes.map { raw in
+            switch raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+            case "mamba", "m": return "M"
+            case "attention", "attn", "*": return "*"
+            case "moe", "expert", "e": return "E"
+            case "mlp", "dense", "-": return "-"
+            default:
+                throw DecodingError.dataCorrupted(
+                    DecodingError.Context(
+                        codingPath: [],
+                        debugDescription: "Unknown NemotronH layers_block_type entry: \(raw)"))
+            }
+        }.joined()
     }
 
     /// Memberwise initializer for testing

--- a/Libraries/MLXLMCommon/ReasoningParser.swift
+++ b/Libraries/MLXLMCommon/ReasoningParser.swift
@@ -660,6 +660,10 @@ extension ReasoningParser {
             return ReasoningParser(startInReasoning: true)
         }
 
+        if compact.hasPrefix("nemotron") {
+            return ReasoningParser(startInReasoning: true)
+        }
+
         if compact.hasPrefix("step3p5")
             || compact.hasPrefix("step3p7")
             || compact.hasPrefix("stepfun")

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -518,6 +518,10 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
             return .xmlFunction
         }
 
+        if compact.hasPrefix("nemotron") {
+            return .nemotron
+        }
+
         // Tencent Hunyuan / Hy3 parser aliases. Product capability stamps
         // may carry a suffix (`hy3-preview`, `hy_v3_preview`) rather than
         // the exact parser family name.

--- a/Tests/MLXLMTests/NemotronHTests.swift
+++ b/Tests/MLXLMTests/NemotronHTests.swift
@@ -114,6 +114,74 @@ public class NemotronHTests: XCTestCase {
         XCTAssertEqual(config.hybridOverridePattern, "M*M-")
     }
 
+    func testConfigurationDecodingWithUltraLayersBlockType() throws {
+        let config = try decodeUltraStyleConfig(exactDimensions: true)
+
+        XCTAssertEqual(config.numHiddenLayers, 108)
+        XCTAssertEqual(config.hybridOverridePattern.count, 108)
+        XCTAssertEqual(config.hybridOverridePattern.filter { $0 == "M" }.count, 48)
+        XCTAssertEqual(config.hybridOverridePattern.filter { $0 == "E" }.count, 48)
+        XCTAssertEqual(config.hybridOverridePattern.filter { $0 == "*" }.count, 12)
+        XCTAssertEqual(config.moeLatentSize, 2048)
+        XCTAssertEqual(config.nRoutedExperts, 512)
+
+        let smallConfig = try decodeUltraStyleConfig()
+        let model = NemotronHModel(smallConfig)
+        let cache = model.newCache(parameters: nil)
+        XCTAssertEqual(cache.count, 60)
+        XCTAssertEqual(model.kvHeads.count, 60)
+        XCTAssertEqual(model.kvHeads.filter { $0 == 0 }.count, 48)
+        XCTAssertEqual(model.kvHeads.filter { $0 == 2 }.count, 12)
+        XCTAssertEqual(cache.filter { $0 is MambaCache }.count, 48)
+        XCTAssertEqual(cache.filter { $0 is KVCacheSimple }.count, 12)
+    }
+
+    func testUltraNestedJANGTQBitsDispatchToOneBitNemotronH() async throws {
+        let data = try ultraStyleConfigData(extra: [
+            "format": "jangtq",
+            "mxtq_seed": 42,
+            "mxtq_bits": [
+                "mamba_projection": 8,
+                "routed_expert": [
+                    "up_proj": 1,
+                    "down_proj": 1,
+                ],
+                "shared_expert": 8,
+            ],
+        ])
+
+        let model = try await LLMTypeRegistry.shared.createModel(
+            configuration: data, modelType: "nemotron_h")
+        let nemotron = try XCTUnwrap(model as? NemotronHModel)
+        XCTAssertEqual(nemotron.jangtqContext?.bits, 1)
+        XCTAssertEqual(nemotron.jangtqContext?.mxtqSeed, 42)
+        XCTAssertEqual(nemotron.newCache(parameters: nil).count, 60)
+    }
+
+    func testNemotronThreeParserAliasesResolveToBundleProtocol() throws {
+        XCTAssertEqual(ToolCallFormat.fromCapabilityName("nemotron"), .nemotron)
+        XCTAssertEqual(ToolCallFormat.fromCapabilityName("nemotron_h"), .nemotron)
+        XCTAssertEqual(ToolCallFormat.fromCapabilityName("nemotron_v3"), .nemotron)
+        XCTAssertEqual(ToolCallFormat.fromCapabilityName("nemotron_3"), .nemotron)
+        XCTAssertNotNil(ReasoningParser.fromCapabilityName("nemotron_v3"))
+        XCTAssertNotNil(ReasoningParser.fromCapabilityName("nemotron_3"))
+
+        let parser = ToolCallFormat.nemotron.createParser()
+        let calls = parser.parseEOS(
+            """
+            <tool_call>
+            <function=memory_search>
+            <parameter=query>
+            prefix cache
+            </parameter>
+            </function>
+            </tool_call>
+            """,
+            tools: nil)
+        XCTAssertEqual(calls.first?.function.name, "memory_search")
+        XCTAssertEqual(calls.count, 1)
+    }
+
     func testConfigurationDecodingWithTimeStepLimitArray() throws {
         // Canonical mlx-lm form: `time_step_limit: [min, max]` (single key holding
         // the pair). The test was originally authored against an early decoder
@@ -648,5 +716,87 @@ public class NemotronHTests: XCTestCase {
 
         // Only M and * contribute to kvHeads
         XCTAssertEqual(model.kvHeads, [0, 2])
+    }
+
+    private func decodeUltraStyleConfig(
+        exactDimensions: Bool = false, extra: [String: Any] = [:]
+    ) throws -> NemotronHConfiguration {
+        try JSONDecoder.json5().decode(
+            NemotronHConfiguration.self,
+            from: ultraStyleConfigData(exactDimensions: exactDimensions, extra: extra))
+    }
+
+    private func ultraStyleConfigData(
+        exactDimensions: Bool = false, extra: [String: Any] = [:]
+    ) throws -> Data {
+        var dict: [String: Any] = [
+            "model_type": "nemotron_h",
+            "vocab_size": 128,
+            "hidden_size": 64,
+            "num_hidden_layers": 108,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "head_dim": 16,
+            "mamba_num_heads": 4,
+            "mamba_head_dim": 16,
+            "ssm_state_size": 16,
+            "conv_kernel": 4,
+            "n_groups": 2,
+            "intermediate_size": 128,
+            "moe_intermediate_size": 64,
+            "moe_latent_size": 32,
+            "moe_shared_expert_intermediate_size": 64,
+            "n_routed_experts": 4,
+            "n_shared_experts": 1,
+            "num_experts_per_tok": 2,
+            "n_group": 1,
+            "topk_group": 1,
+            "norm_topk_prob": true,
+            "routed_scaling_factor": 5.0,
+            "layer_norm_epsilon": 1e-5,
+            "time_step_limit": [0.0, 1e20],
+            "layers_block_type": Self.ultraLayerTypes(),
+        ]
+        if exactDimensions {
+            for (key, value) in [
+                "vocab_size": 131072,
+                "hidden_size": 8192,
+                "num_attention_heads": 64,
+                "head_dim": 128,
+                "mamba_num_heads": 256,
+                "mamba_head_dim": 64,
+                "ssm_state_size": 128,
+                "n_groups": 8,
+                "intermediate_size": 5120,
+                "moe_intermediate_size": 5120,
+                "moe_latent_size": 2048,
+                "moe_shared_expert_intermediate_size": 10240,
+                "n_routed_experts": 512,
+                "num_experts_per_tok": 22,
+            ] as [String: Any] {
+                dict[key] = value
+            }
+        }
+        for (key, value) in extra {
+            dict[key] = value
+        }
+        return try JSONSerialization.data(withJSONObject: dict)
+    }
+
+    private static func ultraLayerTypes() -> [String] {
+        var layers: [String] = []
+        for index in 0..<108 {
+            if [7, 14, 21, 28, 35, 42, 49, 56, 63, 70, 77, 84].contains(index) {
+                layers.append("attention")
+            } else if layers.filter({ $0 == "mamba" }).count < 48 {
+                layers.append("mamba")
+            } else {
+                layers.append("moe")
+            }
+        }
+        precondition(layers.filter { $0 == "mamba" }.count == 48)
+        precondition(layers.filter { $0 == "attention" }.count == 12)
+        precondition(layers.filter { $0 == "moe" }.count == 48)
+        return layers
     }
 }


### PR DESCRIPTION
Summary
- Decode Nemotron 3 Ultra `layers_block_type` into the Nemotron-H hybrid pattern.
- Route nested JANGTQ `mxtq_bits.routed_expert` metadata to the 1-bit Nemotron-H JANGTQ runtime path.
- Add Nemotron-3 parser aliases for reasoning/tool metadata while preserving the existing Nemotron XML/DSML family parser.

Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter NemotronHTests --jobs 1 --no-parallel`
- `git diff --check`

Notes
- Actual local bundle inspected: `/Volumes/EricsLLMDrive/jangq-ai/NVIDIA-Nemotron-3-Ultra-550B-A55B-JANGTQ_1L`.
- Bundle is text-only, 108 layers, 48 Mamba + 48 MoE + 12 attention; cache topology source test expects 48 `MambaCache` entries and 12 `KVCacheSimple` entries.
- Bundle generation defaults remain from `generation_config.json`; this PR does not add sampler overrides or output-shaping guards.
