### PR TITLE
Preserve MiniMax reasoning prose around tool calls

### DIFF
--- a/Libraries/MLXLMCommon/GenerationStreamRouting.swift
+++ b/Libraries/MLXLMCommon/GenerationStreamRouting.swift
@@ -37,7 +37,7 @@ public func routeGenerationText(
         case .content:
             events.append(.chunk(visible))
         case .reasoning:
-            if !parsedToolCallInChunk {
+            if !parsedToolCallInChunk || toolCallProcessor.preservesReasoningTextAroundToolCalls {
                 events.append(.reasoning(visible))
             }
         }

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -239,6 +239,20 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
         }
     }
 
+    /// Whether non-tool prose returned while parsing a reasoning-channel tool
+    /// call should remain on the reasoning rail. MiniMax emits legitimate
+    /// natural-language deliberation around `<minimax:tool_call>...` envelopes;
+    /// channel-style families such as Gemma4 intentionally suppress wrapper
+    /// residue once a native tool call is extracted.
+    public var preservesReasoningTextAroundToolCalls: Bool {
+        switch self {
+        case .minimaxM2:
+            return true
+        default:
+            return false
+        }
+    }
+
     /// Infer the tool call format based on model type from config.json.
     ///
     /// This method maps known model types to their corresponding tool call formats,

--- a/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
@@ -30,6 +30,7 @@ public class ToolCallProcessor {
     private let tools: [[String: any Sendable]]?
     public let parsesToolCallsFromReasoningChannel: Bool
     public let usesTaggedOnlyReasoningExtraction: Bool
+    public let preservesReasoningTextAroundToolCalls: Bool
     private var state = State.normal
     private var toolCallBuffer = ""
     private var leadingTextBeforeToolCall = ""
@@ -75,6 +76,8 @@ public class ToolCallProcessor {
         self.tools = tools
         self.parsesToolCallsFromReasoningChannel = format.parsesToolCallsFromReasoningChannel
         self.usesTaggedOnlyReasoningExtraction = format.usesTaggedOnlyReasoningExtraction
+        self.preservesReasoningTextAroundToolCalls =
+            format.preservesReasoningTextAroundToolCalls
     }
 
     // MARK: - Computed Properties


### PR DESCRIPTION
Summary
- Preserve MiniMax reasoning-channel prose around parsed native tool-call envelopes.
- Keep Gemma4/Zyphra channel-artifact suppression unchanged.
- Route the behavior through an explicit ToolCallFormat policy instead of changing all reasoning-channel tool extraction.

Validation
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter GenerationReasoningEventTests/testMiniMaxToolCallInsideReasoningDoesNotLeak --jobs 1 --no-parallel
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter Gemma4ZyphraToolParserFocusedTests/gemma4RoutesZyphraToolCallsInsideReasoningWrapperWithoutLeak --jobs 1 --no-parallel
- git diff --check
