### PR TITLE
Restore ZAYA CCA disk cache hits

### DIFF
--- a/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
@@ -334,14 +334,11 @@ public final class CacheCoordinator: @unchecked Sendable {
                 return true
             }
             // Format-v2 disk payloads carry first-class layer state for
-            // most path-dependent caches. ZAYA CCA is intentionally excluded
-            // until its disk-restore path has separate live proof: restoring
-            // a ZAYA prefix from disk without a proven companion boundary can
-            // corrupt follow-up required-tool arguments even when the XML
-            // wrapper still parses as a tool call. Prefer a full prefill over
-            // a false cache hit.
+            // path-dependent caches. For ZAYA CCA, LayerKind.zayaCCA stores
+            // KV plus conv/previous-hidden companion tensors in the same
+            // payload, so a separate recurrent SSM sidecar is not required.
             if let diskArrays, TQDiskSerializer.formatVersion(of: diskArrays) >= 2 {
-                return !Self.containsZayaCCADiskPayload(diskArrays)
+                return true
             }
             return false
         }
@@ -442,12 +439,6 @@ public final class CacheCoordinator: @unchecked Sendable {
 
         // All tiers missed
         return .miss
-    }
-
-    private static func containsZayaCCADiskPayload(_ arrays: [String: MLXArray]) -> Bool {
-        arrays.keys.contains { key in
-            key.hasPrefix("zaya_") || key.contains("_zaya_")
-        }
     }
 
     /// Resolve SSM companion state for a disk-cache hit on a hybrid model.

--- a/Tests/MLXLMCommonFocusedTests/CacheCoordinatorTopologyFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/CacheCoordinatorTopologyFocusedTests.swift
@@ -323,8 +323,8 @@ struct CacheCoordinatorTopologyFocusedTests {
         }
     }
 
-    @Test("ZAYA CCA format-v2 disk payload is not reused without proven companion boundary")
-    func zayaCCADiskHitRequiresProvenCompanionBoundary() {
+    @Test("ZAYA CCA format-v2 disk payload restores growing prompt boundary")
+    func zayaCCADiskHitRestoresGrowingPromptBoundary() {
         FocusedMLXTestSupport.withLock {
         let tmp = makeTempDir("zaya-cca-disk")
         defer { try? FileManager.default.removeItem(at: tmp) }
@@ -352,10 +352,15 @@ struct CacheCoordinatorTopologyFocusedTests {
             cache: [cache])
 
         switch coordinator.fetch(tokens: tokens + [55]) {
-        case .hit:
-            Issue.record("ZAYA CCA disk payload must not be promoted to a reusable prefix hit without a proven companion boundary")
+        case .hit(let matchedTokens, let remainingTokens, let detail, let blocks, _, let diskArrays):
+            #expect(matchedTokens == tokens.count)
+            #expect(remainingTokens == [55])
+            #expect(detail == .disk)
+            #expect(blocks.isEmpty)
+            #expect(diskArrays?["zaya_0_conv_state"] != nil)
+            #expect(diskArrays?["zaya_0_prev_hs"] != nil)
         case .miss:
-            break
+            Issue.record("ZAYA CCA format-v2 payload should restore a complete growing prompt boundary")
         }
         }
     }


### PR DESCRIPTION
Summary
- Allow complete format-v2 disk payloads to satisfy hybrid cache companion requirements.
- Treat ZAYA CCA LayerKind.zayaCCA payloads as self-contained path-dependent cache state, because they include KV plus conv/previous-hidden tensors.
- Update the focused growing-prompt test to require a disk prefix hit with remaining suffix tokens.

Validation
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter CacheCoordinator --jobs 1 --no-parallel
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter NemotronHTests --jobs 1 --no-parallel
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter ReasoningParserTests --jobs 1 --no-parallel
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter MultiTurnFamilyMatrixTests --jobs 1 --no-parallel
- git diff --check