### PR TITLE
Fix Nemotron Ultra JANGTQ load path

### DIFF
--- a/Libraries/MLXLMCommon/JANGTQStreamingExperts.swift
+++ b/Libraries/MLXLMCommon/JANGTQStreamingExperts.swift
@@ -105,7 +105,7 @@ public enum JANGTQStreamingExperts {
             #"^(?:language_model\.)?model\.layers\.\d+\.(?:mlp|block_sparse_moe)\.switch_mlp\.(gate_proj|up_proj|down_proj)\.(tq_packed|tq_norms)$"#,
             #"^(?:language_model\.)?model\.layers\.\d+\.(?:mlp\.)?zaya_block\.experts\.switch_mlp\.(gate_proj|up_proj|down_proj)\.(tq_packed|tq_norms)$"#,
             #"^layers\.\d+\.ffn\.switch_mlp\.(w1|w2|w3)\.(tq_packed|tq_norms)$"#,
-            #"^backbone\.layers\.\d+\.mixer\.switch_mlp\.(up_proj|down_proj)\.(tq_packed|tq_norms)$"#,
+            #"^backbone\.layers\.\d+\.mixer\.switch_mlp\.(up_proj|down_proj|fc1|fc2)\.(tq_packed|tq_norms)$"#,
         ]
         return patterns.contains { pattern in
             key.range(of: pattern, options: .regularExpression) != nil
@@ -1883,10 +1883,12 @@ private final class JANGTQStreamingExpertIndex: @unchecked Sendable {
                 ]
             ),
             (
-                #"^backbone\.layers\.(\d+)\.mixer\.switch_mlp\.(up_proj|down_proj)\.(tq_packed|tq_norms)$"#,
+                #"^backbone\.layers\.(\d+)\.mixer\.switch_mlp\.(up_proj|down_proj|fc1|fc2)\.(tq_packed|tq_norms)$"#,
                 [
                     "up_proj": .up,
                     "down_proj": .down,
+                    "fc1": .up,
+                    "fc2": .down,
                 ]
             ),
         ]

--- a/Source/MLXNN/Module.swift
+++ b/Source/MLXNN/Module.swift
@@ -707,6 +707,9 @@ open class Module {
                         case (.value(.module(let m)), .dictionary(let d)):
                             try m.update(modules: NestedDictionary(values: d), verify: verify)
 
+                        case (_, .none):
+                            continue
+
                         default:
                             throw UpdateError.mismatchedContainers(
                                 base: describeType(self), key: key)

--- a/Tests/MLXLMCommonFocusedTests/JANGTQStreamingExpertDescriptorTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/JANGTQStreamingExpertDescriptorTests.swift
@@ -2,10 +2,96 @@
 // SPDX-License-Identifier: MIT
 
 import Foundation
+@testable import MLXLLM
 @testable import MLXLMCommon
 import XCTest
 
 final class JANGTQStreamingExpertDescriptorTests: XCTestCase {
+    func testNemotronUltraLayersBlockTypeDecodesToHybridPattern() throws {
+        let json = """
+        {
+          "model_type": "nemotron_h",
+          "vocab_size": 131072,
+          "hidden_size": 8192,
+          "num_hidden_layers": 4,
+          "num_attention_heads": 64,
+          "num_key_value_heads": 2,
+          "mamba_num_heads": 256,
+          "mamba_head_dim": 64,
+          "ssm_state_size": 128,
+          "conv_kernel": 4,
+          "n_groups": 8,
+          "intermediate_size": 5120,
+          "moe_intermediate_size": 5120,
+          "moe_shared_expert_intermediate_size": 5120,
+          "n_routed_experts": 512,
+          "num_experts_per_tok": 22,
+          "layers_block_type": ["mamba", "attention", "mlp", "moe"],
+          "layer_norm_epsilon": 1e-5,
+          "n_group": 8,
+          "topk_group": 4
+        }
+        """
+
+        let config = try JSONDecoder().decode(
+            NemotronHConfiguration.self,
+            from: Data(json.utf8))
+
+        XCTAssertEqual(config.hybridOverridePattern, "M*-E")
+        XCTAssertEqual(config.numHiddenLayers, 4)
+        XCTAssertEqual(config.numExpertsPerTok, 22)
+    }
+
+    func testNemotronUltraStackedFc1AndFc2TensorsAreStreamable() throws {
+        let directory = try makeTemporaryModelDirectory()
+        try writeSafetensors(
+            at: directory.appendingPathComponent("model.safetensors"),
+            tensors: [
+                "backbone.layers.1.mixer.switch_mlp.fc1.tq_packed": TensorFixture(
+                    dtype: "U8", shape: [4, 2, 4], range: 0 ..< 32),
+                "backbone.layers.1.mixer.switch_mlp.fc1.tq_norms": TensorFixture(
+                    dtype: "F16", shape: [4, 2], range: 32 ..< 48),
+                "backbone.layers.1.mixer.switch_mlp.fc2.tq_packed": TensorFixture(
+                    dtype: "U8", shape: [4, 2, 4], range: 48 ..< 80),
+                "backbone.layers.1.mixer.switch_mlp.fc2.tq_norms": TensorFixture(
+                    dtype: "F16", shape: [4, 2], range: 80 ..< 96),
+            ])
+
+        XCTAssertTrue(
+            JANGTQStreamingExperts.isStreamableRoutedTensorKey(
+                "backbone.layers.1.mixer.switch_mlp.fc1.tq_packed"))
+        XCTAssertTrue(
+            JANGTQStreamingExperts.isStreamableRoutedTensorKey(
+                "backbone.layers.1.mixer.switch_mlp.fc2.tq_norms"))
+        XCTAssertTrue(JANGTQStreamingExperts.hasStreamableExperts(in: directory))
+
+        let up = JANGTQStreamingExperts.stackedOffsetDescriptor(
+            in: directory,
+            layerIdx: 1,
+            projectionName: "up_proj",
+            suffixName: "tq_packed")
+        let down = JANGTQStreamingExperts.stackedOffsetDescriptor(
+            in: directory,
+            layerIdx: 1,
+            projectionName: "down_proj",
+            suffixName: "tq_packed")
+
+        XCTAssertEqual(up?.storageLayout, "stacked-contiguous")
+        XCTAssertEqual(up?.expertCount, 4)
+        XCTAssertEqual(up?.spanByteCount, 32)
+        XCTAssertEqual(up?.expertByteCount, 8)
+        XCTAssertEqual(down?.storageLayout, "stacked-contiguous")
+        XCTAssertEqual(down?.expertCount, 4)
+    }
+
+    func testModuleUpdateArrayRecursionSkipsSparseNilEntries() throws {
+        let moduleSource = try String(
+            contentsOfFile: "Source/MLXNN/Module.swift",
+            encoding: .utf8)
+
+        XCTAssertTrue(moduleSource.contains("case (_, .none):\n                            continue"))
+    }
+
     func testDescriptorReportsContiguousStackedTensorLayout() throws {
         let directory = try makeTemporaryModelDirectory()
         try writeSafetensors(


### PR DESCRIPTION
## Summary
- Recognize Nemotron Ultra stacked `switch_mlp.fc1/fc2` JANGTQ tensors as streamable routed tensors.
- Let sparse recursive `Module.update(modules:)` skip nil entries when replacing only the layers that have quantized modules.
- Add focused coverage for Ultra `fc1/fc2` streaming descriptors and sparse update recursion.

## Validation
- `git diff --check`
- `/Users/eric/vmlx-swift`: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift build --target MLXLMCommonFocusedTests --jobs 1`
- `/Users/eric/vmlx-swift`: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift build --target RunBench --jobs 1`

## Live status
- `NVIDIA-Nemotron-3-Ultra-550B-A55B-JANGTQ_1L` now gets past config decode, sparse quantized module update, and active-expert tensor indexing.
- Load proof: `after_load rss_mib=412 footprint_mib=222 loadSec=3.04`, `indexed active-expert JANGTQ tensors layers=48 experts=0 stackedLayers=48`.
- Decode speed is still partial: the current ReLU-squared Nemotron streaming path is not yet wired to the offset-dispatch kernels, and the watchdog stopped a 4-token row when free pages fell to 12,653 before token output.

## Clean worktree note
A clean worktree from latest `main` fails before these Swift changes on `Libraries/CmlxDistributedShim/MlxCDistributedGroup.cpp:5:10: fatal error: 'mlx/c/distributed_group.h' file not found`. The same focused target compiles in the active repo checkout where the Cmlx checkout is present.
