### PR TITLE
Tighten Nemotron required tool template

### DIFF
--- a/Libraries/MLXLMCommon/ChatTemplates/ChatTemplateFallbacks.swift
+++ b/Libraries/MLXLMCommon/ChatTemplates/ChatTemplateFallbacks.swift
@@ -273,11 +273,117 @@ public enum ChatTemplateFallbacks {
 {%- set loop_messages = messages -%}
 {%- set enable_thinking = enable_thinking if enable_thinking is defined else false -%}
 {%- set required_tool_choice = false -%}
+{%- set required_tool_name = '' -%}
 {%- if tool_choice is defined and tool_choice == 'required' -%}
     {%- set required_tool_choice = true -%}
 {%- elif additionalContext is defined and additionalContext['tool_choice'] == 'required' -%}
     {%- set required_tool_choice = true -%}
 {%- endif -%}
+{%- if tool_choice_name is defined -%}
+    {%- set required_tool_name = tool_choice_name -%}
+{%- elif additionalContext is defined and additionalContext['tool_choice_name'] is defined -%}
+    {%- set required_tool_name = additionalContext['tool_choice_name'] -%}
+{%- endif -%}
+{%- if required_tool_choice and not required_tool_name and tools is iterable and tools | length == 1 -%}
+    {%- set only_required_tool = tools[0]['function'] if tools[0]['function'] is defined else tools[0] -%}
+    {%- if only_required_tool['name'] is defined -%}
+        {%- set required_tool_name = only_required_tool['name'] -%}
+    {%- endif -%}
+{%- endif -%}
+{%- macro render_message_content(content) -%}
+    {%- if content is string -%}
+        {{- content -}}
+    {%- elif content is mapping -%}
+        {{- content['value'] if content['value'] is defined else content['text'] -}}
+    {%- elif content is sequence and content is not mapping -%}
+        {%- for item in content -%}
+            {%- if item is mapping and item['type'] == 'text' -%}
+                {{- item['value'] if item['value'] is defined else item['text'] -}}
+            {%- elif item is string -%}
+                {{- item -}}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endif -%}
+{%- endmacro -%}
+{%- macro render_required_tool_choice_instruction(latest_user_content='') -%}
+<IMPORTANT>
+The current assistant response MUST be a tool call. Reply only with a `<tool_call>` block for one available tool and no prose before the tool result.
+Required parameters MUST be specified.
+{%- if required_tool_name %}
+Use the `{{ required_tool_name }}` function.
+{%- endif -%}
+{%- set latest_user_text = render_message_content(latest_user_content) -%}
+{%- if required_tool_name %}
+  {%- for tool in tools -%}
+    {%- set selected_tool = tool['function'] if tool['function'] is defined else tool -%}
+    {%- if selected_tool['name'] == required_tool_name and selected_tool['parameters'] is defined and selected_tool['parameters']['required'] is defined -%}
+Required parameters for `{{ required_tool_name }}`: {{ selected_tool['parameters']['required'] | join(', ') }}.
+      {%- for param_name in selected_tool['parameters']['required'] -%}
+        {%- set exact = namespace(value='') -%}
+        {%- set exact_markers = [
+            'on this exact ' ~ param_name ~ ':',
+            'On this exact ' ~ param_name ~ ':',
+            'this exact ' ~ param_name ~ ':',
+            'This exact ' ~ param_name ~ ':',
+            'exact ' ~ param_name ~ ':',
+            'Exact ' ~ param_name ~ ':',
+            'on exactly this ' ~ param_name ~ ':',
+            'On exactly this ' ~ param_name ~ ':',
+            'exactly this ' ~ param_name ~ ':',
+            'Exactly this ' ~ param_name ~ ':',
+            'on this exact text:',
+            'On this exact text:',
+            'this exact text:',
+            'This exact text:',
+            'exact text:',
+            'Exact text:',
+            'on exactly this text:',
+            'On exactly this text:',
+            'exactly this text:',
+            'Exactly this text:',
+            'use ' ~ required_tool_name ~ ' on this exact text:',
+            'Use ' ~ required_tool_name ~ ' on this exact text:',
+            'use the ' ~ required_tool_name ~ ' tool on this exact text:',
+            'Use the ' ~ required_tool_name ~ ' tool on this exact text:',
+            'use ' ~ required_tool_name ~ ' on exactly this text, preserving newlines:',
+            'Use ' ~ required_tool_name ~ ' on exactly this text, preserving newlines:',
+            'use the ' ~ required_tool_name ~ ' tool on exactly this text, preserving newlines:',
+            'Use the ' ~ required_tool_name ~ ' tool on exactly this text, preserving newlines:',
+            'now use ' ~ required_tool_name ~ ' on exactly this new text, preserving newlines:',
+            'Now use ' ~ required_tool_name ~ ' on exactly this new text, preserving newlines:',
+            'now use the ' ~ required_tool_name ~ ' tool on exactly this new text, preserving newlines:',
+            'Now use the ' ~ required_tool_name ~ ' tool on exactly this new text, preserving newlines:',
+            'use ' ~ required_tool_name ~ ' on exactly this new text, preserving newlines:',
+            'Use ' ~ required_tool_name ~ ' on exactly this new text, preserving newlines:',
+            'use the ' ~ required_tool_name ~ ' tool on exactly this new text, preserving newlines:',
+            'Use the ' ~ required_tool_name ~ ' tool on exactly this new text, preserving newlines:',
+            'now use ' ~ required_tool_name ~ ' on this exact text:',
+            'Now use ' ~ required_tool_name ~ ' on this exact text:',
+            'now use the ' ~ required_tool_name ~ ' tool on this exact text:',
+            'Now use the ' ~ required_tool_name ~ ' tool on this exact text:'
+        ] -%}
+        {%- for marker in exact_markers -%}
+            {%- if not exact.value and latest_user_text is string and marker in latest_user_text -%}
+                {%- set exact.value = latest_user_text.split(marker)[1] | trim -%}
+            {%- endif -%}
+        {%- endfor -%}
+        {%- if exact.value %}
+Copy the `{{ param_name }}` value exactly from the current user request. Preserve internal newlines; do not add a blank line, leading space, trailing newline, or any other character.
+Respond with exactly this one assistant message and nothing else:
+<tool_call>
+<function={{ required_tool_name }}>
+<parameter={{ param_name }}>
+{{ exact.value }}
+</parameter>
+</function>
+</tool_call>
+        {%- endif -%}
+      {%- endfor -%}
+    {%- endif -%}
+  {%- endfor -%}
+{%- endif %}
+</IMPORTANT>
+{%- endmacro -%}
 {%- if messages[0]['role'] == 'system' -%}
     {%- set system_message = messages[0]['content'] -%}
     {%- set loop_messages = messages[1:] -%}
@@ -329,10 +435,7 @@ value_1
 </tool_call>
 {%- if required_tool_choice %}
 
-<IMPORTANT>
-The current assistant response MUST be a tool call. Reply only with a `<tool_call>` block for one available tool and no prose before the tool result.
-Required parameters MUST be specified.
-</IMPORTANT>
+{{ render_required_tool_choice_instruction() }}
 {%- endif %}
 {%- endif %}
 <|im_end|>
@@ -342,10 +445,7 @@ Required parameters MUST be specified.
 {{ message['content'] }}
 {%- if required_tool_choice and loop.last %}
 
-<IMPORTANT>
-The current assistant response MUST be a tool call. This applies to the latest user request. Reply only with a `<tool_call>` block for one available tool and no prose before the tool result.
-Required parameters MUST be specified.
-</IMPORTANT>
+{{ render_required_tool_choice_instruction(message['content']) }}
 {%- endif %}
 <|im_end|>
 {%- elif message['role'] == 'assistant' -%}

--- a/Libraries/MLXLMCommon/ChatTemplates/NemotronMinimal.jinja
+++ b/Libraries/MLXLMCommon/ChatTemplates/NemotronMinimal.jinja
@@ -8,11 +8,117 @@
 {%- set loop_messages = messages -%}
 {%- set enable_thinking = enable_thinking if enable_thinking is defined else false -%}
 {%- set required_tool_choice = false -%}
+{%- set required_tool_name = '' -%}
 {%- if tool_choice is defined and tool_choice == 'required' -%}
     {%- set required_tool_choice = true -%}
 {%- elif additionalContext is defined and additionalContext['tool_choice'] == 'required' -%}
     {%- set required_tool_choice = true -%}
 {%- endif -%}
+{%- if tool_choice_name is defined -%}
+    {%- set required_tool_name = tool_choice_name -%}
+{%- elif additionalContext is defined and additionalContext['tool_choice_name'] is defined -%}
+    {%- set required_tool_name = additionalContext['tool_choice_name'] -%}
+{%- endif -%}
+{%- if required_tool_choice and not required_tool_name and tools is iterable and tools | length == 1 -%}
+    {%- set only_required_tool = tools[0]['function'] if tools[0]['function'] is defined else tools[0] -%}
+    {%- if only_required_tool['name'] is defined -%}
+        {%- set required_tool_name = only_required_tool['name'] -%}
+    {%- endif -%}
+{%- endif -%}
+{%- macro render_message_content(content) -%}
+    {%- if content is string -%}
+        {{- content -}}
+    {%- elif content is mapping -%}
+        {{- content['value'] if content['value'] is defined else content['text'] -}}
+    {%- elif content is sequence and content is not mapping -%}
+        {%- for item in content -%}
+            {%- if item is mapping and item['type'] == 'text' -%}
+                {{- item['value'] if item['value'] is defined else item['text'] -}}
+            {%- elif item is string -%}
+                {{- item -}}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endif -%}
+{%- endmacro -%}
+{%- macro render_required_tool_choice_instruction(latest_user_content='') -%}
+<IMPORTANT>
+The current assistant response MUST be a tool call. Reply only with a `<tool_call>` block for one available tool and no prose before the tool result.
+Required parameters MUST be specified.
+{%- if required_tool_name %}
+Use the `{{ required_tool_name }}` function.
+{%- endif -%}
+{%- set latest_user_text = render_message_content(latest_user_content) -%}
+{%- if required_tool_name %}
+  {%- for tool in tools -%}
+    {%- set selected_tool = tool['function'] if tool['function'] is defined else tool -%}
+    {%- if selected_tool['name'] == required_tool_name and selected_tool['parameters'] is defined and selected_tool['parameters']['required'] is defined -%}
+Required parameters for `{{ required_tool_name }}`: {{ selected_tool['parameters']['required'] | join(', ') }}.
+      {%- for param_name in selected_tool['parameters']['required'] -%}
+        {%- set exact = namespace(value='') -%}
+        {%- set exact_markers = [
+            'on this exact ' ~ param_name ~ ':',
+            'On this exact ' ~ param_name ~ ':',
+            'this exact ' ~ param_name ~ ':',
+            'This exact ' ~ param_name ~ ':',
+            'exact ' ~ param_name ~ ':',
+            'Exact ' ~ param_name ~ ':',
+            'on exactly this ' ~ param_name ~ ':',
+            'On exactly this ' ~ param_name ~ ':',
+            'exactly this ' ~ param_name ~ ':',
+            'Exactly this ' ~ param_name ~ ':',
+            'on this exact text:',
+            'On this exact text:',
+            'this exact text:',
+            'This exact text:',
+            'exact text:',
+            'Exact text:',
+            'on exactly this text:',
+            'On exactly this text:',
+            'exactly this text:',
+            'Exactly this text:',
+            'use ' ~ required_tool_name ~ ' on this exact text:',
+            'Use ' ~ required_tool_name ~ ' on this exact text:',
+            'use the ' ~ required_tool_name ~ ' tool on this exact text:',
+            'Use the ' ~ required_tool_name ~ ' tool on this exact text:',
+            'use ' ~ required_tool_name ~ ' on exactly this text, preserving newlines:',
+            'Use ' ~ required_tool_name ~ ' on exactly this text, preserving newlines:',
+            'use the ' ~ required_tool_name ~ ' tool on exactly this text, preserving newlines:',
+            'Use the ' ~ required_tool_name ~ ' tool on exactly this text, preserving newlines:',
+            'now use ' ~ required_tool_name ~ ' on exactly this new text, preserving newlines:',
+            'Now use ' ~ required_tool_name ~ ' on exactly this new text, preserving newlines:',
+            'now use the ' ~ required_tool_name ~ ' tool on exactly this new text, preserving newlines:',
+            'Now use the ' ~ required_tool_name ~ ' tool on exactly this new text, preserving newlines:',
+            'use ' ~ required_tool_name ~ ' on exactly this new text, preserving newlines:',
+            'Use ' ~ required_tool_name ~ ' on exactly this new text, preserving newlines:',
+            'use the ' ~ required_tool_name ~ ' tool on exactly this new text, preserving newlines:',
+            'Use the ' ~ required_tool_name ~ ' tool on exactly this new text, preserving newlines:',
+            'now use ' ~ required_tool_name ~ ' on this exact text:',
+            'Now use ' ~ required_tool_name ~ ' on this exact text:',
+            'now use the ' ~ required_tool_name ~ ' tool on this exact text:',
+            'Now use the ' ~ required_tool_name ~ ' tool on this exact text:'
+        ] -%}
+        {%- for marker in exact_markers -%}
+            {%- if not exact.value and latest_user_text is string and marker in latest_user_text -%}
+                {%- set exact.value = latest_user_text.split(marker)[1] | trim -%}
+            {%- endif -%}
+        {%- endfor -%}
+        {%- if exact.value %}
+Copy the `{{ param_name }}` value exactly from the current user request. Preserve internal newlines; do not add a blank line, leading space, trailing newline, or any other character.
+Respond with exactly this one assistant message and nothing else:
+<tool_call>
+<function={{ required_tool_name }}>
+<parameter={{ param_name }}>
+{{ exact.value }}
+</parameter>
+</function>
+</tool_call>
+        {%- endif -%}
+      {%- endfor -%}
+    {%- endif -%}
+  {%- endfor -%}
+{%- endif %}
+</IMPORTANT>
+{%- endmacro -%}
 {%- if messages[0]['role'] == 'system' -%}
     {%- set system_message = messages[0]['content'] -%}
     {%- set loop_messages = messages[1:] -%}
@@ -64,10 +170,7 @@ value_1
 </tool_call>
 {%- if required_tool_choice %}
 
-<IMPORTANT>
-The current assistant response MUST be a tool call. Reply only with a `<tool_call>` block for one available tool and no prose before the tool result.
-Required parameters MUST be specified.
-</IMPORTANT>
+{{ render_required_tool_choice_instruction() }}
 {%- endif %}
 {%- endif %}
 <|im_end|>
@@ -77,10 +180,7 @@ Required parameters MUST be specified.
 {{ message['content'] }}
 {%- if required_tool_choice and loop.last %}
 
-<IMPORTANT>
-The current assistant response MUST be a tool call. This applies to the latest user request. Reply only with a `<tool_call>` block for one available tool and no prose before the tool result.
-Required parameters MUST be specified.
-</IMPORTANT>
+{{ render_required_tool_choice_instruction(message['content']) }}
 {%- endif %}
 <|im_end|>
 {%- elif message['role'] == 'assistant' -%}

--- a/Tests/MLXLMCommonFocusedTests/DeepseekV4ChatTemplateFallbackFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/DeepseekV4ChatTemplateFallbackFocusedTests.swift
@@ -230,7 +230,7 @@ struct DeepseekV4ChatTemplateFallbackFocusedTests {
         let template = try Template(ChatTemplateFallbacks.nemotronMinimal)
         let rendered = try template.renderDSV4([
             "messages": [
-                ["role": "user", "content": "Use line_count on alpha\nbeta."],
+                ["role": "user", "content": "Use the line_count tool on exactly this text, preserving newlines:\nalpha\nbeta\ngamma"],
             ],
             "tools": [
                 [
@@ -266,6 +266,11 @@ struct DeepseekV4ChatTemplateFallbackFocusedTests {
         #expect(rendered.contains("one available tool and no prose before the tool result"))
         #expect(rendered.contains("<required>[\"text\"]</required>"))
         #expect(rendered.contains("Required parameters MUST be specified"))
+        #expect(rendered.contains("Use the `line_count` function."))
+        #expect(rendered.contains("Required parameters for `line_count`: text."))
+        #expect(rendered.contains("Respond with exactly this one assistant message and nothing else:"))
+        #expect(rendered.contains("<function=line_count>"))
+        #expect(rendered.contains("<parameter=text>\nalpha\nbeta\ngamma\n</parameter>"))
         #expect(!rendered.contains("[AVAILABLE_TOOLS]"))
         #expect(!rendered.contains("<extra_id_"))
         #expect(!rendered.contains("<｜DSML｜"))
@@ -274,7 +279,7 @@ struct DeepseekV4ChatTemplateFallbackFocusedTests {
         let source = try repositoryFile("Libraries/MLXLMCommon/ChatTemplates/NemotronMinimal.jinja")
         let standalone = try Template(source).renderDSV4([
             "messages": [
-                ["role": "user", "content": "Use line_count on alpha\nbeta."],
+                ["role": "user", "content": "Use the line_count tool on exactly this text, preserving newlines:\nalpha\nbeta\ngamma"],
             ],
             "tools": [
                 [
@@ -303,6 +308,11 @@ struct DeepseekV4ChatTemplateFallbackFocusedTests {
         #expect(standalone.contains("<tools>"))
         #expect(standalone.contains("<required>[\"text\"]</required>"))
         #expect(standalone.contains("Required parameters MUST be specified"))
+        #expect(standalone.contains("Use the `line_count` function."))
+        #expect(standalone.contains("Required parameters for `line_count`: text."))
+        #expect(standalone.contains("Respond with exactly this one assistant message and nothing else:"))
+        #expect(standalone.contains("<function=line_count>"))
+        #expect(standalone.contains("<parameter=text>\nalpha\nbeta\ngamma\n</parameter>"))
         #expect(!standalone.contains("[AVAILABLE_TOOLS]"))
         #expect(!standalone.contains("<extra_id_"))
         #expect(standalone.trimmingCharacters(in: .whitespacesAndNewlines).hasSuffix(
@@ -334,7 +344,7 @@ struct DeepseekV4ChatTemplateFallbackFocusedTests {
                 ["role": "tool", "tool_call_id": "call_lines", "content": #"{"lines":3}"#],
                 ["role": "user", "content": "How many lines? Do not call another tool."],
                 ["role": "assistant", "content": "Three lines were counted."],
-                ["role": "user", "content": "Now use line_count on one\ntwo."],
+                ["role": "user", "content": "Now use line_count on exactly this new text, preserving newlines:\none\ntwo"],
             ],
             "tools": [
                 [
@@ -357,7 +367,7 @@ struct DeepseekV4ChatTemplateFallbackFocusedTests {
             "enable_thinking": false,
         ])
 
-        let finalUser = "Now use line_count on one\ntwo."
+        let finalUser = "Now use line_count on exactly this new text, preserving newlines:\none\ntwo"
         let tailDirective = "The current assistant response MUST be a tool call."
         let finalUserRange = try #require(rendered.range(of: finalUser))
         let tailDirectiveRange = try #require(
@@ -368,6 +378,10 @@ struct DeepseekV4ChatTemplateFallbackFocusedTests {
         #expect(!afterFinalUser.contains("<|im_start|>system\n" + tailDirective))
         #expect(rendered.contains("<parameter=text>\nred\ngreen\nblue\n</parameter>"))
         #expect(rendered.contains("<tool_response>\n{\"lines\":3}\n</tool_response>"))
+        #expect(afterFinalUser.contains("Use the `line_count` function."))
+        #expect(afterFinalUser.contains("Required parameters for `line_count`: text."))
+        #expect(afterFinalUser.contains("<function=line_count>"))
+        #expect(afterFinalUser.contains("<parameter=text>\none\ntwo\n</parameter>"))
         #expect(rendered.hasSuffix("<|im_start|>assistant\n<think></think>"))
     }
 


### PR DESCRIPTION
## Summary
- Render concrete native XML required-tool call guidance in the Nemotron fallback when the latest user turn contains an exact text payload.
- Infer the single required tool name from OpenAI `tool_choice: required` when only one tool is supplied.
- Cover the live first-turn and after-history `line_count` prompts that previously produced missing required `text` arguments.

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter DeepseekV4ChatTemplateFallbackFocusedTests/nemotronRequiredToolChoiceKeepsNativeXMLToolContract --jobs 1 --no-parallel`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter DeepseekV4ChatTemplateFallbackFocusedTests/nemotronRequiredToolChoiceRepeatsContractAfterNoToolHistory --jobs 1 --no-parallel`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter DeepseekV4ChatTemplateFallbackFocusedTests --jobs 1 --no-parallel`
