### PR TITLE
Fix Nemotron fallback macro log escaping

### DIFF
--- a/Libraries/MLXHuggingFaceMacros/HuggingFaceIntegrationMacros.swift
+++ b/Libraries/MLXHuggingFaceMacros/HuggingFaceIntegrationMacros.swift
@@ -198,7 +198,7 @@ public struct TokenizerAdaptorMacro: ExpressionMacro {
                            (env["VMLX_CHAT_TEMPLATE_FALLBACK_DISABLE"] ?? "0") != "1" {
                             if (env["VMLX_CHAT_TEMPLATE_FALLBACK_LOG"] ?? "0") == "1" {
                                 FileHandle.standardError.write(
-                                    "[vmlx] chat-template tools -> NemotronMinimal fallback engaged\n"
+                                    "[vmlx] chat-template tools -> NemotronMinimal fallback engaged\\n"
                                         .data(using: .utf8)!)
                             }
                             return try upstream.applyChatTemplate(


### PR DESCRIPTION
## Summary
- Escape the Nemotron fallback log newline in the tokenizer macro source so macro expansion emits valid Swift.
- No runtime behavior change; this only fixes the generated Swift string literal.

## Root cause
Clean `vmlx-origin/main` failed before focused runtime tests because the macro source used `\n` as a Swift newline in the macro implementation, which expanded into a raw newline inside the generated Swift string literal. The neighboring fallback log paths already use escaped `\\n`; this makes Nemotron match that pattern.

## Validation
- `git diff --check`
- `xcrun swift test --filter NemotronHJANGTQDispatchFocusedTests --jobs 1 --no-parallel` on clean main after this fix: 9 tests passed.
- `xcrun swift test --filter CacheCoordinatorTopologyFocusedTests --jobs 1 --no-parallel` on clean main after seeding metallib: 31 tests passed.
- `xcrun swift test --filter VMLXServerRuntimeSettingsTests --jobs 1 --no-parallel` on clean main after this fix: 32 tests passed.

## Notes
- Current documented Nemotron Ultra Swift speed floor is confirmed by the runtime status report: best warm decode row is 8.335 tok/s, clearing the 8 tok/s release floor.
- Coherence/parser long-run status remains PARTIAL in the runtime docs; this PR only clears the clean-main compile blocker.