### PR TITLE
Cover Nemotron parser settings aliases

### DIFF
--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -549,9 +549,9 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
 
         switch n {
         // Qwen 3.5 / 3.6 family — XML-style <tool_call>…</tool_call>
-        // (vLLM ecosystem name `qwen3_coder` aliased here).
+        // (vLLM ecosystem names `qwen3_coder` / `qwen3_coder_xml` aliased here).
         case "qwen", "qwen3", "qwen3_5", "qwen35", "qwen3_6", "qwen36",
-            "qwen3_coder", "mimo", "mimo_v2", "mimo_v2_flash":
+            "qwen3_coder", "qwen3_coder_xml", "mimo", "mimo_v2", "mimo_v2_flash":
             return .xmlFunction
         // StepFun Step 3.5 / 3.7 parser aliases. JANG
         // Step 3.7 VLM bundles stamp `tool_parser = "step3p5"` because the

--- a/Tests/MLXLMCommonFocusedTests/NemotronHJANGTQDispatchFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NemotronHJANGTQDispatchFocusedTests.swift
@@ -158,7 +158,10 @@ final class NemotronHJANGTQDispatchFocusedTests: XCTestCase {
     func testUltraCapabilityParsersAndGenerationDefaultsStayBundleDriven() throws {
         XCTAssertEqual(ToolCallFormat.fromCapabilityName("nemotron"), .nemotron)
         XCTAssertEqual(ToolCallFormat.infer(from: "nemotron_h"), .nemotron)
+        XCTAssertEqual(ToolCallFormat.fromCapabilityName("qwen3_coder_xml"), .xmlFunction)
         XCTAssertNotNil(ReasoningParser.fromCapabilityName("deepseek_r1"))
+        XCTAssertNotNil(ReasoningParser.fromCapabilityName("nemotron_v3"))
+        XCTAssertNotNil(ReasoningParser.fromCapabilityName("nemotron_3"))
 
         var parser = try XCTUnwrap(
             ReasoningParser.forPrompt(

--- a/Tests/MLXLMCommonFocusedTests/VMLXServerRuntimeSettingsTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/VMLXServerRuntimeSettingsTests.swift
@@ -758,6 +758,7 @@ struct VMLXServerRuntimeSettingsTests {
             ("deepseek_v4_flash", .dsml, "think_xml"),
             ("gemma4", .gemma4, "harmony"),
             ("hy3", .hunyuan, "think_xml"),
+            ("nemotron_h", .nemotron, "think_xml"),
         ]
         let settings = VMLXServerRuntimeSettings()
         let config = settings.cacheCoordinatorConfig(


### PR DESCRIPTION
## Summary
- map `qwen3_coder_xml` to the XML tool-call parser alias set
- cover Nemotron reasoning/parser aliases in focused source tests
- include `nemotron_h` in the automatic runtime cache-policy family matrix

## Validation
- `git diff --check`
- `xcrun swift test --filter 'NemotronHJANGTQDispatchFocusedTests|VMLINUXServerRuntimeSettingsTests' --jobs 1 --no-parallel` selected the Nemotron XCTest class and passed 9 tests after submodule init\n- `xcrun swift test --filter 'VMLXServerRuntimeSettingsTests/automaticRuntimeCachePolicyCoversDownloadedArchitectureFamilies' --jobs 1 --no-parallel` passed 1 Swift Testing test\n\n## Notes\n- This does not change generation defaults or force model behavior.\n- The documented Nemotron Ultra speed floor remains confirmed at 8.335 tok/s against the 8.000 tok/s floor; broader coherence/cache live proof remains tracked separately as partial.