### PR TITLE
[codex] Fix Nemotron perf mmap harness split

### DIFF
--- a/RunBench/Bench.swift
+++ b/RunBench/Bench.swift
@@ -2331,6 +2331,9 @@ func runBatchEngineDiskRestore(modelPath: String, maxNew: Int) async throws {
 /// Turn 2 starts with turn 1's prompt plus the generated assistant answer,
 /// so a prompt-boundary-only store is guaranteed to miss. A pass proves the
 /// engine stored a post-answer boundary that the next growing prompt can hit.
+///
+/// Set `BENCH_GROWING_MMAP=1` to use the same low-footprint mmap load path
+/// as the perf harness. The default remains the original resident load path.
 func runGrowingChatCacheReuse(modelPath: String, maxNew: Int) async throws {
     let modelDir = URL(fileURLWithPath: modelPath)
     let modelName = modelDir.lastPathComponent
@@ -2349,6 +2352,7 @@ func runGrowingChatCacheReuse(modelPath: String, maxNew: Int) async throws {
     print("\n=== BENCH_GROWING_CHAT_CACHE — \(modelName) ===")
     print("Cache dir: \(cacheDir.path)")
     let nativeMTPDepth = env["BENCH_GROWING_NATIVE_MTP_DEPTH"].flatMap(Int.init)
+    let useMmap = env["BENCH_GROWING_MMAP"] == "1"
     let loadStart = CFAbsoluteTimeGetCurrent()
     let context: ModelContext
     if nativeMTPDepth != nil {
@@ -2362,6 +2366,12 @@ func runGrowingChatCacheReuse(modelPath: String, maxNew: Int) async throws {
                 useMmapSafetensors: true,
                 nativeMTP: true))
         context = loaded.0
+    } else if useMmap {
+        let loaded = try await MLXLMCommon.loadModel(
+            from: modelDir,
+            using: #huggingFaceTokenizerLoader(),
+            loadConfiguration: LoadConfiguration(useMmapSafetensors: true))
+        context = loaded.0
     } else {
         context = try await MLXLMCommon.loadModel(
             from: modelDir, using: #huggingFaceTokenizerLoader())
@@ -2369,6 +2379,7 @@ func runGrowingChatCacheReuse(modelPath: String, maxNew: Int) async throws {
     print(String(format: "Load: %.2fs  Model: %@",
         CFAbsoluteTimeGetCurrent() - loadStart,
         String(describing: type(of: context.model))))
+    print("Load mode: \(useMmap || nativeMTPDepth != nil ? "mmap" : "resident")")
     print("Tool format: \(context.configuration.toolCallFormat.map { "\($0)" } ?? "json")")
     print("Reasoning stamp: \(context.configuration.reasoningParserName ?? "nil")")
     print("Native MTP depth: \(nativeMTPDepth.map(String.init) ?? "off")")

--- a/RunBench/Bench.swift
+++ b/RunBench/Bench.swift
@@ -7266,9 +7266,18 @@ func runPerfBench(
             context = loaded.0
             jangPressRuntime = loaded.1
         } else {
-            context = try await MLXLMCommon.loadModel(
-                from: modelDir, using: #huggingFaceTokenizerLoader())
-            jangPressRuntime = nil
+            if useMmap {
+                let loaded = try await MLXLMCommon.loadModel(
+                    from: modelDir,
+                    using: #huggingFaceTokenizerLoader(),
+                    loadConfiguration: LoadConfiguration(useMmapSafetensors: true))
+                context = loaded.0
+                jangPressRuntime = loaded.1
+            } else {
+                context = try await MLXLMCommon.loadModel(
+                    from: modelDir, using: #huggingFaceTokenizerLoader())
+                jangPressRuntime = nil
+            }
         }
         let rssAfterLoad = currentRSSMiB()
         let footprintAfterLoad = currentPhysFootprintMiB()

--- a/Tests/MLXLMCommonFocusedTests/NemotronHJANGTQDispatchFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NemotronHJANGTQDispatchFocusedTests.swift
@@ -126,6 +126,9 @@ final class NemotronHJANGTQDispatchFocusedTests: XCTestCase {
         let streamingSource = try String(
             contentsOfFile: "Libraries/MLXLMCommon/JANGTQStreamingExperts.swift",
             encoding: .utf8)
+        let benchSource = try String(
+            contentsOfFile: "RunBench/Bench.swift",
+            encoding: .utf8)
 
         XCTAssertTrue(modelSource.contains("JANGTQ_DISABLE_NEMOTRON_ACTIVATION_BF16"))
         XCTAssertTrue(modelSource.contains("JANGTQ_DISABLE_NEMOTRON_WEIGHTED_MOE_FASTPATH"))
@@ -141,6 +144,8 @@ final class NemotronHJANGTQDispatchFocusedTests: XCTestCase {
         XCTAssertTrue(streamingSource.contains("public func reduced(_ x: MLXArray, indices: MLXArray, scores: MLXArray) -> MLXArray"))
         XCTAssertTrue(streamingSource.contains("relu_reduce.call_chunk"))
         XCTAssertTrue(streamingSource.contains("relu_reduce.score_sum_build"))
+        XCTAssertTrue(benchSource.contains("BENCH_GROWING_MMAP"))
+        XCTAssertTrue(benchSource.contains("LoadConfiguration(useMmapSafetensors: true)"))
     }
 
     func testStackedNemotronWeightedDecodeDoesNotUseRejectedScoredDownProjectionKernel() throws {

--- a/Tests/MLXLMCommonFocusedTests/NemotronHJANGTQDispatchFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NemotronHJANGTQDispatchFocusedTests.swift
@@ -133,11 +133,24 @@ final class NemotronHJANGTQDispatchFocusedTests: XCTestCase {
         XCTAssertTrue(modelSource.contains("residual.asType(x.dtype)"))
         XCTAssertTrue(modelSource.contains("out.asType(lmHead.weight.dtype)"))
         XCTAssertTrue(jangtqSource.contains("func weightedDecode(_ x: MLXArray, _ indices: MLXArray, scores: MLXArray) -> MLXArray?"))
+        XCTAssertTrue(jangtqSource.contains("let y = callAsFunction(x, indices)\n        return (y * scores[.ellipsis, .newAxis]).sum(axis: -2)"))
+        XCTAssertFalse(jangtqSource.contains("JANGTQKernels.gatherTQTopKScored("))
+        XCTAssertFalse(jangtqSource.contains("JANGTQ_ENABLE_NEMOTRON_SWITCHMLP_COMPILE"))
         XCTAssertTrue(jangtqSource.contains("extension StreamingTurboQuantSwitchReLUSquaredMLP: NemotronHSwitchMLPLayer"))
         XCTAssertTrue(jangtqSource.contains("reduced(x, indices: indices, scores: scores)"))
         XCTAssertTrue(streamingSource.contains("public func reduced(_ x: MLXArray, indices: MLXArray, scores: MLXArray) -> MLXArray"))
         XCTAssertTrue(streamingSource.contains("relu_reduce.call_chunk"))
         XCTAssertTrue(streamingSource.contains("relu_reduce.score_sum_build"))
+    }
+
+    func testStackedNemotronWeightedDecodeDoesNotUseRejectedScoredDownProjectionKernel() throws {
+        let kernelSource = try String(
+            contentsOfFile: "Libraries/MLXLMCommon/JANGTQKernels.swift",
+            encoding: .utf8)
+
+        XCTAssertFalse(kernelSource.contains("kGatherTQScoredSource"))
+        XCTAssertFalse(kernelSource.contains("jangtq_gather_tq_scored_matmul"))
+        XCTAssertFalse(kernelSource.contains("public static func gatherTQTopKScored("))
     }
 
     func testUltraHybridCacheTopologyIsFortyEightMambaPlusTwelveAttentionKV() throws {

--- a/docs/NEMOTRON_ULTRA_RUNTIME_STATUS_2026_06_06.md
+++ b/docs/NEMOTRON_ULTRA_RUNTIME_STATUS_2026_06_06.md
@@ -1,0 +1,157 @@
+# Nemotron Ultra Runtime Status - 2026-06-06
+
+## Scope
+
+Model: `/Users/eric/models/NVIDIA-Nemotron-3-Ultra-550B-A55B-JANGTQ_1L`
+
+This note records the current vMLX Swift status for the Ultra JANGTQ_1L
+runtime after rechecking the Python-doc `8 tok/s` claim against live Swift
+resident and mmap paths.
+
+## Code Changes
+
+- Fixed `BENCH_PERF_MMAP=1` in `RunBench` so the perf harness explicitly uses
+  `LoadConfiguration(useMmapSafetensors: true)`.
+- Preserved the original resident load call when `BENCH_PERF_MMAP=0`.
+  Passing `LoadConfiguration(useMmapSafetensors: false)` is not equivalent to
+  the original resident path and regressed decode to about `0.6 tok/s`.
+- Added source coverage that keeps the rejected stacked scored down-projection
+  experiment out of the default Nemotron-H JANGTQ path.
+
+No sampler, prompt, generation-config, reasoning parser, or tool parser
+behavior was changed.
+
+## Rejected Experiment
+
+The attempted stacked scored down-projection kernel was removed from the patch.
+It looked plausible because it avoided materializing `(tokens, K, hidden)` for
+the final weighted reduction, but live resident rows proved it was slower:
+
+- `/tmp/vmlx-nemotron-compiled-weighted-perf-resident-20260606-034324.log`
+  - `tokps_median=3.0`
+  - `peak_footprint_mib=102031`
+- `/tmp/vmlx-nemotron-scored-weighted-perf-resident-rebuilt-20260606-034903.log`
+  - `tokps_median=0.6`
+  - `peak_footprint_mib=102019`
+
+The default runtime keeps the previously proven `weightedDecode` shape:
+
+```swift
+let y = callAsFunction(x, indices)
+return (y * scores[.ellipsis, .newAxis]).sum(axis: -2).asType(y.dtype)
+```
+
+## Validation
+
+Focused source/compile coverage:
+
+```sh
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
+  xcrun swift test --filter NemotronHJANGTQDispatchFocusedTests \
+  --jobs 1 --no-parallel
+```
+
+Artifact: `/tmp/vmlx-nemotron-restored-weighted-focused-20260606-035551.log`
+
+Result: passed, 10 tests.
+
+RunBench build after the harness fix:
+
+```sh
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
+  xcrun swift build --product RunBench --jobs 1
+```
+
+Artifact:
+`/tmp/vmlx-nemotron-runbench-rebuild-resident-load-fix-20260606-040134.log`
+
+Result: passed.
+
+## Live Rows
+
+Resident Swift speed row:
+
+```sh
+BENCH_MODEL=/Users/eric/models/NVIDIA-Nemotron-3-Ultra-550B-A55B-JANGTQ_1L \
+BENCH_PERF=1 \
+BENCH_PERF_VARIANT=nemotron_resident_original_load \
+BENCH_MAX_TOKENS=32 \
+BENCH_PERF_WARMUP=1 \
+BENCH_PERF_RUNS=1 \
+BENCH_PERF_USE_GENERATION_CONFIG=1 \
+BENCH_PERF_SEED=42 \
+BENCH_PERF_MMAP=0 \
+.build/debug/RunBench
+```
+
+Artifact: `/tmp/vmlx-nemotron-resident-original-load-20260606-040225.log`
+
+Result:
+
+- `tokps_median=8.1`
+- `peak_footprint_mib=102736`
+- `samplingSource=bundle-defaults`
+- `temp=1.00 topP=0.95 topK=0 rep=nil`
+- coherent visible text, no loop, no parser marker leak
+
+Explicit mmap Swift row:
+
+```sh
+BENCH_MODEL=/Users/eric/models/NVIDIA-Nemotron-3-Ultra-550B-A55B-JANGTQ_1L \
+BENCH_PERF=1 \
+BENCH_PERF_VARIANT=nemotron_mmap_explicit_load \
+BENCH_MAX_TOKENS=16 \
+BENCH_PERF_WARMUP=0 \
+BENCH_PERF_RUNS=1 \
+BENCH_PERF_USE_GENERATION_CONFIG=1 \
+BENCH_PERF_SEED=42 \
+BENCH_PERF_MMAP=1 \
+.build/debug/RunBench
+```
+
+Artifact: `/tmp/vmlx-nemotron-mmap-explicit-load-20260606-040324.log`
+
+Result:
+
+- `tokps_median=3.9`
+- `peak_footprint_mib=1353`
+- `samplingSource=bundle-defaults`
+- `temp=1.00 topP=0.95 topK=0 rep=nil`
+- coherent visible text, no loop, no parser marker leak
+
+Low-footprint JPREG row from the same worktree:
+
+Artifact: `/tmp/vmlx-nemotron-scored-weighted-jpreg-20260606-033442.log`
+
+Result:
+
+- post-load footprint `0.3 GB`
+- post-quiesce footprint `4.2 GB`
+- `avgApiDecode=3.8 tok/s`
+- three-turn text row coherent, `looping=no`
+- `TQ disk round-trip: PASS`
+- thinking-on probe remained partial: `offReasoning=0c onReasoning=812c`
+
+## Current Verdict
+
+PARTIAL.
+
+Fixed/proven:
+
+- The perf harness now distinguishes the resident and mmap load paths.
+- Current Swift resident decode confirms the documented `8 tok/s` class:
+  `8.1 tok/s` with bundle generation defaults.
+- Current Swift low-footprint mmap decode is coherent and stays around
+  `1.35 GB` footprint.
+- The attempted scored-kernel optimization was proven slower and removed from
+  the default path.
+
+Still not complete:
+
+- The release-friendly low-footprint mmap path is `3.8-3.9 tok/s`, not
+  `8-10 tok/s`.
+- The resident `8.1 tok/s` row uses about `100 GB` physical footprint.
+- Thinking-on parser behavior is still partial in the short JPREG row because
+  the model emitted reasoning but no visible answer within the token budget.
+- The current rows are text-only. Full Osaurus chat, tool-call, and hybrid SSM
+  companion prefix-cache proof still need a separate live app/API pass.

--- a/docs/NEMOTRON_ULTRA_RUNTIME_STATUS_2026_06_06.md
+++ b/docs/NEMOTRON_ULTRA_RUNTIME_STATUS_2026_06_06.md
@@ -15,6 +15,8 @@ resident and mmap paths.
 - Preserved the original resident load call when `BENCH_PERF_MMAP=0`.
   Passing `LoadConfiguration(useMmapSafetensors: false)` is not equivalent to
   the original resident path and regressed decode to about `0.6 tok/s`.
+- Added `BENCH_GROWING_MMAP=1` so the growing-chat cache harness can run the
+  same low-footprint mmap load path as the perf harness.
 - Added source coverage that keeps the rejected stacked scored down-projection
   experiment out of the default Nemotron-H JANGTQ path.
 
@@ -64,6 +66,18 @@ DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
 
 Artifact:
 `/tmp/vmlx-nemotron-runbench-rebuild-resident-load-fix-20260606-040134.log`
+
+Result: passed.
+
+RunBench build after the growing-cache mmap knob:
+
+```sh
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
+  xcrun swift build --product RunBench --jobs 1
+```
+
+Artifact:
+`/tmp/vmlx-nemotron-runbench-rebuild-growing-mmap-20260606-040923.log`
 
 Result: passed.
 
@@ -132,6 +146,42 @@ Result:
 - `TQ disk round-trip: PASS`
 - thinking-on probe remained partial: `offReasoning=0c onReasoning=812c`
 
+Hybrid SSM exact-replay cache row:
+
+Artifact: `/tmp/vmlx-nemotron-mmap-cache-hybrid-ssm-20260606-040758.log`
+
+Result:
+
+- mmap load, bundle generation defaults
+- `tokps_median=4.5`
+- `peak_footprint_mib=2131`
+- run 0 stores disk state: `disk{hits=0,misses=1,stores=1}`
+- run 1 restores disk plus SSM companion state:
+  `disk{hits=1,misses=2,stores=2}` and `ssm{hits=1,misses=0,reDerives=0}`
+- `hybrid=true pagedIncompatible=true`, so Nemotron-H does not accept unsafe
+  paged-only cache hits
+- coherent visible text, no loop, no parser marker leak
+
+Growing-chat post-answer cache row:
+
+Artifact: `/tmp/vmlx-nemotron-growing-cache-mmap-20260606-041017.log`
+
+Result:
+
+- `Load mode: mmap`
+- topology: `layers=60,kvLayers=12,mambaLayers=48,companion=ssm,restore=disk-backed`
+- turn 1: `prompt=30 gen=5 finish=stop promptTime=1.420s`, visible
+  `vmlx-cache-green`
+- prompt-boundary salted probe hit: `matched=30/31`
+- post-answer salted probe hit: `matched=35/36`
+- nil-salt probes missed, proving salt isolation
+- before turn 2: `disk{hits=2,misses=8,stores=2}` and
+  `ssm{hits=2,misses=0,reDerives=0}`
+- turn 2 growing prompt: `prompt=62 gen=5 finish=stop promptTime=1.215s`,
+  visible `vmlx-cache-green`
+- after turn 2: `disk{hits=4,misses=11,stores=4}` and
+  `ssm{hits=4,misses=0,reDerives=0}`
+
 ## Current Verdict
 
 PARTIAL.
@@ -143,6 +193,8 @@ Fixed/proven:
   `8.1 tok/s` with bundle generation defaults.
 - Current Swift low-footprint mmap decode is coherent and stays around
   `1.35 GB` footprint.
+- Hybrid SSM disk-backed prefix cache hits are proven for exact replay and
+  growing chat, including SSM companion-state hits and salt isolation.
 - The attempted scored-kernel optimization was proven slower and removed from
   the default path.
 
@@ -153,5 +205,7 @@ Still not complete:
 - The resident `8.1 tok/s` row uses about `100 GB` physical footprint.
 - Thinking-on parser behavior is still partial in the short JPREG row because
   the model emitted reasoning but no visible answer within the token budget.
-- The current rows are text-only. Full Osaurus chat, tool-call, and hybrid SSM
-  companion prefix-cache proof still need a separate live app/API pass.
+- Live async SSM rederive was not triggered in these cache rows:
+  `reDerives=0`. The proven path is disk-backed SSM companion restore/hit.
+- The current rows are vMLX harness rows. Full Osaurus chat and tool-call proof
+  still need a separate live app/API pass.


### PR DESCRIPTION
## Summary
- Fix `RunBench` perf loading so `BENCH_PERF_MMAP=1` explicitly uses `LoadConfiguration(useMmapSafetensors: true)`.
- Preserve the original resident load path for `BENCH_PERF_MMAP=0`; explicit `useMmapSafetensors: false` was proven not equivalent and regressed resident decode to ~0.6 tok/s.
- Add `BENCH_GROWING_MMAP=1` so the growing-chat cache harness can exercise the low-footprint mmap load path.
- Add focused source coverage and a status note documenting the accepted rows, the cache evidence, and the rejected scored-kernel experiment.

## Validation
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter NemotronHJANGTQDispatchFocusedTests --jobs 1 --no-parallel`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift build --product RunBench --jobs 1`
- Resident live row: `/tmp/vmlx-nemotron-resident-original-load-20260606-040225.log` -> `tokps_median=8.1`, `peak_footprint_mib=102736`, coherent/no leak/no loop, bundle defaults.
- Explicit mmap live row: `/tmp/vmlx-nemotron-mmap-explicit-load-20260606-040324.log` -> `tokps_median=3.9`, `peak_footprint_mib=1353`, coherent/no leak/no loop, bundle defaults.
- Hybrid SSM exact-replay cache row: `/tmp/vmlx-nemotron-mmap-cache-hybrid-ssm-20260606-040758.log` -> mmap, `tokps_median=4.5`, `peak_footprint_mib=2131`, disk hit on run 1, `ssm{hits=1,misses=0,reDerives=0}`, `pagedIncompatible=true`.
- Growing-chat post-answer cache row: `/tmp/vmlx-nemotron-growing-cache-mmap-20260606-041017.log` -> mmap, prompt-boundary and post-answer salted disk hits, nil-salt misses, turn 2 growing prompt hit, `ssm{hits=4,misses=0,reDerives=0}` after turn 2.

## Status
PARTIAL for the full Nemo Ultra release gate:
- Proven: Swift resident confirms the 8 tok/s class with bundle generation defaults.
- Proven: low-footprint mmap is coherent and exercises disk-backed hybrid SSM companion cache hits for exact replay and growing chat.
- Not proven: low-footprint mmap is not 8-10 tok/s; current mmap/JPREG rows are 3.8-4.5 tok/s.
- Not proven: live async SSM rederive did not trigger in these rows (`reDerives=0`); the proven path is disk-backed companion restore/hit.
- Still pending: full Osaurus app/API tool-call and reasoning parser e2e for Nemo Ultra.
