### PR TITLE
Keep Osaurus MLXPress cold tier opt-in

### DIFF
--- a/Libraries/MLXLMCommon/Cache/LoadConfiguration.swift
+++ b/Libraries/MLXLMCommon/Cache/LoadConfiguration.swift
@@ -181,12 +181,13 @@ public struct LoadConfiguration: Sendable, Equatable {
 
     /// Production host preset for Osaurus/vMLX server integrations.
     ///
-    /// This keeps the conservative load-time memory caps and mmap
-    /// safetensors path from ``default``, while opting validated hosts
-    /// into MLXPress auto-detection for routed bundles that exceed half
-    /// of physical RAM. Native MTP remains a separate per-bundle
-    /// decision resolved by ``VMLXServerRuntimeSettings``.
-    public static let osaurusProduction = experimentalJangPressAuto
+    /// Keep the conservative load-time memory caps and mmap safetensors
+    /// path from ``default`` without automatically engaging the
+    /// experimental routed-expert cold tier. Hosts that have validated
+    /// MLXPress for a specific bundle family should pass
+    /// ``experimentalJangPressAuto`` or an explicit
+    /// ``JangPressPolicy/enabled(coldFraction:)`` policy from settings.
+    public static let osaurusProduction = LoadConfiguration.default
 
     /// Everything off — strict byte-compat with pre-iter-23 behavior.
     /// MLXPress disabled, no caps, no mmap loader.

--- a/RunBench/Bench.swift
+++ b/RunBench/Bench.swift
@@ -396,11 +396,10 @@ struct Bench {
 
         // BENCH_JPREG=1 (2026-05-03): per-bundle regression sweep that
         // exercises the new typed `LoadConfiguration` path end-to-end.
-        // Loads with `LoadConfiguration.default` (auto JangPress + 70%
-        // resident cap), runs 3-turn coherency, samples RSS at four
-        // checkpoints, verifies the JangPress controller advances past
-        // .armed during a 6s quiesce window, plus hybrid-SSM warm-pass
-        // and TurboQuant disk round-trip checks where applicable.
+        // Loads with `LoadConfiguration.default` (JangPress disabled +
+        // 70% caps + mmap), runs 3-turn coherency, samples RSS at four
+        // checkpoints, and exercises hybrid-SSM warm-pass plus
+        // TurboQuant disk round-trip checks where applicable.
         // Designed to be invoked once per bundle from a shell loop so
         // each model gets a fresh process.
         if (env["BENCH_JPREG"] ?? "0") == "1" {

--- a/RunBench/JangPressRegressionBench.swift
+++ b/RunBench/JangPressRegressionBench.swift
@@ -6,9 +6,9 @@
 //
 // What each row checks:
 //   1. Load via the new `loadModel(from:using:loadConfiguration:)`
-//      overload (LoadConfiguration.default → auto JangPress + 70%
-//      resident cap). Verify status reports `enabled=true` for routed
-//      bundles and `enabled=false` for dense ones.
+//      overload (LoadConfiguration.default → JangPress disabled + 70%
+//      resident cap + mmap safetensors). Force mode can still verify
+//      explicit JangPress behavior for routed bundles.
 //   2. RSS sample at: pre-load, post-load, post-warm, post-quiesce.
 //   3. 3-turn coherency on a fixed prompt set. Looping detector flags
 //      runs that emit ≥3 identical 16-char windows back-to-back.
@@ -82,7 +82,8 @@ enum JangPressRegressionBench {
     /// the compression path on bundles that the auto threshold would
     /// otherwise leave disabled (i.e. bundles ≤ 50% of physical RAM).
     /// Default false — production-default `LoadConfiguration.default`
-    /// path.
+    /// path, which keeps JangPress opt-in while preserving mmap and
+    /// memory caps.
     private static let forceJangPress: Bool = {
         ProcessInfo.processInfo.environment["BENCH_JPREG_FORCE"] == "1"
     }()

--- a/Tests/MLXLMCommonFocusedTests/VMLXServerRuntimeSettingsTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/VMLXServerRuntimeSettingsTests.swift
@@ -33,12 +33,29 @@ struct VMLXServerRuntimeSettingsTests {
         #expect(settings.mtp.acceptedTokensOnlyEnterBaseCache)
     }
 
-    @Test("Osaurus production preset enables MLXPress auto while preserving MTP resolution")
-    func osaurusProductionPresetEnablesMLXPressAutoWhilePreservingMTPResolution() {
+    @Test("Osaurus production preset keeps MLXPress opt-in while preserving MTP resolution")
+    func osaurusProductionPresetKeepsMLXPressOptInWhilePreservingMTPResolution() {
         let settings = VMLXServerRuntimeSettings()
 
         let resolved = settings.resolvedLoadConfiguration(
             base: .osaurusProduction,
+            configData: nil,
+            jangConfig: nil,
+            status: nil)
+
+        #expect(resolved.jangPress == .disabled)
+        #expect(resolved.maxResidentBytes == .default)
+        #expect(resolved.memoryLimit == .default)
+        #expect(resolved.useMmapSafetensors)
+        #expect(!resolved.nativeMTP)
+    }
+
+    @Test("experimental MLXPress preset remains available for explicit host opt-in")
+    func experimentalMLXPressPresetRemainsAvailableForExplicitHostOptIn() {
+        let settings = VMLXServerRuntimeSettings()
+
+        let resolved = settings.resolvedLoadConfiguration(
+            base: .experimentalJangPressAuto,
             configData: nil,
             jangConfig: nil,
             status: nil)

--- a/docs/NEMOTRON_ULTRA_RUNTIME_STATUS_2026_06_06.md
+++ b/docs/NEMOTRON_ULTRA_RUNTIME_STATUS_2026_06_06.md
@@ -516,3 +516,26 @@ Source interpretation:
   reasoning parser, or tool parser. It is a real MoE/Mamba graph or kernel
   reduction that preserves the existing JANGTQ math contract and the fp32
   router-selection floor.
+
+## Follow-Up Trace - 2026-06-06 13:45 PDT
+
+Aligned Osaurus production load policy with the proven mmap harness boundary:
+
+- `LoadConfiguration.default` already uses mmap safetensors and 70% memory
+  caps while keeping MLXPress/JangPress disabled unless explicitly requested.
+- The saved low-footprint vMLX rows above use that disabled-cold-tier mmap path
+  and decode in the `3.8-4.5 tok/s` class.
+- The Osaurus app proof used the `osaurusProduction` preset, which previously
+  aliased `experimentalJangPressAuto`. On the 98 GB Nemotron Ultra routed
+  bundle, that can auto-enable the experimental cold-tier because the bundle is
+  larger than half of physical RAM.
+- Since the current enabled-cold-tier path is not speed-proven for Nemotron
+  Ultra and prior active-streaming rows were slower, `osaurusProduction` now
+  aliases `LoadConfiguration.default`.
+- `experimentalJangPressAuto` remains available for explicit host/settings
+  opt-in after a bundle family has live proof.
+
+This change does not alter sampler defaults, prompt templates, reasoning/tool
+parsers, quantized matmul math, JANGTQ kernels, or SSM cache semantics. It keeps
+the Osaurus default on the proven mmap + memory-cap behavior instead of
+silently selecting an experimental cold-tier path for large routed bundles.


### PR DESCRIPTION
## Summary
- keep `LoadConfiguration.osaurusProduction` on the proven default path: mmap safetensors + 70% caps, with MLXPress/JangPress cold-tier disabled unless explicitly requested
- preserve `experimentalJangPressAuto` for hosts/settings that have live proof for a bundle family
- update Nemo Ultra status notes and focused settings tests so Osaurus does not silently auto-select the unproven cold-tier for large routed bundles

## Validation
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter 'LoadConfigurationTests|VMLXServerRuntimeSettingsTests|NemotronHJANGTQDispatchFocusedTests' --jobs 1 --no-parallel`

## Runtime boundary
- This is not a sampler, prompt, parser, quantized-kernel, or SSM-cache behavior change.
- It aligns Osaurus production defaults with the already-proven low-footprint mmap harness path; full 8-10 tok/s remains resident-path proof, while mmap/Osaurus low-footprint speed remains a separate runtime optimization target.
