### PR TITLE
Optimize Nemotron-H decode convolution

### DIFF
--- a/Libraries/MLXLLM/Models/NemotronH.swift
+++ b/Libraries/MLXLLM/Models/NemotronH.swift
@@ -132,6 +132,101 @@ internal class NemotronHRMSNormGated: Module {
     }
 }
 
+private func nemotronHMambaConvFastPathDisabled() -> Bool {
+    nemotronHEnvFlag("VMLINUX_DISABLE_NEMOTRON_MAMBA_CONV_FASTPATH")
+}
+
+private func makeNemotronHMambaDepthwiseDecodeConvKernel() -> MLXFast.MLXFastKernel? {
+    let source = """
+            auto c = thread_position_in_grid.x;
+            auto b = thread_position_in_grid.y;
+
+            if (c >= C || b >= Bsz) {
+                return;
+            }
+
+            float acc = 0.0;
+            auto state_base = (b * (K - 1)) * C + c;
+            auto weight_base = c * K;
+
+            for (int k = 0; k < K - 1; ++k) {
+                acc += static_cast<float>(state[state_base + k * C])
+                    * static_cast<float>(weight[weight_base + k]);
+            }
+            acc += static_cast<float>(input[b * C + c])
+                * static_cast<float>(weight[weight_base + K - 1]);
+            acc += static_cast<float>(bias[c]);
+
+            auto sigmoid = 1.0f / (1.0f + fast::exp(-acc));
+            out[b * C + c] = static_cast<T>(acc * sigmoid);
+
+            auto next_base = (b * (K - 1)) * C + c;
+            for (int k = 0; k < K - 2; ++k) {
+                next_state[next_base + k * C] = state[state_base + (k + 1) * C];
+            }
+            if (K > 1) {
+                next_state[next_base + (K - 2) * C] = input[b * C + c];
+            }
+        """
+
+    return MLXFast.metalKernel(
+        name: "nemotron_h_mamba_depthwise_decode_conv",
+        inputNames: ["input", "state", "weight", "bias"],
+        outputNames: ["out", "next_state"],
+        source: source
+    )
+}
+
+private final class NemotronHMambaConvKernelManager: Sendable {
+    static let shared = NemotronHMambaConvKernelManager()
+
+    let decodeKernel: MLXFast.MLXFastKernel?
+
+    private init() {
+        decodeKernel = makeNemotronHMambaDepthwiseDecodeConvKernel()
+    }
+}
+
+internal func nemotronHMambaDepthwiseDecodeConv(
+    input: MLXArray,
+    state: MLXArray,
+    weight: MLXArray,
+    bias: MLXArray,
+    channels: Int,
+    kernelSize: Int
+) -> (MLXArray, MLXArray)? {
+    guard !nemotronHMambaConvFastPathDisabled(),
+        input.dim(1) == 1,
+        state.dim(1) == kernelSize - 1,
+        state.dim(2) == channels,
+        weight.dim(0) == channels,
+        weight.dim(1) == kernelSize,
+        weight.dim(2) == 1,
+        bias.dim(0) == channels,
+        let kernel = NemotronHMambaConvKernelManager.shared.decodeKernel
+    else {
+        return nil
+    }
+
+    let batch = input.dim(0)
+    let outputDType = input.dtype
+    let outputs = kernel(
+        [input, state, weight, bias],
+        template: [
+            ("T", outputDType),
+            ("Bsz", batch),
+            ("C", channels),
+            ("K", kernelSize),
+        ],
+        grid: (channels, batch, 1),
+        threadGroup: (min(256, channels), 1, 1),
+        outputShapes: [[batch, 1, channels], [batch, kernelSize - 1, channels]],
+        outputDTypes: [outputDType, outputDType]
+    )
+
+    return (outputs[0], outputs[1])
+}
+
 // MARK: - Mamba2Mixer
 
 internal class NemotronHMamba2Mixer: Module, NemotronHMixer {
@@ -216,6 +311,22 @@ internal class NemotronHMamba2Mixer: Module, NemotronHMixer {
             } else {
                 convState = MLXArray.zeros([batch, 0, convDim], dtype: dtype)
             }
+        }
+
+        if convInput.dim(1) == 1,
+            let bias = conv1d.bias,
+            let (convOutput, nextState) = nemotronHMambaDepthwiseDecodeConv(
+                input: convInput,
+                state: convState!,
+                weight: conv1d.weight,
+                bias: bias,
+                channels: convDim,
+                kernelSize: convKernelSize)
+        {
+            if let cache {
+                cache[0] = nextState
+            }
+            return convOutput
         }
 
         let padded = concatenated([convState!, convInput], axis: 1)

--- a/Tests/MLXLMCommonFocusedTests/NemotronHJANGTQDispatchFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NemotronHJANGTQDispatchFocusedTests.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import Foundation
+import MLX
 @testable import MLXLLM
 @testable import MLXLMCommon
 import XCTest
@@ -158,6 +159,50 @@ final class NemotronHJANGTQDispatchFocusedTests: XCTestCase {
         XCTAssertFalse(kernelSource.contains("public static func gatherTQTopKScored("))
     }
 
+    func testNemotronMambaDecodeDepthwiseConvFastPathMatchesGenericConv1d() throws {
+        try FocusedMLXTestSupport.withLock {
+            let batch = 2
+            let channels = 3
+            let kernelSize = 4
+
+            let input = MLXArray([
+                Float(0.25), -0.5, 0.75,
+                -1.0, 1.25, 0.5,
+            ], [batch, 1, channels])
+            let state = MLXArray([
+                Float(0.1), 0.2, 0.3,
+                0.4, 0.5, 0.6,
+                0.7, 0.8, 0.9,
+                -0.1, -0.2, -0.3,
+                -0.4, -0.5, -0.6,
+                -0.7, -0.8, -0.9,
+            ], [batch, kernelSize - 1, channels])
+            let weight = MLXArray([
+                Float(0.5), -0.25, 0.75, 1.0,
+                -0.5, 0.25, 0.125, -0.75,
+                0.625, -0.375, 0.875, -0.125,
+            ], [channels, kernelSize, 1])
+            let bias = MLXArray([Float(0.1), -0.2, 0.3])
+
+            let padded = concatenated([state, input], axis: 1)
+            let expectedRaw = conv1d(padded, weight, groups: channels) + bias
+            let expected = expectedRaw * sigmoid(expectedRaw)
+            let expectedState = padded[0..., 1..., 0...]
+
+            let (actual, actualState) = try XCTUnwrap(
+                nemotronHMambaDepthwiseDecodeConv(
+                    input: input,
+                    state: state,
+                    weight: weight,
+                    bias: bias,
+                    channels: channels,
+                    kernelSize: kernelSize))
+
+            Self.assertClose(actual, expected, tolerance: 1e-5)
+            Self.assertClose(actualState, expectedState, tolerance: 1e-5)
+        }
+    }
+
     func testUltraHybridCacheTopologyIsFortyEightMambaPlusTwelveAttentionKV() throws {
         let pattern = Self.ultraLayerBlockTypes
         XCTAssertEqual(pattern.count, 108)
@@ -277,5 +322,16 @@ final class NemotronHJANGTQDispatchFocusedTests: XCTestCase {
         "moe", "mamba", "attention", "moe", "mamba", "moe", "mamba",
         "moe", "mamba", "moe", "mamba", "moe",
     ]
+
+    private static func assertClose(_ actual: MLXArray, _ expected: MLXArray, tolerance: Float) {
+        MLX.eval(actual, expected)
+        let actualValues = actual.asArray(Float.self)
+        let expectedValues = expected.asArray(Float.self)
+        XCTAssertEqual(actualValues.count, expectedValues.count)
+        let maxDiff = zip(actualValues, expectedValues)
+            .map { abs($0 - $1) }
+            .max() ?? 0
+        XCTAssertLessThanOrEqual(maxDiff, tolerance, "maxDiff=\(maxDiff)")
+    }
 
 }

--- a/docs/NEMOTRON_ULTRA_RUNTIME_STATUS_2026_06_06.md
+++ b/docs/NEMOTRON_ULTRA_RUNTIME_STATUS_2026_06_06.md
@@ -539,3 +539,72 @@ This change does not alter sampler defaults, prompt templates, reasoning/tool
 parsers, quantized matmul math, JANGTQ kernels, or SSM cache semantics. It keeps
 the Osaurus default on the proven mmap + memory-cap behavior instead of
 silently selecting an experimental cold-tier path for large routed bundles.
+
+## Follow-Up Trace - 2026-06-06 14:52 PDT
+
+Added a narrow Nemotron-H decode-only depthwise-conv fast path:
+
+- Scope: Mamba `conv1d` only when `seqLen == 1`, the rolling Mamba conv state is
+  available or initialized, and the bundle has a conv bias. Prefill and no-bias
+  variants still use generic `Conv1d`.
+- Math contract: the kernel computes the same depthwise convolution over
+  `[previous_state, current_token]`, applies the same SiLU, and emits the next
+  rolling conv state. It does not change SSM recurrence, MoE routing, JANGTQ
+  kernels, generation defaults, templates, reasoning parsers, or tool parsers.
+- Diagnostic opt-out:
+  `VMLINUX_DISABLE_NEMOTRON_MAMBA_CONV_FASTPATH=1`.
+
+Focused validation:
+
+```sh
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
+  xcrun swift test --filter NemotronHJANGTQDispatchFocusedTests \
+  --jobs 1 --no-parallel
+```
+
+Artifact:
+`/tmp/vmlx-nemotron-depthwise-conv-focused-rerun2-20260606-144944.log`
+
+Result: passed, 11 tests. The new numerical parity test compares the custom
+decode kernel against generic `conv1d + bias + SiLU` and verifies the emitted
+rolling state.
+
+Fresh mmap speed row:
+
+- Artifact:
+  `/tmp/vmlx-nemotron-mmap-depthwise-conv-fastpath-20260606-145009.log`
+- Result: `tokps_median=4.1`, `peak_footprint_mib=1360`, bundle generation
+  defaults, coherent visible output, no reasoning/tool leaks.
+
+Disabled fast-path control:
+
+- Artifact:
+  `/tmp/vmlx-nemotron-mmap-depthwise-conv-disabled-control-20260606-145034.log`
+- Result: `tokps_median=4.0`, `peak_footprint_mib=1362`, same visible output.
+
+Resident control:
+
+- Artifact:
+  `/tmp/vmlx-nemotron-resident-depthwise-conv-fastpath-20260606-145051.log`
+- Result: `tokps_median=8.8`, `peak_footprint_mib=101573`, coherent visible
+  output, no reasoning/tool leaks.
+
+Graph-stats row:
+
+- Artifact:
+  `/tmp/vmlx-nemotron-mmap-depthwise-conv-graphstats-20260606-145155.log`
+- DOT:
+  `/tmp/vmlx-nemotron-mmap-depthwise-conv-dot-20260606-145155.dot`
+- Result: `decodeNodes=5375`, `asType=1056`, `tokps_median=5.0` for the
+  4-token graph probe.
+
+Interpretation:
+
+- This is a real graph reduction versus the prior clean-main graph row
+  (`5711` decode nodes, `1152` `AsType` nodes), and it preserves the low
+  footprint and coherency envelope.
+- It is not the final low-footprint speed fix. The fresh 16-token mmap row is
+  still about `4 tok/s`, not `8-10 tok/s`.
+- The remaining low-footprint gap is still MoE/Mamba graph/kernel work or a
+  resident-compute/reclaim mechanism, not Osaurus wiring or parser/default
+  behavior.


### PR DESCRIPTION
## Summary

- Add a decode-only Nemotron-H Mamba depthwise-conv Metal fast path for `seqLen == 1` with conv bias.
- Keep prefill, no-bias variants, SSM recurrence, MoE routing, JANGTQ kernels, parser behavior, and generation defaults unchanged.
- Add focused parity coverage against generic `conv1d + bias + SiLU` and document fresh Nemo Ultra rows.

## Validation

- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter NemotronHJANGTQDispatchFocusedTests --jobs 1 --no-parallel`
  - Artifact: `/tmp/vmlx-nemotron-depthwise-conv-focused-rerun2-20260606-144944.log`
  - Result: 11 tests passed

Live Nemo Ultra controls from `/Users/eric/models/NVIDIA-Nemotron-3-Ultra-550B-A55B-JANGTQ_1L`:

- mmap fast path: `/tmp/vmlx-nemotron-mmap-depthwise-conv-fastpath-20260606-145009.log`
  - `tokps_median=4.1`, `peak_footprint_mib=1360`, coherent, no leaks
- mmap disabled control: `/tmp/vmlx-nemotron-mmap-depthwise-conv-disabled-control-20260606-145034.log`
  - `tokps_median=4.0`, `peak_footprint_mib=1362`, same output
- resident control: `/tmp/vmlx-nemotron-resident-depthwise-conv-fastpath-20260606-145051.log`
  - `tokps_median=8.8`, `peak_footprint_mib=101573`, coherent, no leaks
- mmap graph stats: `/tmp/vmlx-nemotron-mmap-depthwise-conv-graphstats-20260606-145155.log`
  - `decodeNodes=5375`, `asType=1056`
  - Previous clean-main graph row was `5711` / `1152`

## Caveat

This is a real graph reduction, but it is not the final low-footprint speed fix. The mmap/Osaurus-default path remains about `4 tok/s`, not `8-10 tok/s`.
