### PR TITLE
Auto BF16 mmap conversion for Nemotron JANGTQ

### DIFF
--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -667,15 +667,19 @@ public func loadWeights(
     //
     // For non-mmap JANGTQ loads, still convert non-TQ Mamba/attention/router
     // weights so resident decode avoids preventable fp16 AsType cascades. For
-    // mmap/JangPress loads, default to preserving file-backed tensor residency:
-    // converting a mapped tensor materializes a new array and can blow the low
-    // footprint gate. The mmap conversion path is left as an explicit diagnostic
-    // knob so it can be benchmarked without changing production memory policy.
+    // mmap/JangPress loads, default to preserving file-backed tensor residency
+    // unless the bundle is Nemotron-H: Ultra live rows show converting only
+    // non-TQ tensors keeps the low-footprint gate while removing avoidable
+    // decode AsType work. Other native JANGTQ families remain opt-in until
+    // they have their own mmap footprint/speed proof.
     let mmapSafetensorsActive = envFlag("MLX_SAFETENSORS_MMAP")
         || envFlag("VMLINUX_MMAP_SAFETENSORS")
     let allowJANGTQMmapBFloat16 = envFlag("VMLINUX_JANGTQ_BF16_MMAP")
         || envFlag("MLX_JANGTQ_BF16_MMAP")
-    if !isJANGTQNative || !mmapSafetensorsActive || allowJANGTQMmapBFloat16 {
+    let autoJANGTQMmapBFloat16 = isNemotronHBundle(modelDirectory)
+    if !isJANGTQNative || !mmapSafetensorsActive || allowJANGTQMmapBFloat16
+        || autoJANGTQMmapBFloat16
+    {
         convertToBFloat16(
             model: model,
             shouldSkip: isJANGTQNative ? isJANGTQParameterKey : { _ in false })
@@ -701,6 +705,18 @@ public func loadWeights(
 /// preserving the dtype contract.
 private func isJANGTQParameterKey(_ key: String) -> Bool {
     key.hasSuffix(".tq_packed") || key.hasSuffix(".tq_norms")
+}
+
+private func isNemotronHBundle(_ modelDirectory: URL) -> Bool {
+    let configURL = modelDirectory.appendingPathComponent("config.json")
+    guard
+        let data = try? Data(contentsOf: configURL),
+        let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+        let modelType = object["model_type"] as? String
+    else {
+        return false
+    }
+    return modelType.lowercased() == "nemotron_h"
 }
 
 private func envFlag(_ key: String) -> Bool {

--- a/Tests/MLXLMTests/LoadConfigurationTests.swift
+++ b/Tests/MLXLMTests/LoadConfigurationTests.swift
@@ -211,7 +211,11 @@ struct LoadConfigurationTests {
 
         #expect(source.contains("let mmapSafetensorsActive = envFlag(\"MLX_SAFETENSORS_MMAP\")"))
         #expect(source.contains("let allowJANGTQMmapBFloat16 = envFlag(\"VMLINUX_JANGTQ_BF16_MMAP\")"))
+        #expect(source.contains("let autoJANGTQMmapBFloat16 = isNemotronHBundle(modelDirectory)"))
         #expect(source.contains("if !isJANGTQNative || !mmapSafetensorsActive || allowJANGTQMmapBFloat16"))
+        #expect(source.contains("|| autoJANGTQMmapBFloat16"))
+        #expect(source.contains("private func isNemotronHBundle(_ modelDirectory: URL) -> Bool"))
+        #expect(source.contains("modelType.lowercased() == \"nemotron_h\""))
         #expect(source.contains("shouldSkip: isJANGTQNative ? isJANGTQParameterKey"))
         #expect(source.contains("key.hasSuffix(\".tq_packed\") || key.hasSuffix(\".tq_norms\")"))
         #expect(!source.contains("if !isJANGTQNative {\n        convertToBFloat16(model: model)\n    }"))


### PR DESCRIPTION
Summary
- Auto-enable non-TQ BF16 conversion for mmap-loaded native Nemotron-H JANGTQ bundles.
- Keep .tq_packed and .tq_norms raw, and leave other native JANGTQ families env-opt-in.
- Keep MLXPress/streaming expert dispatch explicit-only; current live control is too slow for release.

Validation
- swift test --filter LoadConfigurationTests/jangtqLoadDoesNotSkipWholeModelBFloat16Conversion --jobs 1 --no-parallel
- swift test --filter NemotronHJANGTQDispatchFocusedTests --jobs 1 --no-parallel
- Nemo Ultra mmap 64-token live row without BF16 env: tokps_median=5.3, peak_footprint_mib=1926, graphNodes=4799, asType=480, coherent/no leaks.
- Explicit MLXPress streaming control: tokps_median=0.3, so not promoted.

Notes
- This improves the production low-footprint mmap default, but it is not the final 8-10 tok/s fix. The remaining target is the regular stacked Nemotron ReLU-squared JANGTQ MoE path.