### PR TITLE
Avoid redundant hybrid SSM rederive for exact snapshots

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -2197,12 +2197,16 @@ public actor BatchEngine {
                         !requiresDiskBackedRestore &&
                         !slot.originalInput.hasMediaContent
                     {
-                        return reDeriveAndStoreSSMStatesForPromptBoundaries(
+                        return exactBoundarySSMStatesFromSnapshotIfSufficient(
                             coordinator: coordinator,
-                            model: context.model,
-                            promptTokenIds: tokens,
-                            mediaSalt: slot.mediaSalt,
-                            prefillStepSize: slot.parameters.prefillStepSize)
+                            snapshot: snapshot,
+                            tokenCount: tokens.count)
+                            ?? reDeriveAndStoreSSMStatesForPromptBoundaries(
+                                coordinator: coordinator,
+                                model: context.model,
+                                promptTokenIds: tokens,
+                                mediaSalt: slot.mediaSalt,
+                                prefillStepSize: slot.parameters.prefillStepSize)
                     }
                     return extractSSMStates(from: snapshot)
                 }()

--- a/Libraries/MLXLMCommon/Cache/SSMReDerive.swift
+++ b/Libraries/MLXLMCommon/Cache/SSMReDerive.swift
@@ -288,6 +288,31 @@ public func captureCleanSSMStateInline(
     log("ok/captured stateCount=\(states.count)")
 }
 
+/// Return exact-boundary SSM states from an already-captured prompt/cache
+/// snapshot when that snapshot is sufficient for the coordinator's current
+/// prefix-cache policy.
+///
+/// This is intentionally narrower than ``captureCleanSSMStateInline``:
+/// callers use it after they already hold an exact boundary snapshot. If the
+/// paged KV tier may later restore shorter full-block prefixes, hybrid models
+/// still need companion SSM states at those intermediate block boundaries, so
+/// the caller must fall back to ``reDeriveAndStoreSSMStatesForPromptBoundaries``.
+public func exactBoundarySSMStatesFromSnapshotIfSufficient(
+    coordinator: CacheCoordinator,
+    snapshot: [KVCache],
+    tokenCount: Int
+) -> [MLXArray]? {
+    guard coordinator.isHybrid, tokenCount > 0 else { return nil }
+
+    if coordinator.pagedCache != nil, !coordinator.isPagedIncompatible {
+        let blockSize = max(1, coordinator.config.pagedBlockSize)
+        guard tokenCount <= blockSize else { return nil }
+    }
+
+    let states = extractSSMStates(from: snapshot)
+    return states.isEmpty ? nil : states
+}
+
 public func reDeriveSSMStates(
     model: any LanguageModel,
     tokens: [Int],

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1764,16 +1764,24 @@ public struct TokenIterator: TokenIteratorProtocol {
             let perLayerData = requiresDiskBackedRestore
                 ? []
                 : extractLayerData(from: snapshot)
-            let ssmCapture: [MLXArray]? = coordinator.isHybrid &&
-                coordinator.config.enableSSMReDerive &&
-                !requiresDiskBackedRestore &&
-                !originalInput.hasMediaContent
-                ? reDeriveAndStoreSSMStatesForPromptBoundaries(
+            let ssmCapture: [MLXArray]? = {
+                guard coordinator.isHybrid else { return nil }
+                guard coordinator.config.enableSSMReDerive,
+                    !requiresDiskBackedRestore,
+                    !originalInput.hasMediaContent
+                else {
+                    return extractSSMStates(from: snapshot)
+                }
+                return exactBoundarySSMStatesFromSnapshotIfSufficient(
                     coordinator: coordinator,
-                    model: model,
-                    promptTokenIds: tokens,
-                    mediaSalt: mediaSalt)
-                : (coordinator.isHybrid ? extractSSMStates(from: snapshot) : nil)
+                    snapshot: snapshot,
+                    tokenCount: tokens.count)
+                    ?? reDeriveAndStoreSSMStatesForPromptBoundaries(
+                        coordinator: coordinator,
+                        model: model,
+                        promptTokenIds: tokens,
+                        mediaSalt: mediaSalt)
+            }()
             let diskStoreCache = makeDiskStoreCache(
                 fromPromptBoundary: snapshot,
                 kvBits: diskKVBits,

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -413,17 +413,25 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 let perLayerData = requiresDiskBackedRestore
                     ? []
                     : extractLayerData(from: cacheSnapshot)
-                let ssmCapture: [MLXArray]? = coordinator.isHybrid &&
-                    coordinator.config.enableSSMReDerive &&
-                    !requiresDiskBackedRestore &&
-                    !originalInput.hasMediaContent
-                    ? reDeriveAndStoreSSMStatesForPromptBoundaries(
+                let ssmCapture: [MLXArray]? = {
+                    guard coordinator.isHybrid else { return nil }
+                    guard coordinator.config.enableSSMReDerive,
+                        !requiresDiskBackedRestore,
+                        !originalInput.hasMediaContent
+                    else {
+                        return extractSSMStates(from: cacheSnapshot)
+                    }
+                    return exactBoundarySSMStatesFromSnapshotIfSufficient(
                         coordinator: coordinator,
-                        model: model,
-                        promptTokenIds: tokens,
-                        mediaSalt: mediaSalt,
-                        prefillStepSize: cacheInitParameters.prefillStepSize)
-                    : (coordinator.isHybrid ? extractSSMStates(from: cacheSnapshot) : nil)
+                        snapshot: cacheSnapshot,
+                        tokenCount: tokens.count)
+                        ?? reDeriveAndStoreSSMStatesForPromptBoundaries(
+                            coordinator: coordinator,
+                            model: model,
+                            promptTokenIds: tokens,
+                            mediaSalt: mediaSalt,
+                            prefillStepSize: cacheInitParameters.prefillStepSize)
+                }()
                 let diskStoreCache = makeDiskStoreCache(
                     fromPromptBoundary: cacheSnapshot,
                     parameters: cacheInitParameters)

--- a/Tests/MLXLMTests/SSMReDeriveParityTests.swift
+++ b/Tests/MLXLMTests/SSMReDeriveParityTests.swift
@@ -119,6 +119,55 @@ final class SSMReDeriveParityTests: XCTestCase {
         XCTAssertEqual(coordinator.ssmStateCache.reDerives, 1)
     }
 
+    func testExactSnapshotSSMStatesAvoidReDeriveWhenNoIntermediateBoundaryIsNeeded() throws {
+        let model = TinyHybridSSMModel()
+        let tokens = [3, 4, 5, 6, 7]
+        let coordinator = CacheCoordinator(config: CacheCoordinatorConfig(
+            usePagedCache: true,
+            enableDiskCache: false,
+            pagedBlockSize: 8,
+            modelKey: "tiny-hybrid|exact-snapshot"))
+        coordinator.setHybrid(true)
+
+        let cache = model.newCache(parameters: nil)
+        try runWarmPass(model: model, cache: cache, tokens: tokens, prefillStepSize: 2)
+        let snapshot = cache.map { $0.copy() }
+
+        let states = try XCTUnwrap(
+            exactBoundarySSMStatesFromSnapshotIfSufficient(
+                coordinator: coordinator,
+                snapshot: snapshot,
+                tokenCount: tokens.count))
+        let warm = extractSSMStates(from: cache)
+
+        assertStatesEqual(states, warm)
+        XCTAssertEqual(
+            coordinator.ssmStateCache.reDerives,
+            0,
+            "Exact snapshot extraction must not count as a fresh SSM re-derive")
+    }
+
+    func testExactSnapshotSSMStatesDeclineWhenPagedIntermediateBoundaryIsNeeded() throws {
+        let model = TinyHybridSSMModel()
+        let tokens = [3, 4, 5, 6, 7]
+        let coordinator = CacheCoordinator(config: CacheCoordinatorConfig(
+            usePagedCache: true,
+            enableDiskCache: false,
+            pagedBlockSize: 4,
+            modelKey: "tiny-hybrid|needs-block-boundary"))
+        coordinator.setHybrid(true)
+
+        let cache = model.newCache(parameters: nil)
+        try runWarmPass(model: model, cache: cache, tokens: tokens, prefillStepSize: 2)
+
+        XCTAssertNil(
+            exactBoundarySSMStatesFromSnapshotIfSufficient(
+                coordinator: coordinator,
+                snapshot: cache.map { $0.copy() },
+                tokenCount: tokens.count),
+            "Paged hybrid prompts longer than one block still need re-derive to capture intermediate SSM boundaries")
+    }
+
     private func warmPassStates(
         model: TinyHybridSSMModel,
         tokens: [Int],


### PR DESCRIPTION
## Summary
- Prefer exact-boundary SSM extraction from an already captured cache snapshot when no intermediate paged companion boundary is needed.
- Keep the existing prompt-boundary rederive fallback when paged KV may restore shorter full-block prefixes.
- Apply the same policy to TokenIterator, BatchEngine, and NativeMTP cache-store paths.

## Validation
- git diff --check
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter SSMReDeriveParityTests --jobs 1 --no-parallel
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter CacheCoordinatorTopologyFocusedTests --jobs 1 --no-parallel
- DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter NemotronHJANGTQDispatchFocusedTests --jobs 1 --no-parallel

## Notes
This does not change sampler, prompt, parser, or generation defaults. It is a cache-store latency fix for safe exact-boundary hybrid SSM cases; longer paged prompts still use rederive so intermediate companion states remain available.