### PR TITLE
Document Nemotron Ultra decode profiling

### DIFF
--- a/Libraries/MLXLLM/Models/NemotronH.swift
+++ b/Libraries/MLXLLM/Models/NemotronH.swift
@@ -42,6 +42,15 @@ internal enum NemotronHBlockType {
         default: fatalError("Unknown NemotronH block type: \(char)")
         }
     }
+
+    var profileName: String {
+        switch self {
+        case .mamba: return "mamba"
+        case .attention: return "attention"
+        case .mlp: return "mlp"
+        case .moe: return "moe"
+        }
+    }
 }
 
 // MARK: - Mixer Protocol
@@ -82,6 +91,41 @@ private func nemotronHActivationBF16RetentionEnabled() -> Bool {
 
 private func nemotronHWeightedMoEFastPathEnabled() -> Bool {
     !nemotronHEnvFlag("JANGTQ_DISABLE_NEMOTRON_WEIGHTED_MOE_FASTPATH")
+}
+
+private func nemotronHLayerProfileEnabled() -> Bool {
+    nemotronHEnvFlag("VMLINUX_NEMOTRON_LAYER_PROFILE")
+}
+
+private final class NemotronHLayerProfiler: @unchecked Sendable {
+    static let shared = NemotronHLayerProfiler()
+
+    private let lock = NSLock()
+    private var rows: [String: (count: Int, totalMs: Double)] = [:]
+
+    func record(_ label: String, seconds: Double) {
+        lock.lock()
+        let current = rows[label] ?? (0, 0)
+        rows[label] = (current.count + 1, current.totalMs + seconds * 1000)
+        lock.unlock()
+    }
+
+    func printSummary() {
+        lock.lock()
+        let snapshot = rows
+        rows.removeAll()
+        lock.unlock()
+
+        for key in snapshot.keys.sorted() {
+            guard let value = snapshot[key], value.count > 0 else { continue }
+            let avg = value.totalMs / Double(value.count)
+            FileHandle.standardError.write(Data(
+                String(
+                    format: "NEMOTRON_LAYER_PROFILE label=%@ count=%d total_ms=%.3f avg_ms=%.3f\n",
+                    key, value.count, value.totalMs, avg
+                ).utf8))
+        }
+    }
 }
 
 // MARK: - Activations
@@ -731,9 +775,21 @@ internal class NemotronHMoE: Module, UnaryLayer, NemotronHMixer {
     }
 
     func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let profile = nemotronHLayerProfileEnabled()
+
+        let gateStart = profile ? CFAbsoluteTimeGetCurrent() : 0
         let (inds, scores) = gate(x)
+        if profile {
+            MLX.eval(inds, scores)
+            NemotronHLayerProfiler.shared.record("moe.gate", seconds: CFAbsoluteTimeGetCurrent() - gateStart)
+        }
         JangPressCanonicalExpertAdvisor.shared.observe(layer: layerIdx, indices: inds)
+        let fc1Start = profile ? CFAbsoluteTimeGetCurrent() : 0
         let expertInput = fc1LatentProj.map { $0(x) } ?? x
+        if profile {
+            MLX.eval(expertInput)
+            NemotronHLayerProfiler.shared.record("moe.fc1_latent", seconds: CFAbsoluteTimeGetCurrent() - fc1Start)
+        }
         // Dispatch through the type-erased protocol — both
         // `NemotronHSwitchMLP` (affine) and `NemotronHJANGTQSwitchMLP`
         // (TurboQuant) implement `callAsFunction(_:_:)`.
@@ -741,6 +797,7 @@ internal class NemotronHMoE: Module, UnaryLayer, NemotronHMixer {
             fatalError("NemotronHMoE.switch_mlp must conform to NemotronHSwitchMLPLayer (got \(type(of: switchMLP)))")
         }
         var y: MLXArray
+        let switchStart = profile ? CFAbsoluteTimeGetCurrent() : 0
         if nemotronHWeightedMoEFastPathEnabled(),
             let weighted = layer.weightedDecode(expertInput, inds, scores: scores)
         {
@@ -749,12 +806,26 @@ internal class NemotronHMoE: Module, UnaryLayer, NemotronHMixer {
             y = layer(expertInput, inds)
             y = (y * scores[.ellipsis, .newAxis]).sum(axis: -2).asType(y.dtype)
         }
+        if profile {
+            MLX.eval(y)
+            NemotronHLayerProfiler.shared.record("moe.switch_mlp", seconds: CFAbsoluteTimeGetCurrent() - switchStart)
+        }
         if let fc2LatentProj {
+            let fc2Start = profile ? CFAbsoluteTimeGetCurrent() : 0
             y = fc2LatentProj(y)
+            if profile {
+                MLX.eval(y)
+                NemotronHLayerProfiler.shared.record("moe.fc2_latent", seconds: CFAbsoluteTimeGetCurrent() - fc2Start)
+            }
         }
 
         if let sharedExperts {
+            let sharedStart = profile ? CFAbsoluteTimeGetCurrent() : 0
             y = y + sharedExperts(x)
+            if profile {
+                MLX.eval(y)
+                NemotronHLayerProfiler.shared.record("moe.shared", seconds: CFAbsoluteTimeGetCurrent() - sharedStart)
+            }
         }
 
         return y
@@ -815,18 +886,41 @@ internal class NemotronHBlock: Module {
         ssmMask: MLXArray?,
         cache: KVCache?
     ) -> MLXArray {
+        let profile = nemotronHLayerProfileEnabled()
+        let label = blockType.profileName
+
+        let normStart = profile ? CFAbsoluteTimeGetCurrent() : 0
         let hidden = norm(x)
+        if profile {
+            MLX.eval(hidden)
+            NemotronHLayerProfiler.shared.record("\(label).norm", seconds: CFAbsoluteTimeGetCurrent() - normStart)
+        }
 
         // Cast to protocol and call - all mixer types conform to NemotronHMixer
         let mixerFunc = mixer as! NemotronHMixer
+        let mixerStart = profile ? CFAbsoluteTimeGetCurrent() : 0
         let output = mixerFunc(hidden, attentionMask: attentionMask, ssmMask: ssmMask, cache: cache)
+        if profile {
+            MLX.eval(output)
+            NemotronHLayerProfiler.shared.record("\(label).mixer", seconds: CFAbsoluteTimeGetCurrent() - mixerStart)
+        }
 
+        let residualStart = profile ? CFAbsoluteTimeGetCurrent() : 0
         let residual = x + output
         if nemotronHActivationBF16RetentionEnabled(),
             (x.dtype == .bfloat16 || x.dtype == .float16),
             residual.dtype != x.dtype
         {
-            return residual.asType(x.dtype)
+            let casted = residual.asType(x.dtype)
+            if profile {
+                MLX.eval(casted)
+                NemotronHLayerProfiler.shared.record("\(label).residual", seconds: CFAbsoluteTimeGetCurrent() - residualStart)
+            }
+            return casted
+        }
+        if profile {
+            MLX.eval(residual)
+            NemotronHLayerProfiler.shared.record("\(label).residual", seconds: CFAbsoluteTimeGetCurrent() - residualStart)
         }
         return residual
     }
@@ -1011,6 +1105,10 @@ public class NemotronHModel: Module, LLMModel, KVCacheDimensionProvider, LoRAMod
         } else {
             out = backbone.embeddings.asLinear(out)
         }
+        if nemotronHLayerProfileEnabled() {
+            MLX.eval(out)
+            NemotronHLayerProfiler.shared.printSummary()
+        }
         return out
     }
 
@@ -1032,6 +1130,10 @@ public class NemotronHModel: Module, LLMModel, KVCacheDimensionProvider, LoRAMod
             out = lmHead(out)
         } else {
             out = backbone.embeddings.asLinear(out)
+        }
+        if nemotronHLayerProfileEnabled() {
+            MLX.eval(out)
+            NemotronHLayerProfiler.shared.printSummary()
         }
         return out
     }

--- a/README.md
+++ b/README.md
@@ -60,15 +60,16 @@ cache topology, and parser state attached.
 | Model | Runtime path | Evidence | Status |
 |---|---|---:|---|
 | Nemotron Ultra 550B A55B `JANGTQ_1L` | resident Swift decode | 8.1 tok/s | Proven with bundle generation defaults, coherent output, and no parser leak |
-| Nemotron Ultra 550B A55B `JANGTQ_1L` | low-footprint mmap decode | 5.3 tok/s | Coherent and cache-correct with auto BF16 non-TQ tensors, but speed-open |
+| Nemotron Ultra 550B A55B `JANGTQ_1L` | low-footprint mmap decode | 7.0 tok/s full-run, 9.8-9.9 tok/s tail | Coherent, cache-correct, low-footprint; first-decode cost remains speed-open |
 
 The resident Nemotron Ultra row confirms the documented 8 tok/s Swift decode
 class. It uses about 100 GB physical footprint and is not the same claim as the
-low-footprint mmap/JangPress path. The mmap path currently decodes at
-5.3 tok/s while staying under 2 GB physical footprint in the latest 64-token
-perf row. It proves hybrid SSM disk-backed prefix-cache restore, including SSM
-companion hits and cache-salt isolation, but it does not yet reach the
-8-10 tok/s target. See
+low-footprint mmap/JangPress path. The current mmap path decodes at about
+7.0 tok/s over the full short run while staying under 2 GB physical footprint
+in the latest current-main rows; excluding the first decode step, the tail
+estimate is about 9.8-9.9 tok/s. It proves hybrid SSM disk-backed prefix-cache
+restore, including SSM companion hits and cache-salt isolation, but the
+first-decode cost remains the open low-footprint speed gap. See
 [`docs/NEMOTRON_ULTRA_RUNTIME_STATUS_2026_06_06.md`](docs/NEMOTRON_ULTRA_RUNTIME_STATUS_2026_06_06.md)
 for the exact commands and artifacts.
 

--- a/RunBench/Bench.swift
+++ b/RunBench/Bench.swift
@@ -7383,6 +7383,16 @@ func runPerfBench(
                 genSec > 0 ? Double(genTokens) / genSec : 0
             }
 
+            var firstDecodeSecEstimate: Double {
+                max(0, ttftSec - promptSec)
+            }
+
+            var tailTokpsEstimate: Double {
+                guard genTokens > 1 else { return 0 }
+                let tailSec = genSec - firstDecodeSecEstimate
+                return tailSec > 0 ? Double(genTokens - 1) / tailSec : 0
+            }
+
             func promptTokensPerSecond(promptTokenCount: Int) -> Double {
                 promptSec > 0 ? Double(promptTokenCount) / promptSec : 0
             }
@@ -7613,12 +7623,14 @@ func runPerfBench(
                 let leaks = markerLeaks(in: result.text).joined(separator: ",")
                 let loop = lagunaLoopHeuristic(visible)
                 print(String(format:
-                    "  PERF_RUN label=%@ samplingSource=%@ seed=%@ ttft_ms=%.0f prompt_ms=%.0f prompt_tps=%.0f genTokens=%d genSec=%.3f tokps=%.1f rss_mib=%.0f footprint_mib=%.0f temp=%.2f topP=%.2f topK=%d minP=%.2f rep=%@ stop=%@ unclosedReasoning=%@ textChars=%d reasoningChars=%d toolCalls=%d loop=%@ leaks=%@",
+                    "  PERF_RUN label=%@ samplingSource=%@ seed=%@ ttft_ms=%.0f prompt_ms=%.0f prompt_tps=%.0f first_decode_ms=%.0f genTokens=%d genSec=%.3f tokps=%.1f tail_tokps_est=%.1f rss_mib=%.0f footprint_mib=%.0f temp=%.2f topP=%.2f topK=%d minP=%.2f rep=%@ stop=%@ unclosedReasoning=%@ textChars=%d reasoningChars=%d toolCalls=%d loop=%@ leaks=%@",
                     label, samplingSource, perfSeedLabel,
                     result.ttftSec * 1000,
                     result.promptSec * 1000,
                     result.promptTokensPerSecond(promptTokenCount: promptTokens.count),
+                    result.firstDecodeSecEstimate * 1000,
                     result.genTokens, result.genSec, result.tokps,
+                    result.tailTokpsEstimate,
                     result.rssMiB, result.footprintMiB,
                     Double(params.temperature), Double(params.topP),
                     params.topK, Double(params.minP),

--- a/Tests/MLXLMCommonFocusedTests/NemotronHJANGTQDispatchFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NemotronHJANGTQDispatchFocusedTests.swift
@@ -133,6 +133,8 @@ final class NemotronHJANGTQDispatchFocusedTests: XCTestCase {
 
         XCTAssertTrue(modelSource.contains("JANGTQ_DISABLE_NEMOTRON_ACTIVATION_BF16"))
         XCTAssertTrue(modelSource.contains("JANGTQ_DISABLE_NEMOTRON_WEIGHTED_MOE_FASTPATH"))
+        XCTAssertTrue(modelSource.contains("VMLINUX_NEMOTRON_LAYER_PROFILE"))
+        XCTAssertTrue(modelSource.contains("NEMOTRON_LAYER_PROFILE label=%@"))
         XCTAssertTrue(modelSource.contains("weightedDecode(expertInput, inds, scores: scores)"))
         XCTAssertTrue(modelSource.contains("residual.asType(x.dtype)"))
         XCTAssertTrue(modelSource.contains("out.asType(lmHead.weight.dtype)"))

--- a/docs/NEMOTRON_ULTRA_RUNTIME_STATUS_2026_06_06.md
+++ b/docs/NEMOTRON_ULTRA_RUNTIME_STATUS_2026_06_06.md
@@ -664,3 +664,93 @@ Interpretation:
 - The next real speed lane is regular stacked Nemotron MoE/Mamba graph and
   kernel work, not JangPress streaming, top-k reduction, prompt changes, or
   sampler changes.
+
+## Follow-Up Trace - 2026-06-06 19:35 PDT
+
+Rechecked current `vmlx-origin/main` after the scoped Nemotron merges and
+rejected two more non-fixes:
+
+- Compiled SwitchMLP reduced the graph only under an unsafe compile lane and
+  did not move default decode enough:
+  - control `/tmp/vmlx-nemotron-ultra-compiled-switch-control-20260606-185207.log`:
+    `6.9 tok/s`
+  - candidate `/tmp/vmlx-nemotron-ultra-compiled-switch-candidate-20260606-185231.log`:
+    `6.9 tok/s`
+  - unsafe diagnostic `/tmp/vmlx-nemotron-ultra-compiled-switch-unsafe-20260606-185308.log`:
+    `7.1 tok/s`
+- Explicit JangPress/streaming-expert mode is still rejected for the production
+  default:
+  `/tmp/vmlx-nemotron-ultra-explicit-streaming-diagnostic-20260606-185920.log`
+  reports about `0.7 tok/s`.
+- A scored-offset down-projection candidate was coherent but slower and was
+  reverted:
+  `/tmp/vmlx-nemotron-ultra-scored-offset-capital-20260606-191817.log`
+  reports `4.4 tok/s`.
+
+Fresh current-main low-footprint rows after the revert:
+
+- `/tmp/vmlx-nemotron-ultra-reverted-tq33-capital-20260606-192246.log`
+  - `tokps_median=7.0`
+  - `tail_tokps_est=9.9`
+  - `first_decode_ms=761`
+  - `peak_footprint_mib=1932`
+  - bundle defaults, coherent visible answer, no parser leak, no loop
+- `/tmp/vmlx-nemotron-ultra-reverted-graphstats-capital-20260606-192305.log`
+  - `decodeNodes=4799`
+  - `asType=480`
+  - `tokps_median=6.6`
+  - `tail_tokps_est=19.8`
+  - visible answer: `Tokyo is the capital of Japan.`
+- `/tmp/vmlx-nemotron-ultra-warmup-tq33-capital-20260606-192411.log`
+  - warmup did not remove the first-decode cost:
+    `tokps_median=7.0`, `tail_tokps_est=9.9`, `first_decode_ms=765`
+- `/tmp/vmlx-nemotron-ultra-batch-tq33-capital-20260606-192442.log`
+  - BatchEngine path matches the iterator path:
+    `tokps_median=7.0`, `tail_tokps_est=9.8`, `first_decode_ms=759`
+
+Python comparison from the same local model:
+
+- `/tmp/nemotron-ultra-python-live-short-20260606-190521.json`
+  - math: `8.808 tok/s` excluding first decode
+  - capital: `8.684 tok/s` excluding first decode
+
+Interpretation:
+
+- Swift low-footprint sustained/tail decode is now in the same `8-10 tok/s`
+  class as the Python documentation when compared on the same exclude-first
+  basis.
+- Full-run short prompts remain around `7 tok/s` because the first decode step
+  costs about `760 ms`.
+- Osaurus path selection is not the speed gap; BatchEngine and direct iterator
+  rows are equivalent.
+- The remaining work is model-forward dispatch in Nemotron-H MoE/Mamba, not
+  sampler, template, tool parser, reasoning parser, top-k reduction, attention,
+  or JangPress streaming.
+
+Added current diagnostic instrumentation:
+
+- `RunBench` now prints `first_decode_ms` and `tail_tokps_est` in `PERF_RUN`
+  rows so the resident/mmap/Python comparison is not hidden by the first-decode
+  cost.
+- `VMLINUX_NEMOTRON_LAYER_PROFILE=1` enables an explicit diagnostic profiler
+  for Nemotron-H block and MoE subcomponent timings. The flag is default-off and
+  inserts synchronization only when enabled.
+
+Diagnostic profiler rows:
+
+- `/tmp/vmlx-nemotron-ultra-layer-profile-20260606-192922.log`
+  shows decode-token work dominated by Mamba and MoE mixers, with attention
+  around `9-10 ms`.
+- `/tmp/vmlx-nemotron-ultra-moe-subprofile-20260606-193036.log`
+  shows MoE work split mainly across `moe.switch_mlp`, `moe.shared`, gate, and
+  latent projections.
+
+Focused verification:
+
+```sh
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
+  xcrun swift test --filter NemotronHJANGTQDispatchFocusedTests \
+  --jobs 1 --no-parallel
+```
+
+Result: passed, 11 tests.


### PR DESCRIPTION
## Summary

- Add default-off Nemotron-H layer/MoE profiling behind `VMLINUX_NEMOTRON_LAYER_PROFILE=1`.
- Add `first_decode_ms` and `tail_tokps_est` to `RunBench` `PERF_RUN` output.
- Refresh Nemotron Ultra runtime docs with the current-main low-footprint rows: about 7.0 tok/s full short run, 9.8-9.9 tok/s tail, with first-decode cost still open.

## Validation

- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter NemotronHJANGTQDispatchFocusedTests --jobs 1 --no-parallel`
  - `/tmp/vmlx-nemotron-dispatch-focused-final-20260606-193632.log`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift build --product RunBench --jobs 1`
  - `/tmp/vmlx-nemotron-runbench-final-20260606-193652.log`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift build -c release --product RunBench --jobs 1`
  - `/tmp/vmlx-nemotron-runbench-release-final-20260606-193728.log`

## Current Nemotron Ultra interpretation

- Current low-footprint mmap rows are coherent, use bundle defaults, and stay under the low-footprint gate.
- Full short-run Swift decode is about 7.0 tok/s because the first decode step costs about 760 ms.
- Tail/exclude-first Swift decode is about 9.8-9.9 tok/s, matching the Python documentation comparison basis.
- Explicit JangPress/streaming-expert mode and the scored-offset down-projection candidate remain rejected for the default path.
