### PR TITLE
Fix streamed tool parser regressions

### DIFF
--- a/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
@@ -1344,6 +1344,13 @@ public class ToolCallProcessor {
 
     private func shouldBufferPotentialBareToolMarker(_ text: String) -> Bool {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty,
+            Self.requestToolXMLPrefixes.contains(where: {
+                $0.hasPrefix(trimmed) && trimmed.count < $0.count
+            })
+        {
+            return true
+        }
         if !trimmed.isEmpty {
             for name in inlineFunctionToolNames() {
                 if name.hasPrefix(trimmed) { return true }

--- a/Tests/MLXLMCommonFocusedTests/Gemma4ZyphraToolParserFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/Gemma4ZyphraToolParserFocusedTests.swift
@@ -107,7 +107,7 @@ struct Gemma4ZyphraToolParserFocusedTests {
         )
 
         #expect(call.function.name == "line_count")
-        #expect(call.function.arguments["text"] == .string("one\\ntwo"))
+        #expect(call.function.arguments["text"] == .string("one\ntwo"))
     }
 
     private func lineCountToolSpec() -> [String: any Sendable] {


### PR DESCRIPTION
Summary\n- Buffer streamed DSV4 request_tool XML prefixes before they leak into visible text.\n- Align Gemma4 native tool-call fixture with parser behavior that decodes escaped string values.\n\nValidation\n- git diff --check\n- xcrun swift test --filter DSMLToolCallParserFocusedTests --jobs 1 --no-parallel\n- xcrun swift test --filter Gemma4ZyphraToolParserFocusedTests --jobs 1 --no-parallel\n\nNotes\n- Clean-main broader focused slices compiled after submodule init, but GPU-backed suites in the temp worktree stop on missing default.metallib; parser-only regressions above are fixed and rerun green.