### PR TITLE
Fix hybrid SSM companion rederive boundaries

### DIFF
--- a/Libraries/MLXLMCommon/Cache/SSMCompanionDiskStore.swift
+++ b/Libraries/MLXLMCommon/Cache/SSMCompanionDiskStore.swift
@@ -20,8 +20,9 @@
 //   <cacheDir>/ssm-<sha>.safetensors    — N MLX arrays keyed `state_0`…`state_N-1`
 //   <cacheDir>/ssm-<sha>.json           — metadata { is_complete, num_states, model_key }
 //
-// Cache key derivation matches the in-memory `SSMStateCache`:
-//   key = SHA-256( modelKey + ":" + tokens[..<boundary].joined(",") )
+// Cache key derivation delegates to the in-memory `SSMStateCache.makeKey`
+// implementation so model key and media salt isolation cannot drift between
+// memory and disk companion caches.
 //
 // Concurrency: store/fetch/clear are serialized with an
 // `OSAllocatedUnfairLock`, and MLX safetensors IO also takes

--- a/Libraries/MLXLMCommon/Cache/SSMReDerive.swift
+++ b/Libraries/MLXLMCommon/Cache/SSMReDerive.swift
@@ -143,75 +143,15 @@ public func maybeReDeriveSSMState(
     let stripped = Array(promptTokenIds.prefix(promptTokenIds.count - genPromptLen))
     guard !stripped.isEmpty else { log("skip/empty-stripped"); return }
 
-    do {
-        let blockBoundary = hybridBlockDiskBoundary(
-            coordinator: coordinator,
-            strippedTokenCount: stripped.count)
-
-        if let blockBoundary {
-            let statesByBoundary = try reDeriveSSMStatesAtBoundaries(
-                model: model,
-                tokens: stripped,
-                boundaries: [blockBoundary, stripped.count])
-            guard let exactStates = statesByBoundary[stripped.count],
-                  !exactStates.isEmpty
-            else { log("skip/no-ssm-states"); return }
-            var storedBlockBoundary = false
-            if let blockStates = statesByBoundary[blockBoundary],
-               !blockStates.isEmpty
-            {
-                coordinator.ssmStateCache.store(
-                    ssmStates: blockStates,
-                    tokens: stripped,
-                    boundary: blockBoundary
-                )
-                storedBlockBoundary = true
-            }
-            coordinator.ssmStateCache.store(
-                ssmStates: exactStates,
-                tokens: stripped,
-                boundary: stripped.count
-            )
-            log("ok/stored stateCount=\(exactStates.count) blockBoundary=\(blockBoundary) blockStored=\(storedBlockBoundary)")
-        } else {
-            guard let states = try reDeriveSSMStates(
-                model: model, tokens: stripped
-            ) else { log("skip/no-ssm-states"); return }
-            coordinator.ssmStateCache.store(
-                ssmStates: states,
-                tokens: stripped,
-                boundary: stripped.count
-            )
-            log("ok/stored stateCount=\(states.count)")
-        }
-        // Surface the re-derive event as a stats counter so
-        // users watching the CachePanel can see "hybrid SSM helper
-        // watcher" activity instead of wondering whether it ever ran.
-        coordinator.ssmStateCache.markReDeriveFired()
-    } catch {
-        // Best-effort. A failed re-derive just means the next turn
-        // re-prefills normally — no worse than the pre-2026-04-14
-        // contamination-skip behavior. Log the specific error so
-        // operators can see if this is a recurring failure mode on
-        // their platform/model combo.
-        log("fail/\(error)")
+    let states = reDeriveAndStoreSSMStatesForPromptBoundaries(
+        coordinator: coordinator,
+        model: model,
+        promptTokenIds: stripped)
+    guard let states, !states.isEmpty else {
+        log("skip/no-ssm-states")
+        return
     }
-}
-
-/// Largest BlockDisk boundary that can actually be restored on a later
-/// partial-prefix hit. BlockDisk persists full paged blocks only; hybrid SSM
-/// must have a companion snapshot at the same boundary or the KV restore is
-/// rejected for correctness.
-private func hybridBlockDiskBoundary(
-    coordinator: CacheCoordinator,
-    strippedTokenCount: Int
-) -> Int? {
-    // Block-level disk cache is not wired in this package yet. Keep the
-    // helper as the single integration point so the re-derive path can
-    // add block-boundary snapshots when that tier lands.
-    _ = coordinator
-    _ = strippedTokenCount
-    return nil
+    log("ok/stored stateCount=\(states.count) boundaryMode=prompt-and-paged-blocks")
 }
 
 /// §440 — capture-during-prefill (Python #109 native port). When the

--- a/Tests/MLXLMCommonFocusedTests/CacheCoordinatorTopologyFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/CacheCoordinatorTopologyFocusedTests.swift
@@ -276,6 +276,33 @@ struct CacheCoordinatorTopologyFocusedTests {
         }
     }
 
+    @Test("hybrid disk hit rejects legacy KV-only payload without companion state")
+    func hybridDiskHitRejectsLegacyKVOnlyPayloadWithoutSSMCompanion() {
+        FocusedMLXTestSupport.withLock {
+        let tmp = makeTempDir("hybrid-disk-legacy-kv-only")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let coordinator = makeCoordinator(
+            usePagedCache: false,
+            enableDiskCache: true,
+            diskCacheDir: tmp,
+            modelKey: "nemotron-ultra-hybrid-legacy-kv-only")
+        coordinator.setHybrid(true)
+        let tokens = [91, 92, 93, 94, 95]
+
+        coordinator.storeAfterGeneration(
+            promptTokens: tokens,
+            perLayerData: fakeLayerData(tokenCount: tokens.count),
+            ssmStates: nil)
+
+        if case .hit = coordinator.fetch(tokens: tokens + [96]) {
+            Issue.record(
+                "Nemotron-style hybrid disk cache must not accept legacy KV-only L2 payloads without complete SSM companion state")
+        }
+        #expect(coordinator.ssmStateCache.snapshotStats().hits == 0)
+        #expect(coordinator.ssmStateCache.snapshotStats().misses > 0)
+        }
+    }
+
     @Test("DSV4 paged-incompatible cache skips paged blocks and restores CSA HSA pools from disk")
     func dsv4PagedIncompatibleUsesDiskWithPools() {
         FocusedMLXTestSupport.withLock {
@@ -482,6 +509,38 @@ struct CacheCoordinatorTopologyFocusedTests {
                 tokens: tokens,
                 boundary: tokens.count,
                 modelKey: reasoningOn))
+    }
+
+    @Test("SSM companion disk key stays identical to memory key with model and media salt")
+    func ssmCompanionDiskKeyMatchesMemoryKeyWithModelAndMediaSalt() {
+        let tokens = [111, 112, 113, 114, 115]
+        let modelKey = "nemotron-ultra|reasoning=deepseek_r1|tools=nemotron|kv=tq3x3"
+        let mediaSalt = "text-only|no-media-processors"
+
+        let memoryKey = SSMStateCache.makeKey(
+            tokens: tokens,
+            boundary: 4,
+            mediaSalt: mediaSalt,
+            modelKey: modelKey)
+        let diskKey = SSMCompanionDiskStore.keyFor(
+            tokens: tokens,
+            boundary: 4,
+            mediaSalt: mediaSalt,
+            modelKey: modelKey)
+
+        #expect(diskKey == memoryKey)
+        #expect(
+            SSMCompanionDiskStore.keyFor(
+                tokens: tokens,
+                boundary: 4,
+                mediaSalt: "text-only|different-policy",
+                modelKey: modelKey) != diskKey)
+        #expect(
+            SSMCompanionDiskStore.keyFor(
+                tokens: tokens,
+                boundary: 4,
+                mediaSalt: mediaSalt,
+                modelKey: "other-model") != diskKey)
     }
 
     @Test("cache scope salt includes semantic reasoning and tool-choice keys")

--- a/Tests/MLXLMTests/SSMReDeriveParityTests.swift
+++ b/Tests/MLXLMTests/SSMReDeriveParityTests.swift
@@ -119,6 +119,50 @@ final class SSMReDeriveParityTests: XCTestCase {
         XCTAssertEqual(coordinator.ssmStateCache.reDerives, 1)
     }
 
+    func testLegacyMaybeRederiveWrapperStoresPagedBlockAndExactBoundaries() throws {
+        let model = TinyHybridSSMModel()
+        let promptOnly = [3, 5, 7, 11, 13]
+        let generationPrompt = [101, 102]
+        let fullPrompt = promptOnly + generationPrompt
+
+        let coordinator = CacheCoordinator(config: CacheCoordinatorConfig(
+            usePagedCache: true,
+            enableDiskCache: false,
+            pagedBlockSize: 2,
+            modelKey: "tiny-hybrid|legacy-wrapper"))
+        coordinator.setHybrid(true)
+
+        maybeReDeriveSSMState(
+            coordinator: coordinator,
+            model: model,
+            promptTokenIds: fullPrompt,
+            genPromptLen: generationPrompt.count,
+            enableSSMReDerive: true)
+
+        let blockBoundary = 4
+        let blockStates = try XCTUnwrap(
+            coordinator.ssmStateCache.fetch(
+                tokens: promptOnly,
+                boundary: blockBoundary))
+        let exactStates = try XCTUnwrap(
+            coordinator.ssmStateCache.fetch(
+                tokens: promptOnly,
+                boundary: promptOnly.count))
+
+        let warmBlock = try warmPassStates(
+            model: model,
+            tokens: Array(promptOnly.prefix(blockBoundary)),
+            prefillStepSize: 2)
+        let warmExact = try warmPassStates(
+            model: model,
+            tokens: promptOnly,
+            prefillStepSize: 2)
+
+        assertStatesEqual(blockStates, warmBlock)
+        assertStatesEqual(exactStates, warmExact)
+        XCTAssertEqual(coordinator.ssmStateCache.reDerives, 1)
+    }
+
     func testExactSnapshotSSMStatesAvoidReDeriveWhenNoIntermediateBoundaryIsNeeded() throws {
         let model = TinyHybridSSMModel()
         let tokens = [3, 4, 5, 6, 7]

--- a/docs/NEMOTRON_ULTRA_RUNTIME_STATUS_2026_06_06.md
+++ b/docs/NEMOTRON_ULTRA_RUNTIME_STATUS_2026_06_06.md
@@ -754,3 +754,50 @@ DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
 ```
 
 Result: passed, 11 tests.
+
+## Follow-Up Trace - 2026-06-06 21:12 PDT
+
+Added a narrow hybrid SSM cache correctness fix from the clean main branch:
+
+- `maybeReDeriveSSMState` now delegates to
+  `reDeriveAndStoreSSMStatesForPromptBoundaries`, so the legacy wrapper stores
+  both paged-block and exact prompt SSM companion boundaries instead of only
+  relying on the exact-boundary path.
+- Removed the dead single-boundary helper that always returned `nil`.
+- Updated the SSM companion disk-cache comment to reflect the real
+  `SSMStateCache.makeKey` key path with model-key and media-salt isolation.
+- Added focused coverage that rejects legacy hybrid KV-only L2 payloads without
+  complete SSM companion state, proves disk and memory SSM companion keys stay
+  identical, and proves the legacy wrapper stores paged-block plus exact SSM
+  boundaries.
+
+No sampler, template, parser, reasoning, generation-config, quantized matmul,
+JANGTQ kernel, Gemma4, Qwen, Mistral, MiniMax, DSV4, or VLM runtime behavior was
+changed.
+
+Focused verification from `/private/tmp/vmlx-nemotron-ultra-clean-pr`:
+
+```sh
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
+  xcrun swift test \
+  --filter 'SSMReDeriveParityTests|CacheCoordinatorTopologyFocusedTests|NemotronHJANGTQDispatchFocusedTests|Gemma4VLMFocusedSourceContractsTests|MTPRuntimeFocusedTests|VMLXServerRuntimeSettingsTests/automaticRuntimeCachePolicyCoversDownloadedArchitectureFamilies' \
+  --jobs 1 --no-parallel
+```
+
+Result:
+
+- Build passed.
+- `git diff --check` passed.
+- `99` selected tests passed.
+- Coverage included:
+  - hybrid SSM paged/disk companion-state rejection and restore boundaries
+  - DSV4 disk-backed CSA/HSA pool restore
+  - ZAYA CCA companion-state disk restore and salt isolation
+  - Gemma4 mixed/full rotating cache topology and Gemma4 VLM source wiring
+  - Qwen MTP / Qwen3.5 recurrent-prefix runtime metadata
+  - Nemotron Ultra JANGTQ dispatch, parser/default source guards, and
+    48-Mamba / 12-attention cache topology
+  - downloaded-family automatic cache policy source coverage
+
+Current verdict is unchanged: this closes a cache-wrapper correctness gap, but
+does not claim a new heavy live model row or a new low-footprint speed result.


### PR DESCRIPTION
## Summary
- Route the legacy SSM rederive wrapper through the prompt/paged-boundary helper so hybrid models store both paged-block and exact prompt companion states.
- Reject legacy hybrid disk KV-only payloads without complete SSM companion state in focused coverage.
- Pin SSM companion disk-key parity with the in-memory key path, including model-key and media-salt isolation.
- Record the source/test result in the Nemotron Ultra runtime status note without claiming a new heavy live row.

## Validation
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter 'SSMReDeriveParityTests|CacheCoordinatorTopologyFocusedTests|NemotronHJANGTQDispatchFocusedTests|Gemma4VLMFocusedSourceContractsTests|MTPRuntimeFocusedTests|VMLXServerRuntimeSettingsTests/automaticRuntimeCachePolicyCoversDownloadedArchitectureFamilies' --jobs 1 --no-parallel`
  - Build passed.
  - 99 selected tests passed.

## Notes
- No sampler, template, parser, reasoning, generation-config, quantized matmul, JANGTQ kernel, Gemma4, Qwen, Mistral, MiniMax, DSV4, or VLM runtime behavior changed.
- This closes a hybrid SSM cache-wrapper correctness gap. It does not claim a new heavy live model row or a new low-footprint speed result.
