### PR TITLE
Harden LFM required-tool cache restore and parser validation

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -810,7 +810,18 @@ public actor BatchEngine {
     }
 
     private func shouldSkipDiskBackedToolPromptSeedBoundary(for slot: BatchSlot) -> Bool {
-        guard slot.disablesGeneratedCacheBoundary else { return false }
+        shouldSkipDiskBackedToolPromptSeedBoundary(
+            toolSchemas: slot.originalInput.toolSchemas,
+            disablesGeneratedCacheBoundary: slot.disablesGeneratedCacheBoundary)
+    }
+
+    private func shouldSkipDiskBackedToolPromptSeedBoundary(
+        toolSchemas: [ToolSpec]?,
+        disablesGeneratedCacheBoundary: Bool
+    ) -> Bool {
+        guard disablesGeneratedCacheBoundary || toolSchemas?.isEmpty == false else {
+            return false
+        }
         let modelName = context.configuration.name.lowercased()
         if modelName.contains("lfm2.5") && modelName.contains("mxfp8") {
             return true
@@ -822,7 +833,18 @@ public actor BatchEngine {
     }
 
     private func shouldDisableDiskBackedRequiredToolRestore(for slot: BatchSlot) -> Bool {
-        guard slot.disablesGeneratedCacheBoundary else { return false }
+        shouldDisableDiskBackedRequiredToolRestore(
+            toolSchemas: slot.originalInput.toolSchemas,
+            disablesGeneratedCacheBoundary: slot.disablesGeneratedCacheBoundary)
+    }
+
+    private func shouldDisableDiskBackedRequiredToolRestore(
+        toolSchemas: [ToolSpec]?,
+        disablesGeneratedCacheBoundary: Bool
+    ) -> Bool {
+        guard disablesGeneratedCacheBoundary || toolSchemas?.isEmpty == false else {
+            return false
+        }
         let modelName = context.configuration.name.lowercased()
         return modelName.contains("lfm2.5") && modelName.contains("mxfp8")
     }
@@ -834,6 +856,9 @@ public actor BatchEngine {
     ) -> AsyncStream<Generation> {
         let promptTokenCount = input.text.tokens.size
         let toolSchemas = input.toolSchemas
+        let disableDiskBackedRequiredToolRestore = shouldDisableDiskBackedRequiredToolRestore(
+            toolSchemas: toolSchemas,
+            disablesGeneratedCacheBoundary: false)
         let fastPathID = UUID()
         var soloParameters = parameters
         soloParameters.extraStopStrings = mergeStopStrings(
@@ -885,7 +910,8 @@ public actor BatchEngine {
                     model: context.model,
                     cache: nil,
                     parameters: soloParameters,
-                    cacheCoordinator: cacheCoordinator)
+                    cacheCoordinator: cacheCoordinator,
+                    disableDiskBackedRequiredToolRestore: disableDiskBackedRequiredToolRestore)
                 (sourceStream, generationTask) = generateTask(
                     promptTokenCount: promptTokenCount,
                     modelConfiguration: context.configuration,

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1103,6 +1103,10 @@ public struct TokenIterator: TokenIteratorProtocol {
     // Multi-tier cache coordinator (skeleton integration)
     let cacheCoordinator: CacheCoordinator?
 
+    /// Caller-proven policy gate for required-tool rows whose disk-backed
+    /// warm restore can pollute prompt boundaries before tool selection.
+    let disableDiskBackedRequiredToolRestore: Bool
+
     /// Prompt token IDs captured at init for cache store after generation.
     public private(set) var promptTokenIds: [Int]
 
@@ -1176,6 +1180,7 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.kvMode = parameters.kvMode
 
         self.cacheCoordinator = nil
+        self.disableDiskBackedRequiredToolRestore = false
         self.promptTokenIds = []
         self.cachePrefixTokenCounts = []
         self.originalInput = LMInput(text: y)
@@ -1210,13 +1215,15 @@ public struct TokenIterator: TokenIteratorProtocol {
     public init(
         input: LMInput, model: any LanguageModel, cache: [KVCache]? = nil,
         parameters: GenerateParameters,
-        cacheCoordinator: CacheCoordinator? = nil
+        cacheCoordinator: CacheCoordinator? = nil,
+        disableDiskBackedRequiredToolRestore: Bool = false
     ) throws {
         _ = try AccelerationRuntime.resolveTextDecode(parameters.accelerationMode)
 
         self.model = model
         self.y = input.text
         self.cacheCoordinator = cacheCoordinator
+        self.disableDiskBackedRequiredToolRestore = disableDiskBackedRequiredToolRestore
         let promptTokenCount = input.text.tokens.size
         var effectiveParameters = parameters
         if let coordinator = cacheCoordinator {
@@ -1318,12 +1325,17 @@ public struct TokenIterator: TokenIteratorProtocol {
                 }
             }
             let requiresDiskBackedRestore = cacheRequiresDiskBackedCoordinatorRestore(self.cache)
-            let result = coordinator.fetch(
-                tokens: cacheLookupTokenIds,
-                mediaSalt: mediaSalt,
-                skipExactDiskBoundary: requiresDiskBackedRestore)
-            switch result {
-            case .hit(_, let remainingTokens, let detail, let blocks, let ssmStates, let diskArrays):
+            if requiresDiskBackedRestore && disableDiskBackedRequiredToolRestore {
+                Self.logger.info(
+                    "TokenIterator: skipped disk-backed required-tool cache restore; warm restore is not proven safe for this topology"
+                )
+            } else {
+                let result = coordinator.fetch(
+                    tokens: cacheLookupTokenIds,
+                    mediaSalt: mediaSalt,
+                    skipExactDiskBoundary: requiresDiskBackedRestore)
+                switch result {
+                case .hit(_, let remainingTokens, let detail, let blocks, let ssmStates, let diskArrays):
                 var restored = false
                 if !blocks.isEmpty {
                     let restoredTokens = restoreLayerData(from: blocks, into: self.cache)
@@ -1444,9 +1456,9 @@ public struct TokenIterator: TokenIteratorProtocol {
                         }
                     }
                 }
-            case .miss:
-                let count = cacheLookupTokenIds.count
-                Self.logger.debug("Cache miss for \(count) prompt tokens")
+                case .miss:
+                    let count = cacheLookupTokenIds.count
+                    Self.logger.debug("Cache miss for \(count) prompt tokens")
 
                 // 2026-05-05 (Ling-2.6-flash multi-turn fix): coordinator
                 // missed but the cache may already hold a previous turn's
@@ -1512,6 +1524,7 @@ public struct TokenIterator: TokenIteratorProtocol {
                         )
                     }
                 }
+                }
             }
         } else if cacheCoordinator != nil,
                   !promptTokenIds.isEmpty,
@@ -1570,6 +1583,7 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.kvMode = .none
 
         self.cacheCoordinator = nil
+        self.disableDiskBackedRequiredToolRestore = false
         self.promptTokenIds = []
         self.cachePrefixTokenCounts = input.cachePrefixTokenCounts
         self.originalInput = input

--- a/Libraries/MLXLMCommon/Tool/Parsers/PythonicToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/PythonicToolCallParser.swift
@@ -75,6 +75,9 @@ public struct PythonicToolCallParser: ToolCallParser, Sendable {
         }
 
         let arguments = parseArguments(argsString, funcName: funcName, tools: tools)
+        guard acceptsToolCall(name: funcName, arguments: arguments, tools: tools) else {
+            return nil
+        }
         return ToolCall(function: .init(name: funcName, arguments: arguments))
     }
 
@@ -134,6 +137,9 @@ public struct PythonicToolCallParser: ToolCallParser, Sendable {
             let funcName = String(text[nameRange])
             let argsString = String(text[argsRange])
             let arguments = parseArguments(argsString, funcName: funcName, tools: tools)
+            guard acceptsToolCall(name: funcName, arguments: arguments, tools: tools) else {
+                continue
+            }
             results.append(ToolCall(function: .init(name: funcName, arguments: arguments)))
         }
         return results
@@ -225,6 +231,24 @@ public struct PythonicToolCallParser: ToolCallParser, Sendable {
             return required
         }
         return []
+    }
+
+    private func acceptsToolCall(
+        name: String,
+        arguments: [String: any Sendable],
+        tools: [[String: any Sendable]]?
+    ) -> Bool {
+        guard let tools, !tools.isEmpty else { return true }
+        guard toolNames(tools: tools).contains(name) else { return false }
+
+        let spec = toolSpec(named: name, tools: tools)
+        if let required = spec.required, !required.isEmpty {
+            guard required.allSatisfy({ arguments[$0] != nil }) else { return false }
+        }
+        if let properties = spec.properties, !properties.isEmpty {
+            guard arguments.keys.allSatisfy({ properties.contains($0) }) else { return false }
+        }
+        return true
     }
 
     private func parseToolKeyedJSONEnvelope(

--- a/Tests/MLXLMCommonFocusedTests/CacheCoordinatorTopologyFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/CacheCoordinatorTopologyFocusedTests.swift
@@ -589,20 +589,27 @@ struct CacheCoordinatorTopologyFocusedTests {
 
     @Test("Known unsafe required-tool rows skip disk-backed prompt seed boundary")
     func knownUnsafeRequiredToolRowsSkipDiskBackedPromptSeedBoundary() throws {
-        let source = try String(
+        let batchSource = try String(
             contentsOfFile: "Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift",
             encoding: .utf8)
+        let evaluateSource = try String(
+            contentsOfFile: "Libraries/MLXLMCommon/Evaluate.swift",
+            encoding: .utf8)
 
-        #expect(source.contains("shouldSkipDiskBackedToolPromptSeedBoundary"))
-        #expect(source.contains("slot.disablesGeneratedCacheBoundary"))
-        #expect(source.contains(#"modelName.contains("lfm2.5")"#))
-        #expect(source.contains(#"modelName.contains("mxfp8")"#))
-        #expect(source.contains(#"modelName.contains("gemma-4")"#))
-        #expect(source.contains(#"modelName.contains("mxfp4")"#))
-        #expect(source.contains("!shouldSkipDiskBackedToolPromptSeedBoundary(for: slot)"))
-        #expect(source.contains("shouldDisableDiskBackedRequiredToolRestore"))
-        #expect(source.contains("Skipped disk-backed required-tool cache restore"))
-        #expect(source.contains("Skipped disk-backed tool prompt seed boundary"))
+        #expect(batchSource.contains("shouldSkipDiskBackedToolPromptSeedBoundary"))
+        #expect(batchSource.contains("slot.disablesGeneratedCacheBoundary"))
+        #expect(batchSource.contains(#"modelName.contains("lfm2.5")"#))
+        #expect(batchSource.contains(#"modelName.contains("mxfp8")"#))
+        #expect(batchSource.contains(#"modelName.contains("gemma-4")"#))
+        #expect(batchSource.contains(#"modelName.contains("mxfp4")"#))
+        #expect(batchSource.contains("!shouldSkipDiskBackedToolPromptSeedBoundary(for: slot)"))
+        #expect(batchSource.contains("shouldDisableDiskBackedRequiredToolRestore"))
+        #expect(batchSource.contains("disableDiskBackedRequiredToolRestore: disableDiskBackedRequiredToolRestore"))
+        #expect(batchSource.contains("Skipped disk-backed required-tool cache restore"))
+        #expect(batchSource.contains("Skipped disk-backed tool prompt seed boundary"))
+        #expect(evaluateSource.contains("disableDiskBackedRequiredToolRestore"))
+        #expect(evaluateSource.contains("TokenIterator: skipped disk-backed required-tool cache restore"))
+        #expect(evaluateSource.contains("requiresDiskBackedRestore && disableDiskBackedRequiredToolRestore"))
     }
 
     @Test("KV policy changes dynamic cache salt")

--- a/Tests/MLXLMTests/ToolTests.swift
+++ b/Tests/MLXLMTests/ToolTests.swift
@@ -525,6 +525,24 @@ struct ToolTests {
         #expect(call.function.arguments["text"] == .string("one\ntwo"))
     }
 
+    @Test("LFM2 parser rejects native pythonic calls outside supplied tool schema")
+    func lfm2ParserRejectsNativePythonicCallsOutsideSuppliedToolSchema() {
+        let tools = lineCountTools()
+        let parser = LFM2ToolCallParser()
+
+        #expect(parser.parse(
+            content: #"<|tool_call_start|>[break()]<|tool_call_end|>"#,
+            tools: tools) == nil)
+        #expect(parser.parseEOS(
+            #"<|tool_call_start|>[break()]<|tool_call_end|>"#,
+            tools: tools).isEmpty)
+
+        let processor = ToolCallProcessor(format: .lfm2, tools: tools)
+        #expect(processor.processChunk(#"<|tool_call_start|>[break()]<|tool_call_end|>"#) == nil)
+        #expect(processor.processEOS() == nil)
+        #expect(processor.toolCalls.isEmpty)
+    }
+
     @Test("LFM2 parser does not coerce plain code fence into a tool call")
     func lfm2ParserDoesNotCoercePlainCodeFenceIntoToolCall() {
         let processor = ToolCallProcessor(format: .lfm2, tools: lineCountTools())


### PR DESCRIPTION
## Summary
- skip disk-backed restore for the known unsafe LFM2.5 MXFP8 required-tool solo path before decode
- validate Pythonic/LFM tool calls against supplied tool schemas so unregistered names or missing/unknown args are rejected
- add focused coverage for the cache-boundary policy and schema-gated Pythonic parser behavior

## Verification
- env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter lfm2ParserRejectsNativePythonicCallsOutsideSuppliedToolSchema --jobs 1 --no-parallel
- env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter knownUnsafeRequiredToolRowsSkipDiskBackedPromptSeedBoundary --jobs 1 --no-parallel

## Runtime boundary
Osaurus live proof against this SHA has a passing cold LFM2.5 MXFP8 row and one warm row with disk/SSM companion cache hits, but repeat warm required-tool behavior remains partial. This PR should not be described as full LFM2.5 MXFP8 release readiness.