### PR TITLE
Add Osaurus memory safety settings contract

### DIFF
--- a/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
+++ b/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
@@ -19,6 +19,7 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
     public var tools: VMLXServerToolSettings
     public var multimodal: VMLXServerMultimodalSettings
     public var mtp: VMLXServerMTPSettings
+    public var memorySafety: VMLXMemorySafetySettings
 
     public init(
         network: VMLXServerNetworkSettings = .init(),
@@ -28,7 +29,8 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
         generation: VMLXServerGenerationDefaults = .init(),
         tools: VMLXServerToolSettings = .init(),
         multimodal: VMLXServerMultimodalSettings = .init(),
-        mtp: VMLXServerMTPSettings = .init()
+        mtp: VMLXServerMTPSettings = .init(),
+        memorySafety: VMLXMemorySafetySettings = .init()
     ) {
         self.network = network
         self.concurrency = concurrency
@@ -38,6 +40,7 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
         self.tools = tools
         self.multimodal = multimodal
         self.mtp = mtp
+        self.memorySafety = memorySafety
     }
 
     public func validationIssues(
@@ -274,6 +277,7 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
                     message: "MTP force-on was requested without a bundle status snapshot."))
             }
         }
+        issues.append(contentsOf: memorySafety.validationIssues())
 
         return issues
     }
@@ -425,6 +429,122 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
             jangConfig: jangConfig,
             status: status).launchMode == .speculative
         return resolved
+    }
+
+    /// Resolve the single memory-safety slider into concrete engine knobs.
+    ///
+    /// This helper is intentionally policy-only. It does not inspect Activity
+    /// Monitor free memory, does not alter generation defaults, and does not
+    /// hide runtime bugs with sampler/template changes. Strict modes may return
+    /// typed blocking issues before load/request execution; non-strict modes
+    /// return warnings so hosts can show the risk while still allowing an
+    /// explicit user launch.
+    public func resolvedMemorySafetyPlan(
+        baseLoadConfiguration: LoadConfiguration = .default,
+        bundleFacts: LoadBundleFacts? = nil,
+        host: MemoryStatus? = nil,
+        request: VMLXMemoryRequestEstimate? = nil
+    ) -> VMLXResolvedMemorySafetyPlan {
+        let profile = memorySafety.profile
+        let physicalMemory = host?.physicalMemory
+            ?? bundleFacts?.physicalMemory
+            ?? ProcessInfo.processInfo.physicalMemory
+        let requestedFraction = memorySafety.customPhysicalMemoryFraction
+            ?? profile.loadFraction
+        let loadCap = ResidentCap.fraction(requestedFraction)
+        let allocatorCap = memorySafety.customAllocatorCacheBytes.map(ResidentCap.absolute)
+            ?? profile.allocatorCap
+
+        var loadConfiguration = baseLoadConfiguration
+        loadConfiguration.memoryLimit = loadCap
+        loadConfiguration.maxResidentBytes = allocatorCap
+        loadConfiguration.useMmapSafetensors = true
+        loadConfiguration.jangPress = resolvedMemorySafetyJangPress(
+            base: baseLoadConfiguration.jangPress,
+            facts: bundleFacts)
+
+        var resolvedConcurrency = concurrency
+        resolvedConcurrency.maxConcurrentSequences =
+            memorySafety.customMaxConcurrentSequences
+            ?? resolvedConcurrency.maxConcurrentSequences
+            ?? profile.maxConcurrentSequences
+
+        var resolvedCache = cache
+        resolvedCache.prefix.enabled = true
+        resolvedCache.pagedKV.enabled = true
+        resolvedCache.blockDisk.enabled = true
+        resolvedCache.legacyDisk.enabled = false
+        if resolvedCache.prefix.memoryLimitMB == nil {
+            resolvedCache.prefix.memoryLimitMB = profile.prefixMemoryLimitMB
+        }
+        if resolvedCache.prefix.memoryPercent == nil {
+            resolvedCache.prefix.memoryPercent = profile.prefixMemoryPercent
+        }
+        resolvedCache.defaultMaxKVSize =
+            memorySafety.customDefaultMaxKVSize
+            ?? resolvedCache.defaultMaxKVSize
+            ?? profile.defaultMaxKVSize
+
+        var warnings = profile.warnings
+        var blockingIssues: [VMLXServerSettingsIssue] = []
+
+        if case .diagnosticDangerous = memorySafety.mode {
+            warnings.append("Diagnostic memory mode uses caller-supplied limits and may exceed the host working set.")
+        }
+        if !memorySafety.allowExperimentalMLXPress,
+           baseLoadConfiguration.jangPress != .disabled {
+            warnings.append("MLXPress/JangPress was not selected by the memory slider. It remains disabled unless the host enables a proven routed-bundle lane explicitly.")
+        }
+
+        let resolvedBudgetBytes = loadCap.resolve(physicalMemory: physicalMemory)
+        if let estimate = request {
+            if estimate.workingSetBytes == nil,
+               memorySafety.failClosedWhenEstimateUnknown || profile.failClosedWhenEstimateUnknown {
+                blockingIssues.append(.error(
+                    field: "memorySafety.requestEstimate",
+                    message: "Strict memory safety requires a request working-set estimate before launch."))
+            }
+            if let budget = resolvedBudgetBytes,
+               let estimateBytes = estimate.workingSetBytes,
+               estimateBytes > budget {
+                let message = "Estimated request working set \(estimateBytes) bytes exceeds resolved memory budget \(budget) bytes."
+                if profile.blocksOverBudget {
+                    blockingIssues.append(.error(
+                        field: "memorySafety.requestEstimate",
+                        message: message))
+                } else {
+                    warnings.append(message)
+                }
+            }
+        }
+
+        let displaySummary = "mode=\(memorySafety.mode.rawValue) slider=\(memorySafety.slider) load_cap=\(requestedFraction) allocator_cap=\(allocatorCap.displayValue) max_concurrent=\(resolvedConcurrency.maxConcurrentSequences ?? 0) kv_cap=\(resolvedCache.defaultMaxKVSize ?? 0)"
+
+        return VMLXResolvedMemorySafetyPlan(
+            loadConfiguration: loadConfiguration,
+            cache: resolvedCache,
+            concurrency: resolvedConcurrency,
+            resolvedPhysicalMemoryBytes: physicalMemory,
+            resolvedLoadBudgetBytes: resolvedBudgetBytes,
+            warnings: warnings,
+            blockingIssues: blockingIssues,
+            displaySummary: displaySummary)
+    }
+
+    private func resolvedMemorySafetyJangPress(
+        base: JangPressPolicy,
+        facts: LoadBundleFacts?
+    ) -> JangPressPolicy {
+        guard memorySafety.allowExperimentalMLXPress else {
+            return .disabled
+        }
+        guard let facts,
+              facts.isRouted,
+              facts.hasJangConfig || facts.hasJangTQRuntime
+        else {
+            return .disabled
+        }
+        return base
     }
 
     /// Apply explicit server-panel parser overrides to a model configuration.
@@ -985,6 +1105,199 @@ public struct VMLXResolvedMTPLaunch: Codable, Sendable, Equatable {
     }
 }
 
+public enum VMLXMemorySafetyMode: String, Codable, Sendable, Equatable, CaseIterable {
+    case performance
+    case balanced
+    case safeAuto = "safe_auto"
+    case strict
+    case diagnosticDangerous = "diagnostic_dangerous"
+}
+
+public struct VMLXMemorySafetySettings: Codable, Sendable, Equatable {
+    public var mode: VMLXMemorySafetyMode
+    public var slider: Int
+    public var allowExperimentalMLXPress: Bool
+    public var failClosedWhenEstimateUnknown: Bool
+    public var customPhysicalMemoryFraction: Double?
+    public var customAllocatorCacheBytes: UInt64?
+    public var customDefaultMaxKVSize: Int?
+    public var customMaxConcurrentSequences: Int?
+
+    public init(
+        mode: VMLXMemorySafetyMode = .safeAuto,
+        slider: Int = 2,
+        allowExperimentalMLXPress: Bool = false,
+        failClosedWhenEstimateUnknown: Bool = false,
+        customPhysicalMemoryFraction: Double? = nil,
+        customAllocatorCacheBytes: UInt64? = nil,
+        customDefaultMaxKVSize: Int? = nil,
+        customMaxConcurrentSequences: Int? = nil
+    ) {
+        self.mode = mode
+        self.slider = slider
+        self.allowExperimentalMLXPress = allowExperimentalMLXPress
+        self.failClosedWhenEstimateUnknown = failClosedWhenEstimateUnknown
+        self.customPhysicalMemoryFraction = customPhysicalMemoryFraction
+        self.customAllocatorCacheBytes = customAllocatorCacheBytes
+        self.customDefaultMaxKVSize = customDefaultMaxKVSize
+        self.customMaxConcurrentSequences = customMaxConcurrentSequences
+    }
+
+    public func validationIssues() -> [VMLXServerSettingsIssue] {
+        var issues: [VMLXServerSettingsIssue] = []
+        if !(0...4).contains(slider) {
+            issues.append(.error(
+                field: "memorySafety.slider",
+                message: "Memory safety slider must be between 0 and 4."))
+        }
+        if let fraction = customPhysicalMemoryFraction,
+           fraction <= 0 || fraction > 1 {
+            issues.append(.error(
+                field: "memorySafety.customPhysicalMemoryFraction",
+                message: "Custom physical-memory fraction must be greater than 0 and at most 1."))
+        }
+        if let bytes = customAllocatorCacheBytes, bytes == 0 {
+            issues.append(.error(
+                field: "memorySafety.customAllocatorCacheBytes",
+                message: "Custom allocator cache bytes must be positive."))
+        }
+        if let kv = customDefaultMaxKVSize, kv <= 0 {
+            issues.append(.error(
+                field: "memorySafety.customDefaultMaxKVSize",
+                message: "Custom max KV size must be positive."))
+        }
+        if let maxConcurrent = customMaxConcurrentSequences, maxConcurrent <= 0 {
+            issues.append(.error(
+                field: "memorySafety.customMaxConcurrentSequences",
+                message: "Custom max concurrent sequences must be positive."))
+        }
+        return issues
+    }
+
+    fileprivate var profile: VMLXMemorySafetyProfile {
+        switch mode {
+        case .performance:
+            return .init(
+                loadFraction: customPhysicalMemoryFraction ?? 0.90,
+                allocatorCap: customAllocatorCacheBytes.map(ResidentCap.absolute) ?? .unlimited,
+                maxConcurrentSequences: customMaxConcurrentSequences ?? 2,
+                prefixMemoryLimitMB: nil,
+                prefixMemoryPercent: 20,
+                defaultMaxKVSize: customDefaultMaxKVSize,
+                failClosedWhenEstimateUnknown: false,
+                blocksOverBudget: false,
+                warnings: ["Performance memory mode may allow macOS compression or swap before refusing a request."])
+        case .balanced:
+            return .init(
+                loadFraction: customPhysicalMemoryFraction ?? 0.75,
+                allocatorCap: customAllocatorCacheBytes.map(ResidentCap.absolute) ?? .absolute(1 << 30),
+                maxConcurrentSequences: customMaxConcurrentSequences ?? 2,
+                prefixMemoryLimitMB: 512,
+                prefixMemoryPercent: 15,
+                defaultMaxKVSize: customDefaultMaxKVSize ?? 8192,
+                failClosedWhenEstimateUnknown: false,
+                blocksOverBudget: false,
+                warnings: [])
+        case .safeAuto:
+            return .init(
+                loadFraction: customPhysicalMemoryFraction ?? 0.70,
+                allocatorCap: customAllocatorCacheBytes.map(ResidentCap.absolute) ?? .absolute(128 << 20),
+                maxConcurrentSequences: customMaxConcurrentSequences ?? 1,
+                prefixMemoryLimitMB: 128,
+                prefixMemoryPercent: 15,
+                defaultMaxKVSize: customDefaultMaxKVSize ?? 8192,
+                failClosedWhenEstimateUnknown: false,
+                blocksOverBudget: false,
+                warnings: [])
+        case .strict:
+            return .init(
+                loadFraction: customPhysicalMemoryFraction ?? 0.60,
+                allocatorCap: customAllocatorCacheBytes.map(ResidentCap.absolute) ?? .absolute(128 << 20),
+                maxConcurrentSequences: customMaxConcurrentSequences ?? 1,
+                prefixMemoryLimitMB: 128,
+                prefixMemoryPercent: 10,
+                defaultMaxKVSize: customDefaultMaxKVSize ?? 4096,
+                failClosedWhenEstimateUnknown: true,
+                blocksOverBudget: true,
+                warnings: [])
+        case .diagnosticDangerous:
+            return .init(
+                loadFraction: customPhysicalMemoryFraction ?? 1.0,
+                allocatorCap: customAllocatorCacheBytes.map(ResidentCap.absolute) ?? .unlimited,
+                maxConcurrentSequences: customMaxConcurrentSequences ?? 1,
+                prefixMemoryLimitMB: nil,
+                prefixMemoryPercent: nil,
+                defaultMaxKVSize: customDefaultMaxKVSize,
+                failClosedWhenEstimateUnknown: failClosedWhenEstimateUnknown,
+                blocksOverBudget: false,
+                warnings: [])
+        }
+    }
+}
+
+fileprivate struct VMLXMemorySafetyProfile: Sendable, Equatable {
+    var loadFraction: Double
+    var allocatorCap: ResidentCap
+    var maxConcurrentSequences: Int
+    var prefixMemoryLimitMB: Int?
+    var prefixMemoryPercent: Double?
+    var defaultMaxKVSize: Int?
+    var failClosedWhenEstimateUnknown: Bool
+    var blocksOverBudget: Bool
+    var warnings: [String]
+}
+
+public struct VMLXMemoryRequestEstimate: Sendable, Equatable {
+    public var workingSetBytes: UInt64?
+    public var promptTokens: Int?
+    public var maxNewTokens: Int?
+
+    public init(
+        workingSetBytes: UInt64? = nil,
+        promptTokens: Int? = nil,
+        maxNewTokens: Int? = nil
+    ) {
+        self.workingSetBytes = workingSetBytes
+        self.promptTokens = promptTokens
+        self.maxNewTokens = maxNewTokens
+    }
+}
+
+public struct VMLXResolvedMemorySafetyPlan: Sendable, Equatable {
+    public var loadConfiguration: LoadConfiguration
+    public var cache: VMLXServerCacheSettings
+    public var concurrency: VMLXServerConcurrencySettings
+    public var resolvedPhysicalMemoryBytes: UInt64
+    public var resolvedLoadBudgetBytes: UInt64?
+    public var warnings: [String]
+    public var blockingIssues: [VMLXServerSettingsIssue]
+    public var displaySummary: String
+
+    public init(
+        loadConfiguration: LoadConfiguration,
+        cache: VMLXServerCacheSettings,
+        concurrency: VMLXServerConcurrencySettings,
+        resolvedPhysicalMemoryBytes: UInt64,
+        resolvedLoadBudgetBytes: UInt64?,
+        warnings: [String],
+        blockingIssues: [VMLXServerSettingsIssue],
+        displaySummary: String
+    ) {
+        self.loadConfiguration = loadConfiguration
+        self.cache = cache
+        self.concurrency = concurrency
+        self.resolvedPhysicalMemoryBytes = resolvedPhysicalMemoryBytes
+        self.resolvedLoadBudgetBytes = resolvedLoadBudgetBytes
+        self.warnings = warnings
+        self.blockingIssues = blockingIssues
+        self.displaySummary = displaySummary
+    }
+
+    public var allowed: Bool {
+        blockingIssues.isEmpty
+    }
+}
+
 public struct VMLXServerSettingsIssue: Codable, Sendable, Equatable {
     public enum Severity: String, Codable, Sendable, Equatable {
         case warning
@@ -1007,5 +1320,18 @@ public struct VMLXServerSettingsIssue: Codable, Sendable, Equatable {
 
     public static func error(field: String, message: String) -> VMLXServerSettingsIssue {
         .init(severity: .error, field: field, message: message)
+    }
+}
+
+private extension ResidentCap {
+    var displayValue: String {
+        switch self {
+        case .unlimited:
+            return "unlimited"
+        case .fraction(let value):
+            return "fraction(\(value))"
+        case .absolute(let bytes):
+            return "absolute(\(bytes))"
+        }
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -791,6 +791,7 @@ let package = Package(
                 "MTPRuntimeFocusedTests.swift",
                 "MLXPressCLISourceContractsTests.swift",
                 "VMLXServerRuntimeSettingsTests.swift",
+                "VMLXMemorySafetySettingsTests.swift",
                 "DSV4AgenticToolSourceTests.swift",
                 "NoHiddenReasoningCloseBiasFocusedTests.swift",
                 "TokenizerAddedTokenRegexFocusedTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/VMLXMemorySafetySettingsTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/VMLXMemorySafetySettingsTests.swift
@@ -1,0 +1,192 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import MLXLMCommon
+import Testing
+
+@Suite("VMLX memory safety settings")
+struct VMLXMemorySafetySettingsTests {
+    @Test("defaults resolve Safe Auto without sampler changes")
+    func defaultsResolveSafeAutoWithoutSamplerChanges() {
+        let settings = VMLXServerRuntimeSettings()
+        let facts = LoadBundleFacts(
+            totalSafetensorsBytes: 12 << 30,
+            isRouted: false,
+            physicalMemory: 64 << 30,
+            modelType: "gemma4",
+            weightFormat: "mxfp4")
+
+        let plan = settings.resolvedMemorySafetyPlan(
+            baseLoadConfiguration: .osaurusProduction,
+            bundleFacts: facts,
+            request: VMLXMemoryRequestEstimate(
+                workingSetBytes: 20 << 30,
+                promptTokens: 4096,
+                maxNewTokens: 256))
+        let generate = settings.resolvedGenerateParameters(
+            generationConfig: GenerationConfigFile(
+                temperature: 0.7,
+                topP: 0.95,
+                topK: 64,
+                doSample: true),
+            fallback: GenerateParameters(
+                maxTokens: 128,
+                temperature: 0.2,
+                topP: 1.0,
+                topK: 0,
+                repetitionPenalty: nil))
+
+        #expect(settings.memorySafety.mode == .safeAuto)
+        #expect(settings.memorySafety.slider == 2)
+        #expect(plan.allowed)
+        #expect(plan.loadConfiguration.memoryLimit == .fraction(0.70))
+        #expect(plan.loadConfiguration.maxResidentBytes == .absolute(128 << 20))
+        #expect(plan.loadConfiguration.useMmapSafetensors)
+        #expect(plan.loadConfiguration.jangPress == .disabled)
+        #expect(plan.cache.prefix.enabled)
+        #expect(plan.cache.pagedKV.enabled)
+        #expect(plan.cache.blockDisk.enabled)
+        #expect(!plan.cache.legacyDisk.enabled)
+        #expect(plan.cache.defaultMaxKVSize == 8192)
+        #expect(plan.cache.enableSSMReDerive)
+        #expect(plan.concurrency.maxConcurrentSequences == 1)
+        #expect(generate.temperature == 0.7)
+        #expect(generate.topP == 0.95)
+        #expect(generate.topK == 64)
+        #expect(generate.repetitionPenalty == nil)
+    }
+
+    @Test("validation rejects invalid custom values")
+    func validationRejectsInvalidCustomValues() {
+        var settings = VMLXServerRuntimeSettings()
+        settings.memorySafety.slider = 9
+        settings.memorySafety.customPhysicalMemoryFraction = 1.2
+        settings.memorySafety.customAllocatorCacheBytes = 0
+        settings.memorySafety.customDefaultMaxKVSize = 0
+        settings.memorySafety.customMaxConcurrentSequences = 0
+
+        let fields = Set(settings.validationIssues().map(\.field))
+
+        #expect(fields.contains("memorySafety.slider"))
+        #expect(fields.contains("memorySafety.customPhysicalMemoryFraction"))
+        #expect(fields.contains("memorySafety.customAllocatorCacheBytes"))
+        #expect(fields.contains("memorySafety.customDefaultMaxKVSize"))
+        #expect(fields.contains("memorySafety.customMaxConcurrentSequences"))
+    }
+
+    @Test("strict mode returns typed refusal for unknown and over budget estimates")
+    func strictModeReturnsTypedRefusalForUnknownAndOverBudgetEstimates() {
+        var settings = VMLXServerRuntimeSettings()
+        settings.memorySafety.mode = .strict
+        settings.memorySafety.slider = 3
+        let facts = LoadBundleFacts(
+            totalSafetensorsBytes: 20 << 30,
+            isRouted: true,
+            physicalMemory: 24 << 30,
+            modelType: "gemma4",
+            weightFormat: "jang_4m",
+            hasJangConfig: true)
+
+        let unknown = settings.resolvedMemorySafetyPlan(
+            baseLoadConfiguration: .osaurusProduction,
+            bundleFacts: facts,
+            request: VMLXMemoryRequestEstimate())
+        let overBudget = settings.resolvedMemorySafetyPlan(
+            baseLoadConfiguration: .osaurusProduction,
+            bundleFacts: facts,
+            request: VMLXMemoryRequestEstimate(workingSetBytes: 20 << 30))
+
+        #expect(!unknown.allowed)
+        #expect(unknown.blockingIssues.contains {
+            $0.field == "memorySafety.requestEstimate"
+                && $0.message.contains("requires a request working-set estimate")
+        })
+        #expect(!overBudget.allowed)
+        #expect(overBudget.blockingIssues.contains {
+            $0.field == "memorySafety.requestEstimate"
+                && $0.message.contains("exceeds resolved memory budget")
+        })
+        #expect(overBudget.loadConfiguration.memoryLimit == .fraction(0.60))
+        #expect(overBudget.cache.defaultMaxKVSize == 4096)
+    }
+
+    @Test("memory safety does not make MLXPress the universal slider")
+    func memorySafetyDoesNotMakeMLXPressTheUniversalSlider() {
+        var settings = VMLXServerRuntimeSettings()
+        let denseGemma = LoadBundleFacts(
+            totalSafetensorsBytes: 30 << 30,
+            isRouted: false,
+            physicalMemory: 24 << 30,
+            modelType: "gemma4",
+            weightFormat: "mxfp4")
+        let routedJang = LoadBundleFacts(
+            totalSafetensorsBytes: 30 << 30,
+            isRouted: true,
+            physicalMemory: 24 << 30,
+            modelType: "mimo_v2",
+            weightFormat: "jangtq",
+            hasJangConfig: true,
+            hasJangTQRuntime: true,
+            numRoutedExperts: 64,
+            topK: 8)
+
+        let densePlan = settings.resolvedMemorySafetyPlan(
+            baseLoadConfiguration: .osaurusProduction,
+            bundleFacts: denseGemma)
+        var provenRoutedBase = LoadConfiguration.osaurusProduction
+        provenRoutedBase.jangPress = .auto(envFallback: true)
+        let routedWithoutOptIn = settings.resolvedMemorySafetyPlan(
+            baseLoadConfiguration: provenRoutedBase,
+            bundleFacts: routedJang)
+        settings.memorySafety.allowExperimentalMLXPress = true
+        let routedPlan = settings.resolvedMemorySafetyPlan(
+            baseLoadConfiguration: provenRoutedBase,
+            bundleFacts: routedJang)
+
+        #expect(densePlan.loadConfiguration.jangPress == .disabled)
+        #expect(densePlan.warnings.isEmpty)
+        #expect(routedWithoutOptIn.loadConfiguration.jangPress == .disabled)
+        #expect(routedWithoutOptIn.warnings.contains {
+            $0.contains("MLXPress/JangPress was not selected")
+        })
+        #expect(routedPlan.loadConfiguration.jangPress == .auto(envFallback: true))
+    }
+
+    @Test("memory safety preserves hybrid SSM and engine selected cache topology")
+    func memorySafetyPreservesHybridSSMAndEngineSelectedCacheTopology() {
+        var settings = VMLXServerRuntimeSettings()
+        settings.cache.liveKVCodec = .engineSelected
+        settings.cache.enableSSMReDerive = true
+        let facts = LoadBundleFacts(
+            totalSafetensorsBytes: 18 << 30,
+            isRouted: true,
+            physicalMemory: 64 << 30,
+            modelType: "qwen3_6",
+            weightFormat: "mxfp4")
+
+        let plan = settings.resolvedMemorySafetyPlan(
+            baseLoadConfiguration: .default,
+            bundleFacts: facts)
+        let coordinator = VMLXServerRuntimeSettings(
+            concurrency: plan.concurrency,
+            cache: plan.cache,
+            memorySafety: settings.memorySafety)
+            .cacheCoordinatorConfig(
+                modelKey: "qwen3.6|mtp=preserved|cache=engine_selected",
+                ssmMaxEntries: 96)
+
+        #expect(plan.cache.liveKVCodec == .engineSelected)
+        #expect(plan.cache.enableSSMReDerive)
+        #expect(coordinator.usePagedCache)
+        #expect(coordinator.enableDiskCache)
+        #expect(coordinator.enableSSMReDerive)
+        #expect(coordinator.ssmMaxEntries == 96)
+        if case .turboQuant(let keyBits, let valueBits) = coordinator.defaultKVMode {
+            #expect(keyBits == 3)
+            #expect(valueBits == 3)
+        } else {
+            Issue.record("Memory safety should preserve engine-selected TurboQuant KV policy.")
+        }
+    }
+}

--- a/docs/OSAURUS_MEMORY_SAFETY_SLIDER_SPEC.md
+++ b/docs/OSAURUS_MEMORY_SAFETY_SLIDER_SPEC.md
@@ -1,0 +1,204 @@
+# Osaurus Memory Safety Slider Spec
+
+This is the vMLX/Osaurus contract for a user-visible memory safety control.
+It is not a hardcoded RAM rejection rule and must not change model behavior to
+hide memory issues.
+
+## Goals
+
+- Give Osaurus UI, CLI, and API one persisted memory safety setting.
+- Resolve that setting into real engine controls: load cap, allocator cache
+  cap, mmap safetensors, cache policy, concurrency, and typed admission issues.
+- Keep Safe Auto as the default for 24 GB-class hosts without blocking every
+  large-model attempt from a single free-RAM snapshot.
+- Fail before unsafe MLX/Metal allocation when a real estimate and selected
+  policy require refusal.
+- Preserve model defaults from `generation_config.json`.
+
+## Non-Goals
+
+- Do not expose MLXPress/JangPress as the primary user setting.
+- Do not use sampler, prompt, parser, reasoning, or output stripping as memory
+  fixes.
+- Do not silently truncate context unless the user explicitly selected a
+  truncation policy.
+- Do not infer TurboQuant KV, media support, native MTP, or companion cache
+  support from model names alone.
+- Do not catch/retry after native process-fatal MLX/Metal failures.
+
+## User Modes
+
+| Slider | Mode | UI label | Behavior |
+| --- | --- | --- | --- |
+| 0 | `performance` | Performance | Higher memory pressure, fewer automatic caps, warnings over budget. |
+| 1 | `balanced` | Balanced | Moderate caps, paged KV, block disk L2, 1-2 concurrent sequences. |
+| 2 | `safe_auto` | Safe Auto | Default. Conservative caps, mmap safetensors, paged KV, block disk L2, one sequence. |
+| 3 | `strict` | Strict | Low-RAM mode. Blocks unknown or over-budget estimates before load/decode. |
+| 4 | `diagnostic_dangerous` | Diagnostic | Explicit advanced/custom settings only. |
+
+Safe Auto is the default. It should not be described as a guarantee; it is a
+conservative plan with typed warnings/refusals when estimates prove unsafe.
+
+## vMLX API
+
+`VMLXServerRuntimeSettings` owns the contract:
+
+```swift
+public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
+    public var memorySafety: VMLXMemorySafetySettings
+
+    public func resolvedMemorySafetyPlan(
+        baseLoadConfiguration: LoadConfiguration = .default,
+        bundleFacts: LoadBundleFacts? = nil,
+        host: MemoryStatus? = nil,
+        request: VMLXMemoryRequestEstimate? = nil
+    ) -> VMLXResolvedMemorySafetyPlan
+}
+```
+
+Persist this setting in Osaurus:
+
+```swift
+public struct VMLXMemorySafetySettings: Codable, Sendable, Equatable {
+    public var mode: VMLXMemorySafetyMode
+    public var slider: Int
+    public var allowExperimentalMLXPress: Bool
+    public var failClosedWhenEstimateUnknown: Bool
+    public var customPhysicalMemoryFraction: Double?
+    public var customAllocatorCacheBytes: UInt64?
+    public var customDefaultMaxKVSize: Int?
+    public var customMaxConcurrentSequences: Int?
+}
+```
+
+Request-time estimates:
+
+```swift
+public struct VMLXMemoryRequestEstimate: Sendable, Equatable {
+    public var workingSetBytes: UInt64?
+    public var promptTokens: Int?
+    public var maxNewTokens: Int?
+}
+```
+
+Resolved plan:
+
+```swift
+public struct VMLXResolvedMemorySafetyPlan: Sendable, Equatable {
+    public var loadConfiguration: LoadConfiguration
+    public var cache: VMLXServerCacheSettings
+    public var concurrency: VMLXServerConcurrencySettings
+    public var resolvedPhysicalMemoryBytes: UInt64
+    public var resolvedLoadBudgetBytes: UInt64?
+    public var warnings: [String]
+    public var blockingIssues: [VMLXServerSettingsIssue]
+    public var displaySummary: String
+    public var allowed: Bool
+}
+```
+
+## Current Resolver Mapping
+
+| Mode | Load cap | Allocator cache cap | Max concurrent | Prefix cap | Default KV cap | Blocking |
+| --- | --- | --- | --- | --- | --- | --- |
+| `performance` | 0.90 physical unless custom | unlimited unless custom | 2 unless set | existing or 20 percent | existing/custom | warn over budget |
+| `balanced` | 0.75 physical unless custom | 1 GiB unless custom | 2 unless set | 512 MB, 15 percent | 8192 | warn over budget |
+| `safe_auto` | 0.70 physical unless custom | 128 MiB unless custom | 1 unless set | 128 MB, 15 percent | 8192 | warn over budget |
+| `strict` | 0.60 physical unless custom | 128 MiB unless custom | 1 unless set | 128 MB, 10 percent | 4096 | block unknown/over-budget request estimates |
+| `diagnostic_dangerous` | 1.0 physical unless custom | unlimited unless custom | 1 unless set | existing | existing/custom | explicit advanced only |
+
+The resolver always enables mmap safetensors, paged KV, and block disk L2 in
+safe plans. It disables legacy disk when paged KV is enabled.
+
+## MLXPress/JangPress Boundary
+
+Memory safety is not MLXPress.
+
+- Dense Gemma/MXFP rows must keep `jangPress == .disabled`.
+- JANG filenames do not automatically enable MLXPress.
+- MLXPress/JangPress can pass through only when:
+  - `allowExperimentalMLXPress == true`,
+  - bundle facts prove a routed JANG/JANGTQ row,
+  - the selected bundle lane is already proven or explicitly diagnostic.
+- The UI should show MLXPress as disabled, eligible, active, or refused with a
+  reason, but not as the primary slider.
+
+## Model-Family Requirements
+
+Gemma 4 MXFP4/JANG_4M:
+
+- Preserve bundle sampler defaults.
+- Do not claim TurboQuant KV when telemetry reports zero TurboQuant KV layers.
+- Preserve rotating/full KV and disk-backed restore.
+- Image, audio, and video must remain per-modality claims with real media proof.
+
+Qwen MTP / hybrid SSM:
+
+- Native MTP is separate from memory safety.
+- Keep `native_mtp_status` and tuning requirements separate from the slider.
+- Cache proof requires KV plus SSM companion rederive/hits.
+
+MiMo V2.5:
+
+- TurboQuant KV can apply only to proven full-attention KV components.
+- It must not replace SWA/rotating state.
+- Cache proof must show rotating topology and disk-backed restore.
+
+VL/audio/video/omni:
+
+- Include media tokens and processor-side tensors in estimates.
+- Cache keys must include media hash/salt, modality metadata, processor state,
+  and template identity.
+- Text-only proof does not promote media support.
+
+## Osaurus UI/CLI Work
+
+Osaurus should:
+
+- Persist `memorySafety` with the existing runtime settings.
+- Add CLI/API fields for `mode`, `slider`, and advanced custom values.
+- Show the selected mode and resolved plan.
+- Say when a setting takes effect only on next model load.
+- Return typed user-facing refusals from `blockingIssues`.
+- Never convert warnings into hidden sampler/template/parser changes.
+
+Required status/admin fields:
+
+- `memory_safety.mode`
+- `memory_safety.slider`
+- `memory_safety.allowed`
+- `memory_safety.display_summary`
+- `memory_safety.resolved_physical_memory_bytes`
+- `memory_safety.resolved_load_budget_bytes`
+- `memory_safety.load_configuration.memory_limit`
+- `memory_safety.load_configuration.max_resident_bytes`
+- `memory_safety.load_configuration.use_mmap_safetensors`
+- `memory_safety.load_configuration.jang_press_policy`
+- `memory_safety.cache.prefix_enabled`
+- `memory_safety.cache.paged_kv_enabled`
+- `memory_safety.cache.block_disk_enabled`
+- `memory_safety.cache.live_kv_codec`
+- `memory_safety.cache.default_max_kv_size`
+- `memory_safety.cache.enable_ssm_rederive`
+- `memory_safety.concurrency.max_concurrent_sequences`
+- `memory_safety.warnings`
+- `memory_safety.blocking_issues`
+- `memory_safety.active_runtime.cache_topology`
+- `memory_safety.active_runtime.mlxpress_status`
+- `memory_safety.active_runtime.physical_footprint_bytes` when available
+
+## Required Proof
+
+- Settings encode/decode with Safe Auto default.
+- Invalid slider/custom values produce validation issues.
+- Each mode resolves expected load/cache/concurrency settings.
+- Strict unknown-estimate and over-budget estimate return typed refusals.
+- Dense Gemma does not enable MLXPress.
+- Proven routed JANG/JANGTQ can opt into MLXPress only through explicit
+  advanced/proven settings.
+- Qwen hybrid cache preserves SSM companion rederive.
+- Gemma rotating cache does not force TurboQuant KV.
+- Osaurus UI/CLI/status proves the selected setting changes the next resolved
+  plan.
+- Low-RAM model/request rows either run or refuse gracefully before unsafe
+  native allocation.


### PR DESCRIPTION
## Summary

- add `VMLXServerRuntimeSettings.memorySafety` and a single resolver that maps memory safety modes to load, cache, and concurrency settings
- add typed request-estimate refusal for strict memory safety without changing sampler, prompt, reasoning, or parser defaults
- document the Osaurus UI integration contract in `docs/OSAURUS_MEMORY_SAFETY_SLIDER_SPEC.md`
- add focused tests for Safe Auto defaults, strict refusal, validation, MLXPress boundaries, and hybrid SSM/cache preservation

## Notes

Memory safety is not exposed as MLXPress/JangPress. The resolver keeps MLXPress disabled unless the host explicitly allows a proven routed lane and provides a non-disabled base policy. Dense Gemma/MXFP rows remain disabled.

Safe Auto defaults to mmap, paged KV, block disk L2, one concurrent sequence, a 70% load cap, a small allocator cache cap, and an 8192 KV cap. Strict mode can fail closed from request estimates. The resolver does not alter generation defaults.

## Test

```sh
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter 'VMLXMemorySafetySettingsTests' --jobs 1
```

Passed: 5 tests in 1 suite.
