### PR TITLE
Fix Gemma4 QAT loading and cache defaults for Osaurus

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,27 @@
 See `~/AGENTS.md` for the global Codex environment, wiki protocol, hard rules,
 machine context, and useful commands.
 
+## Active Focus: Gemma Cache Defaults + Harness Proof
+
+Until this lane is merged, focus only on the Gemma cache-default and harness
+compatibility PR:
+
+- Default model loading must not enable the paged RAM KV cache. Paged RAM cache
+  may still be exercised by explicit benchmark or regression-test settings, but
+  ordinary single-batch chat/server loads should start with it off.
+- Gemma JANG and MXFP bundles must use real TurboQuant KV cache by default when
+  loaded through Osaurus chat or Osaurus server settings. Prove this through the
+  server runtime settings contract and runtime cache telemetry; do not use
+  prompts, sampler tweaks, or parser masking as a substitute.
+- Compare Gemma BF16/source bundles against the QAT/MXFP/JANG quantized bundles
+  in the Osaurus harness compatibility lane. Record pass/fail counts, token/s
+  where generation occurs, cache topology, and every failure cause.
+- Add real prefill progress telemetry so Osaurus can show prompt-processing
+  percentage during long first-token waits. Progress must come from runtime
+  prefill/cache/media stages, not from a UI timer guess.
+- Keep progress and remaining proof in the repo docs before claiming the PR is
+  merge-ready. This branch is not a broad model-runtime cleanup lane.
+
 ## MLXPress Non-Negotiables
 
 For any MLXPress, JANGTQ, cache-stack, model-runtime, or Osaurus-facing work,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,24 +3,27 @@
 See `~/AGENTS.md` for the global Codex environment, wiki protocol, hard rules,
 machine context, and useful commands.
 
-## Active Focus: Gemma Cache Defaults + Harness Proof
+## Active Focus: Gemma 4 QAT Correctness Checkpoint
 
-Until this lane is merged, focus only on the Gemma cache-default and harness
-compatibility PR:
+Until this lane is merged and consumed by Osaurus, focus only on the Gemma 4
+QAT MXFP4/JANG_4M correctness checkpoint:
 
 - Default model loading must not enable the paged RAM KV cache. Paged RAM cache
   may still be exercised by explicit benchmark or regression-test settings, but
   ordinary single-batch chat/server loads should start with it off.
-- Gemma JANG and MXFP bundles must use real TurboQuant KV cache by default when
-  loaded through Osaurus chat or Osaurus server settings. Prove this through the
-  server runtime settings contract and runtime cache telemetry; do not use
-  prompts, sampler tweaks, or parser masking as a substitute.
-- Compare Gemma BF16/source bundles against the QAT/MXFP/JANG quantized bundles
-  in the Osaurus harness compatibility lane. Record pass/fail counts, token/s
-  where generation occurs, cache topology, and every failure cause.
+- Gemma JANG_4M and MXFP4 QAT bundles must load and run through the real
+  Osaurus/vMLX runtime path with bundle-driven generation config, parser/tool
+  fixes, no protocol marker leakage, and no prompt or sampler masking.
+- Cache claims must match telemetry. If the runtime reports rotating KV plus
+  disk-backed restore and `turbo_quant_kv_layer_count=0`, do not claim a
+  TurboQuant-KV-layer topology; report the effective KV mode, prefix/paged/L2
+  counters, and disk-backed restore state exactly.
 - Add real prefill progress telemetry so Osaurus can show prompt-processing
   percentage during long first-token waits. Progress must come from runtime
   prefill/cache/media stages, not from a UI timer guess.
+- Defer raw speed benchmarking and Gemma4 audio support until after the
+  correctness PR. Do not load or benchmark BF16/source Gemma bundles for this
+  checkpoint.
 - Keep progress and remaining proof in the repo docs before claiming the PR is
   merge-ready. This branch is not a broad model-runtime cleanup lane.
 

--- a/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
+++ b/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
@@ -234,6 +234,9 @@ public enum ChatSessionTests {
                 break
             case .toolCall(let toolCall):
                 toolCalls.append(toolCall)
+            case .prefillProgress:
+
+                break
             case .info(let completionInfo):
                 info = completionInfo
             }
@@ -670,7 +673,10 @@ public enum BatchEngineIntegrationTests {
             case .chunk(let text):
                 print(text, terminator: "")
                 result += text
-            case .info, .toolCall, .reasoning:
+            case .prefillProgress:
+
+                break
+            case .info, .prefillProgress, .toolCall, .reasoning:
                 break
             }
         }
@@ -904,7 +910,7 @@ public enum ToolCallTests {
                     text += chunk
                 case .toolCall(let toolCall):
                     toolCalls.append(toolCall)
-                case .reasoning, .info:
+                case .reasoning, .prefillProgress, .info:
                     break
                 }
             }

--- a/Libraries/MLXEmbedders/Model2VecStaticEmbeddingPipeline.swift
+++ b/Libraries/MLXEmbedders/Model2VecStaticEmbeddingPipeline.swift
@@ -1,0 +1,124 @@
+// Copyright © 2026 Osaurus
+
+import Foundation
+import MLX
+import MLXLMCommon
+
+public enum Model2VecStaticEmbeddingError: LocalizedError {
+    case missingWeights(URL)
+    case missingEmbeddingTensor(URL)
+    case invalidEmbeddingRank([Int])
+    case emptyBatch
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingWeights(let url):
+            return "Missing Model2Vec weights at \(url.path)"
+        case .missingEmbeddingTensor(let url):
+            return "Missing Model2Vec 'embeddings' tensor in \(url.path)"
+        case .invalidEmbeddingRank(let shape):
+            return "Model2Vec embeddings tensor must be rank 2, got shape \(shape)"
+        case .emptyBatch:
+            return "Model2Vec embedding batch must contain at least one text"
+        }
+    }
+}
+
+public struct Model2VecStaticEmbeddingConfiguration: Decodable, Sendable {
+    public let normalize: Bool?
+    public let hiddenDim: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case normalize
+        case hiddenDim = "hidden_dim"
+    }
+}
+
+/// Lightweight Model2Vec/static-embedding pipeline for bundles such as
+/// `minishlab/potion-base-4M`.
+///
+/// This keeps static embeddings inside vmlx-swift instead of pulling the
+/// separate `swift-embeddings` package and its external transformer graph into
+/// Osaurus.
+public actor Model2VecStaticEmbeddingPipeline {
+    public let dimension: Int
+
+    private let embeddings: MLXArray
+    private let tokenizer: any Tokenizer
+    private let unknownTokenId: Int?
+    private let normalize: Bool
+
+    public init(
+        embeddings: MLXArray,
+        tokenizer: any Tokenizer,
+        normalize: Bool
+    ) throws {
+        guard embeddings.shape.count == 2 else {
+            throw Model2VecStaticEmbeddingError.invalidEmbeddingRank(embeddings.shape)
+        }
+        self.embeddings = embeddings
+        self.tokenizer = tokenizer
+        self.unknownTokenId = tokenizer.unknownTokenId
+        self.normalize = normalize
+        self.dimension = embeddings.shape[1]
+        eval(embeddings)
+    }
+
+    public static func load(
+        from directory: URL,
+        using tokenizerLoader: any TokenizerLoader
+    ) async throws -> Model2VecStaticEmbeddingPipeline {
+        let weightsURL = directory.appending(component: "model.safetensors")
+        guard FileManager.default.fileExists(atPath: weightsURL.path) else {
+            throw Model2VecStaticEmbeddingError.missingWeights(weightsURL)
+        }
+
+        let configURL = directory.appending(component: "config.json")
+        let config = try? JSONDecoder.json5().decode(
+            Model2VecStaticEmbeddingConfiguration.self,
+            from: Data(contentsOf: configURL)
+        )
+        let weights = try loadArrays(url: weightsURL)
+        guard let embeddings = weights["embeddings"] else {
+            throw Model2VecStaticEmbeddingError.missingEmbeddingTensor(weightsURL)
+        }
+        let tokenizer = try await tokenizerLoader.load(from: directory)
+        return try Model2VecStaticEmbeddingPipeline(
+            embeddings: embeddings,
+            tokenizer: tokenizer,
+            normalize: config?.normalize ?? false
+        )
+    }
+
+    public func embed(text: String) throws -> [Float] {
+        try embed(texts: [text])[0]
+    }
+
+    public func embed(texts: [String]) throws -> [[Float]] {
+        guard !texts.isEmpty else {
+            throw Model2VecStaticEmbeddingError.emptyBatch
+        }
+        return try texts.map(embedOne(_:))
+    }
+
+    private func embedOne(_ text: String) throws -> [Float] {
+        let tokens = tokenizer.encode(text: text, addSpecialTokens: false).filter { token in
+            if let unknownTokenId {
+                return token != unknownTokenId
+            }
+            return true
+        }
+
+        guard !tokens.isEmpty else {
+            return Array(repeating: 0, count: dimension)
+        }
+
+        let ids = MLXArray(tokens.map(Int32.init))
+        var vector = embeddings.take(ids, axis: 0).mean(axis: 0)
+        if normalize {
+            vector = vector.l2Normalized()
+        }
+        eval(vector)
+        return vector.asArray(Float.self)
+    }
+}

--- a/Libraries/MLXLLM/LLMModel.swift
+++ b/Libraries/MLXLLM/LLMModel.swift
@@ -65,6 +65,7 @@ extension LLMModel {
             MLX.eval(cache)
             flatTokens = flatTokens[prefillStepSize...]
             if let m = flatMask { flatMask = m[prefillStepSize...] }
+            PrefillProgressReporter.reportCompletedUnits(input.text.tokens.size - flatTokens.size)
             Memory.clearCache()
         }
 

--- a/Libraries/MLXLLM/Models/Gemma4Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma4Text.swift
@@ -381,47 +381,6 @@ class Gemma4MLP: Module {
     }
 }
 
-// MARK: - ScaledLinear (for per-layer model projection)
-
-/// Linear layer with fixed output scaling (not a learnable parameter).
-/// Python: (x @ self.weight.T) * scalar
-class Gemma4ScaledLinear: Module {
-    @ParameterInfo(key: "weight") var weight: MLXArray
-    @ParameterInfo(key: "scales") var scales: MLXArray
-    @ParameterInfo(key: "biases") var biases: MLXArray?
-    let scalar: Float
-    let inputDims: Int
-    let outputDims: Int
-
-    init(inputDims: Int, outputDims: Int, scalar: Float) {
-        self._weight.wrappedValue = MLXArray.zeros([outputDims, inputDims])
-        self._scales.wrappedValue = MLXArray.mlxNone
-        self._biases.wrappedValue = MLXArray.mlxNone
-        self.scalar = scalar
-        self.inputDims = inputDims
-        self.outputDims = outputDims
-        super.init()
-    }
-
-    func callAsFunction(_ x: MLXArray, prefixShape: [Int]? = nil) -> MLXArray {
-        let leadingShape = prefixShape ?? Array(x.shape.dropLast())
-        let flatInput = x.reshaped([leadingShape.reduce(1, *)] + [inputDims])
-        let outputShape = leadingShape + [outputDims]
-
-        if !scales.shape.isEmpty {
-            let inferred = JangLoader.inferBitWidthAndGroupSize(
-                weight: weight, scales: scales, knownGroupSize: 32)
-            let hasAffineBiases = biases?.ctx.ctx != nil
-            let mode: QuantizationMode = hasAffineBiases ? .affine : .mxfp4
-            let projected = quantizedMM(
-                flatInput, weight, scales: scales, biases: biases, transpose: true,
-                groupSize: inferred.groupSize, bits: inferred.bits, mode: mode)
-            return projected.reshaped(outputShape) * scalar
-        }
-        return matmul(flatInput, weight.T).reshaped(outputShape) * scalar
-    }
-}
-
 // MARK: - Router (Softmax, with RMSNormNoScale pre-norm)
 
 class Gemma4Router: Module {
@@ -648,10 +607,11 @@ public class Gemma4Model: Module {
     // Per-layer embeddings (E2B/E4B models, nil for 26B/31B)
     @ModuleInfo(key: "embed_tokens_per_layer") var embedTokensPerLayer: Embedding?
     @ModuleInfo(key: "per_layer_model_projection") var perLayerModelProjection:
-        Gemma4ScaledLinear?
+        Linear?
     @ModuleInfo(key: "per_layer_projection_norm") var perLayerProjectionNorm: Gemma4RMSNorm?
 
     let config: Gemma4TextConfiguration
+    let perLayerProjectionScale: Float
 
     // KV sharing: maps layer index → source layer index for shared KVs
     let previousKVs: [Int]
@@ -667,15 +627,18 @@ public class Gemma4Model: Module {
 
         // Per-layer embeddings (E2B/E4B)
         if config.hiddenSizePerLayerInput > 0 {
+            self.perLayerProjectionScale = pow(Float(config.hiddenSize), -0.5)
             self._embedTokensPerLayer.wrappedValue = Embedding(
                 embeddingCount: config.vocabSizePerLayerInput,
                 dimensions: config.numHiddenLayers * config.hiddenSizePerLayerInput)
-            self._perLayerModelProjection.wrappedValue = Gemma4ScaledLinear(
-                inputDims: config.hiddenSize,
-                outputDims: config.numHiddenLayers * config.hiddenSizePerLayerInput,
-                scalar: pow(Float(config.hiddenSize), -0.5))
+            self._perLayerModelProjection.wrappedValue = Linear(
+                config.hiddenSize,
+                config.numHiddenLayers * config.hiddenSizePerLayerInput,
+                bias: false)
             self._perLayerProjectionNorm.wrappedValue = Gemma4RMSNorm(
                 dimensions: config.hiddenSizePerLayerInput, eps: config.rmsNormEps)
+        } else {
+            self.perLayerProjectionScale = 1.0
         }
 
         // KV sharing map
@@ -714,7 +677,7 @@ public class Gemma4Model: Module {
         _ inputEmbeds: MLXArray, prefixShape: [Int], perLayerInputs: MLXArray?
     ) -> MLXArray? {
         guard let perLayerModelProjection, let perLayerProjectionNorm else { return nil }
-        var proj = perLayerModelProjection(inputEmbeds, prefixShape: prefixShape)
+        var proj = perLayerModelProjection(inputEmbeds) * perLayerProjectionScale
         let layerShape = prefixShape + [
             config.numHiddenLayers, config.hiddenSizePerLayerInput,
         ]

--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -923,6 +923,13 @@ public actor BatchEngine {
         context.jangPressRuntime.recordPromptTokenActivity(
             input.text.tokens.reshaped(-1).asArray(Int.self))
 
+        let (outStream, continuation) = AsyncStream<Generation>.makeStream()
+        continuation.yield(.prefillProgress(PrefillProgress(
+            stage: .queued,
+            completedUnitCount: 0,
+            totalUnitCount: promptTokenCount,
+            detail: "solo")))
+
         let sourceStream: AsyncStream<Generation>
         let generationTask: Task<Void, Never>
         do {
@@ -955,7 +962,10 @@ public actor BatchEngine {
                     cache: nil,
                     parameters: soloParameters,
                     cacheCoordinator: cacheCoordinator,
-                    disableDiskBackedRequiredToolRestore: disableDiskBackedRequiredToolRestore)
+                    disableDiskBackedRequiredToolRestore: disableDiskBackedRequiredToolRestore,
+                    prefillProgressHandler: { progress in
+                        continuation.yield(.prefillProgress(progress))
+                    })
                 (sourceStream, generationTask) = generateTask(
                     promptTokenCount: promptTokenCount,
                     modelConfiguration: context.configuration,
@@ -969,13 +979,20 @@ public actor BatchEngine {
             Self.logger.error(
                 "Solo fast path setup failed: \(error.localizedDescription, privacy: .public)"
             )
-            return cancelledGenerationStream(promptTokenCount: promptTokenCount)
+            continuation.yield(.info(GenerateCompletionInfo(
+                promptTokenCount: promptTokenCount,
+                generationTokenCount: 0,
+                promptTime: 0,
+                generationTime: 0,
+                stopReason: .cancelled
+            )))
+            continuation.finish()
+            return outStream
         }
 
         soloFastPathID = fastPathID
         soloFastPathTask = generationTask
 
-        let (outStream, continuation) = AsyncStream<Generation>.makeStream()
         continuation.onTermination = { @Sendable _ in
             generationTask.cancel()
         }

--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -52,6 +52,43 @@ private func cancelledGenerationStream(
     return stream
 }
 
+private final class PrefillProgressAccumulator: @unchecked Sendable {
+    private let continuation: AsyncStream<BatchGeneration>.Continuation
+    private let completedBeforePrefill: Int
+    private let totalPromptUnits: Int
+    private let lock = NSLock()
+    private var lastReportedCompleted: Int
+
+    init(
+        continuation: AsyncStream<BatchGeneration>.Continuation,
+        completedBeforePrefill: Int,
+        totalPromptUnits: Int
+    ) {
+        self.continuation = continuation
+        self.completedBeforePrefill = completedBeforePrefill
+        self.totalPromptUnits = totalPromptUnits
+        self.lastReportedCompleted = completedBeforePrefill
+    }
+
+    func report(completedInPrepare: Int) {
+        let completed = min(
+            totalPromptUnits,
+            completedBeforePrefill + max(0, completedInPrepare))
+        lock.lock()
+        guard completed > lastReportedCompleted else {
+            lock.unlock()
+            return
+        }
+        lastReportedCompleted = completed
+        lock.unlock()
+        continuation.yield(.prefillProgress(PrefillProgress(
+            stage: .prefill,
+            completedUnitCount: completed,
+            totalUnitCount: totalPromptUnits,
+            detail: "chunk")))
+    }
+}
+
 private func debugLogReasoningPromptTail(
     modelName: String,
     promptTail: String?,
@@ -1606,13 +1643,22 @@ public actor BatchEngine {
         // Prefill: either full input (cache miss) or remaining tokens (cache hit).
         let prepareResult: PrepareResult
         do {
-            prepareResult = try context.model.prepare(
-                inputForPrepare,
-                cache: slot.cache,
-                windowSize: effectivePrefillWindow(
-                    requested: slot.prefillStepSize,
-                    input: inputForPrepare,
-                    cache: slot.cache))
+            let completedBeforePrefill = max(0, totalPromptUnits - remainingPromptUnits)
+            let progressAccumulator = PrefillProgressAccumulator(
+                continuation: slot.continuation,
+                completedBeforePrefill: completedBeforePrefill,
+                totalPromptUnits: totalPromptUnits)
+            prepareResult = try PrefillProgressReporter.$current.withValue({
+                progressAccumulator.report(completedInPrepare: $0)
+            }) {
+                try context.model.prepare(
+                    inputForPrepare,
+                    cache: slot.cache,
+                    windowSize: effectivePrefillWindow(
+                        requested: slot.prefillStepSize,
+                        input: inputForPrepare,
+                        cache: slot.cache))
+            }
         } catch {
             // Prefill failed (e.g., invalid input) — finish with cancellation
             finishSlot(slot, reason: .cancelled)

--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -621,6 +621,8 @@ public actor BatchEngine {
                     emitChunkThroughStop(text)
                 case .reasoning:
                     continuation.yield(event)
+                case .prefillProgress:
+                    continuation.yield(event)
                 case .toolCall:
                     continuation.yield(event)
                 case .info:
@@ -716,6 +718,8 @@ public actor BatchEngine {
 
             for await event in tokenStream {
                 switch event {
+                case .prefillProgress(let progress):
+                    continuation.yield(.prefillProgress(progress))
                 case .token(let id):
                     generatedTokenCount += 1
                     detokenizer.append(token: id)
@@ -1239,6 +1243,11 @@ public actor BatchEngine {
             }
 
             let slot = BatchSlot(from: request, cache: cache, stopTokenIDs: stopTokenIDs)
+            slot.continuation.yield(.prefillProgress(PrefillProgress(
+                stage: .queued,
+                completedUnitCount: 0,
+                totalUnitCount: slot.promptTokenCount,
+                detail: "admitted")))
             activeSlots.append(slot)
             activeCountHighWatermark = max(activeCountHighWatermark, activeSlots.count)
         }
@@ -1302,6 +1311,12 @@ public actor BatchEngine {
     /// After prefill, samples the first decode token and transitions the slot to `.decode`.
     private func stepPrefill(slotIndex: Int) {
         var slot = activeSlots[slotIndex]
+        let totalPromptUnits = max(0, slot.promptTokenCount)
+        slot.continuation.yield(.prefillProgress(PrefillProgress(
+            stage: .cacheLookup,
+            completedUnitCount: 0,
+            totalUnitCount: totalPromptUnits,
+            detail: cacheCoordinator == nil ? "disabled" : "checking")))
 
         // Check multi-tier cache for a prefix match before running full prefill.
         // On cache hit, restore KV state and only prefill remaining tokens.
@@ -1363,6 +1378,11 @@ public actor BatchEngine {
                                 restoreSSMStates(ssm, into: slot.cache)
                             }
                             restored = true
+                            slot.continuation.yield(.prefillProgress(PrefillProgress(
+                                stage: .cacheRestore,
+                                completedUnitCount: min(restoredTokens, totalPromptUnits),
+                                totalUnitCount: totalPromptUnits,
+                                detail: detail.rawValue)))
                             Self.logger.info(
                                 "Cache \(detail.rawValue) hit for slot \(slot.id): restored \(restoredTokens) tokens, prefilling \(remaining.count) remaining"
                             )
@@ -1399,6 +1419,11 @@ public actor BatchEngine {
                             // commits before prefill encoding starts.
                             MLX.eval(slot.cache)
                             restored = true
+                            slot.continuation.yield(.prefillProgress(PrefillProgress(
+                                stage: .cacheRestore,
+                                completedUnitCount: min(diskRestored, totalPromptUnits),
+                                totalUnitCount: totalPromptUnits,
+                                detail: detail.rawValue)))
                             Self.logger.info(
                                 "Cache \(detail.rawValue) hit for slot \(slot.id): restored \(diskRestored) tokens from disk, prefilling \(remaining.count) remaining"
                             )
@@ -1570,6 +1595,14 @@ public actor BatchEngine {
     ) {
         var slot = initialSlot ?? activeSlots[slotIndex]
 
+        let totalPromptUnits = max(0, slot.promptTokenCount)
+        let remainingPromptUnits = max(0, inputForPrepare.text.tokens.size)
+        slot.continuation.yield(.prefillProgress(PrefillProgress(
+            stage: .prefill,
+            completedUnitCount: max(0, totalPromptUnits - remainingPromptUnits),
+            totalUnitCount: totalPromptUnits,
+            detail: "running")))
+
         // Prefill: either full input (cache miss) or remaining tokens (cache hit).
         let prepareResult: PrepareResult
         do {
@@ -1587,6 +1620,12 @@ public actor BatchEngine {
             activeSlots[slotIndex] = slot
             return
         }
+
+        slot.continuation.yield(.prefillProgress(PrefillProgress(
+            stage: .complete,
+            completedUnitCount: totalPromptUnits,
+            totalUnitCount: totalPromptUnits,
+            detail: "decode_ready")))
 
         // Extract the first generated token from the prepare result
         let firstToken: MLXArray

--- a/Libraries/MLXLMCommon/BatchEngine/BatchTypes.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchTypes.swift
@@ -42,6 +42,9 @@ public enum BatchGeneration: Sendable {
     /// A single generated token ID.
     case token(Int)
 
+    /// Prompt-processing progress before the first decoded token.
+    case prefillProgress(PrefillProgress)
+
     /// Completion information with metrics. This is the final event before
     /// the stream closes.
     case info(GenerateCompletionInfo)

--- a/Libraries/MLXLMCommon/Cache/CacheCoordinatorConfig.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheCoordinatorConfig.swift
@@ -101,7 +101,7 @@ public struct CacheCoordinatorConfig: Sendable {
     public var longPromptMultiplier: Double
 
     public init(
-        usePagedCache: Bool = true,
+        usePagedCache: Bool = false,
         enableDiskCache: Bool = false,
         pagedBlockSize: Int = 64,
         maxCacheBlocks: Int = 1000,

--- a/Libraries/MLXLMCommon/ChunkedPrefillVLM.swift
+++ b/Libraries/MLXLMCommon/ChunkedPrefillVLM.swift
@@ -65,6 +65,7 @@ public func chunkedPrefillEmbedding<Result>(
         _ = step(chunk)
         MLX.eval(cache)
         offset = end
+        PrefillProgressReporter.reportCompletedUnits(offset)
         MLX.Memory.clearCache()
     }
 

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -3315,6 +3315,49 @@ public struct GenerateCompletionInfo: Sendable {
     }
 }
 
+/// Runtime progress for the prompt-processing phase before the first decoded token.
+///
+/// Progress is measured in real runtime work units. For text-only generation
+/// that means prompt tokens restored from cache or consumed by prefill. Model
+/// families whose `prepare()` implementation hides internal media/chunk work
+/// may emit only stage boundary events until that deeper implementation exposes
+/// per-chunk callbacks.
+public struct PrefillProgress: Sendable, Equatable {
+    public enum Stage: String, Sendable {
+        case queued
+        case cacheLookup
+        case cacheRestore
+        case prefill
+        case complete
+    }
+
+    public let stage: Stage
+    public let completedUnitCount: Int
+    public let totalUnitCount: Int
+    public let detail: String?
+
+    public var fractionCompleted: Double {
+        guard totalUnitCount > 0 else { return 0 }
+        return min(1, max(0, Double(completedUnitCount) / Double(totalUnitCount)))
+    }
+
+    public var percentCompleted: Double {
+        fractionCompleted * 100
+    }
+
+    public init(
+        stage: Stage,
+        completedUnitCount: Int,
+        totalUnitCount: Int,
+        detail: String? = nil
+    ) {
+        self.stage = stage
+        self.completedUnitCount = max(0, completedUnitCount)
+        self.totalUnitCount = max(0, totalUnitCount)
+        self.detail = detail
+    }
+}
+
 /// Represents the different stages or outputs of the token generation process.
 ///
 /// This enum distinguishes between the following:
@@ -3322,6 +3365,7 @@ public struct GenerateCompletionInfo: Sendable {
 /// - `.reasoning`: A streaming chain-of-thought chunk (content between `<think>` /
 ///   `</think>` tags, or the family-specific equivalent). Emitted only when the
 ///   runtime has an active `ReasoningParser` stamped on the model configuration.
+/// - `.prefillProgress`: Real prompt-processing progress before first token.
 /// - `.toolCall`: A tool call parsed from the generated output.
 /// - `.info`: Metadata and performance statistics about the generation process.
 public enum Generation: Sendable {
@@ -3349,6 +3393,9 @@ public enum Generation: Sendable {
     /// Completion information summarizing token counts and performance metrics.
     case info(GenerateCompletionInfo)
 
+    /// Prompt-processing progress before the first decoded token.
+    case prefillProgress(PrefillProgress)
+
     /// A tool call from the language model.
     case toolCall(ToolCall)
 
@@ -3358,6 +3405,7 @@ public enum Generation: Sendable {
         case .chunk(let string): string
         case .reasoning: nil
         case .info: nil
+        case .prefillProgress: nil
         case .toolCall: nil
         }
     }
@@ -3368,6 +3416,7 @@ public enum Generation: Sendable {
         case .chunk: nil
         case .reasoning(let string): string
         case .info: nil
+        case .prefillProgress: nil
         case .toolCall: nil
         }
     }
@@ -3378,6 +3427,18 @@ public enum Generation: Sendable {
         case .chunk: nil
         case .reasoning: nil
         case .info(let info): info
+        case .prefillProgress: nil
+        case .toolCall: nil
+        }
+    }
+
+    /// Prefill progress or nil
+    public var prefillProgress: PrefillProgress? {
+        switch self {
+        case .chunk: nil
+        case .reasoning: nil
+        case .info: nil
+        case .prefillProgress(let progress): progress
         case .toolCall: nil
         }
     }
@@ -3388,6 +3449,7 @@ public enum Generation: Sendable {
         case .chunk: nil
         case .reasoning: nil
         case .info: nil
+        case .prefillProgress: nil
         case .toolCall(let toolCall): toolCall
         }
     }
@@ -3409,11 +3471,15 @@ public enum TokenGeneration: Sendable {
     /// Completion information summarizing token counts and performance metrics.
     case info(GenerateCompletionInfo)
 
+    /// Prompt-processing progress before the first decoded token.
+    case prefillProgress(PrefillProgress)
+
     /// Token ID or nil
     public var token: Int? {
         switch self {
         case .token(let token): token
         case .info: nil
+        case .prefillProgress: nil
         }
     }
 
@@ -3422,6 +3488,16 @@ public enum TokenGeneration: Sendable {
         switch self {
         case .token: nil
         case .info(let info): info
+        case .prefillProgress: nil
+        }
+    }
+
+    /// Prefill progress or nil
+    public var prefillProgress: PrefillProgress? {
+        switch self {
+        case .token: nil
+        case .info: nil
+        case .prefillProgress(let progress): progress
         }
     }
 
@@ -3674,7 +3750,7 @@ private struct TextToolTokenLoopHandler: TokenLoopHandler, @unchecked Sendable {
                 return false
             }
             return !stopSequenceHit
-        case .reasoning, .toolCall, .info:
+        case .reasoning, .prefillProgress, .toolCall, .info:
             if case .toolCall = event {
                 emittedToolCall = true
             }

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1049,6 +1049,43 @@ private enum MLXPressGenerationProfile {
 /// Port of `generate_step()` from https://github.com/ml-explore/mlx-examples/blob/main/llms/mlx_lm/utils.py
 ///
 /// Note: this uses `asyncEval()` and there may be an async evaluation running after a call to `next()`.
+private final class SoloPrefillProgressAccumulator: @unchecked Sendable {
+    private let handler: @Sendable (PrefillProgress) -> Void
+    private let completedBeforePrefill: Int
+    private let totalPromptUnits: Int
+    private let lock = NSLock()
+    private var lastReportedCompleted: Int
+
+    init(
+        handler: @escaping @Sendable (PrefillProgress) -> Void,
+        completedBeforePrefill: Int,
+        totalPromptUnits: Int
+    ) {
+        self.handler = handler
+        self.completedBeforePrefill = completedBeforePrefill
+        self.totalPromptUnits = totalPromptUnits
+        self.lastReportedCompleted = completedBeforePrefill
+    }
+
+    func report(completedInPrepare: Int) {
+        let completed = Swift.min(
+            totalPromptUnits,
+            completedBeforePrefill + Swift.max(0, completedInPrepare))
+        lock.lock()
+        guard completed > lastReportedCompleted else {
+            lock.unlock()
+            return
+        }
+        lastReportedCompleted = completed
+        lock.unlock()
+        handler(PrefillProgress(
+            stage: .prefill,
+            completedUnitCount: completed,
+            totalUnitCount: totalPromptUnits,
+            detail: "chunk"))
+    }
+}
+
 public struct TokenIterator: TokenIteratorProtocol {
 
     private static let logger = Logger(subsystem: "vmlx", category: "TokenIterator")
@@ -1216,7 +1253,8 @@ public struct TokenIterator: TokenIteratorProtocol {
         input: LMInput, model: any LanguageModel, cache: [KVCache]? = nil,
         parameters: GenerateParameters,
         cacheCoordinator: CacheCoordinator? = nil,
-        disableDiskBackedRequiredToolRestore: Bool = false
+        disableDiskBackedRequiredToolRestore: Bool = false,
+        prefillProgressHandler: (@Sendable (PrefillProgress) -> Void)? = nil
     ) throws {
         _ = try AccelerationRuntime.resolveTextDecode(parameters.accelerationMode)
 
@@ -1536,15 +1574,42 @@ public struct TokenIterator: TokenIteratorProtocol {
         }
 
         // Prefill: either full input (cache miss) or remaining tokens (cache hit).
+        let remainingPromptUnits = Swift.max(0, inputForPrepare.text.tokens.size)
+        let completedBeforePrefill = Swift.max(0, promptTokenCount - remainingPromptUnits)
+        prefillProgressHandler?(PrefillProgress(
+            stage: .prefill,
+            completedUnitCount: completedBeforePrefill,
+            totalUnitCount: promptTokenCount,
+            detail: "running"))
+
+        let modelPrepareProgressHandler: PrefillProgressReporter.Handler?
+        if let prefillProgressHandler {
+            let progressAccumulator = SoloPrefillProgressAccumulator(
+                handler: prefillProgressHandler,
+                completedBeforePrefill: completedBeforePrefill,
+                totalPromptUnits: promptTokenCount)
+            modelPrepareProgressHandler = { completedInPrepare in
+                progressAccumulator.report(completedInPrepare: completedInPrepare)
+            }
+        } else {
+            modelPrepareProgressHandler = nil
+        }
         self.promptPrefillTime = try measure {
             try MLXPressGenerationProfile.time("prompt.prepare_total") {
-                try prepare(
-                    input: inputForPrepare,
-                    windowSize: effectivePrefillWindow(
-                        requested: effectiveParameters.prefillStepSize,
-                        input: inputForPrepare))
+                try PrefillProgressReporter.$current.withValue(modelPrepareProgressHandler) {
+                    try prepare(
+                        input: inputForPrepare,
+                        windowSize: effectivePrefillWindow(
+                            requested: effectiveParameters.prefillStepSize,
+                            input: inputForPrepare))
+                }
             }
         }
+        prefillProgressHandler?(PrefillProgress(
+            stage: .complete,
+            completedUnitCount: promptTokenCount,
+            totalUnitCount: promptTokenCount,
+            detail: "decode_ready"))
         self.promptCacheSnapshot = makePromptBoundaryCacheSnapshot(from: self.cache)
 
         if effectiveParameters.enableCompiledDecode && !Self.compiledDecodeDenied(for: model) {

--- a/Libraries/MLXLMCommon/JangLoader.swift
+++ b/Libraries/MLXLMCommon/JangLoader.swift
@@ -1672,6 +1672,7 @@ public struct JangLoader: Sendable {
         weights: [String: MLXArray],
         jangConfig: JangConfig,
         hiddenSizeHint: Int? = nil,
+        hiddenSizePerLayerInputHint: Int? = nil,
         linearAttnValueDimHint: Int? = nil,
         expertIntermediateSizeHint: Int? = nil,
         validInDims: Set<Int> = [],
@@ -1904,6 +1905,10 @@ public struct JangLoader: Sendable {
                 || basePath.hasSuffix(".mixer.o_proj")
             let isZayaCCAOutputProjection =
                 basePath.hasSuffix(".sub.o_proj")
+            let isPerLayerProjection =
+                basePath.hasSuffix(".per_layer_projection")
+            let isPerLayerModelProjection =
+                basePath.hasSuffix(".per_layer_model_projection")
             let isExpertDownProjection =
                 basePath.hasSuffix("switch_mlp.down_proj")
                 || basePath.hasSuffix("switch_glu.down_proj")
@@ -2009,6 +2014,25 @@ public struct JangLoader: Sendable {
                     knownGroupSize: groupSize,
                     bitWidthsUsed: bitWidthsUsed,
                     expectedInDim: ccaOutputDim)
+            } else if isPerLayerProjection,
+                      let perLayerInputDim = hiddenSizePerLayerInputHint,
+                      perLayerInputDim > 0
+            {
+                (bits, inferredGroupSize) = inferBitWidthAndGroupSize(
+                    packedDim: packedDim,
+                    numGroups: numGroups,
+                    knownGroupSize: groupSize,
+                    bitWidthsUsed: bitWidthsUsed,
+                    expectedInDim: perLayerInputDim)
+            } else if isPerLayerModelProjection,
+                      let hiddenSize = hiddenSizeHint, hiddenSize > 0
+            {
+                (bits, inferredGroupSize) = inferBitWidthAndGroupSize(
+                    packedDim: packedDim,
+                    numGroups: numGroups,
+                    knownGroupSize: groupSize,
+                    bitWidthsUsed: bitWidthsUsed,
+                    expectedInDim: hiddenSize)
             } else if isExpertDownProjection,
                       let expertIntermediateSize = expertIntermediateSizeHint,
                       expertIntermediateSize > 0

--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -357,6 +357,7 @@ public func loadWeights(
         // `(gs=32, bits=8)` for layers actually packed at `(gs=64,
         // bits=4)`) and would re-introduce the wrong values.
         let hiddenHint = readHiddenSizeHint(at: modelDirectory)
+        let hiddenSizePerLayerInputHint = readHiddenSizePerLayerInputHint(at: modelDirectory)
         let linearAttnValueDimHint = readLinearAttnValueDimHint(at: modelDirectory)
         let expertIntermediateSizeHint = readExpertIntermediateSizeHint(at: modelDirectory)
         let validInDims = readValidInDims(at: modelDirectory)
@@ -365,6 +366,7 @@ public func loadWeights(
         let inferred = JangLoader.inferPerLayerQuantization(
             weights: weights, jangConfig: jangConfig,
             hiddenSizeHint: hiddenHint,
+            hiddenSizePerLayerInputHint: hiddenSizePerLayerInputHint,
             linearAttnValueDimHint: linearAttnValueDimHint,
             expertIntermediateSizeHint: expertIntermediateSizeHint,
             validInDims: validInDims,
@@ -864,6 +866,18 @@ private func readHiddenSizeHint(at modelDirectory: URL) -> Int? {
     }
     if let hiddenSize = top["hidden_size"] as? Int, hiddenSize > 0 {
         return hiddenSize
+    }
+    return nil
+}
+
+private func readHiddenSizePerLayerInputHint(at modelDirectory: URL) -> Int? {
+    let configURL = modelDirectory.appendingPathComponent("config.json")
+    guard let data = try? Data(contentsOf: configURL),
+          let top = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else { return nil }
+    let config = (top["text_config"] as? [String: Any]) ?? top
+    if let value = config["hidden_size_per_layer_input"] as? Int, value > 0 {
+        return value
     }
     return nil
 }

--- a/Libraries/MLXLMCommon/PrefillProgressReporter.swift
+++ b/Libraries/MLXLMCommon/PrefillProgressReporter.swift
@@ -1,0 +1,14 @@
+// Copyright © 2026 osaurus.
+
+/// Task-local callback used by model `prepare` implementations to report
+/// completed prompt-processing units without changing the `LanguageModel`
+/// protocol signature.
+public enum PrefillProgressReporter {
+    public typealias Handler = @Sendable (Int) -> Void
+
+    @TaskLocal public static var current: Handler?
+
+    public static func reportCompletedUnits(_ count: Int) {
+        current?(max(0, count))
+    }
+}

--- a/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
+++ b/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
@@ -471,7 +471,6 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
 
         var resolvedCache = cache
         if resolvedCache.prefix.enabled {
-            resolvedCache.pagedKV.enabled = true
             resolvedCache.blockDisk.enabled = true
             resolvedCache.legacyDisk.enabled = false
             if resolvedCache.prefix.memoryLimitMB == nil {
@@ -693,6 +692,10 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
         let diskDirectory: String?
         if reuseEnabled, cache.pagedKV.enabled {
             diskEnabled = cache.blockDisk.enabled
+            diskMaxSizeGB = cache.blockDisk.maxSizeGB
+            diskDirectory = cache.blockDisk.directory
+        } else if reuseEnabled, cache.blockDisk.enabled {
+            diskEnabled = true
             diskMaxSizeGB = cache.blockDisk.maxSizeGB
             diskDirectory = cache.blockDisk.directory
         } else if reuseEnabled {
@@ -917,7 +920,7 @@ public struct VMLXPagedKVCacheSettings: Codable, Sendable, Equatable {
     public var blockSize: Int?
     public var maxBlocks: Int?
 
-    public init(enabled: Bool = true, blockSize: Int? = nil, maxBlocks: Int? = nil) {
+    public init(enabled: Bool = false, blockSize: Int? = nil, maxBlocks: Int? = nil) {
         self.enabled = enabled
         self.blockSize = blockSize
         self.maxBlocks = maxBlocks

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -1206,7 +1206,28 @@ public class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
         }
 
         let paddedCache = padCache(cache)
-        let out = languageModel(llmTokens, inputEmbedding: emb, cache: paddedCache)
+        let prefillStepSize = windowSize ?? 512
+        let tokenCount = emb.dim(1)
+        let out: MLXArray
+        if prefillStepSize > 0, tokenCount > prefillStepSize {
+            var offset = 0
+            while offset + prefillStepSize < tokenCount {
+                let end = offset + prefillStepSize
+                let tokenChunk = llmTokens[0..., offset ..< end]
+                let embeddingChunk = emb[0..., offset ..< end, 0...]
+                _ = languageModel(tokenChunk, inputEmbedding: embeddingChunk, cache: paddedCache)
+                MLX.eval(cache)
+                PrefillProgressReporter.reportCompletedUnits(end)
+                offset = end
+                MLX.Memory.clearCache()
+            }
+            out = languageModel(
+                llmTokens[0..., offset...],
+                inputEmbedding: emb[0..., offset..., 0...],
+                cache: paddedCache)
+        } else {
+            out = languageModel(llmTokens, inputEmbedding: emb, cache: paddedCache)
+        }
         return .logits(.init(logits: out))
     }
 

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -663,43 +663,6 @@ private class UnifiedVisionEmbedder: Module {
     }
 }
 
-// MARK: - ScaledLinear (for per-layer model projection)
-
-private class G4ScaledLinear: Module {
-    @ParameterInfo(key: "weight") var weight: MLXArray
-    @ParameterInfo(key: "scales") var scales: MLXArray
-    @ParameterInfo(key: "biases") var biases: MLXArray?
-    let scalar: Float
-    let inputDims: Int
-    let outputDims: Int
-    init(inputDims: Int, outputDims: Int, scalar: Float) {
-        self._weight.wrappedValue = MLXArray.zeros([outputDims, inputDims])
-        self._scales.wrappedValue = MLXArray.mlxNone
-        self._biases.wrappedValue = MLXArray.mlxNone
-        self.scalar = scalar
-        self.inputDims = inputDims
-        self.outputDims = outputDims
-        super.init()
-    }
-    func callAsFunction(_ x: MLXArray, prefixShape: [Int]? = nil) -> MLXArray {
-        let leadingShape = prefixShape ?? Array(x.shape.dropLast())
-        let flatInput = x.reshaped([leadingShape.reduce(1, *)] + [inputDims])
-        let outputShape = leadingShape + [outputDims]
-
-        if !scales.shape.isEmpty {
-            let inferred = JangLoader.inferBitWidthAndGroupSize(
-                weight: weight, scales: scales, knownGroupSize: 32)
-            let hasAffineBiases = biases?.ctx.ctx != nil
-            let mode: QuantizationMode = hasAffineBiases ? .affine : .mxfp4
-            let projected = quantizedMM(
-                flatInput, weight, scales: scales, biases: biases, transpose: true,
-                groupSize: inferred.groupSize, bits: inferred.bits, mode: mode)
-            return projected.reshaped(outputShape) * scalar
-        }
-        return matmul(flatInput, weight.T).reshaped(outputShape) * scalar
-    }
-}
-
 // MARK: - Text Model Components (inline for VLM — MLXVLM can't import MLXLLM)
 
 // Text Attention, MLP, Router, Experts, DecoderLayer, Model — same as Gemma4Text.swift
@@ -904,9 +867,10 @@ private class TextLayer: Module {
 private class TextModel: Module {
     @ModuleInfo(key: "embed_tokens") var emb: Embedding; @ModuleInfo var layers: [TextLayer]; @ModuleInfo var norm: G4RMSNorm
     @ModuleInfo(key: "embed_tokens_per_layer") var embPL: Embedding?
-    @ModuleInfo(key: "per_layer_model_projection") var plProj: G4ScaledLinear?
+    @ModuleInfo(key: "per_layer_model_projection") var plProj: Linear?
     @ModuleInfo(key: "per_layer_projection_norm") var plNorm: G4RMSNorm?
     let cfg: G4TextConfig
+    let perLayerProjectionScale: Float
     let previousKVs: [Int]
 
     init(_ cfg: G4TextConfig) {
@@ -914,12 +878,16 @@ private class TextModel: Module {
         _layers.wrappedValue = (0 ..< cfg.numHiddenLayers).map { TextLayer(cfg, i: $0) }
         self.norm = G4RMSNorm(dimensions: cfg.hiddenSize, eps: cfg.rmsNormEps)
         if cfg.hiddenSizePerLayerInput > 0 {
+            self.perLayerProjectionScale = pow(Float(cfg.hiddenSize), -0.5)
             _embPL.wrappedValue = Embedding(embeddingCount: cfg.vocabSizePerLayerInput,
                 dimensions: cfg.numHiddenLayers * cfg.hiddenSizePerLayerInput)
-            _plProj.wrappedValue = G4ScaledLinear(inputDims: cfg.hiddenSize,
-                outputDims: cfg.numHiddenLayers * cfg.hiddenSizePerLayerInput,
-                scalar: pow(Float(cfg.hiddenSize), -0.5))
+            _plProj.wrappedValue = Linear(
+                cfg.hiddenSize,
+                cfg.numHiddenLayers * cfg.hiddenSizePerLayerInput,
+                bias: false)
             _plNorm.wrappedValue = G4RMSNorm(dimensions: cfg.hiddenSizePerLayerInput, eps: cfg.rmsNormEps)
+        } else {
+            self.perLayerProjectionScale = 1.0
         }
         let lt = cfg.layerTypes.isEmpty ? Array(repeating: "sliding_attention", count: cfg.numHiddenLayers) : cfg.layerTypes
         var pkvs = Array(0 ..< cfg.numHiddenLayers)
@@ -942,7 +910,7 @@ private class TextModel: Module {
         guard let plProj, let plNorm else { return nil }
         let layerShape = prefixShape + [cfg.numHiddenLayers, cfg.hiddenSizePerLayerInput]
         let flatShape = prefixShape + [cfg.numHiddenLayers * cfg.hiddenSizePerLayerInput]
-        var p = plProj(h, prefixShape: prefixShape)
+        var p = plProj(h) * perLayerProjectionScale
         eval(p)
         p = plNorm(p.reshaped(layerShape))
         eval(p)

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -1342,7 +1342,12 @@ public struct Gemma4Processor: UserInputProcessor {
         if Self.requiresToolChoice(input.additionalContext) {
             messages = Self.compactCompletedToolHistoryForRequiredChoice(messages)
         }
-        var tokens = try tokenizer.applyChatTemplate(messages: messages, tools: input.tools, additionalContext: input.additionalContext)
+        let chatTemplateTools = MLXLMCommon.normalizedToolsForChatTemplate(input.tools)
+        var tokens = try tokenizer.applyChatTemplate(
+            messages: messages,
+            tools: chatTemplateTools,
+            additionalContext: input.additionalContext
+        )
 
         var processedImage: LMInput.ProcessedImage?
         if !input.images.isEmpty {

--- a/RunBench/Bench.swift
+++ b/RunBench/Bench.swift
@@ -1145,7 +1145,7 @@ func runBatchEngineTurn(
             reasoning += r
             chunkCount += 1
             if chunkCount > maxNew * 2 { break }
-        case .info, .toolCall:
+        case .prefillProgress, .info, .toolCall:
             break
         }
     }
@@ -1224,6 +1224,9 @@ func runBatchEngineToolCall(modelPath: String, maxNew: Int) async throws {
             switch event {
             case .token(let id):
                 tokenIds.append(id)
+            case .prefillProgress:
+
+                break
             case .info(let i):
                 info = i
             }
@@ -1267,6 +1270,9 @@ func runBatchEngineToolCall(modelPath: String, maxNew: Int) async throws {
                 argText = String(describing: call.function.arguments)
             }
             toolCallDetails.append("\(call.function.name)(\(argText))")
+        case .prefillProgress:
+
+            break
         case .info(let i):
             info = i
         }
@@ -1710,6 +1716,9 @@ func runBatchScenario(
                 firstTokAt = CFAbsoluteTimeGetCurrent() - t0
             }
             tokens.append(id)
+        case .prefillProgress:
+
+            break
         case .info(let info):
             stopReason = info.stopReason
         }
@@ -1818,6 +1827,9 @@ func runCrossEngineValidation(modelPath: String, maxNew: Int) async throws {
             case .token(let id):
                 engineTokens.append(id)
                 if engineTokens.count >= maxNew { break }
+            case .prefillProgress:
+
+                break
             case .info:
                 break
             }
@@ -2070,6 +2082,9 @@ func runBatchEngineCacheHit(modelPath: String, maxNew: Int) async throws {
                 reasoning += chunk
             case .toolCall:
                 toolCalls += 1
+            case .prefillProgress:
+
+                break
             case .info(let info):
                 completionInfo = info
                 promptTime = info.promptTime
@@ -2251,6 +2266,9 @@ func runBatchEngineDiskRestore(modelPath: String, maxNew: Int) async throws {
     for await event in streamA {
         switch event {
         case .token(let id): idsA.append(id)
+        case .prefillProgress:
+
+            break
         case .info(let info): promptTimeA = info.promptTime
         }
     }
@@ -2323,6 +2341,9 @@ func runBatchEngineDiskRestore(modelPath: String, maxNew: Int) async throws {
     for await event in streamB {
         switch event {
         case .token(let id): idsB.append(id)
+        case .prefillProgress:
+
+            break
         case .info(let info): promptTimeB = info.promptTime
         }
     }
@@ -2519,6 +2540,9 @@ func runGrowingChatCacheReuse(modelPath: String, maxNew: Int) async throws {
                 switch event {
                 case .token(let id):
                     out.append(id)
+                case .prefillProgress:
+
+                    break
                 case .info(let i):
                     info = i
                 }
@@ -2530,6 +2554,9 @@ func runGrowingChatCacheReuse(modelPath: String, maxNew: Int) async throws {
                 switch event {
                 case .token(let id):
                     out.append(id)
+                case .prefillProgress:
+
+                    break
                 case .info(let i):
                     info = i
                 }
@@ -2945,6 +2972,9 @@ private func collectBatchStreamsWithOverlapAndInfo(
                     switch e {
                     case .token(let id):
                         ids.append(id)
+                    case .prefillProgress:
+
+                        break
                     case .info(let completionInfo):
                         info = completionInfo
                     }
@@ -3136,6 +3166,9 @@ func runBatchEngineTurboQuantB2(modelPath: String, maxNew: Int) async throws {
         switch e {
         case .token(let id):
             refTokens.append(id)
+        case .prefillProgress:
+
+            break
         case .info(let info):
             refInfo = info
         }
@@ -3496,6 +3529,9 @@ func runBatchEngineCancelMidStream(modelPath: String, maxNew: Int) async throws 
                     switch e {
                     case .token(let id):
                         ids.append(id)
+                    case .prefillProgress:
+
+                        break
                     case .info(let info):
                         stop = info.stopReason
                     }
@@ -3653,6 +3689,9 @@ func runBatchEngineLongContext(
             }
             engineTokens.append(id)
             if engineTokens.count >= maxNew { break }
+        case .prefillProgress:
+
+            break
         case .info(let info):
             promptTime = info.promptTime
         }
@@ -3757,7 +3796,7 @@ func runHarmonyReasoningCheck(modelPath: String, maxNew: Int) async throws {
             case .reasoning(let r):
                 reasoningText += r
                 reasoningCount += 1
-            case .toolCall, .info:
+            case .prefillProgress, .toolCall, .info:
                 break
             }
         }
@@ -3851,7 +3890,7 @@ func runQwenThinkingReasoningCheck(modelPath: String, maxNew: Int) async throws 
                 case .reasoning(let r):
                     reasoningText += r
                     reasoningCount += 1
-                case .toolCall, .info:
+                case .prefillProgress, .toolCall, .info:
                     break
                 }
             }
@@ -5308,6 +5347,9 @@ func runThinkingLoopProbe(modelPath: String, maxNew: Int) async throws {
                 reasoningOut += text
             case .toolCall:
                 break
+            case .prefillProgress:
+
+                break
             case .info(let info):
                 rawTokenCount = max(rawTokenCount, info.generationTokenCount)
                 switch info.stopReason {
@@ -5351,6 +5393,9 @@ func runThinkingLoopProbe(modelPath: String, maxNew: Int) async throws {
                 } else {
                     contentOut += piece
                 }
+            case .prefillProgress:
+
+                break
             case .info(let info):
                 switch info.stopReason {
                 case .stop: finishReason = "stop (EOS)"
@@ -5509,6 +5554,9 @@ func runLagunaLoopProbe(modelPath: String, maxNew: Int) async throws {
                 result.reasoning += r
                 result.reasoningDeltas += 1
             case .toolCall:
+                break
+            case .prefillProgress:
+
                 break
             case .info(let info):
                 result.genTokens = info.generationTokenCount
@@ -5824,6 +5872,9 @@ func runNoGuardSamplingProbe(modelPath: String, maxNew: Int) async throws {
                 result.reasoning += text
             case .toolCall:
                 result.toolCalls += 1
+            case .prefillProgress:
+
+                break
             case .info(let info):
                 result.genTokens = info.generationTokenCount
                 result.genSec = info.generateTime
@@ -6150,6 +6201,9 @@ func runReasoningTurnMatrix(modelPath: String, maxNew: Int) async throws {
                 if ttft == nil { ttft = CFAbsoluteTimeGetCurrent() - t0 }
                 reasoning += r
                 chunks += 1
+            case .prefillProgress:
+
+                break
             case .info(let i):
                 info = i
             default:
@@ -6480,6 +6534,9 @@ func runDSV4CoherenceGate(modelPath: String, maxNew: Int) async throws {
             case .reasoning(let r):
                 reasoning += r
                 chunks += 1
+            case .prefillProgress:
+
+                break
             case .info(let i):
                 info = i
             default:
@@ -6853,6 +6910,9 @@ func runDSV4AgenticToolCheck(modelPath: String, maxNew: Int) async throws {
                 result.reasoning += reasoning
             case .toolCall(let call):
                 result.toolCalls.append(call)
+            case .prefillProgress:
+
+                break
             case .info(let info):
                 result.genTokens = info.generationTokenCount
                 result.stop = "\(info.stopReason)"
@@ -7173,6 +7233,9 @@ func runQwenMultiturnToolCheck(modelPath: String, maxNew: Int) async throws {
                 reasoningCount += 1
             case .toolCall:
                 toolCallCount += 1
+            case .prefillProgress:
+
+                break
             case .info:
                 break
             }
@@ -7571,6 +7634,9 @@ func runPerfBench(
                             result.ttftSec = CFAbsoluteTimeGetCurrent() - start
                         }
                         result.toolCalls += 1
+                    case .prefillProgress:
+
+                        break
                     case .info(let info):
                         result.genTokens = info.generationTokenCount
                         result.promptSec = info.promptTime
@@ -7590,6 +7656,9 @@ func runPerfBench(
                             result.ttftSec = CFAbsoluteTimeGetCurrent() - start
                         }
                         rawTokens.append(token)
+                    case .prefillProgress:
+
+                        break
                     case .info(let info):
                         result.genTokens = info.generationTokenCount
                         result.promptSec = info.promptTime
@@ -7619,6 +7688,9 @@ func runPerfBench(
                             result.ttftSec = CFAbsoluteTimeGetCurrent() - start
                         }
                         result.toolCalls += 1
+                    case .prefillProgress:
+
+                        break
                     case .info(let info):
                         result.genTokens = info.generationTokenCount
                         result.promptSec = info.promptTime
@@ -7843,6 +7915,9 @@ func runCrashFuzz(modelPath: String, maxNew: Int) async throws {
         for await e in stream {
             switch e {
             case .token(let id): ids.append(id)
+            case .prefillProgress:
+
+                break
             case .info(let info): stop = info.stopReason
             }
             if ids.count >= cap { break }
@@ -8165,6 +8240,9 @@ func runCrashFuzzV2(modelPath: String, maxNew: Int) async throws {
             case .chunk(let c): chunks += c
             case .reasoning(let r): reasoning += r
             case .toolCall: tools += 1
+            case .prefillProgress:
+
+                break
             case .info: break
             }
         }
@@ -8387,6 +8465,9 @@ func runOfficialMultiTurn(modelPath: String, maxNew: Int) async throws {
                 if ttft == nil { ttft = CFAbsoluteTimeGetCurrent() - t0 }
                 reasoning += r; reasoningDeltas += 1
             case .toolCall: toolCalls += 1
+            case .prefillProgress:
+
+                break
             case .info: break
             }
         }
@@ -8770,6 +8851,9 @@ func runProdMatrix(modelPath: String, maxNew: Int) async throws {
                 if ttft == nil { ttft = CFAbsoluteTimeGetCurrent() - t0 }
                 r.reasoning += rs; deltas += 1
             case .toolCall: r.tools += 1
+            case .prefillProgress:
+
+                break
             case .info(let info):
                 r.promptSec = info.promptTime
                 r.genTokens = info.generationTokenCount

--- a/RunBench/OmniBench.swift
+++ b/RunBench/OmniBench.swift
@@ -1244,6 +1244,8 @@ enum OmniBench {
                 events += 1
             case .info(let generationInfo):
                 info = generationInfo
+            case .prefillProgress:
+                break
             case .toolCall:
                 break
             }

--- a/RunBench/VLBench.swift
+++ b/RunBench/VLBench.swift
@@ -200,6 +200,9 @@ enum VLBench {
                 text += chunk
                 chunkCount += 1
                 if chunkCount > maxNew * 2 { break }
+            case .prefillProgress:
+
+                break
             case .info(let info):
                 generationTokens = info.generationTokenCount
                 promptTokensPerSecond = info.promptTokensPerSecond
@@ -403,7 +406,7 @@ enum VLBench {
                     chunkCount += 1
                 case .reasoning:
                     reasoningCount += 1
-                case .info, .toolCall:
+                case .prefillProgress, .info, .toolCall:
                     break
                 }
             }
@@ -546,7 +549,7 @@ enum VLBench {
             case .reasoning(let r):
                 if ttft == nil { ttft = CFAbsoluteTimeGetCurrent() - t0 }
                 reasoningText += r; reasoningDeltas += 1; sawAnyEvent = true
-            case .info, .toolCall:
+            case .prefillProgress, .info, .toolCall:
                 break
             }
         }
@@ -815,6 +818,9 @@ enum VLBench {
             case .token(let id):
                 engineTokens.append(id)
                 if engineTokens.count >= maxNewTokens { break }
+            case .prefillProgress:
+
+                break
             case .info: break
             }
             if engineTokens.count >= maxNewTokens { break }
@@ -899,6 +905,9 @@ enum VLBench {
         for await event in streamA {
             switch event {
             case .token: turn1Gen += 1
+            case .prefillProgress:
+
+                break
             case .info(let info): turn1PromptTime = info.promptTime
             }
         }
@@ -946,6 +955,9 @@ enum VLBench {
         for await event in streamB {
             switch event {
             case .token: turn2Gen += 1
+            case .prefillProgress:
+
+                break
             case .info(let info): turn2PromptTime = info.promptTime
             }
         }
@@ -1179,6 +1191,9 @@ enum VLBench {
             case .token(let id):
                 if ttft == nil { ttft = CFAbsoluteTimeGetCurrent() - t0 }
                 tokenIds.append(id)
+            case .prefillProgress:
+
+                break
             case .info(let info):
                 promptTime = info.promptTime
             }
@@ -1213,6 +1228,9 @@ enum VLBench {
                 text += chunk
             case .reasoning(let chunk):
                 reasoning += chunk
+            case .prefillProgress:
+
+                break
             case .info(let info):
                 promptTime = info.promptTime
                 tokenCount = info.generationTokenCount
@@ -1309,6 +1327,9 @@ enum VLBench {
                 if ttftMs == nil { ttftMs = (CFAbsoluteTimeGetCurrent() - t0) * 1000 }
                 tokens.append(id)
                 if tokens.count >= maxNewTokens { break }
+            case .prefillProgress:
+
+                break
             case .info: break
             }
             if tokens.count >= maxNewTokens { break }

--- a/Source/MLX/Transforms+Eval.swift
+++ b/Source/MLX/Transforms+Eval.swift
@@ -14,7 +14,7 @@ let evalLock = NSRecursiveLock()
 /// ### See Also
 /// - <doc:lazy-evaluation>
 public func eval(_ arrays: MLXArray...) {
-    let vector_array = new_mlx_vector_array(arrays.filter(\.hasBackingArray))
+    let vector_array = newEvalVectorArray(arrays)
     mlx_eval(vector_array)
     mlx_vector_array_free(vector_array)
 }
@@ -24,7 +24,7 @@ public func eval(_ arrays: MLXArray...) {
 /// ### See Also
 /// - <doc:lazy-evaluation>
 public func eval(_ arrays: some Collection<MLXArray>) {
-    let vector_array = new_mlx_vector_array(arrays.filter(\.hasBackingArray))
+    let vector_array = newEvalVectorArray(arrays)
     mlx_eval(vector_array)
     mlx_vector_array_free(vector_array)
 }
@@ -35,7 +35,7 @@ public func eval(_ arrays: some Collection<MLXArray>) {
 /// - <doc:lazy-evaluation>
 /// - ``asyncEval(_:)-(Collection<MLXArray>)``
 public func asyncEval(_ arrays: some Collection<MLXArray>) {
-    let vector_array = new_mlx_vector_array(arrays.filter(\.hasBackingArray))
+    let vector_array = newEvalVectorArray(arrays)
     mlx_async_eval(vector_array)
     mlx_vector_array_free(vector_array)
 }
@@ -209,4 +209,12 @@ private extension MLXArray {
     var hasBackingArray: Bool {
         ctx.ctx != nil
     }
+}
+
+@inline(__always)
+private func newEvalVectorArray(_ arrays: some Collection<MLXArray>) -> mlx_vector_array {
+    if arrays.contains(where: { !$0.hasBackingArray }) {
+        return new_mlx_vector_array(arrays.filter(\.hasBackingArray))
+    }
+    return new_mlx_vector_array(arrays)
 }

--- a/Sources/MLXPress/MLXPress.swift
+++ b/Sources/MLXPress/MLXPress.swift
@@ -108,7 +108,7 @@ public struct MLXPressCacheConfiguration: Sendable, Equatable {
 
     public init(
         enabled: Bool = true,
-        usePagedCache: Bool = true,
+        usePagedCache: Bool = false,
         enableDiskCache: Bool = true,
         maxCacheBlocks: Int = 2_000,
         diskCacheMaxGB: Float = 10.0,

--- a/Sources/MLXPressCLI/main.swift
+++ b/Sources/MLXPressCLI/main.swift
@@ -200,6 +200,8 @@ struct MLXPressCLI {
                         fflush(stdout)
                     case .reasoning(let text):
                         reasoningText += text
+                    case .prefillProgress:
+                        break
                     case .toolCall:
                         break
                     case .info(let info):
@@ -1148,7 +1150,7 @@ private struct Options {
       For strict thinking-on validation, thinking-on validation prompts must ask for a visible final answer.
       Do not use prompts that ask the model to think privately; pair thinking-on proof rows with
       --min-visible-chars and --fail-on-length-stop so reasoning-only length stops remain failures.
-      --cache-stack defaults to on: paged cache, disk L2, TurboQuant KV defaulting, and long-prompt KV cap are enabled.
+      --cache-stack defaults to on: disk L2, TurboQuant KV defaulting, and long-prompt KV cap are enabled; paged RAM cache is opt-in.
       --disk-cache-dir isolates disk L2 state for cold/warm validation runs.
       --ephemeral-prestack builds a temporary routed JANGTQ overlay under the system temp directory, uses the mmap loader, and removes the overlay after mmap load with a process-exit fallback. It is a MiniMax-class resident-compute diagnostic, not a permanent prestack cache.
       --compiled-decode is diagnostic opt-in for the single-sequence compiled decode path. MiniMax remains blocked unless --allow-minimax-compiled-decode is also set, because older compiled traces diverged.

--- a/Sources/MLXPressSelfCheck/main.swift
+++ b/Sources/MLXPressSelfCheck/main.swift
@@ -322,7 +322,7 @@ private func checkLoadConfigurationDefaults() throws {
     try expect(defaultConfiguration.disableDecodeFusedGateUp, "expected fused gate/up disabled")
     try expect(!defaultConfiguration.enableActiveExpertStreaming, "expected active streaming default-off")
     try expect(defaultConfiguration.cache.enabled, "expected cache stack default-on")
-    try expect(defaultConfiguration.cache.usePagedCache, "expected paged cache default-on")
+    try expect(!defaultConfiguration.cache.usePagedCache, "expected paged cache default-off")
     try expect(defaultConfiguration.cache.enableDiskCache, "expected disk cache default-on")
     try expect(defaultConfiguration.cache.defaultKVMode == .turboQuant(keyBits: 3, valueBits: 3), "expected TurboQuant KV default")
 

--- a/Tests/MLXLMCommonFocusedTests/CacheCoordinatorTopologyFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/CacheCoordinatorTopologyFocusedTests.swift
@@ -681,6 +681,18 @@ struct CacheCoordinatorTopologyFocusedTests {
         try? FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
         return url
     }
+
+    @Test("Gemma4 processor normalizes tool schemas before applying chat template")
+    func gemma4ProcessorNormalizesToolSchemasBeforeChatTemplate() throws {
+        let sourceURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Libraries/MLXVLM/Models/Gemma4.swift")
+        let source = try String(contentsOf: sourceURL)
+        #expect(source.contains("normalizedToolsForChatTemplate(input.tools)"))
+        #expect(source.contains("tools: chatTemplateTools"))
+    }
 }
 
 @Suite("BatchArraysCache focused contracts", .serialized)

--- a/Tests/MLXLMCommonFocusedTests/VMLXMemorySafetySettingsTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/VMLXMemorySafetySettingsTests.swift
@@ -45,7 +45,7 @@ struct VMLXMemorySafetySettingsTests {
         #expect(plan.loadConfiguration.useMmapSafetensors)
         #expect(plan.loadConfiguration.jangPress == .disabled)
         #expect(plan.cache.prefix.enabled)
-        #expect(plan.cache.pagedKV.enabled)
+        #expect(!plan.cache.pagedKV.enabled)
         #expect(plan.cache.blockDisk.enabled)
         #expect(!plan.cache.legacyDisk.enabled)
         #expect(plan.cache.defaultMaxKVSize == 8192)
@@ -208,7 +208,7 @@ struct VMLXMemorySafetySettingsTests {
 
         #expect(plan.cache.liveKVCodec == .engineSelected)
         #expect(plan.cache.enableSSMReDerive)
-        #expect(coordinator.usePagedCache)
+        #expect(!coordinator.usePagedCache)
         #expect(coordinator.enableDiskCache)
         #expect(coordinator.enableSSMReDerive)
         #expect(coordinator.ssmMaxEntries == 96)

--- a/Tests/MLXLMCommonFocusedTests/VMLXServerRuntimeSettingsTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/VMLXServerRuntimeSettingsTests.swift
@@ -15,7 +15,7 @@ struct VMLXServerRuntimeSettingsTests {
         #expect(settings.network.host == "127.0.0.1")
         #expect(settings.concurrency.continuousBatching)
         #expect(settings.cache.prefix.enabled)
-        #expect(settings.cache.pagedKV.enabled)
+        #expect(!settings.cache.pagedKV.enabled)
         #expect(settings.cache.blockDisk.enabled)
         #expect(settings.cache.legacyDisk.enabled == false)
         #expect(settings.cache.liveKVCodec == .engineSelected)
@@ -788,7 +788,7 @@ struct VMLXServerRuntimeSettingsTests {
             promptTokenCount: 32_768)
 
         #expect(settings.concurrency.continuousBatching)
-        #expect(config.usePagedCache)
+        #expect(!config.usePagedCache)
         #expect(config.enableDiskCache)
         #expect(config.enableSSMReDerive)
         #expect(config.modelKey == "matrix|reasoning=auto|tools=auto")
@@ -818,6 +818,17 @@ struct VMLXServerRuntimeSettingsTests {
 
         #expect(!config.usePagedCache)
         #expect(!config.enableDiskCache)
+    }
+
+    @Test("explicit paged cache opt-in still enables coordinator paged tier")
+    func explicitPagedCacheOptInStillEnablesCoordinatorPagedTier() {
+        var settings = VMLXServerRuntimeSettings()
+        settings.cache.pagedKV.enabled = true
+
+        let config = settings.cacheCoordinatorConfig()
+
+        #expect(config.usePagedCache)
+        #expect(config.enableDiskCache)
     }
 
     @Test("parser overrides validate known aliases")

--- a/Tests/MLXLMTests/BatchEngineCompileWiringTests.swift
+++ b/Tests/MLXLMTests/BatchEngineCompileWiringTests.swift
@@ -55,8 +55,13 @@ class BatchEngineCompileWiringTests: XCTestCase {
         var info: GenerateCompletionInfo?
         for await event in stream {
             switch event {
+            case .prefillProgress:
+                break
             case .token(let id):
                 tokens.append(id)
+            case .prefillProgress:
+
+                break
             case .info(let i):
                 info = i
             }

--- a/Tests/MLXLMTests/BatchEngineEOSFirstTokenTests.swift
+++ b/Tests/MLXLMTests/BatchEngineEOSFirstTokenTests.swift
@@ -70,8 +70,13 @@ class BatchEngineEOSFirstTokenTests: XCTestCase {
         var stopReason: GenerateStopReason?
         for await event in stream {
             switch event {
+            case .prefillProgress:
+                break
             case .token:
                 tokenCount += 1
+            case .prefillProgress:
+
+                break
             case .info(let info):
                 stopReason = info.stopReason
             }

--- a/Tests/MLXLMTests/BatchEngineSpecDecTests.swift
+++ b/Tests/MLXLMTests/BatchEngineSpecDecTests.swift
@@ -77,9 +77,14 @@ struct BatchEngineSpecDecTests {
         var chunks = 0, toolCalls = 0, infoCount = 0
         for await ev in stream {
             switch ev {
+            case .prefillProgress:
+                break
             case .chunk: chunks += 1
             case .reasoning: break
             case .toolCall: toolCalls += 1
+            case .prefillProgress:
+
+                break
             case .info: infoCount += 1
             @unknown default: break
             }

--- a/Tests/MLXLMTests/BatchEngineTests.swift
+++ b/Tests/MLXLMTests/BatchEngineTests.swift
@@ -858,6 +858,35 @@ class BatchEngineIntegrationTests: XCTestCase {
         XCTAssertFalse(finalSoloActive)
     }
 
+    func testGenerateSoloFastPathEmitsPrefillProgress() async throws {
+        let engine = makeSlowPrefillEngine(
+            prefillDelayMicroseconds: 20_000,
+            maxBatchSize: 1)
+
+        let stream = await engine.generate(
+            input: LMInput(tokens: MLXArray(Int32(1) ..< Int32(5))),
+            parameters: GenerateParameters(maxTokens: 2, temperature: 0)
+        )
+
+        var progress = [PrefillProgress]()
+        var sawChunkOrInfo = false
+        for await generation in stream {
+            switch generation {
+            case .prefillProgress(let p):
+                XCTAssertFalse(sawChunkOrInfo, "prefill progress must arrive before output/info")
+                progress.append(p)
+            case .chunk, .reasoning, .toolCall, .info:
+                sawChunkOrInfo = true
+            }
+        }
+
+        XCTAssertEqual(progress.first?.stage, .queued)
+        XCTAssertTrue(progress.contains { $0.stage == .prefill })
+        XCTAssertEqual(progress.last?.stage, .complete)
+        XCTAssertEqual(progress.last?.completedUnitCount, 4)
+        XCTAssertEqual(progress.last?.totalUnitCount, 4)
+    }
+
     /// If a raw `submit(...)` arrives while the direct B=1 `generate(...)`
     /// path owns the model, it must queue without starting the actor decode
     /// loop. Starting both would create two concurrent MLX paths over the same

--- a/Tests/MLXLMTests/BatchEngineTests.swift
+++ b/Tests/MLXLMTests/BatchEngineTests.swift
@@ -523,15 +523,20 @@ class BatchEngineIntegrationTests: XCTestCase {
         let stream = await engine.generate(input: input, parameters: params)
         for await generation in stream {
             switch generation {
+            case .prefillProgress:
+                break
             case .chunk(let text):
                 XCTAssertFalse(text.isEmpty, "Chunk should not be empty")
                 tokenCount += 1
+            case .prefillProgress:
+
+                break
             case .info(let info):
                 gotInfo = true
                 XCTAssertEqual(info.promptTokenCount, 5)
                 XCTAssertGreaterThan(info.generationTokenCount, 0)
                 XCTAssertEqual(info.stopReason, .length)
-            case .reasoning, .toolCall:
+            case .reasoning, .prefillProgress, .toolCall:
                 break
             @unknown default:
                 break
@@ -874,11 +879,16 @@ class BatchEngineIntegrationTests: XCTestCase {
             var info: GenerateCompletionInfo?
             for await event in stream {
                 switch event {
-                case .chunk(let text):
+                case .prefillProgress:
+                break
+            case .chunk(let text):
                     chunks.append(text)
+                case .prefillProgress:
+
+                    break
                 case .info(let i):
                     info = i
-                case .reasoning, .toolCall:
+                case .reasoning, .prefillProgress, .toolCall:
                     break
                 @unknown default:
                     break
@@ -1088,8 +1098,13 @@ class BatchEngineIntegrationTests: XCTestCase {
         var info: GenerateCompletionInfo?
         for await event in stream {
             switch event {
+            case .prefillProgress:
+                break
             case .token(let id):
                 tokens.append(id)
+            case .prefillProgress:
+
+                break
             case .info(let i):
                 info = i
             }
@@ -1104,11 +1119,16 @@ class BatchEngineIntegrationTests: XCTestCase {
         var info: GenerateCompletionInfo?
         for await event in stream {
             switch event {
+            case .prefillProgress:
+                break
             case .chunk(let text):
                 chunks.append(text)
+            case .prefillProgress:
+
+                break
             case .info(let i):
                 info = i
-            case .reasoning, .toolCall:
+            case .reasoning, .prefillProgress, .toolCall:
                 break
             @unknown default:
                 break

--- a/Tests/MLXLMTests/BatchEngineTurboQuantTests.swift
+++ b/Tests/MLXLMTests/BatchEngineTurboQuantTests.swift
@@ -374,6 +374,32 @@ struct BatchQuantizeHookTests {
             #expect(!cache.contains { $0 is TurboQuantKVCache })
         }
     }
+
+    @Test("Gemma SWA contract keeps full attention TQ-eligible and sliding disk-backed")
+    func testGemmaSWATopologyContract() throws {
+        let gemmaSource = try String(
+            contentsOfFile: "Libraries/MLXLLM/Models/Gemma4Text.swift",
+            encoding: .utf8)
+        let batchQuantizeSource = try String(
+            contentsOfFile: "Libraries/MLXLMCommon/BatchEngine/BatchQuantize.swift",
+            encoding: .utf8)
+
+        #expect(gemmaSource.contains(#"if layerType == "full_attention""#))
+        #expect(gemmaSource.contains("return KVCacheSimple()"))
+        #expect(gemmaSource.contains(#"return RotatingKVCache(maxSize: config.slidingWindow, keep: 0)"#))
+        #expect(batchQuantizeSource.contains("ordinary `KVCacheSimple` layers compress"))
+        #expect(batchQuantizeSource.contains("Preserves `RotatingKVCache`, `DeepseekV4Cache`, `MambaCache`,"))
+
+        let topology = ModelCacheTopologySnapshot(cache: [
+            TurboQuantKVCache(),
+            RotatingKVCache(maxSize: 1024, keep: 0),
+            RotatingKVCache(maxSize: 1024, keep: 0),
+            TurboQuantKVCache(),
+        ])
+        #expect(topology.turboQuantKVLayerCount == 2)
+        #expect(topology.rotatingKVLayerCount == 2)
+        #expect(topology.requiresDiskBackedCoordinatorRestore)
+    }
 }
 
 // MARK: - Integration Tests: BatchEngine + TurboQuant
@@ -412,6 +438,8 @@ class BatchEngineTurboQuantIntegrationTests: XCTestCase {
         var info: GenerateCompletionInfo?
         for await event in stream {
             switch event {
+            case .prefillProgress:
+                break
             case .token(let id):
                 tokens.append(id)
             case .info(let i):
@@ -665,6 +693,8 @@ class BatchEngineMultiTurnTests: XCTestCase {
         var info: GenerateCompletionInfo?
         for await event in stream {
             switch event {
+            case .prefillProgress:
+                break
             case .token(let id):
                 tokens.append(id)
             case .info(let i):

--- a/Tests/MLXLMTests/CacheCoordinatorKVPolicyTests.swift
+++ b/Tests/MLXLMTests/CacheCoordinatorKVPolicyTests.swift
@@ -16,6 +16,14 @@ import Testing
 @Suite("CacheCoordinator KV policy")
 struct CacheCoordinatorKVPolicyTests {
 
+    @Test("coordinator defaults keep paged RAM cache off")
+    func coordinatorDefaultsKeepPagedRAMCacheOff() {
+        let config = CacheCoordinatorConfig()
+
+        #expect(!config.usePagedCache)
+        #expect(!config.enableDiskCache)
+    }
+
     // MARK: - defaultKVMode
 
     @Test("explicit request kvMode wins over coordinator default")

--- a/Tests/MLXLMTests/LLMPreparePrefillTests.swift
+++ b/Tests/MLXLMTests/LLMPreparePrefillTests.swift
@@ -28,6 +28,22 @@ import XCTest
 /// extension is shared. These tests pin the behaviour with a tiny random
 /// Llama so regressions surface under `swift test` without any model files.
 final class LLMPreparePrefillTests: XCTestCase {
+    private final class ProgressRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var values: [Int] = []
+
+        func append(_ value: Int) {
+            lock.lock()
+            values.append(value)
+            lock.unlock()
+        }
+
+        func snapshot() -> [Int] {
+            lock.lock()
+            defer { lock.unlock() }
+            return values
+        }
+    }
 
     /// Small random-init Llama that exercises the default `LLMModel.prepare`.
     private func makeModel(vocab: Int = 64) -> LlamaModel {
@@ -97,6 +113,20 @@ final class LLMPreparePrefillTests: XCTestCase {
         XCTAssertEqual(
             remainder.tokens.ndim, 1,
             "prepare must return a 1D tokens remainder even for 2D input")
+    }
+
+    func testChunkedPrefillReportsCompletedUnitsAfterEachChunk() throws {
+        let model = makeModel()
+        let cache = model.newCache(parameters: nil)
+        let recorder = ProgressRecorder()
+
+        let tokens = MLXArray((0..<totalLen).map { Int32($0 % 64) })[.newAxis, 0...]
+        let input = LMInput(text: .init(tokens: tokens))
+        _ = try PrefillProgressReporter.$current.withValue({ recorder.append($0) }) {
+            try model.prepare(input, cache: cache, windowSize: step)
+        }
+
+        XCTAssertEqual(recorder.snapshot(), [step, step * 2])
     }
 
     // MARK: - Short input (no chunking)

--- a/Tests/MLXLMTests/SpecDecStreamTests.swift
+++ b/Tests/MLXLMTests/SpecDecStreamTests.swift
@@ -146,8 +146,11 @@ struct SpecDecStreamTests {
         for await ev in stream {
             switch ev {
             case .chunk(let c): chunks.append(c)
+            case .prefillProgress:
+
+                break
             case .info: infoCount += 1
-            case .reasoning, .toolCall: break
+            case .reasoning, .prefillProgress, .toolCall: break
             @unknown default: break
             }
         }
@@ -198,8 +201,11 @@ struct SpecDecStreamTests {
         for await ev in stream {
             switch ev {
             case .chunk(let c): chunks.append(c)
+            case .prefillProgress:
+
+                break
             case .info: infoCount += 1
-            case .reasoning, .toolCall: break
+            case .reasoning, .prefillProgress, .toolCall: break
             @unknown default: break
             }
         }

--- a/Tests/MLXLMTests/ZayaSmokeJANGTQ2Tests.swift
+++ b/Tests/MLXLMTests/ZayaSmokeJANGTQ2Tests.swift
@@ -270,12 +270,17 @@ struct ZayaSmokeJANGTQ2Tests {
         var unclosedReasoning = false
         for await event in stream {
             switch event {
+            case .prefillProgress:
+                break
             case .chunk(let chunk):
                 text += chunk
             case .reasoning(let chunk):
                 reasoning += chunk
             case .toolCall:
                 toolCalls += 1
+            case .prefillProgress:
+
+                break
             case .info(let info):
                 unclosedReasoning = info.unclosedReasoning
             }

--- a/docs/GEMMA4_QAT_SPEED_METHOD_2026_06_12.md
+++ b/docs/GEMMA4_QAT_SPEED_METHOD_2026_06_12.md
@@ -1,0 +1,426 @@
+# Gemma 4 QAT Speed Method - 2026-06-12
+
+## Priority
+
+Current release priority for Gemma 4 QAT MXFP4/JANG_4M is:
+
+1. Speed: raw vmlx-swift release speed must be pushed toward llama.cpp GGUF
+   speed before broad release claims.
+2. Tool calling support: once raw speed/load is healthy, prove Osaurus
+   tool-call and agent-loop behavior on the same pinned engine.
+
+Do not promote a row from tool correctness alone if the raw vMLX engine speed
+path is broken or unmeasured.
+
+## Current Release Gate Status
+
+Status: `PARTIAL`.
+
+The current vMLX branch has Gemma 4 QAT sidecar loading fixes for MXFP4 and
+JANG_4M, and the local E2B text rows load and generate coherently through
+release `RunBench`. This is not yet a full Osaurus release checkpoint.
+
+Do not mark the Osaurus PR merge-ready until all of these are true on the
+pinned engine:
+
+- Raw vMLX speed is understood and either improved or explicitly accepted
+  against a matching llama.cpp GGUF baseline.
+- Osaurus app/API loads MXFP4 and JANG_4M without RAM surprises on the target
+  device class.
+- Multi-turn chat is coherent with no loops, no protocol markers, no strange
+  characters, and token/s recorded.
+- Tool calling works through the Osaurus agent loop with exact tool names and
+  JSON arguments.
+- Prefix cache, disk L2 cache, and paged-cache-disabled behavior are proven
+  from active runtime telemetry.
+- VL/audio rows use real media payloads where the model supports them.
+
+Known app-facing proof exists for a 12B JANG_4M checkpoint, but that proof is
+not the full MXFP4/JANG_4M Gemma matrix and does not close the raw speed gate.
+
+## Standard Token/S Definition
+
+All raw vMLX Gemma 4 QAT speed claims must use `RunBench BENCH_PERF=1` from a
+release build.
+
+The reported decode token/s is:
+
+```text
+tokps = genTokens / genSec
+```
+
+where `genTokens` and `genSec` come from the generation completion info emitted
+by the vMLX generation path. The promoted row is `tokps_median` over measured
+runs after warmup. Do not mix this with wall-clock HTTP request time, UI TTFT,
+small tool-call turns, or Osaurus agent-loop timing.
+
+Minimum standard shape:
+
+- Build: `swift build -c release --product RunBench`.
+- Path: `BENCH_PERF_PATH=batch`.
+- Batch: single request, no multibatch.
+- Prompt: `Write one long paragraph describing ocean waves. Be verbose and detailed.`
+- Tokens: `BENCH_MAX_TOKENS=128`.
+- Warmup: `BENCH_PERF_WARMUP=1`.
+- Runs: `BENCH_PERF_RUNS=3`.
+- Promote: median decode tok/s, best tok/s, TTFT, prompt tok/s, RSS, physical
+  footprint, model path, vMLX commit, and artifact root.
+
+## Two Required Speed Rows
+
+Every model needs two separate rows because sampler settings change the
+runtime path and output shape.
+
+### Row A: Deterministic Engine Comparison
+
+Purpose: compare vMLX decode hot path against llama.cpp with as few sampler
+variables as possible.
+
+Required settings:
+
+```bash
+BENCH_PERF=1
+BENCH_PERF_TEMP=0
+BENCH_PERF_TOP_P=1
+BENCH_PERF_TOP_K=0
+BENCH_PERF_MIN_P=0
+BENCH_PERF_USE_GENERATION_CONFIG unset
+```
+
+This row answers whether vMLX kernels/loading/cache are near GGUF speed.
+
+### Row B: Bundle Defaults
+
+Purpose: measure the actual user-facing bundle defaults.
+
+Required settings:
+
+```bash
+BENCH_PERF=1
+BENCH_PERF_USE_GENERATION_CONFIG=1
+BENCH_PERF_SEED=1234
+```
+
+Explicit `BENCH_PERF_TEMP`, `BENCH_PERF_TOP_P`, `BENCH_PERF_TOP_K`,
+`BENCH_PERF_MIN_P`, and repetition overrides must be absent unless the test is
+explicitly labeled as an override diagnostic.
+
+## Standard Script
+
+Use:
+
+```bash
+scripts/run-gemma4-qat-speed-standard.sh
+```
+
+With no arguments, it runs E2B MXFP4 and E2B JANG_4M. To run the full matrix,
+pass explicit local model directories under `/Users/eric/models`.
+
+The script writes:
+
+- `METADATA.txt`
+- `SUMMARY.txt`
+- one stdout/stderr pair for every model and mode
+
+## llama.cpp Comparison
+
+Use llama.cpp `llama-bench` for the GGUF baseline and compare only decode rows
+with `n_gen=128` against vMLX deterministic Row A. Keep prompt eval separate.
+
+Current known E2B GGUF baseline artifact:
+
+- `/tmp/vmlx-gemma4-e2b-compare-20260612T155643Z/gguf-llama-bench.json`
+
+Current known GGUF numbers:
+
+- Prompt eval: `7384.720274 tok/s`
+- Decode: `173.677288 tok/s`
+
+Current E2B QAT comparison against that decode target:
+
+| Row | vMLX tok/s | GGUF tok/s | Gap |
+|---|---:|---:|---:|
+| E2B MXFP4 deterministic, current-main clean PR branch | `122.1` | `173.677` | `29.7%` slower |
+| E2B JANG_4M deterministic, current-main clean PR branch | `115.0` | `173.677` | `33.8%` slower |
+| E2B MXFP4 deterministic, older PR base diagnostic | `143.2` | `173.677` | `17.5%` slower |
+| E2B JANG_4M deterministic, older PR base diagnostic | `132.5` | `173.677` | `23.7%` slower |
+
+Do not compare only MXFP4 against JANG_4M. Every speed row with a documented
+GGUF peer must report the vMLX-vs-GGUF gap.
+
+There is no current local 12B/31B GGUF peer artifact in this doc. Do not infer
+their GGUF gap from E2B; first create matching llama.cpp `n_gen=128` baselines
+for the same local bundle/quant tier.
+
+## SwitchGLU Speed Work
+
+Gemma 4 MoE uses `SwitchGLU` for routed experts. JANG/MXFP bundles can carry
+`gate_up_proj` and `down_proj` tensor layouts that must be remapped into the
+runtime `switch_glu` module contract before speed tuning.
+
+SwitchGLU speed work must follow these rules:
+
+- First prove the exact weight remap/load path, including `gate_up_proj`,
+  `down_proj`, `scales`, and `biases` handling.
+- Run the standard deterministic speed row before and after any SwitchGLU
+  change.
+- Run the standard bundle-default speed row before and after any SwitchGLU
+  change.
+- Do not enable whole-SwitchGLU compile or a TurboQuant replacement by default
+  unless output quality, no-loop behavior, and token identity/semantic parity
+  pass on the standard rows.
+- Any SwitchGLU diagnostic must be labeled as diagnostic until it passes the
+  same coherency, leak, and speed gates as the default path.
+
+## Current E2B Release Numbers
+
+Artifact:
+
+- `/tmp/vmlx-gemma4-qatsidecar-clean-postrevert-e2b-20260612T182246Z`
+
+Rows:
+
+- E2B MXFP4 deterministic release: `tokps_median=122.1`,
+  `tokps_best=122.3`, `TTFT ~113-120 ms`, `prompt_tps ~689-727`.
+- E2B MXFP4 bundle defaults: `tokps_median=118.6`,
+  `tokps_best=118.8`, `temp=1.00`, `topP=0.95`, `topK=64`.
+- E2B JANG_4M deterministic release: `tokps_median=115.0`,
+  `tokps_best=118.2`, `TTFT ~100-104 ms`, `prompt_tps ~699-729`.
+- E2B JANG_4M bundle defaults: `tokps_median=110.3`,
+  `tokps_best=110.7`, `temp=1.00`, `topP=0.95`, `topK=64`.
+
+Interpretation versus GGUF E2B decode `173.677288 tok/s`:
+
+- MXFP4 is about 29.7 percent slower than GGUF on this raw deterministic row.
+- JANG_4M is about 33.8 percent slower than GGUF on this raw deterministic row.
+
+This is no longer a load failure after the sidecar patch, but speed remains an
+active vMLX optimization target before broad Osaurus release claims.
+
+## Current QAT Text Speed Matrix
+
+Artifacts below use the standard release `RunBench BENCH_PERF=1` method from
+this document. These rows prove text load/decode speed only. They do not prove
+Osaurus app tool-loop execution, SSD prefix cache TTFT, VL/audio behavior, or
+lower-spec physical footprint gates.
+
+| Model | Quant | Deterministic | Bundle Defaults | Artifact |
+|---|---|---:|---:|---|
+| E2B | MXFP4 | `122.1 tok/s` | `118.6 tok/s` | `/tmp/vmlx-gemma4-qatsidecar-clean-postrevert-e2b-20260612T182246Z/SUMMARY.txt` |
+| E2B | JANG_4M | `115.0 tok/s` | `110.3 tok/s` | `/tmp/vmlx-gemma4-qatsidecar-clean-postrevert-e2b-20260612T182246Z/SUMMARY.txt` |
+| E4B | MXFP4 | `93.8 tok/s` | `90.4 tok/s` | `/tmp/vmlx-gemma4-upstream-ple-linear-router-e4b-26b-20260612T172809Z/SUMMARY.txt` |
+| E4B | JANG_4M | `82.6 tok/s` | `80.4 tok/s` | `/tmp/vmlx-gemma4-upstream-ple-linear-router-e4b-26b-20260612T172809Z/SUMMARY.txt` |
+| 12B | MXFP4 | `39.8 tok/s`, `loop=YES` | `37.8 tok/s` | `/tmp/vmlx-gemma4-upstream-ple-linear-router-12b-31b-20260612T172930Z/SUMMARY.txt` |
+| 12B | JANG_4M | `32.7 tok/s` | `32.6 tok/s` | `/tmp/vmlx-gemma4-upstream-ple-linear-router-12b-31b-20260612T172930Z/SUMMARY.txt` |
+| 26B A4B | MXFP4 | `97.2 tok/s` | `91.9 tok/s`, `unclosedReasoning=YES` | `/tmp/vmlx-gemma4-upstream-ple-linear-router-e4b-26b-20260612T172809Z/SUMMARY.txt` |
+| 26B A4B | JANG_4M | `84.2 tok/s` | `81.1 tok/s` | `/tmp/vmlx-gemma4-upstream-ple-linear-router-e4b-26b-20260612T172809Z/SUMMARY.txt` |
+| 31B | MXFP4 | `18.4 tok/s` | `18.8 tok/s` | `/tmp/vmlx-gemma4-upstream-ple-linear-router-12b-31b-20260612T172930Z/SUMMARY.txt` |
+| 31B | JANG_4M | `17.2 tok/s` | `16.6 tok/s`, `unclosedReasoning=YES` | `/tmp/vmlx-gemma4-upstream-ple-linear-router-12b-31b-20260612T172930Z/SUMMARY.txt` |
+
+Behavior caveats from the same artifacts:
+
+- 12B MXFP4 deterministic is speed-measured but not a clean behavior pass
+  because the row reports `loop=YES`.
+- 26B A4B MXFP4 bundle-default is speed-measured but not a clean behavior pass
+  because it reports `unclosedReasoning=YES` with hidden reasoning output.
+- 31B JANG_4M bundle-default is speed-measured but not a clean behavior pass
+  because it reports `unclosedReasoning=YES` with hidden reasoning output.
+
+## Current Speed Diagnostics
+
+### Attribution Summary
+
+Fresh artifacts:
+
+- Full standard matrix:
+  `/tmp/vmlx-gemma4-qatsidecar-clean-postrevert-e2b-20260612T182246Z`,
+  `/tmp/vmlx-gemma4-upstream-ple-linear-router-20260612T172733Z`,
+  `/tmp/vmlx-gemma4-upstream-ple-linear-router-e4b-26b-20260612T172809Z`,
+  `/tmp/vmlx-gemma4-upstream-ple-linear-router-12b-31b-20260612T172930Z`
+- Older PR-base control:
+  `/tmp/vmlx-gemma4-qatsidecar-fix-oldbase-e2b-20260612T181842Z`
+- Current-main diagnostics:
+  `/tmp/vmlx-gemma4-qatsidecar-clean-fused-e2b-20260612T181201Z`,
+  `/tmp/vmlx-gemma4-qatsidecar-clean-scaledple-e2b-20260612T181748Z`,
+  `/tmp/vmlx-gemma4-current-512-mxfp4-20260612T181941Z`,
+  `/tmp/vmlx-gemma4-oldbase-512-mxfp4-20260612T181941Z`
+- Graph snapshots:
+  `/tmp/vmlx-gemma4-graph-stats-20260612T173342Z`
+- Compiled decode diagnostic:
+  `/tmp/vmlx-gemma4-compiled-decode-check-20260612T173514Z`
+- TurboQuant KV diagnostic:
+  `/tmp/vmlx-gemma4-tq-kv-speed-check-20260612T173612Z`
+
+Current conclusion:
+
+- This speed gap is not Osaurus UI/API timing. The numbers above are direct
+  `RunBench` release rows against local model folders.
+- This is not TurboQuant KV. The standard rows report `kvMode=none`, and the
+  TurboQuant KV diagnostic was slower for short single-batch E2B.
+- This is not primarily BatchEngine overhead. Current-main E2B MXFP4 batch and
+  direct iterator rows both measured `122.1 tok/s`.
+- This is not primarily VLM-first factory overhead. Forced LLM text controls
+  were same or slower than the VLM inline Gemma4 path.
+- This is not solved by only restoring the older custom scaled PLE projection
+  path on current main. That A/B measured E2B MXFP4 `120.5 tok/s` and JANG_4M
+  `113.2 tok/s`, effectively unchanged.
+- This is not solved by the fused Gemma4 RMSNorm/GELU micro-fragments alone on
+  current main. That A/B measured E2B MXFP4 `121.2 tok/s` and JANG_4M
+  `112.6 tok/s`, effectively unchanged.
+- The upstream PLE design is correct source architecture: use normal `Linear`
+  for `per_layer_model_projection` and multiply by
+  `pow(hidden_size, -0.5)` after projection so loader quantization owns MXFP/JANG
+  sidecars. This cleans the model path but does not close the GGUF gap.
+- The current-main runtime is materially slower than the older PR-base control:
+  E2B MXFP4 `122.1` vs `143.2 tok/s`, and E2B JANG_4M `115.0` vs
+  `132.5 tok/s`. The next speed investigation should bisect current-main
+  runtime changes around eval/decode/cache/model container behavior, not
+  remeasure Osaurus.
+- Dense 12B/31B are the bad speed class. E2B/E4B/26B A4B are usable but still
+  below the E2B GGUF baseline; 12B/31B dense rows are far slower and need
+  focused runtime/kernel work before release promotion.
+
+Representative graph rows:
+
+| Row | tok/s | graphNodes | asType | Notes |
+|---|---:|---:|---:|---|
+| E2B MXFP4 | `149.2` | `2615` | `285` | Clean short graph row. |
+| 26B A4B MXFP4 | `97.9` | `3485` | `272` | Uses fixed router parity path. |
+| 12B MXFP4 | `50.8` | `3404` | `242` | Dense/unified text path. |
+| 31B MXFP4 | `23.8` | `3710` | `242` | Large dense text path. |
+
+This does not look like simple graph-node explosion. The next speed target is
+dense Gemma4 quantized matmul/attention scaling plus compiled decode promotion,
+not more Osaurus request-path measurement.
+
+### Compiled batch decode diagnostic
+
+Artifact:
+
+- `/tmp/vmlx-gemma4-compiled-decode-check-20260612T173514Z`
+
+| Row | Standard | Compiled batch | Result |
+|---|---:|---:|---|
+| E2B MXFP4 | `146.7 tok/s` | `147.8 tok/s` | Noise/small gain. |
+| 12B MXFP4 | `39.8 tok/s` | `50.4 tok/s` | Real gain, but still `loop=YES`. |
+| 31B MXFP4 | `18.4 tok/s` | `23.4 tok/s` | Real gain, still far below desired parity. |
+
+Compiled decode is a real dense-path lever. It is not sufficient alone and
+cannot be enabled as a release fix for 12B until the loop behavior is resolved.
+
+### TurboQuant KV diagnostic
+
+Artifact:
+
+- `/tmp/vmlx-gemma4-tq-kv-speed-check-20260612T173612Z`
+
+| Row | Standard | TurboQuant KV | Result |
+|---|---:|---:|---|
+| E2B MXFP4 | `146.7 tok/s` | `89.7 tok/s` | Slower, higher footprint. |
+| 12B MXFP4 | `39.8 tok/s` | `32.5 tok/s` | Slower, still `loop=YES`. |
+| 31B MXFP4 | `18.4 tok/s` | `16.5 tok/s` | Slower, higher footprint. |
+
+TurboQuant KV can still be a RAM/cache policy feature for long context, but
+for single-batch short-context decode it is not the GGUF-parity speed fix.
+Do not use TurboQuant KV speed rows to claim raw decode improvement unless a
+future long-context benchmark proves it.
+
+### VLM text SDPA cleanup
+
+Artifact:
+
+- `/tmp/vmlx-gemma4-vlm-text-sdpa-fix-20260612T165942Z`
+
+Result: not a meaningful speed fix.
+
+| Row | Before | After | Notes |
+|---|---:|---:|---|
+| E2B MXFP4 deterministic | `144.7 tok/s` | `145.0 tok/s` | Still `graphNodes=2615`, `asType=285`. |
+| E2B JANG_4M deterministic | `130.7 tok/s` | `134.2 tok/s` | Small gain/noise; still `graphNodes=2820`, `asType=285`. |
+| 26B A4B MXFP4 deterministic | `95.4 tok/s` | `95.2 tok/s` | No gain; still `graphNodes=3635`, `asType=272`. |
+| 26B A4B JANG_4M deterministic | `82.4 tok/s` | `81.9 tok/s` | No gain; still `graphNodes=3635`, `asType=272`. |
+
+Interpretation: the VLM inline Gemma4 text path had a stale fp16 attention
+upcast that differed from `Gemma4Text.swift`, but current QAT rows do not get
+their llama.cpp gap from this path.
+
+### SwitchGLU fused gate-up cap
+
+Artifact:
+
+- `/tmp/vmlx-gemma4-switchglu-fused-cap-20260612T170138Z`
+
+Result: fused gate-up is already engaged by default for 26B A4B. Disabling it
+adds about 90 graph nodes and lowers footprint by several GB, but is slower.
+Removing the cache cap with `VMLX_FUSED_GATE_UP_CACHE_LIMIT_MB=-1` does not
+improve speed.
+
+| Row | Default fused | Fused disabled | Fused unlimited |
+|---|---:|---:|---:|
+| 26B A4B MXFP4 deterministic | `95.4 tok/s` | `90.9 tok/s` | `93.9 tok/s` |
+| 26B A4B JANG_4M deterministic | `82.4 tok/s` | `80.2 tok/s` | `80.9 tok/s` |
+
+Interpretation: the default fused affine `SwitchGLU` path is worth keeping for
+speed, but it is not the missing GGUF-parity fix. The remaining gap is still in
+runtime/kernel/path work: affine `gatherQuantizedMM`, graph/asType cleanup,
+compiled decode eligibility, and cache/runtime policy.
+
+### VLM router parity
+
+Artifact:
+
+- `/tmp/vmlx-gemma4-vlm-router-parity-20260612T171031Z`
+
+The VLM inline Gemma4 router now mirrors the text/Python router contract:
+RMSNorm uses the scaled router weight, top-k is selected from raw logits, and
+softmax is applied only over the selected top-k logits. The previous VLM path
+softmaxed over every expert, then gathered and renormalized.
+
+Measured result:
+
+| Row | Before | After | Graph |
+|---|---:|---:|---|
+| 26B A4B MXFP4 deterministic | `93.3-95.4 tok/s` | `96.7 tok/s` | `3635 -> 3485` nodes |
+| 26B A4B JANG_4M deterministic | `82.4-84.6 tok/s` | `81.9 tok/s` | `3635 -> 3485` nodes |
+
+Keep the router parity fix because it removes incorrect extra work and matches
+the model contract. Do not describe it as the full speed fix.
+
+### PLE dense dequantization rejection
+
+Artifact:
+
+- `/tmp/vmlx-gemma4-ple-dense-projection-20260612T171946Z`
+
+Diagnostic: dequantize `per_layer_model_projection` to dense bf16 during
+sanitize.
+
+Result: rejected. It was slower on every tested PLE row:
+
+| Row | Standard | Dense PLE diagnostic |
+|---|---:|---:|
+| E2B MXFP4 | about `144-147 tok/s` | `140.3 tok/s` |
+| E2B JANG_4M | about `135 tok/s` | `129.7 tok/s` |
+| E4B MXFP4 | about `92-94 tok/s` | `89.2 tok/s` |
+| E4B JANG_4M | about `81-83 tok/s` | `78.5 tok/s` |
+
+Do not repeat this as a speed optimization. The correct source architecture is
+normal `Linear` plus post-projection scale, leaving quantized sidecars in the
+normal loader path.
+
+Loader blockers fixed to produce this matrix:
+
+- E4B PLE `per_layer_projection` shape inference now uses
+  `hidden_size_per_layer_input` instead of ambiguous `(bits, group_size)`
+  shape guesses.
+- E2B/E4B PLE `per_layer_model_projection` now uses a normal `Linear` plus a
+  post-projection scale, matching upstream mlx-swift-lm PR #309 and allowing the
+  standard quantized loader path to own MXFP/JANG sidecars.
+- 12B/31B unified model types route to the existing Gemma4 implementation via
+  `gemma4_unified` / `gemma4_unified_text` aliases.
+- Unified text speed loads skip unsupported `vision_embedder.*`; unified VL
+  remains unproven until that vision namespace is implemented.
+- 26B A4B MoE expert tensors split fused
+  `experts.gate_up_proj.{weight,scales,biases}` into
+  `experts.switch_glu.{gate_proj,up_proj}` and remap
+  `experts.down_proj.*` into `experts.switch_glu.down_proj.*`.

--- a/docs/GEMMA_CACHE_DEFAULTS_HARNESS_PR_2026_06_11.md
+++ b/docs/GEMMA_CACHE_DEFAULTS_HARNESS_PR_2026_06_11.md
@@ -1,0 +1,148 @@
+# Gemma Cache Defaults and Harness PR Status
+
+Date: 2026-06-11
+
+This branch is focused only on the Gemma cache-default and Osaurus harness
+compatibility lane.
+
+## Goals
+
+1. Turn paged RAM KV cache off by default for normal model loads. Paged cache is
+   useful for explicit multi-batch/cache-regression lanes, but it does not help
+   most single-batch user generations enough to justify default RAM footprint.
+2. Keep TurboQuant KV cache on by default for Gemma JANG and MXFP bundles from
+   both Osaurus chat and Osaurus server-settings paths. The proof must come from
+   vMLX runtime settings and cache telemetry, not output coercion.
+3. Compare unquantized Gemma BF16/source bundles against QAT/MXFP/JANG
+   quantized Gemma bundles in the Osaurus harness compatibility evals.
+4. Add runtime prefill progress events so Osaurus can show prompt-processing
+   percentage before first token, instead of leaving users staring at a blind
+   wait.
+
+## Current Understanding
+
+- The source default for paged RAM cache is `VMLXPagedKVCacheSettings(enabled:)`
+  in `Libraries/MLXLMCommon/ServerRuntimeSettings.swift`.
+- The lower-level direct runtime default is `CacheCoordinatorConfig(usePagedCache:)`
+  in `Libraries/MLXLMCommon/Cache/CacheCoordinatorConfig.swift`.
+- Memory safety previously re-enabled paged RAM KV whenever prefix cache was
+  enabled. That must remain off unless the caller explicitly opts into paged KV.
+- The Osaurus-facing server settings bridge resolves `.engineSelected` live KV
+  codec into `CacheCoordinatorConfig.defaultKVMode == .turboQuant(...)`.
+- Existing cache topology tests intentionally force `usePagedCache: true` for
+  paged-regression coverage. Those tests should remain explicit and should not
+  define the production default.
+- Osaurus harness compatibility requires real agent-loop eval rows with
+  pass/fail counts and causes attached. Harness bugs must be fixed before
+  publishing a model row; model failures should be recorded honestly.
+- Prefill currently happens before the first generated token in both
+  `TokenIterator` and `BatchEngine`. The existing generation streams do not
+  expose prefill progress events, so the UI cannot distinguish a slow prompt
+  prefill from a frozen model.
+
+## Planned Proof
+
+- Focused source tests:
+  - Default `VMLXServerRuntimeSettings` has `cache.pagedKV.enabled == false`.
+  - Default `cacheCoordinatorConfig()` has `usePagedCache == false`.
+  - Default settings still resolve `defaultKVMode` to TurboQuant KV.
+  - Explicit paged-cache opt-in still works for multi-batch/regression callers.
+- Runtime/bench proof:
+  - Gemma load/generation row records token/s and cache topology.
+  - Gemma JANG/MXFP rows show TurboQuant KV layers in topology/telemetry.
+  - No row is called fixed without visible coherent output, token/s, and the
+    relevant cache evidence.
+- Osaurus harness proof:
+  - Run AgentLoopFrontier and AgentLoop for each Gemma route chosen for the PR.
+  - Compare BF16/source rows against quantized Gemma rows.
+  - Add/update Osaurus docs only after the eval output is real and attributed.
+- Prefill progress proof:
+  - Source tests verify progress events are ordered, monotonic, and bounded
+    from 0...1 for token-only, cache-hit, and media paths.
+  - Live Osaurus chat/API rows show prefill progress before first token on a
+    long prompt, then normal token streaming with token/s in final info.
+- Final app-facing merge gate:
+  - Build the unsigned/dev Osaurus app without keychain or signing prompts.
+  - Load at least one Gemma 4 QAT MXFP4/JANG_4M model from `~/models`.
+  - Chat with it in Osaurus and verify visible coherent multi-turn output.
+  - Exercise a real Osaurus tool call and verify exact tool name/arguments and
+    tool-result continuation inside the app.
+  - Record prefill progress visibility, token/s, cache topology, and RAM /
+    physical-footprint observations during load and generation.
+
+## Status
+
+- Worktree: `/Users/eric/.config/superpowers/worktrees/vmlx-swift/cache-defaults-bf16-qat`
+- Branch: `codex/cache-defaults-bf16-qat`
+- Base: `vmlx-origin/main` at `76047f3b`
+- Implementation: not yet complete.
+- Implementation status:
+  - Paged RAM KV default flipped off in `VMLXPagedKVCacheSettings`.
+  - Direct `CacheCoordinatorConfig()` default flipped off.
+  - Public `MLXPressCacheConfiguration` default flipped off for paged RAM KV.
+  - Memory-safety plan no longer silently turns paged RAM KV back on when
+    prefix cache is enabled.
+  - Engine-selected live KV remains TurboQuant by default.
+  - Gemma SWA cache contract is explicit: full-attention `KVCacheSimple` layers
+    are TurboQuant-eligible; sliding/SWA layers stay `RotatingKVCache` and use
+    disk-backed restore.
+  - Batch generation now emits `PrefillProgress` stage events before first
+    decoded token.
+- Verification:
+  - `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift build --target MLXLMCommon -Xswiftc -F -Xswiftc /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks` passes.
+  - `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter coordinatorDefaultsKeepPagedRAMCacheOff --jobs 2 -Xswiftc -F -Xswiftc /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks` passes.
+  - `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter defaultsPreserveEngineAndBundleSamplingDecisions --jobs 2 -Xswiftc -F -Xswiftc /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks` passes.
+  - `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter automaticRuntimeCachePolicyCoversDownloadedArchitectureFamilies --jobs 2 -Xswiftc -F -Xswiftc /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks` passes.
+  - `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter explicitPagedCacheOptInStillEnablesCoordinatorPagedTier --jobs 2 -Xswiftc -F -Xswiftc /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks` passes.
+  - `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter memorySafetyPreservesHybridSSMAndEngineSelectedCacheTopology --jobs 2 -Xswiftc -F -Xswiftc /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks` passes.
+  - `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter BatchQuantizeHookTests/testGemmaSWATopologyContract --jobs 2 -Xswiftc -F -Xswiftc /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/Library/Frameworks` passes.
+  - Broad suite filter still times out under the Swift Testing helper; use
+    function-name filters for focused proof until that harness issue is
+    resolved.
+  - `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift run mlxpress-selfcheck ...` builds, but runtime is blocked by MLX metallib discovery:
+    `MLX error: Failed to load the default metallib. library not found`.
+- Prefill progress spec: `docs/PREFILL_PROGRESS_RUNTIME_CONTRACT_2026_06_11.md`
+
+## Local Model Download Queue
+
+Requested target: `~/models`.
+
+- Downloader helper: `scripts/download_gemma4_qat_models.py`
+- Detached runner: completed `screen` session `gemma4_qat_download`
+- Active log dir:
+  `/Users/eric/models/.download-logs/gemma4-qat-screen-20260611T222059Z`
+- Current proof:
+  - All 10 requested OsaurusAI Gemma 4 QAT repos completed.
+  - Sizes:
+    - `OsaurusAI--gemma-4-12B-it-qat-JANG_4M`: 9.5G
+    - `OsaurusAI--gemma-4-31B-it-qat-JANG_4M`: 25G
+    - `OsaurusAI--gemma-4-26B-A4B-it-qat-JANG_4M`: 17G
+    - `OsaurusAI--gemma-4-E4B-it-qat-JANG_4M`: 10G
+    - `OsaurusAI--gemma-4-E2B-it-qat-JANG_4M`: 7.3G
+    - `OsaurusAI--gemma-4-31B-it-qat-MXFP4`: 18G
+    - `OsaurusAI--gemma-4-26B-A4B-it-qat-MXFP4`: 15G
+    - `OsaurusAI--gemma-4-12B-it-qat-MXFP4`: 7.4G
+    - `OsaurusAI--gemma-4-E4B-it-qat-MXFP4`: 5.5G
+    - `OsaurusAI--gemma-4-E2B-it-qat-MXFP4`: 3.8G
+
+## Boundaries
+
+- Do not expand into unrelated model families while this lane is open.
+- Do not add forced behavior fixes, hidden sampler overrides, prompt coercion,
+  or fake parser cleanup to make Gemma outputs look better.
+- Do not claim TurboQuant KV unless the runtime settings and cache telemetry
+  prove it.
+- Do not show fake prefill percentages from wall-clock timers. If a model path
+  cannot provide fine-grained progress yet, emit truthful stage-level progress
+  and document the limitation.
+
+## Open Items
+
+- Find/download the Gemma 4 BF16/source models for the harness comparison rows.
+  Current `~/models` inventory has the 10 QAT MXFP4/JANG_4M repos but no
+  obvious BF16/source Gemma 4 directories.
+- Commit/push or otherwise publish the vMLX change so Osaurus can pin a SHA
+  containing `Generation.prefillProgress`.
+- Re-run Osaurus focused tests after repinning to the updated vMLX SHA.
+- Run the final Osaurus app-facing gate: dev app build, model load, chat,
+  tool-call proof, token/s, cache topology, prefill progress, and RAM footprint.

--- a/docs/PREFILL_PROGRESS_RUNTIME_CONTRACT_2026_06_11.md
+++ b/docs/PREFILL_PROGRESS_RUNTIME_CONTRACT_2026_06_11.md
@@ -1,0 +1,226 @@
+# Prefill Progress Runtime Contract
+
+Date: 2026-06-11
+
+This spec covers runtime and Osaurus UI wiring for showing prompt-prefill
+progress before the first generated token.
+
+## Problem
+
+Long prompt prefill is currently blind. Users can wait 30 seconds or more before
+the first token and cannot tell whether the model is frozen, loading, restoring
+cache, processing media, or simply running slowly on their compute. This is
+especially visible on large Gemma BF16/source rows and lower-RAM machines.
+
+The fix must be runtime-backed. A UI timer or guessed spinner would hide the
+real bottleneck and would not help users understand slow compute.
+
+## Goals
+
+- Emit prefill progress for every normal generation path before first token.
+- Make progress visible through Osaurus chat and server/API streaming.
+- Keep progress monotonic and bounded: `0.0 <= fraction <= 1.0`.
+- Include enough metadata for the UI to render useful labels such as
+  "Restoring cache", "Processing media", and "Prefilling prompt".
+- Preserve normal text, reasoning, tool-call, and final-info streaming behavior.
+- Keep model defaults, samplers, reasoning/tool parsing, and cache policy
+  untouched.
+
+## Non-Goals
+
+- Do not invent speed estimates when no measurement exists.
+- Do not change generation quality or prompt templates.
+- Do not use paged RAM cache just to make progress look better.
+- Do not make the UI responsible for calculating model-internal progress.
+
+## Runtime API Shape
+
+Add a public progress payload shared by token and text streams:
+
+```swift
+public struct PrefillProgress: Sendable, Equatable {
+    public enum Stage: String, Sendable, Equatable {
+        case queued
+        case cacheLookup
+        case cacheRestore
+        case prefill
+        case complete
+    }
+
+    public let stage: Stage
+    public let completedUnitCount: Int
+    public let totalUnitCount: Int
+    public let detail: String?
+
+    public var fractionCompleted: Double
+    public var percentCompleted: Double
+}
+```
+
+Extend stream enums:
+
+```swift
+public enum Generation: Sendable {
+    case prefillProgress(PrefillProgress)
+    case chunk(String)
+    case reasoning(String)
+    case info(GenerateCompletionInfo)
+    case toolCall(ToolCall)
+}
+
+public enum TokenGeneration: Sendable {
+    case prefillProgress(PrefillProgress)
+    case token(Int)
+    case info(GenerateCompletionInfo)
+}
+
+public enum BatchGeneration: Sendable {
+    case prefillProgress(PrefillProgress)
+    case token(Int)
+    case info(GenerateCompletionInfo)
+}
+```
+
+Existing callers that switch exhaustively will need a source update. That is
+acceptable because Osaurus must explicitly handle the new event and old clients
+should not silently drop progress in a user-facing release.
+
+## Calculation
+
+The denominator is the effective number of prompt tokens the runtime will
+process for the current request after cache policy is resolved.
+
+For token-only LLM paths:
+
+- `totalTokens = inputForPrepare.text.tokens.size`
+- `prefillStepSize = effectivePrefillWindow(...)`
+- `chunkCount = ceil(totalTokens / prefillStepSize)`
+- After each completed prefill chunk, emit:
+  - `processedTokens = min(totalTokens, completedChunks * prefillStepSize)`
+  - `fraction = processedTokens / totalTokens`
+
+For cache-hit paths:
+
+- Cache lookup emits stage `.cacheLookup` with `fraction = 0`.
+- Cache restore emits `.cacheRestore` with:
+  - `restoredTokens = restored token count`
+  - `totalTokens = restoredTokens + remainingTokens.count`
+  - `processedTokens = restoredTokens`
+  - `fraction = restoredTokens / totalTokens`
+- Prompt prefill then counts only `remainingTokens.count`, but the displayed
+  fraction uses the full prompt denominator so users see that cache restored
+  real work.
+- If correctness rules roll back to full prefill for media placeholders, hybrid
+  SSM partial hits, or missing companion state, emit a stage message and reset
+  `processedTokens` to `0` against the full prompt denominator.
+
+For VLM/media paths:
+
+- Media preprocessing is a stage, not token progress. Emit media-stage events
+  before prompt prefill starts once the model path exposes that boundary.
+- If the model can expose image/video/audio patch counts, use them in the
+  message and keep `fraction` below the prompt-prefill range until media is
+  done. If not, emit stage-level `mediaEncode` start and completion events.
+- After media embeddings are spliced and effective prompt tokens are known,
+  prompt prefill uses the effective token count reported by `PrepareResult`
+  when available.
+
+For hybrid SSM, ZAYA/CCA, DSV4, and other path-dependent caches:
+
+- Progress follows the same cache-restore and prompt-prefill math, but rollback
+  rules are authoritative. If partial restore is unsafe, do not show the cache
+  hit as saved work; emit the rollback message and full-prefill denominator.
+- SSM/companion rederive after prompt boundary is a cache-maintenance stage. It
+  may be shown as a short post-prefill stage only if it happens before first
+  token; work intentionally deferred after first token should not block the
+  displayed prefill percentage.
+
+For TurboQuant KV:
+
+- TurboQuant compression after prefill is part of the prefill pipeline when it
+  blocks first token. Emit a final `.promptPrefill` or `.firstToken` transition
+  only after required compression/materialization has completed.
+- The progress event must not claim TurboQuant KV is active unless cache
+  topology proves the cache actually contains TurboQuant layers.
+
+## Wiring Points
+
+vMLX runtime:
+
+- Add `PrefillProgress` and enum cases in `Evaluate.swift` and
+  `BatchEngine/BatchTypes.swift`.
+- Thread a progress sink through `TokenIterator` and `BatchEngine`.
+- Add a prepare-progress observer so `LanguageModel.prepare(...)` can report
+  chunk completion without changing model outputs.
+- For model implementations that already chunk internally, call the observer at
+  each real chunk boundary.
+- For black-box/full-prompt VLM prepare implementations, emit truthful
+  stage-level start/end until finer-grained media/token counts are available.
+
+Osaurus:
+
+- Update the MLX generation adapter to forward `prefillProgress` events through
+  chat/API streaming.
+- Add a UI prefill progress row on the assistant message while no first token
+  has arrived.
+- Replace the progress row with normal streaming output once `.chunk`,
+  `.reasoning`, `.toolCall`, or final `.info` arrives.
+- For API streaming, include a typed progress event rather than encoding it as
+  assistant text.
+
+## Model Suggestion Interaction
+
+Model suggestions should be recalibrated around maximum useful capability that
+fits the device:
+
+- Rank higher-capability Gemma rows only when estimated load footprint,
+  prefill working set, and KV growth fit the host memory profile.
+- Prefer quantized Gemma QAT/MXFP/JANG rows on lower-RAM machines when BF16
+  source rows would make prefill unreasonably slow or memory-risky.
+- Keep the recommendation explanation honest: show that a model is suggested
+  because it balances capability, RAM, prefill latency, and expected token/s.
+- Do not silently alter generation defaults to make a suggested model look
+  better.
+
+## Tests
+
+Focused vMLX tests:
+
+- `Generation` and `BatchGeneration` expose progress events without swallowing
+  chunk/reasoning/tool/info events.
+- Token-only prefill progress is monotonic and ends at 100% before first token.
+- Cache-hit progress accounts for restored tokens and remaining prefill tokens.
+- Rollback paths reset progress to the full-prefill denominator.
+- Explicit cancellation during prefill finishes streams without stale progress
+  events or orphan slots.
+
+Osaurus tests/proof:
+
+- Chat UI shows prefill progress on a long prompt before first token.
+- Server/API streaming emits typed progress events.
+- Gemma BF16/source and quantized rows record prefill time, token/s, cache
+  topology, and final harness score.
+
+## Status
+
+- Spec written.
+- vMLX implementation partial:
+  - Public `PrefillProgress` is added to `Generation`, `TokenGeneration`, and
+    `BatchGeneration`.
+  - `BatchEngine` emits real stage/token-boundary progress before first token:
+    `queued`, `cacheLookup`, optional `cacheRestore`, `prefill`, and `complete`.
+  - Current batch implementation is intentionally stage-level around
+    `model.prepare(...)`; deeper per-chunk percentages require adding a prepare
+    progress observer to model implementations that chunk internally.
+- Source build passes for `MLXLMCommon`.
+- Osaurus UI/API implementation is patched in the integration checkout; focused
+  tests are blocked until Osaurus pins a vMLX SHA containing
+  `Generation.prefillProgress`.
+- Live proof pending.
+
+## Completion Gate
+
+This feature is not done from source tests alone. The final PR must prove the
+dev Osaurus app can load a Gemma model, show prefill progress before first
+token, complete a normal chat turn, complete a tool-call turn, and report
+token/s plus RAM/physical-footprint observations during the run.

--- a/scripts/download_gemma4_qat_models.py
+++ b/scripts/download_gemma4_qat_models.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Download Gemma 4 QAT model repos into ~/models.
+
+This is a deterministic Hugging Face Hub download helper, not an agent runner.
+It materializes each repo sequentially so disk and network pressure stay bounded.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+from huggingface_hub import snapshot_download
+
+
+REPOS = [
+    "OsaurusAI/gemma-4-12B-it-qat-JANG_4M",
+    "OsaurusAI/gemma-4-31B-it-qat-JANG_4M",
+    "OsaurusAI/gemma-4-26B-A4B-it-qat-JANG_4M",
+    "OsaurusAI/gemma-4-E4B-it-qat-JANG_4M",
+    "OsaurusAI/gemma-4-E2B-it-qat-JANG_4M",
+    "OsaurusAI/gemma-4-31B-it-qat-MXFP4",
+    "OsaurusAI/gemma-4-26B-A4B-it-qat-MXFP4",
+    "OsaurusAI/gemma-4-12B-it-qat-MXFP4",
+    "OsaurusAI/gemma-4-E4B-it-qat-MXFP4",
+    "OsaurusAI/gemma-4-E2B-it-qat-MXFP4",
+]
+
+
+def repo_slug(repo: str) -> str:
+    return repo.replace("/", "--")
+
+
+def log(line: str, log_file: Path) -> None:
+    stamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    text = f"[{stamp}] {line}"
+    print(text, flush=True)
+    with log_file.open("a", encoding="utf-8") as handle:
+        handle.write(text + "\n")
+
+
+def main() -> int:
+    models_dir = Path(os.environ.get("MODELS_DIR", str(Path.home() / "models"))).expanduser()
+    log_dir = Path(os.environ["DOWNLOAD_LOG_DIR"]).expanduser()
+    models_dir.mkdir(parents=True, exist_ok=True)
+    log_dir.mkdir(parents=True, exist_ok=True)
+    log_file = log_dir / "download-all.log"
+    status_file = log_dir / "status.jsonl"
+
+    for repo in REPOS:
+        dest = models_dir / repo_slug(repo)
+        dest.mkdir(parents=True, exist_ok=True)
+        started = time.time()
+        log(f"START {repo} -> {dest}", log_file)
+        record = {
+            "repo": repo,
+            "dest": str(dest),
+            "started_at": started,
+            "status": "started",
+        }
+        with status_file.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, sort_keys=True) + "\n")
+        try:
+            snapshot_download(
+                repo_id=repo,
+                local_dir=str(dest),
+                max_workers=8,
+            )
+        except Exception as exc:
+            record = {
+                "repo": repo,
+                "dest": str(dest),
+                "finished_at": time.time(),
+                "status": "failed",
+                "error": repr(exc),
+            }
+            with status_file.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(record, sort_keys=True) + "\n")
+            log(f"FAIL {repo}: {exc!r}", log_file)
+            continue
+
+        record = {
+            "repo": repo,
+            "dest": str(dest),
+            "finished_at": time.time(),
+            "elapsed_seconds": round(time.time() - started, 3),
+            "status": "ok",
+        }
+        with status_file.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, sort_keys=True) + "\n")
+        log(f"OK {repo}", log_file)
+
+    log("DONE", log_file)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/run-gemma4-qat-speed-standard.sh
+++ b/scripts/run-gemma4-qat-speed-standard.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUNBENCH="$ROOT/.build/arm64-apple-macosx/release/RunBench"
+STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+ARTIFACT_ROOT="${ARTIFACT_ROOT:-/tmp/vmlx-gemma4-qat-speed-standard-$STAMP}"
+MAX_TOKENS="${MAX_TOKENS:-128}"
+RUNS="${RUNS:-3}"
+WARMUP="${WARMUP:-1}"
+PROMPT="${PROMPT:-Write one long paragraph describing ocean waves. Be verbose and detailed.}"
+
+DEFAULT_MODELS=(
+  "/Users/eric/models/OsaurusAI--gemma-4-E2B-it-qat-MXFP4"
+  "/Users/eric/models/OsaurusAI--gemma-4-E2B-it-qat-JANG_4M"
+)
+
+MODELS=("$@")
+if [[ ${#MODELS[@]} -eq 0 ]]; then
+  MODELS=("${DEFAULT_MODELS[@]}")
+fi
+
+mkdir -p "$ARTIFACT_ROOT"
+
+if [[ "${SKIP_BUILD:-0}" != "1" ]]; then
+  swift build -c release --product RunBench --jobs "${SWIFT_JOBS:-4}"
+fi
+
+MLXPRESS_BUILD_CONFIGURATION=release "$ROOT/scripts/prepare-mlx-metal.sh" >/dev/null
+
+if [[ ! -x "$RUNBENCH" ]]; then
+  echo "missing RunBench executable: $RUNBENCH" >&2
+  exit 1
+fi
+
+run_row() {
+  local model="$1"
+  local mode="$2"
+  local name variant out err
+  name="$(basename "$model")"
+  variant="$name-$mode"
+  out="$ARTIFACT_ROOT/$variant.out"
+  err="$ARTIFACT_ROOT/$variant.err"
+
+  if [[ ! -d "$model" ]]; then
+    echo "missing model directory: $model" | tee "$ARTIFACT_ROOT/$variant.missing"
+    return 1
+  fi
+
+  case "$mode" in
+    deterministic)
+      if ! BENCH_PERF=1 \
+      BENCH_MODEL="$model" \
+      BENCH_PERF_VARIANT="$variant" \
+      BENCH_PERF_PROMPT="$PROMPT" \
+      BENCH_MAX_TOKENS="$MAX_TOKENS" \
+      BENCH_PERF_RUNS="$RUNS" \
+      BENCH_PERF_WARMUP="$WARMUP" \
+      BENCH_PERF_PATH=batch \
+      BENCH_PERF_TEMP=0 \
+      BENCH_PERF_TOP_P=1 \
+      BENCH_PERF_TOP_K=0 \
+      BENCH_PERF_MIN_P=0 \
+      "$RUNBENCH" >"$out" 2>"$err"; then
+        echo "FAILED $variant" | tee -a "$ARTIFACT_ROOT/SUMMARY.txt"
+        tail -40 "$err" | tee -a "$ARTIFACT_ROOT/SUMMARY.txt"
+        return 1
+      fi
+      ;;
+    bundle-defaults)
+      if ! BENCH_PERF=1 \
+      BENCH_MODEL="$model" \
+      BENCH_PERF_VARIANT="$variant" \
+      BENCH_PERF_PROMPT="$PROMPT" \
+      BENCH_MAX_TOKENS="$MAX_TOKENS" \
+      BENCH_PERF_RUNS="$RUNS" \
+      BENCH_PERF_WARMUP="$WARMUP" \
+      BENCH_PERF_PATH=batch \
+      BENCH_PERF_USE_GENERATION_CONFIG=1 \
+      BENCH_PERF_SEED="${BENCH_PERF_SEED:-1234}" \
+      "$RUNBENCH" >"$out" 2>"$err"; then
+        echo "FAILED $variant" | tee -a "$ARTIFACT_ROOT/SUMMARY.txt"
+        tail -40 "$err" | tee -a "$ARTIFACT_ROOT/SUMMARY.txt"
+        return 1
+      fi
+      ;;
+    *)
+      echo "unknown mode: $mode" >&2
+      return 2
+      ;;
+  esac
+
+  if ! rg '^PERF( |_)|^  PERF_RUN' "$out" | tee -a "$ARTIFACT_ROOT/SUMMARY.txt"; then
+    echo "FAILED $variant: no PERF lines emitted" | tee -a "$ARTIFACT_ROOT/SUMMARY.txt"
+    tail -40 "$out" | tee -a "$ARTIFACT_ROOT/SUMMARY.txt"
+    return 1
+  fi
+}
+
+{
+  echo "artifact_root=$ARTIFACT_ROOT"
+  echo "max_tokens=$MAX_TOKENS"
+  echo "runs=$RUNS"
+  echo "warmup=$WARMUP"
+  echo "prompt=$PROMPT"
+  echo "runbench=$RUNBENCH"
+  git -C "$ROOT" rev-parse HEAD | sed 's/^/vmlx_head=/'
+} > "$ARTIFACT_ROOT/METADATA.txt"
+
+: > "$ARTIFACT_ROOT/SUMMARY.txt"
+for model in "${MODELS[@]}"; do
+  run_row "$model" deterministic
+  run_row "$model" bundle-defaults
+done
+
+echo "artifact_root=$ARTIFACT_ROOT"


### PR DESCRIPTION
## Summary

Gemma 4 QAT correctness checkpoint for Osaurus.

This PR fixes the vMLX-side runtime/load/parser/cache pieces needed by Osaurus PR #1469 for Gemma 4 QAT MXFP4 and JANG_4M rows:

- loads Gemma 4 QAT per-layer projection tensors with the correct quantized shape context
- accepts `gemma4_unified` / `gemma4_unified_text` aliases where needed
- tolerates unified config gaps such as missing `vision_soft_tokens_per_image`
- skips unsupported `vision_embedder.*` keys only for text-only loads
- remaps fused MoE `gate_up_proj`/`down_proj` tensors into the expected SwitchGLU expert layout
- preserves Gemma parser/tool-call fixes for native and observed Zyphra/Gemma drift formats without visible protocol leakage
- defaults server/runtime cache settings so ordinary single-batch loading does not enable paged RAM KV cache
- keeps engine-selected KV codec, block-disk/L2 cache settings, and prefill progress reporting available to Osaurus
- adds Model2Vec static embedding APIs required by current Osaurus main

## Current Scope

This is the vMLX dependency for the Osaurus Gemma correctness PR. Raw speed work and Gemma4 audio are intentionally deferred. Do not use BF16/source Gemma bundles as this checkpoint's load target.

Cache claims must follow telemetry. If a runtime row reports rotating KV plus disk-backed restore and `turbo_quant_kv_layer_count=0`, the row should be documented that way rather than promoted as a TurboQuant-KV-layer topology.

## Validation

Local proof after merging current vMLX main:

- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build --target MLXLMCommon --target MLXLLM --target MLXVLM`
  - log: `/tmp/vmlx-gemma4-qatsidecar-build-20260612T202403Z/build-mlxllm-mlxvlm-common.log`
- Focused source-contract test run covered server settings, Gemma parser/no-leak contracts, cache topology contracts, prefill prep, and BatchEngine TurboQuant contracts before hitting this machine's local MLX `default.metallib` discovery boundary:
  - log: `/tmp/vmlx-gemma4-qatsidecar-main-merge-20260612T201533Z/focused-swift-tests.log`

The local Swift test runner path is not a clean full-runtime proof on this machine right now because reruns can hang after MLX `default.metallib` initialization. The Osaurus PR carries the app-facing proof and CI gate for the consumed pin.

## Osaurus Dependency

Osaurus PR #1469 is green and mergeable against this vMLX branch head. After this vMLX PR lands on main, Osaurus must repin to the resulting vMLX main SHA if it differs from this PR head.
