### PR TITLE
Add DiffusionGemma MXFP quant prep

### DIFF
--- a/docs/DIFFUSIONGEMMA_ENGINE_QUANT_PREP_2026_06_12.md
+++ b/docs/DIFFUSIONGEMMA_ENGINE_QUANT_PREP_2026_06_12.md
@@ -151,13 +151,50 @@ Run actual conversion with the JANG MLX venv:
   --replace
 ```
 
-The current `/Users/eric/models` volume has about 19 GiB free after the BF16
-source download. That is enough for metadata and smoke tests, but not enough to
-reliably hold the full MXFP8 output and may be too tight for a complete MXFP4
-artifact plus temporary write pressure. Free space or a different output volume
-is required before the full conversion should be launched.
+Actual conversion proof with the JANG MLX venv:
 
-Synthetic conversion proof passed with the JANG MLX venv:
+- MXFP4 output:
+  `/Users/eric/models/OsaurusAI/diffusiongemma-26B-A4B-it-MXFP4`
+- MXFP4 log: `/tmp/diffusiongemma-mxfp4-convert-20260612T191053Z.log`
+- MXFP4 result: 1,047/1,047 source tensors processed, 295 quantized tensors,
+  752 passthrough tensors, 0 skipped tensors, 1,342 indexed output tensors,
+  15 shards, 15 GB on disk, `total_size=15944852880`
+- MXFP4 timing: 74.38 seconds wall, 14,044,954,624-byte max RSS, 0 swaps
+- MXFP8 output:
+  `/Users/eric/models/OsaurusAI/diffusiongemma-26B-A4B-it-MXFP8`
+- MXFP8 log: `/tmp/diffusiongemma-mxfp8-convert-20260612T191232Z.log`
+- MXFP8 result: 1,047/1,047 source tensors processed, 295 quantized tensors,
+  752 passthrough tensors, 0 skipped tensors, 1,342 indexed output tensors,
+  23 shards, 26 GB on disk, `total_size=27918936056`
+- MXFP8 timing: 65.80 seconds wall, 14,894,694,400-byte max RSS, 0 swaps
+
+Final bundle verification passed for both MXFP4 and MXFP8:
+
+- `config.json`, `jang_config.json`, `model.safetensors.index.json`, and
+  `diffusiongemma_mxfp_manifest.json` agree on `weight_format`, quant mode,
+  quant bits, `group_size=32`, shard count, indexed tensor count, and total
+  size.
+- Every index entry resolves to an existing shard and every indexed tensor key
+  is present in its safetensors shard.
+- Modality metadata remains `image=true`, `video=true`, `audio=false`.
+- Sampled tensor layout:
+  - MXFP4 attention: `q_proj.weight (4096, 352) uint32`,
+    `q_proj.scales (4096, 88) uint8`
+  - MXFP4 dense MLP override:
+    `mlp.down_proj.weight (2816, 528) uint32`,
+    `mlp.down_proj.scales (2816, 66) uint8`
+  - MXFP4 experts: `experts.down_proj.weight (128, 2816, 88) uint32`,
+    `experts.down_proj.scales (128, 2816, 22) uint8`
+  - MXFP8 attention: `q_proj.weight (4096, 704) uint32`,
+    `q_proj.scales (4096, 88) uint8`
+  - MXFP8 dense MLP: `mlp.down_proj.weight (2816, 528) uint32`,
+    `mlp.down_proj.scales (2816, 66) uint8`
+  - MXFP8 experts: `experts.down_proj.weight (128, 2816, 176) uint32`,
+    `experts.down_proj.scales (128, 2816, 22) uint8`
+  - Embeddings stay passthrough:
+    `model.decoder.embed_tokens.weight (262144, 2816) float16`
+
+Synthetic conversion proof also passed with the JANG MLX venv:
 
 - output `weight_format=mxfp4`
 - attention/expert tensors emitted `weight` + `scales`

--- a/docs/DIFFUSIONGEMMA_ENGINE_QUANT_PREP_2026_06_12.md
+++ b/docs/DIFFUSIONGEMMA_ENGINE_QUANT_PREP_2026_06_12.md
@@ -1,0 +1,172 @@
+# DiffusionGemma Engine + Quant Prep
+
+Date: 2026-06-12
+
+## Source
+
+Target source bundle:
+
+- HF repo: `google/diffusiongemma-26B-A4B-it`
+- Local path: `/Users/eric/models/google/diffusiongemma-26B-A4B-it`
+- Downloaded size: 48 GB on disk, 20 files, 11 safetensors shards
+- Architecture: `DiffusionGemmaForBlockDiffusion`
+- `model_type`: `diffusion_gemma`
+- Text config: `diffusion_gemma_text`, 30 layers, 128 experts, top-8 experts, 1024-token sliding window
+- Canvas: 256 tokens
+- Generation config: `max_new_tokens=256`, `max_denoising_steps=48`, entropy-bound sampler, `confidence_threshold=0.005`, `stability_threshold=1`
+
+This is not a normal autoregressive Gemma 4 decode row. The runtime has an
+encoder/prompt KV path plus a bidirectional denoising canvas. A plain
+`TokenIterator` next-token loop is the wrong engine.
+
+## Modality Gate
+
+The bundle has a real VL path:
+
+- `vision_config.model_type = gemma4_vision`
+- `image_token_id = 258880`
+- `vision_soft_tokens_per_image = 280`
+
+The bundle does not expose a usable audio path:
+
+- `audio_config = null`
+- `audio_token_id = null`
+- MLX-VLM's DiffusionGemma processor reference rejects audio inputs
+
+Do not mark audio supported for this model unless a later source bundle adds an
+audio config/token and the vMLX runtime proves real audio payload generation.
+The immediate modality gate is text + image/VL. `processor_config.json` has a
+video processor object, but `config.json` has no `video_token_id`; video remains
+unproven until processor/token/runtime evidence is present and a real video
+payload row passes.
+
+## Engine Work
+
+Required vMLX work before speed or release claims:
+
+1. Add a `diffusion_gemma` model family instead of aliasing to Gemma 4 AR.
+2. Port the block-diffusion generation loop:
+   - prompt encoder prefill and cache,
+   - 256-token canvas initialization,
+   - decoder forward with bidirectional canvas attention,
+   - self-conditioning logits,
+   - entropy-bound accept/renoise,
+   - adaptive stopping,
+   - append finalized canvas to the encoder cache.
+3. Reuse Gemma 4 MoE and proportional/full/sliding RoPE pieces where tensor
+   names and config shape match.
+4. Wire the Gemma 4 vision tower/image soft-token path before claiming VL.
+5. Add tests that fail if `diffusion_gemma` silently routes through AR decode.
+
+Useful upstream references:
+
+- HF Transformers: `src/transformers/models/diffusion_gemma/generation_diffusion_gemma.py`
+- HF Transformers: `src/transformers/models/diffusion_gemma/modeling_diffusion_gemma.py`
+- MLX-VLM: `mlx_vlm/models/diffusion_gemma/`
+
+## First-Party Quant Plan
+
+The required output targets are first-party bundles:
+
+- `/Users/eric/models/OsaurusAI/diffusiongemma-26B-A4B-it-MXFP4`
+- `/Users/eric/models/OsaurusAI/diffusiongemma-26B-A4B-it-MXFP8`
+
+`mlx-community/diffusiongemma-26B-A4B-it-4bit` is useful only as metadata
+comparison. It is not the deliverable.
+
+Converter:
+
+- `scripts/vmlx-convert-diffusiongemma-mxfp.py`
+- Uses native MLX MXFP calls: `mx.quantize(..., mode="mxfp4")` or
+  `mx.quantize(..., mode="mxfp8")`
+- Emits MLX `weight` / `scales` companions. It does not emit old affine 4-bit
+  `biases` as the primary format.
+
+Current quant policy:
+
+- MXFP4 profile: decoder attention and MoE experts use MXFP4; dense MLP and
+  router projections use MXFP8 overrides.
+- MXFP8 profile: decoder attention, dense MLP, router projections, and MoE
+  experts use MXFP8.
+- Keep norms, layer scalars, router control scalars, embeddings, multimodal
+  projector/vision path, and self-conditioning path in fp16/bf16 until parity is
+  proven.
+- Use `group_size=32` to match current vMLX MXFP loader expectations.
+- Stamp `weight_format=mxfp4` / `weight_format=mxfp8` and
+  `quantization.mode=mxfp4` / `mxfp8` in generated configs.
+
+Run the deterministic prep once the BF16 source download is complete:
+
+```sh
+scripts/vmlx-diffusiongemma-quant-prep.sh \
+  --src /Users/eric/models/google/diffusiongemma-26B-A4B-it \
+  --out-root /Users/eric/models/OsaurusAI
+```
+
+This writes manifests under `docs/local/diffusiongemma-quant-prep/` and fails
+closed if the source is incomplete.
+
+Run dry-runs:
+
+```sh
+python3 scripts/vmlx-convert-diffusiongemma-mxfp.py \
+  --src /Users/eric/models/google/diffusiongemma-26B-A4B-it \
+  --bits 4 \
+  --dry-run \
+  --quiet
+
+python3 scripts/vmlx-convert-diffusiongemma-mxfp.py \
+  --src /Users/eric/models/google/diffusiongemma-26B-A4B-it \
+  --bits 8 \
+  --dry-run \
+  --quiet
+```
+
+Dry-run proof from the downloaded source:
+
+- Source tensors: 1,047
+- MXFP4 profile: 175 tensors MXFP4, 120 tensors MXFP8, 752 tensors fp16
+  passthrough
+- MXFP8 profile: 295 tensors MXFP8, 752 tensors fp16 passthrough
+- Quantized source-weight mass: about 45.62 GiB
+- Passthrough source-weight mass: about 2.48 GiB
+
+Run actual conversion with the JANG MLX venv:
+
+```sh
+/Users/eric/jang/jang-tools/.venv/bin/python \
+  scripts/vmlx-convert-diffusiongemma-mxfp.py \
+  --src /Users/eric/models/google/diffusiongemma-26B-A4B-it \
+  --out /Users/eric/models/OsaurusAI/diffusiongemma-26B-A4B-it-MXFP4 \
+  --bits 4 \
+  --group-size 32 \
+  --replace
+
+/Users/eric/jang/jang-tools/.venv/bin/python \
+  scripts/vmlx-convert-diffusiongemma-mxfp.py \
+  --src /Users/eric/models/google/diffusiongemma-26B-A4B-it \
+  --out /Users/eric/models/OsaurusAI/diffusiongemma-26B-A4B-it-MXFP8 \
+  --bits 8 \
+  --group-size 32 \
+  --replace
+```
+
+The current `/Users/eric/models` volume has about 19 GiB free after the BF16
+source download. That is enough for metadata and smoke tests, but not enough to
+reliably hold the full MXFP8 output and may be too tight for a complete MXFP4
+artifact plus temporary write pressure. Free space or a different output volume
+is required before the full conversion should be launched.
+
+Synthetic conversion proof passed with the JANG MLX venv:
+
+- output `weight_format=mxfp4`
+- attention/expert tensors emitted `weight` + `scales`
+- dense MLP in the MXFP4 profile emitted `mode=mxfp8` per-layer override
+- vision/self-conditioning passthrough layers were stamped as skip overrides
+
+## Current Boundary
+
+The source download and manifest prep do not make the runtime working. The
+engine remains `PARTIAL` until native block-diffusion text generation works,
+then `PARTIAL` until image/VL payloads work, and only then should MXFP4/MXFP8
+speed numbers be trusted.

--- a/scripts/vmlx-convert-diffusiongemma-mxfp.py
+++ b/scripts/vmlx-convert-diffusiongemma-mxfp.py
@@ -1,0 +1,680 @@
+#!/usr/bin/env python3
+"""Convert DiffusionGemma BF16 source to native MLX MXFP4/MXFP8 bundles.
+
+This is a first-party converter for google/diffusiongemma-26B-A4B-it. It does
+not emit old affine 4-bit weights. Quantized tensors are produced with
+``mx.quantize(..., mode="mxfp4"|"mxfp8")`` and stored as MLX ``weight`` /
+``scales`` companions.
+
+Dry-run mode intentionally avoids importing MLX so source/policy checks can run
+in the system Python. Real conversion requires a Python environment with MLX.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import shutil
+import struct
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from safetensors import safe_open
+from safetensors.numpy import save_file
+
+try:
+    from tqdm import tqdm
+except Exception:  # pragma: no cover - cosmetic fallback
+    tqdm = None
+
+
+MAX_SHARD_BYTES = 1_000_000_000
+DEFAULT_SOURCE = Path("/Users/eric/models/google/diffusiongemma-26B-A4B-it")
+DEFAULT_OUTPUT_ROOT = Path("/Users/eric/models/OsaurusAI")
+TARGET_BASE_NAME = "diffusiongemma-26B-A4B-it"
+
+SIDECAR_FILES = [
+    "README.md",
+    "LICENSE",
+    "chat_template.jinja",
+    "chat_template.json",
+    "generation_config.json",
+    "processor_config.json",
+    "preprocessor_config.json",
+    "special_tokens_map.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
+]
+
+
+@dataclass(frozen=True)
+class QuantPolicy:
+    method: str  # "mxfp" | "passthrough" | "skip"
+    bits: int
+    role: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class TensorItem:
+    name: str
+    shape: tuple[int, ...]
+    shard: Path
+    dtype: str | None
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _write_json(path: Path, data: dict[str, Any]) -> None:
+    path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _read_safetensors_header(path: Path) -> tuple[dict[str, Any], int]:
+    with path.open("rb") as f:
+        header_size = struct.unpack("<Q", f.read(8))[0]
+        header = json.loads(f.read(header_size))
+    return header, 8 + header_size
+
+
+def _load_bf16_tensor(path: Path, tensor_name: str, shape: tuple[int, ...]) -> np.ndarray:
+    header, data_start = _read_safetensors_header(path)
+    info = header[tensor_name]
+    dtype = str(info.get("dtype", "")).upper()
+    if dtype != "BF16":
+        raise TypeError(f"manual loader only handles BF16, got {dtype} for {tensor_name}")
+    start, end = info["data_offsets"]
+    with path.open("rb") as f:
+        f.seek(data_start + start)
+        raw = f.read(end - start)
+    values = np.frombuffer(raw, dtype="<u2").copy()
+    fp32_bits = values.astype(np.uint32) << 16
+    return fp32_bits.view(np.float32).reshape(shape)
+
+
+def _load_tensor(path: Path, tensor_name: str, shape: tuple[int, ...]) -> np.ndarray:
+    with safe_open(str(path), framework="numpy") as f:
+        try:
+            tensor = f.get_tensor(tensor_name)
+            if not isinstance(tensor, np.ndarray):
+                tensor = np.array(tensor)
+        except Exception:
+            tensor = _load_bf16_tensor(path, tensor_name, shape)
+    if tensor.dtype != np.float32:
+        tensor = tensor.astype(np.float32)
+    return tensor
+
+
+def _scan_source(src: Path) -> list[TensorItem]:
+    index_path = src / "model.safetensors.index.json"
+    if not index_path.exists():
+        raise FileNotFoundError(f"missing model.safetensors.index.json: {index_path}")
+
+    index = _read_json(index_path)
+    by_shard: dict[str, list[str]] = {}
+    for key, shard in index.get("weight_map", {}).items():
+        by_shard.setdefault(shard, []).append(key)
+
+    items: list[TensorItem] = []
+    for shard_name, keys in sorted(by_shard.items()):
+        shard = src / shard_name
+        if not shard.is_file():
+            raise FileNotFoundError(f"missing source shard: {shard}")
+        header, _ = _read_safetensors_header(shard)
+        for key in sorted(keys):
+            if key.endswith("_scale_inv"):
+                continue
+            info = header.get(key)
+            if not isinstance(info, dict):
+                raise KeyError(f"{key} missing from {shard}")
+            items.append(
+                TensorItem(
+                    name=key,
+                    shape=tuple(int(v) for v in info.get("shape", [])),
+                    shard=shard,
+                    dtype=info.get("dtype"),
+                )
+            )
+    return items
+
+
+def _is_norm_or_scalar_control(name: str) -> bool:
+    low = name.lower()
+    return (
+        "norm" in low
+        or name.endswith(".bias")
+        or name.endswith(".layer_scalar")
+        or name.endswith("router.scale")
+        or name.endswith("router.per_expert_scale")
+        or name.endswith("embed_scale")
+        or name.endswith("pos_embedding")
+    )
+
+
+def _is_decoder_attention(name: str) -> bool:
+    return (
+        name.startswith("model.decoder.layers.")
+        and ".self_attn." in name
+        and name.endswith(".weight")
+        and any(f".{proj}_proj.weight" in name for proj in ("q", "k", "v", "o"))
+    )
+
+
+def _is_decoder_dense_mlp(name: str) -> bool:
+    return (
+        name.startswith("model.decoder.layers.")
+        and ".mlp." in name
+        and name.endswith(".weight")
+        and any(f".{proj}_proj.weight" in name for proj in ("gate", "up", "down"))
+    )
+
+
+def _is_decoder_router(name: str) -> bool:
+    return (
+        name.startswith("model.decoder.layers.")
+        and name.endswith(".router.proj.weight")
+    )
+
+
+def _is_decoder_expert(name: str) -> bool:
+    return (
+        name.startswith("model.decoder.layers.")
+        and (
+            name.endswith(".experts.gate_up_proj")
+            or name.endswith(".experts.down_proj")
+            or name.endswith(".experts.gate_up_proj.weight")
+            or name.endswith(".experts.down_proj.weight")
+        )
+    )
+
+
+def _is_self_conditioning(name: str) -> bool:
+    return name.startswith("model.decoder.self_conditioning.")
+
+
+def quant_policy(name: str, shape: tuple[int, ...], profile_bits: int) -> QuantPolicy:
+    if name.endswith("_scale_inv"):
+        return QuantPolicy("skip", 0, "scale_inv", "stale source-side quant metadata")
+
+    if len(shape) < 2:
+        return QuantPolicy("passthrough", 16, "scalar", "rank<2")
+
+    if _is_norm_or_scalar_control(name):
+        return QuantPolicy("passthrough", 16, "control", "norm/bias/router scalar")
+
+    if name.endswith("model.decoder.embed_tokens.weight"):
+        return QuantPolicy("passthrough", 16, "embedding", "tied embedding/output projection")
+
+    if name.startswith("model.encoder."):
+        return QuantPolicy("passthrough", 16, "vision_encoder", "VL encoder path preserved")
+
+    if _is_self_conditioning(name):
+        return QuantPolicy("passthrough", 16, "self_conditioning", "block diffusion parity guard")
+
+    if _is_decoder_router(name):
+        return QuantPolicy("mxfp", 8, "router", "router logits kept MXFP8")
+
+    if _is_decoder_dense_mlp(name):
+        bits = 8 if profile_bits == 4 else 8
+        return QuantPolicy("mxfp", bits, "dense_mlp", f"dense MLP MXFP{bits}")
+
+    if _is_decoder_attention(name):
+        return QuantPolicy("mxfp", profile_bits, "attention", f"attention MXFP{profile_bits}")
+
+    if _is_decoder_expert(name):
+        return QuantPolicy("mxfp", profile_bits, "experts", f"MoE experts MXFP{profile_bits}")
+
+    if name.startswith("model.decoder.") and name.endswith(".weight"):
+        return QuantPolicy("mxfp", profile_bits, "decoder_other", f"decoder linear MXFP{profile_bits}")
+
+    return QuantPolicy("passthrough", 16, "unmatched", "not a recognized decoder linear")
+
+
+def _quant_base_name(name: str) -> str:
+    if name.endswith(".weight"):
+        return name[: -len(".weight")]
+    return name
+
+
+def _assert_quantizable_shape(name: str, tensor: np.ndarray, group_size: int) -> None:
+    if tensor.ndim < 2:
+        raise ValueError(f"{name}: MXFP quantization expects rank >= 2, got {tensor.shape}")
+    if tensor.shape[-1] % group_size != 0:
+        raise ValueError(
+            f"{name}: last dim {tensor.shape[-1]} is not divisible by group_size={group_size}"
+        )
+
+
+def _lazy_import_mlx():
+    try:
+        import mlx.core as mx  # type: ignore
+    except Exception as exc:
+        raise SystemExit(
+            "MLX is required for conversion. Use a Python env with mlx installed, "
+            "for example /Users/eric/jang/jang-tools/.venv/bin/python."
+        ) from exc
+    return mx
+
+
+def _mxfp_quantize(
+    tensor: np.ndarray,
+    *,
+    bits: int,
+    group_size: int,
+    mx: Any,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray | None]:
+    _assert_quantizable_shape("tensor", tensor, group_size)
+    original_shape = tensor.shape if tensor.ndim >= 3 else None
+    matrix = tensor.reshape(-1, tensor.shape[-1]) if original_shape is not None else tensor
+
+    q_weights: list[np.ndarray] = []
+    q_scales: list[np.ndarray] = []
+    q_biases: list[np.ndarray] = []
+    mode = f"mxfp{bits}"
+    chunk_rows = max(1, min(matrix.shape[0], 100_000_000 // max(1, matrix.shape[1])))
+    for start in range(0, matrix.shape[0], chunk_rows):
+        chunk = mx.array(matrix[start : start + chunk_rows].astype(np.float16))
+        quantized = mx.quantize(chunk, group_size=group_size, bits=bits, mode=mode)
+        qw, qs = quantized[:2]
+        qb = quantized[2] if len(quantized) > 2 else None
+        mx.eval(qw, qs, *([] if qb is None else [qb]))
+        q_weights.append(np.array(qw))
+        q_scales.append(np.array(qs))
+        if qb is not None:
+            q_biases.append(np.array(qb))
+        del chunk, qw, qs, qb
+
+    weight = np.concatenate(q_weights, axis=0)
+    scales = np.concatenate(q_scales, axis=0)
+    biases = np.concatenate(q_biases, axis=0) if q_biases else None
+    if original_shape is not None:
+        weight = weight.reshape(*original_shape[:-1], weight.shape[-1])
+        scales = scales.reshape(*original_shape[:-1], scales.shape[-1])
+        if biases is not None:
+            biases = biases.reshape(*original_shape[:-1], biases.shape[-1])
+    return weight, scales, biases
+
+
+def _copy_sidecars(src: Path, out: Path) -> None:
+    for name in SIDECAR_FILES:
+        src_file = src / name
+        if src_file.exists():
+            shutil.copy2(src_file, out / name)
+    tok_cfg = out / "tokenizer_config.json"
+    template = out / "chat_template.jinja"
+    if tok_cfg.exists() and template.exists():
+        cfg = _read_json(tok_cfg)
+        cfg["chat_template"] = template.read_text(encoding="utf-8")
+        _write_json(tok_cfg, cfg)
+
+
+def _remove_stale_output(out: Path) -> None:
+    if not out.exists():
+        return
+    for path in out.glob("model-*.safetensors"):
+        path.unlink()
+    for name in ("model.safetensors", "model.safetensors.index.json", "config.json", "jang_config.json"):
+        path = out / name
+        if path.exists():
+            path.unlink()
+
+
+def _validate_source(src: Path) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    cfg = _read_json(src / "config.json")
+    gen = _read_json(src / "generation_config.json") if (src / "generation_config.json").exists() else {}
+    proc = _read_json(src / "processor_config.json") if (src / "processor_config.json").exists() else {}
+    if cfg.get("model_type") != "diffusion_gemma":
+        raise SystemExit(f"expected model_type='diffusion_gemma', got {cfg.get('model_type')!r}")
+    arch = cfg.get("architectures") or []
+    if "DiffusionGemmaForBlockDiffusion" not in arch:
+        raise SystemExit(f"expected DiffusionGemmaForBlockDiffusion architecture, got {arch!r}")
+    return cfg, gen, proc
+
+
+def _target_from_args(src: Path, out: Path | None, out_root: Path | None, bits: int) -> Path:
+    if out is not None:
+        return out.expanduser()
+    root = (out_root or DEFAULT_OUTPUT_ROOT).expanduser()
+    return root / f"{TARGET_BASE_NAME}-MXFP{bits}"
+
+
+def _policy_summary(items: list[TensorItem], bits: int) -> dict[str, Any]:
+    counts: dict[str, int] = {}
+    roles: dict[str, int] = {}
+    estimated_quantized_source_bytes = 0
+    estimated_passthrough_source_bytes = 0
+    overrides: list[str] = []
+    skips: list[str] = []
+    for item in items:
+        policy = quant_policy(item.name, item.shape, bits)
+        counts[f"{policy.method}-{policy.bits}"] = counts.get(f"{policy.method}-{policy.bits}", 0) + 1
+        roles[policy.role] = roles.get(policy.role, 0) + 1
+        source_bytes = int(np.prod(item.shape, dtype=np.int64)) * 2 if item.shape else 0
+        if policy.method == "mxfp":
+            estimated_quantized_source_bytes += source_bytes
+            if bits == 4 and policy.bits != bits:
+                overrides.append(_quant_base_name(item.name))
+        elif policy.method == "passthrough":
+            estimated_passthrough_source_bytes += source_bytes
+            if item.name.endswith(".weight"):
+                skips.append(_quant_base_name(item.name))
+    return {
+        "counts": counts,
+        "roles": roles,
+        "mxfp8_overrides_for_mxfp4": sorted(set(overrides)),
+        "passthrough_weight_bases": sorted(set(skips)),
+        "estimated_source_gb_by_policy": {
+            "quantized": round(estimated_quantized_source_bytes / (1024 ** 3), 2),
+            "passthrough_fp16": round(estimated_passthrough_source_bytes / (1024 ** 3), 2),
+        },
+    }
+
+
+def _build_quant_config(
+    *,
+    bits: int,
+    group_size: int,
+    quantized_policies: dict[str, QuantPolicy],
+    passthrough_bases: set[str],
+) -> dict[str, Any]:
+    weight_format = f"mxfp{bits}"
+    config: dict[str, Any] = {
+        "bits": bits,
+        "group_size": group_size,
+        "mode": weight_format,
+        "quantization_backend": "mx.quantize",
+        "family": "diffusion_gemma",
+        "canvas_length": 256,
+        "quantized_roles": sorted({p.role for p in quantized_policies.values()}),
+        "passthrough_roles": [
+            "embedding",
+            "norms",
+            "router_scalars",
+            "self_conditioning",
+            "vision_encoder",
+        ],
+    }
+    for base, policy in sorted(quantized_policies.items()):
+        if bits == 4 and policy.bits != bits:
+            config[base] = {"bits": policy.bits, "group_size": group_size, "mode": f"mxfp{policy.bits}"}
+    for base in sorted(passthrough_bases):
+        config[base] = False
+    return config
+
+
+def _write_configs(
+    *,
+    src: Path,
+    out: Path,
+    source_config: dict[str, Any],
+    generation_config: dict[str, Any],
+    processor_config: dict[str, Any],
+    bits: int,
+    group_size: int,
+    shard_map: dict[str, str],
+    total_size: int,
+    quantized_policies: dict[str, QuantPolicy],
+    passthrough_bases: set[str],
+    quantized_count: int,
+    passthrough_count: int,
+    skipped_count: int,
+) -> None:
+    weight_format = f"mxfp{bits}"
+    cfg = dict(source_config)
+    cfg.pop("quantization_config", None)
+    cfg["weight_format"] = weight_format
+    cfg["quantization"] = _build_quant_config(
+        bits=bits,
+        group_size=group_size,
+        quantized_policies=quantized_policies,
+        passthrough_bases=passthrough_bases,
+    )
+    cfg["modalities"] = {
+        "text": True,
+        "image": bool(source_config.get("vision_config")),
+        "vision": bool(source_config.get("vision_config")),
+        "video": bool(processor_config.get("video_processor")),
+        "audio": False,
+    }
+    cfg["has_vision"] = bool(source_config.get("vision_config"))
+    cfg["has_video"] = bool(processor_config.get("video_processor"))
+    cfg["has_audio"] = False
+    cfg["modality_notes"] = {
+        "image": "vision_config plus image_token_id are present; runtime proof still required",
+        "video": "processor_config has video_processor, but config has no video_token_id; proof required",
+        "audio": "processor_config has feature_extractor metadata, but config has no audio_config/audio_token_id",
+    }
+    _write_json(out / "config.json", cfg)
+
+    jang_config = {
+        "version": 2,
+        "weight_format": weight_format,
+        "profile": f"MXFP{bits}",
+        "source_model": {
+            "repo_id": "google/diffusiongemma-26B-A4B-it",
+            "path": str(src),
+            "architecture": source_config.get("architectures"),
+            "model_type": source_config.get("model_type"),
+            "text_model_type": (source_config.get("text_config") or {}).get("model_type"),
+        },
+        "modalities": cfg["modalities"],
+        "has_vision": cfg["has_vision"],
+        "has_video": cfg["has_video"],
+        "has_audio": cfg["has_audio"],
+        "quantization": {
+            "method": weight_format,
+            "mode": weight_format,
+            "bits": bits,
+            "group_size": group_size,
+            "quantization_backend": "mx.quantize",
+            "native_mx_format": True,
+            "passthrough_tensor_count": passthrough_count,
+            "quantized_tensor_count": quantized_count,
+            "skipped_tensor_count": skipped_count,
+            "mxfp8_override_count": sum(1 for p in quantized_policies.values() if p.bits == 8 and bits == 4),
+        },
+        "runtime": {
+            "total_weight_bytes": total_size,
+            "total_weight_gb": round(total_size / (1024 ** 3), 2),
+            "canvas_length": source_config.get("canvas_length"),
+            "max_new_tokens": generation_config.get("max_new_tokens"),
+            "max_denoising_steps": generation_config.get("max_denoising_steps"),
+            "sampler_config": generation_config.get("sampler_config"),
+            "cache": "encoder_kv_plus_bidirectional_denoising_canvas",
+        },
+    }
+    _write_json(out / "jang_config.json", jang_config)
+
+    manifest = {
+        "source": str(src),
+        "output": str(out),
+        "weight_format": weight_format,
+        "group_size": group_size,
+        "total_size": total_size,
+        "shards": sorted(set(shard_map.values())),
+        "tensor_counts": {
+            "quantized": quantized_count,
+            "passthrough": passthrough_count,
+            "skipped": skipped_count,
+            "indexed_output_tensors": len(shard_map),
+        },
+        "modalities": cfg["modalities"],
+    }
+    _write_json(out / "diffusiongemma_mxfp_manifest.json", manifest)
+
+
+def convert(args: argparse.Namespace) -> int:
+    src = args.src.expanduser()
+    if not src.exists():
+        raise SystemExit(f"source does not exist: {src}")
+    source_config, generation_config, processor_config = _validate_source(src)
+    out = _target_from_args(src, args.out, args.out_root, args.bits)
+    weight_format = f"mxfp{args.bits}"
+
+    items = _scan_source(src)
+    policy = _policy_summary(items, args.bits)
+    summary = {
+        "source": str(src),
+        "output": str(out),
+        "weight_format": weight_format,
+        "group_size": args.group_size,
+        "tensors": len(items),
+        "policy": policy,
+        "modalities": {
+            "image": bool(source_config.get("vision_config")),
+            "video_processor": bool(processor_config.get("video_processor")),
+            "video_token_id": source_config.get("video_token_id"),
+            "audio_config": source_config.get("audio_config"),
+            "audio_token_id": source_config.get("audio_token_id"),
+        },
+    }
+    if args.dry_run:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+        return 0
+
+    mx = _lazy_import_mlx()
+    out.mkdir(parents=True, exist_ok=True)
+    if args.replace:
+        _remove_stale_output(out)
+    elif any(out.glob("model-*.safetensors")) or (out / "model.safetensors.index.json").exists():
+        raise SystemExit(f"output already has model artifacts; pass --replace: {out}")
+
+    _copy_sidecars(src, out)
+
+    shard_idx = 0
+    shard_tensors: dict[str, np.ndarray] = {}
+    shard_bytes = 0
+    shard_map: dict[str, str] = {}
+    quantized_policies: dict[str, QuantPolicy] = {}
+    passthrough_bases: set[str] = set()
+    quantized_count = 0
+    passthrough_count = 0
+    skipped_count = 0
+
+    def flush_shard() -> None:
+        nonlocal shard_idx, shard_tensors, shard_bytes
+        if not shard_tensors:
+            return
+        shard_idx += 1
+        name = f"model-{shard_idx:05d}-of-XXXXX.safetensors"
+        save_file(shard_tensors, str(out / name), metadata={"format": "mlx"})
+        for key in shard_tensors:
+            shard_map[key] = name
+        if not args.quiet:
+            print(f"shard {shard_idx}: {len(shard_tensors)} tensors, {shard_bytes / 1e9:.2f} GB")
+        shard_tensors = {}
+        shard_bytes = 0
+
+    def add_tensor(name: str, array: np.ndarray) -> None:
+        nonlocal shard_bytes
+        shard_tensors[name] = np.ascontiguousarray(array)
+        shard_bytes += int(shard_tensors[name].nbytes)
+        if shard_bytes >= MAX_SHARD_BYTES:
+            flush_shard()
+
+    iterator = items
+    if tqdm is not None and not args.quiet:
+        iterator = tqdm(items, desc=f"converting {weight_format}")  # type: ignore[assignment]
+
+    for item in iterator:
+        policy_item = quant_policy(item.name, item.shape, args.bits)
+        if policy_item.method == "skip":
+            skipped_count += 1
+            continue
+
+        tensor = _load_tensor(item.shard, item.name, item.shape)
+        if policy_item.method == "passthrough":
+            add_tensor(item.name, tensor.astype(np.float16))
+            if item.name.endswith(".weight") or _is_self_conditioning(item.name):
+                passthrough_bases.add(_quant_base_name(item.name))
+            passthrough_count += 1
+        else:
+            _assert_quantizable_shape(item.name, tensor, args.group_size)
+            qw, qs, qb = _mxfp_quantize(tensor, bits=policy_item.bits, group_size=args.group_size, mx=mx)
+            base = _quant_base_name(item.name)
+            add_tensor(f"{base}.weight", qw)
+            add_tensor(f"{base}.scales", qs)
+            if qb is not None:
+                add_tensor(f"{base}.biases", qb)
+            quantized_policies[base] = policy_item
+            quantized_count += 1
+            del qw, qs, qb
+
+        del tensor
+        if (quantized_count + passthrough_count) % 100 == 0:
+            gc.collect()
+            mx.clear_cache()
+
+    flush_shard()
+    for idx in range(1, shard_idx + 1):
+        old = out / f"model-{idx:05d}-of-XXXXX.safetensors"
+        new = out / f"model-{idx:05d}-of-{shard_idx:05d}.safetensors"
+        if old.exists():
+            old.rename(new)
+    shard_map = {key: value.replace("XXXXX", f"{shard_idx:05d}") for key, value in shard_map.items()}
+    total_size = sum((out / shard).stat().st_size for shard in set(shard_map.values()))
+    _write_json(
+        out / "model.safetensors.index.json",
+        {"metadata": {"format": weight_format, "total_size": total_size}, "weight_map": shard_map},
+    )
+    _write_configs(
+        src=src,
+        out=out,
+        source_config=source_config,
+        generation_config=generation_config,
+        processor_config=processor_config,
+        bits=args.bits,
+        group_size=args.group_size,
+        shard_map=shard_map,
+        total_size=total_size,
+        quantized_policies=quantized_policies,
+        passthrough_bases=passthrough_bases,
+        quantized_count=quantized_count,
+        passthrough_count=passthrough_count,
+        skipped_count=skipped_count,
+    )
+
+    print(
+        json.dumps(
+            {
+                "output": str(out),
+                "weight_format": weight_format,
+                "shards": shard_idx,
+                "total_weight_gb": round(total_size / (1024 ** 3), 2),
+                "quantized_tensors": quantized_count,
+                "passthrough_tensors": passthrough_count,
+                "skipped_tensors": skipped_count,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Convert DiffusionGemma BF16 source to first-party native MLX MXFP4/MXFP8."
+    )
+    parser.add_argument("--src", type=Path, default=DEFAULT_SOURCE)
+    parser.add_argument("--out", type=Path, default=None)
+    parser.add_argument("--out-root", type=Path, default=DEFAULT_OUTPUT_ROOT)
+    parser.add_argument("--bits", type=int, choices=(4, 8), default=4)
+    parser.add_argument("--group-size", type=int, default=32)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--replace", action="store_true")
+    parser.add_argument("--quiet", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    return convert(parse_args(argv or sys.argv[1:]))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/vmlx-diffusiongemma-quant-prep.sh
+++ b/scripts/vmlx-diffusiongemma-quant-prep.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'USAGE'
+usage: scripts/vmlx-diffusiongemma-quant-prep.sh [--src DIR] [--out-root DIR] [--artifact-root DIR] [--allow-incomplete]
+
+Preflight DiffusionGemma BF16 source and write first-party native MLX
+MXFP4/MXFP8 quantization prep manifests. This does not quantize weights; it
+refuses to pretend the bundle is ready when source shards or modality metadata
+are missing.
+USAGE
+  exit 64
+}
+
+SRC="/Users/eric/models/google/diffusiongemma-26B-A4B-it"
+OUT_ROOT="/Users/eric/models/OsaurusAI"
+ARTIFACT_ROOT=""
+ALLOW_INCOMPLETE=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --src) SRC="${2:-}"; shift 2 ;;
+    --out-root) OUT_ROOT="${2:-}"; shift 2 ;;
+    --artifact-root) ARTIFACT_ROOT="${2:-}"; shift 2 ;;
+    --allow-incomplete) ALLOW_INCOMPLETE=1; shift ;;
+    -h|--help) usage ;;
+    *) echo "unknown argument: $1" >&2; usage ;;
+  esac
+done
+
+if [[ -z "$ARTIFACT_ROOT" ]]; then
+  STAMP="$(date -u +%Y%m%dT%H%M%SZ)"
+  ARTIFACT_ROOT="docs/local/diffusiongemma-quant-prep/$STAMP"
+fi
+
+python3 - "$SRC" "$OUT_ROOT" "$ARTIFACT_ROOT" "$ALLOW_INCOMPLETE" <<'PY'
+import json
+import os
+import shutil
+import sys
+from collections import Counter
+from pathlib import Path
+
+src = Path(sys.argv[1]).expanduser()
+out_root = Path(sys.argv[2]).expanduser()
+artifact_root = Path(sys.argv[3])
+allow_incomplete = sys.argv[4] == "1"
+
+required_small = [
+    "README.md",
+    "chat_template.jinja",
+    "config.json",
+    "generation_config.json",
+    "model.safetensors.index.json",
+    "processor_config.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
+]
+
+missing = [name for name in required_small if not (src / name).is_file()]
+config_path = src / "config.json"
+if not config_path.is_file():
+    raise SystemExit(f"missing config.json: {config_path}")
+
+config = json.loads(config_path.read_text())
+generation_config = {}
+if (src / "generation_config.json").is_file():
+    generation_config = json.loads((src / "generation_config.json").read_text())
+
+index = None
+if (src / "model.safetensors.index.json").is_file():
+    index = json.loads((src / "model.safetensors.index.json").read_text())
+
+text_config = config.get("text_config") or {}
+vision_config = config.get("vision_config")
+audio_config = config.get("audio_config")
+model_type = config.get("model_type")
+arch = config.get("architectures") or []
+canvas_length = config.get("canvas_length")
+
+if model_type != "diffusion_gemma":
+    raise SystemExit(f"unexpected model_type={model_type!r}; refusing DiffusionGemma prep")
+if "DiffusionGemmaForBlockDiffusion" not in arch:
+    raise SystemExit(f"unexpected architectures={arch!r}; refusing DiffusionGemma prep")
+
+shard_files = sorted(src.glob("model-*-of-*.safetensors"))
+expected_shards = 0
+if index:
+    expected_shards = len(set(index.get("weight_map", {}).values()))
+else:
+    expected_shards = 11
+
+complete = not missing and len(shard_files) == expected_shards
+if not complete and not allow_incomplete:
+    lines = [
+        "DiffusionGemma source is incomplete.",
+        f"src={src}",
+        f"missing={missing}",
+        f"shards={len(shard_files)}/{expected_shards}",
+        "Use --allow-incomplete only for metadata-only prep.",
+    ]
+    raise SystemExit("\n".join(lines))
+
+artifact_root.mkdir(parents=True, exist_ok=True)
+target_base = "diffusiongemma-26B-A4B-it"
+targets = {
+    "MXFP4": out_root / f"{target_base}-MXFP4",
+    "MXFP8": out_root / f"{target_base}-MXFP8",
+}
+
+weight_counts = Counter()
+if index:
+    for key in index.get("weight_map", {}):
+        if key.endswith(".weight"):
+            weight_counts["weights"] += 1
+        elif key.endswith(".scales"):
+            weight_counts["scales"] += 1
+        elif key.endswith(".biases"):
+            weight_counts["biases"] += 1
+        else:
+            weight_counts["other"] += 1
+
+tensor_policy = {
+    "native_mx_quantize": [
+        "uses mx.quantize(..., mode='mxfp4'|'mxfp8')",
+        "emits MLX weight/scales companions, not affine 4-bit biases",
+    ],
+    "quantize_mxfp4_profile": [
+        "model.decoder.layers.*.self_attn.{q,k,v,o}_proj.weight",
+        "model.decoder.layers.*.experts.{gate_up,down}_proj.weight",
+        "model.decoder.layers.*.mlp.{gate,up,down}_proj.weight as MXFP8 override",
+        "model.decoder.layers.*.router.proj.weight as MXFP8 override",
+    ],
+    "quantize_mxfp8_profile": [
+        "model.decoder.layers.*.self_attn.{q,k,v,o}_proj.weight",
+        "model.decoder.layers.*.experts.{gate_up,down}_proj.weight",
+        "model.decoder.layers.*.mlp.{gate,up,down}_proj.weight",
+        "model.decoder.layers.*.router.proj.weight",
+    ],
+    "keep_fp16_or_bf16": [
+        "norms, layer_scalar, per_expert_scale, router.scale",
+        "token embeddings and LM head for first parity pass",
+        "vision tower, multimodal projector/embedder, image soft-token path",
+        "self_conditioning projections until text parity passes",
+    ],
+    "blocked_until_engine": [
+        "do not benchmark MXFP bundles with autoregressive TokenIterator",
+        "do not advertise audio; source has no audio_config/audio_token_id and MLX-VLM reference rejects audio",
+        "do not claim video until processor/video-token/runtime evidence passes",
+    ],
+}
+
+base_manifest = {
+    "source": {
+        "path": str(src),
+        "repo_id": "google/diffusiongemma-26B-A4B-it",
+        "complete": complete,
+        "missing": missing,
+        "shards_present": len(shard_files),
+        "shards_expected": expected_shards,
+    },
+    "model": {
+        "model_type": model_type,
+        "architectures": arch,
+        "canvas_length": canvas_length,
+        "max_new_tokens": generation_config.get("max_new_tokens"),
+        "max_denoising_steps": generation_config.get("max_denoising_steps"),
+        "sampler_config": generation_config.get("sampler_config"),
+        "confidence_threshold": generation_config.get("confidence_threshold"),
+        "stability_threshold": generation_config.get("stability_threshold"),
+        "text_model_type": text_config.get("model_type"),
+        "hidden_size": text_config.get("hidden_size"),
+        "num_hidden_layers": text_config.get("num_hidden_layers"),
+        "num_experts": text_config.get("num_experts"),
+        "top_k_experts": text_config.get("top_k_experts"),
+        "sliding_window": text_config.get("sliding_window"),
+        "layer_types": text_config.get("layer_types"),
+        "vision_model_type": (vision_config or {}).get("model_type") if isinstance(vision_config, dict) else None,
+        "image_token_id": config.get("image_token_id"),
+        "vision_soft_tokens_per_image": config.get("vision_soft_tokens_per_image"),
+        "audio_config_present": audio_config is not None,
+        "audio_token_id": config.get("audio_token_id"),
+        "video_token_id": config.get("video_token_id"),
+    },
+    "weight_index": {
+        "present": index is not None,
+        "counts": dict(weight_counts),
+    },
+    "tensor_policy": tensor_policy,
+    "targets": {},
+}
+
+for profile, out_dir in targets.items():
+    bits = 4 if profile == "MXFP4" else 8
+    manifest = dict(base_manifest)
+    manifest["quantization"] = {
+        "profile": profile,
+        "mode": profile.lower(),
+        "bits": bits,
+        "group_size": 32,
+        "weight_format": profile.lower(),
+        "first_party": True,
+        "source_converter_status": "ready",
+        "source_converter": "scripts/vmlx-convert-diffusiongemma-mxfp.py",
+        "example_command": (
+            "scripts/vmlx-convert-diffusiongemma-mxfp.py "
+            f"--src {src} --out {out_dir} --bits {bits} --group-size 32 --replace"
+        ),
+    }
+    manifest["output"] = {
+        "path": str(out_dir),
+        "estimated_min_free_bytes_before_run": int(1.25 * (src.stat().st_size if src.is_file() else sum(p.stat().st_size for p in src.rglob('*') if p.is_file()))),
+    }
+    manifest["targets"] = {profile: str(out_dir)}
+    (artifact_root / f"{profile.lower()}-manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+    )
+
+summary = {
+    "source": str(src),
+    "complete": complete,
+    "missing": missing,
+    "shards_present": len(shard_files),
+    "shards_expected": expected_shards,
+    "artifact_root": str(artifact_root),
+    "targets": {k: str(v) for k, v in targets.items()},
+    "vl": {
+        "status": "required",
+        "vision_config_present": vision_config is not None,
+        "image_token_id": config.get("image_token_id"),
+        "vision_soft_tokens_per_image": config.get("vision_soft_tokens_per_image"),
+    },
+    "audio": {
+        "status": "unsupported_by_source_bundle_and_reference_processor",
+        "audio_config_present": audio_config is not None,
+        "audio_token_id": config.get("audio_token_id"),
+    },
+    "video": {
+        "status": "processor_present_runtime_proof_required",
+        "video_processor_present": isinstance(json.loads((src / "processor_config.json").read_text()).get("video_processor"), dict) if (src / "processor_config.json").is_file() else False,
+        "video_token_id": config.get("video_token_id"),
+    },
+}
+(artifact_root / "SUMMARY.json").write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+
+print(json.dumps(summary, indent=2, sort_keys=True))
+PY


### PR DESCRIPTION
## Summary

Adds first-party DiffusionGemma quant prep for `google/diffusiongemma-26B-A4B-it`:

- strict source/prep manifest script for MXFP4 and MXFP8 targets
- native MLX converter using `mx.quantize(..., mode="mxfp4"|"mxfp8")`
- documented block-diffusion engine boundary, modality boundary, and completed local quant proof

This is quant/prep work only. It does not claim native DiffusionGemma generation is implemented yet.

## Current source truth

- Source: `/Users/eric/models/google/diffusiongemma-26B-A4B-it`
- Source complete: 11/11 safetensors shards, no missing required sidecars
- Model type: `diffusion_gemma`
- Architecture: `DiffusionGemmaForBlockDiffusion`
- Image/VL metadata present: `vision_config`, `image_token_id=258880`, `vision_soft_tokens_per_image=280`
- Audio unsupported in this source: no `audio_config`, no `audio_token_id`
- Video processor metadata exists, but no `video_token_id`; runtime proof required

## Quant policy

- MXFP4 profile: attention + MoE experts as MXFP4; dense MLP + router projections as MXFP8 overrides
- MXFP8 profile: attention, dense MLP, router, and experts as MXFP8
- Embeddings, norms, router scalar controls, self-conditioning, and vision encoder path stay fp16 passthrough for first parity
- Generated config stamps `weight_format=mxfp4|mxfp8` and `quantization.mode=mxfp4|mxfp8`

## Local quant outputs

- MXFP4: `/Users/eric/models/OsaurusAI/diffusiongemma-26B-A4B-it-MXFP4`
  - 15 GB on disk, 15 shards, `total_size=15944852880`
  - 295 quantized tensors, 752 passthrough tensors, 0 skipped, 1,342 indexed output tensors
  - conversion log: `/tmp/diffusiongemma-mxfp4-convert-20260612T191053Z.log`
  - wall time: 74.38s, max RSS 14,044,954,624 bytes, 0 swaps
- MXFP8: `/Users/eric/models/OsaurusAI/diffusiongemma-26B-A4B-it-MXFP8`
  - 26 GB on disk, 23 shards, `total_size=27918936056`
  - 295 quantized tensors, 752 passthrough tensors, 0 skipped, 1,342 indexed output tensors
  - conversion log: `/tmp/diffusiongemma-mxfp8-convert-20260612T191232Z.log`
  - wall time: 65.80s, max RSS 14,894,694,400 bytes, 0 swaps

## Validation

- `python3 -m py_compile scripts/vmlx-convert-diffusiongemma-mxfp.py`
- `bash -n scripts/vmlx-diffusiongemma-quant-prep.sh`
- `git diff --check`
- `scripts/vmlx-diffusiongemma-quant-prep.sh --artifact-root /tmp/diffusiongemma-quant-prep-pr45-refresh`
- `python3 scripts/vmlx-convert-diffusiongemma-mxfp.py --dry-run --bits 4 --quiet`
- `python3 scripts/vmlx-convert-diffusiongemma-mxfp.py --dry-run --bits 8 --quiet`
- `/Users/eric/jang/jang-tools/.venv/bin/python` final bundle verification for both MXFP4 and MXFP8:
  - config/index/manifest consistency
  - every index entry resolves to an existing shard tensor
  - sampled attention, dense MLP, expert, and embedding tensor shapes/dtypes match expected native MLX MXFP layout

Dry-run counts from the real source:

- MXFP4: 175 tensors MXFP4, 120 tensors MXFP8, 752 tensors passthrough
- MXFP8: 295 tensors MXFP8, 752 tensors passthrough
- Exact-shape output estimates matched actual outputs: about 14.85 GiB for MXFP4, about 26.0 GiB for MXFP8

## Boundary

Native block-diffusion generation still needs engine work in vMLX before Osaurus can promote a live text/VL row. The local MXFP bundles are ready for that engine work, but speed/runtime claims remain blocked until the block-diffusion engine runs the bundles directly.
