### PR TITLE
Gemma4 speed parity with GGUF baselines + native audio (unified raw + E-series conformer tower)

### DIFF
--- a/Libraries/MLXLLM/Models/Gemma4Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma4Text.swift
@@ -684,9 +684,20 @@ public class Gemma4Model: Module {
         let flatShape = prefixShape + [
             config.numHiddenLayers * config.hiddenSizePerLayerInput,
         ]
-        eval(proj)
+        // Materializing the projection here is load-bearing for decode
+        // throughput: without these evals the solo decode path drops from
+        // ~120 tok/s to ~42 tok/s on E2B QAT (measured 2026-06-12, M5 Max,
+        // greedy parity identical). Inside a compiled trace they are both
+        // unnecessary (the traced graph materializes once) and illegal
+        // (eval during compile transforms is a fatal error), so skip them
+        // while tracing.
+        if !CompiledDecodeTrace.isActive {
+            eval(proj)
+        }
         proj = perLayerProjectionNorm(proj.reshaped(layerShape))
-        eval(proj)
+        if !CompiledDecodeTrace.isActive {
+            eval(proj)
+        }
         proj = proj.reshaped(flatShape)
 
         guard let perLayerInputs else { return proj }

--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -1665,7 +1665,7 @@ public actor BatchEngine {
                 continuation: slot.continuation,
                 completedBeforePrefill: completedBeforePrefill,
                 totalPromptUnits: totalPromptUnits)
-            prepareResult = try PrefillProgressReporter.$current.withValue({
+            prepareResult = try PrefillProgressReporter.withHandler({
                 progressAccumulator.report(completedInPrepare: $0)
             }) {
                 try context.model.prepare(

--- a/Libraries/MLXLMCommon/CompiledDecodeTrace.swift
+++ b/Libraries/MLXLMCommon/CompiledDecodeTrace.swift
@@ -28,3 +28,28 @@ public enum CompiledDecodeTrace {
         return try body()
     }
 }
+
+/// Process-level tied-head quantization policy, set by the host (Osaurus)
+/// from `VMLXServerPerformanceSettings.tiedHeadCodec` before model load.
+/// Same host-set-static pattern as `NativeMTPActivation` /
+/// `JangPressActivation`. The loader applies it only to bundles that are
+/// themselves quantized and whose tied head ships without quantization
+/// sidecars; `VMLX_QUANT_TIED_HEAD_BITS` env remains a bench override.
+public enum TiedHeadQuantizationPolicy {
+    public struct Quantization: Sendable, Equatable {
+        public var bits: Int
+        public var groupSize: Int
+        public init(bits: Int, groupSize: Int = 64) {
+            self.bits = bits
+            self.groupSize = groupSize
+        }
+    }
+
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var _current: Quantization?
+
+    public static var current: Quantization? {
+        get { lock.withLock { _current } }
+        set { lock.withLock { _current = newValue } }
+    }
+}

--- a/Libraries/MLXLMCommon/CompiledDecodeTrace.swift
+++ b/Libraries/MLXLMCommon/CompiledDecodeTrace.swift
@@ -1,0 +1,30 @@
+// Marks when the current thread is building an MLX `compile` trace for
+// compiled decode. Model forward paths that use mid-graph `eval` as a
+// scheduling/materialization aid (e.g. Gemma4 per-layer-input projection)
+// must skip those evals while tracing: `eval` during a compile transform is
+// a fatal error in MLX, and the traced graph materializes shared
+// subexpressions once anyway.
+//
+// A plain static is sufficient: the compile trace executes the closure
+// synchronously on the calling thread, and compiled replays do not re-run
+// the Swift closure body.
+
+import Foundation
+
+public enum CompiledDecodeTrace {
+    @TaskLocal private static var taskLocalActive = false
+
+    nonisolated(unsafe) private static var threadActive: Bool {
+        get { (Thread.current.threadDictionary["vmlx.compiledDecodeTrace"] as? Bool) ?? false }
+        set { Thread.current.threadDictionary["vmlx.compiledDecodeTrace"] = newValue }
+    }
+
+    public static var isActive: Bool { threadActive }
+
+    public static func withActive<T>(_ body: () throws -> T) rethrows -> T {
+        let previous = threadActive
+        threadActive = true
+        defer { threadActive = previous }
+        return try body()
+    }
+}

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1596,7 +1596,7 @@ public struct TokenIterator: TokenIteratorProtocol {
         }
         self.promptPrefillTime = try measure {
             try MLXPressGenerationProfile.time("prompt.prepare_total") {
-                try PrefillProgressReporter.$current.withValue(modelPrepareProgressHandler) {
+                try PrefillProgressReporter.withHandler(modelPrepareProgressHandler) {
                     try prepare(
                         input: inputForPrepare,
                         windowSize: effectivePrefillWindow(

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1780,21 +1780,29 @@ public struct TokenIterator: TokenIteratorProtocol {
         case .none where kvBits != nil:
             return
         case .none:
-            if cache.allSatisfy({ $0 is KVCacheSimple }) {
-                // KVCacheSimple -> CompilableKVCache (static buffer, graph-visible
-                // offset). Plain KVCacheSimple reads `offset` as an Int, which compile
-                // captures at trace-build time and then reuses for later tokens.
-                promoted = cache.map { layer in
-                    CompilableKVCache(from: layer, maxLength: maxCacheLength) as KVCache
+            // Promote per layer so hybrid sliding/full topologies compile too.
+            // Gemma4-class models mix KVCacheSimple (full-attention layers)
+            // and RotatingKVCache (sliding-window layers) in one cache array;
+            // requiring a homogeneous cache type silently disabled compiled
+            // decode for exactly the families that need it most. Each layer's
+            // cache is independent in the traced graph, so promotion is
+            // per-layer:
+            //   KVCacheSimple   -> CompilableKVCache (static buffer,
+            //                      graph-visible offset; plain KVCacheSimple
+            //                      reads `offset` as an Int, which compile
+            //                      captures at trace-build time and then
+            //                      reuses for later tokens)
+            //   RotatingKVCache -> CompilableRotatingKVCache
+            let allPromotable = cache.allSatisfy { layer in
+                layer is KVCacheSimple
+                    || (layer is RotatingKVCache && !(layer is CompilableRotatingKVCache))
+            }
+            guard allPromotable else { return }
+            promoted = cache.map { layer in
+                if let rotating = layer as? RotatingKVCache {
+                    return CompilableRotatingKVCache(from: rotating) as KVCache
                 }
-            } else if cache.allSatisfy({
-                $0 is RotatingKVCache && !($0 is CompilableRotatingKVCache)
-            }) {
-                promoted = cache.map { layer in
-                    CompilableRotatingKVCache(from: layer as! RotatingKVCache) as KVCache
-                }
-            } else {
-                return
+                return CompilableKVCache(from: layer, maxLength: maxCacheLength) as KVCache
             }
         }
         MLX.eval(promoted)
@@ -1806,11 +1814,18 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.compiledForward = compile(
             inputs: cacheRef, outputs: cacheRef
         ) { (args: [MLXArray]) -> [MLXArray] in
-            let result = capturedModel(
-                LMInput.Text(tokens: args[0])[text: .newAxis],
-                cache: cacheRef.isEmpty ? nil : cacheRef,
-                state: nil)
-            return [result.logits]
+            // The closure body only runs while MLX records the trace
+            // (replays reuse the recorded graph), so this flag exactly
+            // brackets trace-time execution. Model forwards consult it to
+            // skip mid-graph `eval` scheduling aids that are illegal
+            // inside compile transforms.
+            CompiledDecodeTrace.withActive {
+                let result = capturedModel(
+                    LMInput.Text(tokens: args[0])[text: .newAxis],
+                    cache: cacheRef.isEmpty ? nil : cacheRef,
+                    state: nil)
+                return [result.logits]
+            }
         }
     }
 

--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -679,6 +679,35 @@ public func loadWeights(
     weights.removeAll(keepingCapacity: false)
     MLX.Memory.clearCache()
 
+    // VMLX_QUANT_TIED_HEAD_BITS=<bits> (experiment gate): quantize a plain
+    // fp16/bf16 `embed_tokens` at load time. Tied-embedding families
+    // (Gemma4 QAT) ship the decoder quantized but the 262k-vocab embedding
+    // unquantized; `asLinear` then streams the full fp16 table per decoded
+    // token (E2B: ~1.07 GB/token), which dominates decode bandwidth.
+    // llama.cpp ships the equivalent output head quantized (Q6_K-class) in
+    // the GGUF baselines this engine is compared against.
+    if let bitsRaw = ProcessInfo.processInfo.environment["VMLX_QUANT_TIED_HEAD_BITS"],
+        let headBits = Int(bitsRaw), headBits > 0
+    {
+        let headGroupSize =
+            ProcessInfo.processInfo.environment["VMLX_QUANT_TIED_HEAD_GS"].flatMap(Int.init) ?? 64
+        var headUpdates: [(String, Module)] = []
+        for (path, mod) in model.namedModules() {
+            guard path.hasSuffix("embed_tokens"), type(of: mod) == Embedding.self,
+                let emb = mod as? Embedding
+            else { continue }
+            headUpdates.append(
+                (path, QuantizedEmbedding(emb, groupSize: headGroupSize, bits: headBits)))
+        }
+        if !headUpdates.isEmpty {
+            try model.update(modules: ModuleChildren.unflattened(headUpdates), verify: .none)
+            MLX.eval(model)
+            MLX.Memory.clearCache()
+            FileHandle.standardError.write(Data(
+                "[Load] quantized tied embedding head bits=\(headBits) gs=\(headGroupSize) paths=\(headUpdates.map(\.0))\n".utf8))
+        }
+    }
+
     // Convert float16/float32 parameters to bfloat16 to prevent AsType cascades.
     // float16 causes AsType when mixed with internal float32 ops (softmax, RMSNorm).
     // bfloat16 shares float32's exponent range, so promotion is cheaper/eliminated.

--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -679,18 +679,28 @@ public func loadWeights(
     weights.removeAll(keepingCapacity: false)
     MLX.Memory.clearCache()
 
-    // VMLX_QUANT_TIED_HEAD_BITS=<bits> (experiment gate): quantize a plain
-    // fp16/bf16 `embed_tokens` at load time. Tied-embedding families
-    // (Gemma4 QAT) ship the decoder quantized but the 262k-vocab embedding
-    // unquantized; `asLinear` then streams the full fp16 table per decoded
-    // token (E2B: ~1.07 GB/token), which dominates decode bandwidth.
-    // llama.cpp ships the equivalent output head quantized (Q6_K-class) in
-    // the GGUF baselines this engine is compared against.
-    if let bitsRaw = ProcessInfo.processInfo.environment["VMLX_QUANT_TIED_HEAD_BITS"],
-        let headBits = Int(bitsRaw), headBits > 0
+    // Tied-head load-time quantization: quantize a plain fp16/bf16
+    // `embed_tokens` at load. Tied-embedding families (Gemma4 QAT) ship
+    // the decoder quantized but the 262k-vocab embedding unquantized;
+    // `asLinear` then streams the full fp16 table per decoded token
+    // (E2B: ~1.07 GB/token), which dominates decode bandwidth. llama.cpp
+    // ships the equivalent output head quantized (Q6_K-class) in the GGUF
+    // baselines this engine is compared against.
+    //
+    // Policy precedence: VMLX_QUANT_TIED_HEAD_BITS env (bench override) >
+    // host-set TiedHeadQuantizationPolicy (server settings) > off.
+    // Applied ONLY when the bundle itself is quantized — an fp16 bundle's
+    // head is part of the bundle's declared precision contract.
+    let envHeadBits = ProcessInfo.processInfo.environment["VMLX_QUANT_TIED_HEAD_BITS"]
+        .flatMap(Int.init)
+    let policyHeadQuant = TiedHeadQuantizationPolicy.current
+    let bundleIsQuantized = quantization != nil || perLayerQuantization != nil
+    if let headBits = envHeadBits ?? (bundleIsQuantized ? policyHeadQuant?.bits : nil),
+        headBits > 0
     {
         let headGroupSize =
-            ProcessInfo.processInfo.environment["VMLX_QUANT_TIED_HEAD_GS"].flatMap(Int.init) ?? 64
+            ProcessInfo.processInfo.environment["VMLX_QUANT_TIED_HEAD_GS"].flatMap(Int.init)
+            ?? policyHeadQuant?.groupSize ?? 64
         var headUpdates: [(String, Module)] = []
         for (path, mod) in model.namedModules() {
             guard path.hasSuffix("embed_tokens"), type(of: mod) == Embedding.self,

--- a/Libraries/MLXLMCommon/PrefillProgressReporter.swift
+++ b/Libraries/MLXLMCommon/PrefillProgressReporter.swift
@@ -1,14 +1,46 @@
 // Copyright © 2026 osaurus.
 
-/// Task-local callback used by model `prepare` implementations to report
+import Foundation
+
+/// Scoped callback used by model `prepare` implementations to report
 /// completed prompt-processing units without changing the `LanguageModel`
 /// protocol signature.
 public enum PrefillProgressReporter {
     public typealias Handler = @Sendable (Int) -> Void
 
-    @TaskLocal public static var current: Handler?
+    private final class HandlerBox {
+        let handler: Handler
+
+        init(_ handler: @escaping Handler) {
+            self.handler = handler
+        }
+    }
+
+    private static let threadDictionaryKey = "ai.osaurus.vmlx.prefillProgressReporter"
+
+    public static func withHandler<T>(
+        _ handler: Handler?,
+        operation: () throws -> T
+    ) rethrows -> T {
+        guard let handler else { return try operation() }
+
+        let dictionary = Thread.current.threadDictionary
+        let previous = dictionary[threadDictionaryKey]
+        dictionary[threadDictionaryKey] = HandlerBox(handler)
+        defer {
+            if let previous {
+                dictionary[threadDictionaryKey] = previous
+            } else {
+                dictionary.removeObject(forKey: threadDictionaryKey)
+            }
+        }
+        return try operation()
+    }
 
     public static func reportCompletedUnits(_ count: Int) {
-        current?(max(0, count))
+        guard let box = Thread.current.threadDictionary[threadDictionaryKey] as? HandlerBox else {
+            return
+        }
+        box.handler(max(0, count))
     }
 }

--- a/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
+++ b/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
@@ -20,6 +20,13 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
     public var multimodal: VMLXServerMultimodalSettings
     public var mtp: VMLXServerMTPSettings
     public var memorySafety: VMLXMemorySafetySettings
+    /// Optional so existing server-runtime.json files decode unchanged.
+    /// `effectivePerformance` resolves nil to defaults.
+    public var performance: VMLXServerPerformanceSettings?
+
+    public var effectivePerformance: VMLXServerPerformanceSettings {
+        performance ?? .init()
+    }
 
     public init(
         network: VMLXServerNetworkSettings = .init(),
@@ -30,7 +37,8 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
         tools: VMLXServerToolSettings = .init(),
         multimodal: VMLXServerMultimodalSettings = .init(),
         mtp: VMLXServerMTPSettings = .init(),
-        memorySafety: VMLXMemorySafetySettings = .init()
+        memorySafety: VMLXMemorySafetySettings = .init(),
+        performance: VMLXServerPerformanceSettings? = nil
     ) {
         self.network = network
         self.concurrency = concurrency
@@ -41,6 +49,7 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
         self.multimodal = multimodal
         self.mtp = mtp
         self.memorySafety = memorySafety
+        self.performance = performance
     }
 
     public func validationIssues(
@@ -889,6 +898,59 @@ public struct VMLXServerCacheSettings: Codable, Sendable, Equatable {
                 return .none
             }
             return .turboQuant(keyBits: keyBits, valueBits: valueBits)
+        }
+    }
+}
+
+/// Decode-throughput settings the host wires to its server settings panel.
+///
+/// Optional on ``VMLXServerRuntimeSettings`` so pre-existing
+/// `server-runtime.json` files decode unchanged (nil = all defaults).
+public struct VMLXServerPerformanceSettings: Codable, Sendable, Equatable {
+    /// Load-time codec for tied LM heads that ship UNQUANTIZED in an
+    /// otherwise-quantized bundle (Gemma4 QAT ships the 262k-vocab tied
+    /// embedding fp16; `asLinear` then streams the full fp16 table per
+    /// decoded token — ~1.07 GB/token on E2B). llama.cpp ships the
+    /// equivalent GGUF output head quantized (Q6_K-class), which is the
+    /// documented baseline this engine is compared against.
+    ///
+    /// `fp16Passthrough` (default) changes nothing. Quantized codecs are
+    /// applied only when the bundle itself is quantized AND the head has
+    /// no quantization sidecars of its own — a pre-quantized head always
+    /// loads as shipped.
+    public var tiedHeadCodec: VMLXTiedHeadCodec
+    /// Experimental MLX compiled decode. Measured +25% decode on Gemma4
+    /// E2B QAT (132.5 -> 165.3 tok/s, M5 Max, 2026-06-12). Off by
+    /// default pending the PR #1173 model-switch corruption root cause;
+    /// hosts surface this as an explicit experimental toggle.
+    public var compiledDecode: Bool
+
+    public init(
+        tiedHeadCodec: VMLXTiedHeadCodec = .fp16Passthrough,
+        compiledDecode: Bool = false
+    ) {
+        self.tiedHeadCodec = tiedHeadCodec
+        self.compiledDecode = compiledDecode
+    }
+}
+
+public enum VMLXTiedHeadCodec: String, Codable, Sendable, Equatable, CaseIterable {
+    /// Load the head exactly as shipped (default).
+    case fp16Passthrough = "fp16_passthrough"
+    /// Quantize an unquantized tied head at load: 8-bit affine, gs=64.
+    case q8
+    /// 6-bit affine, gs=64 — bandwidth/quality point closest to the
+    /// llama.cpp Q6_K output head used by the documented GGUF baselines.
+    case q6
+    /// 4-bit affine, gs=64 — fastest, largest numeric delta.
+    case q4
+
+    public var quantization: (bits: Int, groupSize: Int)? {
+        switch self {
+        case .fp16Passthrough: return nil
+        case .q8: return (8, 64)
+        case .q6: return (6, 64)
+        case .q4: return (4, 64)
         }
     }
 }

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -725,7 +725,14 @@ private class TextAttn: Module {
             else { q = rope(q, offset: off) }
             cK = sharedKV.keys; cV = sharedKV.values
         } else {
-            off = cache?.offset ?? 0
+            // Reading `cache.offset` (Int) forces a host readback; inside a
+            // compiled-decode trace the Compilable* caches keep the offset
+            // graph-visible and `.item()` is illegal. The Int is only used
+            // for the rope fallback (graph offsets take precedence via
+            // applyRotaryPosition/sharedOffsetArray) and the intermediates
+            // bookkeeping, where shared-KV consumers also prefer the
+            // graph offset under trace.
+            off = CompiledDecodeTrace.isActive ? 0 : (cache?.offset ?? 0)
             var k = kP(x).reshaped(B, L, nKV, hD)
             let v: MLXArray
             if useKEqV { v = rmsNormNoScale(k, eps: eps) } else if let vP { v = rmsNormNoScale(vP(x).reshaped(B, L, nKV, hD), eps: eps) } else { v = rmsNormNoScale(k, eps: eps) }
@@ -911,9 +918,18 @@ private class TextModel: Module {
         let layerShape = prefixShape + [cfg.numHiddenLayers, cfg.hiddenSizePerLayerInput]
         let flatShape = prefixShape + [cfg.numHiddenLayers * cfg.hiddenSizePerLayerInput]
         var p = plProj(h) * perLayerProjectionScale
-        eval(p)
+        // Load-bearing scheduling evals (same contract as
+        // Gemma4Text.projectPerLayerInputs): without them solo decode drops
+        // ~3x on E2B QAT. Skip while building a compiled-decode trace, where
+        // eval is illegal and the recorded graph materializes shared
+        // subexpressions once.
+        if !CompiledDecodeTrace.isActive {
+            eval(p)
+        }
         p = plNorm(p.reshaped(layerShape))
-        eval(p)
+        if !CompiledDecodeTrace.isActive {
+            eval(p)
+        }
         p = p.reshaped(flatShape)
         guard let pli else { return p }
         return ((p + pli) * pow(Float(2.0), Float(-0.5))).reshaped(flatShape)

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -297,12 +297,19 @@ struct G4TextConfig: Codable, Sendable {
 public struct Gemma4Configuration: Codable, Sendable {
     let textConfig: G4TextConfig
     let visionConfig: Gemma4VisionConfig
+    /// Full `audio_config` when present. `model_type == "gemma4_audio"`
+    /// (E2B/E4B) means the bundle ships a conformer `audio_tower`;
+    /// `gemma4_unified_audio` (12B) is the encoder-free raw-chunking path.
+    let audioConfig: Gemma4AudioConfig?
     let modelType: String
     let imageTokenId: Int
     let audioTokenId: Int
     let audioEmbedDim: Int
     let visionSoftTokensPerImage: Int
     let quantization: BaseConfiguration.Quantization?
+
+    /// True when the bundle's audio_config requires the conformer tower.
+    var hasConformerAudioTower: Bool { audioConfig?.isConformerTower ?? false }
 
     enum CodingKeys: String, CodingKey {
         case textConfig = "text_config"
@@ -338,6 +345,7 @@ public struct Gemma4Configuration: Codable, Sendable {
         modelType = try c.decodeIfPresent(String.self, forKey: .modelType) ?? "gemma4"
         imageTokenId = try c.decodeIfPresent(Int.self, forKey: .imageTokenId) ?? 258880
         audioTokenId = try c.decodeIfPresent(Int.self, forKey: .audioTokenId) ?? 258881
+        audioConfig = try c.decodeIfPresent(Gemma4AudioConfig.self, forKey: .audioConfig)
         if let audioConfig = try? c.nestedContainer(keyedBy: AudioCodingKeys.self, forKey: .audioConfig) {
             audioEmbedDim =
                 try audioConfig.decodeIfPresent(Int.self, forKey: .audioEmbedDim)
@@ -1080,6 +1088,7 @@ private func maskedScatter(input: MLXArray, mask: MLXArray, source: MLXArray) th
 public class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
     @ModuleInfo(key: "vision_tower") private var visionTower: VisionTower?
     @ModuleInfo(key: "vision_embedder") private var unifiedVisionEmbedder: UnifiedVisionEmbedder?
+    @ModuleInfo(key: "audio_tower") private var audioTower: Gemma4AudioTower?
     @ModuleInfo(key: "language_model") private var languageModel: G4LanguageModel
     @ModuleInfo(key: "embed_vision") private var embedVision: MultimodalEmbedder
     @ModuleInfo(key: "embed_audio") private var embedAudio: MultimodalEmbedder
@@ -1102,6 +1111,14 @@ public class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
             _unifiedVisionEmbedder.wrappedValue = UnifiedVisionEmbedder(config.visionConfig)
         } else {
             _visionTower.wrappedValue = VisionTower(config.visionConfig)
+        }
+        // The conformer audio tower exists only on E-series bundles
+        // (audio_config.model_type == "gemma4_audio"). Unified 12B bundles
+        // (gemma4_unified_audio) and audio-less 26B/31B bundles stay
+        // tower-free; their `audio_tower.*` weights (if any) are discarded
+        // in sanitize().
+        if let audioConfig = config.audioConfig, audioConfig.isConformerTower {
+            _audioTower.wrappedValue = Gemma4AudioTower(audioConfig)
         }
         _languageModel.wrappedValue = G4LanguageModel(config.textConfig)
         _embedVision.wrappedValue = MultimodalEmbedder(embDim: config.visionConfig.outputProjectionDimensions, textDim: config.textConfig.hiddenSize)
@@ -1159,11 +1176,62 @@ public class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
         }
 
         if let audio = input.audio {
-            guard let audioFeatures = audio.preEncodedEmbedding else {
+            let audioFeatures: MLXArray
+            if let preEncoded = audio.preEncodedEmbedding {
+                audioFeatures = preEncoded
+            } else if let audioTower {
+                // E-series mel + conformer path: Gemma4Processor put log-mel
+                // frames [N, T, 128] into ProcessedAudio.waveform (padded
+                // rows exactly zero, HF mask-zeroed extractor contract).
+                let mel = audio.waveform
+                guard mel.ndim == 3, mel.dim(-1) == Gemma4AudioMel.melBins else {
+                    throw VLMError.processing(
+                        "Gemma4 audio tower expects mel frames [N, T, \(Gemma4AudioMel.melBins)] "
+                            + "in LMInput.audio.waveform; got shape \(mel.shape).")
+                }
+                // Per-item valid (prefix) frame counts: a frame is valid iff
+                // it is not the all-zero padding row.
+                let frameValid = (mel .!= MLXArray(Float(0))).any(axis: -1)
+                let validFlags = frameValid.asArray(Bool.self)
+                let (N, T) = (mel.dim(0), mel.dim(1))
+                var validCounts = [Int]()
+                validCounts.reserveCapacity(N)
+                for i in 0 ..< N {
+                    var count = 0
+                    for t in 0 ..< T where validFlags[i * T + t] { count += 1 }
+                    validCounts.append(count)
+                }
+                let towerOut = audioTower(mel, validFrameCounts: validCounts)
+                // Parity-debug hook: dump mel frames + tower output as
+                // safetensors for comparison against the HF reference
+                // implementation (used by tools/Gemma4AudioSmoke proofs).
+                if let dumpDir = ProcessInfo.processInfo
+                    .environment["VMLX_GEMMA4_AUDIO_DUMP_DIR"]
+                {
+                    let dir = URL(fileURLWithPath: dumpDir)
+                    try? FileManager.default.createDirectory(
+                        at: dir, withIntermediateDirectories: true)
+                    try? MLX.save(
+                        arrays: [
+                            "mel": mel.asType(.float32),
+                            "tower": towerOut.asType(.float32),
+                        ],
+                        url: dir.appendingPathComponent("gemma4-audio-dump.safetensors"))
+                }
+                // Keep exactly the valid post-subsampling tokens per item —
+                // the same count the processor used for <|audio|> expansion.
+                var perItem = [MLXArray]()
+                for (i, frames) in validCounts.enumerated() {
+                    let tokens = gemma4AudioSoftTokenCount(melFrameCount: frames)
+                    perItem.append(towerOut[i, ..<tokens])
+                }
+                audioFeatures = perItem.count == 1 ? perItem[0] : concatenated(perItem, axis: 0)
+            } else {
                 throw VLMError.processing(
                     "Gemma4 audio reached prepare() without extracted features. " +
-                    "Gemma4Processor extracts unified raw-waveform frames (or accepts pre-encoded features) before prepare; " +
-                    "LMInput.audio.preEncodedEmbedding must be populated.")
+                    "Gemma4Processor extracts unified raw-waveform frames or E-series mel frames " +
+                    "(or accepts pre-encoded features) before prepare; this bundle has no audio tower " +
+                    "and LMInput.audio.preEncodedEmbedding is nil.")
             }
             guard audioFeatures.dim(-1) == config.audioEmbedDim else {
                 throw VLMError.processing(
@@ -1212,17 +1280,36 @@ public class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
     }
 
     public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        let hasAudioTower = config.hasConformerAudioTower
         var p = [String: MLXArray]()
         for (k, v) in weights {
             var nk = k
             if nk.hasPrefix("model.") { nk = String(nk.dropFirst("model.".count)) }
-            // Until the Gemma4 audio tower encoder is implemented, text and
-            // pre-encoded audio paths keep `embed_audio.embedding_projection`
-            // while raw `audio_tower.*` weights are rejected.
-            if nk.hasPrefix("audio_tower.") { continue }
+            if nk.hasPrefix("audio_tower.") {
+                // E-series bundles (audio_config.model_type == "gemma4_audio")
+                // load the conformer tower; bundles without that config keep
+                // discarding audio_tower.* so 12B/26B/31B still load.
+                guard hasAudioTower else { continue }
+                // Conv weight layout: checkpoints ship the subsampling Conv2d
+                // weights in PyTorch NCHW order [O, I, 3, 3] (MLX wants
+                // [O, 3, 3, I]); the depthwise Conv1d may arrive as either
+                // [O, 1, K] (PyTorch) or [O, K, 1] (MLX). Normalize to MLX.
+                if nk.hasSuffix("conv.weight"), v.ndim == 4, v.dim(2) == 3, v.dim(3) == 3 {
+                    p[nk] = v.transposed(0, 2, 3, 1)
+                    continue
+                }
+                if nk.hasSuffix("depthwise_conv1d.weight"), v.ndim == 3, v.dim(2) != 1 {
+                    p[nk] = v.transposed(0, 2, 1)
+                    continue
+                }
+                p[nk] = v
+                continue
+            }
             if nk.hasPrefix("vision_tower.") && config.visionConfig.usesUnifiedVisionEmbedder { continue }
             if nk.hasPrefix("vision_embedder.") && !config.visionConfig.usesUnifiedVisionEmbedder { continue }
-            // Skip clipped linear params — training artifacts, not used in inference (we use plain Linear)
+            // Skip clipped linear params on non-audio modules — the vision
+            // tower uses plain Linear. (Audio tower keys are handled above
+            // and KEEP their input/output clipping scalars.)
             if nk.contains("input_min") || nk.contains("input_max") || nk.contains("output_min") || nk.contains("output_max") { continue }
             if nk.contains("rotary_emb") { continue }
             // Remap language_model keys to include model. prefix
@@ -1500,6 +1587,7 @@ public struct Gemma4Processor: UserInputProcessor {
         var embeddings = [MLXArray]()
         var tokenCounts = [Int]()
         var waveforms = [MLXArray]()
+        var melFrames = [MLXArray]()
         var sampleRate = config.audioSamplingRate
 
         for audio in audios {
@@ -1515,12 +1603,53 @@ public struct Gemma4Processor: UserInputProcessor {
                 sampleRate = sr
             case .url, .samples, .array:
                 let pcm = try rawWaveform(from: audio, targetSampleRate: config.audioSamplingRate)
-                let features = try unifiedWaveformFeatures(pcm, config: config)
-                embeddings.append(features)
-                tokenCounts.append(features.dim(0))
+                if config.audioFeatureExtractorType == "Gemma4AudioFeatureExtractor" {
+                    // E-series: 128-bin log-mel frames; the conformer
+                    // audio_tower consumes them inside Gemma4.prepare.
+                    // Placeholder count = post-subsampling token count
+                    // (HF replace_audio_token: two stride-2 convs ⇒ ⌈T/4⌉).
+                    guard !pcm.isEmpty else {
+                        throw VLMError.processing(
+                            "Gemma4 audio input decoded to an empty waveform.")
+                    }
+                    let mel = gemma4ExtractMelFeatures(pcm)
+                    melFrames.append(mel)
+                    tokenCounts.append(gemma4AudioSoftTokenCount(melFrameCount: mel.dim(0)))
+                } else {
+                    let features = try unifiedWaveformFeatures(pcm, config: config)
+                    embeddings.append(features)
+                    tokenCounts.append(features.dim(0))
+                }
                 waveforms.append(MLXArray(pcm).reshaped(1, pcm.count))
                 sampleRate = config.audioSamplingRate
             }
+        }
+
+        if !melFrames.isEmpty {
+            guard embeddings.isEmpty else {
+                throw VLMError.processing(
+                    "Gemma4 E-series bundles cannot mix pre-encoded audio embeddings with raw audio "
+                        + "in one request; provide all audio in one form.")
+            }
+            // Stack mel features [N, Tmax, 128]; shorter items are padded
+            // with all-zero rows — the exact contract the audio tower uses
+            // to recover per-item valid frame counts (HF zeroes masked
+            // frames the same way).
+            let maxFrames = melFrames.map { $0.dim(0) }.max() ?? 0
+            let stacked = melFrames.map { mel -> MLXArray in
+                let t = mel.dim(0)
+                let paddedMel =
+                    t == maxFrames
+                    ? mel : MLX.padded(mel, widths: [[0, maxFrames - t], [0, 0]])
+                return paddedMel.expandedDimensions(axis: 0)
+            }
+            return (
+                LMInput.ProcessedAudio(
+                    waveform: stacked.count == 1 ? stacked[0] : concatenated(stacked, axis: 0),
+                    sampleRate: sampleRate,
+                    preEncodedEmbedding: nil),
+                tokenCounts
+            )
         }
 
         let embedding =
@@ -1542,7 +1671,7 @@ public struct Gemma4Processor: UserInputProcessor {
     ) throws -> [Float] {
         switch audio {
         case .url(let url):
-            return try nemotronOmniLoadAudioFile(url, targetSampleRate: targetSampleRate)
+            return try nemotronOmniLoadAudioFile(url, targetSampleRate: Double(targetSampleRate))
         case .samples(let pcm, let sr):
             return sr == targetSampleRate
                 ? pcm : linearResamplePCM(pcm, fromRate: sr, toRate: targetSampleRate)
@@ -1574,9 +1703,10 @@ public struct Gemma4Processor: UserInputProcessor {
             || config.processorClass == "Gemma4UnifiedProcessor"
         else {
             throw VLMError.processing(
-                "Gemma4 raw audio for this bundle requires the \(config.audioFeatureExtractorType ?? "Gemma4AudioFeatureExtractor") " +
-                "mel + audio_tower pipeline, which is not wired in Swift yet. " +
-                "Unified bundles (Gemma4UnifiedAudioFeatureExtractor) decode raw audio natively.")
+                "Gemma4 raw audio for this bundle declares feature_extractor_type "
+                    + "\(config.audioFeatureExtractorType ?? "<missing>"), which has no Swift pipeline. "
+                    + "Supported: Gemma4UnifiedAudioFeatureExtractor (raw chunking) and "
+                    + "Gemma4AudioFeatureExtractor (mel + audio_tower pipeline).")
         }
         guard !pcm.isEmpty else {
             throw VLMError.processing("Gemma4 audio input decoded to an empty waveform.")
@@ -1722,6 +1852,10 @@ private struct Gemma4MessageGenerator: MessageGenerator {
         var content: [[String: String]] = []
         content.append(contentsOf: message.images.map { _ in ["type": "image"] })
         content.append(contentsOf: message.videos.map { _ in ["type": "video"] })
+        // The Gemma4 chat template renders `<|audio|>` for content items of
+        // type "audio"; without this the processor has no placeholder to
+        // expand and audio embeddings would be dropped silently.
+        content.append(contentsOf: message.audios.map { _ in ["type": "audio"] })
         if !message.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             content.append(["type": "text", "text": message.content])
         }

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -1161,8 +1161,9 @@ public class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
         if let audio = input.audio {
             guard let audioFeatures = audio.preEncodedEmbedding else {
                 throw VLMError.processing(
-                    "Gemma4 audio requires pre-encoded features matching this bundle's configured audio embedding width. " +
-                    "Raw waveform feature extraction is not implemented for Gemma4 yet.")
+                    "Gemma4 audio reached prepare() without extracted features. " +
+                    "Gemma4Processor extracts unified raw-waveform frames (or accepts pre-encoded features) before prepare; " +
+                    "LMInput.audio.preEncodedEmbedding must be populated.")
             }
             guard audioFeatures.dim(-1) == config.audioEmbedDim else {
                 throw VLMError.processing(
@@ -1271,6 +1272,16 @@ public struct Gemma4ProcessorConfiguration: Codable, Sendable {
     public let poolingKernelSize: Int
     public let imageSeqLength: Int
     public let audioSeqLength: Int
+    /// `feature_extractor.feature_extractor_type` from `processor_config.json`.
+    /// `Gemma4UnifiedAudioFeatureExtractor` = encoder-free raw-waveform chunking
+    /// (12B unified bundles); `Gemma4AudioFeatureExtractor` = 128-mel + conformer
+    /// `audio_tower` (E-series bundles).
+    public let audioFeatureExtractorType: String?
+    /// Raw 16 kHz samples per audio soft token for the unified extractor
+    /// (`feature_extractor.audio_samples_per_token`, 640 = 40 ms).
+    public let audioSamplesPerToken: Int
+    /// `feature_extractor.sampling_rate`; both extractor families use 16 kHz.
+    public let audioSamplingRate: Int
 
     enum CodingKeys: String, CodingKey {
         case processorClass = "processor_class"
@@ -1281,6 +1292,14 @@ public struct Gemma4ProcessorConfiguration: Codable, Sendable {
         case audioSeqLength = "audio_seq_length"
         case imageProcessor = "image_processor"
         case videoProcessor = "video_processor"
+        case featureExtractor = "feature_extractor"
+    }
+
+    enum FeatureExtractorKeys: String, CodingKey {
+        case featureExtractorType = "feature_extractor_type"
+        case audioSamplesPerToken = "audio_samples_per_token"
+        case featureSize = "feature_size"
+        case samplingRate = "sampling_rate"
     }
 
     public init(from decoder: Decoder) throws {
@@ -1301,6 +1320,25 @@ public struct Gemma4ProcessorConfiguration: Codable, Sendable {
             ?? 3
         imageSeqLength = try c.decodeIfPresent(Int.self, forKey: .imageSeqLength) ?? 280
         audioSeqLength = try c.decodeIfPresent(Int.self, forKey: .audioSeqLength) ?? 750
+        if let fe = try? c.nestedContainer(keyedBy: FeatureExtractorKeys.self, forKey: .featureExtractor) {
+            audioFeatureExtractorType = try fe.decodeIfPresent(String.self, forKey: .featureExtractorType)
+            // The unified extractor's frame width is `audio_samples_per_token`;
+            // `feature_size` mirrors it in shipped configs. For the mel extractor
+            // `feature_size` is the mel-bin count (128), which is NOT a chunk
+            // width, so only fall back to it for the unified extractor type.
+            let parsedSamplesPerToken = try fe.decodeIfPresent(Int.self, forKey: .audioSamplesPerToken)
+            let parsedFeatureSize = try fe.decodeIfPresent(Int.self, forKey: .featureSize)
+            if audioFeatureExtractorType == "Gemma4UnifiedAudioFeatureExtractor" {
+                audioSamplesPerToken = parsedSamplesPerToken ?? parsedFeatureSize ?? 640
+            } else {
+                audioSamplesPerToken = parsedSamplesPerToken ?? 640
+            }
+            audioSamplingRate = try fe.decodeIfPresent(Int.self, forKey: .samplingRate) ?? 16_000
+        } else {
+            audioFeatureExtractorType = nil
+            audioSamplesPerToken = 640
+            audioSamplingRate = 16_000
+        }
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -1311,6 +1349,10 @@ public struct Gemma4ProcessorConfiguration: Codable, Sendable {
         try c.encode(poolingKernelSize, forKey: .poolingKernelSize)
         try c.encode(imageSeqLength, forKey: .imageSeqLength)
         try c.encode(audioSeqLength, forKey: .audioSeqLength)
+        var fe = c.nestedContainer(keyedBy: FeatureExtractorKeys.self, forKey: .featureExtractor)
+        try fe.encodeIfPresent(audioFeatureExtractorType, forKey: .featureExtractorType)
+        try fe.encode(audioSamplesPerToken, forKey: .audioSamplesPerToken)
+        try fe.encode(audioSamplingRate, forKey: .samplingRate)
     }
 }
 
@@ -1422,7 +1464,7 @@ public struct Gemma4Processor: UserInputProcessor {
 
         var processedAudio: LMInput.ProcessedAudio?
         if !input.audios.isEmpty {
-            let prepared = try Self.preEncodedAudio(from: input.audios)
+            let prepared = try Self.processedAudio(from: input.audios, config: config)
             processedAudio = prepared.audio
 
             let audioId = tokenizer.convertTokenToId("<|audio|>") ?? 258881
@@ -1452,13 +1494,13 @@ public struct Gemma4Processor: UserInputProcessor {
             toolSchemas: input.tools)
     }
 
-    private static func preEncodedAudio(
-        from audios: [UserInput.Audio]
+    private static func processedAudio(
+        from audios: [UserInput.Audio], config: Gemma4ProcessorConfiguration
     ) throws -> (audio: LMInput.ProcessedAudio, tokenCounts: [Int]) {
         var embeddings = [MLXArray]()
         var tokenCounts = [Int]()
         var waveforms = [MLXArray]()
-        var sampleRate = 16_000
+        var sampleRate = config.audioSamplingRate
 
         for audio in audios {
             switch audio {
@@ -1472,9 +1514,12 @@ public struct Gemma4Processor: UserInputProcessor {
                 waveforms.append(MLXArray(samples).reshaped(1, samples.count))
                 sampleRate = sr
             case .url, .samples, .array:
-                throw VLMError.processing(
-                    "Gemma4 raw audio feature extraction is not implemented. " +
-                    "Provide UserInput.Audio.preEncoded with configured-width Gemma4 audio features.")
+                let pcm = try rawWaveform(from: audio, targetSampleRate: config.audioSamplingRate)
+                let features = try unifiedWaveformFeatures(pcm, config: config)
+                embeddings.append(features)
+                tokenCounts.append(features.dim(0))
+                waveforms.append(MLXArray(pcm).reshaped(1, pcm.count))
+                sampleRate = config.audioSamplingRate
             }
         }
 
@@ -1488,6 +1533,67 @@ public struct Gemma4Processor: UserInputProcessor {
                 preEncodedEmbedding: embedding),
             tokenCounts
         )
+    }
+
+    /// Decode and resample a raw `UserInput.Audio` resource to mono PCM at
+    /// `targetSampleRate` (16 kHz for all shipped Gemma4 bundles).
+    private static func rawWaveform(
+        from audio: UserInput.Audio, targetSampleRate: Int
+    ) throws -> [Float] {
+        switch audio {
+        case .url(let url):
+            return try nemotronOmniLoadAudioFile(url, targetSampleRate: targetSampleRate)
+        case .samples(let pcm, let sr):
+            return sr == targetSampleRate
+                ? pcm : linearResamplePCM(pcm, fromRate: sr, toRate: targetSampleRate)
+        case .array(let arr, let sr):
+            let pcm = arr.reshaped([-1]).asType(.float32).asArray(Float.self)
+            return sr == targetSampleRate
+                ? pcm : linearResamplePCM(pcm, fromRate: sr, toRate: targetSampleRate)
+        case .preEncoded(let pcm, let sr, _):
+            return sr == targetSampleRate
+                ? pcm : linearResamplePCM(pcm, fromRate: sr, toRate: targetSampleRate)
+        }
+    }
+
+    /// Gemma4UnifiedAudioFeatureExtractor parity: chunk a raw 16 kHz mono
+    /// waveform into `[tokens, audioSamplesPerToken]` frames. Each frame of
+    /// `audio_samples_per_token` (640 = 40 ms) raw samples IS one audio soft
+    /// token's feature vector — the unified 12B checkpoint is encoder-free and
+    /// `embed_audio.embedding_projection` consumes the frames directly. The
+    /// waveform is zero-padded to a whole number of frames and capped at
+    /// `audio_seq_length` (750 tokens = 30 s) like the upstream extractor.
+    ///
+    /// E-series (E2B/E4B) bundles use the mel-spectrogram
+    /// `Gemma4AudioFeatureExtractor` plus a conformer `audio_tower`; that
+    /// pipeline is separate and gated on `audioFeatureExtractorType`.
+    private static func unifiedWaveformFeatures(
+        _ pcm: [Float], config: Gemma4ProcessorConfiguration
+    ) throws -> MLXArray {
+        guard config.audioFeatureExtractorType == "Gemma4UnifiedAudioFeatureExtractor"
+            || config.processorClass == "Gemma4UnifiedProcessor"
+        else {
+            throw VLMError.processing(
+                "Gemma4 raw audio for this bundle requires the \(config.audioFeatureExtractorType ?? "Gemma4AudioFeatureExtractor") " +
+                "mel + audio_tower pipeline, which is not wired in Swift yet. " +
+                "Unified bundles (Gemma4UnifiedAudioFeatureExtractor) decode raw audio natively.")
+        }
+        guard !pcm.isEmpty else {
+            throw VLMError.processing("Gemma4 audio input decoded to an empty waveform.")
+        }
+        let samplesPerToken = config.audioSamplesPerToken
+        var padded = pcm
+        let remainder = padded.count % samplesPerToken
+        if remainder != 0 {
+            padded.append(contentsOf: [Float](repeating: 0, count: samplesPerToken - remainder))
+        }
+        var tokens = padded.count / samplesPerToken
+        if tokens > config.audioSeqLength {
+            // Upstream truncates to `audio_seq_length` soft tokens per segment.
+            tokens = config.audioSeqLength
+            padded = Array(padded.prefix(tokens * samplesPerToken))
+        }
+        return MLXArray(padded).reshaped(tokens, samplesPerToken)
     }
 
     private static func requiresToolChoice(_ context: [String: any Sendable]?) -> Bool {

--- a/Libraries/MLXVLM/Models/Gemma4Audio.swift
+++ b/Libraries/MLXVLM/Models/Gemma4Audio.swift
@@ -1,0 +1,804 @@
+// Copyright © 2024-2026 Jinho Jang (eric@jangq.ai)
+//
+// Gemma 4 E-series (E2B/E4B) audio tower — Universal Speech Model (USM)
+// style conformer encoder. Port source of truth:
+// transformers/models/gemma4/{feature_extraction,configuration,modeling}_gemma4.py
+//
+// Pipeline (exact HF parity, all params verified against the
+// OsaurusAI--gemma-4-E2B-it-qat-JANG_4M bundle's config.json /
+// processor_config.json and the bundled-python transformers reference):
+//
+//   1. Waveform → log-mel frames `[T, 128]` (Gemma4AudioFeatureExtractor):
+//      - 16 kHz mono PCM, truncated at 480 000 samples (30 s)
+//      - semicausal padding: prepend frame_length/2 = 160 zeros
+//      - frame_length 320 (20 ms), hop_length 160 (10 ms)
+//      - per frame: take 320 samples (preemphasis = 0), multiply by a
+//        PERIODIC Hann window w[n] = 0.5 − 0.5·cos(2πn/320)
+//      - rFFT with fft_length 512 (frame right-zero-padded), MAGNITUDE
+//        spectrum (not power)
+//      - HTK mel filterbank: 128 filters, 0…8000 Hz, norm=None,
+//        mel = 2595·log10(1 + f/700); fft bins linspace(0, 8000, 257)
+//      - log(mel + mel_floor 1e-3); no per-bin mean/stddev in shipped configs
+//   2. Subsampling: two Conv2d k=3 s=2 p=1 blocks over (time, mel) with
+//      channels 1 → 128 → 32, each followed by bias-less LayerNorm over
+//      channels + ReLU; flatten (mel/4=32) × 32ch = 1024 → input_proj_linear
+//      (1024 → hidden_size 1024). Time reduction ×4: T → ⌈T/2⌉ → ⌈T/4⌉.
+//   3. 12 conformer layers (hidden 1024, 8 heads, head_dim 128):
+//      ff1 → (clip, RMSNorm) → chunked local self-attention → (clip,
+//      RMSNorm) + residual → causal light conv (GLU + depthwise k=5)
+//      → ff2 → (clip, RMSNorm out). Feed-forwards scale their branch by
+//      residual_weight 0.5. RMSNorm eps 1e-6, weight used directly (no +1).
+//      Attention: chunk 12, left context 13 (max_past = 12), right 0,
+//      logit softcap 50 (tanh), invalid logit −1e9, relative position
+//      bias from a sinusoidal table of context_size/2 + 1 = 13 positions,
+//      q scaled by head_dim^-0.5/ln2 · softplus(per_dim_scale),
+//      k scaled by ln(1+e)/ln2. The blocked validity mask is ANDed with a
+//      sliding window of (attention_context_left − 1, attention_context_right)
+//      per HF `create_bidirectional_mask(and_mask_function=...)`.
+//      NOTE: the bundled-python transformers snapshot has a mask-dtype bug —
+//      `create_bidirectional_mask` returns a float ADDITIVE mask (0 / −inf)
+//      but `Gemma4AudioAttention.forward` applies it with
+//      `masked_fill(mask.logical_not(), −1e9)`, which treats 0.0 as "drop"
+//      and −inf as "keep", i.e. attends the COMPLEMENT of the window. This
+//      port implements the intended (trained) window semantics instead;
+//      proof: verbatim transcription of synthesized speech through the E2B
+//      QAT bundle (see /tmp/gemma4-audio-proof and the PR notes), which is
+//      impossible with the inverted mask.
+//   4. output_proj (1024 → output_proj_dims 1536, bias).
+//   5. `embed_audio` (Gemma4MultimodalEmbedder in Gemma4.swift) consumes the
+//      1536-wide tower output: RMSNorm(no scale) → Linear(1536 → text hidden).
+//
+// Clipped linears (use_clipped_linears = true): every q/k/v/post and
+// ffw/lconv linear is wrapped with scalar input_min/input_max/output_min/
+// output_max tensors from the checkpoint; inference clamps the linear's
+// input and output to those bounds (HF Gemma4ClippableLinear.forward).
+//
+// Soft-token count parity (HF Gemma4Processor.replace_audio_token):
+// simulate the two k=3 s=2 p=1 convs on the frame mask —
+// t_out = (t − 1)/2 + 1 applied twice, keeping every other frame — which
+// for a contiguous valid prefix is exactly ⌈T/4⌉ tokens. 30 s of audio
+// → 2999 mel frames → 750 tokens = audio_seq_length.
+//
+// Design: the mel extractor runs in `Gemma4Processor.prepare` (CPU/vDSP,
+// no model weights needed) so the processor can expand `<|audio|>`
+// placeholders to the exact post-subsampling token count. The conformer
+// tower needs checkpoint weights, so it runs inside `Gemma4.prepare`:
+// mel frames travel in `LMInput.ProcessedAudio.waveform` (shape
+// `[N, T, 128]`, padded rows exactly 0 like the HF extractor's
+// mask-zeroed output) with `preEncodedEmbedding == nil`; pre-encoded
+// embeddings keep bypassing the tower.
+
+import Accelerate
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+// MARK: - Configuration
+
+/// `config.json` → `audio_config` for `model_type == "gemma4_audio"`
+/// (E2B/E4B). Defaults mirror HF `Gemma4AudioConfig`.
+public struct Gemma4AudioConfig: Codable, Sendable {
+    public let modelType: String
+    public let hiddenSize: Int
+    public let numHiddenLayers: Int
+    public let numAttentionHeads: Int
+    public let subsamplingConvChannels: [Int]
+    public let convKernelSize: Int
+    public let residualWeight: Float
+    public let attentionChunkSize: Int
+    public let attentionContextLeft: Int
+    public let attentionContextRight: Int
+    public let attentionLogitCap: Float
+    public let attentionInvalidLogitsValue: Float
+    public let useClippedLinears: Bool
+    public let rmsNormEps: Float
+    public let gradientClipping: Float
+    public let outputProjDims: Int
+
+    /// The conformer tower is only instantiated for the E-series
+    /// `gemma4_audio` config. The unified 12B bundles carry
+    /// `model_type == "gemma4_unified_audio"` (encoder-free raw chunking)
+    /// and must NOT build a tower.
+    public var isConformerTower: Bool { modelType == "gemma4_audio" }
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case hiddenSize = "hidden_size"
+        case numHiddenLayers = "num_hidden_layers"
+        case numAttentionHeads = "num_attention_heads"
+        case subsamplingConvChannels = "subsampling_conv_channels"
+        case convKernelSize = "conv_kernel_size"
+        case residualWeight = "residual_weight"
+        case attentionChunkSize = "attention_chunk_size"
+        case attentionContextLeft = "attention_context_left"
+        case attentionContextRight = "attention_context_right"
+        case attentionLogitCap = "attention_logit_cap"
+        case attentionInvalidLogitsValue = "attention_invalid_logits_value"
+        case useClippedLinears = "use_clipped_linears"
+        case rmsNormEps = "rms_norm_eps"
+        case gradientClipping = "gradient_clipping"
+        case outputProjDims = "output_proj_dims"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        modelType = try c.decodeIfPresent(String.self, forKey: .modelType) ?? ""
+        hiddenSize = try c.decodeIfPresent(Int.self, forKey: .hiddenSize) ?? 1024
+        numHiddenLayers = try c.decodeIfPresent(Int.self, forKey: .numHiddenLayers) ?? 12
+        numAttentionHeads = try c.decodeIfPresent(Int.self, forKey: .numAttentionHeads) ?? 8
+        subsamplingConvChannels =
+            try c.decodeIfPresent([Int].self, forKey: .subsamplingConvChannels) ?? [128, 32]
+        convKernelSize = try c.decodeIfPresent(Int.self, forKey: .convKernelSize) ?? 5
+        residualWeight = try c.decodeIfPresent(Float.self, forKey: .residualWeight) ?? 0.5
+        attentionChunkSize = try c.decodeIfPresent(Int.self, forKey: .attentionChunkSize) ?? 12
+        attentionContextLeft = try c.decodeIfPresent(Int.self, forKey: .attentionContextLeft) ?? 13
+        attentionContextRight =
+            try c.decodeIfPresent(Int.self, forKey: .attentionContextRight) ?? 0
+        attentionLogitCap = try c.decodeIfPresent(Float.self, forKey: .attentionLogitCap) ?? 50.0
+        attentionInvalidLogitsValue =
+            try c.decodeIfPresent(Float.self, forKey: .attentionInvalidLogitsValue) ?? -1.0e9
+        useClippedLinears = try c.decodeIfPresent(Bool.self, forKey: .useClippedLinears) ?? true
+        rmsNormEps = try c.decodeIfPresent(Float.self, forKey: .rmsNormEps) ?? 1e-6
+        gradientClipping = try c.decodeIfPresent(Float.self, forKey: .gradientClipping) ?? 1e10
+        outputProjDims = try c.decodeIfPresent(Int.self, forKey: .outputProjDims) ?? 1536
+    }
+}
+
+// MARK: - Mel feature extractor (Gemma4AudioFeatureExtractor parity)
+
+/// Fixed extractor parameters from `processor_config.json` / HF defaults.
+/// All shipped E-series bundles use exactly these values (verified against
+/// OsaurusAI--gemma-4-E2B-it-qat-JANG_4M processor_config.json).
+enum Gemma4AudioMel {
+    static let sampleRate = 16_000
+    static let melBins = 128
+    static let frameLength = 320  // 20 ms
+    static let hopLength = 160  // 10 ms
+    static let fftLength = 512  // 2^ceil(log2(320)), fft_overdrive=false
+    static let melFloor: Float = 1e-3
+    static let minFrequency: Float = 0
+    static let maxFrequency: Float = 8000
+    /// Feature-extractor `max_length` — 30 s at 16 kHz, yielding 2999 mel
+    /// frames → exactly `audio_seq_length` (750) soft tokens.
+    static let maxSamples = 480_000
+}
+
+/// HF `Gemma4Processor.replace_audio_token` parity: number of `<|audio|>`
+/// soft tokens for `melFrameCount` valid mel frames. Two simulated
+/// k=3 s=2 p=1 convs keep frames at indices ≡ 0 (mod 4), i.e. ⌈T/4⌉
+/// for a contiguous valid prefix. This must equal the conformer tower's
+/// valid output length so `maskedScatter` sees a 1:1 match.
+func gemma4AudioSoftTokenCount(melFrameCount: Int) -> Int {
+    melFrameCount > 0 ? (melFrameCount + 3) / 4 : 0
+}
+
+/// HTK mel filterbank, transformers `mel_filter_bank(norm=None,
+/// mel_scale="htk")` parity. Returns `[nBins][nMels]` (257 × 128).
+private func gemma4HTKMelFilterbank(
+    nBins: Int, nMels: Int, minFrequency: Float, maxFrequency: Float
+) -> [[Float]] {
+    func hzToMel(_ f: Float) -> Float { 2595.0 * log10(1.0 + f / 700.0) }
+    func melToHz(_ m: Float) -> Float { 700.0 * (pow(10.0, m / 2595.0) - 1.0) }
+
+    let melMin = hzToMel(minFrequency)
+    let melMax = hzToMel(maxFrequency)
+    // num_mel_filters + 2 corner frequencies
+    var filterFreqs = [Float](repeating: 0, count: nMels + 2)
+    for i in 0 ..< (nMels + 2) {
+        let mel = melMin + (melMax - melMin) * Float(i) / Float(nMels + 1)
+        filterFreqs[i] = melToHz(mel)
+    }
+    // fft_freqs = linspace(0, sampling_rate // 2, num_frequency_bins)
+    var fftFreqs = [Float](repeating: 0, count: nBins)
+    for k in 0 ..< nBins {
+        fftFreqs[k] = maxFrequency * Float(k) / Float(nBins - 1)
+    }
+
+    var filters = [[Float]](repeating: [Float](repeating: 0, count: nMels), count: nBins)
+    for k in 0 ..< nBins {
+        for m in 0 ..< nMels {
+            let down = -(filterFreqs[m] - fftFreqs[k]) / (filterFreqs[m + 1] - filterFreqs[m])
+            let up = (filterFreqs[m + 2] - fftFreqs[k]) / (filterFreqs[m + 2] - filterFreqs[m + 1])
+            filters[k][m] = max(0, min(down, up))
+        }
+    }
+    return filters
+}
+
+private let gemma4MelFilterbank: [[Float]] = gemma4HTKMelFilterbank(
+    nBins: Gemma4AudioMel.fftLength / 2 + 1,
+    nMels: Gemma4AudioMel.melBins,
+    minFrequency: Gemma4AudioMel.minFrequency,
+    maxFrequency: Gemma4AudioMel.maxFrequency)
+
+/// Periodic Hann window of `frameLength`: w[n] = 0.5 − 0.5·cos(2πn/N).
+private let gemma4HannWindow: [Float] = (0 ..< Gemma4AudioMel.frameLength).map { n in
+    0.5 - 0.5 * cos(2.0 * Float.pi * Float(n) / Float(Gemma4AudioMel.frameLength))
+}
+
+/// Extract Gemma4 log-mel features from 16 kHz mono PCM.
+/// Returns `[T, 128]` Float32; `T = (L − 1)/hop + 1 − frame/hop` over the
+/// semicausally padded waveform (≥ 1 frame requires ≥ 161 input samples;
+/// shorter clips are zero-extended to the minimum analyzable length).
+func gemma4ExtractMelFeatures(_ pcm: [Float]) -> MLXArray {
+    let frameLength = Gemma4AudioMel.frameLength
+    let hop = Gemma4AudioMel.hopLength
+    let nFFT = Gemma4AudioMel.fftLength
+    let nBins = nFFT / 2 + 1
+    let nMels = Gemma4AudioMel.melBins
+
+    var samples = pcm
+    if samples.count > Gemma4AudioMel.maxSamples {
+        samples = Array(samples.prefix(Gemma4AudioMel.maxSamples))
+    }
+    // The unfold window is frame_length + 1 samples; with the semicausal
+    // left pad of frame_length/2 the first frame needs L ≥ 161. Zero-extend
+    // ultra-short clips so they still produce one frame.
+    let minSamples = frameLength + 1 - frameLength / 2
+    if samples.count < minSamples {
+        samples.append(contentsOf: [Float](repeating: 0, count: minSamples - samples.count))
+    }
+
+    // Semicausal time padding: prepend frame_length/2 zeros.
+    var padded = [Float](repeating: 0, count: frameLength / 2)
+    padded.append(contentsOf: samples)
+
+    let windowSize = frameLength + 1
+    let nFrames = (padded.count - windowSize) / hop + 1
+
+    let log2n = vDSP_Length(log2(Double(nFFT)))
+    guard let setup = vDSP_create_fftsetup(log2n, FFTRadix(kFFTRadix2)) else {
+        return MLXArray.zeros([0, nMels])
+    }
+    defer { vDSP_destroy_fftsetup(setup) }
+
+    var mel = [Float](repeating: 0, count: nFrames * nMels)
+    var frame = [Float](repeating: 0, count: nFFT)
+    var realIn = [Float](repeating: 0, count: nFFT / 2)
+    var imagIn = [Float](repeating: 0, count: nFFT / 2)
+    var magnitude = [Float](repeating: 0, count: nBins)
+
+    for f in 0 ..< nFrames {
+        let start = f * hop
+        // preemphasis == 0 → frame = first frame_length samples of the
+        // (frame_length + 1)-sample unfold window, then Hann, then
+        // right-zero-pad to fft_length (np.fft.rfft(n=512) semantics).
+        for i in 0 ..< frameLength {
+            frame[i] = padded[start + i] * gemma4HannWindow[i]
+        }
+        for i in frameLength ..< nFFT { frame[i] = 0 }
+
+        frame.withUnsafeBytes { rawBuf in
+            let ptr = rawBuf.baseAddress!.assumingMemoryBound(to: DSPComplex.self)
+            realIn.withUnsafeMutableBufferPointer { rPtr in
+                imagIn.withUnsafeMutableBufferPointer { iPtr in
+                    var split = DSPSplitComplex(
+                        realp: rPtr.baseAddress!, imagp: iPtr.baseAddress!)
+                    vDSP_ctoz(ptr, 2, &split, 1, vDSP_Length(nFFT / 2))
+                    vDSP_fft_zrip(setup, &split, 1, log2n, FFTDirection(FFT_FORWARD))
+                    // vDSP zrip output is 2× numpy's rfft; scale by 0.5.
+                    // Magnitude spectrum (NOT power) per the HF extractor.
+                    let r0 = rPtr[0] * 0.5
+                    magnitude[0] = abs(r0)
+                    let rn = iPtr[0] * 0.5
+                    magnitude[nFFT / 2] = abs(rn)
+                    for k in 1 ..< (nFFT / 2) {
+                        let re = rPtr[k] * 0.5
+                        let im = iPtr[k] * 0.5
+                        magnitude[k] = sqrt(re * re + im * im)
+                    }
+                }
+            }
+        }
+
+        for m in 0 ..< nMels {
+            var s: Float = 0
+            for k in 0 ..< nBins {
+                s += magnitude[k] * gemma4MelFilterbank[k][m]
+            }
+            mel[f * nMels + m] = log(s + Gemma4AudioMel.melFloor)
+        }
+    }
+
+    return MLXArray(mel).reshaped(nFrames, nMels)
+}
+
+// MARK: - Tower building blocks
+
+/// RMSNorm with scale, weight used directly (HF Gemma4RMSNorm, no +1).
+private class AudioRMSNorm: Module, UnaryLayer {
+    let weight: MLXArray
+    let eps: Float
+    init(dimensions: Int, eps: Float = 1e-6) {
+        self.weight = MLXArray.ones([dimensions])
+        self.eps = eps
+        super.init()
+    }
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        MLXFast.rmsNorm(x, weight: weight, eps: eps)
+    }
+}
+
+/// LayerNorm with elementwise affine weight but NO bias
+/// (HF `nn.LayerNorm(..., elementwise_affine=True, bias=False)`).
+private class AudioLayerNorm: Module, UnaryLayer {
+    let weight: MLXArray
+    let eps: Float
+    init(dimensions: Int, eps: Float) {
+        self.weight = MLXArray.ones([dimensions])
+        self.eps = eps
+        super.init()
+    }
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let xf = x.asType(.float32)
+        let mu = xf.mean(axis: -1, keepDims: true)
+        let centered = xf - mu
+        let variance = (centered * centered).mean(axis: -1, keepDims: true)
+        return (centered * rsqrt(variance + eps) * weight.asType(.float32)).asType(x.dtype)
+    }
+}
+
+/// HF Gemma4ClippableLinear: clamp input and output to scalar bounds
+/// shipped in the checkpoint (`input_min/input_max/output_min/output_max`).
+private class Gemma4ClippedLinear: Module {
+    @ModuleInfo(key: "linear") var linear: Linear
+    @ParameterInfo(key: "input_min") var inputMin: MLXArray
+    @ParameterInfo(key: "input_max") var inputMax: MLXArray
+    @ParameterInfo(key: "output_min") var outputMin: MLXArray
+    @ParameterInfo(key: "output_max") var outputMax: MLXArray
+    let clipped: Bool
+
+    init(_ inputDims: Int, _ outputDims: Int, clipped: Bool) {
+        self.clipped = clipped
+        _linear.wrappedValue = Linear(inputDims, outputDims, bias: false)
+        _inputMin.wrappedValue = MLXArray(-Float.infinity)
+        _inputMax.wrappedValue = MLXArray(Float.infinity)
+        _outputMin.wrappedValue = MLXArray(-Float.infinity)
+        _outputMax.wrappedValue = MLXArray(Float.infinity)
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = x
+        if clipped {
+            h = clip(h, min: inputMin.asType(h.dtype), max: inputMax.asType(h.dtype))
+        }
+        h = linear(h)
+        if clipped {
+            h = clip(h, min: outputMin.asType(h.dtype), max: outputMax.asType(h.dtype))
+        }
+        return h
+    }
+}
+
+/// One subsampling block: Conv2d k=3 s=2 p=1 (no bias) → channel
+/// LayerNorm (no bias) → ReLU. Input/output NHWC `[B, T, F, C]`.
+private class Gemma4AudioSubSampleConvLayer: Module {
+    @ModuleInfo(key: "conv") var conv: Conv2d
+    @ModuleInfo(key: "norm") var norm: AudioLayerNorm
+
+    init(inChannels: Int, outChannels: Int, eps: Float) {
+        _conv.wrappedValue = Conv2d(
+            inputChannels: inChannels, outputChannels: outChannels,
+            kernelSize: 3, stride: 2, padding: 1, bias: false)
+        _norm.wrappedValue = AudioLayerNorm(dimensions: outChannels, eps: eps)
+        super.init()
+    }
+
+    /// `timeMask` is a float `[B, T]` validity mask multiplied in before
+    /// the conv, mirroring HF's `hidden_states * mask[:, None, :, None]`.
+    func callAsFunction(_ x: MLXArray, timeMask: MLXArray?) -> MLXArray {
+        var h = x
+        if let timeMask {
+            h = h * timeMask.expandedDimensions(axes: [-1, -2]).asType(h.dtype)
+        }
+        h = conv(h.asType(conv.weight.dtype))
+        return relu(norm(h))
+    }
+}
+
+private class Gemma4AudioSubSampleConvProjection: Module {
+    @ModuleInfo(key: "layer0") var layer0: Gemma4AudioSubSampleConvLayer
+    @ModuleInfo(key: "layer1") var layer1: Gemma4AudioSubSampleConvLayer
+    @ModuleInfo(key: "input_proj_linear") var inputProjLinear: Linear
+
+    init(_ config: Gemma4AudioConfig, melBins: Int) {
+        _layer0.wrappedValue = Gemma4AudioSubSampleConvLayer(
+            inChannels: 1, outChannels: config.subsamplingConvChannels[0],
+            eps: config.rmsNormEps)
+        _layer1.wrappedValue = Gemma4AudioSubSampleConvLayer(
+            inChannels: config.subsamplingConvChannels[0],
+            outChannels: config.subsamplingConvChannels[1],
+            eps: config.rmsNormEps)
+        let projInputDim = (melBins / 4) * config.subsamplingConvChannels[1]
+        _inputProjLinear.wrappedValue = Linear(projInputDim, config.hiddenSize, bias: false)
+        super.init()
+    }
+
+    /// `features`: `[B, T, melBins]`; `timeMask`: float `[B, T]` or nil.
+    /// Returns `[B, ceil(T/4), hidden]`.
+    func callAsFunction(_ features: MLXArray, timeMask: MLXArray?) -> MLXArray {
+        var h = features.expandedDimensions(axis: -1)  // NHWC [B, T, F, 1]
+        h = layer0(h, timeMask: timeMask)
+        let mask1 = timeMask.map { $0[0..., .stride(by: 2)] }
+        h = layer1(h, timeMask: mask1)
+        // NHWC [B, T4, F4, C] → [B, T4, F4*C]; identical element order to
+        // HF's permute(0, 2, 3, 1).reshape(b, t, f*c) from NCHW.
+        let (B, t) = (h.dim(0), h.dim(1))
+        h = h.reshaped(B, t, -1)
+        return inputProjLinear(h)
+    }
+}
+
+/// HF Gemma4AudioFeedForward: clip → RMSNorm → 4× linear (clipped) →
+/// SiLU → linear (clipped) → clip → RMSNorm → ×residual_weight + residual.
+private class Gemma4AudioFeedForward: Module {
+    @ModuleInfo(key: "ffw_layer_1") var ffw1: Gemma4ClippedLinear
+    @ModuleInfo(key: "ffw_layer_2") var ffw2: Gemma4ClippedLinear
+    @ModuleInfo(key: "pre_layer_norm") var preLayerNorm: AudioRMSNorm
+    @ModuleInfo(key: "post_layer_norm") var postLayerNorm: AudioRMSNorm
+    let residualWeight: Float
+    let gradClip: Float
+
+    init(_ config: Gemma4AudioConfig) {
+        _ffw1.wrappedValue = Gemma4ClippedLinear(
+            config.hiddenSize, config.hiddenSize * 4, clipped: config.useClippedLinears)
+        _ffw2.wrappedValue = Gemma4ClippedLinear(
+            config.hiddenSize * 4, config.hiddenSize, clipped: config.useClippedLinears)
+        _preLayerNorm.wrappedValue = AudioRMSNorm(dimensions: config.hiddenSize)
+        _postLayerNorm.wrappedValue = AudioRMSNorm(dimensions: config.hiddenSize)
+        residualWeight = config.residualWeight
+        gradClip = config.gradientClipping
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let residual = x
+        var h = clip(x, min: MLXArray(-gradClip), max: MLXArray(gradClip))
+        h = preLayerNorm(h)
+        h = ffw1(h)
+        h = silu(h)
+        h = ffw2(h)
+        h = clip(h, min: MLXArray(-gradClip), max: MLXArray(gradClip))
+        h = postLayerNorm(h)
+        return h * residualWeight + residual
+    }
+}
+
+/// HF Gemma4AudioLightConv1d: RMSNorm → GLU(linear 2×) → causal
+/// depthwise conv k=5 → clip → RMSNorm → SiLU → linear → + residual.
+private class Gemma4AudioLightConv1d: Module {
+    @ModuleInfo(key: "linear_start") var linearStart: Gemma4ClippedLinear
+    @ModuleInfo(key: "linear_end") var linearEnd: Gemma4ClippedLinear
+    @ModuleInfo(key: "depthwise_conv1d") var depthwiseConv: Conv1d
+    @ModuleInfo(key: "pre_layer_norm") var preLayerNorm: AudioRMSNorm
+    @ModuleInfo(key: "conv_norm") var convNorm: AudioRMSNorm
+    let leftPad: Int
+    let gradClip: Float
+
+    init(_ config: Gemma4AudioConfig) {
+        _linearStart.wrappedValue = Gemma4ClippedLinear(
+            config.hiddenSize, config.hiddenSize * 2, clipped: config.useClippedLinears)
+        _linearEnd.wrappedValue = Gemma4ClippedLinear(
+            config.hiddenSize, config.hiddenSize, clipped: config.useClippedLinears)
+        _depthwiseConv.wrappedValue = Conv1d(
+            inputChannels: config.hiddenSize, outputChannels: config.hiddenSize,
+            kernelSize: config.convKernelSize, groups: config.hiddenSize, bias: false)
+        _preLayerNorm.wrappedValue = AudioRMSNorm(
+            dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        _convNorm.wrappedValue = AudioRMSNorm(
+            dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        // Gemma4AudioCausalConv1d.left_pad = effective_kernel − stride.
+        leftPad = config.convKernelSize - 1
+        gradClip = config.gradientClipping
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let residual = x
+        var h = preLayerNorm(x)
+        h = linearStart(h)
+        let half = h.dim(-1) / 2
+        h = h[.ellipsis, ..<half] * sigmoid(h[.ellipsis, half...])  // GLU
+        h = padded(h, widths: [[0, 0], [leftPad, 0], [0, 0]])
+        h = depthwiseConv(h)
+        h = clip(h, min: MLXArray(-gradClip), max: MLXArray(gradClip))
+        h = convNorm(h)
+        h = silu(h)
+        h = linearEnd(h)
+        return h + residual
+    }
+}
+
+/// Chunked local attention with relative position bias (HF
+/// Gemma4AudioAttention). Computation runs in float32 like the reference.
+private class Gemma4AudioAttention: Module {
+    @ModuleInfo(key: "q_proj") var qProj: Gemma4ClippedLinear
+    @ModuleInfo(key: "k_proj") var kProj: Gemma4ClippedLinear
+    @ModuleInfo(key: "v_proj") var vProj: Gemma4ClippedLinear
+    @ModuleInfo(key: "post") var post: Gemma4ClippedLinear
+    @ModuleInfo(key: "relative_k_proj") var relativeKProj: Linear
+    @ParameterInfo(key: "per_dim_scale") var perDimScale: MLXArray
+
+    let numHeads: Int
+    let headDim: Int
+    let chunkSize: Int
+    let maxPast: Int
+    let maxFuture: Int
+    let contextSize: Int
+    let qScale: Float
+    let kScale: Float
+    let softcap: Float
+    let invalidLogit: Float
+
+    init(_ config: Gemma4AudioConfig) {
+        numHeads = config.numAttentionHeads
+        headDim = config.hiddenSize / config.numAttentionHeads
+        chunkSize = config.attentionChunkSize
+        maxPast = config.attentionContextLeft - 1
+        maxFuture = config.attentionContextRight
+        contextSize = chunkSize + maxPast + maxFuture
+        qScale = pow(Float(headDim), -0.5) / log(2.0)
+        kScale = log(1.0 + exp(1.0)) / log(2.0)
+        softcap = config.attentionLogitCap
+        invalidLogit = config.attentionInvalidLogitsValue
+        let h = config.hiddenSize
+        _qProj.wrappedValue = Gemma4ClippedLinear(h, h, clipped: config.useClippedLinears)
+        _kProj.wrappedValue = Gemma4ClippedLinear(h, h, clipped: config.useClippedLinears)
+        _vProj.wrappedValue = Gemma4ClippedLinear(h, h, clipped: config.useClippedLinears)
+        _post.wrappedValue = Gemma4ClippedLinear(h, h, clipped: config.useClippedLinears)
+        _relativeKProj.wrappedValue = Linear(h, h, bias: false)
+        _perDimScale.wrappedValue = MLXArray.zeros([headDim])
+        super.init()
+    }
+
+    /// Overlapping context windows of `contextSize` per block, stride
+    /// `chunkSize` (HF `_extract_block_context` unfold).
+    private func extractBlockContext(_ x: MLXArray, numBlocks: Int) -> MLXArray {
+        let p = padded(
+            x, widths: [[0, 0], [maxPast, maxFuture + chunkSize - 1], [0, 0], [0, 0]])
+        var idx = [Int32]()
+        idx.reserveCapacity(numBlocks * contextSize)
+        for b in 0 ..< numBlocks {
+            for j in 0 ..< contextSize {
+                idx.append(Int32(b * chunkSize + j))
+            }
+        }
+        let indices = MLXArray(idx).reshaped(numBlocks, contextSize)
+        return p.take(indices, axis: 1)  // [B, nb, ctx, H, D]
+    }
+
+    /// HF `_rel_shift` (Transformer-XL appendix B) for blocked attention.
+    private func relShift(_ x: MLXArray) -> MLXArray {
+        let (B, H, nb, bs, posLen) = (x.dim(0), x.dim(1), x.dim(2), x.dim(3), x.dim(4))
+        var y = padded(
+            x, widths: [[0, 0], [0, 0], [0, 0], [0, 0], [0, contextSize + 1 - posLen]])
+        y = y.reshaped(B, H, nb, bs * (contextSize + 1))
+        y = y[.ellipsis, ..<(bs * contextSize)]
+        return y.reshaped(B, H, nb, bs, contextSize)
+    }
+
+    /// `x`: `[B, T, hidden]`; `positionEmbeddings`: `[numPos, hidden]`
+    /// float32; `blockedMask`: bool `[B, 1, nb, chunk, ctx]`.
+    func callAsFunction(
+        _ x: MLXArray, positionEmbeddings: MLXArray, blockedMask: MLXArray
+    ) -> MLXArray {
+        let (B, T) = (x.dim(0), x.dim(1))
+        var q = qProj(x).asType(.float32).reshaped(B, T, numHeads, headDim)
+        var k = kProj(x).asType(.float32).reshaped(B, T, numHeads, headDim)
+        let v = vProj(x).asType(.float32).reshaped(B, T, numHeads, headDim)
+
+        q = q * (softplus(perDimScale.asType(.float32)) * qScale)
+        k = k * kScale
+
+        let nb = (T + chunkSize - 1) / chunkSize
+        let padQ = nb * chunkSize - T
+        var qb = q
+        if padQ > 0 {
+            qb = padded(qb, widths: [[0, 0], [0, padQ], [0, 0], [0, 0]])
+        }
+        qb = qb.reshaped(B, nb, chunkSize, numHeads, headDim)
+        let kb = extractBlockContext(k, numBlocks: nb)
+        let vb = extractBlockContext(v, numBlocks: nb)
+
+        var relK = relativeKProj(positionEmbeddings.asType(relativeKProj.weight.dtype))
+        relK = relK.asType(.float32).reshaped(-1, numHeads, headDim)  // [P, H, D]
+
+        let queries = qb.transposed(0, 3, 1, 2, 4)  // [B, H, nb, chunk, D]
+        let matrixAC = matmul(queries, kb.transposed(0, 3, 1, 4, 2))  // [B,H,nb,chunk,ctx]
+
+        let qFlat = queries.reshaped(B, numHeads, nb * chunkSize, headDim)
+        var matrixBD = matmul(qFlat, relK.transposed(1, 2, 0))  // [B, H, Q, P]
+        matrixBD = matrixBD.reshaped(B, numHeads, nb, chunkSize, -1)
+        matrixBD = relShift(matrixBD)
+
+        var attn = matrixAC + matrixBD
+        attn = tanh(attn / softcap) * softcap
+        attn = MLX.where(blockedMask, attn, MLXArray(invalidLogit))
+        attn = softmax(attn, axis: -1, precise: true)
+
+        var out = matmul(attn, vb.transposed(0, 3, 1, 2, 4))  // [B, H, nb, chunk, D]
+        out = out.transposed(0, 2, 3, 1, 4).reshaped(B, nb * chunkSize, numHeads * headDim)
+        out = out[0..., ..<T]
+        return post(out.asType(post.linear.weight.dtype))
+    }
+}
+
+private class Gemma4AudioLayer: Module {
+    @ModuleInfo(key: "feed_forward1") var feedForward1: Gemma4AudioFeedForward
+    @ModuleInfo(key: "feed_forward2") var feedForward2: Gemma4AudioFeedForward
+    @ModuleInfo(key: "self_attn") var selfAttn: Gemma4AudioAttention
+    @ModuleInfo(key: "lconv1d") var lconv1d: Gemma4AudioLightConv1d
+    @ModuleInfo(key: "norm_pre_attn") var normPreAttn: AudioRMSNorm
+    @ModuleInfo(key: "norm_post_attn") var normPostAttn: AudioRMSNorm
+    @ModuleInfo(key: "norm_out") var normOut: AudioRMSNorm
+    let gradClip: Float
+
+    init(_ config: Gemma4AudioConfig) {
+        _feedForward1.wrappedValue = Gemma4AudioFeedForward(config)
+        _feedForward2.wrappedValue = Gemma4AudioFeedForward(config)
+        _selfAttn.wrappedValue = Gemma4AudioAttention(config)
+        _lconv1d.wrappedValue = Gemma4AudioLightConv1d(config)
+        _normPreAttn.wrappedValue = AudioRMSNorm(dimensions: config.hiddenSize)
+        _normPostAttn.wrappedValue = AudioRMSNorm(dimensions: config.hiddenSize)
+        _normOut.wrappedValue = AudioRMSNorm(dimensions: config.hiddenSize)
+        gradClip = config.gradientClipping
+        super.init()
+    }
+
+    func callAsFunction(
+        _ x: MLXArray, positionEmbeddings: MLXArray, blockedMask: MLXArray
+    ) -> MLXArray {
+        var h = feedForward1(x)
+        let residual = h
+        h = clip(h, min: MLXArray(-gradClip), max: MLXArray(gradClip))
+        h = normPreAttn(h)
+        h = selfAttn(h, positionEmbeddings: positionEmbeddings, blockedMask: blockedMask)
+        h = clip(h, min: MLXArray(-gradClip), max: MLXArray(gradClip))
+        h = normPostAttn(h)
+        h = h + residual
+        h = lconv1d(h)
+        h = feedForward2(h)
+        h = clip(h, min: MLXArray(-gradClip), max: MLXArray(gradClip))
+        return normOut(h)
+    }
+}
+
+// MARK: - Tower
+
+/// Gemma 4 E-series conformer audio encoder (`audio_tower.*` weights).
+/// Tensor keys mirror the checkpoint weight map exactly, e.g.
+/// `audio_tower.layers.0.feed_forward1.ffw_layer_1.linear.weight`.
+class Gemma4AudioTower: Module {
+    @ModuleInfo(key: "subsample_conv_projection")
+    fileprivate var subsampleConvProjection: Gemma4AudioSubSampleConvProjection
+    @ModuleInfo(key: "layers") fileprivate var layers: [Gemma4AudioLayer]
+    @ModuleInfo(key: "output_proj") var outputProj: Linear
+
+    let config: Gemma4AudioConfig
+
+    init(_ config: Gemma4AudioConfig, melBins: Int = Gemma4AudioMel.melBins) {
+        self.config = config
+        _subsampleConvProjection.wrappedValue = Gemma4AudioSubSampleConvProjection(
+            config, melBins: melBins)
+        _layers.wrappedValue = (0 ..< config.numHiddenLayers).map { _ in
+            Gemma4AudioLayer(config)
+        }
+        _outputProj.wrappedValue = Linear(config.hiddenSize, config.outputProjDims, bias: true)
+        super.init()
+    }
+
+    /// Sinusoidal relative positional table, `[contextSize/2 + 1, hidden]`,
+    /// positions contextSize/2 … 0, layout `[sin…, cos…]`
+    /// (HF Gemma4AudioRelPositionalEncoding).
+    private func relPositionEmbeddings() -> MLXArray {
+        let hidden = config.hiddenSize
+        let contextSize =
+            config.attentionChunkSize + config.attentionContextLeft - 1
+            + config.attentionContextRight
+        let numTimescales = hidden / 2
+        let logIncrement = log(10000.0) / Double(max(numTimescales - 1, 1))
+        let numPos = contextSize / 2 + 1
+        var table = [Float](repeating: 0, count: numPos * hidden)
+        for (row, position) in stride(from: contextSize / 2, through: 0, by: -1).enumerated() {
+            for i in 0 ..< numTimescales {
+                let invTimescale = exp(Double(i) * -logIncrement)
+                let t = Double(position) * invTimescale
+                table[row * hidden + i] = Float(sin(t))
+                table[row * hidden + numTimescales + i] = Float(cos(t))
+            }
+        }
+        return MLXArray(table).reshaped(numPos, hidden)
+    }
+
+    /// Blocked attention mask, bool `[B, 1, nb, chunk, ctx]`:
+    /// kv must be a real, valid frame AND inside the sliding window
+    /// 0 ≤ q − kv < attention_context_left − 1 (HF
+    /// `create_bidirectional_mask` + `sliding_window_mask_function`
+    /// + `_convert_4d_mask_to_blocked_5d`).
+    private func blockedMask(
+        seqLength: Int, numBlocks: Int, validLengths: [Int]
+    ) -> MLXArray {
+        let chunk = config.attentionChunkSize
+        let leftWindow = config.attentionContextLeft - 1
+        let rightWindow = config.attentionContextRight
+        let ctx = chunk + leftWindow + rightWindow
+        let B = validLengths.count
+        var bools = [Bool](repeating: false, count: B * numBlocks * chunk * ctx)
+        var offset = 0
+        for b in 0 ..< B {
+            let valid = min(validLengths[b], seqLength)
+            for block in 0 ..< numBlocks {
+                let kvStart = block * chunk - leftWindow
+                for i in 0 ..< chunk {
+                    let qPos = block * chunk + i
+                    for j in 0 ..< ctx {
+                        let kvPos = kvStart + j
+                        if qPos < seqLength, kvPos >= 0, kvPos < valid {
+                            let dist = qPos - kvPos
+                            let inLeft = dist >= 0 && dist < leftWindow
+                            let inRight = dist < 0 && -dist < rightWindow
+                            bools[offset] = inLeft || inRight
+                        }
+                        offset += 1
+                    }
+                }
+            }
+        }
+        return MLXArray(bools).reshaped(B, 1, numBlocks, chunk, ctx)
+    }
+
+    /// Encode mel features.
+    ///
+    /// - Parameters:
+    ///   - melFeatures: `[B, T, melBins]` log-mel frames; padded rows
+    ///     (beyond each item's valid length) must be exactly zero, the
+    ///     same contract as the HF extractor's mask-zeroed output.
+    ///   - validFrameCounts: per-item count of valid (prefix) mel frames;
+    ///     nil ⇒ all frames valid.
+    /// - Returns: `[B, ceil(T/4), output_proj_dims]`; item `b` has
+    ///   `gemma4AudioSoftTokenCount(melFrameCount: validFrameCounts[b])`
+    ///   valid output tokens.
+    func callAsFunction(_ melFeatures: MLXArray, validFrameCounts: [Int]? = nil) -> MLXArray {
+        let (B, T) = (melFeatures.dim(0), melFeatures.dim(1))
+        let validLengths = validFrameCounts ?? Array(repeating: T, count: B)
+        precondition(validLengths.count == B, "validFrameCounts must have one entry per item")
+
+        // Float time mask for the subsampling convs (HF zeroes invalid
+        // frames between conv layers). Skip when everything is valid.
+        var timeMask: MLXArray? = nil
+        if validLengths.contains(where: { $0 < T }) {
+            var maskValues = [Float](repeating: 0, count: B * T)
+            for b in 0 ..< B {
+                for t in 0 ..< min(validLengths[b], T) { maskValues[b * T + t] = 1 }
+            }
+            timeMask = MLXArray(maskValues).reshaped(B, T)
+        }
+
+        var h = subsampleConvProjection(melFeatures, timeMask: timeMask)
+        let t4 = h.dim(1)
+        let nb = (t4 + config.attentionChunkSize - 1) / config.attentionChunkSize
+        // Two stride-2 convs: valid length subsamples as ceil(v/4)
+        // (= indices ≡ 0 mod 4), matching replace_audio_token.
+        let validSubsampled = validLengths.map { gemma4AudioSoftTokenCount(melFrameCount: $0) }
+        let mask = blockedMask(seqLength: t4, numBlocks: nb, validLengths: validSubsampled)
+        let positionEmbeddings = relPositionEmbeddings()
+
+        var intermediates: [String: MLXArray] = [:]
+        let dumpDir = ProcessInfo.processInfo.environment["VMLX_GEMMA4_AUDIO_DUMP_DIR"]
+        if dumpDir != nil { intermediates["subsample"] = h.asType(.float32) }
+        for (i, layer) in layers.enumerated() {
+            h = layer(h, positionEmbeddings: positionEmbeddings, blockedMask: mask)
+            if dumpDir != nil { intermediates["layer\(i)"] = h.asType(.float32) }
+        }
+        if let dumpDir {
+            let dir = URL(fileURLWithPath: dumpDir)
+            try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+            try? MLX.save(
+                arrays: intermediates,
+                url: dir.appendingPathComponent("gemma4-audio-tower-intermediates.safetensors"))
+        }
+        return outputProj(h)
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -323,6 +323,7 @@ let package = Package(
         .executable(name: "DistributedModelInventory", targets: ["DistributedModelInventory"]),
         .executable(name: "DistributedReplicaSmoke", targets: ["DistributedReplicaSmoke"]),
         .executable(name: "ANEProbe", targets: ["ANEProbe"]),
+        .executable(name: "Gemma4AudioSmoke", targets: ["Gemma4AudioSmoke"]),
         .executable(name: "OmniAudioLatencyBench", targets: ["OmniAudioLatencyBench"]),
         .executable(name: "OmniAudioChunkStabilityBench", targets: ["OmniAudioChunkStabilityBench"]),
         .executable(name: "mlxpress", targets: ["MLXPressCLI"]),
@@ -676,6 +677,17 @@ let package = Package(
             name: "ANEProbe",
             dependencies: ["MLXLMCommon"],
             path: "tools/ANEProbe"
+        ),
+        .executableTarget(
+            name: "Gemma4AudioSmoke",
+            dependencies: [
+                "MLXLMCommon",
+                "MLXVLM",
+                "MLXHuggingFace",
+                "MLX",
+                "VMLXTokenizers",
+            ],
+            path: "tools/Gemma4AudioSmoke"
         ),
         .executableTarget(
             name: "OmniAudioLatencyBench",

--- a/Tests/MLXLMTests/Gemma4AudioGuardTests.swift
+++ b/Tests/MLXLMTests/Gemma4AudioGuardTests.swift
@@ -53,24 +53,44 @@ struct Gemma4AudioGuardTests {
         #expect(source.contains("if input.video != nil {"),
             "Gemma4.prepare must reject unsupported video before proceeding.")
         #expect(!source.contains("if input.audio != nil || input.video != nil {"),
-            "Gemma4.prepare must not reject the pre-encoded audio lane.")
+            "Gemma4.prepare must not reject the audio lane.")
 
         #expect(source.contains("throw VLMError.processing("),
             "Unsupported media must surface as VLMError.processing, not fatalError or silent fallthrough.")
         #expect(source.contains("@ModuleInfo(key: \"embed_audio\") private var embedAudio"),
             "Gemma4 must keep the audio projection module.")
-        #expect(source.contains("if nk.hasPrefix(\"audio_tower.\") { continue }"),
-            "Gemma4 should reject raw audio tower weights until the encoder is implemented.")
         #expect(!source.contains("nk.hasPrefix(\"embed_audio.\")"),
             "Gemma4 must not drop embed_audio projection weights.")
         #expect(source.contains("audioFeatures.dim(-1) == config.audioEmbedDim"),
-            "Gemma4 must validate pre-encoded audio feature width before projection.")
+            "Gemma4 must validate audio feature width before projection.")
         #expect(source.contains("let projectedAudio = embedAudio(audioFeatures).asType(emb.dtype)"),
-            "Gemma4 must project pre-encoded audio into the text embedding dimension.")
+            "Gemma4 must project audio features into the text embedding dimension.")
         #expect(!source.contains("pre-encoded 640-dim"),
             "Gemma4 raw/pre-encoded audio errors must not hard-code 640; E-series bundles use a different configured width.")
-        #expect(source.contains("Gemma4 raw audio feature extraction is not implemented"),
-            "Raw audio must fail with a clear typed unsupported message.")
+    }
+
+    /// Pins the unified raw-waveform chunking contract
+    /// (Gemma4UnifiedAudioFeatureExtractor parity).
+    @Test("Gemma4Processor chunks raw waveforms for unified bundles and gates the mel/tower pipeline")
+    func unifiedRawAudioChunkingContract() throws {
+        let source = try Self.gemma4Source()
+
+        // The unified extractor is encoder-free: raw 16 kHz frames of
+        // `audio_samples_per_token` samples are the soft-token features.
+        #expect(source.contains("unifiedWaveformFeatures"),
+            "Gemma4Processor must implement unified raw-waveform chunking.")
+        #expect(source.contains("Gemma4UnifiedAudioFeatureExtractor"),
+            "Unified chunking must be gated on the bundle's feature_extractor_type.")
+        #expect(source.contains("audio_samples_per_token"),
+            "Frame width must come from processor_config.json feature_extractor, not a hard-coded constant.")
+        #expect(source.contains("tokens > config.audioSeqLength"),
+            "Unified chunking must cap soft tokens at audio_seq_length like the upstream extractor.")
+        #expect(source.contains("linearResamplePCM"),
+            "Raw PCM at non-16kHz rates must be resampled, not rejected or misinterpreted.")
+        // Mel + conformer audio_tower bundles (E-series) stay typed-refused
+        // until that pipeline is wired; refusal must name the real pipeline.
+        #expect(source.contains("mel + audio_tower pipeline"),
+            "Non-unified raw audio must fail with a typed message naming the missing mel/audio_tower pipeline.")
     }
 
     /// Pins the image-token-id resolution path in `Gemma4Processor.prepare`.

--- a/Tests/MLXLMTests/Gemma4AudioGuardTests.swift
+++ b/Tests/MLXLMTests/Gemma4AudioGuardTests.swift
@@ -87,10 +87,72 @@ struct Gemma4AudioGuardTests {
             "Unified chunking must cap soft tokens at audio_seq_length like the upstream extractor.")
         #expect(source.contains("linearResamplePCM"),
             "Raw PCM at non-16kHz rates must be resampled, not rejected or misinterpreted.")
-        // Mel + conformer audio_tower bundles (E-series) stay typed-refused
-        // until that pipeline is wired; refusal must name the real pipeline.
-        #expect(source.contains("mel + audio_tower pipeline"),
-            "Non-unified raw audio must fail with a typed message naming the missing mel/audio_tower pipeline.")
+        // E-series mel + conformer bundles now route raw audio through
+        // gemma4ExtractMelFeatures instead of a typed refusal.
+        #expect(
+            source.contains(
+                "config.audioFeatureExtractorType == \"Gemma4AudioFeatureExtractor\""),
+            "Gemma4Processor must route Gemma4AudioFeatureExtractor bundles through the mel pipeline.")
+        #expect(source.contains("gemma4ExtractMelFeatures"),
+            "E-series raw audio must run through the Gemma4 mel extractor.")
+    }
+
+    /// Resolves `Libraries/MLXVLM/Models/Gemma4Audio.swift` (the E-series
+    /// conformer tower + mel extractor).
+    private static func gemma4AudioSource() throws -> String {
+        let repo = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // .../Tests/MLXLMTests
+            .deletingLastPathComponent()  // .../Tests
+            .deletingLastPathComponent()  // repo root
+        let url = repo
+            .appendingPathComponent("Libraries")
+            .appendingPathComponent("MLXVLM")
+            .appendingPathComponent("Models")
+            .appendingPathComponent("Gemma4Audio.swift")
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    /// Pins the E-series conformer audio tower contract:
+    /// tower gated on audio_config, sanitize keeps audio_tower.* when the
+    /// tower exists, and placeholder counts use the post-subsampling formula.
+    @Test("Gemma4 instantiates the conformer audio tower only for gemma4_audio configs")
+    func conformerAudioTowerContract() throws {
+        let source = try Self.gemma4Source()
+        let audioSource = try Self.gemma4AudioSource()
+
+        // Tower instantiation is gated on audio_config presence + type.
+        #expect(source.contains("audioConfig.isConformerTower"),
+            "Gemma4.init must gate the audio tower on audio_config.model_type == gemma4_audio.")
+        #expect(audioSource.contains("modelType == \"gemma4_audio\""),
+            "isConformerTower must require model_type gemma4_audio so unified 12B bundles stay tower-free.")
+        #expect(source.contains("@ModuleInfo(key: \"audio_tower\") private var audioTower"),
+            "Gemma4 must register the audio tower under the audio_tower checkpoint prefix.")
+
+        // sanitize() must keep audio_tower.* when the tower exists and keep
+        // discarding it otherwise (unified 12B has no tower weights anyway;
+        // 26B/31B have no audio_config at all).
+        #expect(source.contains("guard hasAudioTower else { continue }"),
+            "sanitize() must discard audio_tower.* only when no tower is instantiated.")
+        #expect(!source.contains("if nk.hasPrefix(\"audio_tower.\") { continue }"),
+            "sanitize() must not unconditionally drop audio_tower weights.")
+
+        // Clipped-linear sidecars are consumed by the tower, not dropped.
+        #expect(audioSource.contains("@ParameterInfo(key: \"input_min\")"),
+            "Gemma4ClippedLinear must load the input_min/input_max/output_min/output_max scalars.")
+
+        // Placeholder count parity: <|audio|> expansion must use the
+        // post-subsampling formula (two stride-2 convs => ceil(T/4)),
+        // matching HF Gemma4Processor.replace_audio_token.
+        #expect(audioSource.contains("func gemma4AudioSoftTokenCount(melFrameCount: Int) -> Int"),
+            "The soft-token count formula must exist in Gemma4Audio.swift.")
+        #expect(audioSource.contains("(melFrameCount + 3) / 4"),
+            "Soft-token count must be ceil(melFrames / 4) per HF replace_audio_token.")
+        #expect(source.contains("gemma4AudioSoftTokenCount(melFrameCount: mel.dim(0))"),
+            "The processor must expand <|audio|> placeholders with the post-subsampling token count.")
+
+        // The chat template needs audio content items to emit <|audio|>.
+        #expect(source.contains("message.audios.map { _ in [\"type\": \"audio\"] }"),
+            "Gemma4MessageGenerator must emit audio content parts so the template renders <|audio|>.")
     }
 
     /// Pins the image-token-id resolution path in `Gemma4Processor.prepare`.

--- a/Tests/MLXLMTests/LLMPreparePrefillTests.swift
+++ b/Tests/MLXLMTests/LLMPreparePrefillTests.swift
@@ -122,7 +122,7 @@ final class LLMPreparePrefillTests: XCTestCase {
 
         let tokens = MLXArray((0..<totalLen).map { Int32($0 % 64) })[.newAxis, 0...]
         let input = LMInput(text: .init(tokens: tokens))
-        _ = try PrefillProgressReporter.$current.withValue({ recorder.append($0) }) {
+        _ = try PrefillProgressReporter.withHandler({ recorder.append($0) }) {
             try model.prepare(input, cache: cache, windowSize: step)
         }
 

--- a/tools/Gemma4AudioSmoke/main.swift
+++ b/tools/Gemma4AudioSmoke/main.swift
@@ -1,0 +1,105 @@
+// Gemma4 E-series audio tower runtime smoke.
+//
+// Loads a Gemma 4 E2B/E4B bundle (conformer `audio_tower` + mel
+// `Gemma4AudioFeatureExtractor`), feeds a wav file plus a text prompt
+// through the full chat-template → mel → tower → embed_audio →
+// decode pipeline, and prints the generated text.
+//
+// Usage:
+//   GEMMA4_SMOKE_MODEL=/path/to/bundle \
+//   GEMMA4_SMOKE_AUDIO=/path/to/audio.wav \
+//   GEMMA4_SMOKE_PROMPT="What do you hear?" \
+//   GEMMA4_SMOKE_MAX_TOKENS=64 \
+//   swift run Gemma4AudioSmoke
+//
+// Requires the MLX metallib next to the executable —
+// run scripts/prepare-mlx-metal.sh first.
+
+import Foundation
+import MLX
+import MLXHuggingFace
+import MLXLMCommon
+import MLXVLM
+@preconcurrency import VMLXTokenizers
+
+@main
+struct Gemma4AudioSmoke {
+    static func main() async throws {
+        setvbuf(stdout, nil, _IONBF, 0)
+        let env = ProcessInfo.processInfo.environment
+        guard let modelPath = env["GEMMA4_SMOKE_MODEL"], !modelPath.isEmpty else {
+            fputs("Set GEMMA4_SMOKE_MODEL to a Gemma 4 E-series bundle path\n", stderr)
+            exit(1)
+        }
+        guard let audioPath = env["GEMMA4_SMOKE_AUDIO"], !audioPath.isEmpty else {
+            fputs("Set GEMMA4_SMOKE_AUDIO to a wav/audio file path\n", stderr)
+            exit(1)
+        }
+        let prompt = env["GEMMA4_SMOKE_PROMPT"] ?? "What do you hear in this audio clip?"
+        let maxTokens = max(1, Int(env["GEMMA4_SMOKE_MAX_TOKENS"] ?? "64") ?? 64)
+
+        let modelDir = URL(fileURLWithPath: modelPath)
+        let audioURL = URL(fileURLWithPath: audioPath)
+        guard FileManager.default.fileExists(atPath: audioURL.path) else {
+            fputs("audio file not found: \(audioURL.path)\n", stderr)
+            exit(1)
+        }
+
+        print("[smoke] loading \(modelDir.lastPathComponent) ...")
+        let loadStart = CFAbsoluteTimeGetCurrent()
+        let context = try await MLXLMCommon.loadModel(
+            from: modelDir, using: #huggingFaceTokenizerLoader())
+        print(String(
+            format: "[smoke] loaded %@ in %.1fs (model type: %@)",
+            modelDir.lastPathComponent,
+            CFAbsoluteTimeGetCurrent() - loadStart,
+            String(describing: type(of: context.model))))
+
+        let chat: [Chat.Message] = [
+            .user(prompt, audios: [.url(audioURL)])
+        ]
+        var userInput = UserInput(chat: chat)
+        userInput.additionalContext = ["enable_thinking": false]
+
+        let prepareStart = CFAbsoluteTimeGetCurrent()
+        let lmInput = try await context.processor.prepare(input: userInput)
+        let promptTokens = lmInput.text.tokens.dim(-1)
+        print(String(
+            format: "[smoke] processor.prepare: %.0f ms, prompt tokens: %d, audio: %@",
+            (CFAbsoluteTimeGetCurrent() - prepareStart) * 1000,
+            promptTokens,
+            lmInput.audio.map { "waveform shape \($0.waveform.shape), preEncoded: \($0.preEncodedEmbedding != nil)" }
+                ?? "nil"))
+
+        var parameters = GenerateParameters(
+            generationConfig: context.configuration.generationDefaults)
+        parameters.maxTokens = maxTokens
+        parameters.temperature = 0.0
+
+        let genStart = CFAbsoluteTimeGetCurrent()
+        let iterator = try TokenIterator(
+            input: lmInput, model: context.model, parameters: parameters)
+        var tokenIds: [Int] = []
+        let eosIds = Set(context.configuration.extraEOSTokens.compactMap {
+            context.tokenizer.convertTokenToId($0)
+        })
+        let eosTokenId = context.tokenizer.eosTokenId
+        for token in iterator {
+            if token == eosTokenId || eosIds.contains(token) { break }
+            tokenIds.append(token)
+            if tokenIds.count >= maxTokens { break }
+        }
+        let genSeconds = CFAbsoluteTimeGetCurrent() - genStart
+        let text = context.tokenizer.decode(tokenIds: tokenIds)
+        print(String(
+            format: "[smoke] generated %d tokens in %.1fs (%.1f tok/s)",
+            tokenIds.count, genSeconds,
+            Double(tokenIds.count) / max(genSeconds, 0.001)))
+        print("[smoke] output: \(text)")
+        if tokenIds.isEmpty {
+            fputs("[smoke] FAIL: no tokens generated\n", stderr)
+            exit(2)
+        }
+        print("[smoke] PASS")
+    }
+}


### PR DESCRIPTION
## Summary

Closes the documented Gemma 4 raw-speed gap to llama.cpp GGUF and implements native Gemma 4 audio for every checkpoint that ships audio tensors. All numbers measured on M5 Max, E2B QAT, greedy, 128 new tokens, BENCH_PERF median of 3.

## Speed (E2B, vs documented GGUF baseline 7384.7 prefill / 173.7 decode tok/s)

| stage | MXFP4 | JANG_4M |
|---|---|---|
| main 020ec0d | segfault at generation start | segfault |
| + TaskLocal crash fix (dc52096 cherry-pick) | 120.1 | 111.7 |
| + tied-head q6 load-time quantization | 132.5 | — |
| + compiled decode (opt-in) | **165.3** | **165.1** |

Prefill: **10,068 tok/s** on a 1,957-token prompt (vs GGUF 7,384.7) — measured with the same binary, artifacts under `/tmp/gemma4-speed-proof/`.

- **dc52096 was never on main**: the TaskLocal prefill reporter crash fix lived only on `codex/gemma-prefill-tasklocal-crash`; the Osaurus PR #1469 final repin to main silently dropped it. Without it any raw Gemma4 QAT generation crashes (`swift_task_localValuePushImpl` EXC_BAD_ACCESS).
- **Tied-head quantization** (`VMLXServerPerformanceSettings.tiedHeadCodec`, default `fp16_passthrough`): all ten OsaurusAI Gemma 4 QAT bundles ship the 262144-vocab tied embedding unquantized; `asLinear` streams ~1.07 GB/token on E2B. q8/q6/q4 measured 128.6/132.5/134.5 tok/s with identical greedy prefixes and coherent text; q6 mirrors the llama.cpp Q6_K output head the baselines use. Only applies to bundles that are themselves quantized; pre-quantized heads always load as shipped. `VMLX_QUANT_TIED_HEAD_BITS` env is the bench override.
- **Compiled decode for hybrid cache topologies**: `setupCompiledDecode` required a homogeneous cache array, silently disabling compile for sliding+full SWA families (Gemma4-class). Now promotes per layer (`KVCacheSimple→CompilableKVCache`, `RotatingKVCache→CompilableRotatingKVCache`). `CompiledDecodeTrace` marks trace-time execution so the Gemma4 PLE projection's mid-graph evals — load-bearing uncompiled (removing them drops decode to ~42 tok/s; greedy parity verified) — are skipped only while tracing, and `TextAttn` no longer reads `cache.offset` (host readback) under trace. CPU step build cost: 3.18 ms → 0.32 ms/token. Still gated behind `VMLX_ENABLE_UNSAFE_COMPILE` + the new `performance.compiledDecode` setting (default off) pending the PR #1173 model-switch corruption root cause.

## Audio

- **12B unified (gemma4_unified)**: encoder-free raw-waveform chunking with `Gemma4UnifiedAudioFeatureExtractor` parity — 16 kHz mono PCM chunked into `[tokens, 640]` frames (40 ms/token), zero-padded tail, capped at `audio_seq_length` (750), fed directly to `embed_audio.embedding_projection`. Frame width/sampling rate/extractor type parsed from `processor_config.json`.
- **E2B/E4B (gemma4 + audio_config)**: full conformer `audio_tower` port in `Gemma4Audio.swift` — 128-mel front end (frame 320/hop 160/fft 512, periodic Hann, semicausal pad, HTK filterbank, log(mel+1e-3)), 2× stride-2 subsampling convs, 12 conformer layers (chunked attention chunk 12 / left ctx 13 / softcap 50, rel-pos with Transformer-XL shift, per-dim scale, causal GLU lightconv k5, dual ½-residual FFWs), output projection to 1536, clipped-linear scalars applied per checkpoint. `<|audio|>` placeholders expand to ceil(melFrames/4). Mel parity vs HF reference: max abs diff 1.758e-3; subsample-conv cosine 0.999973. Decisive proof: **E2B transcribed synthesized speech verbatim** (artifacts in `/tmp/gemma4-audio-proof/`, see PROOF-SUMMARY.txt). The bundled transformers reference has an attention-mask bug (attends the window complement) — traced and documented; the Swift port implements the intended window, arbitrated empirically by the transcription result.
- **26B-A4B / 31B**: ship no audio tensors; loading behavior unchanged (audio_tower.* discarded only when no tower is configured).

## Boundaries

- Compiled decode and non-default head codecs are opt-in; defaults change nothing. Both shift numerics at the single-token level (same class as GGUF Q6_K head deltas).
- The Gemma4 audio guard tests + prefill tests pass; full live-app proof (tools/VL/audio through Osaurus) is the follow-up Osaurus PR that repins to this merge.
- JANG_4M E2B's ~7 GB footprint is the bundle's own size (7.3 GB on disk, mixed-precision profile), not a runtime leak.