### PR TITLE
Add DiffusionGemma block-diffusion runtime

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -36,6 +36,9 @@ public enum LLMTypeRegistry {
             "gemma4_text": create(Gemma4TextConfiguration.self, Gemma4TextModel.init),
             "gemma4_unified": create(Gemma4TextConfiguration.self, Gemma4TextModel.init),
             "gemma4_unified_text": create(Gemma4TextConfiguration.self, Gemma4TextModel.init),
+            // Block-diffusion family — generation runs through
+            // BlockDiffusionTokenIterator, never the AR TokenIterator.
+            "diffusion_gemma": create(DiffusionGemmaConfiguration.self, DiffusionGemmaModel.init),
             "qwen2": create(Qwen2Configuration.self, Qwen2Model.init),
             "qwen3": create(Qwen3Configuration.self, Qwen3Model.init),
             "qwen3_moe": create(Qwen3MoEConfiguration.self, Qwen3MoEModel.init),

--- a/Libraries/MLXLLM/Models/DiffusionGemma.swift
+++ b/Libraries/MLXLLM/Models/DiffusionGemma.swift
@@ -22,7 +22,6 @@
 
 import Foundation
 import MLX
-import MLXFast
 import MLXLMCommon
 import MLXNN
 

--- a/Libraries/MLXLLM/Models/DiffusionGemma.swift
+++ b/Libraries/MLXLLM/Models/DiffusionGemma.swift
@@ -1,0 +1,788 @@
+// Copyright © 2026 Jinho Jang (eric@jangq.ai)
+//
+// DiffusionGemma (google/diffusiongemma-26B-A4B-it) — block-diffusion text
+// generation. 30-layer Gemma4-style MoE transformer (128 experts, top-8,
+// parallel dense MLP + routed experts) with two forward modes sharing one
+// set of weights:
+//
+//   - encoder: causal forward over committed tokens (prompt, then each
+//     finalized canvas); writes the KV cache. Uses per-layer encoder
+//     scalars (`model.encoder.language_model.layers.N.layer_scalar`).
+//   - decoder: bidirectional forward over a 256-token noisy canvas; reads
+//     the encoder cache without mutating it, with self-conditioning soft
+//     embeddings mixed into the canvas embedding.
+//
+// Generation is driven by BlockDiffusionTokenIterator (MLXLMCommon) — this
+// model must NEVER be routed through autoregressive next-token decode, so
+// `prepare` throws.
+//
+// Python references:
+//   mlx_vlm/models/diffusion_gemma/language.py
+//   transformers/models/diffusion_gemma/modeling_diffusion_gemma.py
+
+import Foundation
+import MLX
+import MLXFast
+import MLXLMCommon
+import MLXNN
+
+// MARK: - Configuration
+
+public struct DiffusionGemmaTextConfiguration: Codable, Sendable {
+    let modelType: String
+    let hiddenSize: Int
+    let numHiddenLayers: Int
+    let numAttentionHeads: Int
+    let numKeyValueHeads: Int
+    let numGlobalKeyValueHeads: Int?
+    let headDim: Int
+    let globalHeadDim: Int
+    let intermediateSize: Int
+    let moeIntermediateSize: Int
+    let numExperts: Int
+    let topKExperts: Int
+    let vocabSize: Int
+    let rmsNormEps: Float
+    let slidingWindow: Int
+    let layerTypes: [String]
+    let finalLogitSoftcapping: Float?
+    let attentionBias: Bool
+    let padTokenId: Int
+    let ropeParameters: [String: [String: StringOrNumber]]
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case hiddenSize = "hidden_size"
+        case numHiddenLayers = "num_hidden_layers"
+        case numAttentionHeads = "num_attention_heads"
+        case numKeyValueHeads = "num_key_value_heads"
+        case numGlobalKeyValueHeads = "num_global_key_value_heads"
+        case headDim = "head_dim"
+        case globalHeadDim = "global_head_dim"
+        case intermediateSize = "intermediate_size"
+        case moeIntermediateSize = "moe_intermediate_size"
+        case numExperts = "num_experts"
+        case topKExperts = "top_k_experts"
+        case vocabSize = "vocab_size"
+        case rmsNormEps = "rms_norm_eps"
+        case slidingWindow = "sliding_window"
+        case layerTypes = "layer_types"
+        case finalLogitSoftcapping = "final_logit_softcapping"
+        case attentionBias = "attention_bias"
+        case padTokenId = "pad_token_id"
+        case ropeParameters = "rope_parameters"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        modelType =
+            try container.decodeIfPresent(String.self, forKey: .modelType)
+            ?? "diffusion_gemma_text"
+        hiddenSize = try container.decodeIfPresent(Int.self, forKey: .hiddenSize) ?? 2816
+        numHiddenLayers =
+            try container.decodeIfPresent(Int.self, forKey: .numHiddenLayers) ?? 30
+        numAttentionHeads =
+            try container.decodeIfPresent(Int.self, forKey: .numAttentionHeads) ?? 16
+        numKeyValueHeads =
+            try container.decodeIfPresent(Int.self, forKey: .numKeyValueHeads) ?? 8
+        numGlobalKeyValueHeads =
+            try container.decodeIfPresent(Int.self, forKey: .numGlobalKeyValueHeads)
+        headDim = try container.decodeIfPresent(Int.self, forKey: .headDim) ?? 256
+        globalHeadDim = try container.decodeIfPresent(Int.self, forKey: .globalHeadDim) ?? 512
+        intermediateSize =
+            try container.decodeIfPresent(Int.self, forKey: .intermediateSize) ?? 2112
+        moeIntermediateSize =
+            try container.decodeIfPresent(Int.self, forKey: .moeIntermediateSize) ?? 704
+        numExperts = try container.decodeIfPresent(Int.self, forKey: .numExperts) ?? 128
+        topKExperts = try container.decodeIfPresent(Int.self, forKey: .topKExperts) ?? 8
+        vocabSize = try container.decodeIfPresent(Int.self, forKey: .vocabSize) ?? 262144
+        rmsNormEps = try container.decodeIfPresent(Float.self, forKey: .rmsNormEps) ?? 1e-6
+        slidingWindow = try container.decodeIfPresent(Int.self, forKey: .slidingWindow) ?? 1024
+        let decodedLayerTypes =
+            try container.decodeIfPresent([String].self, forKey: .layerTypes) ?? []
+        if decodedLayerTypes.isEmpty {
+            // Reference default: 5×sliding + 1×full, repeated; last layer full.
+            let pattern =
+                Array(repeating: "sliding_attention", count: 5) + ["full_attention"]
+            var generated = (0 ..< numHiddenLayers).map { pattern[$0 % pattern.count] }
+            if generated.last != "full_attention" {
+                generated[generated.count - 1] = "full_attention"
+            }
+            layerTypes = generated
+        } else {
+            layerTypes = decodedLayerTypes
+        }
+        finalLogitSoftcapping =
+            try container.decodeIfPresent(Float.self, forKey: .finalLogitSoftcapping)
+        attentionBias =
+            try container.decodeIfPresent(Bool.self, forKey: .attentionBias) ?? false
+        padTokenId = try container.decodeIfPresent(Int.self, forKey: .padTokenId) ?? 0
+        ropeParameters =
+            try container.decodeIfPresent(
+                [String: [String: StringOrNumber]].self, forKey: .ropeParameters) ?? [:]
+    }
+}
+
+public struct DiffusionGemmaConfiguration: Codable, Sendable {
+    public let modelType: String
+    public let canvasLength: Int
+    public let eosTokenIds: [Int]
+    public let imageTokenId: Int?
+    let textConfig: DiffusionGemmaTextConfiguration
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case canvasLength = "canvas_length"
+        case eosTokenIds = "eos_token_id"
+        case imageTokenId = "image_token_id"
+        case textConfig = "text_config"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        modelType =
+            try container.decodeIfPresent(String.self, forKey: .modelType) ?? "diffusion_gemma"
+        canvasLength = try container.decodeIfPresent(Int.self, forKey: .canvasLength) ?? 256
+        if let list = try? container.decode([Int].self, forKey: .eosTokenIds) {
+            eosTokenIds = list
+        } else if let single = try? container.decode(Int.self, forKey: .eosTokenIds) {
+            eosTokenIds = [single]
+        } else {
+            eosTokenIds = []
+        }
+        imageTokenId = try container.decodeIfPresent(Int.self, forKey: .imageTokenId)
+        textConfig = try container.decode(
+            DiffusionGemmaTextConfiguration.self, forKey: .textConfig)
+    }
+}
+
+// MARK: - Attention
+
+/// Which forward mode a DiffusionGemma layer runs in.
+enum DiffusionGemmaForwardMode {
+    /// Causal over committed tokens; writes `cache`.
+    case encoder
+    /// Bidirectional over the canvas; reads the encoder KV from `cache`
+    /// without mutating it. Payload is the shared encoder offset used for
+    /// canvas RoPE positions.
+    case decoder(encoderOffset: Int)
+}
+
+class DiffusionGemmaAttention: Module {
+    let nHeads: Int
+    let nKVHeads: Int
+    let headDim: Int
+    let isSliding: Bool
+    let slidingWindow: Int
+    let eps: Float
+
+    @ModuleInfo(key: "q_proj") var queryProj: Linear
+    @ModuleInfo(key: "k_proj") var keyProj: Linear
+    @ModuleInfo(key: "v_proj") var valueProj: Linear?
+    @ModuleInfo(key: "o_proj") var outputProj: Linear
+    @ModuleInfo(key: "q_norm") var queryNorm: Gemma4RMSNorm
+    @ModuleInfo(key: "k_norm") var keyNorm: Gemma4RMSNorm
+    // v_norm is RMSNormNoScale (no learnable weight, not in checkpoint)
+
+    @ModuleInfo var rope: RoPELayer
+
+    init(_ config: DiffusionGemmaTextConfiguration, layerIndex: Int) {
+        let layerType =
+            layerIndex < config.layerTypes.count
+            ? config.layerTypes[layerIndex] : "sliding_attention"
+        self.isSliding = layerType == "sliding_attention"
+        self.slidingWindow = config.slidingWindow
+        self.eps = config.rmsNormEps
+
+        self.nHeads = config.numAttentionHeads
+        if isSliding {
+            self.nKVHeads = config.numKeyValueHeads
+            self.headDim = config.headDim
+        } else {
+            self.nKVHeads = config.numGlobalKeyValueHeads ?? config.numKeyValueHeads
+            self.headDim = config.globalHeadDim
+        }
+
+        self._queryProj.wrappedValue = Linear(
+            config.hiddenSize, nHeads * headDim, bias: config.attentionBias)
+        self._keyProj.wrappedValue = Linear(
+            config.hiddenSize, nKVHeads * headDim, bias: config.attentionBias)
+        // The checkpoint only carries v_proj for sliding layers; full
+        // attention layers share K=V (value path applies RMSNormNoScale to
+        // the raw key projection).
+        if isSliding {
+            self._valueProj.wrappedValue = Linear(
+                config.hiddenSize, nKVHeads * headDim, bias: config.attentionBias)
+        }
+        self._outputProj.wrappedValue = Linear(
+            nHeads * headDim, config.hiddenSize, bias: config.attentionBias)
+        self._queryNorm.wrappedValue = Gemma4RMSNorm(
+            dimensions: headDim, eps: config.rmsNormEps)
+        self._keyNorm.wrappedValue = Gemma4RMSNorm(
+            dimensions: headDim, eps: config.rmsNormEps)
+
+        let layerKey = isSliding ? "sliding_attention" : "full_attention"
+        let ropeParams = config.ropeParameters[layerKey] ?? [:]
+        let ropeTheta =
+            ropeParams["rope_theta"]?.asFloat() ?? (isSliding ? 10000.0 : 1_000_000.0)
+        let partialRotaryFactor =
+            ropeParams["partial_rotary_factor"]?.asFloat() ?? (isSliding ? 1.0 : 0.25)
+        let ropeType: String = {
+            if let typeValue = ropeParams["type"] ?? ropeParams["rope_type"],
+                case .string(let s) = typeValue
+            {
+                return s
+            }
+            return "default"
+        }()
+        // ProportionalRoPE consumes the partial factor itself, so it gets the
+        // full head dim (same convention as Gemma4Text).
+        let ropeDims =
+            ropeType == "proportional"
+            ? headDim : max(1, Int(Float(headDim) * partialRotaryFactor))
+        self.rope = initializeRope(
+            dims: ropeDims, base: ropeTheta, traditional: false,
+            scalingConfig: ropeParams.isEmpty ? nil : ropeParams,
+            maxPositionEmbeddings: nil)
+
+        super.init()
+    }
+
+    /// Read this layer's encoder KV in temporal order without mutating the
+    /// cache. Sliding layers only expose the trailing `slidingWindow - 1`
+    /// positions (the canvas occupies the final window slot).
+    private func encoderKV(from cache: KVCache) -> (keys: MLXArray, values: MLXArray)? {
+        let read: (keys: MLXArray, values: MLXArray)?
+        switch cache {
+        case let rotating as RotatingKVCache:
+            read = rotating.temporallyOrderedKV()
+        case let simple as KVCacheSimple:
+            read = simple.readKV()
+        default:
+            let state = cache.state
+            read = state.count == 2 ? (state[0], state[1]) : nil
+        }
+        guard var kv = read else { return nil }
+        if isSliding {
+            let window = max(slidingWindow - 1, 0)
+            let length = kv.keys.dim(2)
+            if window > 0, length > window {
+                kv = (
+                    kv.keys[.ellipsis, (length - window)..., 0...],
+                    kv.values[.ellipsis, (length - window)..., 0...]
+                )
+            }
+        }
+        return kv
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        mask: MLXFast.ScaledDotProductAttentionMaskMode,
+        cache: KVCache?,
+        mode: DiffusionGemmaForwardMode
+    ) -> MLXArray {
+        let (B, L) = (x.dim(0), x.dim(1))
+
+        var queries = queryProj(x).reshaped(B, L, nHeads, headDim)
+        queries = queryNorm(queries).transposed(0, 2, 1, 3)
+
+        var keys = keyProj(x).reshaped(B, L, nKVHeads, headDim)
+        let values: MLXArray
+        if let valueProj {
+            values = rmsNormNoScale(
+                valueProj(x).reshaped(B, L, nKVHeads, headDim), eps: eps)
+        } else {
+            values = rmsNormNoScale(keys, eps: eps)
+        }
+        keys = keyNorm(keys)
+
+        var keysT = keys.transposed(0, 2, 1, 3)
+        let valuesT = values.transposed(0, 2, 1, 3)
+
+        let attentionKeys: MLXArray
+        let attentionValues: MLXArray
+        switch mode {
+        case .encoder:
+            let offset = cache?.offset ?? 0
+            queries = rope(queries, offset: offset)
+            keysT = rope(keysT, offset: offset)
+            if let cache {
+                (attentionKeys, attentionValues) = cache.update(keys: keysT, values: valuesT)
+            } else {
+                (attentionKeys, attentionValues) = (keysT, valuesT)
+            }
+        case .decoder(let encoderOffset):
+            // Canvas q/k take absolute positions after the committed context;
+            // cached encoder keys were roped at their own absolute positions
+            // when written.
+            queries = rope(queries, offset: encoderOffset)
+            keysT = rope(keysT, offset: encoderOffset)
+            if let cache, let encoder = encoderKV(from: cache) {
+                attentionKeys = concatenated([encoder.keys, keysT], axis: 2)
+                attentionValues = concatenated([encoder.values, valuesT], axis: 2)
+            } else {
+                (attentionKeys, attentionValues) = (keysT, valuesT)
+            }
+        }
+
+        // Gemma4-family attention scale is 1.0 (queries are RMS-normed).
+        let sdpa = MLXFast.scaledDotProductAttention(
+            queries: queries, keys: attentionKeys, values: attentionValues,
+            scale: 1.0, mask: mask)
+        return outputProj(sdpa.transposed(0, 2, 1, 3).reshaped(B, L, -1))
+    }
+}
+
+// MARK: - Router / Experts
+
+class DiffusionGemmaRouter: Module {
+    @ModuleInfo(key: "proj") var proj: Linear
+    @ModuleInfo(key: "scale") var routerScale: MLXArray
+    @ModuleInfo(key: "per_expert_scale") var perExpertScale: MLXArray
+    // pre-norm is RMSNormNoScale folded into the scaled rmsNorm weight below
+
+    let topK: Int
+    let rootSize: Float
+    let eps: Float
+
+    init(_ config: DiffusionGemmaTextConfiguration) {
+        self.topK = config.topKExperts
+        self.rootSize = pow(Float(config.hiddenSize), -0.5)
+        self.eps = config.rmsNormEps
+        self._proj.wrappedValue = Linear(config.hiddenSize, config.numExperts, bias: false)
+        self._routerScale.wrappedValue = MLXArray.ones([config.hiddenSize])
+        self._perExpertScale.wrappedValue = MLXArray.ones([config.numExperts])
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> (indices: MLXArray, weights: MLXArray) {
+        // rms_norm(x, nil) * scale * hidden^-0.5 == rms_norm(x, scale * hidden^-0.5)
+        let h = MLXFast.rmsNorm(x, weight: routerScale * rootSize, eps: eps)
+        let scores = proj(h)
+        let topKIndices = argPartition(-scores, kth: topK - 1, axis: -1)[.ellipsis, ..<topK]
+        let topKLogits = takeAlong(scores, topKIndices, axis: -1)
+        var topKWeights = softmax(topKLogits, axis: -1, precise: true)
+        topKWeights = topKWeights * perExpertScale[topKIndices]
+        return (indices: topKIndices, weights: topKWeights)
+    }
+}
+
+class DiffusionGemmaExperts: Module {
+    @ModuleInfo(key: "switch_glu") var switchGLU: SwitchGLU
+
+    init(_ config: DiffusionGemmaTextConfiguration) {
+        self._switchGLU.wrappedValue = SwitchGLU(
+            inputDims: config.hiddenSize,
+            hiddenDims: config.moeIntermediateSize,
+            numExperts: config.numExperts,
+            activation: { safeGeluApproximate($0) },
+            bias: false)
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray, indices: MLXArray, weights: MLXArray) -> MLXArray {
+        let (B, S, H) = (x.dim(0), x.dim(1), x.dim(2))
+        let K = indices.dim(-1)
+        let expertOut = switchGLU(x.reshaped(B * S, H), indices.reshaped(B * S, K))
+        let weightsFlat = expandedDimensions(weights.reshaped(B * S, K), axis: -1)
+        return (expertOut * weightsFlat).sum(axis: -2).reshaped(B, S, H)
+    }
+}
+
+// MARK: - Decoder layer (parallel dense MLP + routed MoE, Gemma4 structure)
+
+class DiffusionGemmaLayer: Module {
+    let layerIndex: Int
+
+    @ModuleInfo(key: "self_attn") var selfAttention: DiffusionGemmaAttention
+    @ModuleInfo var mlp: Gemma4MLP
+    @ModuleInfo var router: DiffusionGemmaRouter
+    @ModuleInfo var experts: DiffusionGemmaExperts
+
+    @ModuleInfo(key: "input_layernorm") var inputLayernorm: Gemma4RMSNorm
+    @ModuleInfo(key: "post_attention_layernorm") var postAttentionLayernorm: Gemma4RMSNorm
+    @ModuleInfo(key: "pre_feedforward_layernorm") var preFeedforwardLayernorm: Gemma4RMSNorm
+    @ModuleInfo(key: "post_feedforward_layernorm") var postFeedforwardLayernorm: Gemma4RMSNorm
+    @ModuleInfo(key: "pre_feedforward_layernorm_2") var preFeedforwardLayernorm2: Gemma4RMSNorm
+    @ModuleInfo(key: "post_feedforward_layernorm_1") var postFeedforwardLayernorm1:
+        Gemma4RMSNorm
+    @ModuleInfo(key: "post_feedforward_layernorm_2") var postFeedforwardLayernorm2:
+        Gemma4RMSNorm
+
+    @ModuleInfo(key: "layer_scalar") var layerScalar: MLXArray
+
+    init(_ config: DiffusionGemmaTextConfiguration, layerIndex: Int) {
+        self.layerIndex = layerIndex
+        self._selfAttention.wrappedValue = DiffusionGemmaAttention(
+            config, layerIndex: layerIndex)
+        self.mlp = Gemma4MLP(
+            dimensions: config.hiddenSize, hiddenDimensions: config.intermediateSize)
+        self.router = DiffusionGemmaRouter(config)
+        self.experts = DiffusionGemmaExperts(config)
+
+        let norm = { Gemma4RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps) }
+        self._inputLayernorm.wrappedValue = norm()
+        self._postAttentionLayernorm.wrappedValue = norm()
+        self._preFeedforwardLayernorm.wrappedValue = norm()
+        self._postFeedforwardLayernorm.wrappedValue = norm()
+        self._preFeedforwardLayernorm2.wrappedValue = norm()
+        self._postFeedforwardLayernorm1.wrappedValue = norm()
+        self._postFeedforwardLayernorm2.wrappedValue = norm()
+
+        self._layerScalar.wrappedValue = MLXArray([Float(1.0)])
+
+        super.init()
+    }
+
+    /// `scalarOverride` carries the encoder-side layer scalar; the decoder
+    /// pass uses this layer's own `layer_scalar`.
+    func callAsFunction(
+        _ x: MLXArray,
+        mask: MLXFast.ScaledDotProductAttentionMaskMode,
+        cache: KVCache?,
+        mode: DiffusionGemmaForwardMode,
+        scalarOverride: MLXArray? = nil
+    ) -> MLXArray {
+        var residual = x
+        var h = inputLayernorm(x)
+        h = selfAttention(h, mask: mask, cache: cache, mode: mode)
+        h = postAttentionLayernorm(h)
+        h = residual + h
+
+        residual = h
+
+        var h1 = preFeedforwardLayernorm(h)
+        h1 = mlp(h1)
+        h1 = postFeedforwardLayernorm1(h1)
+
+        let (topKIndices, topKWeights) = router(h)
+        var h2 = preFeedforwardLayernorm2(h)
+        h2 = experts(h2, indices: topKIndices, weights: topKWeights)
+        h2 = postFeedforwardLayernorm2(h2)
+
+        h = postFeedforwardLayernorm(h1 + h2)
+        h = residual + h
+        return h * (scalarOverride ?? layerScalar)
+    }
+}
+
+// MARK: - Self-conditioning
+
+class DiffusionGemmaSelfConditioning: Module {
+    @ModuleInfo(key: "pre_norm") var preNorm: Gemma4RMSNorm
+    @ModuleInfo(key: "gate_proj") var gateProj: Linear
+    @ModuleInfo(key: "up_proj") var upProj: Linear
+    @ModuleInfo(key: "down_proj") var downProj: Linear
+    // post-norm is RMSNormNoScale (no learnable weight)
+
+    let eps: Float
+
+    init(_ config: DiffusionGemmaTextConfiguration) {
+        self.eps = config.rmsNormEps
+        self._preNorm.wrappedValue = Gemma4RMSNorm(
+            dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        self._gateProj.wrappedValue = Linear(
+            config.hiddenSize, config.intermediateSize, bias: false)
+        self._upProj.wrappedValue = Linear(
+            config.hiddenSize, config.intermediateSize, bias: false)
+        self._downProj.wrappedValue = Linear(
+            config.intermediateSize, config.hiddenSize, bias: false)
+        super.init()
+    }
+
+    func callAsFunction(_ inputsEmbeds: MLXArray, signal: MLXArray) -> MLXArray {
+        let normed = preNorm(signal)
+        let projected = downProj(safeGeluApproximate(gateProj(normed)) * upProj(normed))
+        return rmsNormNoScale(inputsEmbeds + projected, eps: eps)
+    }
+}
+
+// MARK: - Encoder layer scalars (checkpoint: model.encoder.language_model.layers.N.layer_scalar)
+
+class DiffusionGemmaEncoderScalarLayer: Module {
+    @ModuleInfo(key: "layer_scalar") var layerScalar: MLXArray
+
+    override init() {
+        self._layerScalar.wrappedValue = MLXArray([Float(1.0)])
+        super.init()
+    }
+}
+
+class DiffusionGemmaEncoderScalarStack: Module {
+    @ModuleInfo var layers: [DiffusionGemmaEncoderScalarLayer]
+
+    init(count: Int) {
+        self._layers.wrappedValue = (0 ..< count).map { _ in
+            DiffusionGemmaEncoderScalarLayer()
+        }
+        super.init()
+    }
+}
+
+class DiffusionGemmaEncoderModule: Module {
+    @ModuleInfo(key: "language_model") var languageModel: DiffusionGemmaEncoderScalarStack
+
+    init(layerCount: Int) {
+        self._languageModel.wrappedValue = DiffusionGemmaEncoderScalarStack(count: layerCount)
+        super.init()
+    }
+}
+
+// MARK: - Decoder stack
+
+class DiffusionGemmaDecoderModule: Module {
+    @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
+    @ModuleInfo var layers: [DiffusionGemmaLayer]
+    @ModuleInfo var norm: Gemma4RMSNorm
+    @ModuleInfo(key: "self_conditioning") var selfConditioning: DiffusionGemmaSelfConditioning
+
+    let config: DiffusionGemmaTextConfiguration
+
+    init(_ config: DiffusionGemmaTextConfiguration) {
+        self.config = config
+        self._embedTokens.wrappedValue = Embedding(
+            embeddingCount: config.vocabSize, dimensions: config.hiddenSize)
+        self._layers.wrappedValue = (0 ..< config.numHiddenLayers).map { i in
+            DiffusionGemmaLayer(config, layerIndex: i)
+        }
+        self.norm = Gemma4RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        self._selfConditioning.wrappedValue = DiffusionGemmaSelfConditioning(config)
+        super.init()
+    }
+
+    func embedScale(_ dtype: DType) -> MLXArray {
+        MLXArray(sqrt(Float(config.hiddenSize)), dtype: dtype)
+    }
+}
+
+class DiffusionGemmaInnerModel: Module {
+    @ModuleInfo var decoder: DiffusionGemmaDecoderModule
+    @ModuleInfo var encoder: DiffusionGemmaEncoderModule
+
+    init(_ config: DiffusionGemmaTextConfiguration) {
+        self._decoder.wrappedValue = DiffusionGemmaDecoderModule(config)
+        self._encoder.wrappedValue = DiffusionGemmaEncoderModule(
+            layerCount: config.numHiddenLayers)
+        super.init()
+    }
+}
+
+// MARK: - Top-level model
+
+public class DiffusionGemmaModel: Module, LLMModel {
+
+    @ModuleInfo var model: DiffusionGemmaInnerModel
+
+    public let config: DiffusionGemmaConfiguration
+    let textConfig: DiffusionGemmaTextConfiguration
+
+    public var vocabularySize: Int { textConfig.vocabSize }
+
+    public init(_ config: DiffusionGemmaConfiguration) {
+        self.config = config
+        self.textConfig = config.textConfig
+        self._model.wrappedValue = DiffusionGemmaInnerModel(config.textConfig)
+        super.init()
+    }
+
+    // MARK: AR-route guard
+
+    /// DiffusionGemma cannot be driven by the autoregressive TokenIterator;
+    /// `generate()` dispatches conforming models to
+    /// `BlockDiffusionTokenIterator` instead. Throwing here makes any other
+    /// route fail loudly instead of silently producing AR garbage.
+    public func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws
+        -> PrepareResult
+    {
+        throw BlockDiffusionModelError.requiresBlockDiffusionEngine(config.modelType)
+    }
+
+    // MARK: Cache topology
+
+    public func newCache(parameters: GenerateParameters?) -> [KVCache] {
+        (0 ..< textConfig.numHiddenLayers).map { i in
+            let layerType =
+                i < textConfig.layerTypes.count
+                ? textConfig.layerTypes[i] : "sliding_attention"
+            if layerType == "full_attention" {
+                if let maxKVSize = parameters?.maxKVSize {
+                    return RotatingKVCache(maxSize: maxKVSize, keep: 4)
+                }
+                return KVCacheSimple()
+            }
+            return RotatingKVCache(maxSize: textConfig.slidingWindow, keep: 0)
+        }
+    }
+
+    // MARK: Forward passes
+
+    private func masks(
+        h: MLXArray, cache: [KVCache]
+    ) -> (
+        global: MLXFast.ScaledDotProductAttentionMaskMode,
+        sliding: MLXFast.ScaledDotProductAttentionMaskMode
+    ) {
+        let layerTypes = textConfig.layerTypes
+        let globalIdx =
+            layerTypes.firstIndex(of: "full_attention") ?? (textConfig.numHiddenLayers - 1)
+        let slidingIdx = layerTypes.firstIndex(of: "sliding_attention") ?? 0
+        let globalCache = globalIdx < cache.count ? cache[globalIdx] : nil
+        let slidingCache = slidingIdx < cache.count ? cache[slidingIdx] : nil
+        return (
+            global: createAttentionMask(h: h, cache: globalCache),
+            sliding: createAttentionMask(
+                h: h, cache: slidingCache, windowSize: textConfig.slidingWindow)
+        )
+    }
+
+    func encoderForwardInternal(_ tokens: MLXArray, cache: [KVCache]) {
+        let tokens = tokens.ndim == 1 ? tokens.expandedDimensions(axis: 0) : tokens
+        var h = model.decoder.embedTokens(tokens)
+        h = h * model.decoder.embedScale(h.dtype)
+
+        let (globalMask, slidingMask) = {
+            let m = masks(h: h, cache: cache)
+            return (m.global, m.sliding)
+        }()
+
+        let layerTypes = textConfig.layerTypes
+        for (i, layer) in model.decoder.layers.enumerated() {
+            let isGlobal = i < layerTypes.count && layerTypes[i] == "full_attention"
+            h = layer(
+                h,
+                mask: isGlobal ? globalMask : slidingMask,
+                cache: i < cache.count ? cache[i] : nil,
+                mode: .encoder,
+                scalarOverride: model.encoder.languageModel.layers[i].layerScalar)
+        }
+        // Encoder hidden states are unused — only the KV cache side effect
+        // matters, so the final norm / logits are skipped.
+    }
+
+    func decoderForwardInternal(
+        canvas: MLXArray, cache: [KVCache], selfConditioningLogits: MLXArray?
+    ) -> MLXArray {
+        let canvas = canvas.ndim == 1 ? canvas.expandedDimensions(axis: 0) : canvas
+        let embeds = model.decoder.embedTokens(canvas) * model.decoder.embedScale(.bfloat16)
+
+        let signal: MLXArray
+        if let logits = selfConditioningLogits {
+            // Soft embeddings from the previous step's logits.
+            let probs = softmax(logits.asType(.float32), axis: -1, precise: true)
+            let soft = probs.asType(embeds.dtype).matmul(model.decoder.embedTokens.weight)
+            signal = soft * model.decoder.embedScale(embeds.dtype)
+        } else {
+            signal = MLXArray.zeros(embeds.shape, dtype: embeds.dtype)
+        }
+        var h = model.decoder.selfConditioning(embeds, signal: signal)
+
+        // B=1, no padding: the canvas attends bidirectionally to itself and
+        // to the visible encoder slice each attention layer selects, so no
+        // mask is needed.
+        let encoderOffset = cache.first?.offset ?? 0
+        for (i, layer) in model.decoder.layers.enumerated() {
+            h = layer(
+                h,
+                mask: .none,
+                cache: i < cache.count ? cache[i] : nil,
+                mode: .decoder(encoderOffset: encoderOffset))
+        }
+        h = model.decoder.norm(h)
+
+        var logits = model.decoder.embedTokens.asLinear(h)
+        if let cap = textConfig.finalLogitSoftcapping, cap > 0 {
+            logits = tanh(logits / cap) * cap
+        }
+        return logits
+    }
+
+    // MARK: Weight sanitization
+
+    public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        var processed = [String: MLXArray]()
+        processed.reserveCapacity(weights.count)
+
+        for (key, value) in weights {
+            // Vision tower / multimodal embedder are not part of the text
+            // engine (fp16 passthrough tensors in the bundle).
+            if key.hasPrefix("model.encoder.vision_tower.")
+                || key.hasPrefix("model.encoder.embed_vision.")
+            {
+                continue
+            }
+            if key.hasPrefix("model.encoder.language_model.") {
+                // Only the per-layer encoder scalars are real encoder
+                // weights; everything else is tied to the decoder.
+                if key.hasSuffix(".layer_scalar") {
+                    processed[key] = value
+                }
+                continue
+            }
+            if key == "lm_head.weight" || key.contains("rotary_emb") {
+                continue
+            }
+
+            // Routed experts: the checkpoint ships a fused gate_up_proj and
+            // a bare down_proj as stacked 3-D tensors; the module tree uses
+            // SwitchGLU with separate gate/up projections. Output-axis
+            // splitting is safe for quantized tensors (packing is along the
+            // input axis).
+            if key.hasSuffix(".experts.gate_up_proj.weight")
+                || key.hasSuffix(".experts.gate_up_proj.scales")
+                || key.hasSuffix(".experts.gate_up_proj.biases")
+            {
+                let outputDim = value.dim(-2)
+                let half = outputDim / 2
+                let prefixRange = key.range(of: ".experts.gate_up_proj.")!
+                let base = String(key[..<prefixRange.lowerBound])
+                let suffix = String(key[prefixRange.upperBound...])
+                processed["\(base).experts.switch_glu.gate_proj.\(suffix)"] =
+                    value[.ellipsis, ..<half, 0...]
+                processed["\(base).experts.switch_glu.up_proj.\(suffix)"] =
+                    value[.ellipsis, half..., 0...]
+                continue
+            }
+            if let range = key.range(of: ".experts.down_proj.") {
+                let base = String(key[..<range.lowerBound])
+                let suffix = String(key[range.upperBound...])
+                processed["\(base).experts.switch_glu.down_proj.\(suffix)"] = value
+                continue
+            }
+
+            processed[key] = value
+        }
+
+        return processed
+    }
+}
+
+// MARK: - BlockDiffusionModel conformance
+
+extension DiffusionGemmaModel: BlockDiffusionModel {
+    public var blockDiffusionDefaults: BlockDiffusionParameters {
+        BlockDiffusionParameters(
+            canvasLength: config.canvasLength,
+            eosTokenIds: Set(config.eosTokenIds),
+            padTokenId: textConfig.padTokenId)
+    }
+
+    public var diffusionVocabularySize: Int { textConfig.vocabSize }
+
+    public func encoderForward(_ tokens: MLXArray, cache: [KVCache]) {
+        encoderForwardInternal(tokens, cache: cache)
+    }
+
+    public func decoderForward(
+        canvas: MLXArray, cache: [KVCache], selfConditioningLogits: MLXArray?
+    ) -> MLXArray {
+        decoderForwardInternal(
+            canvas: canvas, cache: cache, selfConditioningLogits: selfConditioningLogits)
+    }
+}
+
+extension DiffusionGemmaModel: LoRAModel {
+    public var loraLayers: [Module] {
+        model.decoder.layers
+    }
+}

--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -537,6 +537,22 @@ public actor BatchEngine {
                 parameters: parameters,
                 promptTail: promptTail)
         }
+        // Block-diffusion models (e.g. diffusion_gemma) generate whole
+        // canvases via denoising and cannot share batched decode slots.
+        // They run as an exclusive solo path; the batched path would fail
+        // loudly anyway via the model's throwing prepare() guard.
+        if context.model is any BlockDiffusionModel {
+            guard canStartExclusiveSoloPath else {
+                Self.logger.error(
+                    "Rejected BatchEngine.generate block-diffusion request: block diffusion is an exclusive solo path until batched canvas scheduling lands."
+                )
+                return cancelledGenerationStream(promptTokenCount: input.text.tokens.size)
+            }
+            return startSoloFastPath(
+                input: input,
+                parameters: parameters,
+                promptTail: promptTail)
+        }
         if canStartSoloFastPath {
             return startSoloFastPath(
                 input: input,
@@ -885,7 +901,25 @@ public actor BatchEngine {
         let sourceStream: AsyncStream<Generation>
         let generationTask: Task<Void, Never>
         do {
-            if let strategy = soloParameters.draftStrategy,
+            if let diffusionModel = context.model as? any BlockDiffusionModel {
+                let options = diffusionModel.blockDiffusionDefaults
+                    .resolving(generationConfig: context.configuration.generationDefaults)
+                let iterator = try BlockDiffusionTokenIterator(
+                    input: input,
+                    model: diffusionModel,
+                    cache: nil,
+                    parameters: soloParameters,
+                    options: options,
+                    cacheCoordinator: cacheCoordinator)
+                (sourceStream, generationTask) = generateTask(
+                    promptTokenCount: promptTokenCount,
+                    modelConfiguration: context.configuration,
+                    tokenizer: context.tokenizer,
+                    iterator: iterator,
+                    extraStopStrings: soloParameters.extraStopStrings,
+                    promptTail: promptTail,
+                    toolSchemas: toolSchemas)
+            } else if let strategy = soloParameters.draftStrategy,
                 case .nativeMTP(depth: let depth, verifierMode: _) = strategy,
                 soloParameters.canUseNativeMTP(for: input)
             {

--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -904,6 +904,7 @@ public actor BatchEngine {
             if let diffusionModel = context.model as? any BlockDiffusionModel {
                 let options = diffusionModel.blockDiffusionDefaults
                     .resolving(generationConfig: context.configuration.generationDefaults)
+                    .overriding(parameters: soloParameters)
                 let iterator = try BlockDiffusionTokenIterator(
                     input: input,
                     model: diffusionModel,

--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -440,6 +440,7 @@ public final class ChatSession {
                             let options = diffusionModel.blockDiffusionDefaults
                                 .resolving(
                                     generationConfig: modelConfiguration.generationDefaults)
+                                .overriding(parameters: generateParameters)
                             let iterator = try BlockDiffusionTokenIterator(
                                 input: input, model: diffusionModel, cache: kvCache,
                                 parameters: generateParameters,

--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -430,19 +430,41 @@ public final class ChatSession {
                             .withToolSchemas(tools)
                         messages.removeAll()
 
-                        // generate output
-                        let iterator = try TokenIterator(
-                            input: input, model: model, cache: kvCache,
-                            parameters: generateParameters,
-                            cacheCoordinator: cacheCoordinator)
-
-                        let (stream, task) = MLXLMCommon.generateTask(
-                            promptTokenCount: input.text.tokens.size,
-                            modelConfiguration: modelConfiguration,
-                            tokenizer: tokenizer,
-                            iterator: iterator,
-                            toolSchemas: input.toolSchemas
-                        )
+                        // generate output — block-diffusion models (e.g.
+                        // diffusion_gemma) use their dedicated iterator; the
+                        // AR TokenIterator path would throw via the model's
+                        // prepare() guard.
+                        let stream: AsyncStream<Generation>
+                        let task: Task<Void, Never>
+                        if let diffusionModel = model as? any BlockDiffusionModel {
+                            let options = diffusionModel.blockDiffusionDefaults
+                                .resolving(
+                                    generationConfig: modelConfiguration.generationDefaults)
+                            let iterator = try BlockDiffusionTokenIterator(
+                                input: input, model: diffusionModel, cache: kvCache,
+                                parameters: generateParameters,
+                                options: options,
+                                cacheCoordinator: cacheCoordinator)
+                            (stream, task) = MLXLMCommon.generateTask(
+                                promptTokenCount: input.text.tokens.size,
+                                modelConfiguration: modelConfiguration,
+                                tokenizer: tokenizer,
+                                iterator: iterator,
+                                toolSchemas: input.toolSchemas
+                            )
+                        } else {
+                            let iterator = try TokenIterator(
+                                input: input, model: model, cache: kvCache,
+                                parameters: generateParameters,
+                                cacheCoordinator: cacheCoordinator)
+                            (stream, task) = MLXLMCommon.generateTask(
+                                promptTokenCount: input.text.tokens.size,
+                                modelConfiguration: modelConfiguration,
+                                tokenizer: tokenizer,
+                                iterator: iterator,
+                                toolSchemas: input.toolSchemas
+                            )
+                        }
 
                         var pendingToolCalls: [ToolCall] = []
 

--- a/Libraries/MLXLMCommon/Diffusion/BlockDiffusion.swift
+++ b/Libraries/MLXLMCommon/Diffusion/BlockDiffusion.swift
@@ -1,0 +1,202 @@
+// Copyright © 2026 Jinho Jang (eric@jangq.ai)
+//
+// Block-diffusion generation primitives.
+//
+// DiffusionGemma generates text by autoregressively producing fixed-size
+// canvases (token blocks). Each canvas is denoised over several decoder
+// forwards: sample candidate tokens, accept the approximately-independent
+// low-entropy subset, renoise the rest, and stop early once the canvas is
+// stable and confident.
+//
+// Python reference: transformers
+// src/transformers/models/diffusion_gemma/generation_diffusion_gemma.py
+// (EntropyBoundSampler, LinearTemperatureScheduleLogitsProcessor,
+//  StableAndConfidentStoppingCriteria).
+
+import Foundation
+import MLX
+
+/// Diffusion-loop parameters for a ``BlockDiffusionModel``.
+///
+/// Values originate from the bundle (`config.json` for `canvasLength`,
+/// `generation_config.json` for the rest) — per repo policy they are not
+/// user-tunable sampling knobs.
+public struct BlockDiffusionParameters: Sendable {
+    public var canvasLength: Int
+    public var maxNewTokens: Int
+    public var maxDenoisingSteps: Int
+    public var entropyBound: Float
+    public var tMin: Float
+    public var tMax: Float
+    public var stabilityThreshold: Int
+    public var confidenceThreshold: Float
+    public var eosTokenIds: Set<Int>
+    public var padTokenId: Int
+
+    public init(
+        canvasLength: Int,
+        maxNewTokens: Int = 256,
+        maxDenoisingSteps: Int = 48,
+        entropyBound: Float = 0.1,
+        tMin: Float = 0.4,
+        tMax: Float = 0.8,
+        stabilityThreshold: Int = 1,
+        confidenceThreshold: Float = 0.005,
+        eosTokenIds: Set<Int> = [],
+        padTokenId: Int = 0
+    ) {
+        self.canvasLength = canvasLength
+        self.maxNewTokens = maxNewTokens
+        self.maxDenoisingSteps = maxDenoisingSteps
+        self.entropyBound = entropyBound
+        self.tMin = tMin
+        self.tMax = tMax
+        self.stabilityThreshold = stabilityThreshold
+        self.confidenceThreshold = confidenceThreshold
+        self.eosTokenIds = eosTokenIds
+        self.padTokenId = padTokenId
+    }
+
+    /// Overlay `generation_config.json` values (when present) onto the
+    /// model's defaults.
+    public func resolving(generationConfig: GenerationConfigFile?) -> BlockDiffusionParameters {
+        guard let generationConfig else { return self }
+        var resolved = self
+        if let v = generationConfig.maxNewTokens { resolved.maxNewTokens = v }
+        if let v = generationConfig.maxDenoisingSteps { resolved.maxDenoisingSteps = v }
+        if let v = generationConfig.samplerConfig?.entropyBound { resolved.entropyBound = v }
+        if let v = generationConfig.tMin { resolved.tMin = v }
+        if let v = generationConfig.tMax { resolved.tMax = v }
+        if let v = generationConfig.stabilityThreshold { resolved.stabilityThreshold = v }
+        if let v = generationConfig.confidenceThreshold { resolved.confidenceThreshold = v }
+        if let v = generationConfig.eosTokenIds?.values, !v.isEmpty {
+            resolved.eosTokenIds = Set(v)
+        }
+        if let v = generationConfig.padTokenId { resolved.padTokenId = v }
+        return resolved
+    }
+}
+
+/// A language model that generates via block diffusion instead of
+/// autoregressive next-token decoding.
+///
+/// The model exposes two explicit forwards:
+/// - the **encoder** runs causally over committed tokens (prompt, then each
+///   finalized canvas) and writes the KV cache;
+/// - the **decoder** runs bidirectionally over a noisy canvas, reading the
+///   encoder cache without mutating it, and returns per-position logits.
+///
+/// `generate()` routes conforming models to ``BlockDiffusionTokenIterator``.
+/// The model's `prepare(_:cache:windowSize:)` must `throw` so the
+/// autoregressive `TokenIterator` path fails loudly instead of silently
+/// producing garbage.
+public protocol BlockDiffusionModel: LanguageModel {
+    /// Diffusion defaults from the bundle's `config.json`
+    /// (`generation_config.json` overrides are applied at dispatch via
+    /// ``BlockDiffusionParameters/resolving(generationConfig:)``).
+    var blockDiffusionDefaults: BlockDiffusionParameters { get }
+
+    /// Vocabulary size used for random canvas initialization.
+    var diffusionVocabularySize: Int { get }
+
+    /// Causal forward over `tokens` [1, T]; writes KV into `cache`.
+    func encoderForward(_ tokens: MLXArray, cache: [KVCache])
+
+    /// Bidirectional forward over `canvas` [1, C] reading (not writing)
+    /// `cache`. Returns logits [1, C, vocab] with any final softcapping
+    /// already applied.
+    func decoderForward(
+        canvas: MLXArray, cache: [KVCache], selfConditioningLogits: MLXArray?
+    ) -> MLXArray
+}
+
+public enum BlockDiffusionModelError: Error, CustomStringConvertible {
+    /// The model only supports block-diffusion generation; it was routed
+    /// through an autoregressive prepare/decode path.
+    case requiresBlockDiffusionEngine(String)
+    case emptyPrompt
+
+    public var description: String {
+        switch self {
+        case .requiresBlockDiffusionEngine(let modelType):
+            "\(modelType) generates via block diffusion and cannot be driven "
+                + "by the autoregressive TokenIterator; use generate() which "
+                + "dispatches to BlockDiffusionTokenIterator"
+        case .emptyPrompt:
+            "block diffusion requires a non-empty prompt"
+        }
+    }
+}
+
+// MARK: - Pure sampling primitives
+
+/// Linear temperature schedule. `curStep` counts DOWN from `maxSteps` to 1
+/// (reverse diffusion), so the first denoising step runs at `tMax` and the
+/// temperature anneals toward `tMin`.
+func blockDiffusionTemperature(curStep: Int, maxSteps: Int, tMin: Float, tMax: Float) -> Float {
+    tMin + ((tMax - tMin) * (Float(curStep) / Float(maxSteps)))
+}
+
+/// Per-position token entropy of `processedLogits` [B, C, V] → [B, C], fp32.
+///
+/// Numerically stable form: H = logSumExp(z) − Σ softmax(z)·z.
+func canvasTokenEntropy(processedLogits: MLXArray) -> MLXArray {
+    let z = processedLogits.asType(.float32)
+    let lse = logSumExp(z, axis: -1)
+    let p = softmax(z, axis: -1, precise: true)
+    return lse - (p * z).sum(axis: -1)
+}
+
+/// Entropy-bound acceptance mask (https://arxiv.org/pdf/2505.24857).
+///
+/// Sort entropies ascending and accept the largest k positions such that
+/// `cumsum(H)_k − H_k <= entropyBound` — an upper bound on the joint mutual
+/// information between the accepted tokens, so they are approximately
+/// independent. Returns a bool mask [B, C] in canvas order.
+func entropyBoundAcceptMask(tokenEntropy: MLXArray, entropyBound: Float) -> MLXArray {
+    let sortedIndices = argSort(tokenEntropy, axis: -1)
+    let sortedEntropy = takeAlong(tokenEntropy, sortedIndices, axis: -1)
+    let cumulative = cumsum(sortedEntropy, axis: -1)
+    // sortedEntropy is the running max because the sort is ascending.
+    let sortedAccept = (cumulative - sortedEntropy) .<= entropyBound
+    // Scatter back to canvas order.
+    return putAlong(
+        MLXArray.zeros(tokenEntropy.shape, dtype: .bool),
+        sortedIndices,
+        values: sortedAccept,
+        axis: -1)
+}
+
+/// Stops a denoising loop when the canvas is stable (identical argmax canvas
+/// across `stabilityThreshold` consecutive prior steps) and confident (mean
+/// token entropy below `confidenceThreshold`).
+struct StableConfidentStopper {
+    let stabilityThreshold: Int
+    let confidenceThreshold: Float
+    private var history: [[Int32]] = []
+
+    init(stabilityThreshold: Int, confidenceThreshold: Float) {
+        self.stabilityThreshold = stabilityThreshold
+        self.confidenceThreshold = confidenceThreshold
+    }
+
+    mutating func reset() {
+        history.removeAll(keepingCapacity: true)
+    }
+
+    mutating func shouldStop(argmaxCanvas: [Int32], meanEntropy: Float) -> Bool {
+        let stable: Bool
+        if stabilityThreshold == 0 {
+            stable = true
+        } else {
+            stable =
+                history.count >= stabilityThreshold
+                && history.suffix(stabilityThreshold).allSatisfy { $0 == argmaxCanvas }
+            history.append(argmaxCanvas)
+            if history.count > stabilityThreshold {
+                history.removeFirst(history.count - stabilityThreshold)
+            }
+        }
+        return stable && meanEntropy < confidenceThreshold
+    }
+}

--- a/Libraries/MLXLMCommon/Diffusion/BlockDiffusion.swift
+++ b/Libraries/MLXLMCommon/Diffusion/BlockDiffusion.swift
@@ -75,6 +75,16 @@ public struct BlockDiffusionParameters: Sendable {
         if let v = generationConfig.padTokenId { resolved.padTokenId = v }
         return resolved
     }
+
+    /// Apply explicit per-request overrides (e.g. an app-level speed/quality
+    /// slider). Clamped to at least 1 step.
+    public func overriding(parameters: GenerateParameters) -> BlockDiffusionParameters {
+        var resolved = self
+        if let steps = parameters.diffusionMaxDenoisingSteps {
+            resolved.maxDenoisingSteps = Swift.max(1, steps)
+        }
+        return resolved
+    }
 }
 
 /// A language model that generates via block diffusion instead of

--- a/Libraries/MLXLMCommon/Diffusion/BlockDiffusionTokenIterator.swift
+++ b/Libraries/MLXLMCommon/Diffusion/BlockDiffusionTokenIterator.swift
@@ -1,0 +1,319 @@
+// Copyright © 2026 Jinho Jang (eric@jangq.ai)
+//
+// Block-diffusion token iterator — drives a BlockDiffusionModel through the
+// reference generation algorithm:
+//
+//   outer loop (per canvas):
+//     1. encoder forward over uncommitted tokens (prompt on prefill, the
+//        previous finalized canvas afterwards) → KV cache append
+//     2. random canvas init, self-conditioning reset
+//     3. inner denoising loop (maxDenoisingSteps..1):
+//        decoder forward → temperature-scheduled logits → categorical
+//        denoiser canvas → entropy-bound accept → renoise rejected →
+//        stable+confident early stop → logits become next step's
+//        self-conditioning signal
+//     4. finalize argmax canvas, truncate after EOS, emit tokens
+//
+// Tokens stream through the standard generateTask pipeline, so reasoning
+// parsing, tool-call parsing, and stop strings behave exactly as they do for
+// autoregressive models. Prompt prefix caching (paged + disk tiers) goes
+// through the same CacheCoordinator hooks the AR iterators use.
+//
+// NOTE: `MLX.eval` below is MLX's graph-materialization API (forces lazy
+// tensor computation); it does not execute code and is unrelated to
+// JavaScript/Python eval().
+//
+// Python reference: transformers
+// src/transformers/models/diffusion_gemma/generation_diffusion_gemma.py
+
+import Foundation
+import MLX
+
+public struct BlockDiffusionTokenIterator: TokenIteratorProtocol {
+    let model: any BlockDiffusionModel
+    var cache: [KVCache]
+    let options: BlockDiffusionParameters
+    let cacheCoordinator: CacheCoordinator?
+    let mediaSalt: String?
+
+    public let maxTokens: Int?
+    public var tokenCount = 0
+    public var promptPrefillTime: TimeInterval = 0
+    public var promptTokenIds: [Int]
+
+    var promptCacheSnapshot: [KVCache]?
+    private let cacheInitParameters: GenerateParameters
+
+    private var pendingTokens: [Int] = []
+    private var pendingIndex = 0
+    private var finished = false
+    private var canvasesEmitted = 0
+    private let maxNewCanvases: Int
+    /// Finalized canvas awaiting its encoder append (run lazily at the start
+    /// of the next cycle so the final canvas is never encoded needlessly).
+    private var pendingEncoderCanvas: [Int32]?
+    private var stopper: StableConfidentStopper
+    private var statsReported = false
+
+    // Instrumentation
+    private(set) var denoisingForwardCount = 0
+    private(set) var encoderForwardCount = 0
+    private var denoiseTime: TimeInterval = 0
+    private var prefixCacheRestoredTokens = 0
+    private let iteratorStartTime = Date.timeIntervalSinceReferenceDate
+
+    public init(
+        input: LMInput,
+        model: any BlockDiffusionModel,
+        cache: [KVCache]? = nil,
+        parameters: GenerateParameters,
+        options: BlockDiffusionParameters,
+        cacheCoordinator: CacheCoordinator? = nil
+    ) throws {
+        let promptTokenIds = input.text.tokens.reshaped(-1).asArray(Int.self)
+        guard !promptTokenIds.isEmpty else {
+            throw BlockDiffusionModelError.emptyPrompt
+        }
+
+        self.model = model
+        self.options = options
+        self.cache = cache ?? model.newCache(parameters: parameters)
+        self.cacheCoordinator = cacheCoordinator
+        self.promptTokenIds = promptTokenIds
+        self.cacheInitParameters = parameters
+        self.mediaSalt = computeCacheSalt(for: input, parameters: parameters)
+        self.stopper = StableConfidentStopper(
+            stabilityThreshold: options.stabilityThreshold,
+            confidenceThreshold: options.confidenceThreshold)
+
+        let requestedTokens = parameters.maxTokens ?? options.maxNewTokens
+        self.maxTokens = requestedTokens
+        self.maxNewCanvases = Swift.max(
+            1, (requestedTokens + options.canvasLength - 1) / options.canvasLength)
+
+        // ---- Prompt prefix cache (paged + disk tiers) -------------------
+        // Diffusion is simpler than AR here: a full prefix hit needs no
+        // trim-and-replay because the decoder reads the cache directly —
+        // the prompt-boundary state is exactly the state the canvas loop
+        // wants.
+        var tokensToEncode = promptTokenIds
+        if let coordinator = cacheCoordinator,
+            !input.requiresPostPrepareCacheKey,
+            !input.hasMediaContent
+        {
+            switch coordinator.fetch(tokens: promptTokenIds, mediaSalt: mediaSalt) {
+            case .hit(let matchedTokens, let remainingTokens, _, let blocks, _, let diskArrays):
+                var restored = false
+                if !blocks.isEmpty {
+                    let restoredTokens = restoreLayerData(from: blocks, into: self.cache)
+                    coordinator.release(blocks: blocks)
+                    restored = restoredTokens > 0
+                }
+                if !restored, let diskArrays {
+                    restored = restoreFromDiskArrays(diskArrays, into: &self.cache) > 0
+                    if restored {
+                        MLX.eval(self.cache)
+                    }
+                }
+                // Validate the restore: every layer must sit exactly at the
+                // matched boundary, otherwise rebuild from scratch.
+                let offsets = self.cache.map(\.offset)
+                if restored,
+                    let first = offsets.first,
+                    offsets.allSatisfy({ $0 == first }),
+                    first == matchedTokens,
+                    matchedTokens + remainingTokens.count == promptTokenIds.count
+                {
+                    tokensToEncode = remainingTokens
+                    prefixCacheRestoredTokens = matchedTokens
+                } else if restored {
+                    self.cache = model.newCache(parameters: parameters)
+                    tokensToEncode = promptTokenIds
+                }
+            case .miss:
+                break
+            }
+        }
+
+        // ---- Chunked encoder prefill ------------------------------------
+        let prefillStart = Date.timeIntervalSinceReferenceDate
+        let stepSize = Swift.max(parameters.prefillStepSize, 1)
+        var remaining = tokensToEncode[...]
+        while !remaining.isEmpty {
+            let chunk = Array(remaining.prefix(stepSize))
+            remaining = remaining.dropFirst(stepSize)
+            let chunkTokens = MLXArray(chunk.map { Int32($0) }).expandedDimensions(axis: 0)
+            model.encoderForward(chunkTokens, cache: self.cache)
+            encoderForwardCount += 1
+            MLX.eval(self.cache)
+            if !remaining.isEmpty {
+                Memory.clearCache()
+            }
+        }
+        self.promptPrefillTime = Date.timeIntervalSinceReferenceDate - prefillStart
+
+        if cacheCoordinator != nil {
+            self.promptCacheSnapshot = makePromptBoundaryCacheSnapshot(from: self.cache)
+        }
+    }
+
+    public mutating func next() -> Int? {
+        if let maxTokens, tokenCount >= maxTokens {
+            reportStatsOnce()
+            return nil
+        }
+
+        while pendingIndex >= pendingTokens.count {
+            if finished || canvasesEmitted >= maxNewCanvases {
+                reportStatsOnce()
+                return nil
+            }
+            runCanvasCycle()
+        }
+
+        let token = pendingTokens[pendingIndex]
+        pendingIndex += 1
+        tokenCount += 1
+        return token
+    }
+
+    // MARK: - Canvas cycle
+
+    private mutating func runCanvasCycle() {
+        // 1. Commit the previous finalized canvas to the encoder cache.
+        if let previous = pendingEncoderCanvas {
+            let tokens = MLXArray(previous).expandedDimensions(axis: 0)
+            model.encoderForward(tokens, cache: cache)
+            encoderForwardCount += 1
+            MLX.eval(cache)
+            pendingEncoderCanvas = nil
+        }
+
+        let cycleStart = Date.timeIntervalSinceReferenceDate
+        let canvasLength = options.canvasLength
+        let vocabSize = model.diffusionVocabularySize
+
+        // 2. Random canvas, reset self-conditioning and stopping state.
+        var canvas = MLX.randInt(0 ..< Int32(vocabSize), [1, canvasLength])
+        var selfConditioning: MLXArray? = nil
+        var argmaxIds = [Int32](repeating: 0, count: canvasLength)
+        stopper.reset()
+
+        // 3. Denoising loop (reverse diffusion: curStep counts down).
+        for curStep in stride(from: options.maxDenoisingSteps, through: 1, by: -1) {
+            let logits = model.decoderForward(
+                canvas: canvas, cache: cache, selfConditioningLogits: selfConditioning)
+
+            let temperature = blockDiffusionTemperature(
+                curStep: curStep, maxSteps: options.maxDenoisingSteps,
+                tMin: options.tMin, tMax: options.tMax)
+            let processed = logits.asType(.float32) / temperature
+
+            let denoiserCanvas = MLX.categorical(processed).asType(.int32)
+            let argmaxCanvas = argMax(processed, axis: -1).asType(.int32)
+            let entropy = canvasTokenEntropy(processedLogits: processed)
+            let acceptMask = entropyBoundAcceptMask(
+                tokenEntropy: entropy, entropyBound: options.entropyBound)
+
+            // Accepted positions adopt the denoiser tokens; rejected
+            // positions are renoised with fresh random tokens.
+            let fresh = MLX.randInt(0 ..< Int32(vocabSize), [1, canvasLength])
+            canvas = MLX.which(acceptMask, denoiserCanvas, fresh)
+
+            denoisingForwardCount += 1
+
+            // Host sync once per step for the stopping criteria.
+            let meanEntropy = entropy.mean()
+            MLX.eval(canvas, argmaxCanvas, meanEntropy)
+            argmaxIds = argmaxCanvas[0].asArray(Int32.self)
+            if stopper.shouldStop(
+                argmaxCanvas: argmaxIds, meanEntropy: meanEntropy.item(Float.self))
+            {
+                break
+            }
+
+            // 5. Logits self-condition the next step.
+            selfConditioning = processed
+        }
+        denoiseTime += Date.timeIntervalSinceReferenceDate - cycleStart
+
+        // 4. Finalize: argmax canvas becomes the committed block; cut the
+        // emitted stream after the first EOS.
+        var emitted = argmaxIds.map(Int.init)
+        if let eosIndex = emitted.firstIndex(where: { options.eosTokenIds.contains($0) }) {
+            emitted = Array(emitted.prefix(through: eosIndex))
+            finished = true
+        } else {
+            // Only an unfinished sequence needs the canvas in the encoder
+            // cache for the next block.
+            pendingEncoderCanvas = argmaxIds
+        }
+        pendingTokens.append(contentsOf: emitted)
+        canvasesEmitted += 1
+    }
+
+    // MARK: - Prefix cache store (paged + disk/SSD tiers)
+
+    public mutating func storeCacheAfterGeneration(
+        generatedTokenIds: [Int],
+        includeGeneratedBoundary: Bool
+    ) {
+        guard let coordinator = cacheCoordinator,
+            !promptTokenIds.isEmpty,
+            let promptCacheSnapshot
+        else {
+            reportStatsOnce()
+            return
+        }
+
+        let cacheSnapshot = promptCacheSnapshot.map { $0.copy() }
+        MLX.eval(cacheSnapshot)
+        let perLayerData = extractLayerData(from: cacheSnapshot)
+        let diskStoreCache = makeDiskStoreCache(
+            fromPromptBoundary: cacheSnapshot,
+            parameters: cacheInitParameters)
+        coordinator.storeAfterGeneration(
+            promptTokens: promptTokenIds,
+            perLayerData: perLayerData,
+            ssmStates: nil,
+            cache: diskStoreCache,
+            mediaSalt: mediaSalt)
+
+        reportStatsOnce()
+    }
+
+    // MARK: - Instrumentation
+
+    private mutating func reportStatsOnce() {
+        guard !statsReported else { return }
+        statsReported = true
+
+        let emittedTokens = tokenCount
+        let tokensPerForward =
+            denoisingForwardCount > 0
+            ? Double(emittedTokens) / Double(denoisingForwardCount) : 0
+        let stepsPerCanvas =
+            canvasesEmitted > 0
+            ? Double(denoisingForwardCount) / Double(canvasesEmitted) : 0
+        let wall = Date.timeIntervalSinceReferenceDate - iteratorStartTime
+        let line = String(
+            format:
+                "[BlockDiffusion] canvases=%d denoisingForwards=%d avgStepsPerCanvas=%.1f "
+                + "emittedTokens=%d tokensPerForward=%.2f encoderForwards=%d "
+                + "prefixCacheRestoredTokens=%d prefillSec=%.3f denoiseSec=%.3f wallSec=%.3f "
+                + "cacheMode=simple+rotating(window) maxDenoisingSteps=%d entropyBound=%.3f\n",
+            canvasesEmitted,
+            denoisingForwardCount,
+            stepsPerCanvas,
+            emittedTokens,
+            tokensPerForward,
+            encoderForwardCount,
+            prefixCacheRestoredTokens,
+            promptPrefillTime,
+            denoiseTime,
+            wall,
+            options.maxDenoisingSteps,
+            options.entropyBound)
+        FileHandle.standardError.write(Data(line.utf8))
+    }
+}

--- a/Libraries/MLXLMCommon/Diffusion/BlockDiffusionTokenIterator.swift
+++ b/Libraries/MLXLMCommon/Diffusion/BlockDiffusionTokenIterator.swift
@@ -62,6 +62,8 @@ public struct BlockDiffusionTokenIterator: TokenIteratorProtocol {
     private(set) var denoisingForwardCount = 0
     private(set) var encoderForwardCount = 0
     private var denoiseTime: TimeInterval = 0
+    private var decoderForwardTime: TimeInterval = 0
+    private var samplerTime: TimeInterval = 0
     private var prefixCacheRestoredTokens = 0
     private let iteratorStartTime = Date.timeIntervalSinceReferenceDate
 
@@ -248,8 +250,14 @@ public struct BlockDiffusionTokenIterator: TokenIteratorProtocol {
 
         // 3. Denoising loop (reverse diffusion: curStep counts down).
         for curStep in stride(from: options.maxDenoisingSteps, through: 1, by: -1) {
+            let forwardStart = Date.timeIntervalSinceReferenceDate
             let logits = model.decoderForward(
                 canvas: canvas, cache: cache, selfConditioningLogits: selfConditioning)
+            // Materializing here splits decoder-forward time from the
+            // sampler pipeline in the stats line; both stay on-GPU.
+            MLX.eval(logits)
+            decoderForwardTime += Date.timeIntervalSinceReferenceDate - forwardStart
+            let samplerStart = Date.timeIntervalSinceReferenceDate
 
             let temperature = blockDiffusionTemperature(
                 curStep: curStep, maxSteps: options.maxDenoisingSteps,
@@ -273,6 +281,7 @@ public struct BlockDiffusionTokenIterator: TokenIteratorProtocol {
             let meanEntropy = entropy.mean()
             MLX.eval(canvas, argmaxCanvas, meanEntropy)
             argmaxIds = argmaxCanvas[0].asArray(Int32.self)
+            samplerTime += Date.timeIntervalSinceReferenceDate - samplerStart
             if stopper.shouldStop(
                 argmaxCanvas: argmaxIds, meanEntropy: meanEntropy.item(Float.self))
             {
@@ -355,7 +364,8 @@ public struct BlockDiffusionTokenIterator: TokenIteratorProtocol {
             format:
                 "[BlockDiffusion] canvases=%d denoisingForwards=%d avgStepsPerCanvas=%.1f "
                 + "emittedTokens=%d tokensPerForward=%.2f encoderForwards=%d "
-                + "prefixCacheRestoredTokens=%d prefillSec=%.3f denoiseSec=%.3f wallSec=%.3f "
+                + "prefixCacheRestoredTokens=%d prefillSec=%.3f denoiseSec=%.3f "
+                + "decoderFwdSec=%.3f samplerSec=%.3f wallSec=%.3f "
                 + "cacheMode=simple+rotating(window) maxDenoisingSteps=%d entropyBound=%.3f\n",
             canvasesEmitted,
             denoisingForwardCount,
@@ -366,6 +376,8 @@ public struct BlockDiffusionTokenIterator: TokenIteratorProtocol {
             prefixCacheRestoredTokens,
             promptPrefillTime,
             denoiseTime,
+            decoderForwardTime,
+            samplerTime,
             wall,
             options.maxDenoisingSteps,
             options.entropyBound)

--- a/Libraries/MLXLMCommon/Diffusion/BlockDiffusionTokenIterator.swift
+++ b/Libraries/MLXLMCommon/Diffusion/BlockDiffusionTokenIterator.swift
@@ -52,6 +52,9 @@ public struct BlockDiffusionTokenIterator: TokenIteratorProtocol {
     /// Finalized canvas awaiting its encoder append (run lazily at the start
     /// of the next cycle so the final canvas is never encoded needlessly).
     private var pendingEncoderCanvas: [Int32]?
+    /// Number of generated tokens already committed to the encoder cache
+    /// (whole prior canvases plus any end-of-turn tail commit).
+    private var committedGeneratedTokens = 0
     private var stopper: StableConfidentStopper
     private var statsReported = false
 
@@ -99,7 +102,11 @@ public struct BlockDiffusionTokenIterator: TokenIteratorProtocol {
         var tokensToEncode = promptTokenIds
         if let coordinator = cacheCoordinator,
             !input.requiresPostPrepareCacheKey,
-            !input.hasMediaContent
+            !input.hasMediaContent,
+            // Only consult the prefix cache when starting from an empty
+            // cache — a live multi-turn cache (ChatSession) already holds
+            // prior turns and must not be overwritten.
+            self.cache.allSatisfy({ $0.offset == 0 })
         {
             switch coordinator.fetch(tokens: promptTokenIds, mediaSalt: mediaSalt) {
             case .hit(let matchedTokens, let remainingTokens, _, let blocks, _, let diskArrays):
@@ -159,12 +166,14 @@ public struct BlockDiffusionTokenIterator: TokenIteratorProtocol {
 
     public mutating func next() -> Int? {
         if let maxTokens, tokenCount >= maxTokens {
+            commitEmittedTailToCache()
             reportStatsOnce()
             return nil
         }
 
         while pendingIndex >= pendingTokens.count {
             if finished || canvasesEmitted >= maxNewCanvases {
+                commitEmittedTailToCache()
                 reportStatsOnce()
                 return nil
             }
@@ -177,6 +186,32 @@ public struct BlockDiffusionTokenIterator: TokenIteratorProtocol {
         return token
     }
 
+    /// End-of-generation cache contract: the encoder cache must hold the
+    /// prompt plus exactly the emitted reply (minus a trailing EOS, matching
+    /// the AR iterator where the final sampled token is never fed back).
+    /// Canvas cycles only commit FULL prior canvases, so the final canvas —
+    /// and any EOS/maxTokens truncation — leaves a tail to encode here.
+    /// Without this, multi-turn sessions reusing the live cache would lose
+    /// the end of the assistant's reply.
+    private mutating func commitEmittedTailToCache() {
+        let emittedCount = Swift.min(tokenCount, pendingTokens.count)
+        var kept = Array(pendingTokens.prefix(emittedCount))
+        if let last = kept.last, options.eosTokenIds.contains(last) {
+            kept.removeLast()
+        }
+        guard kept.count > committedGeneratedTokens else {
+            pendingEncoderCanvas = nil
+            return
+        }
+        let delta = kept[committedGeneratedTokens...].map { Int32($0) }
+        let tokens = MLXArray(delta).expandedDimensions(axis: 0)
+        model.encoderForward(tokens, cache: cache)
+        encoderForwardCount += 1
+        MLX.eval(cache)
+        committedGeneratedTokens = kept.count
+        pendingEncoderCanvas = nil
+    }
+
     // MARK: - Canvas cycle
 
     private mutating func runCanvasCycle() {
@@ -186,6 +221,7 @@ public struct BlockDiffusionTokenIterator: TokenIteratorProtocol {
             model.encoderForward(tokens, cache: cache)
             encoderForwardCount += 1
             MLX.eval(cache)
+            committedGeneratedTokens += previous.count
             pendingEncoderCanvas = nil
         }
 

--- a/Libraries/MLXLMCommon/Diffusion/BlockDiffusionTokenIterator.swift
+++ b/Libraries/MLXLMCommon/Diffusion/BlockDiffusionTokenIterator.swift
@@ -99,6 +99,17 @@ public struct BlockDiffusionTokenIterator: TokenIteratorProtocol {
         // trim-and-replay because the decoder reads the cache directly —
         // the prompt-boundary state is exactly the state the canvas loop
         // wants.
+        //
+        // Rotating sliding-window layers cannot round-trip through paged KV
+        // blocks (ring/rotation metadata is disk-serialized via LayerKind),
+        // so the coordinator must skip the paged tier and serve hits from
+        // the disk tier — same contract as the AR iterators.
+        if let coordinator = cacheCoordinator,
+            !coordinator.isPagedIncompatible,
+            cacheRequiresDiskBackedCoordinatorRestore(self.cache)
+        {
+            coordinator.setPagedIncompatible(true)
+        }
         var tokensToEncode = promptTokenIds
         if let coordinator = cacheCoordinator,
             !input.requiresPostPrepareCacheKey,
@@ -303,8 +314,16 @@ public struct BlockDiffusionTokenIterator: TokenIteratorProtocol {
         }
 
         let cacheSnapshot = promptCacheSnapshot.map { $0.copy() }
-        MLX.eval(cacheSnapshot)
-        let perLayerData = extractLayerData(from: cacheSnapshot)
+        let requiresDiskBackedRestore =
+            cacheRequiresDiskBackedCoordinatorRestore(cacheSnapshot)
+        if !requiresDiskBackedRestore {
+            MLX.eval(cacheSnapshot)
+        }
+        // Rotating layers only round-trip through the disk tier (LayerKind
+        // serialization); paged KV blocks cannot represent them, so skip
+        // the paged store for that topology — same as the AR iterators.
+        let perLayerData =
+            requiresDiskBackedRestore ? [] : extractLayerData(from: cacheSnapshot)
         let diskStoreCache = makeDiskStoreCache(
             fromPromptBoundary: cacheSnapshot,
             parameters: cacheInitParameters)

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -2680,6 +2680,34 @@ public func generate(
             toolSchemas: input.toolSchemas)
         return stream
     }
+    // Native block-diffusion model dispatch (e.g. diffusion_gemma). These
+    // models generate whole canvases via denoising and CANNOT be driven by
+    // the autoregressive TokenIterator — their prepare() throws to keep any
+    // other route from silently producing AR garbage. Diffusion sampling
+    // parameters come from the bundle's generation_config.json, never from
+    // user temperature/top-p; GenerateParameters.maxTokens still caps
+    // output length.
+    if let diffusionModel = context.model as? any BlockDiffusionModel {
+        let options = diffusionModel.blockDiffusionDefaults
+            .resolving(generationConfig: context.configuration.generationDefaults)
+        let iterator = try BlockDiffusionTokenIterator(
+            input: input,
+            model: diffusionModel,
+            cache: cache,
+            parameters: parameters,
+            options: options,
+            cacheCoordinator: cacheCoordinator)
+        let (stream, _) = generateTask(
+            promptTokenCount: input.text.tokens.size,
+            modelConfiguration: context.configuration,
+            tokenizer: context.tokenizer,
+            iterator: iterator,
+            wiredMemoryTicket: wiredMemoryTicket,
+            extraStopStrings: parameters.extraStopStrings,
+            promptTail: promptTail,
+            toolSchemas: input.toolSchemas)
+        return stream
+    }
     // Block-diffusion speculative decoding dispatch. When
     // parameters.draftStrategy is .dflash or .ddtree AND the target
     // model conforms to HiddenStateCaptureModel + TokenEmbedderModel,

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -97,6 +97,14 @@ public struct GenerateParameters: Sendable {
     /// When set, uses ``RotatingKVCache`` instead of ``KVCacheSimple``
     public var maxKVSize: Int?
 
+    /// Block-diffusion speed/quality control: caps the denoising steps per
+    /// canvas for ``BlockDiffusionModel`` generation, overriding the
+    /// bundle's `generation_config.json` value. Lower is faster, higher is
+    /// better quality. Measured on diffusiongemma-26B-A4B MXFP4 (M5 Max):
+    /// 48 (bundle default) ≈ 37 tok/s, 16 ≈ 74 tok/s still coherent,
+    /// 8 breaks coherency. Ignored by autoregressive models.
+    public var diffusionMaxDenoisingSteps: Int?
+
     /// Number of bits to use for KV cache quantization. nil implies no cache quantization.
     public var kvBits: Int?
 
@@ -2690,6 +2698,7 @@ public func generate(
     if let diffusionModel = context.model as? any BlockDiffusionModel {
         let options = diffusionModel.blockDiffusionDefaults
             .resolving(generationConfig: context.configuration.generationDefaults)
+            .overriding(parameters: parameters)
         let iterator = try BlockDiffusionTokenIterator(
             input: input,
             model: diffusionModel,

--- a/Libraries/MLXLMCommon/GenerationConfigFile.swift
+++ b/Libraries/MLXLMCommon/GenerationConfigFile.swift
@@ -18,6 +18,29 @@ public struct GenerationConfigFile: Codable, Equatable, Sendable {
     public var doSample: Bool?
     public var suppressTokens: [Int]?
 
+    // Block-diffusion fields (DiffusionGemma). HF serializes the sampler
+    // config as a nested object with a `_cls_name` discriminator; only the
+    // payload values are decoded here.
+    public var maxDenoisingSteps: Int?
+    public var tMin: Float?
+    public var tMax: Float?
+    public var stabilityThreshold: Int?
+    public var confidenceThreshold: Float?
+    public var padTokenId: Int?
+    public var samplerConfig: SamplerConfig?
+
+    public struct SamplerConfig: Codable, Equatable, Sendable {
+        public var entropyBound: Float?
+
+        public init(entropyBound: Float? = nil) {
+            self.entropyBound = entropyBound
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case entropyBound = "entropy_bound"
+        }
+    }
+
     public init(
         eosTokenIds: IntOrIntArray? = nil,
         maxNewTokens: Int? = nil,
@@ -27,7 +50,14 @@ public struct GenerationConfigFile: Codable, Equatable, Sendable {
         minP: Float? = nil,
         repetitionPenalty: Float? = nil,
         doSample: Bool? = nil,
-        suppressTokens: [Int]? = nil
+        suppressTokens: [Int]? = nil,
+        maxDenoisingSteps: Int? = nil,
+        tMin: Float? = nil,
+        tMax: Float? = nil,
+        stabilityThreshold: Int? = nil,
+        confidenceThreshold: Float? = nil,
+        padTokenId: Int? = nil,
+        samplerConfig: SamplerConfig? = nil
     ) {
         self.eosTokenIds = eosTokenIds
         self.maxNewTokens = maxNewTokens
@@ -38,6 +68,13 @@ public struct GenerationConfigFile: Codable, Equatable, Sendable {
         self.repetitionPenalty = repetitionPenalty
         self.doSample = doSample
         self.suppressTokens = suppressTokens
+        self.maxDenoisingSteps = maxDenoisingSteps
+        self.tMin = tMin
+        self.tMax = tMax
+        self.stabilityThreshold = stabilityThreshold
+        self.confidenceThreshold = confidenceThreshold
+        self.padTokenId = padTokenId
+        self.samplerConfig = samplerConfig
     }
 
     enum CodingKeys: String, CodingKey {
@@ -50,6 +87,13 @@ public struct GenerationConfigFile: Codable, Equatable, Sendable {
         case repetitionPenalty = "repetition_penalty"
         case doSample = "do_sample"
         case suppressTokens = "suppress_tokens"
+        case maxDenoisingSteps = "max_denoising_steps"
+        case tMin = "t_min"
+        case tMax = "t_max"
+        case stabilityThreshold = "stability_threshold"
+        case confidenceThreshold = "confidence_threshold"
+        case padTokenId = "pad_token_id"
+        case samplerConfig = "sampler_config"
     }
 }
 

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -414,6 +414,23 @@ public class KVCacheSimple: BaseKVCache, CustomDebugStringConvertible {
         return (returnedKeys, returnedValues)
     }
 
+    /// Read the cached keys/values trimmed to the valid `offset` without
+    /// mutating cache state. Returns `nil` when nothing has been cached yet.
+    ///
+    /// Counterpart of `RotatingKVCache.temporallyOrderedKV()` for the simple
+    /// cache, used by consumers that attend over the cached context as a
+    /// contiguous block (e.g. the block-diffusion decoder).
+    public func readKV() -> (keys: MLXArray, values: MLXArray)? {
+        guard let keys = self.keys, let values = self.values else { return nil }
+        if offset < keys.dim(2) {
+            return (
+                keys[.ellipsis, ..<offset, 0...],
+                values[.ellipsis, ..<offset, 0...]
+            )
+        }
+        return (keys, values)
+    }
+
     public override var state: [MLXArray] {
         get {
             guard let keys = self.keys, let values = self.values else { return [] }
@@ -701,6 +718,28 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
         offset -= trimmed
         idx -= trimmed
         return trimmed
+    }
+
+    /// Read the cached keys/values in temporal order without mutating
+    /// rotation state (`offset`/`idx` are untouched).
+    ///
+    /// `update(keys:values:)` returns the raw ring buffer once the cache has
+    /// wrapped, which is only valid for causal single-token attention where
+    /// the mask hides the seam. Consumers that attend over the cached context
+    /// as a contiguous block — e.g. the block-diffusion decoder reading the
+    /// encoder cache — need the entries in temporal order. Returns `nil`
+    /// when nothing has been cached yet.
+    public func temporallyOrderedKV() -> (keys: MLXArray, values: MLXArray)? {
+        guard let keys = self.keys, let values = self.values else { return nil }
+        let orderedKeys = temporalOrder(keys)
+        let orderedValues = temporalOrder(values)
+        if offset < orderedKeys.dim(2) {
+            return (
+                orderedKeys[.ellipsis, ..<offset, 0...],
+                orderedValues[.ellipsis, ..<offset, 0...]
+            )
+        }
+        return (orderedKeys, orderedValues)
     }
 
     /// Optimized mask creation for rotating cache with offset capping

--- a/Libraries/MLXLMCommon/ReasoningParser.swift
+++ b/Libraries/MLXLMCommon/ReasoningParser.swift
@@ -910,6 +910,12 @@ public func reasoningStampFromModelType(_ modelType: String?) -> String {
         return "harmony"
     }
 
+    // DiffusionGemma shares the Gemma-4 chat template family and emits the
+    // same `<|channel>thought\n…<channel|>` reasoning envelope.
+    if compact.hasPrefix("diffusiongemma") {
+        return "harmony"
+    }
+
     // GPT-OSS native Harmony envelope (`<|start|>`, `<|channel|>`,
     // `<|end|>`, `<|return|>`, `<|message|>`). Without this stamp the
     // markers leak into the user-visible chunk stream because the

--- a/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
+++ b/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
@@ -77,6 +77,17 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
                 field: "concurrency.maxConcurrentSequences",
                 message: "Max concurrent sequences must be positive."))
         }
+        if let diffusionSteps = generation.diffusionMaxDenoisingSteps {
+            if diffusionSteps < 1 {
+                issues.append(.error(
+                    field: "generation.diffusionMaxDenoisingSteps",
+                    message: "Diffusion denoising steps must be at least 1. Use nil for the bundle default."))
+            } else if diffusionSteps < 12 {
+                issues.append(.warning(
+                    field: "generation.diffusionMaxDenoisingSteps",
+                    message: "Diffusion budgets below 12 steps measurably break coherency on diffusiongemma-26B-A4B (8 steps produces word-salad spans)."))
+            }
+        }
         if let prefillBatchSize = concurrency.prefillBatchSize,
            prefillBatchSize <= 0 {
             issues.append(.error(
@@ -997,6 +1008,15 @@ public struct VMLXServerGenerationDefaults: Codable, Sendable, Equatable {
     public var minP: Double?
     public var repetitionPenalty: Double?
 
+    /// Block-diffusion speed/quality budget (denoising steps per canvas)
+    /// applied to ``BlockDiffusionModel`` generation via
+    /// `GenerateParameters.diffusionMaxDenoisingSteps`. `nil` keeps the
+    /// bundle's `generation_config.json` value. Measured on
+    /// diffusiongemma-26B-A4B MXFP4 (M5 Max): 48 ≈ 37 tok/s,
+    /// 16 ≈ 74 tok/s still coherent, 8 breaks coherency. Ignored by
+    /// autoregressive models.
+    public var diffusionMaxDenoisingSteps: Int?
+
     public init(
         streamInterval: Int? = 1,
         maxTokens: Int? = nil,
@@ -1004,7 +1024,8 @@ public struct VMLXServerGenerationDefaults: Codable, Sendable, Equatable {
         topP: Double? = nil,
         topK: Int? = nil,
         minP: Double? = nil,
-        repetitionPenalty: Double? = nil
+        repetitionPenalty: Double? = nil,
+        diffusionMaxDenoisingSteps: Int? = nil
     ) {
         self.streamInterval = streamInterval
         self.maxTokens = maxTokens
@@ -1013,6 +1034,7 @@ public struct VMLXServerGenerationDefaults: Codable, Sendable, Equatable {
         self.topK = topK
         self.minP = minP
         self.repetitionPenalty = repetitionPenalty
+        self.diffusionMaxDenoisingSteps = diffusionMaxDenoisingSteps
     }
 }
 

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -591,6 +591,10 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
             return .gemma
         case "gemma4", "gemma4_unified", "gemma4_unified_text":
             return .gemma4
+        // DiffusionGemma reuses the Gemma-4 chat template family:
+        // `<|tool_call>call:name{...}<tool_call|>` envelopes.
+        case "diffusion_gemma", "diffusion_gemma_text":
+            return .gemma4
         // Mistral 4 — `[TOOL_CALLS] … [ARGS] …` JSON delimiters.
         case "mistral", "mistral4":
             return .mistral

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -323,6 +323,12 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
         if compact.hasPrefix("gemma4") {
             return .gemma4
         }
+
+        // DiffusionGemma reuses the Gemma-4 chat template family:
+        // `<|tool_call>call:name{...}<tool_call|>` envelopes.
+        if compact.hasPrefix("diffusiongemma") {
+            return .gemma4
+        }
         if compact.hasPrefix("gemma3n") {
             return nil
         }

--- a/RunBench/Bench.swift
+++ b/RunBench/Bench.swift
@@ -630,6 +630,17 @@ struct Bench {
             try await runSoloDiskRestore(modelPath: modelPath, maxNew: maxNew)
             return
         }
+
+        // BENCH_SOLO_LONGFORM=1: single long-form generation through
+        // `BatchEngine.generate` (solo path) with the real chat template.
+        // For block-diffusion models the [BlockDiffusion] stderr line
+        // reports canvases / denoising forwards / tokens-per-forward —
+        // the honest long-form throughput metric. BENCH_PROMPT overrides
+        // the default essay prompt.
+        if (env["BENCH_SOLO_LONGFORM"] ?? "0") == "1" {
+            try await runSoloLongform(modelPath: modelPath, maxNew: maxNew)
+            return
+        }
         if (env["BENCH_GROWING_CHAT_CACHE"] ?? "0") == "1" {
             do {
                 try await runGrowingChatCacheReuse(modelPath: modelPath, maxNew: maxNew)
@@ -2200,6 +2211,58 @@ func runBatchEngineCacheHit(modelPath: String, maxNew: Int) async throws {
 /// Session 1 generates and stores at the prompt boundary; the coordinator
 /// is dropped and a FRESH one is built on the same disk dir; the probe
 /// must hit the disk tier and session 2 must generate normally.
+/// Single long-form generation through the BatchEngine solo path with the
+/// real chat template. Reports wall/decode tok/s from the stream timing;
+/// block-diffusion models additionally print their [BlockDiffusion] stats
+/// line (canvases, denoising forwards, tokens-per-forward) on stderr.
+func runSoloLongform(modelPath: String, maxNew: Int) async throws {
+    let modelDir = URL(fileURLWithPath: modelPath)
+    print("\n=== Solo long-form generation ===")
+    let loadStart = CFAbsoluteTimeGetCurrent()
+    let context = try await loadBenchModelContext(from: modelDir)
+    print(String(format: "Load: %.2fs", CFAbsoluteTimeGetCurrent() - loadStart))
+    print("Model: \(type(of: context.model))")
+
+    let prompt = ProcessInfo.processInfo.environment["BENCH_PROMPT"]
+        ?? "Write a detailed multi-paragraph essay (at least 500 words) about the history of the Internet, from ARPANET to the modern web. Include specific milestones and dates."
+    let params = GenerateParameters(
+        maxTokens: maxNew, temperature: 0, prefillStepSize: 512)
+
+    let input = try await context.processor.prepare(input: UserInput(prompt: prompt))
+    let promptTokens = input.text.tokens.size
+    nonisolated(unsafe) let ctx = context
+    let engine = BatchEngine(context: ctx, maxBatchSize: 1)
+    nonisolated(unsafe) let sendable = input
+
+    var text = ""
+    var generationTokens = 0
+    var firstChunkAt: Double? = nil
+    let t0 = CFAbsoluteTimeGetCurrent()
+    let stream = await engine.generate(input: sendable, parameters: params)
+    for await event in stream {
+        switch event {
+        case .chunk(let chunk):
+            if firstChunkAt == nil { firstChunkAt = CFAbsoluteTimeGetCurrent() - t0 }
+            text += chunk
+        case .info(let info):
+            generationTokens = info.generationTokenCount
+        default:
+            break
+        }
+    }
+    let wall = CFAbsoluteTimeGetCurrent() - t0
+    await engine.shutdown()
+
+    let charCount = text.count
+    print(String(format:
+        "  prompt=%d genTokens=%d wall=%.2fs TTFT=%.2fs wallTokPerSec=%.1f chars=%d",
+        promptTokens, generationTokens, wall, firstChunkAt ?? 0,
+        Double(generationTokens) / max(wall, 0.001), charCount))
+    let preview = text.count > 700 ? String(text.prefix(700)) + "…" : text
+    print("  TEXT:\n\(preview)")
+    print("\n=== Solo long-form done ===")
+}
+
 func runSoloDiskRestore(modelPath: String, maxNew: Int) async throws {
     let modelDir = URL(fileURLWithPath: modelPath)
     print("\n=== Solo-path disk-restore verification ===")

--- a/RunBench/Bench.swift
+++ b/RunBench/Bench.swift
@@ -620,6 +620,16 @@ struct Bench {
             try await runBatchEngineDiskRestore(modelPath: modelPath, maxNew: maxNew)
             return
         }
+
+        // BENCH_SOLO_DISK_RESTORE=1: disk (L2/SSD) round-trip through
+        // `BatchEngine.generate` — the solo fast path. This is the
+        // disk-persistence row for exclusive-solo models (block diffusion,
+        // native MTP) that cannot run on the batched `submit` path the
+        // iter-35 bench uses.
+        if (env["BENCH_SOLO_DISK_RESTORE"] ?? "0") == "1" {
+            try await runSoloDiskRestore(modelPath: modelPath, maxNew: maxNew)
+            return
+        }
         if (env["BENCH_GROWING_CHAT_CACHE"] ?? "0") == "1" {
             do {
                 try await runGrowingChatCacheReuse(modelPath: modelPath, maxNew: maxNew)
@@ -2185,6 +2195,120 @@ func runBatchEngineCacheHit(modelPath: String, maxNew: Int) async throws {
 /// This is the single strongest "does it survive process restart?"
 /// property. Paged (RAM) coordinator state disappears at process exit;
 /// only the disk tier persists.
+/// Disk (L2) round-trip through `BatchEngine.generate` — the solo fast
+/// path used by exclusive-solo models (block diffusion, native MTP).
+/// Session 1 generates and stores at the prompt boundary; the coordinator
+/// is dropped and a FRESH one is built on the same disk dir; the probe
+/// must hit the disk tier and session 2 must generate normally.
+func runSoloDiskRestore(modelPath: String, maxNew: Int) async throws {
+    let modelDir = URL(fileURLWithPath: modelPath)
+    print("\n=== Solo-path disk-restore verification ===")
+    let loadStart = CFAbsoluteTimeGetCurrent()
+    let context = try await loadBenchModelContext(from: modelDir)
+    print(String(format: "Load: %.2fs", CFAbsoluteTimeGetCurrent() - loadStart))
+    print("Model: \(type(of: context.model))")
+
+    let diskDir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("vmlx-bench-solo-disk-\(UUID().uuidString)")
+    try FileManager.default.createDirectory(at: diskDir, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: diskDir) }
+
+    func makeCoordinator() -> CacheCoordinator {
+        var cfg = CacheCoordinatorConfig()
+        cfg.usePagedCache = true
+        cfg.enableDiskCache = true
+        cfg.diskCacheDir = diskDir
+        cfg.pagedBlockSize = 64
+        cfg.maxCacheBlocks = 512
+        cfg.modelKey = modelDir.lastPathComponent
+        return CacheCoordinator(config: cfg)
+    }
+
+    let params = GenerateParameters(
+        maxTokens: maxNew, temperature: 0, prefillStepSize: 512)
+
+    let basePrompt = String(repeating: """
+        You are a careful assistant. Facts to remember across turns: \
+        the sky is blue, grass is green, roses are red, oceans are \
+        deep, fire is hot. Answer concisely and precisely.
+        """, count: 3) + " Q: What is the colour of the sky?"
+
+    let turn1Input = try await context.processor.prepare(
+        input: UserInput(prompt: basePrompt))
+    let promptTokens = turn1Input.text.tokens.reshaped(-1).asArray(Int.self)
+
+    func runSession(
+        engine: BatchEngine, input: consuming sending LMInput, label: String
+    ) async -> Int {
+        var text = ""
+        var generated = 0
+        let t0 = CFAbsoluteTimeGetCurrent()
+        let stream = await engine.generate(input: input, parameters: params)
+        for await event in stream {
+            switch event {
+            case .chunk(let chunk):
+                text += chunk
+                generated += 1
+            default:
+                break
+            }
+        }
+        let wall = CFAbsoluteTimeGetCurrent() - t0
+        let preview = text.count > 160 ? String(text.prefix(160)) + "..." : text
+        print(String(format: "  %@: chunks=%d wall=%.2fs", label, generated, wall))
+    print("    TEXT: \"\(preview)\"")
+        return generated
+    }
+
+    // --- Session 1: cold, writes the prompt boundary to disk -----------
+    nonisolated(unsafe) let ctx1 = context
+    let coordA = makeCoordinator()
+    let engineA = BatchEngine(context: ctx1, maxBatchSize: 1, cacheCoordinator: coordA)
+    nonisolated(unsafe) let in1 = turn1Input
+    let chunks1 = await runSession(engine: engineA, input: in1, label: "Session 1 (cold)")
+    await engineA.shutdown()
+    await Task.yield()
+
+    if chunks1 == 0 {
+        fputs("[SoloDiskRestore] FAIL: session 1 produced no output.\n", stderr)
+        exit(1)
+    }
+
+    // --- Session 2: fresh coordinator on the same disk dir -------------
+    let coordB = makeCoordinator()
+    let tokens2 = MLXArray(promptTokens.map { Int32($0) })[.newAxis, .ellipsis]
+    let turn2Input = LMInput(
+        text: LMInput.Text(tokens: tokens2), image: nil, video: nil,
+        cacheScopeSalt: turn1Input.cacheScopeSalt)
+    let mediaSalt2 = computeCacheSalt(for: turn2Input, parameters: params)
+
+    switch coordB.fetch(tokens: promptTokens, mediaSalt: mediaSalt2) {
+    case .hit(let matched, _, let detail, let blocks, _, let disk):
+        coordB.release(blocks: blocks)
+        print("  Coord B probe: HIT (\(detail.rawValue), matched=\(matched)/\(promptTokens.count), diskArrays=\(disk != nil ? "yes" : "no"))")
+        if detail != .disk {
+            fputs("[SoloDiskRestore] FAIL: probe hit \(detail.rawValue), not disk.\n", stderr)
+            exit(1)
+        }
+    case .miss:
+        fputs("[SoloDiskRestore] FAIL: fresh coordinator at same disk dir returned .miss.\n", stderr)
+        exit(1)
+    }
+
+    nonisolated(unsafe) let ctx2 = context
+    let engineB = BatchEngine(context: ctx2, maxBatchSize: 1, cacheCoordinator: coordB)
+    nonisolated(unsafe) let in2 = turn2Input
+    let chunks2 = await runSession(engine: engineB, input: in2, label: "Session 2 (warm from disk)")
+    await engineB.shutdown()
+
+    if chunks2 == 0 {
+        fputs("[SoloDiskRestore] FAIL: session 2 produced no output after disk hit.\n", stderr)
+        exit(1)
+    }
+    print("  OK — disk tier round-tripped across coordinator instances on the solo path.")
+    print("\n=== Solo-path disk-restore done ===")
+}
+
 func runBatchEngineDiskRestore(modelPath: String, maxNew: Int) async throws {
     let modelDir = URL(fileURLWithPath: modelPath)
     print("\n=== BatchEngine disk-restore verification (iter 35) ===")

--- a/RunBench/Bench.swift
+++ b/RunBench/Bench.swift
@@ -2225,8 +2225,16 @@ func runSoloLongform(modelPath: String, maxNew: Int) async throws {
 
     let prompt = ProcessInfo.processInfo.environment["BENCH_PROMPT"]
         ?? "Write a detailed multi-paragraph essay (at least 500 words) about the history of the Internet, from ARPANET to the modern web. Include specific milestones and dates."
-    let params = GenerateParameters(
+    var params = GenerateParameters(
         maxTokens: maxNew, temperature: 0, prefillStepSize: 512)
+    // Speed/quality slider probe: override the bundle's denoising budget
+    // per request, the same way an app-level setting would.
+    if let stepsRaw = ProcessInfo.processInfo.environment["BENCH_DIFFUSION_STEPS"],
+        let steps = Int(stepsRaw)
+    {
+        params.diffusionMaxDenoisingSteps = steps
+        print("  diffusionMaxDenoisingSteps override: \(steps)")
+    }
 
     let input = try await context.processor.prepare(input: UserInput(prompt: prompt))
     let promptTokens = input.text.tokens.size

--- a/Tests/MLXLMTests/DiffusionGemmaTests.swift
+++ b/Tests/MLXLMTests/DiffusionGemmaTests.swift
@@ -322,6 +322,107 @@ func testDiffusionGemmaEncoderDecoderForward() async throws {
     #expect(cache[1].offset == 14)
 }
 
+// MARK: - BlockDiffusionTokenIterator (Task 5)
+
+@Test(.serialized)
+func testBlockDiffusionTokenIteratorEndToEnd() async throws {
+    let mlxTestLock = lockSerializedMLXTest()
+    defer { mlxTestLock.unlock() }
+
+    let config = try tinyDiffusionGemmaConfiguration()
+    let model = DiffusionGemmaModel(config)
+
+    var parameters = GenerateParameters()
+    parameters.maxTokens = 16
+
+    let prompt = LMInput(
+        text: .init(tokens: MLXArray([10, 11, 12, 13, 14].map { Int32($0) })))
+    var iterator = try BlockDiffusionTokenIterator(
+        input: prompt,
+        model: model,
+        parameters: parameters,
+        options: model.blockDiffusionDefaults)
+
+    var emitted: [Int] = []
+    while let token = iterator.next() {
+        emitted.append(token)
+    }
+
+    // At least one token; never beyond maxTokens; everything within vocab.
+    #expect(!emitted.isEmpty)
+    #expect(emitted.count <= 16)
+    #expect(emitted.allSatisfy { $0 >= 0 && $0 < 64 })
+    #expect(iterator.tokenCount == emitted.count)
+
+    // Denoising loop budget: at most maxDenoisingSteps per canvas, and the
+    // canvas cycle ran at least once.
+    #expect(iterator.denoisingForwardCount >= 1)
+    #expect(iterator.denoisingForwardCount <= 48 * 2)
+
+    // Cache holds the prompt plus any committed canvases (the final canvas
+    // is only encoded when another cycle runs): 5, 5+8, or 5+16.
+    let offset = iterator.cache[0].offset
+    #expect(offset == 5 || offset == 13 || offset == 21)
+    #expect(iterator.cache[1].offset == offset)
+}
+
+@Test(.serialized)
+func testARTokenIteratorRejectsDiffusionModel() async throws {
+    let mlxTestLock = lockSerializedMLXTest()
+    defer { mlxTestLock.unlock() }
+
+    let config = try tinyDiffusionGemmaConfiguration()
+    let model = DiffusionGemmaModel(config)
+    let prompt = LMInput(
+        text: .init(tokens: MLXArray([10, 11, 12].map { Int32($0) })))
+
+    // The AR TokenIterator must fail loudly (model.prepare throws) instead
+    // of silently next-token decoding a diffusion model.
+    #expect(throws: BlockDiffusionModelError.self) {
+        _ = try TokenIterator(
+            input: prompt, model: model, parameters: GenerateParameters())
+    }
+}
+
+// MARK: - Factory registration (Task 6)
+
+@Test(.serialized)
+func testFactoryRegistersDiffusionGemma() async throws {
+    let configData = """
+        {
+          "model_type": "diffusion_gemma",
+          "canvas_length": 8,
+          "eos_token_id": [1, 7],
+          "text_config": {
+            "model_type": "diffusion_gemma_text",
+            "vocab_size": 64,
+            "hidden_size": 8,
+            "intermediate_size": 16,
+            "moe_intermediate_size": 8,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "num_global_key_value_heads": 1,
+            "head_dim": 4,
+            "global_head_dim": 4,
+            "num_experts": 4,
+            "top_k_experts": 2,
+            "sliding_window": 4,
+            "layer_types": ["sliding_attention", "full_attention"],
+            "rms_norm_eps": 1e-6,
+            "pad_token_id": 0
+          }
+        }
+        """.data(using: .utf8)!
+
+    let modelTypeName = try await MLXMetalTestLock.withLock {
+        let model = try await LLMTypeRegistry.shared.createModel(
+            configuration: configData, modelType: "diffusion_gemma")
+        return String(describing: type(of: model))
+    }
+    #expect(modelTypeName.contains("DiffusionGemma"))
+}
+
 // MARK: - generation_config.json diffusion fields (Task 4)
 
 @Test

--- a/Tests/MLXLMTests/DiffusionGemmaTests.swift
+++ b/Tests/MLXLMTests/DiffusionGemmaTests.swift
@@ -359,10 +359,16 @@ func testBlockDiffusionTokenIteratorEndToEnd() async throws {
     #expect(iterator.denoisingForwardCount >= 1)
     #expect(iterator.denoisingForwardCount <= 48 * 2)
 
-    // Cache holds the prompt plus any committed canvases (the final canvas
-    // is only encoded when another cycle runs): 5, 5+8, or 5+16.
+    // End-of-turn cache contract: the encoder cache holds the prompt plus
+    // exactly the emitted reply, minus a trailing EOS (mirrors the AR
+    // iterator, whose final sampled token never re-enters the cache). This
+    // is what makes multi-turn live-cache reuse coherent.
+    var keptTokens = emitted
+    if let last = keptTokens.last, [1, 7].contains(last) {
+        keptTokens.removeLast()
+    }
     let offset = iterator.cache[0].offset
-    #expect(offset == 5 || offset == 13 || offset == 21)
+    #expect(offset == 5 + keptTokens.count)
     #expect(iterator.cache[1].offset == offset)
 }
 

--- a/Tests/MLXLMTests/DiffusionGemmaTests.swift
+++ b/Tests/MLXLMTests/DiffusionGemmaTests.swift
@@ -1,0 +1,203 @@
+// Copyright © 2026 Jinho Jang (eric@jangq.ai)
+//
+// DiffusionGemma block-diffusion engine tests.
+//
+// Covers the ordered KV read APIs the diffusion decoder relies on, the
+// block-diffusion sampling primitives, the DiffusionGemma model family,
+// and the BlockDiffusionTokenIterator generation flow.
+
+import Foundation
+import MLX
+import Testing
+
+@testable import MLXLMCommon
+
+// MARK: - Ordered KV read APIs (Task 1)
+
+@Test(.serialized)
+func testRotatingKVCacheTemporallyOrderedKV() async throws {
+    let mlxTestLock = lockSerializedMLXTest()
+    defer { mlxTestLock.unlock() }
+
+    let cache = RotatingKVCache(maxSize: 4, keep: 0)
+
+    // 6 single-token updates whose key payload encodes the position.
+    for position in 0 ..< 6 {
+        let keys = MLXArray.full([1, 1, 1, 2], values: MLXArray(Float(position)))
+        let values = MLXArray.full([1, 1, 1, 2], values: MLXArray(Float(position) + 100))
+        _ = cache.update(keys: keys, values: values)
+    }
+    #expect(cache.offset == 6)
+
+    let ordered = try #require(cache.temporallyOrderedKV())
+    #expect(ordered.keys.dim(2) == 4)
+    let keyPositions = ordered.keys[0, 0, 0..., 0].asArray(Float.self)
+    #expect(keyPositions == [2, 3, 4, 5])
+    let valuePositions = ordered.values[0, 0, 0..., 0].asArray(Float.self)
+    #expect(valuePositions == [102, 103, 104, 105])
+
+    // Read must not mutate rotation state.
+    #expect(cache.offset == 6)
+    let again = try #require(cache.temporallyOrderedKV())
+    #expect(again.keys[0, 0, 0..., 0].asArray(Float.self) == [2, 3, 4, 5])
+}
+
+@Test(.serialized)
+func testRotatingKVCacheTemporallyOrderedKVBeforeWrap() async throws {
+    let mlxTestLock = lockSerializedMLXTest()
+    defer { mlxTestLock.unlock() }
+
+    let cache = RotatingKVCache(maxSize: 8, keep: 0)
+    for position in 0 ..< 3 {
+        let keys = MLXArray.full([1, 1, 1, 2], values: MLXArray(Float(position)))
+        let values = MLXArray.full([1, 1, 1, 2], values: MLXArray(Float(position)))
+        _ = cache.update(keys: keys, values: values)
+    }
+
+    let ordered = try #require(cache.temporallyOrderedKV())
+    #expect(ordered.keys.dim(2) == 3)
+    #expect(ordered.keys[0, 0, 0..., 0].asArray(Float.self) == [0, 1, 2])
+    #expect(cache.offset == 3)
+}
+
+@Test(.serialized)
+func testKVCacheSimpleReadKV() async throws {
+    let mlxTestLock = lockSerializedMLXTest()
+    defer { mlxTestLock.unlock() }
+
+    let cache = KVCacheSimple()
+    for position in 0 ..< 3 {
+        let keys = MLXArray.full([1, 1, 1, 2], values: MLXArray(Float(position)))
+        let values = MLXArray.full([1, 1, 1, 2], values: MLXArray(Float(position)))
+        _ = cache.update(keys: keys, values: values)
+    }
+
+    let read = try #require(cache.readKV())
+    #expect(read.keys.dim(2) == 3)
+    #expect(read.keys[0, 0, 0..., 0].asArray(Float.self) == [0, 1, 2])
+    #expect(cache.offset == 3)
+
+    let empty = KVCacheSimple()
+    #expect(empty.readKV() == nil)
+    #expect(RotatingKVCache(maxSize: 4).temporallyOrderedKV() == nil)
+}
+
+// MARK: - Block-diffusion primitives (Task 2)
+
+@Test
+func testBlockDiffusionTemperatureSchedule() {
+    // First denoising step (curStep == maxSteps) runs at tMax.
+    #expect(
+        blockDiffusionTemperature(curStep: 48, maxSteps: 48, tMin: 0.4, tMax: 0.8) == 0.8)
+    // Annealing toward tMin as curStep approaches 0.
+    let nearEnd = blockDiffusionTemperature(curStep: 1, maxSteps: 48, tMin: 0.4, tMax: 0.8)
+    #expect(abs(nearEnd - (0.4 + 0.4 / 48)) < 1e-6)
+    // Midpoint.
+    let mid = blockDiffusionTemperature(curStep: 24, maxSteps: 48, tMin: 0.4, tMax: 0.8)
+    #expect(abs(mid - 0.6) < 1e-6)
+}
+
+@Test(.serialized)
+func testCanvasTokenEntropy() async throws {
+    let mlxTestLock = lockSerializedMLXTest()
+    defer { mlxTestLock.unlock() }
+
+    // Near-one-hot logits → entropy ≈ 0; uniform logits → entropy ≈ ln(V).
+    let vocab = 16
+    var oneHot = [Float](repeating: -1e9, count: vocab)
+    oneHot[3] = 0
+    let uniform = [Float](repeating: 0, count: vocab)
+    let logits = MLXArray(oneHot + uniform).reshaped(1, 2, vocab)
+
+    let entropy = canvasTokenEntropy(processedLogits: logits)
+    #expect(entropy.shape == [1, 2])
+    let values = entropy[0].asArray(Float.self)
+    #expect(values[0] < 1e-3)
+    #expect(abs(values[1] - log(Float(vocab))) < 1e-3)
+}
+
+@Test(.serialized)
+func testEntropyBoundAcceptMask() async throws {
+    let mlxTestLock = lockSerializedMLXTest()
+    defer { mlxTestLock.unlock() }
+
+    // Acceptance at sorted rank k requires the SUM of all lower entropies
+    // to stay within the bound (cum_k − sorted_k = Σ_{i<k}).
+    // Entropies [0.0, 5.0, 0.2]: ranks give Σ_{i<k} = [0, 0, 0.2]
+    // → with bound 0.1 accept positions 0 and 2, reject the 5.0 token.
+    let entropy = MLXArray([Float(0.0), 5.0, 0.2]).reshaped(1, 3)
+    let mask = entropyBoundAcceptMask(tokenEntropy: entropy, entropyBound: 0.1)
+    #expect(mask.shape == [1, 3])
+    let accepted = mask[0].asArray(Bool.self)
+    #expect(accepted == [true, false, true])
+
+    // The lowest-entropy token is always accepted, even when above the bound.
+    let high = MLXArray([Float(3.0), 4.0]).reshaped(1, 2)
+    let highMask = entropyBoundAcceptMask(tokenEntropy: high, entropyBound: 0.1)
+    #expect(highMask[0].asArray(Bool.self) == [true, false])
+}
+
+@Test
+func testStableConfidentStopper() {
+    var stopper = StableConfidentStopper(stabilityThreshold: 1, confidenceThreshold: 0.005)
+
+    let canvasA: [Int32] = [1, 2, 3]
+    let canvasB: [Int32] = [1, 2, 4]
+
+    // First step: no history yet → not stable, even when confident.
+    #expect(stopper.shouldStop(argmaxCanvas: canvasA, meanEntropy: 0.001) == false)
+    // Second step, same canvas, confident → stop.
+    #expect(stopper.shouldStop(argmaxCanvas: canvasA, meanEntropy: 0.001) == true)
+
+    stopper.reset()
+    #expect(stopper.shouldStop(argmaxCanvas: canvasA, meanEntropy: 0.001) == false)
+    // Canvas changed → not stable.
+    #expect(stopper.shouldStop(argmaxCanvas: canvasB, meanEntropy: 0.001) == false)
+    // Stable but not confident → keep denoising.
+    #expect(stopper.shouldStop(argmaxCanvas: canvasB, meanEntropy: 0.5) == false)
+    // Stable and confident → stop.
+    #expect(stopper.shouldStop(argmaxCanvas: canvasB, meanEntropy: 0.0001) == true)
+}
+
+// MARK: - generation_config.json diffusion fields (Task 4)
+
+@Test
+func testGenerationConfigFileDecodesDiffusionFields() throws {
+    // Verbatim from the local DiffusionGemma bundles.
+    let json = """
+        {
+          "confidence_threshold": 0.005,
+          "eos_token_id": [1, 106, 50],
+          "max_denoising_steps": 48,
+          "max_new_tokens": 256,
+          "pad_token_id": 0,
+          "sampler_config": {
+            "_cls_name": "EntropyBoundSamplerConfig",
+            "entropy_bound": 0.1
+          },
+          "stability_threshold": 1,
+          "t_max": 0.8,
+          "t_min": 0.4,
+          "transformers_version": "5.8.0.dev0"
+        }
+        """
+    let config = try JSONDecoder().decode(
+        GenerationConfigFile.self, from: Data(json.utf8))
+    #expect(config.eosTokenIds?.values == [1, 106, 50])
+    #expect(config.maxNewTokens == 256)
+    #expect(config.maxDenoisingSteps == 48)
+    #expect(config.samplerConfig?.entropyBound == 0.1)
+    #expect(config.tMin == 0.4)
+    #expect(config.tMax == 0.8)
+    #expect(config.stabilityThreshold == 1)
+    #expect(config.confidenceThreshold == 0.005)
+    #expect(config.padTokenId == 0)
+
+    let defaults = BlockDiffusionParameters(canvasLength: 256)
+        .resolving(generationConfig: config)
+    #expect(defaults.canvasLength == 256)
+    #expect(defaults.maxDenoisingSteps == 48)
+    #expect(defaults.entropyBound == 0.1)
+    #expect(defaults.eosTokenIds == Set([1, 106, 50]))
+    #expect(defaults.padTokenId == 0)
+}

--- a/Tests/MLXLMTests/DiffusionGemmaTests.swift
+++ b/Tests/MLXLMTests/DiffusionGemmaTests.swift
@@ -10,6 +10,7 @@ import Foundation
 import MLX
 import Testing
 
+@testable import MLXLLM
 @testable import MLXLMCommon
 
 // MARK: - Ordered KV read APIs (Task 1)
@@ -157,6 +158,168 @@ func testStableConfidentStopper() {
     #expect(stopper.shouldStop(argmaxCanvas: canvasB, meanEntropy: 0.5) == false)
     // Stable and confident → stop.
     #expect(stopper.shouldStop(argmaxCanvas: canvasB, meanEntropy: 0.0001) == true)
+}
+
+// MARK: - DiffusionGemma model family (Task 3)
+
+/// Tiny configuration that exercises every diffusion code path: one sliding
+/// + one full-attention layer, MoE routing, K=V full attention, canvas of 8.
+private func tinyDiffusionGemmaConfiguration() throws -> DiffusionGemmaConfiguration {
+    let json = """
+        {
+          "model_type": "diffusion_gemma",
+          "canvas_length": 8,
+          "eos_token_id": [1, 7],
+          "image_token_id": 60,
+          "text_config": {
+            "model_type": "diffusion_gemma_text",
+            "vocab_size": 64,
+            "hidden_size": 8,
+            "intermediate_size": 16,
+            "moe_intermediate_size": 8,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "num_global_key_value_heads": 1,
+            "head_dim": 4,
+            "global_head_dim": 4,
+            "num_experts": 4,
+            "top_k_experts": 2,
+            "sliding_window": 4,
+            "layer_types": ["sliding_attention", "full_attention"],
+            "final_logit_softcapping": 30.0,
+            "rms_norm_eps": 1e-6,
+            "pad_token_id": 0,
+            "rope_parameters": {
+              "sliding_attention": {"rope_type": "default", "rope_theta": 10000.0},
+              "full_attention": {
+                "rope_type": "proportional",
+                "partial_rotary_factor": 0.25,
+                "rope_theta": 1000000.0
+              }
+            }
+          }
+        }
+        """
+    return try JSONDecoder().decode(
+        DiffusionGemmaConfiguration.self, from: Data(json.utf8))
+}
+
+@Test(.serialized)
+func testDiffusionGemmaCacheTopologyAndDefaults() async throws {
+    let mlxTestLock = lockSerializedMLXTest()
+    defer { mlxTestLock.unlock() }
+
+    let config = try tinyDiffusionGemmaConfiguration()
+    let model = DiffusionGemmaModel(config)
+
+    let cache = model.newCache(parameters: nil)
+    #expect(cache.count == 2)
+    let sliding = try #require(cache[0] as? RotatingKVCache)
+    #expect(sliding.maxSize == 4)
+    #expect(cache[1] is KVCacheSimple)
+
+    let defaults = model.blockDiffusionDefaults
+    #expect(defaults.canvasLength == 8)
+    #expect(defaults.eosTokenIds == Set([1, 7]))
+    #expect(defaults.padTokenId == 0)
+    #expect(model.diffusionVocabularySize == 64)
+}
+
+@Test(.serialized)
+func testDiffusionGemmaPrepareThrowsARGuard() async throws {
+    let mlxTestLock = lockSerializedMLXTest()
+    defer { mlxTestLock.unlock() }
+
+    let config = try tinyDiffusionGemmaConfiguration()
+    let model = DiffusionGemmaModel(config)
+    let input = LMInput(text: .init(tokens: MLXArray([1, 2, 3].map { Int32($0) })))
+
+    #expect(throws: BlockDiffusionModelError.self) {
+        _ = try model.prepare(input, cache: model.newCache(parameters: nil), windowSize: 512)
+    }
+}
+
+@Test(.serialized)
+func testDiffusionGemmaSanitize() async throws {
+    let mlxTestLock = lockSerializedMLXTest()
+    defer { mlxTestLock.unlock() }
+
+    let weights: [String: MLXArray] = [
+        // Fused experts (E=4, out=2*8, in=8) → split into gate/up halves.
+        "model.decoder.layers.0.experts.gate_up_proj.weight": MLXArray.zeros([4, 16, 8]),
+        "model.decoder.layers.0.experts.gate_up_proj.scales": MLXArray.zeros([4, 16, 2]),
+        "model.decoder.layers.0.experts.down_proj.weight": MLXArray.zeros([4, 8, 8]),
+        // Encoder side: keep scalars, drop vision tower / embedder.
+        "model.encoder.language_model.layers.0.layer_scalar": MLXArray.ones([1]),
+        "model.encoder.vision_tower.patch_embedder.input_proj.weight": MLXArray.zeros([4, 4]),
+        "model.encoder.embed_vision.embedding_projection.weight": MLXArray.zeros([4, 4]),
+        // Ordinary decoder weight passes through unchanged.
+        "model.decoder.layers.0.self_attn.q_proj.weight": MLXArray.zeros([8, 8]),
+    ]
+
+    let config = try tinyDiffusionGemmaConfiguration()
+    let model = DiffusionGemmaModel(config)
+    let sanitized = model.sanitize(weights: weights)
+
+    let gate = try #require(
+        sanitized["model.decoder.layers.0.experts.switch_glu.gate_proj.weight"])
+    #expect(gate.shape == [4, 8, 8])
+    let up = try #require(
+        sanitized["model.decoder.layers.0.experts.switch_glu.up_proj.weight"])
+    #expect(up.shape == [4, 8, 8])
+    let gateScales = try #require(
+        sanitized["model.decoder.layers.0.experts.switch_glu.gate_proj.scales"])
+    #expect(gateScales.shape == [4, 8, 2])
+    #expect(sanitized["model.decoder.layers.0.experts.switch_glu.down_proj.weight"] != nil)
+    #expect(sanitized["model.decoder.layers.0.experts.gate_up_proj.weight"] == nil)
+    #expect(sanitized["model.decoder.layers.0.experts.down_proj.weight"] == nil)
+
+    #expect(sanitized["model.encoder.language_model.layers.0.layer_scalar"] != nil)
+    #expect(
+        sanitized["model.encoder.vision_tower.patch_embedder.input_proj.weight"] == nil)
+    #expect(
+        sanitized["model.encoder.embed_vision.embedding_projection.weight"] == nil)
+    #expect(sanitized["model.decoder.layers.0.self_attn.q_proj.weight"] != nil)
+}
+
+@Test(.serialized)
+func testDiffusionGemmaEncoderDecoderForward() async throws {
+    let mlxTestLock = lockSerializedMLXTest()
+    defer { mlxTestLock.unlock() }
+
+    let config = try tinyDiffusionGemmaConfiguration()
+    let model = DiffusionGemmaModel(config)
+    let cache = model.newCache(parameters: nil)
+
+    // Encoder prefill: 6 tokens > sliding window 4, so the rotating cache
+    // wraps and the decoder read path must reorder it.
+    let prompt = MLXArray([3, 4, 5, 6, 7, 8].map { Int32($0) }).expandedDimensions(axis: 0)
+    model.encoderForward(prompt, cache: cache)
+    #expect(cache[0].offset == 6)
+    #expect(cache[1].offset == 6)
+
+    // Decoder forward returns [1, C, V] and must NOT mutate the cache.
+    let canvas = MLXArray((0 ..< 8).map { Int32($0 % 64) }).expandedDimensions(axis: 0)
+    let logits = model.decoderForward(
+        canvas: canvas, cache: cache, selfConditioningLogits: nil)
+    #expect(logits.shape == [1, 8, 64])
+    // Softcap bound holds (forces materialization of the graph).
+    #expect(abs(logits).max().item(Float.self) <= 30.0)
+    #expect(cache[0].offset == 6)
+    #expect(cache[1].offset == 6)
+
+    // Self-conditioning must influence the logits.
+    let conditioned = model.decoderForward(
+        canvas: canvas, cache: cache, selfConditioningLogits: logits)
+    #expect(conditioned.shape == [1, 8, 64])
+    let difference = abs(conditioned - logits).max().item(Float.self)
+    #expect(difference > 1e-4)
+
+    // A second encoder append (the finalized canvas) advances the cache.
+    model.encoderForward(canvas, cache: cache)
+    #expect(cache[0].offset == 14)
+    #expect(cache[1].offset == 14)
 }
 
 // MARK: - generation_config.json diffusion fields (Task 4)

--- a/Tests/MLXLMTests/DiffusionGemmaTests.swift
+++ b/Tests/MLXLMTests/DiffusionGemmaTests.swift
@@ -467,6 +467,15 @@ func testGenerationConfigFileDecodesDiffusionFields() throws {
         .resolving(generationConfig: config)
     #expect(defaults.canvasLength == 256)
     #expect(defaults.maxDenoisingSteps == 48)
+
+    // Per-request speed/quality override (app slider path).
+    var fast = GenerateParameters()
+    fast.diffusionMaxDenoisingSteps = 16
+    #expect(defaults.overriding(parameters: fast).maxDenoisingSteps == 16)
+    var clamped = GenerateParameters()
+    clamped.diffusionMaxDenoisingSteps = 0
+    #expect(defaults.overriding(parameters: clamped).maxDenoisingSteps == 1)
+    #expect(defaults.overriding(parameters: GenerateParameters()).maxDenoisingSteps == 48)
     #expect(defaults.entropyBound == 0.1)
     #expect(defaults.eosTokenIds == Set([1, 106, 50]))
     #expect(defaults.padTokenId == 0)

--- a/docs/DIFFUSIONGEMMA_ENGINE_RUNTIME_2026_06_12.md
+++ b/docs/DIFFUSIONGEMMA_ENGINE_RUNTIME_2026_06_12.md
@@ -96,6 +96,28 @@ higher-precision logits converge in fewer denoising steps (68 vs 98
 forwards for the same essay). Output was a coherent, factually grounded
 multi-paragraph essay on both quants.
 
+Per-step profile (instrumented): the 256-wide decoder forward is 91% of
+denoise time (178 ms/forward MXFP4, 254 ms MXFP8); the sampler pipeline
+(softmax/entropy/sort over the 262k vocab) is 9%. The engine is
+forward-bound — throughput is governed by the model's convergence rate.
+
+### Speed/quality control (`GenerateParameters.diffusionMaxDenoisingSteps`)
+
+Per-request override of the bundle's denoising budget — the hook for an
+app-level Quality ⟷ Speed slider. Swept on MXFP4, same essay prompt:
+
+| max_denoising_steps | Wall tok/s | TTFT | Coherency |
+|---|---|---|---|
+| 48 (bundle default) | 36.9 | 6.7 s | clean |
+| 24 | 57.9 | 4.2 s | clean |
+| 16 | 73.8 | 3.4 s | clean (essay + 3-turn recall verified) |
+| 8 | 140.5 | 1.8 s | BREAKS (word-salad spans) |
+
+Raising `entropy_bound` (0.1 → 0.4 at 48 steps) does not help: 37.9
+tok/s — the step budget is the lever. Recommended app slider range
+16–48, default 48 (quality). The override is clamped to ≥ 1 and ignored
+by autoregressive models.
+
 ### Tool calls (BENCH_BATCH_TOOLCALL, BatchEngine solo path)
 
 Both quants: structured `get_weather({"location":"Tokyo"})` extracted

--- a/docs/DIFFUSIONGEMMA_ENGINE_RUNTIME_2026_06_12.md
+++ b/docs/DIFFUSIONGEMMA_ENGINE_RUNTIME_2026_06_12.md
@@ -1,0 +1,139 @@
+# DiffusionGemma Block-Diffusion Runtime — 2026-06-12
+
+Native `diffusion_gemma` generation engine for
+`google/diffusiongemma-26B-A4B-it` (30-layer Gemma4-style MoE, 128 experts
+top-8, 26B total / ~4B active). Companion to the quant-prep lane in
+`docs/DIFFUSIONGEMMA_ENGINE_QUANT_PREP_2026_06_12.md` (PR #45).
+
+## Engine
+
+DiffusionGemma is NOT autoregressive. Generation runs an outer
+block-autoregressive loop over fixed 256-token canvases; each canvas is
+produced by an inner denoising loop:
+
+1. **Encoder forward** (causal, cache-writing) over committed tokens —
+   the prompt on prefill, then each finalized canvas.
+2. Random canvas init (uniform over vocab), self-conditioning reset.
+3. **Denoising steps** (`max_denoising_steps` 48, counts down):
+   decoder forward (bidirectional over the canvas, reading — never
+   writing — the encoder cache, with self-conditioning soft embeddings),
+   linear temperature schedule (t 0.8 → 0.4), categorical denoiser
+   sampling, entropy-bound acceptance (entropy_bound 0.1,
+   arXiv 2505.24857), renoise of rejected positions, stable+confident
+   adaptive stopping (stability 1, confidence 0.005).
+4. Finalize the argmax canvas; truncate the emitted stream after EOS
+   ([1, 106, 50]).
+
+All diffusion sampling parameters come from the bundle's
+`generation_config.json`. User `maxTokens` only caps output length —
+no synthetic temperature/top-p overrides anywhere in the lane.
+
+Components:
+
+- `Libraries/MLXLLM/Models/DiffusionGemma.swift` — model family
+  (dual-mode attention, parallel dense-MLP+MoE layers, self-conditioning,
+  encoder layer scalars, sanitize for the MXFP bundles).
+- `Libraries/MLXLMCommon/Diffusion/BlockDiffusion.swift` — protocol +
+  sampler primitives (unit-tested against the HF reference math).
+- `Libraries/MLXLMCommon/Diffusion/BlockDiffusionTokenIterator.swift` —
+  the loop, prefix/disk cache integration, instrumentation.
+- Dispatch: `generate()`, `ChatSession`, and `BatchEngine`
+  (exclusive solo path, same mechanism as native MTP) route on
+  `model is BlockDiffusionModel`. The model's `prepare()` throws, so a
+  silent AR route is impossible — `Tests/MLXLMTests/DiffusionGemmaTests`
+  asserts this (15 tests).
+
+## Cache topology
+
+- Encoder cache: `RotatingKVCache(window=1024, keep=0)` on the 25
+  sliding layers, `KVCacheSimple` on the 5 full-attention layers —
+  identical to Gemma4. KV is plain fp16; TurboQuant KV is not enabled
+  for this lane (rotating-cache TQ does not exist upstream for any
+  family yet).
+- Decoder reads the encoder cache via new read-only accessors
+  (`RotatingKVCache.temporallyOrderedKV()`, `KVCacheSimple.readKV()`);
+  decoder forwards never mutate cache offsets (test-asserted).
+- Prefix cache: rotating layers cannot round-trip through paged KV
+  blocks, so the iterator marks the coordinator paged-incompatible and
+  prompt boundaries are served by the disk (L2/SSD) tier — the same
+  contract the AR iterators use for Gemma4.
+- End-of-turn contract: the emitted reply (minus trailing EOS) is
+  committed to the encoder cache, so multi-turn live-cache sessions
+  mirror AR cache state exactly.
+
+## Verification rows (M5 Max, release build, 2026-06-12)
+
+### Multi-turn coherency (BENCH_COHERENT, ChatSession, 3 turns × 2 loops)
+
+MXFP4 (15 GB bundle, load 1.26 s):
+
+| Turn | Reply | Steps | Decode tok/s | TTFT |
+|---|---|---|---|---|
+| 1 "My favorite color is blue." | "Blue is a very popular and calming color!" | 8 | 4.3 | 3.74 s (cold) |
+| 2 "What is my favorite color?" | "Your favorite color is blue." | 3 | 13.1 | 0.60 s |
+| 3 "Is that a warm or cool color?" | "Blue is considered a cool color." | 3 | 14.8 | 0.61 s |
+
+MXFP8 (26 GB bundle, load 1.29 s): same answers; steps 2–6; decode
+7.4–16.2 tok/s; warm TTFT 0.52–0.77 s.
+
+Steady decode rate: ~5.6 denoising forwards/s (MXFP4), ~4.5 (MXFP8).
+Emitted tok/s = forwards/s × tokens-accepted-per-forward — short replies
+under-fill the 256-token canvas, so the long-form row below is the
+representative throughput number.
+
+### Long-form throughput (BENCH_SOLO_LONGFORM, ~740-token essay)
+
+| | MXFP4 | MXFP8 |
+|---|---|---|
+| Wall tok/s | 36.8 | 42.3 |
+| Tokens per forward | 7.49 | 10.94 |
+| Denoise steps per canvas | 32.7 | 22.7 |
+| Canvases | 3 | 3 |
+| TTFT (first full canvas) | 5.9 s | 5.8 s |
+
+MXFP8 is FASTER than MXFP4 long-form despite slower per-forward compute:
+higher-precision logits converge in fewer denoising steps (68 vs 98
+forwards for the same essay). Output was a coherent, factually grounded
+multi-paragraph essay on both quants.
+
+### Tool calls (BENCH_BATCH_TOOLCALL, BatchEngine solo path)
+
+Both quants: structured `get_weather({"location":"Tokyo"})` extracted
+via the Gemma4 parser (`<|tool_call>call:name{...}<tool_call|>`), zero
+raw markers leaked to `.chunk`. MXFP4 25.6 decode tok/s (4 steps),
+MXFP8 40.5 decode tok/s (2 steps). Reasoning stamp resolves to
+`harmony` (`<|channel>thought` envelope; template-verified).
+
+### Prefix + disk (SSD) cache
+
+- `BENCH_SOLO_DISK_RESTORE` (new row, `BatchEngine.generate` solo path):
+  session 1 stores the 138-token prompt boundary; a FRESH coordinator on
+  the same disk dir hits the disk tier (`matched=138/138`); session 2
+  restores fully — `prefixCacheRestoredTokens=138, prefillSec=0.000,
+  encoderForwards=0` — and answers identically.
+- `BENCH_BATCH_CACHE_HIT` passes (turn-2 extension restored from the
+  stored boundary).
+- Warm ChatSession turns prefill in 0.07–0.13 s vs 0.7–1.4 s cold.
+
+### Memory
+
+Peak process RSS during the 3-turn coherent run (release build):
+MXFP4 12.7 GB, MXFP8 23.8 GB.
+
+### Isolation
+
+All shared-surface changes are additive (read-only cache accessors,
+optional `GenerationConfigFile` fields, protocol-gated dispatch
+branches, one registry entry). `DiffusionGemmaTests` 15/15 green; the
+cross-suite parallel-Metal crash seen when running many suites in one
+process reproduces identically on clean main @ 710eb0d7 (pre-existing
+test-infra flake, not introduced by this lane).
+
+## Boundaries
+
+- **Text only.** The vision tower ships in the bundles (fp16) but is
+  not wired; image/VL is not claimed. Video has no `video_token_id`;
+  audio is absent from the bundle config.
+- Block diffusion runs as an exclusive solo path in `BatchEngine`;
+  batched multi-slot canvas scheduling is future work.
+- TurboQuant KV and compiled-decode fast paths are not applicable yet.


### PR DESCRIPTION
## Summary

Adds a native `diffusion_gemma` model family with a real block-diffusion generation engine for `google/diffusiongemma-26B-A4B-it`. DiffusionGemma generates fixed 256-token canvases by iterative denoising — not autoregressive next-token decode.

- `DiffusionGemmaModel` (MLXLLM): Gemma4-style MoE transformer (30 layers, 128 experts top-8, parallel dense MLP + routed experts) with dual forwards — a causal cache-writing encoder over committed tokens, and a bidirectional cache-reading decoder over the canvas with self-conditioning soft embeddings.
- `BlockDiffusionTokenIterator` (MLXLMCommon): the reference generation loop — random canvas init, linear temperature schedule (0.8→0.4), categorical denoiser sampling, entropy-bound acceptance (arXiv 2505.24857), renoise, stable+confident adaptive stopping, per-step self-conditioning; canvases commit to the encoder cache and the stream truncates after EOS.
- All diffusion sampling parameters come from the bundle's `generation_config.json` (steps 48, entropy_bound 0.1, t 0.4–0.8, stability 1, confidence 0.005, eos [1,106,50]); user `maxTokens` only caps length.

## Routing and isolation

- `generate()`, `ChatSession`, and `BatchEngine` (exclusive solo path — same mechanism as native MTP) dispatch on `model is BlockDiffusionModel`. Other models take their existing paths unchanged.
- `DiffusionGemmaModel.prepare()` throws, so any AR route (TokenIterator, batched slots) fails loudly instead of silently next-token-decoding a diffusion model (test-asserted).
- Shared-surface changes are additive only: read-only ordered-KV accessors on `RotatingKVCache`/`KVCacheSimple`, optional `GenerationConfigFile` diffusion fields, one registry entry, protocol-gated dispatch branches.

## Cache stack

- Encoder cache topology matches Gemma4: `RotatingKVCache(window=1024)` sliding layers, `KVCacheSimple` full-attention layers; plain fp16 KV.
- Decoder reads the encoder cache without mutating it (temporally-ordered reads; sliding layers see the trailing window−1 positions).
- Prefix cache served by the disk (L2/SSD) tier — rotating layers can't round-trip through paged blocks, so the iterator marks the coordinator paged-incompatible, same contract as the AR iterators.
- End-of-turn: the emitted reply (minus trailing EOS) commits to the encoder cache, so multi-turn live-cache sessions mirror AR cache state.

## Tool calls / reasoning

`diffusion_gemma` maps to the Gemma-4 tool-call format (`<|tool_call>call:name{...}<tool_call|>`) and the `harmony` reasoning stamp (`<|channel>thought…<channel|>`) — verified against the bundle chat template (Gemma-4 template family).

## Verification (M5 Max, release build — full rows in docs/DIFFUSIONGEMMA_ENGINE_RUNTIME_2026_06_12.md)

- `swift test --filter DiffusionGemmaTests` — 15/15 (sampler math vs HF reference, encoder/decoder forwards incl. ring-wrap reads, cache immutability under decoder, AR-guard, end-to-end iterator, sanitize, factory, generation_config decode).
- Long-form (≈740-token essay): MXFP4 36.8 tok/s wall (7.5 tokens/forward), MXFP8 42.3 tok/s (10.9 tokens/forward) — MXFP8 converges in fewer denoise steps.
- Multi-turn coherency: 3-turn ChatSession with fact recall on both quants; warm-turn prefill 0.07–0.13 s.
- Tool call: structured `get_weather({"location":"Tokyo"})` through the BatchEngine solo path, zero marker leakage, both quants.
- Disk/SSD cache: fresh-coordinator session resume restores the full prompt boundary (`prefixCacheRestoredTokens=138, prefillSec=0.000`); turn-extension cache-hit row passes.
- Memory: peak RSS 12.7 GB (MXFP4) / 23.8 GB (MXFP8).
- Isolation: cross-suite parallel-Metal test crash reproduces identically on clean main @ 710eb0d7 (pre-existing infra flake, not from this lane).

## Boundary

Text generation only. The vision tower ships in the bundles (fp16) but is not wired — image/VL is not claimed; video has no `video_token_id`; audio is absent from the bundle config. Batched multi-slot canvas scheduling and TurboQuant KV are future work.
