### PR TITLE
Strip tool-call control markers when a request offers no tools

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -629,9 +629,21 @@ public actor BatchEngine {
         Task {
             var detokenizer = NaiveStreamingDetokenizer(tokenizer: tokenizer)
             let activeToolSchemas = toolSchemas?.isEmpty == false ? toolSchemas : nil
-            let toolCallProcessor = activeToolSchemas.map {
-                ToolCallProcessor(format: toolCallFormat, tools: $0)
-            }
+            let toolCallProcessor: ToolCallProcessor? = {
+                if let activeToolSchemas {
+                    return ToolCallProcessor(format: toolCallFormat, tools: activeToolSchemas)
+                }
+                // No tools offered: still strip tool-call control markers for
+                // tagged formats so a model that emits tool-call syntax anyway
+                // (e.g. a hallucinated call under thinking) cannot leak literal
+                // `<|tool_call>`/`call:` markers into visible text. Strip-only
+                // mode discards the fabricated call since none was requested.
+                if toolCallFormat.hasTaggedToolMarkers {
+                    return ToolCallProcessor(
+                        format: toolCallFormat, tools: nil, stripOnly: true)
+                }
+                return nil
+            }()
             var reasoningParser = ReasoningParser.forPrompt(
                 stampName: reasoningParserName,
                 promptTail: promptTail)

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -184,6 +184,16 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
 
     // MARK: - Factory Methods
 
+    /// Whether this format wraps tool calls in literal control markers that
+    /// would leak as visible text if not stripped. Used to decide whether a
+    /// strip-only ``ToolCallProcessor`` is needed when a request offers no
+    /// tools but the model may still emit tool-call syntax (e.g. a
+    /// hallucinated call under thinking). Inline/JSON formats have no
+    /// dedicated control markers, so they are excluded.
+    public var hasTaggedToolMarkers: Bool {
+        createParser().startTag != nil
+    }
+
     /// Create the appropriate parser for this format.
     /// - Returns: A parser instance configured for this format
     public func createParser() -> any ToolCallParser {

--- a/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
@@ -28,6 +28,13 @@ public class ToolCallProcessor {
 
     private let parser: any ToolCallParser
     private let tools: [[String: any Sendable]]?
+    /// When true, the processor still detects and strips tool-call control
+    /// markers from visible text, but never surfaces extracted tool calls.
+    /// Used when the model emits tool-call syntax (e.g. a hallucinated call
+    /// under thinking) while the request offered no tools — the markers are
+    /// template control tokens that must not leak, but no tool was requested
+    /// so none is reported.
+    private let stripOnly: Bool
     public let parsesToolCallsFromReasoningChannel: Bool
     public let usesTaggedOnlyReasoningExtraction: Bool
     public let preservesReasoningTextAroundToolCalls: Bool
@@ -39,6 +46,19 @@ public class ToolCallProcessor {
 
     /// The tool calls extracted during processing.
     public var toolCalls: [ToolCall] = []
+
+    /// Record extracted tool calls unless running strip-only (markers are
+    /// stripped from visible text either way; in strip-only mode the call
+    /// itself is discarded because no tools were offered).
+    private func recordToolCall(_ call: ToolCall) {
+        guard !stripOnly else { return }
+        toolCalls.append(call)
+    }
+
+    private func recordToolCalls(_ calls: [ToolCall]) {
+        guard !stripOnly else { return }
+        toolCalls.append(contentsOf: calls)
+    }
 
     // MARK: - State Enum
 
@@ -72,9 +92,14 @@ public class ToolCallProcessor {
     /// - Parameters:
     ///   - format: The tool call format to use (defaults to `.json` for standard JSON format)
     ///   - tools: Optional tool schemas for type-aware parsing
-    public init(format: ToolCallFormat = .json, tools: [[String: any Sendable]]? = nil) {
+    public init(
+        format: ToolCallFormat = .json,
+        tools: [[String: any Sendable]]? = nil,
+        stripOnly: Bool = false
+    ) {
         self.parser = format.createParser()
         self.tools = tools
+        self.stripOnly = stripOnly
         self.parsesToolCallsFromReasoningChannel = format.parsesToolCallsFromReasoningChannel
         self.usesTaggedOnlyReasoningExtraction = format.usesTaggedOnlyReasoningExtraction
         self.preservesReasoningTextAroundToolCalls =
@@ -144,7 +169,7 @@ public class ToolCallProcessor {
         }
 
         let parsed = parser.parseEOS(toolCallBuffer, tools: tools)
-        toolCalls.append(contentsOf: parsed)
+        recordToolCalls(parsed)
         let suppressUnparsedInlineToolIntent =
             parsed.isEmpty
             && state == .collectingInlineToolCall
@@ -199,7 +224,7 @@ public class ToolCallProcessor {
                 if inlineToolCallComplete(toolCallBuffer),
                     let toolCall = parser.parse(content: toolCallBuffer, tools: tools)
                 {
-                    toolCalls.append(toolCall)
+                    recordToolCall(toolCall)
                     toolCallBuffer = ""
                     state = .normal
                     suppressingTextAfterInlineToolCall = true
@@ -222,7 +247,7 @@ public class ToolCallProcessor {
                 if inlineToolCallComplete(toolCallBuffer),
                     let toolCall = parser.parse(content: toolCallBuffer, tools: tools)
                 {
-                    toolCalls.append(toolCall)
+                    recordToolCall(toolCall)
                     toolCallBuffer = ""
                     state = .normal
                     suppressingTextAfterInlineToolCall = true
@@ -243,7 +268,7 @@ public class ToolCallProcessor {
                 state = .collectingInlineToolCall
 
                 if let toolCall = parser.parse(content: toolCallBuffer, tools: tools) {
-                    toolCalls.append(toolCall)
+                    recordToolCall(toolCall)
                     toolCallBuffer = ""
                     state = .normal
                     suppressingTextAfterInlineToolCall = true
@@ -264,7 +289,7 @@ public class ToolCallProcessor {
                 state = .collectingInlineToolCall
 
                 if let toolCall = parser.parse(content: toolCallBuffer, tools: tools) {
-                    toolCalls.append(toolCall)
+                    recordToolCall(toolCall)
                     toolCallBuffer = ""
                     state = .normal
                     suppressingTextAfterInlineToolCall = true
@@ -287,7 +312,7 @@ public class ToolCallProcessor {
                 if requestToolXMLCallComplete(toolCallBuffer),
                     let toolCall = parser.parse(content: toolCallBuffer, tools: tools)
                 {
-                    toolCalls.append(toolCall)
+                    recordToolCall(toolCall)
                     toolCallBuffer = ""
                     state = .normal
                     suppressingTextAfterInlineToolCall = true
@@ -308,7 +333,7 @@ public class ToolCallProcessor {
                 state = .collectingInlineToolCall
 
                 if let toolCall = parser.parse(content: toolCallBuffer, tools: tools) {
-                    toolCalls.append(toolCall)
+                    recordToolCall(toolCall)
                     toolCallBuffer = ""
                     state = .normal
                     suppressingTextAfterInlineToolCall = true
@@ -331,7 +356,7 @@ public class ToolCallProcessor {
                 if bareNameKeyValueCallComplete(toolCallBuffer),
                     let toolCall = parser.parse(content: toolCallBuffer, tools: tools)
                 {
-                    toolCalls.append(toolCall)
+                    recordToolCall(toolCall)
                     toolCallBuffer = ""
                     state = .normal
                     suppressingTextAfterInlineToolCall = true
@@ -354,7 +379,7 @@ public class ToolCallProcessor {
                 state = .collectingInlineToolCall
 
                 if let toolCall = parser.parse(content: toolCallBuffer, tools: tools) {
-                    toolCalls.append(toolCall)
+                    recordToolCall(toolCall)
                     toolCallBuffer = ""
                     state = .normal
                     return visibleInlineLeading(leading)
@@ -381,7 +406,7 @@ public class ToolCallProcessor {
             if shouldAttemptInlineToolParse(toolCallBuffer),
                 let toolCall = parser.parse(content: toolCallBuffer, tools: tools)
             {
-                toolCalls.append(toolCall)
+                recordToolCall(toolCall)
                 toolCallBuffer = ""
                 state = .normal
                 if inlineToolCallKind == .actionJSON
@@ -1307,7 +1332,7 @@ public class ToolCallProcessor {
                     if shouldAttemptInlineToolParse(toolCallBuffer),
                        let toolCall = parser.parse(content: toolCallBuffer, tools: tools)
                     {
-                        toolCalls.append(toolCall)
+                        recordToolCall(toolCall)
                         toolCallBuffer = ""
                         state = .normal
                         suppressingTextAfterInlineToolCall = true
@@ -1329,7 +1354,7 @@ public class ToolCallProcessor {
                     if shouldAttemptInlineToolParse(toolCallBuffer),
                        let toolCall = parser.parse(content: toolCallBuffer, tools: tools)
                     {
-                        toolCalls.append(toolCall)
+                        recordToolCall(toolCall)
                         toolCallBuffer = ""
                         state = .normal
                         suppressingTextAfterInlineToolCall = true
@@ -1491,7 +1516,7 @@ public class ToolCallProcessor {
                 // Parse the completed wrapper. Some formats, including Hy3 /
                 // Hunyuan, can carry multiple calls inside one outer block.
                 let parsed = parser.parseEOS(toolCallBuffer, tools: tools)
-                toolCalls.append(contentsOf: parsed)
+                recordToolCalls(parsed)
 
                 state = .normal
                 toolCallBuffer = ""

--- a/Tests/MLXLMCommonToolParserFocusedTests/Gemma4NoToolsMarkerStripTests.swift
+++ b/Tests/MLXLMCommonToolParserFocusedTests/Gemma4NoToolsMarkerStripTests.swift
@@ -1,0 +1,24 @@
+import Foundation
+import Testing
+@testable import MLXLMCommon
+
+@Suite("Gemma4 tool-marker stripping with no tools in scope")
+struct Gemma4NoToolsMarkerStripTests {
+    // Reproduces the leak: thinking-on + zero tools offered + model
+    // hallucinates a Gemma tool call -> control markers must NOT reach
+    // visible text. Feeds the exact streamed body observed live.
+    @Test("Gemma4 control markers are stripped from visible text when no tools are offered")
+    func stripsMarkersWithoutTools() {
+        let processor = ToolCallProcessor(format: .gemma4, tools: nil, stripOnly: true)
+        var visible = ""
+        for chunk in ["<|tool_call>", "call:osaurus_status{}", "<tool_call|>"] {
+            if let out = processor.processChunk(chunk) { visible += out }
+        }
+        if let tail = processor.processEOS() { visible += tail }
+        #expect(!visible.contains("<|tool_call>"), "leaked start marker: \(visible)")
+        #expect(!visible.contains("<tool_call|>"), "leaked end marker: \(visible)")
+        #expect(!visible.contains("call:"), "leaked bare-call marker: \(visible)")
+        // No tools were offered, so no tool call should be surfaced.
+        #expect(processor.toolCalls.isEmpty, "must not fabricate tool calls when none offered")
+    }
+}


### PR DESCRIPTION
## Summary
Fixes a pre-existing leak: with thinking on and **zero tools in the request**, a Gemma4 bundle that emits tool-call syntax anyway (a hallucinated call) leaked literal control markers into visible text:
```
<|tool_call>call:osaurus_status{}<tool_call|>
```
Root cause: `BatchEngine.swift` only built a `ToolCallProcessor` (which strips these markers) when `toolSchemas` was non-empty; with no tools in scope the Gemma4 control markers passed through unstripped.

## Fix
- `ToolCallProcessor` gains a `stripOnly` mode: it still detects and strips tool-call control markers from visible text, but routes all extracted calls through a single chokepoint that discards them in strip-only mode (no tool was requested, so none is surfaced).
- `ToolCallFormat.hasTaggedToolMarkers` reports whether a format wraps calls in literal control markers (inline/JSON formats have none and are unaffected).
- `BatchEngine` builds a strip-only processor for tagged formats when no tools are offered, so markers can never reach visible content.

**Real-config behavior is unchanged**: the agent route and tool-bearing chat requests always pass tools and use the full parsing processor — that path is byte-identical to before (the change is a new `else` branch for the no-tools case).

## Proof
- 64 tool-parser tests pass, including a new repro test feeding the exact streamed body (`Gemma4NoToolsMarkerStripTests`) — markers stripped, no fabricated tool call.
- **Live dev build** (Osaurus pinned to this branch, 12B MXFP4, thinking on, no tools, explicit tool request): 4/4 runs clean, zero `<|tool_call>`/`call:` markers in visible content. Before the fix this exact request leaked them. Greedy (temp=0) confirms the pipeline is deterministically clean. Artifacts: `/tmp/osaurus-final-pr/proof/i1-repro-after-fix.sse`.