### PR TITLE
Wire DiffusionGemma vision path through the Gemma4 tower

### DIFF
--- a/Libraries/MLXLLM/Models/DiffusionGemma.swift
+++ b/Libraries/MLXLLM/Models/DiffusionGemma.swift
@@ -129,6 +129,9 @@ public struct DiffusionGemmaConfiguration: Codable, Sendable {
     public let imageTokenId: Int?
     let textConfig: DiffusionGemmaTextConfiguration
 
+    /// Text hidden size, exposed for the MLXVLM vision wiring.
+    public var textHiddenSize: Int { textConfig.hiddenSize }
+
     enum CodingKeys: String, CodingKey {
         case modelType = "model_type"
         case canvasLength = "canvas_length"
@@ -522,6 +525,13 @@ class DiffusionGemmaEncoderScalarStack: Module {
 class DiffusionGemmaEncoderModule: Module {
     @ModuleInfo(key: "language_model") var languageModel: DiffusionGemmaEncoderScalarStack
 
+    /// Vision attachment points. The concrete tower/embedder classes live in
+    /// MLXVLM (which depends on this module, not vice versa), so they are
+    /// installed post-init as opaque `Module`s purely for weight loading;
+    /// the compute path is injected as a closure on the top-level model.
+    @ModuleInfo(key: "vision_tower") var visionTower: Module?
+    @ModuleInfo(key: "embed_vision") var embedVision: Module?
+
     init(layerCount: Int) {
         self._languageModel.wrappedValue = DiffusionGemmaEncoderScalarStack(count: layerCount)
         super.init()
@@ -637,20 +647,44 @@ public class DiffusionGemmaModel: Module, LLMModel {
 
     func encoderForwardInternal(_ tokens: MLXArray, cache: [KVCache]) {
         let tokens = tokens.ndim == 1 ? tokens.expandedDimensions(axis: 0) : tokens
-        var h = model.decoder.embedTokens(tokens)
-        h = h * model.decoder.embedScale(h.dtype)
+        let h = embedPromptTokens(tokens)
+        runEncoderLayers(h, cache: cache, visionBlockIds: nil)
+    }
 
-        let (globalMask, slidingMask) = {
-            let m = masks(h: h, cache: cache)
-            return (m.global, m.sliding)
-        }()
+    /// Encoder forward over precomputed embeddings (multimodal prefill).
+    ///
+    /// `visionBlockIds` carries per-position contiguous image-block ids
+    /// (−1 for text positions). Image positions attend bidirectionally
+    /// within their block on top of the causal/sliding mask — the
+    /// `use_bidirectional_attention == "vision"` contract from the
+    /// reference encoder.
+    func encoderForwardInternal(
+        embeddings: MLXArray, cache: [KVCache], visionBlockIds: MLXArray?
+    ) {
+        let h = embeddings.ndim == 2 ? embeddings.expandedDimensions(axis: 0) : embeddings
+        runEncoderLayers(h, cache: cache, visionBlockIds: visionBlockIds)
+    }
+
+    private func runEncoderLayers(
+        _ embeddings: MLXArray, cache: [KVCache], visionBlockIds: MLXArray?
+    ) {
+        var h = embeddings
+        let masks: (
+            global: MLXFast.ScaledDotProductAttentionMaskMode,
+            sliding: MLXFast.ScaledDotProductAttentionMaskMode
+        )
+        if let visionBlockIds {
+            masks = visionOverlayMasks(h: h, cache: cache, visionBlockIds: visionBlockIds)
+        } else {
+            masks = self.masks(h: h, cache: cache)
+        }
 
         let layerTypes = textConfig.layerTypes
         for (i, layer) in model.decoder.layers.enumerated() {
             let isGlobal = i < layerTypes.count && layerTypes[i] == "full_attention"
             h = layer(
                 h,
-                mask: isGlobal ? globalMask : slidingMask,
+                mask: isGlobal ? masks.global : masks.sliding,
                 cache: i < cache.count ? cache[i] : nil,
                 mode: .encoder,
                 scalarOverride: model.encoder.languageModel.layers[i].layerScalar)
@@ -658,6 +692,85 @@ public class DiffusionGemmaModel: Module, LLMModel {
         // Encoder hidden states are unused — only the KV cache side effect
         // matters, so the final norm / logits are skipped.
     }
+
+    /// Causal (+ sliding-window) masks OR'd with bidirectional attention
+    /// inside each contiguous image block. Only used for media prefill,
+    /// which runs single-shot from an empty cache.
+    private func visionOverlayMasks(
+        h: MLXArray, cache: [KVCache], visionBlockIds: MLXArray?
+    ) -> (
+        global: MLXFast.ScaledDotProductAttentionMaskMode,
+        sliding: MLXFast.ScaledDotProductAttentionMaskMode
+    ) {
+        let n = h.dim(1)
+        let offset = cache.first?.offset ?? 0
+        let positions = MLXArray(Int32(offset) ..< Int32(offset + n))
+        let queryPositions = expandedDimensions(positions, axis: -1)
+        let keyPositions = expandedDimensions(positions, axis: 0)
+        let causal = greaterEqual(queryPositions, keyPositions)
+        var overlay = MLXArray.zeros([n, n], dtype: .bool)
+        if let blockIds = visionBlockIds {
+            let ids = blockIds.reshaped(-1)
+            let q = expandedDimensions(ids, axis: -1)
+            let k = expandedDimensions(ids, axis: 0)
+            overlay = logicalAnd(
+                greaterEqual(q, MLXArray(Int32(0))), equal(q, k))
+        }
+        let globalMask = logicalOr(causal, overlay)
+        let window = textConfig.slidingWindow
+        let withinWindow = less(
+            queryPositions, keyPositions + MLXArray(Int32(window)))
+        let slidingMask = logicalOr(logicalAnd(causal, withinWindow), overlay)
+        return (
+            global: .array(globalMask),
+            sliding: .array(slidingMask)
+        )
+    }
+
+    // MARK: Vision attachment (installed by the VLM factory)
+
+    /// Compute closure injected by MLXVLM: builds the full spliced prompt
+    /// embeddings (text embeds + image features scattered over the image
+    /// placeholder positions) for a media-bearing `LMInput`. `nil` (or a
+    /// closure returning `nil`) means text-only operation.
+    public var visionPromptEmbedder:
+        ((LMInput, DiffusionGemmaModel) throws -> (embeddings: MLXArray, visionBlockIds: MLXArray)?)?
+
+    /// Install the vision tower + multimodal embedder modules (for weight
+    /// loading) and the prompt-embedding compute closure. Called by the
+    /// VLM factory before weights load; text-only loads never call this.
+    public func installVision(
+        tower: Module,
+        embedder: Module,
+        promptEmbedder:
+            @escaping (LMInput, DiffusionGemmaModel) throws
+                -> (embeddings: MLXArray, visionBlockIds: MLXArray)?
+    ) {
+        model.encoder.visionTower = tower
+        model.encoder.embedVision = embedder
+        visionPromptEmbedder = promptEmbedder
+    }
+
+    /// Prompt token embedding with image placeholders mapped to pad before
+    /// embedding — the reference encoder always does this, with or without
+    /// pixels. Without it, history turns that re-render `<|image|>`
+    /// placeholders (but carry no pixels) would inject the raw image-token
+    /// embedding 280× and derail the model into immediate EOS.
+    public func embedPromptTokens(_ tokens: MLXArray) -> MLXArray {
+        var tokens = tokens.ndim == 1 ? tokens.expandedDimensions(axis: 0) : tokens
+        if let imageToken = config.imageTokenId {
+            tokens = MLX.where(
+                MLX.equal(tokens, MLXArray(Int32(imageToken))),
+                MLXArray(Int32(textConfig.padTokenId)),
+                tokens)
+        }
+        let h = model.decoder.embedTokens(tokens)
+        return h * model.decoder.embedScale(h.dtype)
+    }
+
+    public var visionTowerModule: Module? { model.encoder.visionTower }
+    public var visionEmbedderModule: Module? { model.encoder.embedVision }
+    public var imageTokenId: Int? { config.imageTokenId }
 
     func decoderForwardInternal(
         canvas: MLXArray, cache: [KVCache], selfConditioningLogits: MLXArray?
@@ -703,11 +816,15 @@ public class DiffusionGemmaModel: Module, LLMModel {
         processed.reserveCapacity(weights.count)
 
         for (key, value) in weights {
-            // Vision tower / multimodal embedder are not part of the text
-            // engine (fp16 passthrough tensors in the bundle).
+            // Vision tower / multimodal embedder: kept (with the checkpoint's
+            // ClippableLinear `.linear.` nesting stripped) when the VLM
+            // factory installed vision modules; dropped for text-only loads.
             if key.hasPrefix("model.encoder.vision_tower.")
                 || key.hasPrefix("model.encoder.embed_vision.")
             {
+                if model.encoder.visionTower != nil {
+                    processed[key.replacingOccurrences(of: ".linear.", with: ".")] = value
+                }
                 continue
             }
             if key.hasPrefix("model.encoder.language_model.") {
@@ -777,6 +894,19 @@ extension DiffusionGemmaModel: BlockDiffusionModel {
     ) -> MLXArray {
         decoderForwardInternal(
             canvas: canvas, cache: cache, selfConditioningLogits: selfConditioningLogits)
+    }
+
+    public func encoderPromptEmbeddings(
+        for input: LMInput
+    ) throws -> (embeddings: MLXArray, visionBlockIds: MLXArray)? {
+        try visionPromptEmbedder?(input, self)
+    }
+
+    public func encoderForward(
+        embeddings: MLXArray, cache: [KVCache], visionBlockIds: MLXArray?
+    ) {
+        encoderForwardInternal(
+            embeddings: embeddings, cache: cache, visionBlockIds: visionBlockIds)
     }
 }
 

--- a/Libraries/MLXLMCommon/Diffusion/BlockDiffusion.swift
+++ b/Libraries/MLXLMCommon/Diffusion/BlockDiffusion.swift
@@ -118,6 +118,33 @@ public protocol BlockDiffusionModel: LanguageModel {
     func decoderForward(
         canvas: MLXArray, cache: [KVCache], selfConditioningLogits: MLXArray?
     ) -> MLXArray
+
+    /// Multimodal prefill hook: the full spliced prompt embeddings (text
+    /// embeds + image features over the placeholder positions) plus
+    /// per-position contiguous image-block ids (−1 for text). Returns `nil`
+    /// for text-only models/inputs; the iterator then uses the token path.
+    func encoderPromptEmbeddings(
+        for input: LMInput
+    ) throws -> (embeddings: MLXArray, visionBlockIds: MLXArray)?
+
+    /// Causal forward over precomputed `embeddings` [1, T]; writes KV into
+    /// `cache`. `visionBlockIds` enables bidirectional attention inside
+    /// each image block.
+    func encoderForward(
+        embeddings: MLXArray, cache: [KVCache], visionBlockIds: MLXArray?)
+}
+
+extension BlockDiffusionModel {
+    public func encoderPromptEmbeddings(
+        for input: LMInput
+    ) throws -> (embeddings: MLXArray, visionBlockIds: MLXArray)? { nil }
+
+    public func encoderForward(
+        embeddings: MLXArray, cache: [KVCache], visionBlockIds: MLXArray?
+    ) {
+        fatalError(
+            "\(Self.self) does not implement embeddings-based encoder prefill")
+    }
 }
 
 public enum BlockDiffusionModelError: Error, CustomStringConvertible {

--- a/Libraries/MLXLMCommon/Diffusion/BlockDiffusionTokenIterator.swift
+++ b/Libraries/MLXLMCommon/Diffusion/BlockDiffusionTokenIterator.swift
@@ -163,8 +163,30 @@ public struct BlockDiffusionTokenIterator: TokenIteratorProtocol {
             }
         }
 
-        // ---- Chunked encoder prefill ------------------------------------
+        // ---- Encoder prefill ---------------------------------------------
         let prefillStart = Date.timeIntervalSinceReferenceDate
+
+        // Multimodal prompts prefill single-shot from spliced embeddings:
+        // image blocks attend bidirectionally inside the prompt, which a
+        // chunk boundary through an image span would break (mirrors the
+        // reference encoder's chunked-prefill policy). The prefix cache is
+        // already skipped for media above.
+        if input.hasMediaContent,
+            let spliced = try model.encoderPromptEmbeddings(for: input)
+        {
+            model.encoderForward(
+                embeddings: spliced.embeddings,
+                cache: self.cache,
+                visionBlockIds: spliced.visionBlockIds)
+            encoderForwardCount += 1
+            MLX.eval(self.cache)
+            self.promptPrefillTime = Date.timeIntervalSinceReferenceDate - prefillStart
+            if cacheCoordinator != nil {
+                self.promptCacheSnapshot = makePromptBoundaryCacheSnapshot(from: self.cache)
+            }
+            return
+        }
+
         let stepSize = Swift.max(parameters.prefillStepSize, 1)
         var remaining = tokensToEncode[...]
         while !remaining.isEmpty {

--- a/Libraries/MLXVLM/Models/DiffusionGemmaVLM.swift
+++ b/Libraries/MLXVLM/Models/DiffusionGemmaVLM.swift
@@ -1,0 +1,123 @@
+// Copyright © 2026 Jinho Jang (eric@jangq.ai)
+//
+// DiffusionGemma VLM wiring — attaches the Gemma4-unified vision tower and
+// multimodal embedder to the MLXLLM block-diffusion engine.
+//
+// The text engine (`DiffusionGemmaModel`, MLXLLM) owns generation; this file
+// only contributes the vision compute path:
+//
+//   pixels → VisionTower → MultimodalEmbedder → text-space features
+//   features scattered over `<|image|>` placeholder positions in the prompt
+//   embeddings (maskedScatter), image blocks attending bidirectionally
+//   during the single-shot encoder prefill.
+//
+// The bundle ships `processor_class: Gemma4Processor` and a `gemma4_vision`
+// tower config, so the processor and vision classes are reused verbatim.
+// Audio is intentionally absent: the DiffusionGemma bundle has no
+// audio_config/audio_token_id.
+//
+// Python reference: mlx_vlm/models/diffusion_gemma/{diffusion_gemma,language}.py
+// (EncoderModel._embed_inputs, _vision_block_overlay).
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import MLXNN
+
+// MARK: - Configuration
+
+public struct DiffusionGemmaVLMConfiguration: Codable, Sendable {
+    public let core: DiffusionGemmaConfiguration
+    public let visionConfig: Gemma4VisionConfig?
+
+    enum CodingKeys: String, CodingKey {
+        case visionConfig = "vision_config"
+    }
+
+    public init(from decoder: Decoder) throws {
+        core = try DiffusionGemmaConfiguration(from: decoder)
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        visionConfig = try container.decodeIfPresent(
+            Gemma4VisionConfig.self, forKey: .visionConfig)
+    }
+}
+
+// MARK: - Factory
+
+/// Build the block-diffusion engine and, when the bundle ships a vision
+/// tower, install the vision modules + the prompt-embedding splice closure.
+/// Text-only bundles (no `vision_config` / `image_token_id`) come back as
+/// the plain text engine.
+public func makeDiffusionGemmaVLM(
+    _ config: DiffusionGemmaVLMConfiguration
+) -> DiffusionGemmaModel {
+    let model = DiffusionGemmaModel(config.core)
+    guard let visionConfig = config.visionConfig,
+        let imageTokenId = config.core.imageTokenId
+    else {
+        return model
+    }
+
+    let tower = makeGemma4VisionTower(visionConfig)
+    let embedder = makeGemma4MultimodalEmbedder(
+        embDim: visionConfig.hiddenSize,
+        textDim: config.core.textHiddenSize)
+
+    model.installVision(tower: tower.module, embedder: embedder.module) { input, model in
+        guard let image = input.image else { return nil }
+        let pixels = image.pixels
+
+        // Per-image tower pass at original (unpadded) dimensions — mirrors
+        // the Gemma4 VLM prepare() contract; every image yields exactly
+        // defaultOutputLength features.
+        let batch = pixels.dim(0)
+        var featuresList = [MLXArray]()
+        featuresList.reserveCapacity(batch)
+        for i in 0 ..< batch {
+            let single: MLXArray
+            if let frames = image.frames, i < frames.count {
+                single = pixels[i, 0..., ..<frames[i].h, ..<frames[i].w]
+                    .expandedDimensions(axis: 0)
+            } else {
+                single = pixels[i].expandedDimensions(axis: 0)
+            }
+            featuresList.append(embedder.compute(tower.compute(single)))
+        }
+        let features = batch == 1 ? featuresList[0] : concatenated(featuresList)
+
+        // Text embeddings with image placeholders masked to pad before
+        // embedding, then features scattered over the placeholder slots.
+        let tokens =
+            input.text.tokens.ndim == 1
+            ? input.text.tokens.expandedDimensions(axis: 0) : input.text.tokens
+        let imageMask = MLX.equal(tokens, MLXArray(Int32(imageTokenId)))
+        var embeds = model.embedPromptTokens(tokens)
+        let maskExpanded = MLX.broadcast(
+            expandedDimensions(imageMask, axis: -1), to: embeds.shape)
+        embeds = try gemma4MaskedScatter(
+            input: embeds, mask: maskExpanded, source: features.asType(embeds.dtype))
+
+        // Contiguous image-token runs → block ids (−1 for text positions),
+        // consumed by the encoder's bidirectional vision-block overlay.
+        let ids = tokens.reshaped(-1).asArray(Int32.self)
+        var blockIds = [Int32](repeating: -1, count: ids.count)
+        var currentBlock: Int32 = -1
+        var insideBlock = false
+        for (index, token) in ids.enumerated() {
+            if token == Int32(imageTokenId) {
+                if !insideBlock {
+                    currentBlock += 1
+                    insideBlock = true
+                }
+                blockIds[index] = currentBlock
+            } else {
+                insideBlock = false
+            }
+        }
+
+        return (embeddings: embeds, visionBlockIds: MLXArray(blockIds))
+    }
+
+    return model
+}

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -1099,6 +1099,35 @@ private func maskedScatter(input: MLXArray, mask: MLXArray, source: MLXArray) th
     return inputFlat.reshaped(inputShape)
 }
 
+// MARK: - Vision reuse facade (DiffusionGemma)
+
+/// Opaque handles for sibling VLM wirings (the block-diffusion Gemma) that
+/// reuse this file's private vision tower / multimodal embedder without
+/// widening their access. The returned `module` goes into the consumer's
+/// module tree for weight loading; `compute` is the forward pass.
+struct Gemma4VisionReuse {
+    let module: Module
+    let compute: (MLXArray) -> MLXArray
+}
+
+func makeGemma4VisionTower(_ config: Gemma4VisionConfig) -> Gemma4VisionReuse {
+    let tower = VisionTower(config)
+    return Gemma4VisionReuse(module: tower, compute: { tower($0) })
+}
+
+func makeGemma4MultimodalEmbedder(embDim: Int, textDim: Int) -> Gemma4VisionReuse {
+    let embedder = MultimodalEmbedder(embDim: embDim, textDim: textDim)
+    return Gemma4VisionReuse(module: embedder, compute: { embedder($0) })
+}
+
+/// Scatter `source` features over `mask` positions of `input` — internal
+/// re-export of this file's private maskedScatter for sibling wirings.
+func gemma4MaskedScatter(
+    input: MLXArray, mask: MLXArray, source: MLXArray
+) throws -> MLXArray {
+    try maskedScatter(input: input, mask: mask, source: source)
+}
+
 // MARK: - Gemma4 VLM
 
 public class Gemma4: Module, VLMModel, KVCacheDimensionProvider {

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -116,6 +116,11 @@ public enum VLMTypeRegistry {
 
     nonisolated(unsafe) private static let _creators: [String: (Data) throws -> any LanguageModel] = [
         "paligemma": create(PaliGemmaConfiguration.self, PaliGemma.init),
+        // Block-diffusion Gemma: the MLXLLM engine with the Gemma4 vision
+        // tower installed. Generation runs via BlockDiffusionTokenIterator;
+        // the throwing prepare() guard keeps AR routes loud.
+        "diffusion_gemma": create(
+            DiffusionGemmaVLMConfiguration.self, makeDiffusionGemmaVLM),
         "qwen2_vl": create(Qwen2VLConfiguration.self, Qwen2VL.init),
         "qwen2_5_vl": create(Qwen25VLConfiguration.self, Qwen25VL.init),
         "qwen3_vl": create(Qwen3VLConfiguration.self, Qwen3VL.init),


### PR DESCRIPTION
## Summary

Adds image support to the DiffusionGemma block-diffusion engine:

- `diffusion_gemma` registered in the VLM factory: the MLXLLM engine plus the Gemma4 vision tower/multimodal embedder, installed post-init via a narrow internal reuse facade in Gemma4.swift (private vision classes stay private — no access widening, no behavior change for Gemma4).
- Multimodal encoder prefill: the bundle's `Gemma4Processor` (`processor_class` stamped in processor_config.json, 280 soft tokens/image) expands placeholders; the VLM closure splices tower features over `<|image|>` positions (maskedScatter) and the encoder runs single-shot with bidirectional attention inside each image block (`use_bidirectional_attention == "vision"` reference contract).
- Image placeholders are pad-masked before token embedding (reference parity) so history turns that re-render `<|image|>` without pixels stay coherent.
- Audio remains unsupported (bundle has no audio config); video unchanged.

## Validation
- `swift test --filter DiffusionGemmaTests` — 15/15
- Real-image proof (BENCH_VL_BATCH_CHAT, synthesized red→blue gradient, BatchEngine.generate solo path):
  - MXFP4: "This image features a vertical gradient transitioning from vibrant red at the top to deep blue at the bottom."
  - MXFP8: same description; follow-up one-word turn answered "Blue".
  - AR-guard verified: the TokenIterator-driven VL bench fails loudly (throwing prepare), as designed.
- Known model behavior: terse prompts under greedy denoising occasionally converge to an EOS-first canvas (empty answer) — stochastic canvas init, present in reference semantics, more frequent on MXFP4.