### PR TITLE
Fix DiffusionGemma MoE router crash on quantized tied head

### DIFF
--- a/Libraries/MLXLLM/Models/DiffusionGemma.swift
+++ b/Libraries/MLXLLM/Models/DiffusionGemma.swift
@@ -782,7 +782,22 @@ public class DiffusionGemmaModel: Module, LLMModel {
         if let logits = selfConditioningLogits {
             // Soft embeddings from the previous step's logits.
             let probs = softmax(logits.asType(.float32), axis: -1, precise: true)
-            let soft = probs.asType(embeds.dtype).matmul(model.decoder.embedTokens.weight)
+            // The tied embedding head ships quantized in many bundles (e.g.
+            // Gemma 4 QAT q6). Its packed `.weight` is grouped along the hidden
+            // axis, so the soft-embedding contraction over the vocab axis is not
+            // a valid quantized matmul and collapses the signal to a 0-D scalar
+            // (crashing the MoE router on denoising step >= 2). Dequantize the
+            // embedding table for this `probs @ W` soft-embedding; dense bundles
+            // keep using the plain weight.
+            let embedTable: MLXArray
+            if let qEmbed = model.decoder.embedTokens as? QuantizedEmbedding {
+                embedTable = dequantized(
+                    qEmbed.weight, scales: qEmbed.scales, biases: qEmbed.biases,
+                    groupSize: qEmbed.groupSize, bits: qEmbed.bits, mode: qEmbed.mode)
+            } else {
+                embedTable = model.decoder.embedTokens.weight
+            }
+            let soft = probs.asType(embeds.dtype).matmul(embedTable.asType(embeds.dtype))
             signal = soft * model.decoder.embedScale(embeds.dtype)
         } else {
             signal = MLXArray.zeros(embeds.shape, dtype: embeds.dtype)


### PR DESCRIPTION
## Problem
`diffusiongemma-26B-A4B` (mxfp4/mxfp8) crashes the entire host process (SIGTRAP) on the second
block-diffusion denoising step. The MoE router's `argPartition(...)[.ellipsis, ..<topK]` trips an
MLXArray indexing precondition because its input collapses to a 0-D scalar.

## Root cause
The decoder's soft self-conditioning embedding is computed as `probs @ embed_tokens.weight`. These
QAT bundles ship a **quantized tied embedding head** (q6), so `embed_tokens` is a `QuantizedEmbedding`
whose packed `.weight` is grouped along the hidden axis. Contracting `probs` over the vocab axis is not
a valid quantized matmul and collapses the signal to a 0-D scalar; the hidden state then becomes rank-0
and the MoE router crashes. Denoising step 1 uses a zeros signal (no matmul), so the crash only appears
once self-conditioning engages on step ≥2. Only the A4B (MoE) diffusion variant has a router, so the
dense path never exercised this.

## Fix
Dequantize the embedding table for the soft-embedding when the head is a `QuantizedEmbedding`; dense
bundles keep using the plain weight. One isolated change in `DiffusionGemma.swift`.

## Verification (live, Release)
- `diffusiongemma-26B-A4B-it-mxfp4` → "The capital of France is Paris." (no crash)
- `diffusiongemma-26B-A4B-it-mxfp8` → "The capital of France is Paris." (no crash)
- Regression: `gemma-4-12B-it-qat-mxfp4` decode 57 tok/s, coherent — unchanged (change is isolated to DiffusionGemma).