### PR TITLE
Fix Gemma tool path scrambling plain prose

### DIFF
--- a/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
@@ -1342,7 +1342,7 @@ public class ToolCallProcessor {
                 if let fragmentIndex = partialInlineBareNameJSONToolCallStart(in: candidate) {
                     let leading = String(candidate[..<fragmentIndex])
                     leadingTextBeforeToolCall = String(candidate[fragmentIndex...])
-                    return visibleInlineLeading(leading)
+                    return leading.isEmpty ? nil : leading
                 }
                 if let callIndex = firstBareCallToolCallStart(in: candidate) {
                     let leading = String(candidate[..<callIndex])
@@ -1364,7 +1364,18 @@ public class ToolCallProcessor {
                 if let fragmentIndex = partialBareCallToolCallStart(in: candidate) {
                     let leading = String(candidate[..<fragmentIndex])
                     leadingTextBeforeToolCall = String(candidate[fragmentIndex...])
-                    return visibleInlineLeading(leading)
+                    return leading.isEmpty ? nil : leading
+                }
+                // A previously buffered bare-call fragment (a trailing "c"/
+                // "ca"/"cal"/"call" that looked like the start of `call:`) did
+                // not continue into a tool call. Flush the held text together
+                // with this chunk, in order, so ordinary prose is never dropped
+                // or reordered. Gemma is the only family with bare-call
+                // fallback and it never enables inline-JSON fallback, so no
+                // later stage would otherwise consume this candidate.
+                if !leadingTextBeforeToolCall.isEmpty {
+                    leadingTextBeforeToolCall = ""
+                    return candidate.isEmpty ? nil : candidate
                 }
             case .collectingInlineToolCall:
                 break

--- a/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
@@ -1292,7 +1292,11 @@ public class ToolCallProcessor {
     }
 
     private func visibleInlineLeading(_ leading: String) -> String? {
-        leading.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : leading
+        // Emit leading text verbatim. Returning nil only for *empty* leading
+        // (never for whitespace-only) keeps ordinary prose byte-exact: a chunk
+        // like " {" must not lose its leading space when the brace triggers a
+        // (possibly false) inline tool-call probe.
+        leading.isEmpty ? nil : leading
     }
 
     /// Process chunk for tagged formats.

--- a/Tests/MLXLMCommonToolParserFocusedTests/Gemma4ProseScrambleTests.swift
+++ b/Tests/MLXLMCommonToolParserFocusedTests/Gemma4ProseScrambleTests.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+/// Regression guard for the "Gemma + tools scrambles prose" bug.
+///
+/// When a Gemma tool format is active, every generated chunk flows through
+/// `ToolCallProcessor`. Gemma's bare-call fallback buffers any trailing
+/// "c"/"ca"/"cal"/"call" (a possible start of the `call:` tool marker). When a
+/// buffered fragment did NOT continue into a tool call, the held text was
+/// neither flushed in order nor cleared, so ordinary prose lost and reordered
+/// characters ("cobblestone" -> "obblestone", a trailing "call" dumped at EOS,
+/// etc.). Gemma is the only family with bare-call fallback, which is why only
+/// Gemma corrupted prose.
+@Suite("Gemma tool formats preserve plain prose")
+struct Gemma4ProseScrambleTests {
+
+    private func chunked(_ s: String, size: Int) -> [String] {
+        var r: [String] = []
+        var i = s.startIndex
+        while i < s.endIndex {
+            let j = s.index(i, offsetBy: size, limitedBy: s.endIndex) ?? s.endIndex
+            r.append(String(s[i..<j]))
+            i = j
+        }
+        return r
+    }
+
+    private func visible(_ chunks: [String], _ proc: ToolCallProcessor) -> String {
+        var out = ""
+        for c in chunks { if let v = proc.processChunk(c) { out += v } }
+        if let tail = proc.processEOS() { out += tail }
+        return out
+    }
+
+    // Prose dense with `c` words (each a false `call:` prefix) plus whitespace.
+    private let prose = """
+        Palm Springs is a spectacular desert oasis. Ivory towers with gilded \
+        domes rise above cobblestone streets, a masterpiece of architectural \
+        elegance and a breathtaking getaway near the Ritz-Carlton.
+        """
+
+    @Test("gemma4 passes plain prose through byte-exact at every chunk size")
+    func gemma4PreservesProse() {
+        for size in [1, 2, 3, 4, 8] {
+            let proc = ToolCallProcessor(format: .gemma4, tools: nil)
+            let out = visible(chunked(prose, size: size), proc)
+            #expect(out == prose, "gemma4 size=\(size) altered prose: \(out.debugDescription)")
+            #expect(proc.toolCalls.isEmpty, "gemma4 size=\(size) fabricated a tool call from prose")
+        }
+    }
+
+    @Test("gemma (legacy) passes plain prose through byte-exact")
+    func gemmaLegacyPreservesProse() {
+        for size in [1, 2, 3, 4, 8] {
+            let proc = ToolCallProcessor(format: .gemma, tools: nil)
+            let out = visible(chunked(prose, size: size), proc)
+            #expect(out == prose, "gemma size=\(size) altered prose: \(out.debugDescription)")
+        }
+    }
+}

--- a/Tests/MLXLMCommonToolParserFocusedTests/ToolCallProcessorFuzzTests.swift
+++ b/Tests/MLXLMCommonToolParserFocusedTests/ToolCallProcessorFuzzTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+/// Deterministic fuzz proof for streaming tool-call processing.
+///
+/// Invariant: when generated text contains NO tool call, the reassembled
+/// visible output equals the input byte-for-byte — for every tool format, at
+/// random chunk sizes. This is the class of bug behind "Gemma + tools scrambles
+/// prose" (held tool-marker fragments must never drop/reorder ordinary text)
+/// and the inline-JSON whitespace-before-brace drop (a chunk like " {" must keep
+/// its leading space). Seeded SplitMix64 makes failures reproducible.
+@Suite("ToolCallProcessor prose-fidelity fuzz")
+struct ToolCallProcessorFuzzTests {
+
+    private struct RNG {
+        var s: UInt64
+        init(_ seed: UInt64) { s = seed }
+        mutating func next() -> UInt64 {
+            s &+= 0x9E37_79B9_7F4A_7C15
+            var z = s
+            z = (z ^ (z >> 30)) &* 0xBF58_476D_1CE4_E5B9
+            z = (z ^ (z >> 27)) &* 0x94D0_49BB_1331_11EB
+            return z ^ (z >> 31)
+        }
+        mutating func int(_ n: Int) -> Int { n <= 0 ? 0 : Int(next() % UInt64(n)) }
+        mutating func pick<T>(_ a: [T]) -> T { a[int(a.count)] }
+    }
+
+    private let vocab = [
+        "call", "calling", "called", "cobblestone", "cactus", "city", "casual", "create",
+        "the", "a", "desert", "pool", "complex", "function", "name", "city:", "value",
+        "weather", "get", "tool", "use", "{", "}", "(", ")", ":", ",", "- ", "* ", "`code`",
+        "\n", "\n\n", "## Heading", "perfect", "masterpiece", "getaway", "architecture",
+        "kids'", "family-friendly", "Ritz-Carlton", "spectacular", "and", "with", "gilded",
+    ]
+
+    private func randomProse(_ rng: inout RNG, words: Int) -> String {
+        var out = ""
+        for i in 0..<words {
+            if i > 0 { out += " " }
+            out += rng.pick(vocab)
+        }
+        return out
+    }
+
+    private func chunked(_ s: String, _ rng: inout RNG) -> [String] {
+        var r: [String] = []
+        var i = s.startIndex
+        while i < s.endIndex {
+            let size = 1 + rng.int(5)
+            let j = s.index(i, offsetBy: size, limitedBy: s.endIndex) ?? s.endIndex
+            r.append(String(s[i..<j]))
+            i = j
+        }
+        return r
+    }
+
+    private func visible(_ chunks: [String], _ proc: ToolCallProcessor) -> String {
+        var out = ""
+        for c in chunks { if let v = proc.processChunk(c) { out += v } }
+        if let tail = proc.processEOS() { out += tail }
+        return out
+    }
+
+    @Test("prose with no tool call survives byte-exact (all formats, random chunking)")
+    func proseFidelity() {
+        let formats: [ToolCallFormat] = [
+            .json, .gemma, .gemma4, .xmlFunction, .glm4, .nemotron, .dsml, .lfm2, .step,
+        ]
+        var failures = 0
+        var first = ""
+        for f in formats {
+            for seed in UInt64(1)...400 {
+                var rng = RNG(seed &* 0x100_0000 &+ UInt64(f.rawValue.count))
+                let prose = randomProse(&rng, words: 8 + rng.int(60))
+                let proc = ToolCallProcessor(format: f, tools: nil)
+                let got = visible(chunked(prose, &rng), proc)
+                if got != prose {
+                    failures += 1
+                    if first.isEmpty {
+                        first = "format=\(f.rawValue) seed=\(seed)\n IN:  \(prose.debugDescription)\n OUT: \(got.debugDescription)"
+                    }
+                }
+            }
+        }
+        #expect(failures == 0, "prose-fidelity fuzz failures=\(failures)\n\(first)")
+    }
+}


### PR DESCRIPTION
## Problem
Users reported Gemma 12B producing scrambled text ("pool complexes"→"pocomol lexes", "masterpiece"→"masterpiee", "cobblestone"→"obblestone") whenever **tools were enabled (Sandbox on)** — on any quant (MXFP8 and JANG_4M reproduced), any context length, streaming or not.

## Root cause (proven model-free)
The corruption is **not** the model, KV cache, quantization, TurboQuant, or detokenization — those are all bypassed in the regression test. When a Gemma tool format (`.gemma`/`.gemma4`) is active, every chunk flows through `ToolCallProcessor`. Gemma is the **only** family with bare-call fallback, which buffers any trailing `c`/`ca`/`cal`/`call` as a possible start of the `call:` marker. When the buffered fragment did not continue into a tool call, the held text was neither flushed in order nor cleared — the tail code returned only the current chunk and abandoned the buffer (gemma never enables inline-JSON fallback, so no later stage consumed it). Result: dropped + reordered characters throughout prose.

Component isolation (deterministic, no model):
```
through: nil          -> verbatim   (model/detok/routing fine)
through: gemma4 proc  -> SCRAMBLED  (the bug)
blast radius @size 3: json OK · gemma CORRUPTED · gemma4 CORRUPTED · xml_function OK · glm4 OK · nemotron OK · dsml OK · lfm2 OK
```

## Fix
In the bare-call `.normal` path: flush the held fragment together with the current chunk, **in order**, once it is no longer a `call:` prefix; and emit partial-fragment leading text verbatim instead of dropping whitespace-only leads. Real tool calls (wrapped `<|tool_call>` envelope and bare `call:`) still parse; only the dropped/reordered prose is fixed.

## Tests
Adds `Gemma4ProseScrambleTests` (model-free, deterministic): gemma/gemma4 pass plain prose byte-exact at chunk sizes 1–8 with no fabricated tool calls. Existing tool-call parsing tests unchanged.