### PR TITLE
Reuse warm prefix cache for SWA/rotating models (skip re-prefill)

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -1566,7 +1566,13 @@ public actor BatchEngine {
                         // remaining.nonEmpty case below.
                         let unsafePartial =
                             slot.originalInput.cacheHitSuffixContainsMediaPlaceholder(remaining)
-                        let unsafeFullHit = remaining.isEmpty && requiresDiskBackedRestore
+                        // Only path-dependent caches (Mamba/CCA/ArraysCache) need the
+                        // SSM-seed full-hit recovery; rotating/SWA + TQ/Quantized KV
+                        // restore exactly and use the standard trim+re-feed fast path.
+                        // Gating on the broad requiresDiskBackedRestore threw away
+                        // perfect Gemma SWA hits and re-prefilled every turn.
+                        let unsafeFullHit =
+                            remaining.isEmpty && cacheContainsPathDependentState(slot.cache)
                         if unsafePartial {
                             let slotIDStr = slot.id.description
                             Self.logger.info(

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1424,7 +1424,15 @@ public struct TokenIterator: TokenIteratorProtocol {
                     }
                     let unsafePartial =
                         input.cacheHitSuffixContainsMediaPlaceholder(remainingTokens)
-                    let unsafeFullHit = remainingTokens.isEmpty && requiresDiskBackedRestore
+                    // A full exact hit only needs the SSM-seed recovery path for
+                    // PATH-DEPENDENT caches (Mamba/CCA/ArraysCache), whose restored
+                    // recurrent state already folds in the last token. Plain
+                    // rotating/SWA (and TurboQuant/Quantized) KV caches restore
+                    // exactly and take the standard trim-last-token + re-feed fast
+                    // path below; gating on the broad requiresDiskBackedRestore
+                    // discarded perfect Gemma SWA hits and re-prefilled every turn.
+                    let unsafeFullHit =
+                        remainingTokens.isEmpty && cacheContainsPathDependentState(self.cache)
                     if unsafePartial {
                         Self.logger.info(
                             "TokenIterator: cache hit rolling back to full prefill (media placeholder tokens remain in cache-hit suffix)"


### PR DESCRIPTION
## Problem
"TTFT too long / no prefix caching" on Gemma. A full exact prefix-cache hit (remaining==0) was **discarded and re-prefilled from scratch** for any cache requiring disk-backed restore — which includes plain rotating/SWA (Gemma), TurboQuant, and Quantized KV, not just path-dependent recurrent caches.

## Proof (instrumented, dev app, gemma-4-12b-mxfp8, identical 7k-token prompt)
```
fetch=HIT detail=disk tokens=5816 remaining=0   ← perfect full-prompt cache hit
restored=true unsafeFullHit=true                ← discarded → full re-prefill (~4.5s every turn)
```
The disk cache hit perfectly; the `unsafeFullHit` rollback threw it away.

## Root cause
`unsafeFullHit = remaining.isEmpty && requiresDiskBackedRestore`. The rollback exists only to protect **path-dependent** caches (Mamba/CCA/ArraysCache) whose restored recurrent state already folds in the last token (trim+re-feed would double-count). But `requiresDiskBackedRestore` is broad (also rotating/SWA/TQ/Quantized), so Gemma — which has no SSM seed state — fell into the recovery path, failed, and re-prefilled every turn.

## Fix
Gate `unsafeFullHit` on `cacheContainsPathDependentState` instead, in both the single-stream (`Evaluate`) and batched (`BatchEngine`) prefill paths. Rotating/SWA/TQ/Quantized full hits now take the existing standard trim-last-token + re-feed fast path.

## Live proof (after fix)
- `unsafeFullHit=false`; warm TTFT **4.5s → ~0.65s (~7×)**.
- Output coherent on warm hits; **tool-call turns correct** on warm rotating restore (the structured-arg safety the old guard protected holds — a full exact restore is complete, so trim+re-feed is safe).

Independent of the slider-KV (#53) and Gemma tool-scramble (#54) PRs.