### PR TITLE
Narrow warm full-hit fast path to standalone rotating caches only

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -1566,13 +1566,15 @@ public actor BatchEngine {
                         // remaining.nonEmpty case below.
                         let unsafePartial =
                             slot.originalInput.cacheHitSuffixContainsMediaPlaceholder(remaining)
-                        // Only path-dependent caches (Mamba/CCA/ArraysCache) need the
-                        // SSM-seed full-hit recovery; rotating/SWA + TQ/Quantized KV
-                        // restore exactly and use the standard trim+re-feed fast path.
-                        // Gating on the broad requiresDiskBackedRestore threw away
-                        // perfect Gemma SWA hits and re-prefilled every turn.
+                        // Only standalone rotating / sliding-window caches (Gemma,
+                        // Mistral SWA) are proven to restore exactly and take the
+                        // standard trim+re-feed fast path on a full hit. Keep the
+                        // conservative full-prefill rollback for every other
+                        // disk-backed topology — path-dependent recurrent, TurboQuant/
+                        // Quantized, HybridPool — whose exact-restore is unverified.
                         let unsafeFullHit =
-                            remaining.isEmpty && cacheContainsPathDependentState(slot.cache)
+                            remaining.isEmpty && requiresDiskBackedRestore
+                            && !cacheHasStandaloneRotatingWindowState(slot.cache)
                         if unsafePartial {
                             let slotIDStr = slot.id.description
                             Self.logger.info(

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1424,15 +1424,18 @@ public struct TokenIterator: TokenIteratorProtocol {
                     }
                     let unsafePartial =
                         input.cacheHitSuffixContainsMediaPlaceholder(remainingTokens)
-                    // A full exact hit only needs the SSM-seed recovery path for
-                    // PATH-DEPENDENT caches (Mamba/CCA/ArraysCache), whose restored
-                    // recurrent state already folds in the last token. Plain
-                    // rotating/SWA (and TurboQuant/Quantized) KV caches restore
-                    // exactly and take the standard trim-last-token + re-feed fast
-                    // path below; gating on the broad requiresDiskBackedRestore
-                    // discarded perfect Gemma SWA hits and re-prefilled every turn.
+                    // Only standalone rotating / sliding-window caches (Gemma,
+                    // Mistral SWA) are PROVEN to restore exactly and take the
+                    // standard trim-last-token + re-feed fast path on a full hit
+                    // (single-turn warm output is bit-exact vs no-cache). Keep the
+                    // conservative full-prefill rollback for every other disk-backed
+                    // topology — path-dependent recurrent (Mamba/CCA/ArraysCache),
+                    // TurboQuant/Quantized, and HybridPool — whose exact-restore is
+                    // not yet verified. (Gating only on path-dependent would have
+                    // enabled an unverified fast path for TQ/Quantized/HybridPool.)
                     let unsafeFullHit =
-                        remainingTokens.isEmpty && cacheContainsPathDependentState(self.cache)
+                        remainingTokens.isEmpty && requiresDiskBackedRestore
+                        && !cacheHasStandaloneRotatingWindowState(self.cache)
                     if unsafePartial {
                         Self.logger.info(
                             "TokenIterator: cache hit rolling back to full prefill (media placeholder tokens remain in cache-hit suffix)"


### PR DESCRIPTION
Follow-up to #55. #55 enabled the warm full-hit fast path for all non-path-dependent disk-backed caches (rotating, TurboQuant, Quantized, HybridPool). Only **standalone rotating/SWA** (Gemma, Mistral) is proven bit-exact on a full hit (single-turn warm == no-cache, gemma mxfp8 + jang_4m). Narrow the gate to `requiresDiskBackedRestore && !cacheHasStandaloneRotatingWindowState` so Gemma keeps the TTFT win while TQ/Quantized/HybridPool stay on the conservative full-prefill rollback until verified. Plain-KV + path-dependent unchanged.