### PR TITLE
Stream prefill progress for block-diffusion models

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -993,18 +993,39 @@ public actor BatchEngine {
                 let options = diffusionModel.blockDiffusionDefaults
                     .resolving(generationConfig: context.configuration.generationDefaults)
                     .overriding(parameters: soloParameters)
-                let iterator = try BlockDiffusionTokenIterator(
-                    input: input,
-                    model: diffusionModel,
-                    cache: nil,
-                    parameters: soloParameters,
-                    options: options,
-                    cacheCoordinator: cacheCoordinator)
-                (sourceStream, generationTask) = generateTask(
+                // Defer iterator construction (and therefore the encoder
+                // prefill) into the streaming task — like the AR path below —
+                // so `.prefillProgress` frames emitted by the block-diffusion
+                // encoder loop reach the consumer LIVE instead of bursting
+                // after the (already-prefilled) iterator is returned. The
+                // prefill itself is unchanged; only frame timing changes.
+                let promptTokenIdsForTail = input.text.tokens.reshaped(-1).asArray(Int.self)
+                let deferredParameters = soloParameters
+                let deferredOptions = options
+                let deferredInputs = SendableBox(
+                    (input, diffusionModel, cacheCoordinator))
+                let deferredContinuation = continuation
+                let makeIterator: @Sendable () throws -> any TokenIteratorProtocol = {
+                    let (deferredInput, deferredModel, deferredCoordinator) =
+                        deferredInputs.consume()
+                    return try BlockDiffusionTokenIterator(
+                        input: deferredInput,
+                        model: deferredModel,
+                        cache: nil,
+                        parameters: deferredParameters,
+                        options: deferredOptions,
+                        cacheCoordinator: deferredCoordinator,
+                        prefillProgressHandler: { progress in
+                            deferredContinuation.yield(
+                                .prefillProgress(prefillGate.clamp(progress)))
+                        })
+                }
+                (sourceStream, generationTask) = generateTaskDeferred(
                     promptTokenCount: promptTokenCount,
                     modelConfiguration: context.configuration,
                     tokenizer: context.tokenizer,
-                    iterator: iterator,
+                    promptTokenIds: promptTokenIdsForTail,
+                    makeIterator: makeIterator,
                     extraStopStrings: soloParameters.extraStopStrings,
                     promptTail: promptTail,
                     toolSchemas: toolSchemas)

--- a/Libraries/MLXLMCommon/Diffusion/BlockDiffusionTokenIterator.swift
+++ b/Libraries/MLXLMCommon/Diffusion/BlockDiffusionTokenIterator.swift
@@ -80,12 +80,24 @@ public struct BlockDiffusionTokenIterator: TokenIteratorProtocol {
         cache: [KVCache]? = nil,
         parameters: GenerateParameters,
         options: BlockDiffusionParameters,
-        cacheCoordinator: CacheCoordinator? = nil
+        cacheCoordinator: CacheCoordinator? = nil,
+        prefillProgressHandler: (@Sendable (PrefillProgress) -> Void)? = nil
     ) throws {
         let promptTokenIds = input.text.tokens.reshaped(-1).asArray(Int.self)
         guard !promptTokenIds.isEmpty else {
             throw BlockDiffusionModelError.emptyPrompt
         }
+        let totalPromptTokens = promptTokenIds.count
+        // The block-diffusion encoder prefill does not flow through the
+        // autoregressive `prepare(...)` path that emits `.prefillProgress`
+        // frames, so we emit them here directly. Without this the UI counter
+        // sits frozen at `0/N` for the entire (potentially many-second) 26B
+        // encoder prefill, which reads as "stuck". Frames are clamped to the
+        // prompt length and reported monotonically by the caller's gate.
+        prefillProgressHandler?(
+            PrefillProgress(
+                stage: .prefill, completedUnitCount: 0,
+                totalUnitCount: totalPromptTokens, detail: "diffusion"))
 
         self.model = model
         self.options = options
@@ -154,6 +166,14 @@ public struct BlockDiffusionTokenIterator: TokenIteratorProtocol {
                 {
                     tokensToEncode = remainingTokens
                     prefixCacheRestoredTokens = matchedTokens
+                    if matchedTokens > 0 {
+                        prefillProgressHandler?(
+                            PrefillProgress(
+                                stage: .cacheRestore,
+                                completedUnitCount: matchedTokens,
+                                totalUnitCount: totalPromptTokens,
+                                detail: "diffusion"))
+                    }
                 } else if restored {
                     self.cache = model.newCache(parameters: parameters)
                     tokensToEncode = promptTokenIds
@@ -181,6 +201,12 @@ public struct BlockDiffusionTokenIterator: TokenIteratorProtocol {
             encoderForwardCount += 1
             MLX.eval(self.cache)
             self.promptPrefillTime = Date.timeIntervalSinceReferenceDate - prefillStart
+            // Media prefill is single-shot (one bidirectional encoder pass),
+            // so there is no incremental progress to report — jump to complete.
+            prefillProgressHandler?(
+                PrefillProgress(
+                    stage: .complete, completedUnitCount: totalPromptTokens,
+                    totalUnitCount: totalPromptTokens, detail: "diffusion"))
             if cacheCoordinator != nil {
                 self.promptCacheSnapshot = makePromptBoundaryCacheSnapshot(from: self.cache)
             }
@@ -189,6 +215,7 @@ public struct BlockDiffusionTokenIterator: TokenIteratorProtocol {
 
         let stepSize = Swift.max(parameters.prefillStepSize, 1)
         var remaining = tokensToEncode[...]
+        var encodedTokens = prefixCacheRestoredTokens
         while !remaining.isEmpty {
             let chunk = Array(remaining.prefix(stepSize))
             remaining = remaining.dropFirst(stepSize)
@@ -196,11 +223,25 @@ public struct BlockDiffusionTokenIterator: TokenIteratorProtocol {
             model.encoderForward(chunkTokens, cache: self.cache)
             encoderForwardCount += 1
             MLX.eval(self.cache)
+            encodedTokens += chunk.count
+            prefillProgressHandler?(
+                PrefillProgress(
+                    stage: remaining.isEmpty ? .complete : .prefill,
+                    completedUnitCount: encodedTokens,
+                    totalUnitCount: totalPromptTokens, detail: "diffusion"))
             if !remaining.isEmpty {
                 Memory.clearCache()
             }
         }
         self.promptPrefillTime = Date.timeIntervalSinceReferenceDate - prefillStart
+        // Emit a terminal complete frame even when there was nothing to encode
+        // (full prefix-cache hit: tokensToEncode empty) so the counter lands at N/N.
+        if tokensToEncode.isEmpty {
+            prefillProgressHandler?(
+                PrefillProgress(
+                    stage: .complete, completedUnitCount: totalPromptTokens,
+                    totalUnitCount: totalPromptTokens, detail: "diffusion"))
+        }
 
         if cacheCoordinator != nil {
             self.promptCacheSnapshot = makePromptBoundaryCacheSnapshot(from: self.cache)


### PR DESCRIPTION
## Summary

Block-diffusion models (DiffusionGemma) showed a prefill progress counter frozen at `0/N` for the entire encoder prefill — which on a 26B model is many seconds — reading as "stuck on loading" even though generation was healthy. The autoregressive path streams `.prefillProgress` frames via the deferred-iterator construction added previously; the block-diffusion path did not, because:

1. `BlockDiffusionTokenIterator` ran the whole encoder prefill in its initializer and emitted **no** progress frames, and
2. `BatchEngine` built that iterator **eagerly** (before the streaming task started), so even if it had emitted frames they would burst out after prefill already finished.

## Changes

- **`BlockDiffusionTokenIterator`**: add an optional `prefillProgressHandler`. Emit an initial `0/N` frame, advancing `.prefill` frames per encoder chunk (`completedUnitCount = tokens encoded so far`), a `.cacheRestore` frame on a partial prefix-cache hit, and a terminal `.complete` frame (covering the chunked path, the single-shot media path, and the full-cache-hit path where nothing is encoded). The prefill computation itself is unchanged — only progress reporting is added.
- **`BatchEngine`**: defer block-diffusion iterator construction into the streaming task via `generateTaskDeferred` (mirroring the AR branch), wiring the handler through the existing `PrefillMonotonicGate` so frames are clamped and monotonic and reach the consumer live.

## Scope / safety

- Only the block-diffusion branch of `startSoloFastPath` changes. The autoregressive and native-MTP branches are untouched.
- No change to diffusion output or correctness — purely UI progress timing.

## Verification (live)

- DiffusionGemma (`diffusiongemma-26b-a4b-it-mxfp4`): prefill counter now advances `0 → 512 → 1024 → … → N (100%)` ending in `.complete`, then the first token — previously frozen at `0/N`.
- AR regression (`gemma-4-12b-it-mxfp8`): prefill still streams (122 frames); the diffusion edit did not disturb the AR path.
