### PR TITLE
Pin package to Swift 5 language mode (fix swift build / older-toolchain BatchEngine data-race errors)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -847,6 +847,18 @@ let package = Package(
             sources: ["CustomFunctionExampleSimple.swift"]
         ),
     ],
+    // Pin the package to the Swift 5 language mode. This is the configuration
+    // consumers actually build and ship in (Osaurus's xcodebuild assigns
+    // SWIFT_VERSION=5 to unpinned package targets), so the code is validated
+    // against v5 data-isolation semantics. Without this pin, `swift build`
+    // (and SPM integrations that honor the tools-version 6.1 default) compile
+    // the high-level LM targets in the Swift 6 language mode, where region-
+    // based-isolation diagnostics ("Sending 'x' risks causing data races") on
+    // benign struct read/mutate/write-back locals in the batch engine are hard
+    // errors on some compiler versions — breaking the build on toolchains the
+    // shipping configuration never exercises. Pinning v5 makes every build
+    // path compile these targets identically to how they ship.
+    swiftLanguageModes: [.v5],
     cxxLanguageStandard: .gnucxx20
 )
 


### PR DESCRIPTION
## Summary

A pure `swift build` (and SPM integrations that honor the `swift-tools-version: 6.1` default) compile the high-level LM targets — `MLXLMCommon` in particular, which have **no explicit language mode set** — in the **Swift 6 language mode**. In that mode, region-based-isolation diagnostics on benign struct read/mutate/write-back locals in the batch engine become **hard errors** on some compiler versions, e.g.:

```
BatchEngine.swift: error: Sending 'slot' risks causing data races
BatchEngine.swift: error: Sending 'inputForPrepare' risks causing data races
```

This breaks the build for contributors on those toolchains (reported on a recent Xcode by a downstream user) — even though the shipping configuration never hits it.

## Root cause

The package is actually built and shipped by consumers in the **Swift 5 language mode**: when Osaurus's `xcodebuild` integrates the package, Xcode assigns `SWIFT_VERSION=5` to package targets that do not pin a language mode. So the sources are only ever validated against v5 data-isolation semantics. The divergence is purely the *language mode the consumer happens to select*, not the code:

- Verified: on Swift 6.3.1, `MLXLMCommon` compiles **cleanly in full Swift 6 language mode** — no "data races" diagnostics at all. The errors are region-isolation over-reports on **older compiler versions** for the classic `var x = arr[i]; f(x); arr[i] = x` value-type pattern.

So there is no actual data race here; the failure is a language-mode/toolchain mismatch.

## Fix

Declare `swiftLanguageModes: [.v5]` at the package level. This makes **every** build path (pure `swift build`, any SPM integration, every toolchain) compile the package identically to how it already ships, eliminating the spurious Swift-6-mode errors.

- **No behavior change for Osaurus** — it already compiles these targets in v5.
- No real concurrency safety is lost (the v6 build is clean on current compilers; this only removes the mode divergence). A proper Swift 6 migration can flip this declaration when the team is ready.

## Validation

- `swift package dump-package` parses clean; `swiftLanguageVersions = ["5"]`.
- Osaurus Release build unaffected (already v5).
