### PR TITLE
Compile MLXLMCommon in the Swift 5 language mode (fix BatchEngine region-isolation errors on Swift 6.0/6.1)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -467,7 +467,21 @@ let package = Package(
             name: "MLXLMCommon",
             dependencies: ["MLX", "MLXNN", "MLXOptimizers", "MLXRandom"],
             path: "Libraries/MLXLMCommon",
-            exclude: mlxLMCommonExcludedFiles
+            exclude: mlxLMCommonExcludedFiles,
+            // Compile this target in the Swift 5 language mode. The package is
+            // otherwise built in Swift 6 mode (the tools-version 6.1 default,
+            // which the vendored Jinja target needs for bare-slash regex
+            // literals). But the batch engine's actor code triggers region-
+            // based-isolation errors ("Sending 'slot'/'inputForPrepare' risks
+            // causing data races") on the struct read/mutate/write-back locals
+            // in `stepPrefill` on some Swift 6.0/6.1 compilers — a known
+            // region-isolation over-report that current toolchains (6.2+) no
+            // longer emit. Compiling just this target in v5 keeps those
+            // diagnostics as warnings so the package builds on the full
+            // tools-version-6.1 toolchain range, while every other target
+            // (incl. Jinja) stays in Swift 6 mode. No real data race exists:
+            // MLXLMCommon compiles cleanly in Swift 6 mode on current compilers.
+            swiftSettings: [.swiftLanguageMode(.v5)]
         ),
         .target(
             name: "MLXLLM",


### PR DESCRIPTION
## Summary

A contributor on a Swift 6.0/6.1 toolchain cannot build the package — `swift build` (and Xcode's SPM integration) compile the package in the **Swift 6 language mode** (the `swift-tools-version: 6.1` default), and the batch engine's actor code emits hard region-based-isolation errors:

```
BatchEngine.swift: error: Sending 'slot' risks causing data races
BatchEngine.swift: error: Sending 'inputForPrepare' risks causing data races
```

These come from the `var slot = activeSlots[i]; …; activeSlots[i] = slot` struct read/mutate/write-back pattern in `stepPrefill`. This is a **known region-isolation over-report** on Swift 6.0/6.1 that current toolchains (6.2+) no longer emit.

## Verification

- On **Swift 6.3.1**, `MLXLMCommon` compiles **cleanly in full Swift 6 language mode** — zero "data races" diagnostics. So there is **no real data race**; this is purely a compiler-version diagnostic difference.

## Fix

Compile **only** the `MLXLMCommon` target in the **Swift 5 language mode** (`swiftSettings: [.swiftLanguageMode(.v5)]`), where those region-isolation diagnostics are warnings rather than errors. Every other target stays in Swift 6 mode.

### Why per-target and not package-wide

A package-wide `swiftLanguageModes: [.v5]` was tried first and **broke the build**: the vendored `VMLXJinja` target uses **bare-slash regex literals** (`/<[^>]+>/`, `/^[ \t]*{[#%]/`), which are only enabled in Swift 6 mode. Pinning the whole package to v5 turned those into parse errors. Scoping the v5 mode to just `MLXLMCommon` keeps Jinja (and everything else) in Swift 6 mode.

## Validation

- `swift package dump-package` parses clean.
- Full Osaurus Release build **succeeds** with `MLXLMCommon` compiled at `-swift-version 5` and `VMLXJinja` at Swift 6 (bare-regex intact).
- No behavior change; no real concurrency safety lost (the v6 build is clean on current compilers).
