### PR TITLE
Gemma4: upcast global full-attention to fp32 for bf16 (fixes long-context <pad>)

### DIFF
--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -756,15 +756,29 @@ private class TextAttn: Module {
         // vision-tower fp32 upcast when the activation dtype is fp16.
         // Critical for sliding-window layers since the windowed key set
         // concentrates softmax mass on fewer entries.
+        //
+        // bf16 does not overflow (it shares fp32's exponent range), but the
+        // GLOBAL full-attention layers (head_dim 512, attention over ALL
+        // positions) are routed to the unfused Metal SDPA fallback because
+        // head_dim 512 is not in the fused set {64, 80, 128}. That fallback
+        // reduces the softmax in the activation dtype, and bf16's 8-bit
+        // mantissa loses enough precision in the reduction over N keys that
+        // past ~26k positions the global-layer logits collapse — every
+        // sampled token becomes <pad> (reproducible cold, content-independent,
+        // already at the first generated token). Upcast those layers to fp32
+        // as well. Sliding layers stay bf16: their key set is capped at the
+        // window (≤1024) so the reduction is precise, and upcasting all 40
+        // sliding prefill layers would multiply attention memory at long ctx.
         let origDType = q.dtype
         var qF = q, kF = cK, vF = cV
-        if origDType == .float16 {
+        let needsUpcast = origDType == .float16 || (origDType == .bfloat16 && !isSliding)
+        if needsUpcast {
             qF = qF.asType(.float32)
             kF = kF.asType(.float32)
             vF = vF.asType(.float32)
         }
         var sdpa = MLXFast.scaledDotProductAttention(queries: qF, keys: kF, values: vF, scale: scale, mask: mask)
-        if origDType == .float16 { sdpa = sdpa.asType(.float16) }
+        if needsUpcast { sdpa = sdpa.asType(origDType) }
         let out = sdpa.transposed(0, 2, 1, 3).reshaped(B, L, -1)
         return (oP(out), cK, cV, off)
     }


### PR DESCRIPTION
## Problem

Gemma-4 (`gemma4_unified`) **bf16** models degenerate to pure `<pad>` from the **first generated token** once the prompt crosses **~26k tokens**. It is:

- **deterministic** and **content-independent** (every cold, unique-content prompt ≥28k fails),
- **prefill-side** — it pads even with `max_tokens=1`, so it is the prefill forward pass, not output/budget accounting,
- masked by the SSD prefix cache (a repeated prompt replays good stored KV and "passes"), which made it look intermittent.

## Root cause

The global **full-attention** layers (8 of 48; `head_dim=512`, attention over **all** positions — sliding layers are capped at `window=1024`) are routed to the **unfused Metal SDPA fallback** because `head_dim 512` is not in the fused set `{64, 80, 128}`. That fallback reduces the softmax in the **activation dtype**.

The existing fp32 upcast guard (added in #52 for fp16 overflow) fired **only** for `.float16`. This model is **bf16**, so the global layers reduced the softmax over `N` keys in bf16. bf16 never *overflows* (it shares fp32's exponent range, so the fp16 guard never covered it), but its **8-bit mantissa** loses enough precision in the reduction over large `N` that past ~26k positions the global-layer logits collapse to a near-uniform distribution → `argmax` lands on `<pad>`.

## Fix

Extend the upcast to also cover **bf16 on the global (non-sliding) layers**:

```swift
let needsUpcast = origDType == .float16 || (origDType == .bfloat16 && !isSliding)
```

Sliding layers stay bf16: their key set is capped at the window (≤1024) so the reduction stays precise, and upcasting all 40 sliding prefill layers would multiply attention memory at long context. Only the **8 global layers** upcast → the decode hot path is negligibly affected.

## Verification (live, gemma-4-12b-it-mxfp8, M5 Max)

Cold, unique-content prompts (prefix cache defeated), secret-recall test:

| context | before | after |
|---|---|---|
| 16k, 24k | ✅ | ✅ |
| 28k, 32k, 36k, 40k, 44k | ❌ pure `<pad>` | ✅ exact recall, `finish=stop` |

Decode speed after fix: ~30 tok/s (short prompt) — unchanged within noise (only 8/48 layers' attention upcast).