### PR TITLE
Gemma4: recognize drifted <|tool_call|> paren-JSON tool-call envelope (fixes leaked markup)

### DIFF
--- a/Libraries/MLXLMCommon/Tool/Parsers/Gemma4ToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/Gemma4ToolCallParser.swift
@@ -33,7 +33,14 @@ public struct Gemma4ToolCallParser: ToolCallParser, Sendable {
     public var supportsBareCallToolFallback: Bool { true }
 
     public var startTagAliases: [String] {
-        native.startTagAliases + zyphra.startTagAliases
+        // Live JANG/CRACK rows occasionally drift the native `<|tool_call>` open
+        // delimiter to `<|tool_call|>` (an extra pipe mirroring the `<tool_call|>`
+        // close) and wrap the arguments in parens, e.g.
+        // `<|tool_call|>call:name({"k":"v"})<tool_call|>`. Recognize the drifted
+        // open tag so the streaming processor buffers the envelope instead of
+        // leaking the raw markup as visible content. The close `<tool_call|>` is
+        // unchanged, so it still pairs through `endTagAliases`.
+        ["<|tool_call|>"] + native.startTagAliases + zyphra.startTagAliases
     }
 
     public var endTagAliases: [String] {

--- a/Libraries/MLXLMCommon/Tool/Parsers/GemmaFunctionParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/GemmaFunctionParser.swift
@@ -45,9 +45,14 @@ public struct GemmaFunctionParser: ToolCallParser, Sendable {
 
         let remaining = String(text[callRange.upperBound...])
 
-        // Extract function name (word characters until {)
+        // Extract function name. Native format is `call:name{...}`; live rows
+        // can drift to a paren-wrapped form `call:name({...})`. Stop the name
+        // at the first `{` (native) or `(` (drift) so the trailing paren never
+        // becomes part of the function name. The argument span below still
+        // reads the inner `{...}`, so JSON-in-parens parses identically.
         guard let braceStart = remaining.firstIndex(of: "{") else { return nil }
-        let funcName = String(remaining[..<braceStart])
+        let nameEnd = remaining.firstIndex(where: { $0 == "{" || $0 == "(" }) ?? braceStart
+        let funcName = String(remaining[..<nameEnd])
             .trimmingCharacters(in: .whitespacesAndNewlines)
 
         guard !funcName.isEmpty else { return nil }

--- a/Tests/MLXLMCommonToolParserFocusedTests/Gemma4DriftedToolCallEnvelopeTests.swift
+++ b/Tests/MLXLMCommonToolParserFocusedTests/Gemma4DriftedToolCallEnvelopeTests.swift
@@ -1,0 +1,83 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import Testing
+@testable import MLXLMCommon
+
+/// Regression: live Gemma-4 JANG/CRACK rows occasionally drift the native
+/// `<|tool_call>call:name{...}<tool_call|>` envelope to
+/// `<|tool_call|>call:name({...})<tool_call|>` — an extra `|` in the open tag
+/// plus JSON arguments wrapped in parens. The streaming processor must still
+/// recognize this as a tool call and must NOT leak the raw markup into visible
+/// text (observed live: the whole envelope printed in the chat transcript).
+@Suite("Gemma4 drifted tool-call envelope")
+struct Gemma4DriftedToolCallEnvelopeTests {
+    private let capabilitiesTool: [[String: any Sendable]] = [
+        [
+            "type": "function",
+            "function": [
+                "name": "capabilities_load",
+                "description": "Load capability tools by id.",
+                "parameters": [
+                    "type": "object",
+                    "properties": [
+                        "ids": ["type": "array", "items": ["type": "string"]]
+                    ],
+                    "required": ["ids"],
+                ],
+            ],
+        ]
+    ]
+
+    private func feed(_ envelope: String, chunkSize: Int, tools: [[String: any Sendable]]?)
+        -> (visible: String, processor: ToolCallProcessor)
+    {
+        let processor = ToolCallProcessor(format: .gemma4, tools: tools)
+        var visible = ""
+        var idx = envelope.startIndex
+        while idx < envelope.endIndex {
+            let end = envelope.index(idx, offsetBy: chunkSize, limitedBy: envelope.endIndex)
+                ?? envelope.endIndex
+            if let out = processor.processChunk(String(envelope[idx..<end])) { visible += out }
+            idx = end
+        }
+        if let tail = processor.processEOS() { visible += tail }
+        return (visible, processor)
+    }
+
+    @Test("drifted <|tool_call|> + paren-JSON envelope parses and does not leak (whole-string)")
+    func parsesDriftedEnvelopeWholeString() throws {
+        let envelope =
+            #"<|tool_call|>call:capabilities_load({"ids":["tool/browser_navigate","tool/browser_click","tool/browser_type"]})<tool_call|>"#
+        let (visible, processor) = feed(envelope, chunkSize: envelope.count, tools: capabilitiesTool)
+
+        #expect(!visible.contains("tool_call"), "leaked envelope markup: \(visible)")
+        #expect(!visible.contains("call:"), "leaked bare-call marker: \(visible)")
+        let call = try #require(processor.toolCalls.first)
+        #expect(processor.toolCalls.count == 1)
+        #expect(call.function.name == "capabilities_load")
+        #expect(call.function.arguments["ids"] != nil, "ids missing: \(call.function.arguments)")
+    }
+
+    @Test("drifted envelope parses and does not leak under tiny streaming chunks")
+    func parsesDriftedEnvelopeStreamed() throws {
+        let envelope =
+            #"<|tool_call|>call:capabilities_load({"ids":["tool/browser_navigate"]})<tool_call|>"#
+        for size in [1, 2, 3, 5, 7] {
+            let (visible, processor) = feed(envelope, chunkSize: size, tools: capabilitiesTool)
+            #expect(!visible.contains("tool_call"), "size \(size) leaked markup: \(visible)")
+            #expect(!visible.contains("call:"), "size \(size) leaked bare-call: \(visible)")
+            #expect(processor.toolCalls.count == 1, "size \(size) missed tool call: \(visible)")
+            #expect(processor.toolCalls.first?.function.name == "capabilities_load")
+        }
+    }
+
+    @Test("native envelope still parses (no regression)")
+    func nativeEnvelopeStillParses() throws {
+        let envelope = #"<|tool_call>call:capabilities_load{ids:["tool/browser_navigate"]}<tool_call|>"#
+        let (visible, processor) = feed(envelope, chunkSize: 4, tools: capabilitiesTool)
+        #expect(!visible.contains("tool_call"), "leaked native markup: \(visible)")
+        #expect(processor.toolCalls.first?.function.name == "capabilities_load")
+    }
+}


### PR DESCRIPTION
## Problem

Live Gemma-4 JANG/CRACK rows occasionally **drift** the native tool-call envelope:

- native:  `<|tool_call>call:name{key:value}<tool_call|>`
- drifted: `<|tool_call|>call:name({"key":"value"})<tool_call|>`  — an **extra `|`** in the open delimiter (mirroring the `<tool_call|>` close) plus **JSON args wrapped in parens**.

Because the streaming `ToolCallProcessor` only knew the native `<|tool_call>` open tag, it never buffered the drifted envelope and **printed the entire raw markup into the visible chat transcript** (observed live: `gemma-4-12b` JANG_4M calling `capabilities_load` in the agent/sandbox flow dumped `<|tool_call|>call:capabilities_load({"ids":[...]})<tool_call|>` as assistant text). Non-streaming survived via the bare-`call:` EOS fallback, which masked it in API tests.

## Fix

1. Add `<|tool_call|>` to Gemma4 `startTagAliases` so the streaming processor **buffers** the drifted envelope instead of leaking it. The close `<tool_call|>` is unchanged and still pairs via `endTagAliases`.
2. In `GemmaFunctionParser`, stop the function name at the first `{` **or `(`** so `call:name({...})` parses (the existing JSON-quoted-key normalization already handles the inner object). Native `call:name{...}` is unchanged.

## Tests

`Gemma4DriftedToolCallEnvelopeTests`: the drifted envelope parses with no leak (whole-string + tiny streaming chunks 1–7), plus a native no-regression case.

## Verification (live, gemma-4-12b JANG_4M)

Forcing the model to emit each envelope, streaming `/v1/chat/completions`:

| envelope | before | after |
|---|---|---|
| `<\|tool_call\|>call:get_weather({"city":"Paris"})<tool_call\|>` | leaked as visible text, `tool_calls: []` | **parsed** `get_weather{city:Paris}`, no leak |
| native `<\|tool_call>call:get_weather{city:Paris}<tool_call\|>` | parsed | parsed (no regression) |