### PR TITLE
Strip tagged tool-call markers when no tools are offered (fixes chat-UI envelope leak)

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -3796,8 +3796,18 @@ private struct TextToolTokenLoopHandler: TokenLoopHandler, @unchecked Sendable {
     ) {
         detokenizer = NaiveStreamingDetokenizer(tokenizer: tokenizer)
         let activeTools = tools?.isEmpty == false ? tools : nil
-        toolCallProcessor = activeTools.map {
-            ToolCallProcessor(format: format, tools: $0)
+        // When tools ARE offered, parse + emit calls. When NONE are offered we
+        // must still strip tagged tool-call control markers (strip-only mode):
+        // a model can emit a tool-call envelope anyway — e.g. an agent loop
+        // whose tool schema rides in the system prompt sends an empty `tools`
+        // field — and without a processor the raw `<|tool_call>…<tool_call|>`
+        // envelope leaks verbatim into visible text. Mirrors BatchEngine.
+        if let activeTools {
+            toolCallProcessor = ToolCallProcessor(format: format, tools: activeTools)
+        } else if format.hasTaggedToolMarkers {
+            toolCallProcessor = ToolCallProcessor(format: format, tools: nil, stripOnly: true)
+        } else {
+            toolCallProcessor = nil
         }
         self.reasoningParser = reasoningParser
         self.stopStringMatcher = stopStringMatcher

--- a/Libraries/MLXLMCommon/SpecDec/SpecDecStream.swift
+++ b/Libraries/MLXLMCommon/SpecDec/SpecDecStream.swift
@@ -54,9 +54,13 @@ public enum SpecDecStream {
                     var detokenizer = NaiveStreamingDetokenizer(
                         tokenizer: tokenizer)
                     let activeToolSchemas = toolSchemas?.isEmpty == false ? toolSchemas : nil
-                    let toolCallProcessor = activeToolSchemas.map {
-                        ToolCallProcessor(format: toolCallFormat, tools: $0)
-                    }
+                    // No tools offered: still strip tagged tool-call markers so a
+                    // model that emits an envelope anyway cannot leak raw markup.
+                    let toolCallProcessor: ToolCallProcessor? =
+                        activeToolSchemas.map { ToolCallProcessor(format: toolCallFormat, tools: $0) }
+                        ?? (toolCallFormat.hasTaggedToolMarkers
+                            ? ToolCallProcessor(format: toolCallFormat, tools: nil, stripOnly: true)
+                            : nil)
                     var reasoningParser = ReasoningParser
                         .fromCapabilityName(reasoningParserName)
 
@@ -117,9 +121,13 @@ public enum SpecDecStream {
                     var detokenizer = NaiveStreamingDetokenizer(
                         tokenizer: tokenizer)
                     let activeToolSchemas = toolSchemas?.isEmpty == false ? toolSchemas : nil
-                    let toolCallProcessor = activeToolSchemas.map {
-                        ToolCallProcessor(format: toolCallFormat, tools: $0)
-                    }
+                    // No tools offered: still strip tagged tool-call markers so a
+                    // model that emits an envelope anyway cannot leak raw markup.
+                    let toolCallProcessor: ToolCallProcessor? =
+                        activeToolSchemas.map { ToolCallProcessor(format: toolCallFormat, tools: $0) }
+                        ?? (toolCallFormat.hasTaggedToolMarkers
+                            ? ToolCallProcessor(format: toolCallFormat, tools: nil, stripOnly: true)
+                            : nil)
                     var reasoningParser = ReasoningParser
                         .fromCapabilityName(reasoningParserName)
 
@@ -227,9 +235,13 @@ public enum SpecDecStream {
                 var detokenizer = NaiveStreamingDetokenizer(
                     tokenizer: tokenizer)
                 let activeToolSchemas = toolSchemas?.isEmpty == false ? toolSchemas : nil
-                let toolCallProcessor = activeToolSchemas.map {
-                    ToolCallProcessor(format: toolCallFormat, tools: $0)
-                }
+                // No tools offered: still strip tagged tool-call markers so a
+                // model that emits an envelope anyway cannot leak raw markup.
+                let toolCallProcessor: ToolCallProcessor? =
+                    activeToolSchemas.map { ToolCallProcessor(format: toolCallFormat, tools: $0) }
+                    ?? (toolCallFormat.hasTaggedToolMarkers
+                        ? ToolCallProcessor(format: toolCallFormat, tools: nil, stripOnly: true)
+                        : nil)
                 var reasoningParser = ReasoningParser
                     .forPrompt(
                         stampName: reasoningParserName,

--- a/Tests/MLXLMCommonToolParserFocusedTests/Gemma4NoToolsMarkerStripTests.swift
+++ b/Tests/MLXLMCommonToolParserFocusedTests/Gemma4NoToolsMarkerStripTests.swift
@@ -21,4 +21,28 @@ struct Gemma4NoToolsMarkerStripTests {
         // No tools were offered, so no tool call should be surfaced.
         #expect(processor.toolCalls.isEmpty, "must not fabricate tool calls when none offered")
     }
+
+    // The agent/sandbox loop sends an empty `tools` field (the schema rides in
+    // the system prompt) yet the model emits a real `capabilities_load` call in
+    // the drifted paren-JSON envelope. With no tools the strip-only processor
+    // must still consume the whole envelope rather than leak the raw markup —
+    // the exact symptom seen live in the chat UI.
+    @Test("Gemma4 strips the paren-JSON capabilities_load envelope when no tools are offered")
+    func stripsParenJSONEnvelopeWithoutTools() {
+        let processor = ToolCallProcessor(format: .gemma4, tools: nil, stripOnly: true)
+        let envelope =
+            #"<|tool_call>call:capabilities_load({"ids": ["skill/Osaurus Browser", "tool/browser_navigate"]})<tool_call|>"#
+        var visible = ""
+        // Feed in small chunks to exercise the streaming state machine.
+        var idx = envelope.startIndex
+        while idx < envelope.endIndex {
+            let end = envelope.index(idx, offsetBy: 3, limitedBy: envelope.endIndex) ?? envelope.endIndex
+            if let out = processor.processChunk(String(envelope[idx..<end])) { visible += out }
+            idx = end
+        }
+        if let tail = processor.processEOS() { visible += tail }
+        #expect(!visible.contains("tool_call"), "leaked tool-call markup: \(visible)")
+        #expect(!visible.contains("call:"), "leaked bare-call marker: \(visible)")
+        #expect(processor.toolCalls.isEmpty, "must not fabricate tool calls when none offered")
+    }
 }


### PR DESCRIPTION
## Problem

In the osaurus chat-UI **agent/sandbox** flow, Gemma-4 printed the raw tool-call envelope into the transcript instead of executing the call:

```
<|tool_call>call:capabilities_load({"ids": ["skill/Osaurus Browser", "tool/browser_navigate", ...]})<tool_call|>
```

Root cause: that flow's tool schema rides in the **system prompt**, so the request's `tools` field is **empty**. The streaming generators in `Evaluate.swift` and `SpecDecStream.swift` built the `ToolCallProcessor` as `activeTools.map { ... }` — yielding a **nil processor** whenever no tools were offered. With no processor, a model that emits a tool-call envelope anyway has its raw control markers passed straight through to visible text.

`BatchEngine` already handled this (strip-only fallback when no tools), but the `Evaluate`/`SpecDec` paths that osaurus actually streams through did not. (This is why API tool tests — which always pass a `tools` array — never reproduced it.)

## Fix

When no tools are offered but the format has tagged tool markers, build a **strip-only** `ToolCallProcessor` so the envelope is consumed instead of leaked. Tools-present behavior is unchanged. Applied to `Evaluate.swift` and all three `SpecDecStream.swift` sites.

## Test

`Gemma4NoToolsMarkerStripTests.stripsParenJSONEnvelopeWithoutTools` feeds the drifted paren-JSON `capabilities_load` envelope (chunked) through a no-tools strip-only processor and asserts nothing leaks.

## Verification (live)

`/v1/chat/completions` streaming, gemma-4-12b JANG_4M, the exact envelope:

| `tools` field | before | after |
|---|---|---|
| `[]` (empty) | leaked raw markup | **clean** (stripped) |
| omitted | leaked | **clean** |
| with tools | clean | clean |

Cross-model matrix (gemma×3, qwen, nemotron, zaya-vl, lfm2, minimax): tool recognition + multiturn + empty-tools regression all pass.