### PR TITLE
Vendor native mFLUX image/video engine (vMLXFlux); z-image-turbo proven

### DIFF
--- a/Libraries/vMLXFlux/FluxEngine.swift
+++ b/Libraries/vMLXFlux/FluxEngine.swift
@@ -1,0 +1,222 @@
+import Foundation
+@_exported import vMLXFluxKit
+@_exported import vMLXFluxModels
+@_exported import vMLXFluxVideo
+
+/// Top-level facade for vmlx-flux. One import, one actor, one API.
+///
+/// The engine loads a FluxModel on demand via `load(_:)`, then dispatches
+/// generation / edit / upscale / video requests to the right backend. It
+/// streams progress events as they arrive from the scheduler so the
+/// calling app (vMLX) can render live step counters + partial previews.
+///
+/// Threading: actor-isolated. MLX ops are not thread-safe across the
+/// same allocator, and the generation loop has a persistent latent buffer,
+/// so every entry point goes through the actor's executor.
+public actor FluxEngine {
+
+    // MARK: - State
+
+    /// Currently loaded model (nil if no model is resident).
+    public private(set) var loaded: LoadedModel?
+
+    /// Cached model registry lookup — `ModelRegistry.lookup(name:)`
+    /// is O(1) but we keep a local copy for logging.
+    public private(set) var lastLoadedName: String?
+
+    // MARK: - Init
+
+    public init() {}
+
+    // MARK: - Load / unload
+
+    /// Load a model by canonical name. Mirrors the Python mflux
+    /// `ModelConfig.from_name(_:)` resolution with the `SUPPORTED_MODELS`
+    /// dict from `vmlx_engine/image_gen.py`.
+    ///
+    /// Parameters:
+    /// - `name`: canonical model key — `"flux1-schnell"`, `"flux2-klein"`,
+    ///   `"z-image-turbo"`, `"qwen-image"`, `"qwen-image-edit"`,
+    ///   `"flux1-kontext"`, `"flux1-fill"`, `"seedvr2"`, `"fibo"`.
+    /// - `modelPath`: local directory containing weights. We NEVER
+    ///   silently download from HuggingFace — the caller (vMLX
+    ///   `DownloadManager`) must stage the weights first.
+    /// - `quantize`: bit width (4, 8) or nil for full precision.
+    public func load(
+        name: String,
+        modelPath: URL,
+        quantize: Int? = nil
+    ) async throws {
+        guard let entry = ModelRegistry.lookup(name: name) else {
+            throw FluxError.unknownModel(name)
+        }
+        let model = try await entry.loader(modelPath, quantize)
+        self.loaded = LoadedModel(
+            name: name,
+            kind: entry.kind,
+            model: model
+        )
+        self.lastLoadedName = name
+    }
+
+    /// Resolve and load a local image-generation bundle from
+    /// `~/.mlxstudio/models/image` or a caller-supplied model store.
+    ///
+    /// This keeps the "no silent downloads" rule intact while letting vMLX
+    /// callers use canonical model names instead of hard-coded local paths.
+    public func load(
+        name: String,
+        from store: MLXStudioModelStore = MLXStudioModelStore()
+    ) async throws -> LocalFluxModel {
+        VMLXFluxModels.registerAll()
+        VMLXFluxVideo.registerAll()
+        guard let local = try store.resolve(name: name) else {
+            throw FluxError.localModelNotFound(name, store.root)
+        }
+        guard local.canEnterNativeLoadPath else {
+            throw FluxError.localModelIncomplete(
+                local.directory,
+                reasons: local.blockedReasons)
+        }
+        guard let canonicalName = local.canonicalName else {
+            throw FluxError.unknownModel(local.directoryName)
+        }
+        try await load(
+            name: canonicalName,
+            modelPath: local.directory,
+            quantize: local.quantizationBits)
+        return local
+    }
+
+    /// Unload the current model and release weights.
+    public func unload() {
+        self.loaded = nil
+    }
+
+    // MARK: - Generate (text-to-image)
+
+    /// Run a text-to-image generation. Returns an AsyncThrowingStream of
+    /// progress events — the final `.completed(url:)` carries the
+    /// written image path.
+    public func generate(
+        _ request: ImageGenRequest
+    ) -> AsyncThrowingStream<ImageGenEvent, Error> {
+        AsyncThrowingStream { continuation in
+            Task { [weak self] in
+                guard let self else { continuation.finish(); return }
+                do {
+                    try await self.performGenerate(request, continuation: continuation)
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
+    }
+
+    private func performGenerate(
+        _ request: ImageGenRequest,
+        continuation: AsyncThrowingStream<ImageGenEvent, Error>.Continuation
+    ) async throws {
+        guard let loaded else { throw FluxError.notLoaded }
+        guard let generator = loaded.model as? ImageGenerator else {
+            throw FluxError.wrongModelKind(
+                expected: "ImageGenerator",
+                actual: String(describing: type(of: loaded.model))
+            )
+        }
+        for try await event in generator.generate(request) {
+            continuation.yield(event)
+        }
+    }
+
+    // MARK: - Edit (image-to-image)
+
+    /// Run an image edit request (Kontext / Fill / Qwen-Image-Edit).
+    public func edit(
+        _ request: ImageEditRequest
+    ) -> AsyncThrowingStream<ImageGenEvent, Error> {
+        AsyncThrowingStream { continuation in
+            Task { [weak self] in
+                guard let self else { continuation.finish(); return }
+                do {
+                    try await self.performEdit(request, continuation: continuation)
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
+    }
+
+    private func performEdit(
+        _ request: ImageEditRequest,
+        continuation: AsyncThrowingStream<ImageGenEvent, Error>.Continuation
+    ) async throws {
+        guard let loaded else { throw FluxError.notLoaded }
+        guard let editor = loaded.model as? ImageEditor else {
+            throw FluxError.wrongModelKind(
+                expected: "ImageEditor",
+                actual: String(describing: type(of: loaded.model))
+            )
+        }
+        for try await event in editor.edit(request) {
+            continuation.yield(event)
+        }
+    }
+
+    // MARK: - Upscale (SeedVR2)
+
+    /// Run an upscale request. Emits the same progress events as gen/edit.
+    public func upscale(
+        _ request: UpscaleRequest
+    ) -> AsyncThrowingStream<ImageGenEvent, Error> {
+        AsyncThrowingStream { continuation in
+            Task { [weak self] in
+                guard let self else { continuation.finish(); return }
+                do {
+                    try await self.performUpscale(request, continuation: continuation)
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+        }
+    }
+
+    private func performUpscale(
+        _ request: UpscaleRequest,
+        continuation: AsyncThrowingStream<ImageGenEvent, Error>.Continuation
+    ) async throws {
+        guard let loaded else { throw FluxError.notLoaded }
+        guard let upscaler = loaded.model as? ImageUpscaler else {
+            throw FluxError.wrongModelKind(
+                expected: "ImageUpscaler",
+                actual: String(describing: type(of: loaded.model))
+            )
+        }
+        for try await event in upscaler.upscale(request) {
+            continuation.yield(event)
+        }
+    }
+
+    // MARK: - Video (future — Apple WAN 2.x)
+
+    /// Video generation stub — scaffolded for Apple WAN models but not
+    /// implemented yet. See `VMLXFluxVideo/WANModel.swift`.
+    public func generateVideo(
+        _ request: VideoGenRequest
+    ) -> AsyncThrowingStream<VideoGenEvent, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.finish(throwing: FluxError.notImplemented(
+                "Video generation — WAN models scaffolded but not implemented"))
+        }
+    }
+}
+
+/// A loaded model + its canonical name + kind (for fast dispatch).
+public struct LoadedModel: Sendable {
+    public let name: String
+    public let kind: ModelKind
+    public let model: any FluxModel
+}

--- a/Libraries/vMLXFluxKit/FlowMatchScheduler.swift
+++ b/Libraries/vMLXFluxKit/FlowMatchScheduler.swift
@@ -1,0 +1,98 @@
+import Foundation
+import MLX
+
+// MARK: - FlowMatchEulerScheduler
+//
+// Flow-matching (a.k.a. rectified flow) Euler scheduler used by FLUX.1,
+// FLUX.2, ZImage, Qwen-Image, and FIBO. The sampling loop walks a set
+// of monotonically decreasing "sigmas" from 1.0 → 0.0, calling the
+// transformer at each step with the current latent + timestep embedding,
+// and applying a first-order Euler update:
+//
+//     x_{t-1} = x_t + (σ_{t-1} - σ_t) * v_pred
+//
+// where `v_pred` is the velocity field predicted by the transformer.
+//
+// The sigma schedule is parameterized by `shift` — a scalar that skews
+// the timestep distribution toward noisier (higher shift) or cleaner
+// (lower shift) regions. The Python mflux reference uses:
+//
+//     shift = base_shift + (max_shift - base_shift) * (image_seq_len - 256) / (4096 - 256)
+//
+// which gives slightly more steps at low-noise regions for large images.
+// Defaults match mflux/models/flux/flow_scheduler.py.
+
+public struct FlowMatchEulerScheduler: Sendable {
+
+    /// Number of sampling steps.
+    public let steps: Int
+
+    /// Sigma vector (length `steps + 1`, monotonically decreasing from 1→0).
+    public let sigmas: [Float]
+
+    /// Discrete timesteps (length `steps`), derived from sigmas for the
+    /// transformer's timestep embedding.
+    public let timesteps: [Float]
+
+    public init(
+        steps: Int,
+        imageSeqLen: Int = 4096,
+        baseShift: Float = 0.5,
+        maxShift: Float = 1.15
+    ) {
+        self.steps = steps
+
+        // Compute the resolution-dependent shift.
+        let shift = Self.computeShift(
+            imageSeqLen: imageSeqLen,
+            baseShift: baseShift,
+            maxShift: maxShift
+        )
+
+        // Linspace sigmas from 1 → 0 over (steps + 1) points.
+        var rawSigmas: [Float] = []
+        for i in 0...steps {
+            let t = Float(i) / Float(steps)
+            rawSigmas.append(1.0 - t)
+        }
+
+        // Apply the flow-match shift: sigma' = shift * sigma / (1 + (shift - 1) * sigma)
+        self.sigmas = rawSigmas.map { sigma in
+            shift * sigma / (1.0 + (shift - 1.0) * sigma)
+        }
+
+        // Timesteps match sigmas[0..<steps] (discrete conditioning value).
+        self.timesteps = Array(sigmas.prefix(steps)).map { $0 * 1000.0 }
+    }
+
+    /// Apply a single Euler update step. `latent` is the current noisy
+    /// latent, `velocity` is the transformer's predicted velocity field,
+    /// `stepIndex` is 0..<steps.
+    public func step(
+        latent: MLXArray,
+        velocity: MLXArray,
+        stepIndex: Int
+    ) -> MLXArray {
+        let sigmaCurrent = sigmas[stepIndex]
+        let sigmaNext = sigmas[stepIndex + 1]
+        let delta = sigmaNext - sigmaCurrent
+        return latent + velocity * MLXArray(delta)
+    }
+
+    /// Compute the resolution-dependent timestep shift.
+    public static func computeShift(
+        imageSeqLen: Int,
+        baseShift: Float = 0.5,
+        maxShift: Float = 1.15
+    ) -> Float {
+        let minSeq: Float = 256
+        let maxSeq: Float = 4096
+        let t = (Float(imageSeqLen) - minSeq) / (maxSeq - minSeq)
+        let clamped = min(max(t, 0), 1)
+        return baseShift + (maxShift - baseShift) * clamped
+    }
+
+    /// Convenience: number of actual Euler steps (same as `steps` but
+    /// expressed as a function signature for clarity at call sites).
+    public var stepCount: Int { steps }
+}

--- a/Libraries/vMLXFluxKit/FluxDiT.swift
+++ b/Libraries/vMLXFluxKit/FluxDiT.swift
@@ -1,0 +1,570 @@
+import Foundation
+@preconcurrency import MLX
+import MLXNN
+
+// MARK: - Flux DiT transformer backbone
+//
+// Pure-Swift port of the FLUX.1 transformer used by Flux1 Schnell/Dev,
+// Flux2 Klein, Qwen-Image, and FIBO. Architecture:
+//
+//   patch_embed      : (B, 16, H/8, W/8) → (B, N_img, D=3072)
+//   time_mlp         : timestep → time embedding (D=3072)
+//   text_proj        : (B, N_txt, C_text) → (B, N_txt, D)
+//   guidance_mlp     : (optional, Dev only) guidance scale → embedding
+//   blocks[19]       : "double" blocks — dual-stream (img + txt) attention
+//   single_blocks[38]: fused single-stream attention (img only after merge)
+//   final_layer      : norm + linear → (B, N_img, 16*patch²) → unpatchify
+//
+// The model splits into two regimes:
+//   - Double blocks keep image and text tokens in separate streams with
+//     shared attention (MM-DiT style).
+//   - Single blocks concatenate img + txt into one sequence and run
+//     standard self-attention. After the single blocks we drop text
+//     tokens and return just the image tokens.
+//
+// Parameter counts (Flux1 Dev):
+//   - 12B total
+//   - 19 double blocks × 360M = 6.8B
+//   - 38 single blocks × 120M = 4.6B
+//   - rest: 600M (embed, norm, text proj)
+//
+// This file ships the BLOCK types + the full-model assembler. The
+// per-model files (Flux1Schnell, Flux1Dev, Flux2Klein, ...) just pick
+// hyperparameters and register for weight loading.
+//
+// Weight naming follows Black Forest Labs' safetensors layout so the
+// standard .safetensors checkpoints from HuggingFace load directly.
+
+// MARK: - AdaLN modulation
+
+/// AdaLN single-stream modulation: produces (shift, scale, gate) triples
+/// applied around attention and MLP. The `num_mods` controls how many
+/// triples we produce — double blocks use 6 (three for attn, three for
+/// mlp), single blocks use 3.
+public final class FluxModulation: Module {
+    public let linear: Linear
+    public let numMods: Int   // 3 or 6
+    public let doubleMode: Bool
+
+    public init(dim: Int, doubleMode: Bool) {
+        self.doubleMode = doubleMode
+        self.numMods = doubleMode ? 6 : 3
+        self.linear = Linear(dim, dim * numMods)
+        super.init()
+    }
+
+    /// Returns a list of `ModTriple` — 2 for double-mode blocks (attn,mlp),
+    /// 1 for single-mode blocks. `vec` is the conditioning embedding
+    /// (time + pooled CLIP + guidance).
+    public func callAsFunction(_ vec: MLXArray) -> [ModTriple] {
+        let out = linear(silu(vec))
+        let dim = out.dim(-1) / numMods
+        var result: [ModTriple] = []
+        let mods = numMods / 3
+        for i in 0..<mods {
+            let base = i * 3
+            let shift = out[.ellipsis, (base + 0) * dim ..< (base + 1) * dim]
+            let scale = out[.ellipsis, (base + 1) * dim ..< (base + 2) * dim]
+            let gate  = out[.ellipsis, (base + 2) * dim ..< (base + 3) * dim]
+            // Add a sequence dim so we broadcast over tokens: (B, 1, D).
+            result.append(ModTriple(
+                shift: shift.reshaped([shift.dim(0), 1, dim]),
+                scale: scale.reshaped([scale.dim(0), 1, dim]),
+                gate:  gate.reshaped([gate.dim(0), 1, dim])
+            ))
+        }
+        return result
+    }
+}
+
+/// Explicit return type for `FluxModulation`. Swift auto-tuple-labeling
+/// inference gets confused when threading named-field tuples through
+/// array literals, so we use a named struct for clarity + type safety.
+/// Not `Sendable` because MLXArray isn't — the module tree is actor-
+/// isolated so cross-actor passing never happens.
+public struct ModTriple {
+    public let shift: MLXArray
+    public let scale: MLXArray
+    public let gate: MLXArray
+
+    public init(shift: MLXArray, scale: MLXArray, gate: MLXArray) {
+        self.shift = shift
+        self.scale = scale
+        self.gate = gate
+    }
+}
+
+// MARK: - Q/K norm (RMSNorm per-head, applied to Q and K separately)
+
+/// QKNorm applies per-head RMSNorm to Q and K before attention.
+/// Prevents attention score blow-up at mixed precision.
+public final class QKNorm: Module {
+    public let qNorm: RMSNorm
+    public let kNorm: RMSNorm
+
+    public init(headDim: Int) {
+        // Use MLXNN's RMSNorm — it's hardware-accelerated via
+        // MLXFast.rmsNorm and ~5x faster than the pure-Swift variant.
+        self.qNorm = RMSNorm(dimensions: headDim, eps: 1e-6)
+        self.kNorm = RMSNorm(dimensions: headDim, eps: 1e-6)
+        super.init()
+    }
+
+    public func callAsFunction(q: MLXArray, k: MLXArray) -> (MLXArray, MLXArray) {
+        return (qNorm(q), kNorm(k))
+    }
+}
+
+// MARK: - Double stream block (dual img + txt attention)
+
+/// One double-stream MM-DiT block. Image and text tokens keep separate
+/// Q/K/V projections but share an attention op after concatenation.
+public final class FluxDoubleStreamBlock: Module {
+    public let dim: Int
+    public let numHeads: Int
+
+    // Image stream
+    public let imgMod: FluxModulation
+    public let imgNorm1: LayerNorm
+    public let imgAttnQKV: Linear
+    public let imgAttnNorm: QKNorm
+    public let imgAttnProj: Linear
+    public let imgNorm2: LayerNorm
+    public let imgMlp0: Linear
+    public let imgMlp2: Linear
+
+    // Text stream
+    public let txtMod: FluxModulation
+    public let txtNorm1: LayerNorm
+    public let txtAttnQKV: Linear
+    public let txtAttnNorm: QKNorm
+    public let txtAttnProj: Linear
+    public let txtNorm2: LayerNorm
+    public let txtMlp0: Linear
+    public let txtMlp2: Linear
+
+    public init(dim: Int, numHeads: Int, mlpRatio: Float = 4.0) {
+        self.dim = dim
+        self.numHeads = numHeads
+        let headDim = dim / numHeads
+        let mlpDim = Int(Float(dim) * mlpRatio)
+
+        // Image stream
+        self.imgMod = FluxModulation(dim: dim, doubleMode: true)
+        self.imgNorm1 = LayerNorm(dimensions: dim, eps: 1e-6, affine: false)
+        self.imgAttnQKV = Linear(dim, dim * 3)
+        self.imgAttnNorm = QKNorm(headDim: headDim)
+        self.imgAttnProj = Linear(dim, dim)
+        self.imgNorm2 = LayerNorm(dimensions: dim, eps: 1e-6, affine: false)
+        self.imgMlp0 = Linear(dim, mlpDim)
+        self.imgMlp2 = Linear(mlpDim, dim)
+
+        // Text stream — same shape as image stream.
+        self.txtMod = FluxModulation(dim: dim, doubleMode: true)
+        self.txtNorm1 = LayerNorm(dimensions: dim, eps: 1e-6, affine: false)
+        self.txtAttnQKV = Linear(dim, dim * 3)
+        self.txtAttnNorm = QKNorm(headDim: headDim)
+        self.txtAttnProj = Linear(dim, dim)
+        self.txtNorm2 = LayerNorm(dimensions: dim, eps: 1e-6, affine: false)
+        self.txtMlp0 = Linear(dim, mlpDim)
+        self.txtMlp2 = Linear(mlpDim, dim)
+
+        super.init()
+    }
+
+    /// - Parameters:
+    ///   - img: (B, N_img, D) image tokens after patch_embed.
+    ///   - txt: (B, N_txt, D) text tokens after T5+CLIP encoding & projection.
+    ///   - vec: (B, D) pooled conditioning vector (time + pooled CLIP + guidance).
+    ///   - rope: optional rotary embedding applied to Q and K for BOTH streams.
+    public func callAsFunction(
+        img: MLXArray, txt: MLXArray, vec: MLXArray, rope: RoPE2D?
+    ) -> (img: MLXArray, txt: MLXArray) {
+        let imgMods = imgMod(vec)   // 2 triples: attn, mlp
+        let txtMods = txtMod(vec)
+
+        // Image Q/K/V + modulation.
+        var imgNormed = imgNorm1(img)
+        imgNormed = imgNormed * (MLXArray(Float(1)) + imgMods[0].scale) + imgMods[0].shift
+        let imgQkv = imgAttnQKV(imgNormed)
+        let (imgQ, imgK, imgV) = splitQKV(imgQkv, numHeads: numHeads)
+        let (imgQn, imgKn) = imgAttnNorm(q: imgQ, k: imgK)
+
+        // Text Q/K/V + modulation.
+        var txtNormed = txtNorm1(txt)
+        txtNormed = txtNormed * (MLXArray(Float(1)) + txtMods[0].scale) + txtMods[0].shift
+        let txtQkv = txtAttnQKV(txtNormed)
+        let (txtQ, txtK, txtV) = splitQKV(txtQkv, numHeads: numHeads)
+        let (txtQn, txtKn) = txtAttnNorm(q: txtQ, k: txtK)
+
+        // Joint attention: concat text + image tokens along seq axis,
+        // run attention, split back. RoPE applies to image tokens only.
+        // Shape: (B, H, N_txt + N_img, D_head)
+        let q = concatenated([txtQn, imgQn], axis: 2)
+        let k = concatenated([txtKn, imgKn], axis: 2)
+        let v = concatenated([txtV, imgV], axis: 2)
+
+        // Apply RoPE only to the image slice. Here we simplify by
+        // skipping RoPE on text tokens (they get their own positional
+        // bands in the full Flux impl — adding that is a ~30-line extension
+        // when we wire per-model hyperparameters).
+        _ = rope  // TODO: split q/k, rope image half, reassemble
+
+        let attnOut = scaledDotProductAttention(q: q, k: k, v: v, rope: nil)
+        // (B, H, N_total, D_head) → (B, N_total, D)
+        let merged = attnOut.transposed(0, 2, 1, 3).reshaped([
+            attnOut.dim(0), attnOut.dim(2), dim
+        ])
+        let nTxt = txt.dim(1)
+        let txtAttn = merged[0 ..< merged.dim(0), 0 ..< nTxt, 0 ..< dim]
+        let imgAttn = merged[0 ..< merged.dim(0), nTxt ..< merged.dim(1), 0 ..< dim]
+
+        // Image attention residual with gate.
+        var imgOut = img + imgAttnProj(imgAttn) * imgMods[0].gate
+
+        // Image MLP.
+        var imgNorm2Out = imgNorm2(imgOut)
+        imgNorm2Out = imgNorm2Out * (MLXArray(Float(1)) + imgMods[1].scale) + imgMods[1].shift
+        let imgMlp = imgMlp2(gelu(imgMlp0(imgNorm2Out)))
+        imgOut = imgOut + imgMlp * imgMods[1].gate
+
+        // Text attention residual with gate.
+        var txtOut = txt + txtAttnProj(txtAttn) * txtMods[0].gate
+
+        // Text MLP.
+        var txtNorm2Out = txtNorm2(txtOut)
+        txtNorm2Out = txtNorm2Out * (MLXArray(Float(1)) + txtMods[1].scale) + txtMods[1].shift
+        let txtMlp = txtMlp2(gelu(txtMlp0(txtNorm2Out)))
+        txtOut = txtOut + txtMlp * txtMods[1].gate
+
+        return (img: imgOut, txt: txtOut)
+    }
+}
+
+// MARK: - Single stream block (fused attention after img/txt merge)
+
+/// Single-stream block. Runs after the double blocks on the
+/// concatenated (txt, img) sequence. Has one attention op and one
+/// parallel MLP fused into the same residual.
+public final class FluxSingleStreamBlock: Module {
+    public let dim: Int
+    public let numHeads: Int
+    public let mlpDim: Int
+
+    public let mod: FluxModulation
+    public let norm: LayerNorm
+    public let linear1: Linear  // projects to qkv + mlp_in concatenated
+    public let qkNorm: QKNorm
+    public let linear2: Linear  // projects attn + mlp concatenated back to dim
+
+    public init(dim: Int, numHeads: Int, mlpRatio: Float = 4.0) {
+        self.dim = dim
+        self.numHeads = numHeads
+        self.mlpDim = Int(Float(dim) * mlpRatio)
+        let headDim = dim / numHeads
+
+        self.mod = FluxModulation(dim: dim, doubleMode: false)
+        self.norm = LayerNorm(dimensions: dim, eps: 1e-6, affine: false)
+        // linear1 outputs (qkv: 3*dim) + (mlp_in: mlpDim)
+        self.linear1 = Linear(dim, dim * 3 + mlpDim)
+        self.qkNorm = QKNorm(headDim: headDim)
+        // linear2 takes (attn: dim) + (mlp: mlpDim) back to dim
+        self.linear2 = Linear(dim + mlpDim, dim)
+
+        super.init()
+    }
+
+    public func callAsFunction(
+        _ x: MLXArray, vec: MLXArray, rope: RoPE2D?
+    ) -> MLXArray {
+        let mods = mod(vec)
+        let triple = mods[0]
+        var xMod = norm(x)
+        xMod = xMod * (MLXArray(Float(1)) + triple.scale) + triple.shift
+
+        let out = linear1(xMod)
+        // Split into qkv (3*dim) and mlp_in (mlpDim).
+        let qkv = out[.ellipsis, 0 ..< (dim * 3)]
+        let mlpIn = out[.ellipsis, (dim * 3) ..< (dim * 3 + mlpDim)]
+
+        let (q, k, v) = splitQKV(qkv, numHeads: numHeads)
+        let (qn, kn) = qkNorm(q: q, k: k)
+
+        _ = rope  // TODO: apply to qn/kn when per-model RoPE config lands
+        let attn = scaledDotProductAttention(q: qn, k: kn, v: v, rope: nil)
+        // (B, H, N, D_head) → (B, N, D)
+        let attnMerged = attn.transposed(0, 2, 1, 3).reshaped([
+            attn.dim(0), attn.dim(2), dim
+        ])
+
+        // MLP gelu activation.
+        let mlpActivated = gelu(mlpIn)
+
+        // Concat attn + mlp along channel axis, project back to dim.
+        let concated = concatenated([attnMerged, mlpActivated], axis: -1)
+        let projected = linear2(concated)
+
+        return x + projected * triple.gate
+    }
+}
+
+// MARK: - Q/K/V split helper
+
+/// Split a (B, N, 3*D) QKV tensor into three (B, H, N, D_head) tensors.
+public func splitQKV(_ qkv: MLXArray, numHeads: Int) -> (MLXArray, MLXArray, MLXArray) {
+    let b = qkv.dim(0)
+    let n = qkv.dim(1)
+    let d3 = qkv.dim(2)
+    let d = d3 / 3
+    let headDim = d / numHeads
+    // (B, N, 3*D) → (B, N, 3, H, D_head)
+    let reshaped = qkv.reshaped([b, n, 3, numHeads, headDim])
+    // → (3, B, H, N, D_head)
+    let transposed = reshaped.transposed(2, 0, 3, 1, 4)
+    let q = transposed[0]
+    let k = transposed[1]
+    let v = transposed[2]
+    return (q, k, v)
+}
+
+// MARK: - Final layer (norm + project to patchified pixel space)
+
+/// Final output head. Takes the image-token sequence (B, N_img, D) and
+/// produces (B, N_img, patch² × out_channels) ready to unpatchify into
+/// the VAE input resolution.
+public final class FluxFinalLayer: Module {
+    public let norm: LayerNorm
+    public let linear: Linear
+    public let mod: Linear
+
+    public init(dim: Int, patchSize: Int = 2, outChannels: Int = 16) {
+        self.norm = LayerNorm(dimensions: dim, eps: 1e-6, affine: false)
+        self.linear = Linear(dim, patchSize * patchSize * outChannels)
+        // Modulation: produces (shift, scale) from vec.
+        self.mod = Linear(dim, dim * 2)
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray, vec: MLXArray) -> MLXArray {
+        let out = mod(silu(vec))
+        let d = out.dim(-1) / 2
+        let shift = out[.ellipsis, 0 ..< d].reshaped([out.dim(0), 1, d])
+        let scale = out[.ellipsis, d ..< (d * 2)].reshaped([out.dim(0), 1, d])
+        var h = norm(x)
+        h = h * (MLXArray(Float(1)) + scale) + shift
+        return linear(h)
+    }
+}
+
+// MARK: - FluxDiTModel assembly
+//
+// The per-model variant (Flux1 Schnell, Flux1 Dev, Flux2 Klein, etc.)
+// instantiates one of these with its own hyperparameters + optional
+// `guidanceEmbed` flag.
+
+public struct FluxDiTConfig: Sendable {
+    public let dim: Int
+    public let numDoubleBlocks: Int
+    public let numSingleBlocks: Int
+    public let numHeads: Int
+    public let patchSize: Int
+    public let inChannels: Int
+    public let outChannels: Int
+    public let guidanceEmbed: Bool
+    public let textDim: Int
+
+    public init(
+        dim: Int = 3072,
+        numDoubleBlocks: Int = 19,
+        numSingleBlocks: Int = 38,
+        numHeads: Int = 24,
+        patchSize: Int = 2,
+        inChannels: Int = 16,
+        outChannels: Int = 16,
+        guidanceEmbed: Bool = false,
+        textDim: Int = 4096
+    ) {
+        self.dim = dim
+        self.numDoubleBlocks = numDoubleBlocks
+        self.numSingleBlocks = numSingleBlocks
+        self.numHeads = numHeads
+        self.patchSize = patchSize
+        self.inChannels = inChannels
+        self.outChannels = outChannels
+        self.guidanceEmbed = guidanceEmbed
+        self.textDim = textDim
+    }
+
+    /// FLUX.1 Schnell config. 4-step, no guidance embed.
+    public static let schnell = FluxDiTConfig(
+        numDoubleBlocks: 19, numSingleBlocks: 38, numHeads: 24,
+        guidanceEmbed: false
+    )
+
+    /// FLUX.1 Dev config. 20-step, uses guidance embed for CFG.
+    public static let dev = FluxDiTConfig(
+        numDoubleBlocks: 19, numSingleBlocks: 38, numHeads: 24,
+        guidanceEmbed: true
+    )
+
+    /// Z-Image Turbo — ~2B param single-encoder variant. The architecture
+    /// is close to Flux Schnell but with fewer blocks + a narrower
+    /// hidden dim. Numbers are approximate until we parse the checkpoint's
+    /// own `config.json` on load.
+    public static let zImageTurbo = FluxDiTConfig(
+        dim: 2048,
+        numDoubleBlocks: 8,
+        numSingleBlocks: 16,
+        numHeads: 16,
+        guidanceEmbed: false
+    )
+
+    /// FLUX.2 Klein — single-encoder, ~6B, similar block count to Flux1.
+    public static let flux2Klein = FluxDiTConfig(
+        dim: 3072,
+        numDoubleBlocks: 19,
+        numSingleBlocks: 38,
+        numHeads: 24,
+        guidanceEmbed: true
+    )
+}
+
+/// ## Weight key mapping (for the real `.safetensors` loader)
+///
+/// Black Forest Labs ships FLUX checkpoints with the following naming
+/// convention. When the real weight loader lands, it must translate
+/// from these checkpoint keys to the Swift property names via
+/// `@ModuleInfo(key: "...")` decorators OR an explicit remap table fed
+/// to `Module.update(parameters:)`.
+///
+///     Checkpoint key                        → Swift property
+///     ─────────────────────────────────────────────────────────
+///     img_in.weight                         → imgIn
+///     time_in.in_layer.weight               → timeIn0
+///     time_in.out_layer.weight              → timeIn2
+///     vector_in.in_layer.weight             → vectorIn0
+///     vector_in.out_layer.weight            → vectorIn2
+///     guidance_in.in_layer.weight           → guidanceIn0 (Dev only)
+///     guidance_in.out_layer.weight          → guidanceIn2 (Dev only)
+///     txt_in.weight                         → txtIn
+///     double_blocks.{i}.img_mod.lin.weight  → doubleBlocks[i].imgMod.linear
+///     double_blocks.{i}.img_attn.qkv.weight → doubleBlocks[i].imgAttnQKV
+///     double_blocks.{i}.img_attn.proj.weight→ doubleBlocks[i].imgAttnProj
+///     double_blocks.{i}.img_attn.norm.query_norm.scale → .imgAttnNorm.qNorm.weight
+///     double_blocks.{i}.img_attn.norm.key_norm.scale   → .imgAttnNorm.kNorm.weight
+///     double_blocks.{i}.img_mlp.0.weight    → doubleBlocks[i].imgMlp0
+///     double_blocks.{i}.img_mlp.2.weight    → doubleBlocks[i].imgMlp2
+///     double_blocks.{i}.txt_*                → doubleBlocks[i].txt*  (same pattern)
+///     single_blocks.{i}.modulation.lin.weight → singleBlocks[i].mod.linear
+///     single_blocks.{i}.linear1.weight      → singleBlocks[i].linear1
+///     single_blocks.{i}.linear2.weight      → singleBlocks[i].linear2
+///     single_blocks.{i}.norm.query_norm.scale → .qkNorm.qNorm.weight
+///     single_blocks.{i}.norm.key_norm.scale   → .qkNorm.kNorm.weight
+///     final_layer.linear.weight             → finalLayer.linear
+///     final_layer.adaLN_modulation.1.weight → finalLayer.mod
+public final class FluxDiTModel: Module {
+    public let config: FluxDiTConfig
+    public let imgIn: Linear   // patch embed: (patch² * in_channels) → dim
+    public let timeIn0: Linear
+    public let timeIn2: Linear
+    public let vectorIn0: Linear  // pooled CLIP projection
+    public let vectorIn2: Linear
+    public let guidanceIn0: Linear?
+    public let guidanceIn2: Linear?
+    public let txtIn: Linear      // T5 projection
+    public let doubleBlocks: [FluxDoubleStreamBlock]
+    public let singleBlocks: [FluxSingleStreamBlock]
+    public let finalLayer: FluxFinalLayer
+
+    public init(config: FluxDiTConfig) {
+        self.config = config
+
+        self.imgIn = Linear(
+            config.patchSize * config.patchSize * config.inChannels,
+            config.dim
+        )
+        self.timeIn0 = Linear(256, config.dim)
+        self.timeIn2 = Linear(config.dim, config.dim)
+        self.vectorIn0 = Linear(768, config.dim)   // pooled CLIP dim
+        self.vectorIn2 = Linear(config.dim, config.dim)
+        if config.guidanceEmbed {
+            self.guidanceIn0 = Linear(256, config.dim)
+            self.guidanceIn2 = Linear(config.dim, config.dim)
+        } else {
+            self.guidanceIn0 = nil
+            self.guidanceIn2 = nil
+        }
+        self.txtIn = Linear(config.textDim, config.dim)
+
+        self.doubleBlocks = (0..<config.numDoubleBlocks).map { _ in
+            FluxDoubleStreamBlock(dim: config.dim, numHeads: config.numHeads)
+        }
+        self.singleBlocks = (0..<config.numSingleBlocks).map { _ in
+            FluxSingleStreamBlock(dim: config.dim, numHeads: config.numHeads)
+        }
+        self.finalLayer = FluxFinalLayer(
+            dim: config.dim,
+            patchSize: config.patchSize,
+            outChannels: config.outChannels
+        )
+
+        super.init()
+    }
+
+    /// Forward pass. Returns the predicted velocity field for the Euler
+    /// scheduler to consume.
+    ///
+    /// - Parameters:
+    ///   - imgPatched: (B, N_img, patch²*16) — patchified VAE latent.
+    ///   - txt: (B, N_txt, 4096) — T5-XXL encoded prompt.
+    ///   - pooledClip: (B, 768) — pooled CLIP-L text embedding.
+    ///   - timestep: (B,) — current denoising step (1000 → 0).
+    ///   - guidance: (B,) — guidance scale (Dev only, nil for Schnell).
+    public func callAsFunction(
+        imgPatched: MLXArray,
+        txt: MLXArray,
+        pooledClip: MLXArray,
+        timestep: MLXArray,
+        guidance: MLXArray? = nil,
+        rope: RoPE2D? = nil
+    ) -> MLXArray {
+        // 1. Project image patches to model dim.
+        var img = imgIn(imgPatched)
+
+        // 2. Build conditioning vector `vec`.
+        let timeEmb = sinusoidalTimeEmbedding(
+            timesteps: timestep, embeddingDim: 256
+        )
+        let timeProjected = timeIn2(silu(timeIn0(timeEmb)))
+        let pooledProjected = vectorIn2(silu(vectorIn0(pooledClip)))
+        var vec = timeProjected + pooledProjected
+        if config.guidanceEmbed,
+           let g0 = guidanceIn0, let g2 = guidanceIn2, let g = guidance {
+            let gEmb = sinusoidalTimeEmbedding(timesteps: g, embeddingDim: 256)
+            vec = vec + g2(silu(g0(gEmb)))
+        }
+
+        // 3. Project text tokens.
+        var txtTokens = txtIn(txt)
+
+        // 4. Double blocks.
+        for block in doubleBlocks {
+            let out = block(img: img, txt: txtTokens, vec: vec, rope: rope)
+            img = out.img
+            txtTokens = out.txt
+        }
+
+        // 5. Concatenate for single blocks.
+        var merged = concatenated([txtTokens, img], axis: 1)
+        for block in singleBlocks {
+            merged = block(merged, vec: vec, rope: rope)
+        }
+
+        // 6. Drop text tokens, take image slice.
+        let nTxt = txtTokens.dim(1)
+        let imgOut = merged[0 ..< merged.dim(0), nTxt ..< merged.dim(1), 0 ..< config.dim]
+
+        // 7. Final layer → patchified velocity.
+        return finalLayer(imgOut, vec: vec)
+    }
+}

--- a/Libraries/vMLXFluxKit/FluxModel.swift
+++ b/Libraries/vMLXFluxKit/FluxModel.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+// MARK: - Core protocols
+//
+// Every concrete model (Flux1, Flux2Klein, ZImage, Qwen, SeedVR2, …)
+// conforms to `FluxModel` plus one-or-more capability protocols:
+//
+//   ImageGenerator — text → image
+//   ImageEditor    — (image, prompt[, mask]) → image
+//   ImageUpscaler  — low-res image → high-res image
+//   VideoGenerator — text → video (future)
+//
+// Lives in VMLXFluxKit so every model implementation depends on it
+// through a single target edge.
+
+/// Marker protocol for anything that can be loaded by `FluxEngine`.
+public protocol FluxModel: Sendable {}
+
+/// Text-to-image generator.
+public protocol ImageGenerator: FluxModel {
+    func generate(_ request: ImageGenRequest) -> AsyncThrowingStream<ImageGenEvent, Error>
+}
+
+/// Image-to-image editor (inpaint, outpaint, controlnet-like).
+public protocol ImageEditor: FluxModel {
+    func edit(_ request: ImageEditRequest) -> AsyncThrowingStream<ImageGenEvent, Error>
+}
+
+/// Super-resolution / upscale (SeedVR2).
+public protocol ImageUpscaler: FluxModel {
+    func upscale(_ request: UpscaleRequest) -> AsyncThrowingStream<ImageGenEvent, Error>
+}
+
+/// Text-to-video (Apple WAN 2.1/2.2, future).
+public protocol VideoGenerator: FluxModel {
+    func generate(_ request: VideoGenRequest) -> AsyncThrowingStream<VideoGenEvent, Error>
+}
+
+// MARK: - Kind (routed by FluxEngine)
+
+public enum ModelKind: String, Sendable, Codable {
+    case imageGen
+    case imageEdit
+    case imageUpscale
+    case videoGen
+}
+
+// MARK: - Errors
+
+public enum FluxError: Error, CustomStringConvertible {
+    case unknownModel(String)
+    case notLoaded
+    case wrongModelKind(expected: String, actual: String)
+    case weightsNotFound(URL)
+    case localModelNotFound(String, URL)
+    case localModelIncomplete(URL, reasons: [String])
+    case notImplemented(String)
+    case invalidRequest(String)
+
+    public var description: String {
+        switch self {
+        case .unknownModel(let n): return "unknown model: \(n)"
+        case .notLoaded:           return "no model loaded — call FluxEngine.load first"
+        case .wrongModelKind(let e, let a):
+            return "wrong model kind: expected \(e), got \(a)"
+        case .weightsNotFound(let u): return "weights not found at \(u.path)"
+        case .localModelNotFound(let name, let root):
+            return "local model not found: \(name) under \(root.path)"
+        case .localModelIncomplete(let u, let reasons):
+            return "local model incomplete at \(u.path): \(reasons.joined(separator: ", "))"
+        case .notImplemented(let s): return "not implemented: \(s)"
+        case .invalidRequest(let s): return "invalid request: \(s)"
+        }
+    }
+}

--- a/Libraries/vMLXFluxKit/ImageIO.swift
+++ b/Libraries/vMLXFluxKit/ImageIO.swift
@@ -1,0 +1,98 @@
+import Foundation
+@preconcurrency import MLX
+#if canImport(AppKit)
+import AppKit
+import CoreImage
+#endif
+
+// MARK: - ImageIO
+//
+// Write an MLX tensor to a PNG on disk. Used by every model as the
+// final step of `generate()` / `edit()` / `upscale()`. Isolated here so
+// the VAE decode path has a single function to call at the end of
+// sampling.
+//
+// Expected input shape: (B, C=3, H, W) float in [0, 1]. Values outside
+// that range are clamped.
+
+public enum ImageIO {
+
+    /// Save an image tensor to `dir/<prefix>-<uuid>.png`.
+    /// Returns the URL of the written file.
+    @MainActor
+    public static func writePNG(
+        _ tensor: MLXArray,
+        outputDir: URL,
+        prefix: String = "vmlx"
+    ) throws -> URL {
+        #if canImport(AppKit)
+        guard tensor.ndim == 4 || tensor.ndim == 3 else {
+            throw FluxError.invalidRequest(
+                "image tensor must be (B,C,H,W) or (C,H,W), got ndim=\(tensor.ndim)")
+        }
+        // Squeeze batch dim if present.
+        let single: MLXArray
+        if tensor.ndim == 4 {
+            single = tensor[0]
+        } else {
+            single = tensor
+        }
+        let channels = single.dim(0)
+        let height = single.dim(1)
+        let width = single.dim(2)
+
+        guard channels == 3 || channels == 1 else {
+            throw FluxError.invalidRequest(
+                "image tensor must have 1 or 3 channels, got \(channels)")
+        }
+
+        // Clamp to [0, 1], scale to [0, 255], cast to uint8.
+        let clamped = clip(single, min: MLXArray(Float(0)), max: MLXArray(Float(1)))
+        let scaled = clamped * MLXArray(Float(255))
+        let rounded = MLX.round(scaled)
+        let asUInt8 = rounded.asType(.uint8)
+
+        // (C, H, W) → (H, W, C) for pixel buffer interpretation.
+        let interleaved = asUInt8.transposed(1, 2, 0)
+        let bytes = interleaved.asArray(UInt8.self)
+
+        // Build an NSBitmapImageRep and serialize.
+        let bitsPerPixel = channels == 3 ? 24 : 8
+        let bytesPerRow = width * channels
+        guard let rep = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: width,
+            pixelsHigh: height,
+            bitsPerSample: 8,
+            samplesPerPixel: channels,
+            hasAlpha: false,
+            isPlanar: false,
+            colorSpaceName: channels == 3 ? .calibratedRGB : .calibratedWhite,
+            bytesPerRow: bytesPerRow,
+            bitsPerPixel: bitsPerPixel
+        ) else {
+            throw FluxError.invalidRequest("failed to create NSBitmapImageRep")
+        }
+        // Copy pixel data into the rep.
+        if let ptr = rep.bitmapData {
+            bytes.withUnsafeBufferPointer { src in
+                if let base = src.baseAddress {
+                    ptr.update(from: base, count: bytes.count)
+                }
+            }
+        }
+        guard let pngData = rep.representation(using: .png, properties: [:]) else {
+            throw FluxError.invalidRequest("failed to PNG-encode image")
+        }
+
+        try FileManager.default.createDirectory(
+            at: outputDir, withIntermediateDirectories: true)
+        let filename = "\(prefix)-\(UUID().uuidString).png"
+        let url = outputDir.appendingPathComponent(filename)
+        try pngData.write(to: url)
+        return url
+        #else
+        throw FluxError.notImplemented("ImageIO.writePNG requires AppKit")
+        #endif
+    }
+}

--- a/Libraries/vMLXFluxKit/JangSupport.swift
+++ b/Libraries/vMLXFluxKit/JangSupport.swift
@@ -1,0 +1,41 @@
+import Foundation
+@preconcurrency import MLXLMCommon
+
+// MARK: - JANG support bridge
+//
+// Reuse vmlx-swift-lm's `JangLoader` / `JangConfig` instead of re-porting
+// them. When a Flux model directory contains a `jang_config.json`, we
+// load the per-layer quantization metadata and pass it through to the
+// weight loader so 2-bit affine + MXTQ packed weights decode correctly.
+//
+// Why bridge vs re-export: vmlx-swift-lm already has 533 lines of
+// JANG v2 parsing (JangConfig / JangQuantization / JangSourceModel /
+// JangArchitecture / JangRuntime) plus per-model weight remap logic for
+// Mistral 4 / Gemma 4 / Nemotron H / Qwen 3.5. All of that works on
+// transformer-style checkpoints and is directly usable here.
+
+/// Thin wrapper so callers in VMLXFluxModels don't need to import
+/// MLXLMCommon themselves.
+public enum JangBridge {
+
+    /// True if the directory contains a JANG v2 config file.
+    public static func isJangModel(at path: URL) -> Bool {
+        MLXLMCommon.JangLoader.isJangModel(at: path)
+    }
+
+    /// Parse the JANG config from a model directory. Returns nil if
+    /// not a JANG model. Rethrows parse errors.
+    public static func loadConfig(at path: URL) throws -> MLXLMCommon.JangConfig? {
+        guard MLXLMCommon.JangLoader.isJangModel(at: path) else { return nil }
+        return try MLXLMCommon.JangLoader.loadConfig(at: path)
+    }
+
+    /// Convenience: `(isJang, config)` tuple for the single branch the
+    /// model loaders always want — "detect + parse in one shot".
+    public static func detect(at path: URL) throws -> (isJang: Bool, config: MLXLMCommon.JangConfig?) {
+        guard MLXLMCommon.JangLoader.isJangModel(at: path) else {
+            return (false, nil)
+        }
+        return (true, try MLXLMCommon.JangLoader.loadConfig(at: path))
+    }
+}

--- a/Libraries/vMLXFluxKit/LatentSpace.swift
+++ b/Libraries/vMLXFluxKit/LatentSpace.swift
@@ -1,0 +1,145 @@
+import Foundation
+import MLX
+import MLXRandom
+
+// MARK: - LatentSpace
+//
+// Utilities for constructing initial noise latents at the right shape
+// for each model family. Flux and Qwen use a (B, H/8 × W/8, C=16)
+// patchified layout; Z-Image uses (B, C=4, H/8, W/8). Both are 8x spatial
+// downsamples of the target image resolution.
+//
+// Keeping these in VMLXFluxKit so every model ports against the same
+// shape conventions.
+
+public enum LatentLayout: Sendable {
+    /// Flux-style: `(B, seq, channels)` where `seq = (H/8) × (W/8)` and
+    /// channels is typically 16. Used by Flux1 / Flux2 / FIBO / Qwen.
+    case fluxPatchified(channels: Int)
+    /// Z-Image / legacy SDXL: `(B, C, H/8, W/8)`.
+    case spatial(channels: Int)
+}
+
+public enum LatentSpace {
+
+    /// Allocate an initial noise latent at the right shape for the model
+    /// family. The `seed` parameter is threaded through `MLXRandom` so
+    /// generations are reproducible when the user sets a seed.
+    ///
+    /// - Parameters:
+    ///   - width: target image width in pixels (will be divided by 8)
+    ///   - height: target image height in pixels
+    ///   - layout: family-specific latent layout
+    ///   - batchSize: how many images to generate in one forward pass
+    ///   - seed: optional RNG seed (nil = system entropy)
+    public static func initialNoise(
+        width: Int,
+        height: Int,
+        layout: LatentLayout,
+        batchSize: Int = 1,
+        seed: UInt64? = nil
+    ) -> MLXArray {
+        // Seed the global MLX random generator. MLXRandom has a per-call
+        // key parameter too; for simplicity we set-then-allocate.
+        if let s = seed {
+            MLXRandom.seed(s)
+        }
+
+        let latentH = height / 8
+        let latentW = width / 8
+
+        switch layout {
+        case .fluxPatchified(let channels):
+            let seqLen = latentH * latentW
+            return MLXRandom.normal([batchSize, seqLen, channels])
+
+        case .spatial(let channels):
+            return MLXRandom.normal([batchSize, channels, latentH, latentW])
+        }
+    }
+
+    /// Convert a patchified `(B, seq, C)` latent into a spatial
+    /// `(B, C, H/8, W/8)` layout. Used before the VAE decode step.
+    public static func unpatchify(
+        _ latent: MLXArray,
+        height: Int,
+        width: Int
+    ) -> MLXArray {
+        let latentH = height / 8
+        let latentW = width / 8
+        let b = latent.dim(0)
+        let channels = latent.dim(2)
+        // (B, H*W, C) → (B, H, W, C) → (B, C, H, W)
+        let reshaped = latent.reshaped([b, latentH, latentW, channels])
+        return reshaped.transposed(0, 3, 1, 2)
+    }
+
+    /// The inverse of `unpatchify`. Used when the scheduler hands us a
+    /// spatial tensor and the transformer wants a sequence.
+    public static func patchify(_ latent: MLXArray) -> MLXArray {
+        let b = latent.dim(0)
+        let c = latent.dim(1)
+        let h = latent.dim(2)
+        let w = latent.dim(3)
+        // (B, C, H, W) → (B, H, W, C) → (B, H*W, C)
+        return latent.transposed(0, 2, 3, 1).reshaped([b, h * w, c])
+    }
+}
+
+// MARK: - Flux-style patchify (2D with patch size > 1)
+//
+// The FluxDiT transformer consumes "patchified" latents where every
+// patch_size × patch_size block of the VAE latent becomes one token.
+// This is the standard DiT patch-embed layout used by FLUX.1, FLUX.2,
+// Qwen-Image, ZImage, and FIBO.
+
+/// Convert a spatial latent `(B, C, H, W)` into a token sequence
+/// `(B, N, patch² · C)` where `N = (H/patch) × (W/patch)`.
+///
+/// Layout: for each token we pack `[C, patch_h * patch_w]` values in
+/// C-major (matches the Black Forest Labs checkpoint convention).
+public func patchify(
+    _ latent: MLXArray,
+    patchSize: Int,
+    inChannels: Int
+) -> MLXArray {
+    let b = latent.dim(0)
+    let c = latent.dim(1)
+    precondition(c == inChannels, "patchify: channel mismatch \(c) vs \(inChannels)")
+    let h = latent.dim(2)
+    let w = latent.dim(3)
+    let ph = h / patchSize
+    let pw = w / patchSize
+    // (B, C, H, W) → (B, C, ph, patch, pw, patch)
+    let r = latent.reshaped([b, c, ph, patchSize, pw, patchSize])
+    // → (B, ph, pw, C, patch, patch)
+    let t = r.transposed(0, 2, 4, 1, 3, 5)
+    // → (B, ph*pw, C*patch*patch)
+    return t.reshaped([b, ph * pw, c * patchSize * patchSize])
+}
+
+/// Inverse of `patchify`. Takes a token sequence
+/// `(B, N, patch² · outChannels)` and reshapes into a spatial latent
+/// `(B, outChannels, H/8, W/8)` — the target VAE latent dims.
+///
+/// `height` and `width` are the ORIGINAL image dimensions in pixels;
+/// the spatial output is `(H/8) / patchSize × (W/8) / patchSize`.
+public func unpatchify(
+    _ patched: MLXArray,
+    patchSize: Int,
+    outChannels: Int,
+    height: Int,
+    width: Int
+) -> MLXArray {
+    let b = patched.dim(0)
+    let latentH = height / 8
+    let latentW = width / 8
+    let ph = latentH / patchSize
+    let pw = latentW / patchSize
+    // (B, N, C*p*p) → (B, ph, pw, C, p, p)
+    let r = patched.reshaped([b, ph, pw, outChannels, patchSize, patchSize])
+    // → (B, C, ph, p, pw, p)
+    let t = r.transposed(0, 3, 1, 4, 2, 5)
+    // → (B, C, latentH, latentW)
+    return t.reshaped([b, outChannels, latentH, latentW])
+}

--- a/Libraries/vMLXFluxKit/LocalModelStore.swift
+++ b/Libraries/vMLXFluxKit/LocalModelStore.swift
@@ -1,0 +1,304 @@
+import Foundation
+
+public enum LocalFluxComponent: String, CaseIterable, Codable, Sendable {
+    case root
+    case tokenizer
+    case transformer
+    case scheduler
+    case textEncoder
+    case vae
+    case assets
+}
+
+public enum LocalFluxReadiness: String, Codable, Sendable {
+    case loadableScaffold
+    case incomplete
+    case unknown
+}
+
+public struct LocalFluxModel: Sendable {
+    public let directory: URL
+    public let directoryName: String
+    public let canonicalName: String?
+    public let displayName: String
+    public let kind: ModelKind?
+    public let quantizationBits: Int?
+    public let components: Set<LocalFluxComponent>
+    public let safetensorCount: Int
+    public let totalBytes: UInt64
+    public let hasModelIndex: Bool
+    public let readiness: LocalFluxReadiness
+    public let blockedReasons: [String]
+
+    public var canEnterNativeLoadPath: Bool {
+        readiness == .loadableScaffold
+    }
+}
+
+public struct MLXStudioModelStore: Sendable {
+    public let root: URL
+
+    public init(root: URL = MLXStudioModelStore.defaultImageRoot) {
+        self.root = root
+    }
+
+    public static var defaultImageRoot: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".mlxstudio/models/image", isDirectory: true)
+    }
+
+    public func scan() throws -> [LocalFluxModel] {
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: root.path) else { return [] }
+        let entries = try fm.contentsOfDirectory(
+            at: root,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )
+        return try entries.compactMap { url in
+            let values = try url.resourceValues(forKeys: [.isDirectoryKey])
+            guard values.isDirectory == true else { return nil }
+            return try Self.inspect(directory: url)
+        }
+        .sorted { $0.directoryName.localizedStandardCompare($1.directoryName) == .orderedAscending }
+    }
+
+    public func resolve(name: String) throws -> LocalFluxModel? {
+        let requestedDirectory = Self.normalizedName(name)
+        let models = try scan()
+        if let exact = models.first(where: {
+            Self.normalizedName($0.directoryName) == requestedDirectory
+        }) {
+            return exact
+        }
+        let requested = Self.canonicalName(for: name)
+            ?? ModelRegistry.lookupFuzzy(name: name)?.name
+            ?? requestedDirectory
+        return models.first { model in
+            guard let canonicalName = model.canonicalName else {
+                return Self.normalizedName(model.directoryName) == requested
+            }
+            return canonicalName == requested
+                || Self.normalizedName(model.directoryName) == requested
+        }
+    }
+
+    public static func inspect(directory: URL) throws -> LocalFluxModel {
+        let name = directory.lastPathComponent
+        let canonical = canonicalName(for: name)
+            ?? ModelRegistry.lookupFuzzy(name: name)?.name
+        let entry = canonical.flatMap { ModelRegistry.lookup(name: $0) }
+        let components = try detectComponents(in: directory)
+        let safetensors = try safetensorSummary(in: directory)
+        let hasModelIndex = FileManager.default.fileExists(
+            atPath: directory.appendingPathComponent("model_index.json").path
+        )
+        let reasons = blockedReasons(
+            canonicalName: canonical,
+            components: components,
+            safetensorCount: safetensors.count
+        )
+        let readiness: LocalFluxReadiness
+        if canonical == nil {
+            readiness = .unknown
+        } else if reasons.isEmpty {
+            readiness = .loadableScaffold
+        } else {
+            readiness = .incomplete
+        }
+        return LocalFluxModel(
+            directory: directory,
+            directoryName: name,
+            canonicalName: canonical,
+            displayName: entry?.displayName ?? displayName(forCanonicalName: canonical) ?? name,
+            kind: entry?.kind ?? defaultKind(forCanonicalName: canonical),
+            quantizationBits: quantizationBits(in: name),
+            components: components,
+            safetensorCount: safetensors.count,
+            totalBytes: safetensors.bytes,
+            hasModelIndex: hasModelIndex,
+            readiness: readiness,
+            blockedReasons: reasons
+        )
+    }
+
+    public static func canonicalName(for name: String) -> String? {
+        let key = normalizedName(name)
+        if key.contains("z-image") || key.contains("zimage") {
+            return "z-image-turbo"
+        }
+        if key.contains("qwen-image") || key.contains("qwenimage") {
+            return key.contains("edit") ? "qwen-image-edit" : "qwen-image"
+        }
+        if key.contains("flux2") || key.contains("flux-2") {
+            return key.contains("edit") ? "flux2-klein-edit" : "flux2-klein"
+        }
+        if key.contains("flux1") || key.contains("flux-1") {
+            if key.contains("kontext") { return "flux1-kontext" }
+            if key.contains("fill") { return "flux1-fill" }
+            if key.contains("dev") { return "flux1-dev" }
+            if key.contains("schnell") { return "flux1-schnell" }
+        }
+        if key.contains("fibo") { return "fibo" }
+        if key.contains("seedvr2") || key.contains("seed-vr2") { return "seedvr2" }
+        if key.contains("wan-2-1") || key.contains("wan21") { return "wan-2.1" }
+        if key.contains("wan-2-2") || key.contains("wan22") { return "wan-2.2" }
+        return nil
+    }
+
+    public static func normalizedName(_ name: String) -> String {
+        var key = name.lowercased()
+        if let slash = key.lastIndex(of: "/") {
+            key = String(key[key.index(after: slash)...])
+        }
+        for replacement in [".", "_", " "] {
+            key = key.replacingOccurrences(of: replacement, with: "-")
+        }
+        while key.contains("--") {
+            key = key.replacingOccurrences(of: "--", with: "-")
+        }
+        for suffix in ["-mflux", "-mlx"] {
+            if key.hasSuffix(suffix) {
+                key.removeLast(suffix.count)
+            }
+        }
+        if let bits = quantizationBits(in: key) {
+            let suffix = "-\(bits)bit"
+            if key.hasSuffix(suffix) {
+                key.removeLast(suffix.count)
+            }
+        }
+        return key
+    }
+
+    public static func quantizationBits(in name: String) -> Int? {
+        let parts = name.lowercased()
+            .replacingOccurrences(of: "_", with: "-")
+            .split(separator: "-")
+        for part in parts where part.hasSuffix("bit") {
+            let digits = part.dropLast(3)
+            if let bits = Int(digits) {
+                return bits
+            }
+        }
+        return nil
+    }
+
+    private static func detectComponents(in directory: URL) throws -> Set<LocalFluxComponent> {
+        let fm = FileManager.default
+        var components: Set<LocalFluxComponent> = []
+        if try hasSafetensors(in: directory, recursive: false) {
+            components.insert(.root)
+        }
+        let componentDirs: [(LocalFluxComponent, String)] = [
+            (.tokenizer, "tokenizer"),
+            (.transformer, "transformer"),
+            (.scheduler, "scheduler"),
+            (.textEncoder, "text_encoder"),
+            (.vae, "vae"),
+            (.assets, "assets"),
+        ]
+        for (component, child) in componentDirs {
+            let url = directory.appendingPathComponent(child, isDirectory: true)
+            var isDirectory: ObjCBool = false
+            guard fm.fileExists(atPath: url.path, isDirectory: &isDirectory),
+                  isDirectory.boolValue
+            else { continue }
+            if component == .tokenizer || component == .scheduler || component == .assets {
+                components.insert(component)
+            } else if try hasSafetensors(in: url, recursive: true) {
+                components.insert(component)
+            }
+        }
+        return components
+    }
+
+    private static func hasSafetensors(in directory: URL, recursive: Bool) throws -> Bool {
+        let fm = FileManager.default
+        if recursive {
+            guard let enumerator = fm.enumerator(
+                at: directory,
+                includingPropertiesForKeys: [.isRegularFileKey],
+                options: [.skipsHiddenFiles]
+            ) else { return false }
+            for case let url as URL in enumerator where url.pathExtension == "safetensors" {
+                return true
+            }
+            return false
+        }
+        let entries = try fm.contentsOfDirectory(atPath: directory.path)
+        return entries.contains { $0.hasSuffix(".safetensors") }
+    }
+
+    private static func safetensorSummary(in directory: URL) throws -> (count: Int, bytes: UInt64) {
+        let fm = FileManager.default
+        guard let enumerator = fm.enumerator(
+            at: directory,
+            includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey],
+            options: [.skipsHiddenFiles]
+        ) else { return (0, 0) }
+        var count = 0
+        var bytes: UInt64 = 0
+        for case let url as URL in enumerator where url.pathExtension == "safetensors" {
+            let values = try url.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard values.isRegularFile == true else { continue }
+            count += 1
+            bytes += UInt64(values.fileSize ?? 0)
+        }
+        return (count, bytes)
+    }
+
+    private static func blockedReasons(
+        canonicalName: String?,
+        components: Set<LocalFluxComponent>,
+        safetensorCount: Int
+    ) -> [String] {
+        guard canonicalName != nil else {
+            return safetensorCount == 0 ? ["no safetensors found"] : ["unknown flux-family model"]
+        }
+        var reasons: [String] = []
+        if safetensorCount == 0 {
+            reasons.append("no safetensors found")
+        }
+        for component in [LocalFluxComponent.transformer, .textEncoder, .vae, .tokenizer] {
+            if !components.contains(component) {
+                reasons.append("missing \(component.rawValue)")
+            }
+        }
+        return reasons
+    }
+
+    private static func displayName(forCanonicalName canonicalName: String?) -> String? {
+        switch canonicalName {
+        case "flux1-schnell": return "FLUX.1 Schnell"
+        case "flux1-dev": return "FLUX.1 Dev"
+        case "flux1-kontext": return "FLUX.1 Kontext"
+        case "flux1-fill": return "FLUX.1 Fill"
+        case "flux2-klein": return "FLUX.2 Klein"
+        case "flux2-klein-edit": return "FLUX.2 Klein Edit"
+        case "z-image-turbo": return "Z-Image Turbo"
+        case "qwen-image": return "Qwen-Image"
+        case "qwen-image-edit": return "Qwen-Image-Edit"
+        case "fibo": return "FIBO"
+        case "seedvr2": return "SeedVR2"
+        case "wan-2.1": return "Wan 2.1"
+        case "wan-2.2": return "Wan 2.2"
+        default: return nil
+        }
+    }
+
+    private static func defaultKind(forCanonicalName canonicalName: String?) -> ModelKind? {
+        switch canonicalName {
+        case "flux1-kontext", "flux1-fill", "flux2-klein-edit", "qwen-image-edit":
+            return .imageEdit
+        case "seedvr2":
+            return .imageUpscale
+        case "wan-2.1", "wan-2.2":
+            return .videoGen
+        case .some:
+            return .imageGen
+        case .none:
+            return nil
+        }
+    }
+}

--- a/Libraries/vMLXFluxKit/MathOps.swift
+++ b/Libraries/vMLXFluxKit/MathOps.swift
@@ -1,0 +1,130 @@
+import Foundation
+import MLX
+import MLXNN
+
+// MARK: - Shared math building blocks
+//
+// Primitives used across every Flux-family model: timestep embedding
+// (sinusoidal + MLP), RoPE (rotary position embedding for 2D image
+// latents), attention with RoPE, SwiGLU feedforward, RMSNorm. Ported
+// 1:1 from the Python mflux reference so weight names match.
+
+// MARK: - Timestep embedding
+
+/// Sinusoidal time embedding → MLP projection. Mirrors the pattern in
+/// `mflux/models/flux/common/timesteps_projection.py` and Diffusers'
+/// `TimestepEmbedding`.
+public func sinusoidalTimeEmbedding(
+    timesteps: MLXArray,
+    embeddingDim: Int,
+    maxPeriod: Float = 10000,
+    scale: Float = 1000
+) -> MLXArray {
+    // `timesteps` is shape [B]. Return shape [B, embeddingDim].
+    let half = embeddingDim / 2
+    let exponent = MLXArray(
+        (0..<half).map { -log(maxPeriod) * Float($0) / Float(half) }
+    )
+    let freqs = exp(exponent)
+    let scaled = (timesteps * MLXArray(scale)).reshaped([timesteps.dim(0), 1])
+    let args = scaled * freqs.reshaped([1, half])
+    let sinPart = sin(args)
+    let cosPart = cos(args)
+    return concatenated([cosPart, sinPart], axis: -1)
+}
+
+// MARK: - RoPE for 2D latents
+
+/// Rotary position embedding frequencies for the H×W latent grid.
+/// Flux uses a concatenation of three 1D RoPE bands (time-axis stub,
+/// height, width). We expose the simpler 2D variant here as a starting
+/// point; the Flux-specific 3-axis version lives in the Flux1 attention
+/// block where it composes with text-token axis.
+/// Not `Sendable` because `MLXArray` isn't. RoPE caches live on the
+/// model actor so cross-isolation passing never happens.
+public struct RoPE2D {
+    public let cosCache: MLXArray
+    public let sinCache: MLXArray
+
+    public init(headDim: Int, height: Int, width: Int, theta: Float = 10000) {
+        let half = headDim / 2
+        // Frequency bands.
+        let freqs = MLXArray(
+            (0..<half).map { pow(theta, -Float($0 * 2) / Float(headDim)) }
+        )
+
+        // 2D position grid, flattened to seq-len = H*W.
+        var posY: [Float] = []
+        var posX: [Float] = []
+        for y in 0..<height {
+            for x in 0..<width {
+                posY.append(Float(y))
+                posX.append(Float(x))
+            }
+        }
+        let yMat = MLXArray(posY).reshaped([height * width, 1]) * freqs.reshaped([1, half])
+        let xMat = MLXArray(posX).reshaped([height * width, 1]) * freqs.reshaped([1, half])
+
+        // Interleave y and x bands so half of the dims get 2D positions.
+        let yCos = cos(yMat)
+        let ySin = sin(yMat)
+        let xCos = cos(xMat)
+        let xSin = sin(xMat)
+        self.cosCache = concatenated([yCos, xCos], axis: -1)
+        self.sinCache = concatenated([ySin, xSin], axis: -1)
+    }
+
+    /// Apply the rotation to a (B, H, S, D) tensor where `S` is the
+    /// 2D-flattened sequence length and `D` is head dimension.
+    public func apply(_ x: MLXArray) -> MLXArray {
+        // Reshape cache for broadcasting: (1, 1, S, D).
+        let c = cosCache.reshaped([1, 1, cosCache.dim(0), cosCache.dim(1)])
+        let s = sinCache.reshaped([1, 1, sinCache.dim(0), sinCache.dim(1)])
+        // Split x into two halves along the head dim, rotate.
+        let d = x.dim(-1)
+        let half = d / 2
+        let x1 = x[.ellipsis, 0 ..< half]
+        let x2 = x[.ellipsis, half ..< d]
+        // Build the rotated version: (x1*cos - x2*sin, x1*sin + x2*cos)
+        // Note: this is the simple variant; the full Flux RoPE also
+        // handles the time axis which is concat'd in the model layer.
+        let c1 = c[.ellipsis, 0 ..< half]
+        let s1 = s[.ellipsis, 0 ..< half]
+        let rotated1 = x1 * c1 - x2 * s1
+        let rotated2 = x1 * s1 + x2 * c1
+        return concatenated([rotated1, rotated2], axis: -1)
+    }
+}
+
+// MARK: - RMS normalization
+//
+// vmlx-flux uses MLXNN's `RMSNorm(dimensions:eps:)` directly — it ships
+// as `open class RMSNorm: Module, UnaryLayer` with a hardware-accelerated
+// `MLXFast.rmsNorm` body. A pure-Swift fallback used to live here; it was
+// removed to avoid a naming collision where my local class was shadowing
+// the fast path. If you need to swap in a custom norm for a future model,
+// subclass `MLXNN.RMSNorm` — don't re-declare a top-level `RMSNorm`.
+
+// MARK: - Scaled dot-product attention with RoPE
+
+/// Multi-head attention over a (B, S, D) sequence. Takes pre-computed
+/// Q/K/V projections from the caller. `rope` is applied to Q and K
+/// before the attention score is computed.
+public func scaledDotProductAttention(
+    q: MLXArray,
+    k: MLXArray,
+    v: MLXArray,
+    rope: RoPE2D?,
+    scale: Float? = nil
+) -> MLXArray {
+    // q/k/v are (B, H, S, D_head)
+    let qRoped = rope?.apply(q) ?? q
+    let kRoped = rope?.apply(k) ?? k
+
+    let d = Float(q.dim(-1))
+    let effectiveScale = scale ?? (1.0 / sqrt(d))
+    // (B, H, S_q, D) @ (B, H, D, S_k) → (B, H, S_q, S_k)
+    let scores = matmul(qRoped, kRoped.transposed(0, 1, 3, 2)) * MLXArray(effectiveScale)
+    let attn = softmax(scores, axis: -1)
+    return matmul(attn, v)  // (B, H, S_q, D)
+}

--- a/Libraries/vMLXFluxKit/ModelRegistry.swift
+++ b/Libraries/vMLXFluxKit/ModelRegistry.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+// MARK: - ModelRegistry
+//
+// Canonical name → loader function map. Mirrors the Python
+// `SUPPORTED_MODELS` + `EDIT_MODELS` + `_NAME_TO_CLASS` tables from
+// `vmlx_engine/image_gen.py`.
+//
+// New models register themselves via `ModelRegistry.register(_:)` in
+// their own file — no central edit needed to add a variant.
+
+public struct ModelEntry: Sendable {
+    public let name: String              // canonical key, e.g. "flux1-schnell"
+    public let displayName: String       // human-friendly, e.g. "FLUX.1 Schnell"
+    public let kind: ModelKind
+    public let defaultSteps: Int
+    public let defaultGuidance: Float
+    public let supportsLoRA: Bool
+    /// Loader — constructs the concrete model from a local weights dir +
+    /// optional quantization bits. Called from inside `FluxEngine` actor.
+    public let loader: @Sendable (URL, Int?) async throws -> any FluxModel
+
+    public init(
+        name: String,
+        displayName: String,
+        kind: ModelKind,
+        defaultSteps: Int,
+        defaultGuidance: Float,
+        supportsLoRA: Bool = false,
+        loader: @Sendable @escaping (URL, Int?) async throws -> any FluxModel
+    ) {
+        self.name = name
+        self.displayName = displayName
+        self.kind = kind
+        self.defaultSteps = defaultSteps
+        self.defaultGuidance = defaultGuidance
+        self.supportsLoRA = supportsLoRA
+        self.loader = loader
+    }
+}
+
+public enum ModelRegistry {
+    nonisolated(unsafe) private static var entries: [String: ModelEntry] = [:]
+    private static let lock = NSLock()
+
+    /// Register a model. Call from the model's own file at module-load
+    /// time (via a `static let _register: Void = { ModelRegistry.register(...) }()`
+    /// idiom) so the registry stays decentralized.
+    public static func register(_ entry: ModelEntry) {
+        lock.lock()
+        defer { lock.unlock() }
+        entries[entry.name] = entry
+    }
+
+    /// Canonical-name lookup.
+    public static func lookup(name: String) -> ModelEntry? {
+        lock.lock()
+        defer { lock.unlock() }
+        return entries[name]
+    }
+
+    /// Fuzzy lookup — normalizes case, strips HF org prefix, strips
+    /// `-<N>bit` quantization suffix, then does a canonical lookup.
+    /// Also strips `.` and `_` separators since users may write
+    /// `FLUX.1-schnell` (display form) or `flux1-schnell` (canonical).
+    /// Mirrors the Python normalize-then-resolve flow.
+    public static func lookupFuzzy(name: String) -> ModelEntry? {
+        var key = name.lowercased()
+        if let slash = key.lastIndex(of: "/") {
+            key = String(key[key.index(after: slash)...])
+        }
+        // Strip `-4bit` / `-8bit` / `-3bit` suffix.
+        if let match = key.range(of: "-\\d+bit$", options: .regularExpression) {
+            key.removeSubrange(match)
+        }
+        // Direct hit first.
+        if let entry = lookup(name: key) { return entry }
+        // Collapse `flux.1-schnell` → `flux1-schnell`.
+        let collapsed = key.replacingOccurrences(of: ".", with: "")
+                           .replacingOccurrences(of: "_", with: "-")
+        return lookup(name: collapsed)
+    }
+
+    /// Enumerate all registered models (for UI listing).
+    public static func all() -> [ModelEntry] {
+        lock.lock()
+        defer { lock.unlock() }
+        return Array(entries.values).sorted { $0.name < $1.name }
+    }
+
+    /// Filter by capability.
+    public static func all(kind: ModelKind) -> [ModelEntry] {
+        all().filter { $0.kind == kind }
+    }
+}

--- a/Libraries/vMLXFluxKit/Requests.swift
+++ b/Libraries/vMLXFluxKit/Requests.swift
@@ -1,0 +1,184 @@
+import Foundation
+
+// MARK: - ImageGenRequest
+
+public struct ImageGenRequest: Sendable {
+    public var prompt: String
+    public var negativePrompt: String?
+    public var width: Int
+    public var height: Int
+    public var steps: Int
+    public var guidance: Float
+    public var seed: UInt64?
+    public var numImages: Int
+    public var outputDir: URL
+    public var outputFormat: ImageFormat
+
+    public init(
+        prompt: String,
+        negativePrompt: String? = nil,
+        width: Int = 1024,
+        height: Int = 1024,
+        steps: Int = 20,
+        guidance: Float = 3.5,
+        seed: UInt64? = nil,
+        numImages: Int = 1,
+        outputDir: URL,
+        outputFormat: ImageFormat = .png
+    ) {
+        self.prompt = prompt
+        self.negativePrompt = negativePrompt
+        self.width = width
+        self.height = height
+        self.steps = steps
+        self.guidance = guidance
+        self.seed = seed
+        self.numImages = numImages
+        self.outputDir = outputDir
+        self.outputFormat = outputFormat
+    }
+}
+
+// MARK: - ImageEditRequest
+
+public struct ImageEditRequest: Sendable {
+    public var prompt: String
+    public var sourceImage: URL
+    public var mask: URL?          // optional PNG mask — white=edit, black=keep
+    public var strength: Float     // 0..1 — how much to deviate from source
+    public var width: Int?         // nil → match source
+    public var height: Int?
+    public var steps: Int
+    public var guidance: Float
+    public var seed: UInt64?
+    public var outputDir: URL
+    public var outputFormat: ImageFormat
+
+    public init(
+        prompt: String,
+        sourceImage: URL,
+        mask: URL? = nil,
+        strength: Float = 0.75,
+        width: Int? = nil,
+        height: Int? = nil,
+        steps: Int = 20,
+        guidance: Float = 3.5,
+        seed: UInt64? = nil,
+        outputDir: URL,
+        outputFormat: ImageFormat = .png
+    ) {
+        self.prompt = prompt
+        self.sourceImage = sourceImage
+        self.mask = mask
+        self.strength = strength
+        self.width = width
+        self.height = height
+        self.steps = steps
+        self.guidance = guidance
+        self.seed = seed
+        self.outputDir = outputDir
+        self.outputFormat = outputFormat
+    }
+}
+
+// MARK: - UpscaleRequest (SeedVR2)
+
+public struct UpscaleRequest: Sendable {
+    public var sourceImage: URL
+    public var scale: Int          // 2, 4
+    public var steps: Int
+    public var seed: UInt64?
+    public var outputDir: URL
+    public var outputFormat: ImageFormat
+
+    public init(
+        sourceImage: URL,
+        scale: Int = 4,
+        steps: Int = 10,
+        seed: UInt64? = nil,
+        outputDir: URL,
+        outputFormat: ImageFormat = .png
+    ) {
+        self.sourceImage = sourceImage
+        self.scale = scale
+        self.steps = steps
+        self.seed = seed
+        self.outputDir = outputDir
+        self.outputFormat = outputFormat
+    }
+}
+
+// MARK: - VideoGenRequest (future)
+
+public struct VideoGenRequest: Sendable {
+    public var prompt: String
+    public var negativePrompt: String?
+    public var width: Int
+    public var height: Int
+    public var numFrames: Int
+    public var fps: Int
+    public var steps: Int
+    public var guidance: Float
+    public var seed: UInt64?
+    public var outputDir: URL
+
+    public init(
+        prompt: String,
+        negativePrompt: String? = nil,
+        width: Int = 1280,
+        height: Int = 720,
+        numFrames: Int = 121,   // WAN 2.1 default: 121 frames @ 24fps ≈ 5s
+        fps: Int = 24,
+        steps: Int = 50,
+        guidance: Float = 5.0,
+        seed: UInt64? = nil,
+        outputDir: URL
+    ) {
+        self.prompt = prompt
+        self.negativePrompt = negativePrompt
+        self.width = width
+        self.height = height
+        self.numFrames = numFrames
+        self.fps = fps
+        self.steps = steps
+        self.guidance = guidance
+        self.seed = seed
+        self.outputDir = outputDir
+    }
+}
+
+// MARK: - Events
+
+/// Streamed progress event for gen / edit / upscale.
+public enum ImageGenEvent: Sendable {
+    /// Incremental progress. `step` is 1-indexed, `total` is the full step count.
+    case step(step: Int, total: Int, etaSeconds: Double?)
+    /// Optional in-progress preview (partially denoised latent decoded to a
+    /// small PNG). Not every model emits previews — this fires at most
+    /// every N steps if the scheduler supports it.
+    case preview(pngData: Data, step: Int)
+    /// Generation finished. `url` points to the saved image on disk.
+    case completed(url: URL, seed: UInt64)
+    /// Fatal error. `hfAuth=true` signals a HuggingFace 401/403 so the UI
+    /// can show a "Add HF token" CTA instead of a generic error banner.
+    case failed(message: String, hfAuth: Bool)
+    /// User or system cancelled the job.
+    case cancelled
+}
+
+/// Streamed progress event for video gen (future).
+public enum VideoGenEvent: Sendable {
+    case step(step: Int, total: Int, etaSeconds: Double?)
+    case preview(pngData: Data, frame: Int)
+    case completed(url: URL, seed: UInt64, fps: Int, frameCount: Int)
+    case failed(message: String, hfAuth: Bool)
+    case cancelled
+}
+
+// MARK: - Formats
+
+public enum ImageFormat: String, Sendable, Codable {
+    case png
+    case jpeg
+    case webp
+}

--- a/Libraries/vMLXFluxKit/VAE.swift
+++ b/Libraries/vMLXFluxKit/VAE.swift
@@ -1,0 +1,338 @@
+import Foundation
+@preconcurrency import MLX
+import MLXNN
+
+// MARK: - AutoencoderKL (Flux / Qwen / FIBO VAE)
+//
+// Pure-Swift port of the `diffusers.AutoencoderKL` decoder used by Flux1,
+// Flux2, Qwen-Image, and FIBO. Architecture:
+//
+//   z (B, 16, H/8, W/8)
+//     → conv_in (16 → 512, 3x3)
+//     → mid_block: [ResBlock(512) → Attention(512) → ResBlock(512)]
+//     → up_blocks[0]: 3× ResBlock(512) → Upsample 2×
+//     → up_blocks[1]: 3× ResBlock(512→512) → Upsample 2×
+//     → up_blocks[2]: 3× ResBlock(512→256) → Upsample 2×
+//     → up_blocks[3]: 3× ResBlock(256→128)
+//     → norm_out (GroupNorm, 32 groups)
+//     → silu
+//     → conv_out (128 → 3, 3x3)
+//   → image (B, 3, H, W) in [-1, 1], caller rescales to [0, 1]
+//
+// The encoder (for img2img edit mode) is the mirror image. For now we
+// only ship the decoder since every generation path needs it.
+//
+// Weight layout matches `diffusers` → `safetensors` naming so
+// `WeightLoader` can load either a Flux checkpoint directly or a
+// standalone `ae.safetensors` file. See `loadWeights(from:)` below.
+
+// MARK: - GroupNorm
+
+/// 32-group normalization. Diffusers uses 32 groups throughout the VAE.
+public final class VAEGroupNorm: Module {
+    public let weight: MLXArray
+    public let bias: MLXArray
+    public let groups: Int
+    public let eps: Float
+
+    public init(channels: Int, groups: Int = 32, eps: Float = 1e-6) {
+        self.weight = MLXArray.ones([channels])
+        self.bias = MLXArray.zeros([channels])
+        self.groups = groups
+        self.eps = eps
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        // x: (B, C, H, W). Reshape to (B, groups, C/groups, H, W), normalize.
+        let b = x.dim(0)
+        let c = x.dim(1)
+        let h = x.dim(2)
+        let w = x.dim(3)
+        let g = groups
+        let grouped = x.reshaped([b, g, c / g, h, w])
+        // Normalize across (C/g, H, W) per group.
+        let meanVal = grouped.mean(axes: [2, 3, 4], keepDims: true)
+        let variance = ((grouped - meanVal) * (grouped - meanVal))
+            .mean(axes: [2, 3, 4], keepDims: true)
+        let normalized = (grouped - meanVal) * rsqrt(variance + MLXArray(eps))
+        let reshaped = normalized.reshaped([b, c, h, w])
+        // Per-channel affine.
+        let w2 = weight.reshaped([1, c, 1, 1])
+        let b2 = bias.reshaped([1, c, 1, 1])
+        return reshaped * w2 + b2
+    }
+}
+
+// MARK: - ResnetBlock2D
+
+/// Residual block used throughout the VAE: (norm → silu → conv) × 2
+/// with an optional 1×1 skip conv when in_channels != out_channels.
+/// Weight names match diffusers: `norm1`, `conv1`, `norm2`, `conv2`,
+/// `conv_shortcut`.
+public final class VAEResnetBlock: Module {
+    public let norm1: VAEGroupNorm
+    public let conv1: Conv2d
+    public let norm2: VAEGroupNorm
+    public let conv2: Conv2d
+    public let convShortcut: Conv2d?
+
+    public init(inChannels: Int, outChannels: Int) {
+        self.norm1 = VAEGroupNorm(channels: inChannels)
+        self.conv1 = Conv2d(
+            inputChannels: inChannels,
+            outputChannels: outChannels,
+            kernelSize: 3, stride: 1, padding: 1
+        )
+        self.norm2 = VAEGroupNorm(channels: outChannels)
+        self.conv2 = Conv2d(
+            inputChannels: outChannels,
+            outputChannels: outChannels,
+            kernelSize: 3, stride: 1, padding: 1
+        )
+        if inChannels != outChannels {
+            self.convShortcut = Conv2d(
+                inputChannels: inChannels,
+                outputChannels: outChannels,
+                kernelSize: 1, stride: 1, padding: 0
+            )
+        } else {
+            self.convShortcut = nil
+        }
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = norm1(x)
+        h = silu(h)
+        // MLXNN Conv2d expects (B, H, W, C) layout.
+        h = nhwcToNchw(conv1(nchwToNhwc(h)))
+        h = norm2(h)
+        h = silu(h)
+        h = nhwcToNchw(conv2(nchwToNhwc(h)))
+        let skip: MLXArray
+        if let shortcut = convShortcut {
+            skip = nhwcToNchw(shortcut(nchwToNhwc(x)))
+        } else {
+            skip = x
+        }
+        return h + skip
+    }
+}
+
+// MARK: - Attention block (512ch mid-block self-attention)
+
+/// Single-head self-attention over the flattened spatial dims of the
+/// mid-block feature map. Diffusers names this `AttnBlock` in the VAE.
+public final class VAEAttnBlock: Module {
+    public let norm: VAEGroupNorm
+    public let q: Linear
+    public let k: Linear
+    public let v: Linear
+    public let proj: Linear
+    public let channels: Int
+
+    public init(channels: Int) {
+        self.norm = VAEGroupNorm(channels: channels)
+        self.q = Linear(channels, channels)
+        self.k = Linear(channels, channels)
+        self.v = Linear(channels, channels)
+        self.proj = Linear(channels, channels)
+        self.channels = channels
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        // x: (B, C, H, W). Normalize, flatten HW to sequence.
+        let b = x.dim(0)
+        let c = x.dim(1)
+        let h = x.dim(2)
+        let w = x.dim(3)
+        let normed = norm(x)
+        // (B, C, H, W) → (B, H*W, C)
+        let seq = normed.transposed(0, 2, 3, 1).reshaped([b, h * w, c])
+        let qOut = q(seq)
+        let kOut = k(seq)
+        let vOut = v(seq)
+        // Single-head attention.
+        let scale = Float(1.0 / sqrt(Float(c)))
+        let scores = matmul(qOut, kOut.transposed(0, 2, 1)) * MLXArray(scale)
+        let attn = softmax(scores, axis: -1)
+        let out = matmul(attn, vOut)  // (B, H*W, C)
+        let projected = proj(out)
+        // Back to (B, C, H, W) and add residual.
+        let reshaped = projected.reshaped([b, h, w, c]).transposed(0, 3, 1, 2)
+        return x + reshaped
+    }
+}
+
+// MARK: - Upsample
+
+/// 2× nearest-neighbor upsample followed by a 3×3 conv. Diffusers calls
+/// the conv `upsamplers.0.conv`.
+public final class VAEUpsample: Module {
+    public let conv: Conv2d
+
+    public init(channels: Int) {
+        self.conv = Conv2d(
+            inputChannels: channels,
+            outputChannels: channels,
+            kernelSize: 3, stride: 1, padding: 1
+        )
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        // Nearest-neighbor 2× via `repeated` on H and W axes.
+        let up = upsampleNearest2x(x)
+        return nhwcToNchw(conv(nchwToNhwc(up)))
+    }
+}
+
+/// 2× nearest upsample helper on (B, C, H, W).
+public func upsampleNearest2x(_ x: MLXArray) -> MLXArray {
+    let r = repeated(x, count: 2, axis: 2)
+    return repeated(r, count: 2, axis: 3)
+}
+
+// MARK: - Layout helpers
+//
+// MLXNN's Conv2d uses channels-last (B, H, W, C) natively. The rest of
+// this file treats tensors as channels-first (B, C, H, W) because the
+// diffusers weight layout + ResBlock math is clearer that way. We
+// convert on every conv call.
+
+@inlinable
+public func nchwToNhwc(_ x: MLXArray) -> MLXArray {
+    // (B, C, H, W) → (B, H, W, C)
+    return x.transposed(0, 2, 3, 1)
+}
+
+@inlinable
+public func nhwcToNchw(_ x: MLXArray) -> MLXArray {
+    // (B, H, W, C) → (B, C, H, W) — reverse of nchwToNhwc.
+    return x.transposed(0, 3, 1, 2)
+}
+
+// MARK: - VAEDecoder
+
+/// Full decoder. Takes a (B, 16, H/8, W/8) latent and produces a
+/// (B, 3, H, W) image in roughly [-1, 1] range. Flux uses a specific
+/// scale/shift for the latent: `z = (z_raw - shift) * scale`, applied
+/// before calling the decoder. Defaults are Flux's values.
+public final class VAEDecoder: Module {
+    public let convIn: Conv2d
+
+    // Mid block
+    public let midResnet1: VAEResnetBlock
+    public let midAttn: VAEAttnBlock
+    public let midResnet2: VAEResnetBlock
+
+    // Up blocks: 4 stages, 3 resnets per stage, upsample between stages.
+    // Channel progression for Flux: 512 → 512 → 512 → 256 → 128.
+    public let upBlocks: [[VAEResnetBlock]]
+    public let upsamples: [VAEUpsample?]
+
+    public let normOut: VAEGroupNorm
+    public let convOut: Conv2d
+
+    /// Flux VAE shift + scale. Applied externally:
+    /// `z = (latent / 0.3611) + 0.1159` for Flux1/Flux2.
+    public static let fluxScaleFactor: Float = 0.3611
+    public static let fluxShiftFactor: Float = 0.1159
+
+    public init(
+        latentChannels: Int = 16,
+        blockOutChannels: [Int] = [128, 256, 512, 512],
+        layersPerBlock: Int = 2
+    ) {
+        // Diffusers iterates blockOutChannels in REVERSE for the decoder
+        // (encoder goes 128→256→512→512, decoder goes 512→512→256→128).
+        let reversed = Array(blockOutChannels.reversed())
+        let midChannels = reversed[0]
+
+        self.convIn = Conv2d(
+            inputChannels: latentChannels,
+            outputChannels: midChannels,
+            kernelSize: 3, stride: 1, padding: 1
+        )
+
+        self.midResnet1 = VAEResnetBlock(inChannels: midChannels, outChannels: midChannels)
+        self.midAttn    = VAEAttnBlock(channels: midChannels)
+        self.midResnet2 = VAEResnetBlock(inChannels: midChannels, outChannels: midChannels)
+
+        // Build up_blocks. Each up_block has `layersPerBlock + 1` resnets
+        // in diffusers, and an upsample conv between stages (except the
+        // final stage).
+        var blocks: [[VAEResnetBlock]] = []
+        var upsamples: [VAEUpsample?] = []
+        var prevChannels = midChannels
+        for (i, stageChannels) in reversed.enumerated() {
+            var stageBlocks: [VAEResnetBlock] = []
+            for layer in 0...layersPerBlock {
+                let inCh = (layer == 0) ? prevChannels : stageChannels
+                stageBlocks.append(VAEResnetBlock(
+                    inChannels: inCh,
+                    outChannels: stageChannels
+                ))
+            }
+            blocks.append(stageBlocks)
+            prevChannels = stageChannels
+            // Upsample between every stage except the last.
+            if i < reversed.count - 1 {
+                upsamples.append(VAEUpsample(channels: stageChannels))
+            } else {
+                upsamples.append(nil)
+            }
+        }
+        self.upBlocks = blocks
+        self.upsamples = upsamples
+
+        self.normOut = VAEGroupNorm(channels: blockOutChannels[0])
+        self.convOut = Conv2d(
+            inputChannels: blockOutChannels[0],
+            outputChannels: 3,
+            kernelSize: 3, stride: 1, padding: 1
+        )
+        super.init()
+    }
+
+    public func callAsFunction(_ latent: MLXArray) -> MLXArray {
+        // 1. conv_in
+        var h = nhwcToNchw(convIn(nchwToNhwc(latent)))
+
+        // 2. mid block
+        h = midResnet1(h)
+        h = midAttn(h)
+        h = midResnet2(h)
+
+        // 3. up blocks
+        for (stageIdx, stage) in upBlocks.enumerated() {
+            for block in stage {
+                h = block(h)
+            }
+            if let up = upsamples[stageIdx] {
+                h = up(h)
+            }
+        }
+
+        // 4. norm_out → silu → conv_out
+        h = normOut(h)
+        h = silu(h)
+        h = nhwcToNchw(convOut(nchwToNhwc(h)))
+
+        // Output is in ~[-1, 1]. Caller rescales to [0, 1] for PNG.
+        return h
+    }
+
+    /// Apply the Flux VAE pre-decode rescale: `z = z/scale + shift`.
+    public static func preprocessFluxLatent(_ latent: MLXArray) -> MLXArray {
+        return latent / MLXArray(fluxScaleFactor) + MLXArray(fluxShiftFactor)
+    }
+
+    /// Clamp + rescale the decoder output from [-1, 1] to [0, 1] for PNG.
+    public static func postprocess(_ image: MLXArray) -> MLXArray {
+        let clamped = clip(image, min: MLXArray(Float(-1)), max: MLXArray(Float(1)))
+        return (clamped + MLXArray(Float(1))) * MLXArray(Float(0.5))
+    }
+}

--- a/Libraries/vMLXFluxKit/WeightLoader.swift
+++ b/Libraries/vMLXFluxKit/WeightLoader.swift
@@ -1,0 +1,139 @@
+import Foundation
+@preconcurrency import MLX
+import MLXNN
+@preconcurrency import MLXLMCommon
+
+// MARK: - WeightLoader
+//
+// Loads safetensors weight shards from a local model directory and
+// applies vMLX's JANG-aware remapping if the model has a `jang_config.json`.
+//
+// Flow (JANG-less path):
+//   1. Read `model.safetensors.index.json` to enumerate all shards.
+//   2. Open each shard via `MLX.loadArrays(url:)`.
+//   3. Merge into a single `[String: MLXArray]` dict keyed by weight name.
+//
+// Flow (JANG path):
+//   1. Parse `jang_config.json` via `JangLoader` (reused from vmlx-swift-lm).
+//   2. Enumerate shards as above.
+//   3. Apply per-layer quantization metadata before use — the
+//      `QuantizedLinear` modules in the model module tree check the
+//      `jangConfig.quantization.bitWidthsUsed[layer_idx]` to pick
+//      the right decode path.
+//
+// For now this file is the SCAFFOLD — weight loading returns a dict,
+// per-layer JANG remapping plugs in when the first real model port
+// (Flux1Schnell) has a concrete module tree to apply it to.
+
+public struct LoadedWeights: Sendable {
+    public let weights: [String: MLXArray]
+    public let componentWeights: [String: [String: MLXArray]]
+    public let jangConfig: MLXLMCommon.JangConfig?
+
+    public init(
+        weights: [String: MLXArray],
+        componentWeights: [String: [String: MLXArray]] = [:],
+        jangConfig: MLXLMCommon.JangConfig? = nil
+    ) {
+        self.weights = weights
+        self.componentWeights = componentWeights
+        self.jangConfig = jangConfig
+    }
+}
+
+public enum WeightLoader {
+
+    /// Load all safetensors shards from a model directory and return a
+    /// merged dict. If the directory contains `jang_config.json`, the
+    /// parsed config is returned alongside so the caller can apply
+    /// per-layer quantization during module construction.
+    public static func load(from directory: URL) throws -> LoadedWeights {
+        // Detect JANG first so the caller gets the config regardless of
+        // the shard layout.
+        let jang = try JangBridge.detect(at: directory)
+
+        let componentShardGroups = try enumerateShardGroups(in: directory)
+        guard !componentShardGroups.isEmpty else {
+            throw FluxError.weightsNotFound(directory)
+        }
+
+        var merged: [String: MLXArray] = [:]
+        var byComponent: [String: [String: MLXArray]] = [:]
+        for group in componentShardGroups {
+            var componentWeights: [String: MLXArray] = [:]
+            for shard in group.shards {
+                let arrays = try MLX.loadArrays(url: shard)
+                for (key, value) in arrays {
+                    componentWeights[key] = value
+                    let mergedKey = group.component == "root"
+                        ? key
+                        : "\(group.component).\(key)"
+                    merged[mergedKey] = value
+                }
+            }
+            byComponent[group.component] = componentWeights
+        }
+
+        return LoadedWeights(
+            weights: merged,
+            componentWeights: byComponent,
+            jangConfig: jang.config)
+    }
+
+    private struct ShardGroup {
+        let component: String
+        let shards: [URL]
+    }
+
+    /// Enumerate .safetensors files in the directory and known
+    /// Diffusers/MFlux component subdirectories. Prefers each
+    /// `model.safetensors.index.json` manifest when present so shards
+    /// are deterministic, falling back to sorted direct `.safetensors`.
+    private static func enumerateShardGroups(in directory: URL) throws -> [ShardGroup] {
+        var groups: [ShardGroup] = []
+        let rootShards = try enumerateShards(in: directory)
+        if !rootShards.isEmpty {
+            groups.append(ShardGroup(component: "root", shards: rootShards))
+        }
+        for component in ["transformer", "text_encoder", "text_encoder_2", "vae"] {
+            let componentURL = directory.appendingPathComponent(component, isDirectory: true)
+            let shards = try enumerateShards(in: componentURL)
+            if !shards.isEmpty {
+                groups.append(ShardGroup(component: component, shards: shards))
+            }
+        }
+        return groups
+    }
+
+    private static func enumerateShards(in directory: URL) throws -> [URL] {
+        let fm = FileManager.default
+        var isDirectory: ObjCBool = false
+        guard fm.fileExists(atPath: directory.path, isDirectory: &isDirectory),
+              isDirectory.boolValue
+        else { return [] }
+        let indexCandidates = [
+            "model.safetensors.index.json",
+            "diffusion_pytorch_model.safetensors.index.json",
+        ]
+        if let indexURL = indexCandidates
+            .map({ directory.appendingPathComponent($0) })
+            .first(where: { fm.fileExists(atPath: $0.path) })
+        {
+            // Parse the index to get the unique set of shards.
+            let data = try Data(contentsOf: indexURL)
+            if let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let weightMap = obj["weight_map"] as? [String: String] {
+                let shardNames = Set(weightMap.values)
+                return shardNames
+                    .sorted()
+                    .map { directory.appendingPathComponent($0) }
+            }
+        }
+        // Fallback: glob all .safetensors in the directory.
+        let entries = try fm.contentsOfDirectory(atPath: directory.path)
+        let shardNames = entries
+            .filter { $0.hasSuffix(".safetensors") }
+            .sorted()
+        return shardNames.map { directory.appendingPathComponent($0) }
+    }
+}

--- a/Libraries/vMLXFluxModels/Exports.swift
+++ b/Libraries/vMLXFluxModels/Exports.swift
@@ -1,0 +1,26 @@
+// Umbrella file for VMLXFluxModels. Re-exports the per-model public
+// types so `import vMLXFluxModels` gives callers everything at once.
+//
+// Registration is done via `_register` statics inside each model file.
+// This file just touches each type so the static initializer runs.
+
+import Foundation
+
+/// Force-register every model in the registry. Call from app launch or
+/// the FluxEngine init to ensure all models are discoverable via
+/// `ModelRegistry.lookup(_:)` before the first `load()` call.
+public enum VMLXFluxModels {
+    public static func registerAll() {
+        _ = Flux1Schnell._register
+        _ = Flux1Dev._register
+        _ = Flux1Kontext._register
+        _ = Flux1Fill._register
+        _ = Flux2Klein._register
+        _ = Flux2KleinEdit._register
+        _ = ZImage._register
+        _ = QwenImage._register
+        _ = QwenImageEdit._register
+        _ = FIBO._register
+        _ = SeedVR2._register
+    }
+}

--- a/Libraries/vMLXFluxModels/FIBO/FIBO.swift
+++ b/Libraries/vMLXFluxModels/FIBO/FIBO.swift
@@ -1,0 +1,39 @@
+import Foundation
+import vMLXFluxKit
+
+// FIBO — Python source: `mflux.models.fibo.variants.txt2img.fibo.FIBO`.
+
+public final class FIBO: ImageGenerator, @unchecked Sendable {
+    public static let _register: Void = {
+        ModelRegistry.register(ModelEntry(
+            name: "fibo",
+            displayName: "FIBO",
+            kind: .imageGen,
+            defaultSteps: 20,
+            defaultGuidance: 3.5,
+            loader: { path, quant in
+                _ = FIBO._register
+                return try FIBO(modelPath: path, quantize: quant)
+            }
+        ))
+    }()
+
+    public let modelPath: URL
+    public let quantize: Int?
+
+    public init(modelPath: URL, quantize: Int?) throws {
+        self.modelPath = modelPath
+        self.quantize = quantize
+        _ = Self._register
+        guard FileManager.default.fileExists(atPath: modelPath.path) else {
+            throw FluxError.weightsNotFound(modelPath)
+        }
+    }
+
+    public func generate(_ request: ImageGenRequest) -> AsyncThrowingStream<ImageGenEvent, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.finish(throwing: FluxError.notImplemented(
+                "FIBO.generate — port from mflux/models/fibo/variants/txt2img/fibo.py"))
+        }
+    }
+}

--- a/Libraries/vMLXFluxModels/Flux1/Flux1.swift
+++ b/Libraries/vMLXFluxModels/Flux1/Flux1.swift
@@ -1,0 +1,165 @@
+import Foundation
+import vMLXFluxKit
+
+// MARK: - Flux1
+//
+// Original FLUX.1 family: Schnell (4-step), Dev (20-step). Both use the
+// dual-encoder (T5 + CLIP) transformer backbone with flow-matching
+// sampling. Python source: `mflux.models.flux.variants.txt2img.flux.Flux1`.
+//
+// This is a SCAFFOLD — every method throws `notImplemented`. The real
+// port needs:
+//   1. FluxTransformer (DiT-style, ~12B params for Dev, ~2.3B for Schnell)
+//   2. T5-XXL text encoder (~5B params)
+//   3. CLIP-L text encoder
+//   4. Autoencoder (VAE)
+//   5. Flow-matching scheduler (Euler step, sigmas from 0→1)
+//   6. Weight loader for mlx .safetensors layout
+// All of that slots into the method bodies below without touching the
+// rest of the package — the protocol contract is stable.
+
+public final class Flux1Schnell: ImageGenerator, @unchecked Sendable {
+    public static let _register: Void = {
+        ModelRegistry.register(ModelEntry(
+            name: "flux1-schnell",
+            displayName: "FLUX.1 Schnell",
+            kind: .imageGen,
+            defaultSteps: 4,
+            defaultGuidance: 0.0,   // Schnell doesn't use CFG
+            supportsLoRA: true,
+            loader: { path, quant in
+                _ = Flux1Schnell._register  // ensure registered
+                return try Flux1Schnell(modelPath: path, quantize: quant)
+            }
+        ))
+    }()
+
+    public let modelPath: URL
+    public let quantize: Int?
+
+    public init(modelPath: URL, quantize: Int?) throws {
+        self.modelPath = modelPath
+        self.quantize = quantize
+        _ = Self._register
+        guard FileManager.default.fileExists(atPath: modelPath.path) else {
+            throw FluxError.weightsNotFound(modelPath)
+        }
+    }
+
+    public func generate(_ request: ImageGenRequest) -> AsyncThrowingStream<ImageGenEvent, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.finish(throwing: FluxError.notImplemented(
+                "Flux1Schnell.generate — port from mflux/models/flux/variants/txt2img/flux.py"))
+        }
+    }
+}
+
+public final class Flux1Dev: ImageGenerator, @unchecked Sendable {
+    public static let _register: Void = {
+        ModelRegistry.register(ModelEntry(
+            name: "flux1-dev",
+            displayName: "FLUX.1 Dev",
+            kind: .imageGen,
+            defaultSteps: 20,
+            defaultGuidance: 3.5,
+            supportsLoRA: true,
+            loader: { path, quant in
+                _ = Flux1Dev._register
+                return try Flux1Dev(modelPath: path, quantize: quant)
+            }
+        ))
+    }()
+
+    public let modelPath: URL
+    public let quantize: Int?
+
+    public init(modelPath: URL, quantize: Int?) throws {
+        self.modelPath = modelPath
+        self.quantize = quantize
+        _ = Self._register
+        guard FileManager.default.fileExists(atPath: modelPath.path) else {
+            throw FluxError.weightsNotFound(modelPath)
+        }
+    }
+
+    public func generate(_ request: ImageGenRequest) -> AsyncThrowingStream<ImageGenEvent, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.finish(throwing: FluxError.notImplemented(
+                "Flux1Dev.generate — port from mflux/models/flux/variants/txt2img/flux.py"))
+        }
+    }
+}
+
+// MARK: - Flux1Kontext (edit via text prompt, no mask required)
+
+public final class Flux1Kontext: ImageEditor, @unchecked Sendable {
+    public static let _register: Void = {
+        ModelRegistry.register(ModelEntry(
+            name: "flux1-kontext",
+            displayName: "FLUX.1 Kontext",
+            kind: .imageEdit,
+            defaultSteps: 28,
+            defaultGuidance: 2.5,
+            loader: { path, quant in
+                _ = Flux1Kontext._register
+                return try Flux1Kontext(modelPath: path, quantize: quant)
+            }
+        ))
+    }()
+
+    public let modelPath: URL
+    public let quantize: Int?
+
+    public init(modelPath: URL, quantize: Int?) throws {
+        self.modelPath = modelPath
+        self.quantize = quantize
+        _ = Self._register
+        guard FileManager.default.fileExists(atPath: modelPath.path) else {
+            throw FluxError.weightsNotFound(modelPath)
+        }
+    }
+
+    public func edit(_ request: ImageEditRequest) -> AsyncThrowingStream<ImageGenEvent, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.finish(throwing: FluxError.notImplemented(
+                "Flux1Kontext.edit — port from mflux/models/flux/variants/kontext/flux_kontext.py"))
+        }
+    }
+}
+
+// MARK: - Flux1Fill (inpaint / outpaint via mask)
+
+public final class Flux1Fill: ImageEditor, @unchecked Sendable {
+    public static let _register: Void = {
+        ModelRegistry.register(ModelEntry(
+            name: "flux1-fill",
+            displayName: "FLUX.1 Fill",
+            kind: .imageEdit,
+            defaultSteps: 28,
+            defaultGuidance: 30.0,
+            loader: { path, quant in
+                _ = Flux1Fill._register
+                return try Flux1Fill(modelPath: path, quantize: quant)
+            }
+        ))
+    }()
+
+    public let modelPath: URL
+    public let quantize: Int?
+
+    public init(modelPath: URL, quantize: Int?) throws {
+        self.modelPath = modelPath
+        self.quantize = quantize
+        _ = Self._register
+        guard FileManager.default.fileExists(atPath: modelPath.path) else {
+            throw FluxError.weightsNotFound(modelPath)
+        }
+    }
+
+    public func edit(_ request: ImageEditRequest) -> AsyncThrowingStream<ImageGenEvent, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.finish(throwing: FluxError.notImplemented(
+                "Flux1Fill.edit — port from mflux/models/flux/variants/fill/flux_fill.py"))
+        }
+    }
+}

--- a/Libraries/vMLXFluxModels/Flux2Klein/Flux2Klein.swift
+++ b/Libraries/vMLXFluxModels/Flux2Klein/Flux2Klein.swift
@@ -1,0 +1,77 @@
+import Foundation
+import vMLXFluxKit
+
+// FLUX.2 Klein family — second-generation single-encoder Flux. Python
+// source: `mflux.models.flux2.variants.txt2img.flux2_klein.Flux2Klein`
+// and `flux2_klein_edit.Flux2KleinEdit`.
+
+public final class Flux2Klein: ImageGenerator, @unchecked Sendable {
+    public static let _register: Void = {
+        ModelRegistry.register(ModelEntry(
+            name: "flux2-klein",
+            displayName: "FLUX.2 Klein",
+            kind: .imageGen,
+            defaultSteps: 28,
+            defaultGuidance: 3.5,
+            supportsLoRA: false,
+            loader: { path, quant in
+                _ = Flux2Klein._register
+                return try Flux2Klein(modelPath: path, quantize: quant)
+            }
+        ))
+    }()
+
+    public let modelPath: URL
+    public let quantize: Int?
+
+    public init(modelPath: URL, quantize: Int?) throws {
+        self.modelPath = modelPath
+        self.quantize = quantize
+        _ = Self._register
+        guard FileManager.default.fileExists(atPath: modelPath.path) else {
+            throw FluxError.weightsNotFound(modelPath)
+        }
+    }
+
+    public func generate(_ request: ImageGenRequest) -> AsyncThrowingStream<ImageGenEvent, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.finish(throwing: FluxError.notImplemented(
+                "Flux2Klein.generate — port from mflux/models/flux2/variants/txt2img/flux2_klein.py"))
+        }
+    }
+}
+
+public final class Flux2KleinEdit: ImageEditor, @unchecked Sendable {
+    public static let _register: Void = {
+        ModelRegistry.register(ModelEntry(
+            name: "flux2-klein-edit",
+            displayName: "FLUX.2 Klein Edit",
+            kind: .imageEdit,
+            defaultSteps: 28,
+            defaultGuidance: 3.5,
+            loader: { path, quant in
+                _ = Flux2KleinEdit._register
+                return try Flux2KleinEdit(modelPath: path, quantize: quant)
+            }
+        ))
+    }()
+
+    public let modelPath: URL
+    public let quantize: Int?
+
+    public init(modelPath: URL, quantize: Int?) throws {
+        self.modelPath = modelPath
+        self.quantize = quantize
+        _ = Self._register
+        guard FileManager.default.fileExists(atPath: modelPath.path) else {
+            throw FluxError.weightsNotFound(modelPath)
+        }
+    }
+
+    public func edit(_ request: ImageEditRequest) -> AsyncThrowingStream<ImageGenEvent, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.finish(throwing: FluxError.notImplemented(
+                "Flux2KleinEdit.edit — port from mflux/models/flux2/variants/edit/flux2_klein_edit.py"))
+        }
+    }
+}

--- a/Libraries/vMLXFluxModels/QwenImage/QwenImage.swift
+++ b/Libraries/vMLXFluxModels/QwenImage/QwenImage.swift
@@ -1,0 +1,75 @@
+import Foundation
+import vMLXFluxKit
+
+// Qwen-Image (gen) + Qwen-Image-Edit — Alibaba's image model family.
+// Python source: `mflux.models.qwen.variants.{txt2img.qwen_image, edit.qwen_image_edit}`.
+
+public final class QwenImage: ImageGenerator, @unchecked Sendable {
+    public static let _register: Void = {
+        ModelRegistry.register(ModelEntry(
+            name: "qwen-image",
+            displayName: "Qwen-Image",
+            kind: .imageGen,
+            defaultSteps: 30,
+            defaultGuidance: 4.0,
+            loader: { path, quant in
+                _ = QwenImage._register
+                return try QwenImage(modelPath: path, quantize: quant)
+            }
+        ))
+    }()
+
+    public let modelPath: URL
+    public let quantize: Int?
+
+    public init(modelPath: URL, quantize: Int?) throws {
+        self.modelPath = modelPath
+        self.quantize = quantize
+        _ = Self._register
+        guard FileManager.default.fileExists(atPath: modelPath.path) else {
+            throw FluxError.weightsNotFound(modelPath)
+        }
+    }
+
+    public func generate(_ request: ImageGenRequest) -> AsyncThrowingStream<ImageGenEvent, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.finish(throwing: FluxError.notImplemented(
+                "QwenImage.generate — port from mflux/models/qwen/variants/txt2img/qwen_image.py"))
+        }
+    }
+}
+
+public final class QwenImageEdit: ImageEditor, @unchecked Sendable {
+    public static let _register: Void = {
+        ModelRegistry.register(ModelEntry(
+            name: "qwen-image-edit",
+            displayName: "Qwen-Image-Edit",
+            kind: .imageEdit,
+            defaultSteps: 30,
+            defaultGuidance: 4.0,
+            loader: { path, quant in
+                _ = QwenImageEdit._register
+                return try QwenImageEdit(modelPath: path, quantize: quant)
+            }
+        ))
+    }()
+
+    public let modelPath: URL
+    public let quantize: Int?
+
+    public init(modelPath: URL, quantize: Int?) throws {
+        self.modelPath = modelPath
+        self.quantize = quantize
+        _ = Self._register
+        guard FileManager.default.fileExists(atPath: modelPath.path) else {
+            throw FluxError.weightsNotFound(modelPath)
+        }
+    }
+
+    public func edit(_ request: ImageEditRequest) -> AsyncThrowingStream<ImageGenEvent, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.finish(throwing: FluxError.notImplemented(
+                "QwenImageEdit.edit — port from mflux/models/qwen/variants/edit/qwen_image_edit.py"))
+        }
+    }
+}

--- a/Libraries/vMLXFluxModels/SeedVR2/SeedVR2.swift
+++ b/Libraries/vMLXFluxModels/SeedVR2/SeedVR2.swift
@@ -1,0 +1,40 @@
+import Foundation
+import vMLXFluxKit
+
+// SeedVR2 — super-resolution / upscale. Python source:
+// `mflux.models.seedvr2.variants.upscale.seedvr2.SeedVR2`.
+
+public final class SeedVR2: ImageUpscaler, @unchecked Sendable {
+    public static let _register: Void = {
+        ModelRegistry.register(ModelEntry(
+            name: "seedvr2",
+            displayName: "SeedVR2 Upscaler",
+            kind: .imageUpscale,
+            defaultSteps: 10,
+            defaultGuidance: 0.0,
+            loader: { path, quant in
+                _ = SeedVR2._register
+                return try SeedVR2(modelPath: path, quantize: quant)
+            }
+        ))
+    }()
+
+    public let modelPath: URL
+    public let quantize: Int?
+
+    public init(modelPath: URL, quantize: Int?) throws {
+        self.modelPath = modelPath
+        self.quantize = quantize
+        _ = Self._register
+        guard FileManager.default.fileExists(atPath: modelPath.path) else {
+            throw FluxError.weightsNotFound(modelPath)
+        }
+    }
+
+    public func upscale(_ request: UpscaleRequest) -> AsyncThrowingStream<ImageGenEvent, Error> {
+        AsyncThrowingStream { continuation in
+            continuation.finish(throwing: FluxError.notImplemented(
+                "SeedVR2.upscale — port from mflux/models/seedvr2/variants/upscale/seedvr2.py"))
+        }
+    }
+}

--- a/Libraries/vMLXFluxModels/ZImage/ZImage.swift
+++ b/Libraries/vMLXFluxModels/ZImage/ZImage.swift
@@ -1,0 +1,162 @@
+import Foundation
+@preconcurrency import MLX
+import MLXRandom
+import vMLXFluxKit
+
+// Z-Image-Turbo — single-encoder turbo model, ~2B params, 4-8 steps.
+// Python source: `mflux.models.z_image.variants.z_image.ZImage`.
+//
+// STATUS: end-to-end wiring + scheduler + weight loading + PNG output.
+// The transformer velocity predictor is a PLACEHOLDER (returns a scaled
+// noise field) until the DiT port lands. With this placeholder the UI
+// gets real progress events, step counts match, and a valid PNG lands
+// on disk. Replacing the velocity predictor with the real transformer
+// forward pass is a localized change.
+
+public final class ZImage: ImageGenerator, @unchecked Sendable {
+    public static let _register: Void = {
+        ModelRegistry.register(ModelEntry(
+            name: "z-image-turbo",
+            displayName: "Z-Image Turbo",
+            kind: .imageGen,
+            defaultSteps: 4,
+            defaultGuidance: 0.0,
+            supportsLoRA: false,
+            loader: { path, quant in
+                _ = ZImage._register
+                return try await ZImage(modelPath: path, quantize: quant)
+            }
+        ))
+    }()
+
+    public let modelPath: URL
+    public let quantize: Int?
+    public let loadedWeights: LoadedWeights
+    private let pipeline: ZImageNativePipeline
+
+    public init(modelPath: URL, quantize: Int?) async throws {
+        self.modelPath = modelPath
+        self.quantize = quantize
+        _ = Self._register
+        guard FileManager.default.fileExists(atPath: modelPath.path) else {
+            throw FluxError.weightsNotFound(modelPath)
+        }
+        // Eagerly load weights via the WeightLoader so we surface any
+        // JANG config / missing-shard errors at `.load` time rather than
+        // on the first generate call.
+        self.loadedWeights = try WeightLoader.load(from: modelPath)
+
+        self.pipeline = try await ZImageNativePipeline(
+            modelPath: modelPath,
+            loadedWeights: loadedWeights)
+    }
+
+    public func generate(_ request: ImageGenRequest) -> AsyncThrowingStream<ImageGenEvent, Error> {
+        AsyncThrowingStream { continuation in
+            Task { [weak self] in
+                guard let self else { continuation.finish(); return }
+                do {
+                    try await self.performGenerate(request, continuation: continuation)
+                    continuation.finish()
+                } catch {
+                    let message = String(describing: error)
+                    let hfAuth = message.contains("401") || message.contains("403")
+                    continuation.yield(.failed(message: message, hfAuth: hfAuth))
+                    continuation.finish()
+                }
+            }
+        }
+    }
+
+    private func performGenerate(
+        _ request: ImageGenRequest,
+        continuation: AsyncThrowingStream<ImageGenEvent, Error>.Continuation
+    ) async throws {
+        guard request.steps > 0 else {
+            throw FluxError.invalidRequest("Z-Image steps must be greater than zero")
+        }
+        let image = try await pipeline.generate(
+            prompt: request.prompt,
+            negativePrompt: request.negativePrompt,
+            guidance: request.guidance,
+            width: request.width,
+            height: request.height,
+            steps: request.steps,
+            seed: request.seed
+        ) { step, total, eta in
+            continuation.yield(.step(step: step, total: total, etaSeconds: eta))
+        }
+
+        // Write the PNG. `ImageIO.writePNG` is @MainActor so the
+        // actor hop happens here.
+        let outURL = try await MainActor.run {
+            try ImageIO.writePNG(
+                image,
+                outputDir: request.outputDir,
+                prefix: "z-image"
+            )
+        }
+        let seed = request.seed ?? 0
+        continuation.yield(.completed(url: outURL, seed: seed))
+    }
+
+    // MARK: - Placeholder math (to be replaced by real transformer + VAE)
+
+    /// Placeholder velocity predictor. Returns a scaled noise field that
+    /// drives the scheduler to a stable-but-meaningless converged state
+    /// so the end-to-end plumbing is testable today.
+    private func velocityPlaceholder(
+        latent: MLXArray,
+        stepIndex: Int,
+        scheduler: FlowMatchEulerScheduler
+    ) -> MLXArray {
+        let noise = MLXRandom.normal(latent.shape)
+        let sigmaDelta = scheduler.sigmas[stepIndex + 1] - scheduler.sigmas[stepIndex]
+        return noise * MLXArray(Float(sigmaDelta * 0.1))
+    }
+
+    /// Placeholder VAE decoder. Converts a (B, 4, H/8, W/8) latent into a
+    /// (B, 3, H, W) image by averaging channel pairs, tanh-squashing to
+    /// [0, 1], and nearest-neighbor upsampling. The output is a blocky
+    /// gradient — not the prompt, but a valid PNG that exercises every
+    /// pipeline stage. Replaced by the real VAE decoder when weights land.
+    private func vaeDecodePlaceholder(
+        latent: MLXArray,
+        targetWidth: Int,
+        targetHeight: Int
+    ) -> MLXArray {
+        let b = latent.dim(0)
+        let h = latent.dim(2)
+        let w = latent.dim(3)
+        let r = mean(latent[0..<b, 0..<2, 0..<h, 0..<w], axis: 1, keepDims: true)
+        let g = mean(latent[0..<b, 1..<3, 0..<h, 0..<w], axis: 1, keepDims: true)
+        let bl = mean(latent[0..<b, 2..<4, 0..<h, 0..<w], axis: 1, keepDims: true)
+        let rgb = concatenated([r, g, bl], axis: 1)
+
+        let squashed = (MLX.tanh(rgb) + MLXArray(Float(1))) * MLXArray(Float(0.5))
+        let upsampled = upsampleNearest(squashed, factor: 8)
+        return cropToSize(upsampled, height: targetHeight, width: targetWidth)
+    }
+
+    /// Nearest-neighbor upsample by an integer factor. (B, C, H, W) →
+    /// (B, C, H*f, W*f). Uses `MLX.repeated(_:count:axis:)` along H and W.
+    private func upsampleNearest(_ x: MLXArray, factor: Int) -> MLXArray {
+        // Repeat along H (axis 2) then W (axis 3). Each repeat expands
+        // that dimension by `factor` via nearest-neighbor duplication.
+        let expandedH = repeated(x, count: factor, axis: 2)
+        let expandedW = repeated(expandedH, count: factor, axis: 3)
+        return expandedW
+    }
+
+    /// Crop an image tensor to exact (height, width). Takes top-left crop
+    /// if the input is larger; smaller-than-target cases fall through
+    /// since upsampleNearest already pads up to `factor * latentDim`.
+    private func cropToSize(_ x: MLXArray, height: Int, width: Int) -> MLXArray {
+        let currentH = x.dim(2)
+        let currentW = x.dim(3)
+        if currentH == height && currentW == width { return x }
+        let h = min(currentH, height)
+        let w = min(currentW, width)
+        return x[0 ..< x.dim(0), 0 ..< x.dim(1), 0 ..< h, 0 ..< w]
+    }
+}

--- a/Libraries/vMLXFluxModels/ZImage/ZImageNative.swift
+++ b/Libraries/vMLXFluxModels/ZImage/ZImageNative.swift
@@ -1,0 +1,1202 @@
+import Foundation
+@preconcurrency import MLX
+import MLXNN
+import MLXRandom
+import VMLXTokenizers
+import vMLXFluxKit
+
+private enum ZImageNative {
+    static let dim = 3840
+    static let textDim = 2560
+    static let heads = 30
+    static let headDim = 128
+    static let layers = 30
+    static let refinerLayers = 2
+    static let patchSize = 2
+    static let framePatchSize = 1
+    static let channels = 16
+    static let tScale: Float = 1000
+    static let quantizationGroupSize = 64
+    static let maxPromptTokens = 512
+    static let vaeScale: Float = 0.3611
+    static let vaeShift: Float = 0.1159
+}
+
+private final class ZImageWeightStore {
+    private let loaded: LoadedWeights
+
+    init(_ loaded: LoadedWeights) {
+        self.loaded = loaded
+    }
+
+    func tensor(_ component: String, _ key: String) throws -> MLXArray {
+        if let value = optionalTensor(component, key) {
+            return value
+        }
+        throw FluxError.invalidRequest("missing \(component) weight \(key)")
+    }
+
+    func optionalTensor(_ component: String, _ key: String) -> MLXArray? {
+        for candidate in candidateKeys(component: component, key: key) {
+            if let value = loaded.componentWeights[component]?[candidate] {
+                return value
+            }
+            if let value = loaded.weights["\(component).\(candidate)"] {
+                return value
+            }
+            if let value = loaded.weights[candidate] {
+                return value
+            }
+        }
+        return nil
+    }
+
+    private func candidateKeys(component: String, key: String) -> [String] {
+        var candidates = [key]
+        if component == "text_encoder" {
+            candidates.append("model.\(key)")
+        }
+        if key.hasPrefix("t_embedder.linear1.") {
+            candidates.append(key.replacingOccurrences(of: "t_embedder.linear1.", with: "t_embedder.mlp.0."))
+        }
+        if key.hasPrefix("t_embedder.linear2.") {
+            candidates.append(key.replacingOccurrences(of: "t_embedder.linear2.", with: "t_embedder.mlp.2."))
+        }
+        if key.hasPrefix("all_final_layer.2-1.adaLN_modulation.0.") {
+            candidates.append(key.replacingOccurrences(
+                of: "all_final_layer.2-1.adaLN_modulation.0.",
+                with: "all_final_layer.2-1.adaLN_modulation.1."))
+        }
+        if component == "vae" {
+            if key.hasPrefix("decoder.conv_in.conv.") {
+                candidates.append(key.replacingOccurrences(of: "decoder.conv_in.conv.", with: "decoder.conv_in."))
+            }
+            if key.hasPrefix("decoder.conv_norm_out.norm.") {
+                candidates.append(key.replacingOccurrences(
+                    of: "decoder.conv_norm_out.norm.",
+                    with: "decoder.conv_norm_out."))
+            }
+            if key.hasPrefix("decoder.conv_out.conv.") {
+                candidates.append(key.replacingOccurrences(of: "decoder.conv_out.conv.", with: "decoder.conv_out."))
+            }
+        }
+        return candidates
+    }
+
+    func linear(
+        component: String,
+        prefix: String,
+        inputDimensions: Int,
+        outputDimensions: Int,
+        bias: Bool
+    ) throws -> ZImageLinear {
+        try ZImageLinear(
+            weight: tensor(component, "\(prefix).weight"),
+            scales: optionalTensor(component, "\(prefix).scales"),
+            biases: optionalTensor(component, "\(prefix).biases"),
+            bias: bias ? optionalTensor(component, "\(prefix).bias") : nil,
+            inputDimensions: inputDimensions,
+            outputDimensions: outputDimensions,
+            name: "\(component).\(prefix)"
+        )
+    }
+
+    func embedding(
+        component: String,
+        prefix: String,
+        dimensions: Int
+    ) throws -> ZImageEmbedding {
+        try ZImageEmbedding(
+            weight: tensor(component, "\(prefix).weight"),
+            scales: optionalTensor(component, "\(prefix).scales"),
+            biases: optionalTensor(component, "\(prefix).biases"),
+            dimensions: dimensions,
+            name: "\(component).\(prefix)"
+        )
+    }
+
+    func rmsNorm(component: String, prefix: String, eps: Float) throws -> ZImageRMSNorm {
+        try ZImageRMSNorm(weight: tensor(component, "\(prefix).weight"), eps: eps)
+    }
+
+    func groupNorm(component: String, prefix: String) throws -> ZImageGroupNorm {
+        try ZImageGroupNorm(
+            weight: tensor(component, "\(prefix).weight"),
+            bias: tensor(component, "\(prefix).bias"))
+    }
+
+    func conv2d(
+        component: String,
+        prefix: String,
+        stride: Int = 1,
+        padding: Int = 0
+    ) throws -> ZImageConv2D {
+        try ZImageConv2D(
+            weight: tensor(component, "\(prefix).weight"),
+            bias: optionalTensor(component, "\(prefix).bias"),
+            stride: stride,
+            padding: padding)
+    }
+}
+
+private final class ZImageLinear {
+    private let weight: MLXArray
+    private let scales: MLXArray?
+    private let biases: MLXArray?
+    private let bias: MLXArray?
+    private let groupSize: Int
+    private let bits: Int
+
+    init(
+        weight: MLXArray,
+        scales: MLXArray?,
+        biases: MLXArray?,
+        bias: MLXArray?,
+        inputDimensions: Int,
+        outputDimensions: Int,
+        name: String
+    ) throws {
+        guard weight.dim(0) == outputDimensions else {
+            throw FluxError.invalidRequest(
+                "\(name) output mismatch: weight=\(weight.shape), expected output \(outputDimensions)")
+        }
+        if weight.ndim == 4, weight.dim(2) == weight.dim(3), weight.dim(1) != weight.dim(2) {
+            self.weight = weight.transposed(0, 2, 3, 1)
+        } else {
+            self.weight = weight
+        }
+        self.scales = scales
+        self.biases = biases
+        self.bias = bias
+
+        if scales != nil {
+            var inferredBits: Int?
+            for candidate in [2, 3, 4, 5, 6, 8] where weight.dim(1) * 32 / candidate == inputDimensions {
+                inferredBits = candidate
+                break
+            }
+            guard let inferredBits else {
+                throw FluxError.invalidRequest(
+                    "\(name) quantized input mismatch: weight=\(weight.shape), expected input \(inputDimensions)")
+            }
+            let scaleColumns = scales?.dim(1) ?? 0
+            guard scaleColumns > 0, inputDimensions % scaleColumns == 0 else {
+                throw FluxError.invalidRequest("\(name) invalid quantization scales \(scales?.shape ?? [])")
+            }
+            self.bits = inferredBits
+            self.groupSize = inputDimensions / scaleColumns
+        } else {
+            guard weight.dim(1) == inputDimensions else {
+                throw FluxError.invalidRequest(
+                    "\(name) input mismatch: weight=\(weight.shape), expected input \(inputDimensions)")
+            }
+            self.bits = 0
+            self.groupSize = 0
+        }
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var y: MLXArray
+        if let scales {
+            y = quantizedMM(
+                x,
+                weight,
+                scales: scales,
+                biases: biases,
+                transpose: true,
+                groupSize: groupSize,
+                bits: bits,
+                mode: .affine)
+        } else {
+            y = matmul(x, weight.T)
+        }
+        if let bias {
+            y = y + bias
+        }
+        return y
+    }
+}
+
+private final class ZImageEmbedding {
+    private let weight: MLXArray
+    private let scales: MLXArray?
+    private let biases: MLXArray?
+    private let groupSize: Int
+    private let bits: Int
+
+    init(
+        weight: MLXArray,
+        scales: MLXArray?,
+        biases: MLXArray?,
+        dimensions: Int,
+        name: String
+    ) throws {
+        self.weight = weight
+        self.scales = scales
+        self.biases = biases
+        if scales != nil {
+            var inferredBits: Int?
+            for candidate in [2, 3, 4, 5, 6, 8] where weight.dim(1) * 32 / candidate == dimensions {
+                inferredBits = candidate
+                break
+            }
+            guard let inferredBits else {
+                throw FluxError.invalidRequest(
+                    "\(name) quantized dimension mismatch: weight=\(weight.shape), expected \(dimensions)")
+            }
+            let scaleColumns = scales?.dim(1) ?? 0
+            guard scaleColumns > 0, dimensions % scaleColumns == 0 else {
+                throw FluxError.invalidRequest("\(name) invalid quantization scales \(scales?.shape ?? [])")
+            }
+            self.bits = inferredBits
+            self.groupSize = dimensions / scaleColumns
+        } else {
+            guard weight.dim(1) == dimensions else {
+                throw FluxError.invalidRequest(
+                    "\(name) dimension mismatch: weight=\(weight.shape), expected \(dimensions)")
+            }
+            self.bits = 0
+            self.groupSize = 0
+        }
+    }
+
+    func callAsFunction(_ ids: MLXArray) -> MLXArray {
+        let selected = weight[ids]
+        guard let scales else {
+            return selected
+        }
+        let selectedScales = scales[ids]
+        let selectedBiases = biases == nil ? nil : biases![ids]
+        return dequantized(
+            selected,
+            scales: selectedScales,
+            biases: selectedBiases,
+            groupSize: groupSize,
+            bits: bits,
+            mode: .affine)
+    }
+}
+
+private final class ZImageRMSNorm {
+    private let weight: MLXArray
+    private let eps: Float
+
+    init(weight: MLXArray, eps: Float) {
+        self.weight = weight
+        self.eps = eps
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        MLXFast.rmsNorm(x, weight: weight, eps: eps)
+    }
+}
+
+private final class ZImageLayerNorm {
+    private let eps: Float
+
+    init(eps: Float) {
+        self.eps = eps
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let meanValue = mean(x, axis: -1, keepDims: true)
+        let centered = x - meanValue
+        let varianceValue = mean(centered * centered, axis: -1, keepDims: true)
+        return centered * rsqrt(varianceValue + MLXArray(eps))
+    }
+}
+
+private final class ZImageGroupNorm {
+    private let weight: MLXArray
+    private let bias: MLXArray
+    private let groups: Int = 32
+    private let eps: Float = 1e-6
+
+    init(weight: MLXArray, bias: MLXArray) {
+        self.weight = weight
+        self.bias = bias
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let batch = x.dim(0)
+        let dims = x.dim(-1)
+        let rest = Array(x.shape.dropFirst().dropLast())
+        let groupSize = dims / groups
+        var y = x.reshaped([batch, -1, groups, groupSize])
+        y = y.transposed(0, 2, 1, 3).reshaped([batch, groups, -1])
+        let meanValue = mean(y, axis: -1, keepDims: true)
+        let centered = y - meanValue
+        let varianceValue = mean(centered * centered, axis: -1, keepDims: true)
+        y = centered * rsqrt(varianceValue + MLXArray(eps))
+        y = y.reshaped([batch, groups, -1, groupSize])
+            .transposed(0, 2, 1, 3)
+            .reshaped([batch] + rest + [dims])
+        return y * weight + bias
+    }
+}
+
+private final class ZImageConv2D {
+    private let weight: MLXArray
+    private let bias: MLXArray?
+    private let stride: Int
+    private let padding: Int
+
+    init(weight: MLXArray, bias: MLXArray?, stride: Int, padding: Int) {
+        self.weight = weight
+        self.bias = bias
+        self.stride = stride
+        self.padding = padding
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var y = conv2d(x, weight, stride: IntOrPair(stride), padding: IntOrPair(padding))
+        if let bias {
+            y = y + bias
+        }
+        return y
+    }
+}
+
+private final class ZImageTokenizer {
+    private let tokenizer: any VMLXTokenizers.Tokenizer
+    private let padTokenId: Int
+
+    init(modelPath: URL) async throws {
+        let tokenizerDirectory = modelPath.appendingPathComponent("tokenizer", isDirectory: true)
+        self.tokenizer = try await AutoTokenizer.from(modelFolder: tokenizerDirectory, strict: false)
+        self.padTokenId = tokenizer.convertTokenToId("<|endoftext|>") ?? tokenizer.eosTokenId ?? 0
+    }
+
+    func tokenizePrompt(_ prompt: String) -> [Int] {
+        let formatted = "<|im_start|>user\n\(prompt)<|im_end|>\n<|im_start|>assistant\n"
+        let encoded = tokenizer.encode(text: formatted, addSpecialTokens: true)
+        if encoded.count > ZImageNative.maxPromptTokens {
+            return Array(encoded.prefix(ZImageNative.maxPromptTokens))
+        }
+        return encoded
+    }
+
+    func inputArray(for prompt: String) -> MLXArray {
+        let tokens = tokenizePrompt(prompt)
+        if tokens.isEmpty {
+            return MLXArray([padTokenId]).reshaped([1, 1]).asType(.int32)
+        }
+        return MLXArray(tokens.map(Int32.init)).reshaped([1, tokens.count])
+    }
+}
+
+private final class ZImageTextAttention {
+    private let numHeads = 32
+    private let numKVHeads = 8
+    private let headDim = 128
+    private let numKVGroups = 4
+    private let scale = Float(1.0 / sqrt(Float(128)))
+    private let qProj: ZImageLinear
+    private let kProj: ZImageLinear
+    private let vProj: ZImageLinear
+    private let oProj: ZImageLinear
+    private let qNorm: ZImageRMSNorm
+    private let kNorm: ZImageRMSNorm
+
+    init(store: ZImageWeightStore, prefix: String) throws {
+        self.qProj = try store.linear(
+            component: "text_encoder", prefix: "\(prefix).q_proj",
+            inputDimensions: 2560, outputDimensions: 4096, bias: false)
+        self.kProj = try store.linear(
+            component: "text_encoder", prefix: "\(prefix).k_proj",
+            inputDimensions: 2560, outputDimensions: 1024, bias: false)
+        self.vProj = try store.linear(
+            component: "text_encoder", prefix: "\(prefix).v_proj",
+            inputDimensions: 2560, outputDimensions: 1024, bias: false)
+        self.oProj = try store.linear(
+            component: "text_encoder", prefix: "\(prefix).o_proj",
+            inputDimensions: 4096, outputDimensions: 2560, bias: false)
+        self.qNorm = try store.rmsNorm(component: "text_encoder", prefix: "\(prefix).q_norm", eps: 1e-6)
+        self.kNorm = try store.rmsNorm(component: "text_encoder", prefix: "\(prefix).k_norm", eps: 1e-6)
+    }
+
+    func callAsFunction(_ hiddenStates: MLXArray, mask: MLXArray, cos: MLXArray, sin: MLXArray) -> MLXArray {
+        let batch = hiddenStates.dim(0)
+        let seqLen = hiddenStates.dim(1)
+        var q = qProj(hiddenStates).reshaped([batch, seqLen, numHeads, headDim])
+        var k = kProj(hiddenStates).reshaped([batch, seqLen, numKVHeads, headDim])
+        var v = vProj(hiddenStates).reshaped([batch, seqLen, numKVHeads, headDim])
+        q = qNorm(q)
+        k = kNorm(k)
+        let roped = applyTextRotary(q: q, k: k, cos: cos, sin: sin)
+        q = roped.q
+        k = roped.k
+        if numKVGroups > 1 {
+            k = repeated(k, count: numKVGroups, axis: 2)
+            v = repeated(v, count: numKVGroups, axis: 2)
+        }
+        q = q.transposed(0, 2, 1, 3)
+        k = k.transposed(0, 2, 1, 3)
+        v = v.transposed(0, 2, 1, 3)
+        let attn = MLX.scaledDotProductAttention(
+            queries: q, keys: k, values: v, scale: scale, mask: mask)
+        let merged = attn.transposed(0, 2, 1, 3).reshaped([batch, seqLen, numHeads * headDim])
+        return oProj(merged)
+    }
+
+    private func applyTextRotary(q: MLXArray, k: MLXArray, cos: MLXArray, sin: MLXArray)
+        -> (q: MLXArray, k: MLXArray)
+    {
+        let cos = cos.reshaped([cos.dim(0), cos.dim(1), 1, cos.dim(2)])
+        let sin = sin.reshaped([sin.dim(0), sin.dim(1), 1, sin.dim(2)])
+        return (
+            q: q * cos + rotateHalf(q) * sin,
+            k: k * cos + rotateHalf(k) * sin
+        )
+    }
+
+    private func rotateHalf(_ x: MLXArray) -> MLXArray {
+        let half = x.dim(-1) / 2
+        return concatenated([-x[.ellipsis, half ..< x.dim(-1)], x[.ellipsis, 0 ..< half]], axis: -1)
+    }
+}
+
+private final class ZImageTextMLP {
+    private let gateProj: ZImageLinear
+    private let upProj: ZImageLinear
+    private let downProj: ZImageLinear
+
+    init(store: ZImageWeightStore, prefix: String) throws {
+        self.gateProj = try store.linear(
+            component: "text_encoder", prefix: "\(prefix).gate_proj",
+            inputDimensions: 2560, outputDimensions: 9728, bias: false)
+        self.upProj = try store.linear(
+            component: "text_encoder", prefix: "\(prefix).up_proj",
+            inputDimensions: 2560, outputDimensions: 9728, bias: false)
+        self.downProj = try store.linear(
+            component: "text_encoder", prefix: "\(prefix).down_proj",
+            inputDimensions: 9728, outputDimensions: 2560, bias: false)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        downProj(silu(gateProj(x)) * upProj(x))
+    }
+}
+
+private final class ZImageTextEncoderLayer {
+    private let inputLayerNorm: ZImageRMSNorm
+    private let postAttentionLayerNorm: ZImageRMSNorm
+    private let selfAttention: ZImageTextAttention
+    private let mlp: ZImageTextMLP
+
+    init(store: ZImageWeightStore, index: Int) throws {
+        let prefix = "layers.\(index)"
+        self.inputLayerNorm = try store.rmsNorm(
+            component: "text_encoder", prefix: "\(prefix).input_layernorm", eps: 1e-6)
+        self.postAttentionLayerNorm = try store.rmsNorm(
+            component: "text_encoder", prefix: "\(prefix).post_attention_layernorm", eps: 1e-6)
+        self.selfAttention = try ZImageTextAttention(store: store, prefix: "\(prefix).self_attn")
+        self.mlp = try ZImageTextMLP(store: store, prefix: "\(prefix).mlp")
+    }
+
+    func callAsFunction(_ hiddenStates: MLXArray, mask: MLXArray, cos: MLXArray, sin: MLXArray) -> MLXArray {
+        let residual = hiddenStates
+        var hiddenStates = selfAttention(inputLayerNorm(hiddenStates), mask: mask, cos: cos, sin: sin)
+        hiddenStates = residual + hiddenStates
+        return hiddenStates + mlp(postAttentionLayerNorm(hiddenStates))
+    }
+}
+
+private final class ZImageTextEncoder {
+    private let embedTokens: ZImageEmbedding
+    private let layers: [ZImageTextEncoderLayer]
+    private let invFreq: MLXArray
+
+    init(store: ZImageWeightStore) throws {
+        self.embedTokens = try store.embedding(
+            component: "text_encoder", prefix: "embed_tokens", dimensions: 2560)
+        var builtLayers: [ZImageTextEncoderLayer] = []
+        builtLayers.reserveCapacity(36)
+        for index in 0..<36 {
+            builtLayers.append(try ZImageTextEncoderLayer(store: store, index: index))
+        }
+        self.layers = builtLayers
+        let values = stride(from: 0, to: 128, by: 2).map {
+            Float(1.0 / pow(1_000_000.0, Float($0) / 128.0))
+        }
+        self.invFreq = MLXArray(values)
+    }
+
+    func encode(inputIds: MLXArray) -> MLXArray {
+        let batch = inputIds.dim(0)
+        let seqLen = inputIds.dim(1)
+        var hiddenStates = embedTokens(inputIds).asType(.float32)
+        let position = MLXArray((0..<seqLen).map(Float.init))
+        let freqs = matmul(position.reshaped([seqLen, 1]), invFreq.reshaped([1, invFreq.dim(0)]))
+        let emb = concatenated([freqs, freqs], axis: -1)
+        let cos = MLX.cos(emb).reshaped([1, seqLen, 128]).asType(hiddenStates.dtype)
+        let sin = MLX.sin(emb).reshaped([1, seqLen, 128]).asType(hiddenStates.dtype)
+        let mask = causalMask(batchSize: batch, seqLen: seqLen, dtype: hiddenStates.dtype)
+        var penultimate = hiddenStates
+        for (index, layer) in layers.enumerated() {
+            hiddenStates = layer(hiddenStates, mask: mask, cos: cos, sin: sin)
+            if index == layers.count - 2 {
+                penultimate = hiddenStates
+            }
+        }
+        return penultimate.asType(.bfloat16)
+    }
+
+    private func causalMask(batchSize: Int, seqLen: Int, dtype: DType) -> MLXArray {
+        let idx = arange(seqLen, dtype: .int32)
+        let allowed = idx.reshaped([seqLen, 1]) .>= idx.reshaped([1, seqLen])
+        let zeros = MLXArray.zeros([seqLen, seqLen], dtype: dtype)
+        let negInf = full([seqLen, seqLen], values: MLXArray(-Float.infinity), dtype: dtype)
+        return MLX.where(allowed, zeros, negInf).reshaped([1, 1, seqLen, seqLen])
+    }
+}
+
+private final class ZImageAttention {
+    private let dim = ZImageNative.dim
+    private let heads = ZImageNative.heads
+    private let headDim = ZImageNative.headDim
+    private let scale = Float(1.0 / sqrt(Float(ZImageNative.headDim)))
+    private let toQ: ZImageLinear
+    private let toK: ZImageLinear
+    private let toV: ZImageLinear
+    private let toOut: ZImageLinear
+    private let normQ: ZImageRMSNorm
+    private let normK: ZImageRMSNorm
+
+    init(store: ZImageWeightStore, prefix: String) throws {
+        self.toQ = try store.linear(
+            component: "transformer", prefix: "\(prefix).to_q",
+            inputDimensions: dim, outputDimensions: dim, bias: false)
+        self.toK = try store.linear(
+            component: "transformer", prefix: "\(prefix).to_k",
+            inputDimensions: dim, outputDimensions: dim, bias: false)
+        self.toV = try store.linear(
+            component: "transformer", prefix: "\(prefix).to_v",
+            inputDimensions: dim, outputDimensions: dim, bias: false)
+        self.toOut = try store.linear(
+            component: "transformer", prefix: "\(prefix).to_out.0",
+            inputDimensions: dim, outputDimensions: dim, bias: false)
+        self.normQ = try store.rmsNorm(component: "transformer", prefix: "\(prefix).norm_q", eps: 1e-5)
+        self.normK = try store.rmsNorm(component: "transformer", prefix: "\(prefix).norm_k", eps: 1e-5)
+    }
+
+    func callAsFunction(_ hiddenStates: MLXArray, freqsCis: MLXArray) -> MLXArray {
+        let batch = hiddenStates.dim(0)
+        let seqLen = hiddenStates.dim(1)
+        var query = toQ(hiddenStates).reshaped([batch, seqLen, heads, headDim])
+        var key = toK(hiddenStates).reshaped([batch, seqLen, heads, headDim])
+        var value = toV(hiddenStates).reshaped([batch, seqLen, heads, headDim])
+        query = applyRotary(normQ(query), freqsCis: freqsCis)
+        key = applyRotary(normK(key), freqsCis: freqsCis)
+        query = query.transposed(0, 2, 1, 3)
+        key = key.transposed(0, 2, 1, 3)
+        value = value.transposed(0, 2, 1, 3)
+        let attended = MLX.scaledDotProductAttention(
+            queries: query, keys: key, values: value, scale: scale, mask: nil)
+        let merged = attended.transposed(0, 2, 1, 3).reshaped([batch, seqLen, dim])
+        return toOut(merged)
+    }
+
+    private func applyRotary(_ x: MLXArray, freqsCis: MLXArray) -> MLXArray {
+        let batch = x.dim(0)
+        let seqLen = x.dim(1)
+        let reshaped = x.reshaped([batch, seqLen, heads, headDim / 2, 2])
+        let freqs = freqsCis.reshaped([1, freqsCis.dim(0), 1, freqsCis.dim(1), 2])
+        let xReal = reshaped[.ellipsis, 0]
+        let xImag = reshaped[.ellipsis, 1]
+        let cosFreqs = freqs[.ellipsis, 0]
+        let sinFreqs = freqs[.ellipsis, 1]
+        let outReal = xReal * cosFreqs - xImag * sinFreqs
+        let outImag = xReal * sinFreqs + xImag * cosFreqs
+        return stacked([outReal, outImag], axis: -1).reshaped([batch, seqLen, heads, headDim])
+    }
+}
+
+private final class ZImageFeedForward {
+    private let w1: ZImageLinear
+    private let w2: ZImageLinear
+    private let w3: ZImageLinear
+
+    init(store: ZImageWeightStore, prefix: String) throws {
+        self.w1 = try store.linear(
+            component: "transformer", prefix: "\(prefix).w1",
+            inputDimensions: ZImageNative.dim, outputDimensions: 10240, bias: false)
+        self.w2 = try store.linear(
+            component: "transformer", prefix: "\(prefix).w2",
+            inputDimensions: 10240, outputDimensions: ZImageNative.dim, bias: false)
+        self.w3 = try store.linear(
+            component: "transformer", prefix: "\(prefix).w3",
+            inputDimensions: ZImageNative.dim, outputDimensions: 10240, bias: false)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        w2(silu(w1(x)) * w3(x))
+    }
+}
+
+private final class ZImageTransformerBlock {
+    private let attention: ZImageAttention
+    private let feedForward: ZImageFeedForward
+    private let attentionNorm1: ZImageRMSNorm
+    private let attentionNorm2: ZImageRMSNorm
+    private let ffnNorm1: ZImageRMSNorm
+    private let ffnNorm2: ZImageRMSNorm
+    private let modulation: ZImageLinear
+
+    init(store: ZImageWeightStore, prefix: String) throws {
+        self.attention = try ZImageAttention(store: store, prefix: "\(prefix).attention")
+        self.feedForward = try ZImageFeedForward(store: store, prefix: "\(prefix).feed_forward")
+        self.attentionNorm1 = try store.rmsNorm(
+            component: "transformer", prefix: "\(prefix).attention_norm1", eps: 1e-5)
+        self.attentionNorm2 = try store.rmsNorm(
+            component: "transformer", prefix: "\(prefix).attention_norm2", eps: 1e-5)
+        self.ffnNorm1 = try store.rmsNorm(
+            component: "transformer", prefix: "\(prefix).ffn_norm1", eps: 1e-5)
+        self.ffnNorm2 = try store.rmsNorm(
+            component: "transformer", prefix: "\(prefix).ffn_norm2", eps: 1e-5)
+        self.modulation = try store.linear(
+            component: "transformer", prefix: "\(prefix).adaLN_modulation.0",
+            inputDimensions: 256, outputDimensions: ZImageNative.dim * 4, bias: true)
+    }
+
+    func callAsFunction(_ x: MLXArray, freqsCis: MLXArray, tEmb: MLXArray) -> MLXArray {
+        let mod = modulation(silu(tEmb)).reshaped([tEmb.dim(0), 1, ZImageNative.dim * 4])
+        let scaleMSA = MLXArray(1) + mod[.ellipsis, 0 ..< ZImageNative.dim]
+        let gateMSA = tanh(mod[.ellipsis, ZImageNative.dim ..< ZImageNative.dim * 2])
+        let scaleMLP = MLXArray(1) + mod[.ellipsis, ZImageNative.dim * 2 ..< ZImageNative.dim * 3]
+        let gateMLP = tanh(mod[.ellipsis, ZImageNative.dim * 3 ..< ZImageNative.dim * 4])
+        var out = x
+        let attnOut = attention(attentionNorm1(out) * scaleMSA, freqsCis: freqsCis)
+        out = out + gateMSA * attentionNorm2(attnOut)
+        let ffnOut = feedForward(ffnNorm1(out) * scaleMLP)
+        out = out + gateMLP * ffnNorm2(ffnOut)
+        return out
+    }
+}
+
+private final class ZImageContextBlock {
+    private let attention: ZImageAttention
+    private let feedForward: ZImageFeedForward
+    private let attentionNorm1: ZImageRMSNorm
+    private let attentionNorm2: ZImageRMSNorm
+    private let ffnNorm1: ZImageRMSNorm
+    private let ffnNorm2: ZImageRMSNorm
+
+    init(store: ZImageWeightStore, prefix: String) throws {
+        self.attention = try ZImageAttention(store: store, prefix: "\(prefix).attention")
+        self.feedForward = try ZImageFeedForward(store: store, prefix: "\(prefix).feed_forward")
+        self.attentionNorm1 = try store.rmsNorm(
+            component: "transformer", prefix: "\(prefix).attention_norm1", eps: 1e-5)
+        self.attentionNorm2 = try store.rmsNorm(
+            component: "transformer", prefix: "\(prefix).attention_norm2", eps: 1e-5)
+        self.ffnNorm1 = try store.rmsNorm(
+            component: "transformer", prefix: "\(prefix).ffn_norm1", eps: 1e-5)
+        self.ffnNorm2 = try store.rmsNorm(
+            component: "transformer", prefix: "\(prefix).ffn_norm2", eps: 1e-5)
+    }
+
+    func callAsFunction(_ x: MLXArray, freqsCis: MLXArray) -> MLXArray {
+        var out = x
+        let attnOut = attention(attentionNorm1(out), freqsCis: freqsCis)
+        out = out + attentionNorm2(attnOut)
+        let ffnOut = feedForward(ffnNorm1(out))
+        out = out + ffnNorm2(ffnOut)
+        return out
+    }
+}
+
+private final class ZImageFinalLayer {
+    private let norm = ZImageLayerNorm(eps: 1e-6)
+    private let linear: ZImageLinear
+    private let modulation: ZImageLinear
+
+    init(store: ZImageWeightStore) throws {
+        self.linear = try store.linear(
+            component: "transformer", prefix: "all_final_layer.2-1.linear",
+            inputDimensions: ZImageNative.dim, outputDimensions: 64, bias: true)
+        self.modulation = try store.linear(
+            component: "transformer", prefix: "all_final_layer.2-1.adaLN_modulation.0",
+            inputDimensions: 256, outputDimensions: ZImageNative.dim, bias: true)
+    }
+
+    func callAsFunction(_ x: MLXArray, tEmb: MLXArray) -> MLXArray {
+        let scale = MLXArray(1) + modulation(silu(tEmb)).reshaped([tEmb.dim(0), 1, ZImageNative.dim])
+        return linear(norm(x) * scale)
+    }
+}
+
+private final class ZImageRopeEmbedder {
+    private let freqsCis: [MLXArray]
+
+    init(theta: Float = 256, axesDims: [Int] = [32, 48, 48], axesLens: [Int] = [1024, 512, 512]) {
+        var caches: [MLXArray] = []
+        for (dim, length) in zip(axesDims, axesLens) {
+            let freqs = MLXArray(stride(from: 0, to: dim, by: 2).map {
+                Float(1.0 / pow(theta, Float($0) / Float(dim)))
+            })
+            let positions = MLXArray((0..<length).map(Float.init))
+            let outer = matmul(positions.reshaped([length, 1]), freqs.reshaped([1, freqs.dim(0)]))
+            caches.append(stacked([cos(outer), sin(outer)], axis: -1))
+        }
+        self.freqsCis = caches
+    }
+
+    func callAsFunction(_ ids: MLXArray) -> MLXArray {
+        var parts: [MLXArray] = []
+        for axis in 0..<freqsCis.count {
+            let indices = ids[0 ..< ids.dim(0), axis].asType(.int32)
+            parts.append(freqsCis[axis][indices])
+        }
+        return concatenated(parts, axis: 1)
+    }
+}
+
+private final class ZImageTransformer {
+    private let xEmbedder: ZImageLinear
+    private let tLinear1: ZImageLinear
+    private let tLinear2: ZImageLinear
+    private let capNorm: ZImageRMSNorm
+    private let capLinear: ZImageLinear
+    private let xPadToken: MLXArray
+    private let capPadToken: MLXArray
+    private let noiseRefiner: [ZImageTransformerBlock]
+    private let contextRefiner: [ZImageContextBlock]
+    private let layers: [ZImageTransformerBlock]
+    private let finalLayer: ZImageFinalLayer
+    private let ropeEmbedder = ZImageRopeEmbedder()
+
+    init(store: ZImageWeightStore) throws {
+        self.xEmbedder = try store.linear(
+            component: "transformer", prefix: "all_x_embedder.2-1",
+            inputDimensions: 64, outputDimensions: ZImageNative.dim, bias: true)
+        self.tLinear1 = try store.linear(
+            component: "transformer", prefix: "t_embedder.linear1",
+            inputDimensions: 256, outputDimensions: 1024, bias: true)
+        self.tLinear2 = try store.linear(
+            component: "transformer", prefix: "t_embedder.linear2",
+            inputDimensions: 1024, outputDimensions: 256, bias: true)
+        self.capNorm = try store.rmsNorm(component: "transformer", prefix: "cap_embedder.0", eps: 1e-5)
+        self.capLinear = try store.linear(
+            component: "transformer", prefix: "cap_embedder.1",
+            inputDimensions: ZImageNative.textDim, outputDimensions: ZImageNative.dim, bias: true)
+        self.xPadToken = try store.tensor("transformer", "x_pad_token")
+        self.capPadToken = try store.tensor("transformer", "cap_pad_token")
+
+        var noise: [ZImageTransformerBlock] = []
+        var context: [ZImageContextBlock] = []
+        var blocks: [ZImageTransformerBlock] = []
+        for index in 0..<ZImageNative.refinerLayers {
+            noise.append(try ZImageTransformerBlock(store: store, prefix: "noise_refiner.\(index)"))
+            context.append(try ZImageContextBlock(store: store, prefix: "context_refiner.\(index)"))
+        }
+        for index in 0..<ZImageNative.layers {
+            blocks.append(try ZImageTransformerBlock(store: store, prefix: "layers.\(index)"))
+        }
+        self.noiseRefiner = noise
+        self.contextRefiner = context
+        self.layers = blocks
+        self.finalLayer = try ZImageFinalLayer(store: store)
+    }
+
+    func callAsFunction(x: MLXArray, timestep: MLXArray, capFeats: MLXArray) -> MLXArray {
+        let tEmb = timestepEmbedding(timestep.asType(.float32) * MLXArray(ZImageNative.tScale))
+        let packed = patchify(image: x, capFeats: capFeats)
+        var xEmb = xEmbedder(packed.image)
+        xEmb = MLX.where(packed.imagePadMask.reshaped([packed.imagePadMask.dim(0), 1]), xPadToken, xEmb)
+        let xFreqs = ropeEmbedder(packed.imagePositionIds)
+        xEmb = xEmb.reshaped([1, xEmb.dim(0), xEmb.dim(1)])
+        for layer in noiseRefiner {
+            xEmb = layer(xEmb, freqsCis: xFreqs, tEmb: tEmb)
+        }
+
+        var capEmb = capLinear(capNorm(packed.caption))
+        capEmb = MLX.where(packed.captionPadMask.reshaped([packed.captionPadMask.dim(0), 1]), capPadToken, capEmb)
+        let capFreqs = ropeEmbedder(packed.captionPositionIds)
+        capEmb = capEmb.reshaped([1, capEmb.dim(0), capEmb.dim(1)])
+        for layer in contextRefiner {
+            capEmb = layer(capEmb, freqsCis: capFreqs)
+        }
+
+        let xLen = xEmb.dim(1)
+        var unified = concatenated([xEmb, capEmb], axis: 1)
+        let freqs = concatenated([xFreqs, capFreqs], axis: 0)
+        for layer in layers {
+            unified = layer(unified, freqsCis: freqs, tEmb: tEmb)
+        }
+        let final = finalLayer(unified, tEmb: tEmb)
+        let imageTokens = final[0, 0 ..< xLen, 0 ..< final.dim(2)]
+        return -unpatchify(
+            imageTokens,
+            size: packed.imageSize,
+            outChannels: ZImageNative.channels)
+    }
+
+    private func timestepEmbedding(_ t: MLXArray) -> MLXArray {
+        let half = 128
+        let freqs = MLXArray((0..<half).map { -log(Float(10000)) * Float($0) / Float(half) })
+        let args = t.reshaped([t.dim(0), 1]) * exp(freqs).reshaped([1, half])
+        return tLinear2(silu(tLinear1(concatenated([cos(args), sin(args)], axis: -1))))
+    }
+
+    private struct Patchified {
+        let image: MLXArray
+        let caption: MLXArray
+        let imageSize: (frames: Int, height: Int, width: Int)
+        let imagePositionIds: MLXArray
+        let captionPositionIds: MLXArray
+        let imagePadMask: MLXArray
+        let captionPadMask: MLXArray
+    }
+
+    private func patchify(image: MLXArray, capFeats: MLXArray) -> Patchified {
+        let capLen = capFeats.dim(0)
+        let capPadding = (32 - (capLen % 32)) % 32
+        let capPositionIds = coordinateGrid(
+            size: (capLen + capPadding, 1, 1),
+            start: (1, 0, 0))
+        let capPadMask = MLXArray(
+            Array(repeating: false, count: capLen) + Array(repeating: true, count: capPadding))
+        let capPadded: MLXArray
+        if capPadding > 0 {
+            capPadded = concatenated(
+                [capFeats, repeated(capFeats[capLen - 1 ..< capLen], count: capPadding, axis: 0)],
+                axis: 0)
+        } else {
+            capPadded = capFeats
+        }
+
+        let channels = image.dim(0)
+        let frames = image.dim(1)
+        let height = image.dim(2)
+        let width = image.dim(3)
+        let frameTokens = frames / ZImageNative.framePatchSize
+        let heightTokens = height / ZImageNative.patchSize
+        let widthTokens = width / ZImageNative.patchSize
+        var packedImage = image.reshaped([
+            channels,
+            frameTokens,
+            ZImageNative.framePatchSize,
+            heightTokens,
+            ZImageNative.patchSize,
+            widthTokens,
+            ZImageNative.patchSize,
+        ])
+        packedImage = packedImage.transposed(1, 3, 5, 2, 4, 6, 0)
+        packedImage = packedImage.reshaped([
+            frameTokens * heightTokens * widthTokens,
+            ZImageNative.framePatchSize * ZImageNative.patchSize * ZImageNative.patchSize * channels,
+        ])
+
+        let imageLen = packedImage.dim(0)
+        let imagePadding = (32 - (imageLen % 32)) % 32
+        var imagePositionIds = coordinateGrid(
+            size: (frameTokens, heightTokens, widthTokens),
+            start: (capLen + capPadding + 1, 0, 0))
+        if imagePadding > 0 {
+            imagePositionIds = concatenated(
+                [imagePositionIds, MLXArray.zeros([imagePadding, 3], dtype: .int32)],
+                axis: 0)
+            packedImage = concatenated(
+                [packedImage, repeated(packedImage[imageLen - 1 ..< imageLen], count: imagePadding, axis: 0)],
+                axis: 0)
+        }
+        let imagePadMask = MLXArray(
+            Array(repeating: false, count: imageLen) + Array(repeating: true, count: imagePadding))
+        return Patchified(
+            image: packedImage,
+            caption: capPadded,
+            imageSize: (frames, height, width),
+            imagePositionIds: imagePositionIds,
+            captionPositionIds: capPositionIds,
+            imagePadMask: imagePadMask,
+            captionPadMask: capPadMask)
+    }
+
+    private func coordinateGrid(size: (Int, Int, Int), start: (Int, Int, Int)) -> MLXArray {
+        var values: [Int32] = []
+        values.reserveCapacity(size.0 * size.1 * size.2 * 3)
+        for f in 0..<size.0 {
+            for h in 0..<size.1 {
+                for w in 0..<size.2 {
+                    values.append(Int32(start.0 + f))
+                    values.append(Int32(start.1 + h))
+                    values.append(Int32(start.2 + w))
+                }
+            }
+        }
+        return MLXArray(values).reshaped([size.0 * size.1 * size.2, 3])
+    }
+
+    private func unpatchify(
+        _ x: MLXArray,
+        size: (frames: Int, height: Int, width: Int),
+        outChannels: Int
+    ) -> MLXArray {
+        let frameTokens = size.frames / ZImageNative.framePatchSize
+        let heightTokens = size.height / ZImageNative.patchSize
+        let widthTokens = size.width / ZImageNative.patchSize
+        let originalLength = frameTokens * heightTokens * widthTokens
+        var out = x[0 ..< originalLength].reshaped([
+            frameTokens,
+            heightTokens,
+            widthTokens,
+            ZImageNative.framePatchSize,
+            ZImageNative.patchSize,
+            ZImageNative.patchSize,
+            outChannels,
+        ])
+        out = out.transposed(6, 0, 3, 1, 4, 2, 5)
+        return out.reshaped([outChannels, size.frames, size.height, size.width])
+    }
+}
+
+private final class ZImageVAEAttention {
+    private let groupNorm: ZImageGroupNorm
+    private let toQ: ZImageLinear
+    private let toK: ZImageLinear
+    private let toV: ZImageLinear
+    private let toOut: ZImageLinear
+    private let channels: Int
+
+    init(store: ZImageWeightStore, prefix: String, channels: Int = 512) throws {
+        self.channels = channels
+        self.groupNorm = try store.groupNorm(component: "vae", prefix: "\(prefix).group_norm")
+        self.toQ = try store.linear(
+            component: "vae", prefix: "\(prefix).to_q",
+            inputDimensions: channels, outputDimensions: channels, bias: true)
+        self.toK = try store.linear(
+            component: "vae", prefix: "\(prefix).to_k",
+            inputDimensions: channels, outputDimensions: channels, bias: true)
+        self.toV = try store.linear(
+            component: "vae", prefix: "\(prefix).to_v",
+            inputDimensions: channels, outputDimensions: channels, bias: true)
+        self.toOut = try store.linear(
+            component: "vae", prefix: "\(prefix).to_out.0",
+            inputDimensions: channels, outputDimensions: channels, bias: true)
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        let nhwc = input.transposed(0, 2, 3, 1)
+        let batch = nhwc.dim(0)
+        let height = nhwc.dim(1)
+        let width = nhwc.dim(2)
+        let normed = groupNorm(nhwc.asType(.float32)).asType(input.dtype)
+        var q = toQ(normed).reshaped([batch, height * width, 1, channels]).transposed(0, 2, 1, 3)
+        var k = toK(normed).reshaped([batch, height * width, 1, channels]).transposed(0, 2, 1, 3)
+        var v = toV(normed).reshaped([batch, height * width, 1, channels]).transposed(0, 2, 1, 3)
+        let scale = Float(1.0 / sqrt(Float(channels)))
+        let attended = MLX.scaledDotProductAttention(queries: q, keys: k, values: v, scale: scale, mask: nil)
+        let out = attended.transposed(0, 2, 1, 3).reshaped([batch, height, width, channels])
+        return (nhwc + toOut(out)).transposed(0, 3, 1, 2)
+    }
+}
+
+private final class ZImageVAEResnetBlock {
+    private let norm1: ZImageGroupNorm
+    private let conv1: ZImageConv2D
+    private let norm2: ZImageGroupNorm
+    private let conv2: ZImageConv2D
+    private let shortcut: ZImageConv2D?
+
+    init(store: ZImageWeightStore, prefix: String) throws {
+        self.norm1 = try store.groupNorm(component: "vae", prefix: "\(prefix).norm1")
+        self.conv1 = try store.conv2d(component: "vae", prefix: "\(prefix).conv1", padding: 1)
+        self.norm2 = try store.groupNorm(component: "vae", prefix: "\(prefix).norm2")
+        self.conv2 = try store.conv2d(component: "vae", prefix: "\(prefix).conv2", padding: 1)
+        if store.optionalTensor("vae", "\(prefix).conv_shortcut.weight") != nil {
+            self.shortcut = try store.conv2d(component: "vae", prefix: "\(prefix).conv_shortcut")
+        } else {
+            self.shortcut = nil
+        }
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        let nhwc = input.transposed(0, 2, 3, 1)
+        var hidden = norm1(nhwc)
+        hidden = silu(hidden)
+        hidden = conv1(hidden)
+        hidden = norm2(hidden)
+        hidden = silu(hidden)
+        hidden = conv2(hidden)
+        let residual = shortcut?(nhwc) ?? nhwc
+        return (residual + hidden).transposed(0, 3, 1, 2)
+    }
+}
+
+private final class ZImageVAEMidBlock {
+    private let resnet0: ZImageVAEResnetBlock
+    private let attention: ZImageVAEAttention
+    private let resnet1: ZImageVAEResnetBlock
+
+    init(store: ZImageWeightStore, prefix: String) throws {
+        self.resnet0 = try ZImageVAEResnetBlock(store: store, prefix: "\(prefix).resnets.0")
+        self.attention = try ZImageVAEAttention(store: store, prefix: "\(prefix).attentions.0")
+        self.resnet1 = try ZImageVAEResnetBlock(store: store, prefix: "\(prefix).resnets.1")
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        resnet1(attention(resnet0(x)))
+    }
+}
+
+private final class ZImageVAEUpSampler {
+    private let conv: ZImageConv2D
+
+    init(store: ZImageWeightStore, prefix: String) throws {
+        self.conv = try store.conv2d(component: "vae", prefix: "\(prefix).conv", padding: 1)
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        let up = repeated(repeated(input, count: 2, axis: 2), count: 2, axis: 3)
+        return conv(up.transposed(0, 2, 3, 1)).transposed(0, 3, 1, 2)
+    }
+}
+
+private final class ZImageVAEUpBlock {
+    private let resnets: [ZImageVAEResnetBlock]
+    private let upsampler: ZImageVAEUpSampler?
+
+    init(store: ZImageWeightStore, index: Int, addUpsample: Bool) throws {
+        var blocks: [ZImageVAEResnetBlock] = []
+        for layer in 0..<3 {
+            blocks.append(try ZImageVAEResnetBlock(
+                store: store,
+                prefix: "decoder.up_blocks.\(index).resnets.\(layer)"))
+        }
+        self.resnets = blocks
+        self.upsampler = addUpsample
+            ? try ZImageVAEUpSampler(store: store, prefix: "decoder.up_blocks.\(index).upsamplers.0")
+            : nil
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var out = x
+        for resnet in resnets {
+            out = resnet(out)
+        }
+        if let upsampler {
+            out = upsampler(out)
+        }
+        return out
+    }
+}
+
+private final class ZImageVAEDecoder {
+    private let convIn: ZImageConv2D
+    private let midBlock: ZImageVAEMidBlock
+    private let upBlocks: [ZImageVAEUpBlock]
+    private let normOut: ZImageGroupNorm
+    private let convOut: ZImageConv2D
+
+    init(store: ZImageWeightStore) throws {
+        self.convIn = try store.conv2d(component: "vae", prefix: "decoder.conv_in.conv", padding: 1)
+        self.midBlock = try ZImageVAEMidBlock(store: store, prefix: "decoder.mid_block")
+        var blocks: [ZImageVAEUpBlock] = []
+        for index in 0..<4 {
+            blocks.append(try ZImageVAEUpBlock(store: store, index: index, addUpsample: index < 3))
+        }
+        self.upBlocks = blocks
+        self.normOut = try store.groupNorm(component: "vae", prefix: "decoder.conv_norm_out.norm")
+        self.convOut = try store.conv2d(component: "vae", prefix: "decoder.conv_out.conv", padding: 1)
+    }
+
+    func decode(_ latents: MLXArray) -> MLXArray {
+        let scaled = latents / MLXArray(ZImageNative.vaeScale) + MLXArray(ZImageNative.vaeShift)
+        var hidden = convIn(scaled.transposed(0, 2, 3, 1)).transposed(0, 3, 1, 2)
+        hidden = midBlock(hidden)
+        for block in upBlocks {
+            hidden = block(hidden)
+        }
+        hidden = normOut(hidden.transposed(0, 2, 3, 1)).transposed(0, 3, 1, 2)
+        hidden = silu(hidden)
+        hidden = convOut(hidden.transposed(0, 2, 3, 1)).transposed(0, 3, 1, 2)
+        return VAEDecoder.postprocess(hidden)
+    }
+}
+
+final class ZImageNativePipeline {
+    private let tokenizer: ZImageTokenizer
+    private let textEncoder: ZImageTextEncoder
+    private let transformer: ZImageTransformer
+    private let vae: ZImageVAEDecoder
+
+    init(modelPath: URL, loadedWeights: LoadedWeights) async throws {
+        let store = ZImageWeightStore(loadedWeights)
+        self.tokenizer = try await ZImageTokenizer(modelPath: modelPath)
+        self.textEncoder = try ZImageTextEncoder(store: store)
+        self.transformer = try ZImageTransformer(store: store)
+        self.vae = try ZImageVAEDecoder(store: store)
+    }
+
+    func generate(
+        prompt: String,
+        negativePrompt: String?,
+        guidance: Float,
+        width: Int,
+        height: Int,
+        steps: Int,
+        seed: UInt64?,
+        progress: (Int, Int, Double?) -> Void
+    ) async throws -> MLXArray {
+        guard width % 16 == 0, height % 16 == 0 else {
+            throw FluxError.invalidRequest("Z-Image width and height must be divisible by 16")
+        }
+        let start = Date()
+        var latents = initialNoise(width: width, height: height, seed: seed)
+        let textEncodings = encodePrompt(prompt)
+        let negativeEncodings = (guidance > 0 && negativePrompt != nil) ? encodePrompt(negativePrompt ?? "") : nil
+        let sigmas = linearSigmas(steps: steps)
+        for step in 0..<steps {
+            if Task.isCancelled {
+                throw CancellationError()
+            }
+            let timestep = MLXArray([Float(1) - sigmas[step]])
+            var noise = transformer(x: latents, timestep: timestep, capFeats: textEncodings)
+            if let negativeEncodings {
+                let negativeNoise = transformer(x: latents, timestep: timestep, capFeats: negativeEncodings)
+                noise = noise + MLXArray(guidance) * (noise - negativeNoise)
+            }
+            latents = latents + noise * MLXArray(sigmas[step + 1] - sigmas[step])
+            eval(latents)
+            let elapsed = Date().timeIntervalSince(start)
+            let perStep = elapsed / Double(step + 1)
+            progress(step + 1, steps, perStep * Double(steps - step - 1))
+        }
+        let unpacked = latents.reshaped([
+            1,
+            ZImageNative.channels,
+            height / 8,
+            width / 8,
+        ])
+        return vae.decode(unpacked)
+    }
+
+    private func encodePrompt(_ prompt: String) -> MLXArray {
+        let inputIds = tokenizer.inputArray(for: prompt)
+        let hidden = textEncoder.encode(inputIds: inputIds)
+        return hidden[0]
+    }
+
+    private func initialNoise(width: Int, height: Int, seed: UInt64?) -> MLXArray {
+        if let seed {
+            MLXRandom.seed(seed)
+        }
+        return MLXRandom.normal(
+            [ZImageNative.channels, 1, height / 8, width / 8],
+            dtype: .bfloat16)
+    }
+
+    private func linearSigmas(steps: Int) -> [Float] {
+        guard steps > 1 else {
+            return [1, 0]
+        }
+        var values: [Float] = []
+        values.reserveCapacity(steps + 1)
+        for index in 0..<steps {
+            let t = Float(index) / Float(steps - 1)
+            values.append(1 - t * (1 - 1 / Float(steps)))
+        }
+        values.append(0)
+        return values
+    }
+}

--- a/Libraries/vMLXFluxVideo/WANModel.swift
+++ b/Libraries/vMLXFluxVideo/WANModel.swift
@@ -1,0 +1,251 @@
+import Foundation
+@preconcurrency import MLX
+import MLXRandom
+import vMLXFluxKit
+
+// MARK: - WAN (Wan 2.1 / Wan 2.2) — Apple Silicon video generation
+//
+// End-to-end scaffold: scheduler → noise latent → WanDiT forward →
+// WanVAEDecoder → MP4. The transformer velocity predictor and the VAE
+// are module-complete (FP32 weights would load directly via
+// WeightLoader) but ship initialized to random weights, so current
+// output is a random noise MP4 — real weights decode into real video
+// once we wire a safetensors loader for Wan's specific file layout.
+//
+// Architecture flow:
+//   1. text → T5-XXL → (B, N_txt, 4096)     [STUB — currently zero tensor]
+//   2. noise latent: (1, 16, T/4, H/8, W/8) via LatentSpace
+//   3. patchify video latent: (1, N_vid, patch_t*patch_h*patch_w*16)
+//   4. For each scheduler step:
+//        velocity = WanDiTModel(video_patched, txt, t)
+//        latent = scheduler.step(latent, velocity, i)
+//        yield progress event
+//   5. unpatchify latent back to (1, 16, T/4, H/8, W/8)
+//   6. WanVAEDecoder(latent) → (1, 3, T, H, W) in [-1, 1]
+//   7. Postprocess → [0, 1]
+//   8. Write MP4 via WanVideoIO
+//   9. Yield .completed
+//
+// This is the REAL pipeline — the only placeholders are the
+// un-loaded weights inside WanDiTModel + WanVAEDecoder.
+
+public final class WANModel: VideoGenerator, @unchecked Sendable {
+    /// Wan 2.1 — the original 1.3B / 14B variants.
+    public static let _registerWan21: Void = {
+        ModelRegistry.register(ModelEntry(
+            name: "wan-2.1",
+            displayName: "Wan 2.1",
+            kind: .videoGen,
+            defaultSteps: 50,
+            defaultGuidance: 5.0,
+            loader: { path, quant in
+                _ = WANModel._registerWan21
+                return try WANModel(modelPath: path, quantize: quant, version: .wan21)
+            }
+        ))
+    }()
+
+    /// Wan 2.2 — second generation with higher resolution defaults.
+    public static let _registerWan22: Void = {
+        ModelRegistry.register(ModelEntry(
+            name: "wan-2.2",
+            displayName: "Wan 2.2",
+            kind: .videoGen,
+            defaultSteps: 50,
+            defaultGuidance: 5.0,
+            loader: { path, quant in
+                _ = WANModel._registerWan22
+                return try WANModel(modelPath: path, quantize: quant, version: .wan22)
+            }
+        ))
+    }()
+
+    public enum Version: Sendable { case wan21, wan22 }
+
+    public let modelPath: URL
+    public let quantize: Int?
+    public let version: Version
+    public let config: WanDiTConfig
+    public let transformer: WanDiTModel
+    public let vae: WanVAEDecoder
+    public let loadedWeights: LoadedWeights
+
+    public init(modelPath: URL, quantize: Int?, version: Version) throws {
+        self.modelPath = modelPath
+        self.quantize = quantize
+        self.version = version
+
+        // Pick the right config for the version. 1.3B vs 14B is decided
+        // at load time by inspecting the checkpoint file sizes; for now
+        // we default to the larger 14B topology.
+        self.config = {
+            switch version {
+            case .wan21: return .wan21_14B
+            case .wan22: return .wan22
+            }
+        }()
+
+        guard FileManager.default.fileExists(atPath: modelPath.path) else {
+            throw FluxError.weightsNotFound(modelPath)
+        }
+
+        // Module construction. Real safetensors → module tree application
+        // plugs in once the Wan-specific key mapping is written; for now
+        // the modules initialize with random weights from their Linear
+        // constructors so the forward pass compiles and runs.
+        self.transformer = WanDiTModel(config: config)
+        self.vae = WanVAEDecoder()
+
+        // Eagerly scan the weights dir so JANG config / missing-shard
+        // errors surface at `.load` time, same as ZImage.
+        self.loadedWeights = try WeightLoader.load(from: modelPath)
+    }
+
+    public func generate(_ request: VideoGenRequest) -> AsyncThrowingStream<VideoGenEvent, Error> {
+        AsyncThrowingStream { continuation in
+            Task { [weak self] in
+                guard let self else { continuation.finish(); return }
+                do {
+                    try await self.performGenerate(request, continuation: continuation)
+                    continuation.finish()
+                } catch {
+                    let msg = String(describing: error)
+                    let hfAuth = msg.contains("401") || msg.contains("403")
+                    continuation.yield(.failed(message: msg, hfAuth: hfAuth))
+                    continuation.finish()
+                }
+            }
+        }
+    }
+
+    private func performGenerate(
+        _ request: VideoGenRequest,
+        continuation: AsyncThrowingStream<VideoGenEvent, Error>.Continuation
+    ) async throws {
+        // 1. Scheduler. Video image-seq-len is (T/4) × (H/8 × W/8) patches,
+        // typically much larger than still-image so the shift is saturated
+        // at maxShift.
+        let patchedSpatial = (request.width / 8 / config.patchSizeH)
+            * (request.height / 8 / config.patchSizeW)
+        let patchedTemporal = (request.numFrames / 4 / config.patchSizeT)
+        let videoSeqLen = max(256, patchedSpatial * patchedTemporal)
+        let scheduler = FlowMatchEulerScheduler(
+            steps: request.steps,
+            imageSeqLen: videoSeqLen,
+            baseShift: 0.5,
+            maxShift: 1.15
+        )
+
+        // 2. Noise latent: (1, 16, T/4, H/8, W/8). LatentSpace only
+        // supports 2D layouts, so we allocate a flat (1, seq, 16)
+        // and reshape.
+        let tLatent = request.numFrames / 4
+        let hLatent = request.height / 8
+        let wLatent = request.width / 8
+        if let seed = request.seed {
+            MLXRandom.seed(seed)
+        }
+        var latent5D = MLXRandom.normal([1, 16, tLatent, hLatent, wLatent])
+
+        // 3. Patchify: (B, 16, T, H, W) → (B, N_vid, patch_t*patch_h*patch_w*16).
+        // For patch (1, 2, 2): reshape + transpose to collect each 1×2×2×16
+        // block into one vector.
+        func patchify(_ x: MLXArray) -> MLXArray {
+            let pT = config.patchSizeT
+            let pH = config.patchSizeH
+            let pW = config.patchSizeW
+            let b = x.dim(0)
+            let c = x.dim(1)
+            let t = x.dim(2)
+            let h = x.dim(3)
+            let w = x.dim(4)
+            // (B, C, T, H, W) → (B, C, T/pT, pT, H/pH, pH, W/pW, pW)
+            let r = x.reshaped([b, c, t / pT, pT, h / pH, pH, w / pW, pW])
+            // → (B, T/pT, H/pH, W/pW, pT, pH, pW, C)
+            let p = r.transposed(0, 2, 4, 6, 3, 5, 7, 1)
+            // → (B, N, pT*pH*pW*C)
+            let n = (t / pT) * (h / pH) * (w / pW)
+            return p.reshaped([b, n, pT * pH * pW * c])
+        }
+        func unpatchify(_ x: MLXArray, t: Int, h: Int, w: Int) -> MLXArray {
+            let pT = config.patchSizeT
+            let pH = config.patchSizeH
+            let pW = config.patchSizeW
+            let b = x.dim(0)
+            let c = 16
+            // (B, N, pT*pH*pW*C) → (B, T/pT, H/pH, W/pW, pT, pH, pW, C)
+            let r = x.reshaped([b, t / pT, h / pH, w / pW, pT, pH, pW, c])
+            // → (B, C, T/pT, pT, H/pH, pH, W/pW, pW)
+            let p = r.transposed(0, 7, 1, 4, 2, 5, 3, 6)
+            return p.reshaped([b, c, t, h, w])
+        }
+
+        // 4. Text encoding. REAL T5-XXL Swift port is future work; for
+        // now feed a zero tensor of the right shape. Wan uses ~256
+        // max tokens for the text stream.
+        let nTxt = 256
+        let txt = MLXArray.zeros([1, nTxt, config.textDim])
+
+        // 5. Sampling loop.
+        let total = scheduler.stepCount
+        let startedAt = Date()
+        for step in 0..<total {
+            if Task.isCancelled {
+                continuation.yield(.cancelled)
+                return
+            }
+            let patched = patchify(latent5D)
+            let timestep = MLXArray([scheduler.timesteps[step]])
+            let velocityPatched = transformer(
+                videoPatched: patched,
+                txt: txt,
+                timestep: timestep
+            )
+            let velocity5D = unpatchify(velocityPatched, t: tLatent, h: hLatent, w: wLatent)
+            // Euler step in 5D space — the scheduler only cares about
+            // shape, not dimensionality.
+            let sigmaCurrent = scheduler.sigmas[step]
+            let sigmaNext = scheduler.sigmas[step + 1]
+            let delta = sigmaNext - sigmaCurrent
+            latent5D = latent5D + velocity5D * MLXArray(Float(delta))
+            _ = latent5D.shape  // force eval
+
+            let elapsed = Date().timeIntervalSince(startedAt)
+            let perStep = elapsed / Double(step + 1)
+            let eta = perStep * Double(total - step - 1)
+            continuation.yield(.step(step: step + 1, total: total, etaSeconds: eta))
+        }
+
+        // 6. VAE decode.
+        let rescaled = WanVAEDecoder.preprocessLatent(latent5D)
+        let decoded = vae(rescaled)   // (1, 3, T, H, W) in ~[-1, 1]
+        let processed = WanVAEDecoder.postprocess(decoded)
+
+        // 7. Drop batch dim and write MP4 + frame PNG sequence.
+        let video = processed[0]   // (3, T, H, W)
+        try FileManager.default.createDirectory(
+            at: request.outputDir, withIntermediateDirectories: true)
+        let mp4URL = request.outputDir.appendingPathComponent(
+            "wan-\(UUID().uuidString.prefix(8)).mp4"
+        )
+        try await MainActor.run {
+            try WanVideoIO.writeMP4(video, outputURL: mp4URL, fps: request.fps)
+        }
+
+        let seed = request.seed ?? 0
+        continuation.yield(.completed(
+            url: mp4URL,
+            seed: seed,
+            fps: request.fps,
+            frameCount: request.numFrames
+        ))
+    }
+}
+
+/// Force-register the video models. Call once at app launch.
+public enum VMLXFluxVideo {
+    public static func registerAll() {
+        _ = WANModel._registerWan21
+        _ = WANModel._registerWan22
+    }
+}

--- a/Libraries/vMLXFluxVideo/WanDiT.swift
+++ b/Libraries/vMLXFluxVideo/WanDiT.swift
@@ -1,0 +1,239 @@
+import Foundation
+@preconcurrency import MLX
+import MLXNN
+import vMLXFluxKit
+
+// MARK: - Wan 2.x DiT transformer
+//
+// Pure-Swift port of the Wan 2.1 / 2.2 video transformer. Architecture:
+//
+//   video patch embed  : (B, 16, T/4, H/8, W/8) → (B, N_vid, D)
+//   time_mlp           : t → (B, D)
+//   text_proj          : (B, N_txt, 4096 T5) → (B, N_txt, D)
+//   blocks[num_layers] : 3D self-attention + cross-attention to text +
+//                        FFN. Attention uses 3D RoPE over (T, H, W).
+//   final              : norm + linear → (B, N_vid, patch_t*patch_h*patch_w*16)
+//   → unpatchify to (B, 16, T/4, H/8, W/8)
+//
+// Hyperparams (Wan 2.1 14B):
+//   dim=1536, num_layers=30, num_heads=12, patch=(1,2,2), text_dim=4096
+//
+// Wan 2.1 1.3B:
+//   dim=1024, num_layers=24, num_heads=8
+//
+// STATUS: module shapes + forward pass scaffolded. Same philosophy as
+// the Flux DiT — compiles cleanly, wiring is stable, replaces the
+// `velocityPlaceholder` inside WANModel.generate once we have real
+// weights. The Wan repository's checkpoint format is 1:1 with the
+// standard safetensors naming we already parse in WeightLoader.
+
+public struct WanDiTConfig: Sendable {
+    public let dim: Int
+    public let numLayers: Int
+    public let numHeads: Int
+    public let patchSizeT: Int
+    public let patchSizeH: Int
+    public let patchSizeW: Int
+    public let inChannels: Int
+    public let outChannels: Int
+    public let textDim: Int
+    public let frequencyDim: Int
+
+    public init(
+        dim: Int = 1536,
+        numLayers: Int = 30,
+        numHeads: Int = 12,
+        patchSizeT: Int = 1,
+        patchSizeH: Int = 2,
+        patchSizeW: Int = 2,
+        inChannels: Int = 16,
+        outChannels: Int = 16,
+        textDim: Int = 4096,
+        frequencyDim: Int = 256
+    ) {
+        self.dim = dim
+        self.numLayers = numLayers
+        self.numHeads = numHeads
+        self.patchSizeT = patchSizeT
+        self.patchSizeH = patchSizeH
+        self.patchSizeW = patchSizeW
+        self.inChannels = inChannels
+        self.outChannels = outChannels
+        self.textDim = textDim
+        self.frequencyDim = frequencyDim
+    }
+
+    /// Wan 2.1 1.3B — fast variant for laptops.
+    public static let wan21_1_3B = WanDiTConfig(
+        dim: 1024, numLayers: 24, numHeads: 8
+    )
+
+    /// Wan 2.1 14B — full quality, desktop / Mac Studio.
+    public static let wan21_14B = WanDiTConfig(
+        dim: 1536, numLayers: 30, numHeads: 12
+    )
+
+    /// Wan 2.2 — assume same topology, different checkpoint.
+    public static let wan22 = WanDiTConfig(
+        dim: 1536, numLayers: 30, numHeads: 12
+    )
+}
+
+// MARK: - Wan transformer block
+
+/// Single Wan transformer block. Runs 3D self-attention over video
+/// tokens, cross-attention to T5 text tokens, then a gated MLP. Uses
+/// AdaLN modulation from the time + text_embed conditioning vector.
+public final class WanDiTBlock: Module {
+    public let dim: Int
+    public let numHeads: Int
+
+    public let modulation: Linear   // → 6*D
+    public let norm1: LayerNorm
+    public let selfAttnQKV: Linear
+    public let selfAttnProj: Linear
+    public let qkNorm: QKNorm
+
+    public let norm2: LayerNorm
+    public let crossAttnQ: Linear
+    public let crossAttnKV: Linear
+    public let crossAttnProj: Linear
+
+    public let norm3: LayerNorm
+    public let mlp0: Linear
+    public let mlp2: Linear
+
+    public init(dim: Int, numHeads: Int, mlpRatio: Float = 4.0) {
+        self.dim = dim
+        self.numHeads = numHeads
+        let headDim = dim / numHeads
+        let mlpDim = Int(Float(dim) * mlpRatio)
+
+        self.modulation = Linear(dim, dim * 6)
+        self.norm1 = LayerNorm(dimensions: dim, eps: 1e-6, affine: false)
+        self.selfAttnQKV = Linear(dim, dim * 3)
+        self.selfAttnProj = Linear(dim, dim)
+        self.qkNorm = QKNorm(headDim: headDim)
+
+        self.norm2 = LayerNorm(dimensions: dim, eps: 1e-6, affine: false)
+        self.crossAttnQ = Linear(dim, dim)
+        self.crossAttnKV = Linear(dim, dim * 2)  // K and V share projection
+        self.crossAttnProj = Linear(dim, dim)
+
+        self.norm3 = LayerNorm(dimensions: dim, eps: 1e-6, affine: false)
+        self.mlp0 = Linear(dim, mlpDim)
+        self.mlp2 = Linear(mlpDim, dim)
+
+        super.init()
+    }
+
+    public func callAsFunction(
+        _ x: MLXArray,
+        txt: MLXArray,
+        vec: MLXArray
+    ) -> MLXArray {
+        // Extract 6 modulation triples from vec.
+        let mods = modulation(silu(vec))
+        let b = mods.dim(0)
+        let d = dim
+        let shift1 = mods[0 ..< b, 0 ..< d].reshaped([b, 1, d])
+        let scale1 = mods[0 ..< b, d ..< 2*d].reshaped([b, 1, d])
+        let gate1  = mods[0 ..< b, 2*d ..< 3*d].reshaped([b, 1, d])
+        let shift2 = mods[0 ..< b, 3*d ..< 4*d].reshaped([b, 1, d])
+        let scale2 = mods[0 ..< b, 4*d ..< 5*d].reshaped([b, 1, d])
+        let gate2  = mods[0 ..< b, 5*d ..< 6*d].reshaped([b, 1, d])
+
+        // 1. Self-attention over video tokens.
+        var h = norm1(x)
+        h = h * (MLXArray(Float(1)) + scale1) + shift1
+        let qkv = selfAttnQKV(h)
+        let (q, k, v) = splitQKV(qkv, numHeads: numHeads)
+        let (qn, kn) = qkNorm(q: q, k: k)
+        let attnOut = scaledDotProductAttention(q: qn, k: kn, v: v, rope: nil)
+        let attnMerged = attnOut.transposed(0, 2, 1, 3).reshaped([
+            attnOut.dim(0), attnOut.dim(2), dim
+        ])
+        var out = x + selfAttnProj(attnMerged) * gate1
+
+        // 2. Cross-attention to T5 text tokens.
+        let normed2 = norm2(out)
+        let crossQ = crossAttnQ(normed2)
+        let crossKV = crossAttnKV(txt)
+        let d2 = crossKV.dim(-1) / 2
+        let cK = crossKV[.ellipsis, 0 ..< d2]
+        let cV = crossKV[.ellipsis, d2 ..< 2*d2]
+        // Multi-head split.
+        let headDim = dim / numHeads
+        let qHead = crossQ.reshaped([crossQ.dim(0), crossQ.dim(1), numHeads, headDim])
+            .transposed(0, 2, 1, 3)
+        let kHead = cK.reshaped([cK.dim(0), cK.dim(1), numHeads, headDim])
+            .transposed(0, 2, 1, 3)
+        let vHead = cV.reshaped([cV.dim(0), cV.dim(1), numHeads, headDim])
+            .transposed(0, 2, 1, 3)
+        let crossOut = scaledDotProductAttention(q: qHead, k: kHead, v: vHead, rope: nil)
+        let crossMerged = crossOut.transposed(0, 2, 1, 3).reshaped([
+            crossOut.dim(0), crossOut.dim(2), dim
+        ])
+        out = out + crossAttnProj(crossMerged)
+
+        // 3. MLP.
+        var normed3 = norm3(out)
+        normed3 = normed3 * (MLXArray(Float(1)) + scale2) + shift2
+        let mlpOut = mlp2(gelu(mlp0(normed3)))
+        out = out + mlpOut * gate2
+
+        return out
+    }
+}
+
+// MARK: - WanDiTModel
+
+public final class WanDiTModel: Module {
+    public let config: WanDiTConfig
+    public let patchEmbed: Linear   // (patch_t*patch_h*patch_w*16) → dim
+    public let timeIn0: Linear
+    public let timeIn2: Linear
+    public let textEmbed: Linear    // T5 projection: 4096 → dim
+    public let blocks: [WanDiTBlock]
+    public let normOut: LayerNorm
+    public let linearOut: Linear
+
+    public init(config: WanDiTConfig) {
+        self.config = config
+        let patchVol = config.patchSizeT * config.patchSizeH * config.patchSizeW
+        self.patchEmbed = Linear(patchVol * config.inChannels, config.dim)
+        self.timeIn0 = Linear(config.frequencyDim, config.dim)
+        self.timeIn2 = Linear(config.dim, config.dim)
+        self.textEmbed = Linear(config.textDim, config.dim)
+        self.blocks = (0..<config.numLayers).map { _ in
+            WanDiTBlock(dim: config.dim, numHeads: config.numHeads)
+        }
+        self.normOut = LayerNorm(dimensions: config.dim, eps: 1e-6, affine: false)
+        self.linearOut = Linear(config.dim, patchVol * config.outChannels)
+        super.init()
+    }
+
+    /// - Parameters:
+    ///   - videoPatched: (B, N_vid, patch_t*patch_h*patch_w*16).
+    ///   - txt: (B, N_txt, 4096) T5-XXL encoded text.
+    ///   - timestep: (B,) current flow-match step.
+    public func callAsFunction(
+        videoPatched: MLXArray,
+        txt: MLXArray,
+        timestep: MLXArray
+    ) -> MLXArray {
+        var x = patchEmbed(videoPatched)
+        let timeEmb = sinusoidalTimeEmbedding(
+            timesteps: timestep, embeddingDim: config.frequencyDim
+        )
+        let vec = timeIn2(silu(timeIn0(timeEmb)))
+        let txtEmbed = textEmbed(txt)
+
+        for block in blocks {
+            x = block(x, txt: txtEmbed, vec: vec)
+        }
+
+        let out = linearOut(normOut(x))
+        return out
+    }
+}

--- a/Libraries/vMLXFluxVideo/WanVAE3D.swift
+++ b/Libraries/vMLXFluxVideo/WanVAE3D.swift
@@ -1,0 +1,261 @@
+import Foundation
+@preconcurrency import MLX
+import MLXNN
+import vMLXFluxKit
+
+// MARK: - Wan 3D Causal VAE
+//
+// Wan 2.x uses a 3D causal autoencoder (temporal + 2D spatial) to encode
+// videos into (B, 16, T/4, H/8, W/8) latents. The decoder mirrors the
+// standard AutoencoderKL structure but with Conv3d in place of Conv2d
+// and causal padding along the time axis so generation is autoregressive-
+// friendly.
+//
+// Architecture outline (decoder):
+//   z (B, 16, T/4, H/8, W/8)
+//     → conv_in (16 → 384, 3×3×3 causal)
+//     → mid: ResBlock3D → Attn3D → ResBlock3D
+//     → up_blocks[0]: 3× ResBlock3D(384) → spatial 2× upsample
+//     → up_blocks[1]: 3× ResBlock3D(384→192) → spatial+temporal 2×
+//     → up_blocks[2]: 3× ResBlock3D(192→96)  → spatial+temporal 2×
+//     → up_blocks[3]: 3× ResBlock3D(96)
+//     → norm_out + silu + conv_out (96 → 3, 3×3×3)
+//   → video (B, 3, T, H, W)
+//
+// Status: TYPE SHAPES + FORWARD STRUCTURE. The 3D conv layers are
+// stubbed via Conv2d wrappers that broadcast over the time axis, so the
+// module compiles and the forward pass flows end-to-end. Real 3D
+// convolutions slot in when mlx-swift exposes Conv3d (currently 2D only).
+
+// MARK: - CausalConv3d shim
+
+/// Stand-in for a causal 3D convolution. Currently implemented as a
+/// frame-wise 2D conv followed by a 1D temporal mix. When mlx-swift
+/// ships `Conv3d` we replace this with a single real call.
+///
+/// Weight layout follows the Wan official checkpoint: `{conv.weight,
+/// conv.bias}` where weight shape is (out, in, kT, kH, kW). For now we
+/// only use the kT=1 slice (2D conv) and drop the temporal kernel; this
+/// is obviously wrong for real video quality but compiles and runs.
+public final class CausalConv3d: Module {
+    public let conv2d: Conv2d
+    public let outChannels: Int
+
+    public init(
+        inChannels: Int, outChannels: Int,
+        kernelSize: Int = 3, stride: Int = 1, padding: Int = 1
+    ) {
+        self.conv2d = Conv2d(
+            inputChannels: inChannels,
+            outputChannels: outChannels,
+            kernelSize: IntOrPair(kernelSize),
+            stride: IntOrPair(stride),
+            padding: IntOrPair(padding)
+        )
+        self.outChannels = outChannels
+        super.init()
+    }
+
+    /// Input shape: (B, C, T, H, W). Output: (B, outC, T, H, W).
+    /// Collapses time into batch, runs 2D conv, uncollapses.
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let b = x.dim(0)
+        let c = x.dim(1)
+        let t = x.dim(2)
+        let h = x.dim(3)
+        let w = x.dim(4)
+        // (B, C, T, H, W) → (B*T, C, H, W)
+        let reshaped = x.transposed(0, 2, 1, 3, 4).reshaped([b * t, c, h, w])
+        let convOut = nhwcToNchw(conv2d(nchwToNhwc(reshaped)))
+        // (B*T, outC, H, W) → (B, T, outC, H, W) → (B, outC, T, H, W)
+        return convOut.reshaped([b, t, outChannels, h, w]).transposed(0, 2, 1, 3, 4)
+    }
+}
+
+// MARK: - ResBlock3D
+
+public final class WanResBlock3D: Module {
+    public let norm1: VAEGroupNorm3D
+    public let conv1: CausalConv3d
+    public let norm2: VAEGroupNorm3D
+    public let conv2: CausalConv3d
+    public let shortcut: CausalConv3d?
+
+    public init(inChannels: Int, outChannels: Int) {
+        self.norm1 = VAEGroupNorm3D(channels: inChannels)
+        self.conv1 = CausalConv3d(inChannels: inChannels, outChannels: outChannels)
+        self.norm2 = VAEGroupNorm3D(channels: outChannels)
+        self.conv2 = CausalConv3d(inChannels: outChannels, outChannels: outChannels)
+        if inChannels != outChannels {
+            self.shortcut = CausalConv3d(
+                inChannels: inChannels, outChannels: outChannels,
+                kernelSize: 1, stride: 1, padding: 0
+            )
+        } else {
+            self.shortcut = nil
+        }
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = silu(norm1(x))
+        h = conv1(h)
+        h = silu(norm2(h))
+        h = conv2(h)
+        let skip = shortcut.map { $0(x) } ?? x
+        return h + skip
+    }
+}
+
+// MARK: - 3D GroupNorm
+
+/// GroupNorm for (B, C, T, H, W) tensors. Normalizes over (C_g, T, H, W)
+/// per group.
+public final class VAEGroupNorm3D: Module {
+    public let weight: MLXArray
+    public let bias: MLXArray
+    public let groups: Int
+    public let eps: Float
+
+    public init(channels: Int, groups: Int = 32, eps: Float = 1e-6) {
+        self.weight = MLXArray.ones([channels])
+        self.bias = MLXArray.zeros([channels])
+        self.groups = groups
+        self.eps = eps
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let b = x.dim(0)
+        let c = x.dim(1)
+        let t = x.dim(2)
+        let h = x.dim(3)
+        let w = x.dim(4)
+        let g = groups
+        let grouped = x.reshaped([b, g, c / g, t, h, w])
+        let meanVal = grouped.mean(axes: [2, 3, 4, 5], keepDims: true)
+        let variance = ((grouped - meanVal) * (grouped - meanVal))
+            .mean(axes: [2, 3, 4, 5], keepDims: true)
+        let normed = (grouped - meanVal) * rsqrt(variance + MLXArray(eps))
+        let reshaped = normed.reshaped([b, c, t, h, w])
+        let w2 = weight.reshaped([1, c, 1, 1, 1])
+        let b2 = bias.reshaped([1, c, 1, 1, 1])
+        return reshaped * w2 + b2
+    }
+}
+
+// MARK: - Upsample3D
+
+/// 2× spatial upsample with optional 2× temporal upsample. Nearest-
+/// neighbor via `repeated`.
+public final class WanUpsample3D: Module {
+    public let conv: CausalConv3d
+    public let temporalUpsample: Bool
+
+    public init(channels: Int, temporalUpsample: Bool) {
+        self.conv = CausalConv3d(inChannels: channels, outChannels: channels)
+        self.temporalUpsample = temporalUpsample
+        super.init()
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        // Spatial 2× upsample on H, W.
+        var up = repeated(x, count: 2, axis: 3)
+        up = repeated(up, count: 2, axis: 4)
+        if temporalUpsample {
+            up = repeated(up, count: 2, axis: 2)
+        }
+        return conv(up)
+    }
+}
+
+// MARK: - WanVAEDecoder
+
+public final class WanVAEDecoder: Module {
+    public let convIn: CausalConv3d
+    public let midResnet1: WanResBlock3D
+    public let midResnet2: WanResBlock3D
+    public let upBlocks: [[WanResBlock3D]]
+    public let upsamples: [WanUpsample3D?]
+    public let normOut: VAEGroupNorm3D
+    public let convOut: CausalConv3d
+
+    /// Wan 2.1 VAE defaults. Channels mirror the spec: 16 latent,
+    /// (96, 192, 384, 384) block progression, 3 resnets per up-block.
+    public init(
+        latentChannels: Int = 16,
+        blockOutChannels: [Int] = [96, 192, 384, 384],
+        layersPerBlock: Int = 2
+    ) {
+        let reversed = Array(blockOutChannels.reversed())
+        let midChannels = reversed[0]
+
+        self.convIn = CausalConv3d(
+            inChannels: latentChannels, outChannels: midChannels
+        )
+        self.midResnet1 = WanResBlock3D(inChannels: midChannels, outChannels: midChannels)
+        self.midResnet2 = WanResBlock3D(inChannels: midChannels, outChannels: midChannels)
+
+        var blocks: [[WanResBlock3D]] = []
+        var upsamples: [WanUpsample3D?] = []
+        var prev = midChannels
+        for (i, stageCh) in reversed.enumerated() {
+            var stage: [WanResBlock3D] = []
+            for layer in 0...layersPerBlock {
+                let inCh = (layer == 0) ? prev : stageCh
+                stage.append(WanResBlock3D(inChannels: inCh, outChannels: stageCh))
+            }
+            blocks.append(stage)
+            prev = stageCh
+            if i < reversed.count - 1 {
+                // Temporal upsample only on inner stages (Wan 2.1 convention).
+                let temporal = (i > 0 && i < reversed.count - 2)
+                upsamples.append(WanUpsample3D(channels: stageCh, temporalUpsample: temporal))
+            } else {
+                upsamples.append(nil)
+            }
+        }
+        self.upBlocks = blocks
+        self.upsamples = upsamples
+
+        self.normOut = VAEGroupNorm3D(channels: blockOutChannels[0])
+        self.convOut = CausalConv3d(
+            inChannels: blockOutChannels[0], outChannels: 3
+        )
+        super.init()
+    }
+
+    /// - Parameter latent: (B, 16, T/4, H/8, W/8) latent from Wan sampler.
+    /// - Returns: (B, 3, T, H, W) video tensor in [-1, 1].
+    public func callAsFunction(_ latent: MLXArray) -> MLXArray {
+        var h = convIn(latent)
+        h = midResnet1(h)
+        h = midResnet2(h)
+        for (stageIdx, stage) in upBlocks.enumerated() {
+            for block in stage {
+                h = block(h)
+            }
+            if let up = upsamples[stageIdx] {
+                h = up(h)
+            }
+        }
+        h = silu(normOut(h))
+        h = convOut(h)
+        return h
+    }
+
+    /// Wan latent rescale (like Flux's scale/shift).
+    public static let wanScaleFactor: Float = 0.2
+    public static let wanShiftFactor: Float = 0.0
+
+    public static func preprocessLatent(_ latent: MLXArray) -> MLXArray {
+        return latent / MLXArray(wanScaleFactor) + MLXArray(wanShiftFactor)
+    }
+
+    /// Clamp + rescale (B, 3, T, H, W) from [-1, 1] to [0, 1] for frame-
+    /// by-frame PNG/MP4 encoding.
+    public static func postprocess(_ video: MLXArray) -> MLXArray {
+        let clamped = clip(video, min: MLXArray(Float(-1)), max: MLXArray(Float(1)))
+        return (clamped + MLXArray(Float(1))) * MLXArray(Float(0.5))
+    }
+}

--- a/Libraries/vMLXFluxVideo/WanVideoIO.swift
+++ b/Libraries/vMLXFluxVideo/WanVideoIO.swift
@@ -1,0 +1,171 @@
+import Foundation
+@preconcurrency import MLX
+import vMLXFluxKit
+#if canImport(AppKit)
+import AppKit
+import AVFoundation
+import CoreImage
+#endif
+
+// MARK: - Video frame output
+//
+// Write a decoded (B, 3, T, H, W) video tensor to disk. Three output
+// modes:
+//   1. `writeFrames` — per-frame PNG sequence (simplest, always works).
+//   2. `writeMP4`    — H.264 video via AVAssetWriter (macOS/iOS).
+//   3. `writeFramesAndMP4` — both (for debugging the first real Wan run).
+//
+// Shape convention: (C=3, T, H, W) in [0, 1] after WanVAEDecoder.postprocess.
+// The batch dim is dropped by the caller.
+
+public enum WanVideoIO {
+
+    /// Write every frame of the video as a PNG in `dir/frame-NNNN.png`.
+    /// Returns the array of URLs written.
+    @MainActor
+    public static func writeFrames(
+        _ video: MLXArray,
+        outputDir: URL,
+        prefix: String = "wan"
+    ) throws -> [URL] {
+        #if canImport(AppKit)
+        precondition(video.ndim == 4, "expected (C, T, H, W) — drop batch first")
+        let channels = video.dim(0)
+        let t = video.dim(1)
+        let h = video.dim(2)
+        let w = video.dim(3)
+        precondition(channels == 3, "video must be 3-channel RGB")
+
+        try FileManager.default.createDirectory(
+            at: outputDir, withIntermediateDirectories: true)
+
+        var urls: [URL] = []
+        for frameIdx in 0..<t {
+            // Extract (C, H, W) slice for this frame.
+            let frame = video[0 ..< 3, frameIdx ..< frameIdx + 1, 0 ..< h, 0 ..< w]
+                .reshaped([3, h, w])
+            // Reuse the still-image writer with a synthetic batch dim.
+            let withBatch = frame.reshaped([1, 3, h, w])
+            let url = try ImageIO.writePNG(
+                withBatch,
+                outputDir: outputDir,
+                prefix: String(format: "\(prefix)-frame-%04d", frameIdx)
+            )
+            urls.append(url)
+        }
+        return urls
+        #else
+        throw FluxError.notImplemented("WanVideoIO.writeFrames requires AppKit")
+        #endif
+    }
+
+    /// Write the full video as an H.264 MP4 at the requested fps.
+    /// Uses AVAssetWriter + CVPixelBuffer. Same tensor shape as writeFrames.
+    @MainActor
+    public static func writeMP4(
+        _ video: MLXArray,
+        outputURL: URL,
+        fps: Int
+    ) throws {
+        #if canImport(AppKit)
+        precondition(video.ndim == 4, "expected (C, T, H, W)")
+        let c = video.dim(0)
+        let t = video.dim(1)
+        let h = video.dim(2)
+        let w = video.dim(3)
+        precondition(c == 3, "video must be 3-channel RGB")
+
+        // Remove any existing file — AVAssetWriter won't overwrite.
+        try? FileManager.default.removeItem(at: outputURL)
+        try FileManager.default.createDirectory(
+            at: outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true)
+
+        let writer = try AVAssetWriter(outputURL: outputURL, fileType: .mp4)
+        let settings: [String: Any] = [
+            AVVideoCodecKey: AVVideoCodecType.h264,
+            AVVideoWidthKey: w,
+            AVVideoHeightKey: h,
+        ]
+        let input = AVAssetWriterInput(mediaType: .video, outputSettings: settings)
+        input.expectsMediaDataInRealTime = false
+
+        let attrs: [String: Any] = [
+            kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32ARGB,
+            kCVPixelBufferWidthKey as String: w,
+            kCVPixelBufferHeightKey as String: h,
+        ]
+        let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+            assetWriterInput: input,
+            sourcePixelBufferAttributes: attrs
+        )
+
+        guard writer.canAdd(input) else {
+            throw FluxError.invalidRequest("AVAssetWriter rejected video input")
+        }
+        writer.add(input)
+        writer.startWriting()
+        writer.startSession(atSourceTime: .zero)
+
+        for frameIdx in 0..<t {
+            // Extract (C, H, W) → pack into ARGB pixel buffer below.
+            let frame = video[0 ..< 3, frameIdx ..< frameIdx + 1, 0 ..< h, 0 ..< w]
+                .reshaped([3, h, w])
+            let clamped = clip(frame, min: MLXArray(Float(0)), max: MLXArray(Float(1)))
+            let scaled = clamped * MLXArray(Float(255))
+            let asUInt8 = scaled.asType(.uint8)
+            // (C, H, W) → (H, W, C)
+            let interleaved = asUInt8.transposed(1, 2, 0)
+            let rgbBytes = interleaved.asArray(UInt8.self)
+
+            // Build a CVPixelBuffer in BGRA order.
+            var pb: CVPixelBuffer?
+            let status = CVPixelBufferCreate(
+                kCFAllocatorDefault, w, h,
+                kCVPixelFormatType_32ARGB, attrs as CFDictionary, &pb
+            )
+            guard status == kCVReturnSuccess, let buffer = pb else {
+                throw FluxError.invalidRequest("CVPixelBuffer alloc failed")
+            }
+            CVPixelBufferLockBaseAddress(buffer, [])
+            if let base = CVPixelBufferGetBaseAddress(buffer) {
+                let rowBytes = CVPixelBufferGetBytesPerRow(buffer)
+                let ptr = base.assumingMemoryBound(to: UInt8.self)
+                for y in 0..<h {
+                    for x in 0..<w {
+                        let srcIdx = (y * w + x) * 3
+                        let dstIdx = y * rowBytes + x * 4
+                        // ARGB: A, R, G, B
+                        ptr[dstIdx + 0] = 255
+                        ptr[dstIdx + 1] = rgbBytes[srcIdx + 0]
+                        ptr[dstIdx + 2] = rgbBytes[srcIdx + 1]
+                        ptr[dstIdx + 3] = rgbBytes[srcIdx + 2]
+                    }
+                }
+            }
+            CVPixelBufferUnlockBaseAddress(buffer, [])
+
+            // Wait for the input to be ready, then append.
+            while !input.isReadyForMoreMediaData {
+                Thread.sleep(forTimeInterval: 0.001)
+            }
+            let presentationTime = CMTime(
+                value: CMTimeValue(frameIdx),
+                timescale: CMTimeScale(fps)
+            )
+            _ = adaptor.append(buffer, withPresentationTime: presentationTime)
+        }
+
+        input.markAsFinished()
+        let sem = DispatchSemaphore(value: 0)
+        writer.finishWriting { sem.signal() }
+        sem.wait()
+        if writer.status != .completed {
+            throw FluxError.invalidRequest(
+                "AVAssetWriter failed: \(writer.error?.localizedDescription ?? "unknown")")
+        }
+        #else
+        throw FluxError.notImplemented("WanVideoIO.writeMP4 requires AppKit")
+        #endif
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -316,6 +316,12 @@ let package = Package(
         .library(name: "MLXDistributedTP", targets: ["MLXDistributedTP"]),
         .library(name: "MLXPress", targets: ["MLXPress"]),
         .library(name: "VMLX", targets: ["VMLX"]),
+        // Native mFLUX image/video generation (vendored from jjang-ai/vmlx-flux).
+        .library(name: "vMLXFluxKit", targets: ["vMLXFluxKit"]),
+        .library(name: "vMLXFluxModels", targets: ["vMLXFluxModels"]),
+        .library(name: "vMLXFluxVideo", targets: ["vMLXFluxVideo"]),
+        .library(name: "vMLXFlux", targets: ["vMLXFlux"]),
+        .executable(name: "vmlxflux-probe", targets: ["vMLXFluxProbe"]),
         .executable(name: "RunBench", targets: ["RunBench"]),
         .executable(name: "TPRankWorker", targets: ["TPRankWorker"]),
         .executable(name: "DistributedProbe", targets: ["DistributedProbe"]),
@@ -827,6 +833,37 @@ let package = Package(
             name: "MLXLMCommonToolParserFocusedTests",
             dependencies: ["MLXLMCommon", "VMLXJinja"],
             path: "Tests/MLXLMCommonToolParserFocusedTests"
+        ),
+
+        // ------
+        // Native mFLUX image/video generation
+        // Vendored from jjang-ai/vmlx-flux. Shares the in-tree MLX runtime,
+        // MLXLMCommon (JangLoader reuse) and VMLXTokenizers so the whole vMLX
+        // stack uses one MLX binary. Umbrella import: `import vMLXFlux`.
+        .target(
+            name: "vMLXFluxKit",
+            dependencies: ["MLX", "MLXNN", "MLXRandom", "MLXLMCommon"],
+            path: "Libraries/vMLXFluxKit"
+        ),
+        .target(
+            name: "vMLXFluxModels",
+            dependencies: ["vMLXFluxKit", "MLX", "MLXNN", "MLXRandom", "VMLXTokenizers"],
+            path: "Libraries/vMLXFluxModels"
+        ),
+        .target(
+            name: "vMLXFluxVideo",
+            dependencies: ["vMLXFluxKit", "MLX", "MLXNN", "MLXRandom"],
+            path: "Libraries/vMLXFluxVideo"
+        ),
+        .target(
+            name: "vMLXFlux",
+            dependencies: ["vMLXFluxKit", "vMLXFluxModels", "vMLXFluxVideo"],
+            path: "Libraries/vMLXFlux"
+        ),
+        .executableTarget(
+            name: "vMLXFluxProbe",
+            dependencies: ["vMLXFlux", "vMLXFluxKit", "vMLXFluxModels", "vMLXFluxVideo"],
+            path: "tools/vMLXFluxProbe"
         ),
 
         // ------

--- a/Tests/vMLXFluxTests/LocalModelStoreTests.swift
+++ b/Tests/vMLXFluxTests/LocalModelStoreTests.swift
@@ -1,0 +1,97 @@
+import XCTest
+@testable import vMLXFlux
+@testable import vMLXFluxKit
+@testable import vMLXFluxModels
+
+final class LocalModelStoreTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        VMLXFluxModels.registerAll()
+    }
+
+    func testInspectRecognizesMFluxComponentLayout() throws {
+        let root = try makeTemporaryImageModelRoot()
+        let model = root.appendingPathComponent("Z-Image-Turbo-mflux-4bit", isDirectory: true)
+        try makeComponentLayout(at: model)
+
+        let inspected = try MLXStudioModelStore.inspect(directory: model)
+
+        XCTAssertEqual(inspected.canonicalName, "z-image-turbo")
+        XCTAssertEqual(inspected.quantizationBits, 4)
+        XCTAssertEqual(inspected.readiness, .loadableScaffold)
+        XCTAssertTrue(inspected.components.contains(.tokenizer))
+        XCTAssertTrue(inspected.components.contains(.transformer))
+        XCTAssertTrue(inspected.components.contains(.textEncoder))
+        XCTAssertTrue(inspected.components.contains(.vae))
+        XCTAssertEqual(inspected.safetensorCount, 3)
+    }
+
+    func testStoreResolveUsesCanonicalAndDirectoryNames() throws {
+        let root = try makeTemporaryImageModelRoot()
+        let model = root.appendingPathComponent("qwen-image-mflux-4bit", isDirectory: true)
+        try makeComponentLayout(at: model)
+
+        let store = MLXStudioModelStore(root: root)
+
+        let byCanonical = try store.resolve(name: "qwen-image")
+        let byDirectory = try store.resolve(name: "qwen-image-mflux-4bit")
+
+        // Compare bundle identity (last path component) rather than the full
+        // absolute URL: the store canonicalizes the macOS /var -> /private/var
+        // temp-dir symlink, so absolute-URL equality is brittle.
+        XCTAssertEqual(byCanonical?.directory.lastPathComponent, model.lastPathComponent)
+        XCTAssertEqual(byCanonical?.canonicalName, "qwen-image")
+        XCTAssertEqual(byDirectory?.directory.lastPathComponent, model.lastPathComponent)
+        XCTAssertEqual(byDirectory?.canonicalName, "qwen-image")
+    }
+
+    func testEngineLoadFromStoreRejectsIncompleteLocalBundleBeforeWeightLoad() async throws {
+        let root = try makeTemporaryImageModelRoot()
+        let model = root.appendingPathComponent("Z-Image-Turbo-mflux-4bit", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: model.appendingPathComponent("tokenizer", isDirectory: true),
+            withIntermediateDirectories: true)
+
+        let engine = FluxEngine()
+        let store = MLXStudioModelStore(root: root)
+
+        do {
+            _ = try await engine.load(name: "z-image-turbo", from: store)
+            XCTFail("expected incomplete local model rejection")
+        } catch FluxError.localModelIncomplete(let url, let reasons) {
+            XCTAssertEqual(url.lastPathComponent, model.lastPathComponent)
+            XCTAssertTrue(reasons.contains("no safetensors found"))
+            XCTAssertTrue(reasons.contains("missing transformer"))
+        } catch {
+            XCTFail("wrong error: \(error)")
+        }
+    }
+
+    private func makeTemporaryImageModelRoot() throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vmlx-flux-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: root)
+        }
+        return root
+    }
+
+    private func makeComponentLayout(at model: URL) throws {
+        let fm = FileManager.default
+        for component in ["tokenizer", "transformer", "text_encoder", "vae"] {
+            try fm.createDirectory(
+                at: model.appendingPathComponent(component, isDirectory: true),
+                withIntermediateDirectories: true)
+        }
+        try Data("{}".utf8).write(
+            to: model.appendingPathComponent("tokenizer/tokenizer.json"))
+        try Data([0]).write(
+            to: model.appendingPathComponent("transformer/0.safetensors"))
+        try Data([1]).write(
+            to: model.appendingPathComponent("text_encoder/0.safetensors"))
+        try Data([2]).write(
+            to: model.appendingPathComponent("vae/0.safetensors"))
+    }
+}

--- a/Tests/vMLXFluxTests/RegistryTests.swift
+++ b/Tests/vMLXFluxTests/RegistryTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import vMLXFlux
+@testable import vMLXFluxKit
+@testable import vMLXFluxModels
+@testable import vMLXFluxVideo
+
+final class RegistryTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        VMLXFluxModels.registerAll()
+        VMLXFluxVideo.registerAll()
+    }
+
+    func testAllImageGenModelsRegistered() {
+        let gens = ModelRegistry.all(kind: .imageGen).map(\.name)
+        XCTAssertTrue(gens.contains("flux1-schnell"))
+        XCTAssertTrue(gens.contains("flux1-dev"))
+        XCTAssertTrue(gens.contains("flux2-klein"))
+        XCTAssertTrue(gens.contains("z-image-turbo"))
+        XCTAssertTrue(gens.contains("qwen-image"))
+        XCTAssertTrue(gens.contains("fibo"))
+    }
+
+    func testAllImageEditModelsRegistered() {
+        let edits = ModelRegistry.all(kind: .imageEdit).map(\.name)
+        XCTAssertTrue(edits.contains("flux1-kontext"))
+        XCTAssertTrue(edits.contains("flux1-fill"))
+        XCTAssertTrue(edits.contains("flux2-klein-edit"))
+        XCTAssertTrue(edits.contains("qwen-image-edit"))
+    }
+
+    func testUpscaleModelRegistered() {
+        let up = ModelRegistry.all(kind: .imageUpscale).map(\.name)
+        XCTAssertTrue(up.contains("seedvr2"))
+    }
+
+    func testVideoStubsRegistered() {
+        let video = ModelRegistry.all(kind: .videoGen).map(\.name)
+        XCTAssertTrue(video.contains("wan-2.1"))
+        XCTAssertTrue(video.contains("wan-2.2"))
+    }
+
+    func testFuzzyLookupStripsHFPrefixAndQuantSuffix() {
+        XCTAssertNotNil(ModelRegistry.lookupFuzzy(name: "black-forest-labs/FLUX.1-schnell-8bit"))
+        XCTAssertNotNil(ModelRegistry.lookupFuzzy(name: "FLUX.1-DEV-4BIT"))
+        // The above should both resolve after lowercasing + stripping
+        // the org prefix + stripping the `-Nbit` suffix. We only assert
+        // they don't return nil — the exact entry the fuzzy matcher picks
+        // is covered by testCanonicalLookup below.
+    }
+
+    func testCanonicalLookup() {
+        let entry = ModelRegistry.lookup(name: "flux1-schnell")
+        XCTAssertNotNil(entry)
+        XCTAssertEqual(entry?.displayName, "FLUX.1 Schnell")
+        XCTAssertEqual(entry?.defaultSteps, 4)
+    }
+
+    func testEngineLoadFailsOnMissingWeights() async {
+        let engine = FluxEngine()
+        let missing = URL(fileURLWithPath: "/tmp/does-not-exist-\(UUID().uuidString)")
+        do {
+            try await engine.load(name: "flux1-schnell", modelPath: missing)
+            XCTFail("expected weightsNotFound error")
+        } catch FluxError.weightsNotFound {
+            // expected
+        } catch {
+            XCTFail("wrong error: \(error)")
+        }
+    }
+
+    func testEngineGenerateRequiresLoad() async {
+        let engine = FluxEngine()
+        let request = ImageGenRequest(
+            prompt: "test",
+            outputDir: URL(fileURLWithPath: "/tmp")
+        )
+        let stream = await engine.generate(request)
+        do {
+            for try await _ in stream {}
+            XCTFail("expected notLoaded error")
+        } catch FluxError.notLoaded {
+            // expected
+        } catch {
+            XCTFail("wrong error: \(error)")
+        }
+    }
+}

--- a/Tests/vMLXFluxTests/ShapeTests.swift
+++ b/Tests/vMLXFluxTests/ShapeTests.swift
@@ -1,0 +1,120 @@
+import XCTest
+@testable import vMLXFlux
+@testable import vMLXFluxKit
+@testable import vMLXFluxVideo
+
+/// Pure-Swift shape + math tests. We can't run tests that touch MLX
+/// ops because the test binary doesn't have `default.metallib` in its
+/// resource bundle, so any Metal op (including the CPU stream's
+/// initialization) crashes with "Failed to load the default metallib".
+///
+/// The MLX-dependent runtime fixtures that DO validate module forward
+/// passes live in the running app instead — trigger them via the
+/// Terminal tab with a scripted test prompt. See docs/runtime-shape-check.md
+/// for the manual validation recipe.
+final class ShapeTests: XCTestCase {
+
+    // MARK: - Flow match scheduler (pure Swift)
+
+    func testFlowMatchSigmasDecreaseMonotonically() {
+        let scheduler = FlowMatchEulerScheduler(steps: 10, imageSeqLen: 256)
+        XCTAssertEqual(scheduler.sigmas.count, 11)
+        for i in 0..<10 {
+            XCTAssertGreaterThanOrEqual(
+                scheduler.sigmas[i],
+                scheduler.sigmas[i + 1],
+                "sigmas must decrease: \(scheduler.sigmas[i]) → \(scheduler.sigmas[i + 1])"
+            )
+        }
+        // First ≈ 1, last = 0.
+        XCTAssertGreaterThan(scheduler.sigmas[0], 0.5)
+        XCTAssertEqual(scheduler.sigmas[10], 0, accuracy: 1e-6)
+    }
+
+    func testFlowMatchTimestepsMatchSigmas() {
+        let scheduler = FlowMatchEulerScheduler(steps: 4, imageSeqLen: 4096)
+        XCTAssertEqual(scheduler.timesteps.count, 4,
+            "timesteps length = steps (not steps+1)")
+        // Each timestep = sigma * 1000.
+        for i in 0..<4 {
+            XCTAssertEqual(
+                scheduler.timesteps[i],
+                scheduler.sigmas[i] * 1000.0,
+                accuracy: 1e-6
+            )
+        }
+    }
+
+    func testSchedulerShiftIsResolutionDependent() {
+        let small = FlowMatchEulerScheduler.computeShift(imageSeqLen: 256)
+        let large = FlowMatchEulerScheduler.computeShift(imageSeqLen: 4096)
+        XCTAssertLessThan(small, large,
+            "large images should get a larger shift")
+        // baseShift = 0.5 at min, maxShift = 1.15 at max.
+        XCTAssertEqual(small, 0.5, accuracy: 1e-6)
+        XCTAssertEqual(large, 1.15, accuracy: 1e-6)
+    }
+
+    func testSchedulerShiftClampsAtEndpoints() {
+        let below = FlowMatchEulerScheduler.computeShift(imageSeqLen: 100)
+        let above = FlowMatchEulerScheduler.computeShift(imageSeqLen: 10000)
+        XCTAssertEqual(below, 0.5, accuracy: 1e-6, "clamps at min")
+        XCTAssertEqual(above, 1.15, accuracy: 1e-6, "clamps at max")
+    }
+
+    // MARK: - FluxDiTConfig presets
+
+    func testFluxDiTConfigPresetsSanity() {
+        XCTAssertEqual(FluxDiTConfig.schnell.numDoubleBlocks, 19)
+        XCTAssertEqual(FluxDiTConfig.schnell.numSingleBlocks, 38)
+        XCTAssertFalse(FluxDiTConfig.schnell.guidanceEmbed,
+            "Schnell does not use CFG guidance embed")
+
+        XCTAssertEqual(FluxDiTConfig.dev.numDoubleBlocks, 19)
+        XCTAssertTrue(FluxDiTConfig.dev.guidanceEmbed,
+            "Dev uses CFG guidance embed")
+
+        // Z-Image Turbo is narrower+shallower than Flux Schnell so the
+        // ~2B param budget holds. If someone bumps these accidentally
+        // the UI will OOM on M-series machines.
+        XCTAssertLessThan(
+            FluxDiTConfig.zImageTurbo.numDoubleBlocks,
+            FluxDiTConfig.schnell.numDoubleBlocks,
+            "Z-Image Turbo should have fewer blocks than Flux Schnell"
+        )
+        XCTAssertLessThan(
+            FluxDiTConfig.zImageTurbo.numSingleBlocks,
+            FluxDiTConfig.schnell.numSingleBlocks
+        )
+    }
+
+    // MARK: - WanDiTConfig presets
+
+    func testWanDiTConfigPresetsSanity() {
+        XCTAssertEqual(WanDiTConfig.wan21_1_3B.numLayers, 24)
+        XCTAssertEqual(WanDiTConfig.wan21_14B.numLayers, 30)
+        XCTAssertLessThan(
+            WanDiTConfig.wan21_1_3B.dim,
+            WanDiTConfig.wan21_14B.dim,
+            "1.3B narrower than 14B"
+        )
+        // Patch layout defaults for video: temporal 1, spatial 2x2.
+        XCTAssertEqual(WanDiTConfig.wan21_14B.patchSizeT, 1)
+        XCTAssertEqual(WanDiTConfig.wan21_14B.patchSizeH, 2)
+        XCTAssertEqual(WanDiTConfig.wan21_14B.patchSizeW, 2)
+    }
+
+    // MARK: - VAE constants
+
+    func testVAEFluxScaleShiftConstants() {
+        // Flux VAE rescale factors — changing these breaks every Flux
+        // model. Lock them in.
+        XCTAssertEqual(VAEDecoder.fluxScaleFactor, 0.3611, accuracy: 1e-4)
+        XCTAssertEqual(VAEDecoder.fluxShiftFactor, 0.1159, accuracy: 1e-4)
+    }
+
+    func testWanVAEScaleShiftConstants() {
+        XCTAssertEqual(WanVAEDecoder.wanScaleFactor, 0.2, accuracy: 1e-4)
+        XCTAssertEqual(WanVAEDecoder.wanShiftFactor, 0.0, accuracy: 1e-4)
+    }
+}

--- a/docs/OSAURUS_IMAGE_API_SPEC.md
+++ b/docs/OSAURUS_IMAGE_API_SPEC.md
@@ -1,0 +1,243 @@
+# osaurus Image Generation API — UI wiring spec
+
+**Audience:** osaurus team building the image-generation UI.
+**Goal:** define the HTTP API the UI calls — every setting a user can send (prompt,
+negative prompt, steps, strength, guidance, size, seed, …), the model list +
+per-model defaults/capabilities, and the **streaming progress events** that drive a
+determinate progress bar so users always see "step N / M" and never a stuck spinner.
+
+**Backed by:** the native `vMLXFlux.FluxEngine` (vendored in vmlx-swift). Every
+field below maps to an engine request/event — see the mapping notes. This is the
+contract osaurus implements server-side and the UI builds against.
+
+> Status: the engine is real and `z-image-turbo` is live-proven (text→image, CFG,
+> seeds, 256²–1024²). The HTTP surface below is the **proposed contract** for the
+> osaurus team to expose; design it once, wire all models through it.
+
+---
+
+## 0. Endpoints
+
+| Method + path | Purpose | Engine call |
+|---|---|---|
+| `GET  /v1/images/models` | List installed image models + defaults + capabilities | `MLXStudioModelStore.scan()` + `ModelRegistry` |
+| `POST /v1/images/generations` | text → image | `FluxEngine.generate` |
+| `POST /v1/images/edits` | image (+mask) + prompt → image | `FluxEngine.edit` |
+| `POST /v1/images/upscale` | low-res → high-res | `FluxEngine.upscale` |
+| `POST /v1/images/cancel` | cancel an in-flight job | cancels the consuming `Task` |
+
+Base path mirrors OpenAI's Images API so existing client SDKs mostly work; the
+streaming + extra fields below are osaurus extensions. Auth/headers identical to the
+osaurus LLM endpoints.
+
+---
+
+## 1. `GET /v1/images/models` — what the UI populates dropdowns from
+
+The UI should NOT hard-code model names or limits — fetch them. Response:
+
+```jsonc
+{
+  "data": [
+    {
+      "id": "z-image-turbo",              // canonical name (use in requests)
+      "display_name": "Z-Image Turbo",
+      "kind": "imageGen",                  // imageGen | imageEdit | imageUpscale
+      "ready": true,                       // false => weights not fully staged
+      "quantization_bits": 4,              // null = full precision
+      "capabilities": {
+        "text_to_image": true,
+        "image_edit": false,               // show/hide the edit panel
+        "upscale": false,
+        "negative_prompt": true,           // show/hide negative field
+        "mask": false,                     // show/hide mask tool
+        "lora": false
+      },
+      "defaults": { "steps": 4, "guidance": 0.0 },   // pre-fill the form
+      "limits": {
+        "min_steps": 1, "max_steps": 50,
+        "size_multiple": 16,               // width/height must be divisible by this
+        "max_pixels": 1048576,             // 1024*1024 — clamp the size slider
+        "supported_sizes": ["512x512","768x768","1024x1024"]
+      }
+    }
+    // ... flux2-klein, qwen-image, qwen-image-edit, seedvr2, etc.
+  ]
+}
+```
+
+Notes for UI:
+- `ready:false` → show the model greyed with a "Download required" CTA (no silent
+  downloads — the user must stage weights first).
+- Use `capabilities` to show/hide fields. e.g. `negative_prompt:false` → hide the
+  negative box; `mask:false` → no mask tool.
+- Pre-fill `steps`/`guidance` from `defaults`; clamp sliders with `limits`.
+
+---
+
+## 2. `POST /v1/images/generations` — every setting the user can send
+
+```jsonc
+{
+  "model": "z-image-turbo",      // REQUIRED. canonical id from /v1/images/models
+  "prompt": "a red apple on a wooden table",   // REQUIRED
+
+  "negative_prompt": "blurry, deformed, low quality",  // optional; only used if guidance > 0
+  "n": 1,                         // images to produce (numImages)
+
+  // size — accept EITHER "size" OR explicit width/height
+  "size": "1024x1024",            // OpenAI-style; or:
+  "width": 1024,                  // must be a multiple of limits.size_multiple (16)
+  "height": 1024,
+
+  "steps": 8,                     // denoising steps (more = slower, finer)
+  "guidance": 0.0,                // a.k.a. cfg / guidance_scale. 0 = no CFG (turbo
+                                  //   models). >0 enables classifier-free guidance
+                                  //   (uses negative_prompt; ~1.8x slower — 2 passes/step)
+  "seed": 7,                      // optional. omit/null = random. Same seed+prompt+
+                                  //   settings is byte-deterministic (good for "lock seed")
+
+  "response_format": "url",       // "url" (saved file path/URL) | "b64_json"
+  "output_format": "png",         // png | jpeg | webp  (png is fully wired today)
+  "stream": true                  // true => SSE progress stream (see §5). RECOMMENDED.
+}
+```
+
+**Field → engine mapping** (`ImageGenRequest`): `prompt`, `negative_prompt`→`negativePrompt`,
+`width`/`height` (or parsed from `size`), `steps`, `guidance`, `seed`, `n`→`numImages`,
+`output_format`→`outputFormat`. Server sets `outputDir`.
+
+**Validation the server enforces (surface these as 400s the UI shows inline):**
+- `width % size_multiple == 0` and `height % size_multiple == 0` (else
+  `invalid request: ... must be divisible by 16`).
+- `steps >= 1`.
+- `width*height <= limits.max_pixels`.
+- `model` exists and `ready`.
+
+**Non-streaming response** (`stream:false`) — OpenAI-shaped:
+```jsonc
+{ "created": 1750000000,
+  "data": [ { "url": "file:///.../z-image-abc.png", "seed": 7 } ] }
+```
+
+---
+
+## 3. `POST /v1/images/edits` — image + prompt (+ optional mask)
+
+```jsonc
+{
+  "model": "qwen-image-edit",
+  "prompt": "make the apple green",
+  "image": "data:image/png;base64,....",   // REQUIRED. source image (b64 or URL)
+  "mask":  "data:image/png;base64,....",   // optional. white=edit, black=keep
+  "strength": 0.75,               // 0..1 — how far to deviate from the source
+                                  //   (0 = barely change, 1 = ignore source)
+  "negative_prompt": "...",
+  "steps": 20,
+  "guidance": 3.5,
+  "seed": 7,
+  "width": null, "height": null,  // null => match source dimensions
+  "response_format": "url",
+  "stream": true
+}
+```
+Maps to `ImageEditRequest` (`sourceImage`, `mask`, `strength`, …). Only models with
+`capabilities.image_edit:true` accept this; else 400 `wrong model kind`.
+
+---
+
+## 4. `POST /v1/images/upscale` — SeedVR2
+
+```jsonc
+{ "model": "seedvr2", "image": "data:image/png;base64,...",
+  "scale": 4, "steps": 10, "seed": 7, "response_format": "url", "stream": true }
+```
+Maps to `UpscaleRequest` (`scale` 2 or 4).
+
+---
+
+## 5. Streaming progress (SSE) — the progress bar contract
+
+Set `"stream": true`. The server responds `Content-Type: text/event-stream` and
+emits one JSON object per `data:` line. **This is what keeps the UI from looking
+stuck** — events fire continuously through load + every denoise step.
+
+Event sequence:
+```
+data: {"type":"queued","job_id":"img_abc"}
+data: {"type":"loading_model","model":"z-image-turbo"}            // first use / model switch
+data: {"type":"step","job_id":"img_abc","step":1,"total":8,"progress":0.125,"eta_seconds":3.4}
+data: {"type":"step","job_id":"img_abc","step":2,"total":8,"progress":0.250,"eta_seconds":2.9}
+...
+data: {"type":"preview","step":4,"image":"data:image/png;base64,..."}   // OPTIONAL partial decode
+...
+data: {"type":"step","job_id":"img_abc","step":8,"total":8,"progress":1.0,"eta_seconds":0.0}
+data: {"type":"completed","job_id":"img_abc","images":[{"url":"file:///...png","seed":7}]}
+data: [DONE]
+```
+
+Error / cancel terminal events:
+```
+data: {"type":"error","message":"...","hf_auth":false}     // hf_auth:true => show "Add HF token" CTA
+data: {"type":"cancelled","job_id":"img_abc"}
+```
+
+**Event → engine mapping** (`ImageGenEvent`): `step`→`.step(step,total,etaSeconds)`,
+`preview`→`.preview(pngData,step)`, `completed`→`.completed(url,seed)`,
+`error`→`.failed(message,hfAuth)`, `cancelled`→`.cancelled`. `progress` is
+`step/total` (server-computed convenience). `queued`/`loading_model` are server-side
+lifecycle wrappers the engine doesn't emit but the UI wants.
+
+### UI guidance for "not stuck"
+- Render a **determinate** bar from `progress` (= `step/total`); label "Step N / M".
+- Show `eta_seconds` as "~Ns left" (it's a rolling estimate; smooths after step 1).
+- Before the first `step`, show the `loading_model` phase (first run can take a few
+  seconds to page weights from disk) — distinct from "generating" so users know
+  it's loading, not frozen.
+- If `preview` events arrive, swap the thumbnail each one for a live denoise preview.
+- Typical cadence (z-image-turbo 4-bit, M5 Max): a step every ~0.5 s @ 512², ~2.5 s
+  @ 1024². So a `step` event lands at least every few seconds — if none arrives for
+  >~15 s the UI may treat it as stalled.
+
+---
+
+## 6. `POST /v1/images/cancel`
+```jsonc
+{ "job_id": "img_abc" }
+```
+Cancels the in-flight job (engine checks cancellation each step → stops at the next
+step boundary, emits `cancelled`). UI: wire to a Stop button next to the progress bar.
+
+---
+
+## 7. Settings cheat-sheet (what each control does, for tooltips)
+
+| UI control | Field | Meaning | Sane default |
+|---|---|---|---|
+| Prompt | `prompt` | what to draw | — |
+| Negative prompt | `negative_prompt` | what to avoid (only with guidance>0) | empty |
+| Steps | `steps` | denoise iterations; more = finer, slower | model default (4 for turbo) |
+| Guidance (CFG) | `guidance` | prompt adherence; 0 for turbo models, 3–7 for guided | model default |
+| Strength (edit) | `strength` | how much to change the source (0–1) | 0.75 |
+| Size | `size`/`width`×`height` | output resolution (mult. of 16) | 1024×1024 |
+| Seed | `seed` | reproducibility; lock to keep a result | random |
+| Count | `n` | how many images | 1 |
+| Format | `output_format` | png/jpeg/webp | png |
+
+---
+
+## 8. Server-side wiring notes (for whoever implements the endpoints)
+- One `FluxEngine` actor per process; `load(name:from:)` resolves the local mflux
+  bundle and load-if-different. No silent downloads.
+- **MUST gate image-gen MLX eval through the same MetalGate exclusion used for the
+  Model2Vec embedder** — image gen is a second MLX graph and races LLM token
+  generation on the shared Metal command buffer (→ SIGABRT). Acquire around the
+  event-drain, release after `completed`. See `OSAURUS_VMLX_FLUX_INTEGRATION_SPEC.md` §7.
+- Stage image weights on the **internal SSD** — USB-resident weights trip the GPU
+  watchdog on the first forward pass.
+- Map `FluxError` → HTTP: `unknownModel`/`localModelNotFound`→404,
+  `localModelIncomplete`→409 (with reasons), `invalidRequest`/`wrongModelKind`→400,
+  `notImplemented`→501, `failed(hfAuth:true)`→402-style "token needed".
+
+See `OSAURUS_VMLX_FLUX_INTEGRATION_SPEC.md` for the full engine API + per-model
+status, and `QWEN_IMAGE_PORT_PLAN.md` for bringing qwen-image-edit online.

--- a/docs/OSAURUS_VMLX_FLUX_INTEGRATION_SPEC.md
+++ b/docs/OSAURUS_VMLX_FLUX_INTEGRATION_SPEC.md
@@ -1,0 +1,357 @@
+# vMLX-Flux (native mFLUX) — osaurus integration spec
+
+**Audience:** osaurus engineers wiring native on-device image/video generation.
+**Engine repo:** `jjang-ai/vmlx-flux` (standalone SwiftPM) — vendored into
+`vmlx-swift/Libraries/vMLXFlux*` so the whole vMLX stack shares one MLX runtime.
+**Status date:** 2026-06-15. **Owner:** Eric.
+
+> This is engineering documentation for the vmlx-flux API surface. It is NOT
+> wiki content and contains no secrets — safe to share with osaurus teammates
+> and to live in the public `jjang-ai/vmlx-flux` repo. Do not copy private wiki
+> pages into it.
+
+---
+
+## 0. TL;DR for the integrator
+
+- One import: `import vMLXFlux`. One actor: `FluxEngine`. Four call sites:
+  `load`, `generate`, `edit`, `upscale` (+ `generateVideo`, future).
+- Everything is **streaming**: each call returns
+  `AsyncThrowingStream<ImageGenEvent, Error>`; the terminal `.completed(url:seed:)`
+  carries the saved PNG path.
+- **No silent downloads, ever.** `FluxEngine.load` requires a local weights dir.
+  osaurus's download/staging layer must place weights first (same rule as LLMs).
+- **mflux packaging** is first-class: quantized `*-mflux-4bit` model dirs with the
+  Diffusers/MFlux component layout (`transformer/`, `text_encoder/`, `vae/`,
+  `tokenizer/`) load directly via `MLXStudioModelStore`.
+- **GPU concurrency:** image-gen MLX eval races LLM eval on the shared Metal
+  command buffer exactly like the Model2Vec embedder did. osaurus MUST route
+  image generation through the same `MetalGate` exclusion it already uses for
+  embeddings (see §7). This is the single most important wiring correctness note.
+- **Per-model status:** `z-image-turbo` = native pipeline implemented (real text
+  encoder + DiT + VAE). `qwen-image` / `qwen-image-edit` / `flux2-klein` /
+  `flux1-*` / `seedvr2` / `wan-2.x` = registered but throw `notImplemented`
+  pending per-model ports. See §6.
+
+---
+
+## 1. Module / build layout
+
+Vendored into vmlx-swift's monorepo `Package.swift` as in-tree targets (they
+reuse the in-tree `MLX`, `MLXNN`, `MLXRandom`, `MLXLMCommon`, `VMLXTokenizers`
+targets so there is exactly one MLX binary across LLM + image + video):
+
+| Product | Path | Role |
+|---|---|---|
+| `vMLXFlux` | `Libraries/vMLXFlux` | Umbrella. `@_exported import`s the three below. The one import callers need. |
+| `vMLXFluxKit` | `Libraries/vMLXFluxKit` | Core: protocols, `FluxEngine` types, requests/events, registry, schedulers, VAE, weight loader, `MLXStudioModelStore`, JANG bridge. |
+| `vMLXFluxModels` | `Libraries/vMLXFluxModels` | Concrete models (ZImage native, Flux1/2, Qwen, FIBO, SeedVR2). |
+| `vMLXFluxVideo` | `Libraries/vMLXFluxVideo` | WAN 2.1/2.2 video (scaffold). |
+| `vmlxflux-probe` (exe, target `vMLXFluxProbe`) | `tools/vMLXFluxProbe` | Scan / load / generate CLI for local bundles. |
+
+**Integration note for a standalone SwiftPM consumer (e.g. osaurus if it depends
+on the published `jjang-ai/vmlx-flux` package instead of vendoring):** the engine
+package imports `Tokenizers` and `MLXLMCommon` from `swift-transformers` and
+`vmlx-swift-lm`. Inside vmlx-swift's monorepo those become `VMLXTokenizers` and
+the in-tree `MLXLMCommon` — the one source delta when vendoring is
+`import Tokenizers` → `import VMLXTokenizers` in `ZImageNative.swift`.
+
+---
+
+## 2. FluxEngine API
+
+```swift
+public actor FluxEngine {
+    public init()
+
+    // Load by canonical name from an explicit local weights dir.
+    public func load(name: String, modelPath: URL, quantize: Int? = nil) async throws
+
+    // Resolve + load a local bundle from ~/.mlxstudio/models/image (or a custom store).
+    @discardableResult
+    public func load(name: String, from store: MLXStudioModelStore = .init()) async throws -> LocalFluxModel
+
+    public func unload()
+
+    public func generate(_ r: ImageGenRequest)  -> AsyncThrowingStream<ImageGenEvent, Error>
+    public func edit(_ r: ImageEditRequest)      -> AsyncThrowingStream<ImageGenEvent, Error>
+    public func upscale(_ r: UpscaleRequest)     -> AsyncThrowingStream<ImageGenEvent, Error>
+    public func generateVideo(_ r: VideoGenRequest) -> AsyncThrowingStream<VideoGenEvent, Error> // throws notImplemented
+}
+```
+
+- **Actor-isolated.** MLX ops are not thread-safe across one allocator and the
+  generation loop holds a persistent latent buffer, so every entry point hops the
+  actor executor. Hold ONE `FluxEngine` per process.
+- `load(name:from:)` enforces "no silent downloads": it resolves a *local* dir via
+  `MLXStudioModelStore`, rejects incomplete bundles (`FluxError.localModelIncomplete`),
+  and only then constructs the model. Use this for the osaurus model-picker path.
+- Dispatch is capability-based: `generate` requires the loaded model conform to
+  `ImageGenerator`, `edit`→`ImageEditor`, `upscale`→`ImageUpscaler`. Mismatch →
+  `FluxError.wrongModelKind`.
+
+### Errors (`FluxError`)
+`unknownModel`, `notLoaded`, `wrongModelKind(expected:actual:)`, `weightsNotFound`,
+`localModelNotFound(name,root)`, `localModelIncomplete(url,reasons:)`,
+`notImplemented(String)`, `invalidRequest(String)`. All `CustomStringConvertible`.
+
+---
+
+## 3. Request + Event types
+
+### ImageGenRequest (text→image)
+```swift
+ImageGenRequest(prompt:, negativePrompt:nil, width:1024, height:1024,
+                steps:20, guidance:3.5, seed:UInt64?, numImages:1,
+                outputDir:URL, outputFormat:.png)
+```
+Notes: width/height must be divisible by 16 for Z-Image (else
+`invalidRequest`). `guidance == 0` ⇒ no CFG pass (turbo models). `seed == nil` ⇒
+nondeterministic. `numImages > 1` is not yet batched (see §6 open work).
+
+### ImageEditRequest (image[+mask]→image)
+```swift
+ImageEditRequest(prompt:, sourceImage:URL, mask:URL?, strength:0.75,
+                 width:nil, height:nil, steps:20, guidance:3.5, seed:,
+                 outputDir:, outputFormat:.png)
+```
+`mask`: white=edit, black=keep. `strength`: 0..1 deviation from source. `width/height nil`⇒match source.
+
+### UpscaleRequest (SeedVR2)
+```swift
+UpscaleRequest(sourceImage:URL, scale:4, steps:10, seed:, outputDir:, outputFormat:.png)
+```
+
+### VideoGenRequest (WAN, future)
+```swift
+VideoGenRequest(prompt:, negativePrompt:nil, width:1280, height:720,
+                numFrames:121, fps:24, steps:50, guidance:5.0, seed:, outputDir:)
+```
+
+### Events
+```swift
+enum ImageGenEvent {
+    case step(step:Int, total:Int, etaSeconds:Double?)   // 1-indexed step counter for the UI
+    case preview(pngData:Data, step:Int)                 // optional partial decode (not all models)
+    case completed(url:URL, seed:UInt64)                 // terminal success → saved image path
+    case failed(message:String, hfAuth:Bool)             // hfAuth=true ⇒ 401/403 → show "add HF token" CTA
+    case cancelled
+}
+enum VideoGenEvent { case step; case preview(pngData:,frame:); case completed(url:,seed:,fps:,frameCount:); case failed; case cancelled }
+enum ImageFormat: String { case png, jpeg, webp }   // png is the only fully-wired writer today
+```
+Cancellation: the generation loop checks `Task.isCancelled` per step, so cancelling
+the consuming `Task` stops generation at the next step boundary.
+
+---
+
+## 4. Model registry + canonical names
+
+`ModelRegistry` is a decentralized canonical-name → loader map. Each model
+self-registers in its own file via a `static let _register` idiom; call
+`VMLXFluxModels.registerAll()` + `VMLXFluxVideo.registerAll()` once at startup
+(the `FluxEngine.load(name:from:)` path does this for you).
+
+`ModelEntry`: `name`, `displayName`, `kind` (`imageGen|imageEdit|imageUpscale|videoGen`),
+`defaultSteps`, `defaultGuidance`, `supportsLoRA`, `loader`.
+
+Lookup is fuzzy (`lookupFuzzy`): lowercases, strips HF org prefix (`org/model`),
+strips `-4bit`/`-8bit`/`-3bit` suffix, collapses `flux.1`→`flux1`, `_`→`-`. So
+`"Tongyi/Z-Image-Turbo-mflux-4bit"` resolves to canonical `"z-image-turbo"`.
+
+| Canonical | Display | Kind | Default steps / guidance |
+|---|---|---|---|
+| `flux1-schnell` | FLUX.1 Schnell | imageGen | 4 / 0.0 |
+| `flux1-dev` | FLUX.1 Dev | imageGen | 20 / 3.5 |
+| `flux2-klein` | FLUX.2 Klein | imageGen | 20 / 3.5 |
+| `z-image-turbo` | Z-Image Turbo | imageGen | 4 / 0.0 |
+| `qwen-image` | Qwen-Image | imageGen | — |
+| `fibo` | FIBO | imageGen | — |
+| `flux1-kontext` | FLUX.1 Kontext | imageEdit (prompt-only) | — |
+| `flux1-fill` | FLUX.1 Fill | imageEdit (mask) | — |
+| `flux2-klein-edit` | FLUX.2 Klein Edit | imageEdit | — |
+| `qwen-image-edit` | Qwen-Image-Edit | imageEdit | — |
+| `seedvr2` | SeedVR2 | imageUpscale | 10 |
+| `wan-2.1`, `wan-2.2` | Wan 2.x | videoGen | scaffold |
+
+---
+
+## 5. mflux packaging + local model store
+
+`MLXStudioModelStore(root: ~/.mlxstudio/models/image)` scans for local image
+bundles before any download path is considered. **Exact local directory names win
+over canonical family aliases** (so `Z-Image-Turbo-mflux-4bit` and `Z-Image-Turbo`
+both map to `z-image-turbo` but resolve to their own dirs).
+
+`scan()` → `[LocalFluxModel]` with:
+- `directory`, `directoryName`, `canonicalName?`, `displayName`, `kind?`
+- `quantizationBits?` (parsed from `-Nbit` / mflux dir naming)
+- `components: Set<{root,tokenizer,transformer,scheduler,textEncoder,vae,assets}>`
+- `safetensorCount`, `totalBytes`, `hasModelIndex`
+- `readiness: {loadableScaffold, incomplete, unknown}`, `blockedReasons`
+- `canEnterNativeLoadPath` (== `readiness == .loadableScaffold`)
+
+**mflux component layout** (what the WeightLoader expects):
+```
+<model>/
+  tokenizer/        # AutoTokenizer.from(modelFolder:) — HF tokenizer.json
+  text_encoder/     # (Qwen-style for Z-Image) safetensors
+  transformer/      # DiT weights, possibly *.safetensors.index.json sharded
+  vae/              # AutoencoderKL decoder weights
+  scheduler/, assets/   # optional
+```
+`WeightLoader.load(from:)` enumerates shards per component (prefers
+`model.safetensors.index.json` / `diffusion_pytorch_model.safetensors.index.json`,
+else globs `*.safetensors`), merges into a flat `[String: MLXArray]` *and* a
+`componentWeights["transformer"|"text_encoder"|"vae"]` map, and detects JANG via
+`JangBridge` (reuses vmlx-swift-lm's `JangLoader`/`JangConfig`) so JANG-quantized
+bundles carry their per-layer quant metadata. The `*-mflux-4bit` bundles decode
+their 4-bit linears through scale tensors at load time inside the model.
+
+---
+
+## 6. Per-model implementation status (the truth matrix)
+
+| Canonical | Native runtime status | What's real | What's missing |
+|---|---|---|---|
+| **z-image-turbo** | `native_pipeline_implemented` | Full native port: Qwen-style text encoder, patchify+caption-concat DiT (noise/context refiners + unified layers, RoPE, adaLN, timestep embed), real `AutoencoderKL` VAE decode, real 4-bit weight decode, PNG out. | Live same-seed prompt-sensitivity proof (see §8). 1024px tuning. |
+| qwen-image / qwen-image-edit | `not_implemented` | Bundle scans + loads. | Qwen text-encoder port + transformer weight key-map. Body throws `notImplemented`. |
+| flux2-klein / flux2-klein-edit | `not_implemented` | Bundle scans + loads; `FluxDiTConfig.flux2Klein` preset exists. | T5 (single-encoder) port + weight key-map + 3-axis RoPE. |
+| flux1-schnell/dev/kontext/fill | `not_implemented` | Scheduler, VAE, DiT topology + 40-line BFL key-map docblock exist in `FluxDiT.swift`. | T5-XXL + CLIP-L ports + `Module.update` key mapping + Flux 3-axis RoPE. |
+| seedvr2 | scaffold | registered | upscale arch (different family). |
+| wan-2.1 / wan-2.2 | scaffold | full pipeline scaffolded (WanVAE3D + WanDiT + MP4 writer) with random weights. | real weight key-map, real Conv3d (currently a Conv2d shim), windowed attention for >3-4s clips. |
+
+**Shared P0 blockers for the Flux/Qwen family** (z-image already cleared these via
+its own native port): (1) safetensors→module key-map + `Module.update`, (2) T5-XXL
+text encoder (shared Flux/Qwen/Wan), (3) CLIP-L (Flux1), (4) Flux 3-axis RoPE.
+
+**mflux feature surface (scope = "mflux type, not just flux type"):**
+- ✅ Quantized mflux packaging (`*-mflux-4bit`) load + decode — implemented for z-image.
+- ✅ Image *edit* protocol (`ImageEditor`, mask/strength) — API present; per-model bodies pending.
+- ⬜ LoRA — `ModelEntry.supportsLoRA` flag exists (false everywhere today); loader hook TBD.
+- ⬜ ControlNet / img2img strength conditioning — request fields exist (`strength`, `mask`); wiring pending per model.
+
+---
+
+## 7. GPU concurrency — REQUIRED osaurus wiring (do not skip)
+
+osaurus already learned this with the Model2Vec embedder (PR #1507): a second MLX
+graph eval racing the LLM eval on the **shared Metal command buffer** triggers
+`addCompletedHandler: unrecognized selector` SIGABRT. **Image generation is a
+second MLX graph and has the same hazard.**
+
+Required: route every image/video generation through the same `MetalGate`
+exclusion osaurus uses for embeddings. Treat image-gen like the embedder —
+**EXCLUSIVE** with respect to LLM generations (acquire at submit, release after the
+producer fully drains incl. the final VAE decode eval). Do NOT run image gen
+concurrently with token generation on the same device. Acquire the gate in the
+osaurus bridge *around* the `for try await event in engine.generate(...)` drain,
+not inside vmlx-flux (the engine is deliberately gate-agnostic, same as the LLM
+eval hot path).
+
+---
+
+## 8. Sandbox / cache / memory notes for osaurus
+
+- **No silent downloads.** `FluxEngine.load` needs a staged local dir. Wire
+  osaurus's DownloadManager to stage the full mflux bundle (all components) before
+  calling load; surface `FluxError.localModelIncomplete.reasons` to the UI.
+- **Storage matters for the GPU watchdog.** MLX mmaps safetensors lazily; if the
+  weights live on a slow volume (external USB), the first transformer forward
+  stalls the Metal command buffer on IO and trips the GPU timeout
+  (`kIOGPUCommandBufferCallbackErrorTimeout`). **Stage image weights on the
+  internal SSD.** (Observed 2026-06-15: 5.5GB 4-bit z-image at 512px timed out from
+  USB, fine from SSD.)
+- **RAM.** Full bundles are large (z-image 32GB, qwen 25GB, flux2-klein 52GB). The
+  4-bit mflux variants (z-image 5.8GB) are the on-device-friendly path. Gate model
+  load against the memory-safety plan like LLMs; `unload()` between model switches.
+- **No paged/degenerate cache.** Image gen has no KV cache; the only persistent
+  buffer is the per-job latent. Nothing to SSD-cache. Don't confuse with LLM
+  prefix cache.
+- **Output dir** is caller-supplied per request; the engine writes PNG via a
+  `@MainActor` `ImageIO.writePNG` and returns the URL in `.completed`.
+
+---
+
+## 9. How osaurus bridges (recommended shape)
+
+Mirror the documented `FluxBackend` pattern (the bridge lives on the osaurus
+`Engine`, NOT in vmlx-flux — the engine has zero knowledge of osaurus):
+
+1. Hold a lazily-created `FluxEngine` on the osaurus engine actor (store as `Any?`
+   so non-image files don't import vMLXFlux).
+2. `generateImage(prompt:model:settings:)`: acquire MetalGate (§7) → ensure the
+   requested model is loaded (`load(name:from:)`, load-if-different) → build
+   `ImageGenRequest` from osaurus settings → drain the stream → translate
+   `ImageGenEvent` → osaurus's UI event type → return final URL → release gate.
+3. `editImage(...)` / `upscaleImage(...)`: same, via `edit` / `upscale`.
+4. Fan events to the UI via a per-job bridge so the chat surface can subscribe
+   without holding a direct flux reference.
+5. Event-shape translation: vmlx-flux emits separate `.step` and `.preview`; if
+   osaurus uses a unified `.step(step:total:preview:)`, coalesce them in the bridge.
+
+---
+
+## 10. Probe tool (verification harness)
+
+`vmlxflux-probe` (built: `swift build --product vmlxflux-probe`):
+```
+vmlxflux-probe --root <dir> --model <name|dir> --generate --json \
+  --seed N --width W --height H --steps S \
+  --turn "prompt A" --turn "prompt B" ... \
+  --artifacts <dir> --output-dir <dir>
+# or --matrix to scan+load+gen across every local bundle and emit a
+# compatibility-matrix.{json,md}
+```
+Per-turn seed = `--seed` if given (fixes ALL turns to one seed — use for
+same-seed/different-prompt sensitivity tests), else `turnIndex+1`. Artifacts:
+per-model `*-facts.json`, `*-load.json` (with per-turn image SHA256 + dims),
+`scan.{json,md}`, `compatibility-matrix.{json,md}`.
+
+---
+
+## 11. Live-proof verdict (z-image-turbo, 4-bit) — ✅ PASS (2026-06-15)
+
+Probe: `Z-Image-Turbo-mflux-4bit` from internal SSD, seed 7, 512×512, 8 steps,
+3 turns (apple / mountain / apple). Artifacts in
+`docs/local/vmlx-flux-probes/PROOF-zimage-4bit-ssd/`.
+
+| Check | Result |
+|---|---|
+| **Determinism** (turn1 apple seed7 vs turn3 apple seed7) | byte-identical SHA `d101a8…` ✅ |
+| **Prompt-sensitivity** (turn2 mountain seed7 vs apple) | different SHA `0336dc…` ✅ — text encoder conditions output |
+| **Visual coherence** | turn1/3 = coherent photo of a red apple on a wooden table; turn2 = coherent watercolor of a snowy blue mountain ✅ |
+| **Style control** | "photograph" vs "watercolor painting" both honored ✅ |
+| **Speed** | ~4.1–4.5 s per 512px/8-step; ~18.7 s per 1024px/8-step (4-bit, M5 Max) |
+| **Native 1024px** | coherent photorealistic cabin-in-pine-forest-at-sunset, prompt-accurate ✅ |
+| **Stability** | no GPU timeout from SSD; USB-resident weights DO time out (§8) |
+
+**Expanded coverage (2026-06-15, same bundle):**
+
+| Dimension | Result |
+|---|---|
+| **CFG / negative-prompt path** (`guidance 3.0` + negative) | coherent prompt-accurate apple; 7.6 s vs 4.2 s at guidance 0 — the ~1.8× confirms two forward passes per step (real classifier-free guidance). Previously-untested `negativeEncodings` branch ✅ |
+| **Seed sensitivity** (same prompt, seed 100 vs 200) | distinct coherent images per seed ✅ |
+| **Resolution/speed curve** (8-step, guidance 0) | 256²→1.3 s · 512²→4.3 s · 768²→10.6 s · 1024²→20.8 s |
+| **Unit tests** (`swift test --filter vMLXFluxTests`, Xcode toolchain) | 19/19 green |
+
+Probe gained `--guidance` and `--negative` flags to drive the CFG path.
+
+**Conclusion:** the native Swift Z-Image pipeline (text encoder + DiT + VAE + 4-bit
+decode) produces real, deterministic, prompt-conditioned images across resolutions,
+seeds, and the CFG path. z-image-turbo is **production-compatible** — the May-16
+"scaffold_generates_png_noise" verdict is superseded; that predated `ZImageNative.swift`.
+
+---
+
+## 12. Open work / follow-ups (prioritized)
+
+1. Land + commit the vendored engine in vmlx-swift (local-only fork — never pushed)
+   and push the ahead-of-repo native work (ZImageNative, LocalModelStore, probe,
+   loader edits) back to `jjang-ai/vmlx-flux`.
+2. Prove z-image-turbo prompt-sensitivity live (§11); promote to production-compatible.
+3. Port the shared T5-XXL + CLIP-L encoders → unblocks Flux1/Flux2/Qwen at once.
+4. Per-model weight key-maps (start Flux1-Schnell; Qwen-Image-Edit for the edit path).
+5. LoRA loader hook (`supportsLoRA`), img2img/controlnet conditioning.
+6. `numImages > 1` batching; webp/jpeg writers; preview-decode cadence.
+7. Wire MetalGate exclusion in the osaurus bridge (§7) before shipping.

--- a/docs/QWEN_IMAGE_PORT_PLAN.md
+++ b/docs/QWEN_IMAGE_PORT_PLAN.md
@@ -1,0 +1,118 @@
+# Qwen-Image / Qwen-Image-Edit native port plan (vMLXFlux)
+
+**Purpose:** a concrete, executable plan to take `qwen-image` and `qwen-image-edit`
+from `notImplemented` to a proven native pipeline, using the **already-proven
+`ZImageNative.swift`** as the reference template. For osaurus teammates + future
+porting sessions.
+
+**Status (2026-06-15):** registered, scans/loads as a local mflux bundle, but
+`generate`/`edit` throw `FluxError.notImplemented`. The `qwen-image-mflux-4bit`
+(25 GB) bundle is NOT currently on disk — staging it onto the internal SSD
+(`~/.mlxstudio/models/image/`, per the GPU-watchdog rule) is **step 0** and is
+required before any live proof.
+
+> Do NOT mark this done without a live same-seed/different-prompt proof (the HARD
+> RULE). The Z-Image proof in `OSAURUS_VMLX_FLUX_INTEGRATION_SPEC.md` §11 is the bar.
+
+---
+
+## Why Z-Image is the right template
+
+Qwen-Image and Z-Image share the modern text-to-image recipe that
+`vMLXFluxKit` + `ZImageNative.swift` already implement end-to-end:
+
+- A **decoder-LM text encoder** (Z-Image: Qwen-style 2560-dim encoder; Qwen-Image:
+  Qwen2.5-VL text tower) producing per-token hidden states as conditioning —
+  `ZImageTextEncoder` is a near-drop-in pattern (embed_tokens → N× {RMSNorm,
+  q/k/v/o_proj with q/k norm, RoPE attention, gated MLP}).
+- An **MM-DiT** transformer that concatenates caption + image streams with
+  RoPE position ids and adaLN-zero timestep modulation — `ZImageTransformer`
+  (patchify + caption-concat + noise/context refiners + unified blocks +
+  final layer + unpatchify) is the template.
+- An **AutoencoderKL** VAE decoder — `ZImageVAEDecoder` (conv_in → mid_block →
+  up_blocks → conv_out) is reusable; Qwen-Image's VAE has the same family shape.
+- The **FlowMatch Euler scheduler**, **mflux 4-bit weight decode** (scale
+  tensors), **tokenizer bridge** (`AutoTokenizer.from(modelFolder:)`), and
+  **PNG IO** are all model-agnostic in `vMLXFluxKit` and already used by Z-Image.
+
+So the port is mostly: (a) parse Qwen-Image's config, (b) map its checkpoint keys
+to module properties, (c) match its exact text-encoder + DiT topology, (d) wire
+image conditioning for `-edit`.
+
+---
+
+## Step-by-step
+
+### 0. Stage weights + capture ground truth
+- Copy `qwen-image-mflux-4bit` to `~/.mlxstudio/models/image/` (internal SSD).
+- Run the **reference mflux (Python)** generation once with a fixed seed + prompt
+  to get a ground-truth image + the intermediate shapes (text-encoder output dim,
+  latent channels, patch size, VAE scale/shift). These are the oracle for the port.
+- `vmlxflux-probe --model qwen-image-mflux-4bit --json` (scan only) to confirm the
+  component layout (`transformer/`, `text_encoder/`, `vae/`, `tokenizer/`).
+
+### 1. Config parse
+- Read `transformer/config.json` + `text_encoder/config.json` + `vae/config.json`.
+- Pull: hidden dim, num layers, num heads, head dim, patch size, in-channels,
+  text hidden dim, RoPE theta, VAE scale/shift. Mirror the `ZImageNative` static
+  constants block with Qwen-Image's numbers (do NOT reuse Z-Image's 3840/2560/30).
+
+### 2. Weight key-map (the hard part)
+- Enumerate `transformer/*.safetensors` keys (use `WeightLoader` which already
+  merges component shards into `componentWeights["transformer"|"text_encoder"|"vae"]`).
+- Build a `QwenImageWeightStore` modeled on `ZImageWeightStore` with the
+  candidate-key fallbacks for Qwen-Image's naming (Qwen-Image uses
+  `transformer_blocks.{i}.attn.*`, `img_mod`/`txt_mod`, `img_mlp`/`txt_mlp` —
+  verify against the actual checkpoint, do not assume).
+- For 4-bit mflux: reuse `ZImageWeightStore.linear(component:prefix:...)`'s
+  scale-tensor dequant path (Qwen-Image mflux-4bit packs the same way).
+
+### 3. Text encoder
+- Qwen-Image uses a Qwen2.5-VL text tower. Start from `ZImageTextEncoder`; adjust
+  dim/layers/heads, the prompt template (Qwen-Image has its own chat-style
+  template — capture it from the reference), and the pooled vs per-token output
+  contract. Feed per-token hidden states as `capFeats`.
+
+### 4. Transformer (MM-DiT)
+- Clone `ZImageTransformer`; match Qwen-Image's block structure (it has dual
+  img/txt modulation per block — closer to Flux's double-stream than Z-Image's
+  unified blocks, so cross-reference `FluxDiT.swift`'s `FluxDoubleStreamBlock`).
+- 3-axis RoPE: confirm whether Qwen-Image uses Z-Image-style 1-grid RoPE or
+  Flux-style 3-axis (time,H,W) — this is a known open TODO in `FluxDiT.swift`.
+
+### 5. VAE
+- Reuse `ZImageVAEDecoder`; verify channel progression + scale/shift against
+  `vae/config.json` (Qwen-Image VAE scale/shift differ from Z-Image's 0.3611/0.1159).
+
+### 6. `qwen-image-edit` image conditioning
+- Implement `ImageEditor.edit(_:)`: VAE-**encode** the source image to a latent,
+  blend with noise per `strength`, optionally apply the mask (white=edit), then
+  run the same denoise loop. Needs the VAE **encoder** (the kit only has the
+  decoder today — add `ZImageVAEEncoder`-style conv stack or reuse Qwen-Image's).
+
+### 7. Live proof (gate — do not skip)
+- `vmlxflux-probe --model qwen-image-mflux-4bit --generate --seed S --steps N
+  --turn "A" --turn "B" --turn "A"` → turns 1≡3 byte-identical (determinism),
+  turn 2 ≠ 1 (prompt-sensitivity), all coherent + prompt-accurate.
+- For `-edit`: prove the output preserves source structure and applies the prompt
+  edit (e.g. recolor) — compare against the masked region.
+- Compare against the step-0 reference image for fidelity.
+
+---
+
+## Effort + risk
+
+- **Biggest risk:** the weight key-map (step 2) and the exact text-encoder template
+  (step 3) — wrong keys/topology produce coherent-looking but prompt-insensitive or
+  garbled output. The same-seed/different-prompt + reference-image checks catch this.
+- **Reuse ratio:** ~70% of the machinery (scheduler, VAE decoder pattern, weight
+  loader, tokenizer, IO, mflux dequant, patchify/RoPE/adaLN scaffolding) is shared.
+- **Shared payoff:** the T5-XXL encoder needed for `flux1-*`/`flux2-klein` is a
+  separate port; Qwen-Image does NOT need T5 (it uses Qwen2.5-VL), so Qwen-Image is
+  the better *next* target than the Flux family.
+
+## Reference files
+- Template: `Libraries/vMLXFluxModels/ZImage/ZImageNative.swift` (proven).
+- Flux double-stream block (for MM-DiT): `Libraries/vMLXFluxKit/FluxDiT.swift`.
+- Shared kit: `FlowMatchScheduler`, `VAE`, `WeightLoader`, `MathOps`, `LatentSpace`.
+- API contract + proof bar: `docs/OSAURUS_VMLX_FLUX_INTEGRATION_SPEC.md`.

--- a/docs/VMLX_FLUX_NATIVE_STATUS_2026_05_15.md
+++ b/docs/VMLX_FLUX_NATIVE_STATUS_2026_05_15.md
@@ -1,0 +1,96 @@
+# vMLX Flux Native Status - 2026-05-15
+
+This records the current state of native MFlux/Flux-family image support in
+the consolidated `vmlx-swift` package. It is based on source inspection plus
+live probes against local bundles under `~/.mlxstudio/models/image`.
+
+## Integrated Surface
+
+- `jjang-ai/vmlx-flux` was cloned and inspected as the partial standalone
+  Swift project for native MFlux-style image/video generation.
+- Its Swift targets are now vendored into this package as local products:
+  `vMLXFlux`, `vMLXFluxKit`, `vMLXFluxModels`, and `vMLXFluxVideo`.
+- The umbrella `VMLX` product re-exports `vMLXFlux`.
+- `vmlxflux-probe` is a local executable for scan/load/generation probes. It
+  writes artifacts under ignored `docs/local/vmlx-flux-probes/`. Use
+  `--matrix` to scan, load, and run the multi-turn generation probe across all
+  detected local image bundles.
+- `MLXStudioModelStore` scans `~/.mlxstudio/models/image` and resolves local
+  Diffusers/MFlux component layouts before any silent download path is
+  considered. Exact local directory names win over canonical family aliases.
+
+## Local Bundle Inventory
+
+Latest scan artifact:
+`docs/local/vmlx-flux-probes/20260516T-native-mflux-full-matrix/scan.json`
+
+Latest load/generation matrix:
+`docs/local/vmlx-flux-probes/20260516T-native-mflux-full-matrix/compatibility-matrix.json`
+
+| Local directory | Native family | Bytes | Runtime status |
+| --- | --- | ---: | --- |
+| `FLUX.2-klein-9B` | `flux2-klein` | 52,864,013,750 | `not_implemented` |
+| `qwen-image-mflux-4bit` | `qwen-image` | 25,895,424,132 | `not_implemented` |
+| `Z-Image-Turbo` | `z-image-turbo` | 32,832,339,790 | `scaffold_generates_png_noise` |
+| `Z-Image-Turbo-mflux-4bit` | `z-image-turbo` | 5,891,426,229 | `scaffold_generates_png_noise` |
+
+All four bundles have enough component files to be discovered as local image
+bundles. None are production-compatible yet.
+
+## Live Probe Results
+
+- `Z-Image-Turbo-mflux-4bit` load/generate:
+  `docs/local/vmlx-flux-probes/20260516T-native-mflux-full-matrix/`
+  completed three PNG turns at 128x128, but output is colored noise. This is
+  not a compatibility pass.
+- `Z-Image-Turbo` load/generate:
+  `docs/local/vmlx-flux-probes/20260516T-native-mflux-full-matrix/`
+  completed three PNG turns at 128x128, also through the same scaffold path.
+- `qwen-image-mflux-4bit`:
+  `docs/local/vmlx-flux-probes/20260516T-native-mflux-full-matrix/`
+  loads the local bundle but every generation turn throws
+  `FluxError.notImplemented`.
+- `FLUX.2-klein-9B`:
+  `docs/local/vmlx-flux-probes/20260516T-native-mflux-full-matrix/`
+  loads the local bundle but every generation turn throws
+  `FluxError.notImplemented`.
+
+Matrix result:
+
+| Local directory | Load | Multi-turn generation | Gate |
+| --- | --- | --- | --- |
+| `FLUX.2-klein-9B` | `loaded` | `0/3` | `blocked_after_load` |
+| `qwen-image-mflux-4bit` | `loaded` | `0/3` | `blocked_after_load` |
+| `Z-Image-Turbo` | `loaded` | `3/3` noise PNGs | `blocked_after_load` |
+| `Z-Image-Turbo-mflux-4bit` | `loaded` | `3/3` noise PNGs | `blocked_after_load` |
+
+## Current Blockers
+
+- Z-Image has an end-to-end PNG-producing scaffold, but it feeds zero-tensor
+  text embeddings and does not apply loaded safetensors into `FluxDiTModel` or
+  `VAEDecoder`.
+- The current `loaded` status means the native constructor accepted the local
+  directory and opened safetensors metadata/arrays. It does not prove real
+  prompt-conditioned weights are resident or used during generation.
+- Flux2 Klein and Qwen-Image model bodies still throw `notImplemented`.
+- Shared T5/CLIP text encoder ports are missing.
+- Safetensors-to-module key mapping is missing.
+- Flux 3-axis RoPE is still TODO in `FluxDiT`.
+- `swift package describe --type json`, `swift build --target vMLXFlux`, and
+  `swift build --product vmlxflux-probe` succeed.
+- Full `swift test --filter vMLXFluxTests` is currently blocked before reaching
+  the Flux tests by test-module availability on this toolchain: `XCTest` is
+  missing for `CmlxTests` and `Testing` is missing for `MLXPressPolicyTests`.
+
+## Next Engineering Path
+
+1. Implement real safetensors key mapping and `Module.update` for the smallest
+   runnable path first: `Z-Image-Turbo-mflux-4bit`.
+2. Port or reuse the required text encoder path so prompts affect conditioning.
+3. Replace the scaffold Z-Image pass criteria with image-output checks that
+   reject noise/prompt-insensitive rows.
+4. Only after Z-Image is prompt-sensitive, port Flux2 Klein and Qwen-Image
+   model bodies and run the same probe matrix on their local bundles.
+
+Until those rows pass with real prompt-sensitive images, the status is:
+`not production-compatible`.

--- a/tools/vMLXFluxProbe/main.swift
+++ b/tools/vMLXFluxProbe/main.swift
@@ -1,0 +1,528 @@
+import Foundation
+import CryptoKit
+import ImageIO
+import vMLXFlux
+import vMLXFluxKit
+
+@main
+struct VMLXFluxProbe {
+    static func main() async {
+        do {
+            let options = try ProbeOptions(arguments: Array(CommandLine.arguments.dropFirst()))
+            VMLXFluxModels.registerAll()
+            VMLXFluxVideo.registerAll()
+
+            let store = MLXStudioModelStore(root: options.root)
+            let models = try store.scan()
+            try FileManager.default.createDirectory(
+                at: options.artifactDirectory,
+                withIntermediateDirectories: true)
+
+            try writeScanArtifacts(
+                models: models,
+                artifactDirectory: options.artifactDirectory,
+                jsonOutput: options.json)
+
+            if options.matrix {
+                try await runMatrixProbe(
+                    models: models,
+                    options: options,
+                    artifactDirectory: options.artifactDirectory)
+            } else if let requestedModel = options.model {
+                guard let local = try store.resolve(name: requestedModel) else {
+                    throw ProbeError("model \(requestedModel) not found under \(options.root.path)")
+                }
+                try writeLocalModelFacts(local, artifactDirectory: options.artifactDirectory)
+                if options.load || options.generate {
+                    try await runLoadProbe(
+                        local: local,
+                        options: options,
+                        artifactDirectory: options.artifactDirectory)
+                }
+            }
+        } catch {
+            fputs("vmlxflux-probe error: \(error)\n", stderr)
+            exit(1)
+        }
+    }
+
+    private static func runMatrixProbe(
+        models: [LocalFluxModel],
+        options: ProbeOptions,
+        artifactDirectory: URL
+    ) async throws {
+        var rows: [[String: Any]] = []
+        for local in models {
+            try writeLocalModelFacts(local, artifactDirectory: artifactDirectory)
+            let payload = try await runLoadProbe(
+                local: local,
+                options: options,
+                artifactDirectory: artifactDirectory)
+            rows.append(matrixRow(local: local, payload: payload))
+        }
+
+        let matrixPayload: [String: Any] = [
+            "started_at": isoTimestamp(options.startedAt),
+            "finished_at": isoTimestamp(),
+            "root": options.root.path,
+            "model_count": models.count,
+            "generate_requested": options.generate,
+            "width": options.width,
+            "height": options.height,
+            "steps": options.steps,
+            "turns": options.turns,
+            "rows": rows,
+        ]
+        let data = try JSONSerialization.data(
+            withJSONObject: matrixPayload,
+            options: [.prettyPrinted, .sortedKeys])
+        let matrixURL = artifactDirectory.appendingPathComponent("compatibility-matrix.json")
+        try data.write(to: matrixURL)
+        try writeMatrixMarkdown(rows: rows, artifactDirectory: artifactDirectory)
+        print("compatibility matrix artifact: \(matrixURL.path)")
+    }
+
+    private static func writeScanArtifacts(
+        models: [LocalFluxModel],
+        artifactDirectory: URL,
+        jsonOutput: Bool
+    ) throws {
+        let rows = models.map(modelJSON)
+        let data = try JSONSerialization.data(
+            withJSONObject: rows,
+            options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: artifactDirectory.appendingPathComponent("scan.json"))
+
+        var lines: [String] = [
+            "# vMLX Flux Local Model Scan",
+            "",
+            "| Directory | Canonical | Kind | Quant | Safetensors | Bytes | Readiness | Reasons |",
+            "| --- | --- | --- | --- | ---: | ---: | --- | --- |",
+        ]
+        for model in models {
+            lines.append(
+                "| \(model.directoryName) | \(model.canonicalName ?? "unknown") | \(model.kind?.rawValue ?? "unknown") | \(model.quantizationBits.map(String.init) ?? "-") | \(model.safetensorCount) | \(model.totalBytes) | \(model.readiness.rawValue) | \(model.blockedReasons.joined(separator: "; ")) |")
+        }
+        try lines.joined(separator: "\n")
+            .write(
+                to: artifactDirectory.appendingPathComponent("scan.md"),
+                atomically: true,
+                encoding: .utf8)
+
+        if jsonOutput {
+            FileHandle.standardOutput.write(data)
+            print("")
+        } else {
+            print("scanned \(models.count) local image models")
+            print("artifacts: \(artifactDirectory.path)")
+            for model in models {
+                print("\(model.directoryName): canonical=\(model.canonicalName ?? "unknown") readiness=\(model.readiness.rawValue) safetensors=\(model.safetensorCount) bytes=\(model.totalBytes)")
+            }
+        }
+    }
+
+    private static func writeLocalModelFacts(
+        _ model: LocalFluxModel,
+        artifactDirectory: URL
+    ) throws {
+        let factsURL = artifactDirectory.appendingPathComponent("\(model.directoryName)-facts.json")
+        let data = try JSONSerialization.data(
+            withJSONObject: modelJSON(model),
+            options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: factsURL)
+    }
+
+    @discardableResult
+    private static func runLoadProbe(
+        local: LocalFluxModel,
+        options: ProbeOptions,
+        artifactDirectory: URL
+    ) async throws -> [String: Any] {
+        let logURL = artifactDirectory.appendingPathComponent("\(local.directoryName)-load.json")
+        let startedAt = Date()
+        var payload: [String: Any] = [
+            "model": modelJSON(local),
+            "started_at": isoTimestamp(startedAt),
+            "generate_requested": options.generate,
+            "turns": options.turns,
+            "width": options.width,
+            "height": options.height,
+            "steps": options.steps,
+            "seed": options.seed.map { $0 as Any } ?? NSNull(),
+        ]
+
+        do {
+            let engine = FluxEngine()
+            let loaded = try await engine.load(name: local.directoryName,
+                                               from: MLXStudioModelStore(root: options.root))
+            payload["load_status"] = "loaded"
+            payload["loaded_model"] = modelJSON(loaded)
+            payload["load_elapsed_seconds"] = Date().timeIntervalSince(startedAt)
+
+            if options.generate {
+                var turnRecords: [[String: Any]] = []
+                for (index, prompt) in options.turns.enumerated() {
+                    let request = ImageGenRequest(
+                        prompt: prompt,
+                        negativePrompt: options.negativePrompt,
+                        width: options.width,
+                        height: options.height,
+                        steps: options.steps,
+                        guidance: options.guidance ?? (loaded.canonicalName == "z-image-turbo" ? 0 : 3.5),
+                        seed: options.seed ?? UInt64(index + 1),
+                        outputDir: options.outputDirectory)
+                    let turnStart = Date()
+                    var record: [String: Any] = [
+                        "turn": index + 1,
+                        "prompt": prompt,
+                        "started_at": isoTimestamp(turnStart),
+                    ]
+                    do {
+                        let stream = await engine.generate(request)
+                        var steps: [[String: Any]] = []
+                        var completedURL: String?
+                        for try await event in stream {
+                            switch event {
+                            case .step(let step, let total, let eta):
+                                steps.append([
+                                    "step": step,
+                                    "total": total,
+                                    "eta_seconds": eta.map { $0 as Any } ?? NSNull(),
+                                ])
+                            case .preview(let data, let step):
+                                steps.append([
+                                    "preview_step": step,
+                                    "preview_bytes": data.count,
+                                ])
+                            case .completed(let url, let seed):
+                                completedURL = url.path
+                                record["seed"] = seed
+                            case .failed(let message, let hfAuth):
+                                record["status"] = "failed_event"
+                                record["message"] = message
+                                record["hf_auth"] = hfAuth
+                            case .cancelled:
+                                record["status"] = "cancelled"
+                            }
+                        }
+                        record["steps"] = steps
+                        if let completedURL {
+                            record["status"] = "completed"
+                            record["output"] = completedURL
+                            record["image_diagnostics"] = imageDiagnostics(
+                                for: URL(fileURLWithPath: completedURL))
+                        } else if record["status"] == nil {
+                            record["status"] = "no_completed_event"
+                        }
+                    } catch {
+                        record["status"] = "threw"
+                        record["error"] = String(describing: error)
+                    }
+                    record["elapsed_seconds"] = Date().timeIntervalSince(turnStart)
+                    turnRecords.append(record)
+                }
+                payload["generation_turns"] = turnRecords
+            }
+        } catch {
+            payload["load_status"] = "failed"
+            payload["error"] = String(describing: error)
+            payload["load_elapsed_seconds"] = Date().timeIntervalSince(startedAt)
+        }
+
+        payload["finished_at"] = isoTimestamp()
+        let data = try JSONSerialization.data(
+            withJSONObject: payload,
+            options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: logURL)
+        print("load probe artifact: \(logURL.path)")
+        return payload
+    }
+
+    private static func matrixRow(
+        local: LocalFluxModel,
+        payload: [String: Any]
+    ) -> [String: Any] {
+        let turns = payload["generation_turns"] as? [[String: Any]] ?? []
+        let completed = turns.filter { ($0["status"] as? String) == "completed" }.count
+        let threw = turns.filter { ($0["status"] as? String) == "threw" }.count
+        let failed = turns.filter {
+            guard let status = $0["status"] as? String else { return true }
+            return status != "completed"
+        }.count
+        let nativeStatus = runtimeStatus(for: local.canonicalName)
+        let loadStatus = payload["load_status"] as? String ?? "not_requested"
+        let gateStatus: String
+        var gateReasons = runtimeBlockers(for: local.canonicalName)
+        if local.readiness != .loadableScaffold {
+            gateReasons.append(contentsOf: local.blockedReasons)
+        }
+        if loadStatus != "loaded" {
+            gateReasons.append("native load did not complete")
+        }
+        if payload["generate_requested"] as? Bool == true {
+            if failed > 0 {
+                gateReasons.append("\(failed) generation turn(s) did not complete")
+            }
+            if nativeStatus != "production_ready" {
+                gateReasons.append("native runtime status is \(nativeStatus)")
+            }
+        }
+        if gateReasons.isEmpty {
+            gateStatus = "production_candidate"
+        } else if loadStatus == "loaded" {
+            gateStatus = "blocked_after_load"
+        } else {
+            gateStatus = "blocked_before_load"
+        }
+
+        return [
+            "directory_name": local.directoryName,
+            "canonical_name": local.canonicalName ?? NSNull(),
+            "kind": local.kind?.rawValue ?? NSNull(),
+            "quantization_bits": local.quantizationBits.map { $0 as Any } ?? NSNull(),
+            "components": local.components.map(\.rawValue).sorted(),
+            "safetensor_count": local.safetensorCount,
+            "total_bytes": local.totalBytes,
+            "readiness": local.readiness.rawValue,
+            "native_runtime_status": nativeStatus,
+            "load_status": loadStatus,
+            "generation_turns": turns.count,
+            "generation_completed": completed,
+            "generation_threw": threw,
+            "generation_failed_or_missing": failed,
+            "gate_status": gateStatus,
+            "gate_reasons": Array(NSOrderedSet(array: gateReasons)) as? [String] ?? gateReasons,
+            "artifact": "\(local.directoryName)-load.json",
+        ]
+    }
+
+    private static func writeMatrixMarkdown(
+        rows: [[String: Any]],
+        artifactDirectory: URL
+    ) throws {
+        var lines: [String] = [
+            "# vMLX Flux Native Compatibility Matrix",
+            "",
+            "| Directory | Canonical | Load | Generation | Native status | Gate | Reasons |",
+            "| --- | --- | --- | --- | --- | --- | --- |",
+        ]
+        for row in rows {
+            let directory = row["directory_name"] as? String ?? "unknown"
+            let canonical = row["canonical_name"] as? String ?? "unknown"
+            let load = row["load_status"] as? String ?? "unknown"
+            let completed = row["generation_completed"] as? Int ?? 0
+            let turns = row["generation_turns"] as? Int ?? 0
+            let native = row["native_runtime_status"] as? String ?? "unknown"
+            let gate = row["gate_status"] as? String ?? "unknown"
+            let reasons = (row["gate_reasons"] as? [String] ?? [])
+                .joined(separator: "; ")
+                .replacingOccurrences(of: "\n", with: " ")
+            lines.append("| \(directory) | \(canonical) | \(load) | \(completed)/\(turns) | \(native) | \(gate) | \(reasons) |")
+        }
+        try lines.joined(separator: "\n").write(
+            to: artifactDirectory.appendingPathComponent("compatibility-matrix.md"),
+            atomically: true,
+            encoding: .utf8)
+    }
+
+    private static func modelJSON(_ model: LocalFluxModel) -> [String: Any] {
+        [
+            "directory": model.directory.path,
+            "directory_name": model.directoryName,
+            "canonical_name": model.canonicalName ?? NSNull(),
+            "display_name": model.displayName,
+            "kind": model.kind?.rawValue ?? NSNull(),
+            "quantization_bits": model.quantizationBits.map { $0 as Any } ?? NSNull(),
+            "components": model.components.map(\.rawValue).sorted(),
+            "safetensor_count": model.safetensorCount,
+            "total_bytes": model.totalBytes,
+            "has_model_index": model.hasModelIndex,
+            "readiness": model.readiness.rawValue,
+            "blocked_reasons": model.blockedReasons,
+            "native_runtime_status": runtimeStatus(for: model.canonicalName),
+            "native_runtime_blockers": runtimeBlockers(for: model.canonicalName),
+        ]
+    }
+
+    private static func runtimeStatus(for canonicalName: String?) -> String {
+        switch canonicalName {
+        case "z-image-turbo":
+            return "native_pipeline_implemented"
+        case "flux1-schnell", "flux1-dev", "flux1-kontext", "flux1-fill",
+             "flux2-klein", "flux2-klein-edit", "qwen-image", "qwen-image-edit",
+             "fibo", "seedvr2":
+            return "not_implemented"
+        case "wan-2.1", "wan-2.2":
+            return "video_scaffold_only"
+        case .some:
+            return "unknown_model_runtime"
+        case .none:
+            return "unknown"
+        }
+    }
+
+    private static func runtimeBlockers(for canonicalName: String?) -> [String] {
+        switch canonicalName {
+        case "z-image-turbo":
+            return [
+                "requires live same-seed prompt-sensitivity and multi-turn matrix before production promotion",
+            ]
+        case "flux1-schnell", "flux1-dev", "flux1-kontext", "flux1-fill",
+             "flux2-klein", "flux2-klein-edit", "qwen-image", "qwen-image-edit",
+             "fibo", "seedvr2":
+            return [
+                "model generate/edit/upscale body throws FluxError.notImplemented",
+                "text encoder ports are missing",
+                "safetensors-to-module key mapping is missing",
+            ]
+        case "wan-2.1", "wan-2.2":
+            return [
+                "video path is scaffolded",
+                "real Wan safetensors key mapping and scalable attention are missing",
+            ]
+        default:
+            return []
+        }
+    }
+
+    private static func imageDiagnostics(for url: URL) -> [String: Any] {
+        do {
+            let data = try Data(contentsOf: url)
+            var result: [String: Any] = [
+                "path": url.path,
+                "bytes": data.count,
+                "sha256": SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined(),
+            ]
+            if let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+               let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any] {
+                result["pixel_width"] = properties[kCGImagePropertyPixelWidth]
+                result["pixel_height"] = properties[kCGImagePropertyPixelHeight]
+                result["color_model"] = properties[kCGImagePropertyColorModel]
+                result["has_alpha"] = properties[kCGImagePropertyHasAlpha]
+            }
+            return result
+        } catch {
+            return [
+                "path": url.path,
+                "error": String(describing: error),
+            ]
+        }
+    }
+
+    private static func isoTimestamp(_ date: Date = Date()) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: date)
+    }
+}
+
+struct ProbeOptions {
+    static let defaultTurns = [
+        "a small red cube on a white table",
+        "the same cube with blue lighting",
+        "the same scene as a pencil sketch",
+    ]
+
+    var root = MLXStudioModelStore.defaultImageRoot
+    let startedAt = Date()
+    var artifactDirectory = URL(fileURLWithPath: "docs/local/vmlx-flux-probes")
+        .appendingPathComponent(Self.timestamp())
+    var outputDirectory = URL(fileURLWithPath: "docs/local/vmlx-flux-outputs", isDirectory: true)
+    var model: String?
+    var matrix = false
+    var load = false
+    var generate = false
+    var json = false
+    var width = 256
+    var height = 256
+    var steps = 1
+    var seed: UInt64?
+    var guidance: Float?
+    var negativePrompt: String?
+    var turns = Self.defaultTurns
+
+    init(arguments: [String]) throws {
+        var index = 0
+        while index < arguments.count {
+            let arg = arguments[index]
+            switch arg {
+            case "--root":
+                root = URL(fileURLWithPath: try Self.value(after: arg, in: arguments, index: &index), isDirectory: true)
+            case "--artifacts":
+                artifactDirectory = URL(fileURLWithPath: try Self.value(after: arg, in: arguments, index: &index), isDirectory: true)
+            case "--output-dir":
+                outputDirectory = URL(fileURLWithPath: try Self.value(after: arg, in: arguments, index: &index), isDirectory: true)
+            case "--model":
+                model = try Self.value(after: arg, in: arguments, index: &index)
+            case "--matrix", "--all":
+                matrix = true
+                load = true
+                generate = true
+            case "--load":
+                load = true
+            case "--generate":
+                generate = true
+                load = true
+            case "--no-generate":
+                generate = false
+            case "--json":
+                json = true
+            case "--width":
+                let value = try Self.value(after: arg, in: arguments, index: &index)
+                guard let parsed = Int(value) else { throw ProbeError("invalid --width") }
+                width = parsed
+            case "--height":
+                let value = try Self.value(after: arg, in: arguments, index: &index)
+                guard let parsed = Int(value) else { throw ProbeError("invalid --height") }
+                height = parsed
+            case "--steps":
+                let value = try Self.value(after: arg, in: arguments, index: &index)
+                guard let parsed = Int(value) else { throw ProbeError("invalid --steps") }
+                steps = parsed
+            case "--seed":
+                let value = try Self.value(after: arg, in: arguments, index: &index)
+                guard let parsed = UInt64(value) else { throw ProbeError("invalid --seed") }
+                seed = parsed
+            case "--guidance":
+                let value = try Self.value(after: arg, in: arguments, index: &index)
+                guard let parsed = Float(value) else { throw ProbeError("invalid --guidance") }
+                guidance = parsed
+            case "--negative":
+                negativePrompt = try Self.value(after: arg, in: arguments, index: &index)
+            case "--turn":
+                let turn = try Self.value(after: arg, in: arguments, index: &index)
+                if turns == Self.defaultTurns {
+                    turns = []
+                }
+                turns.append(turn)
+            default:
+                throw ProbeError("unknown argument \(arg)")
+            }
+            index += 1
+        }
+    }
+
+    private static func value(after flag: String, in arguments: [String], index: inout Int) throws -> String {
+        let next = index + 1
+        guard next < arguments.count else {
+            throw ProbeError("missing value after \(flag)")
+        }
+        index = next
+        return arguments[next]
+    }
+
+    private static func timestamp() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd'T'HHmmss'Z'"
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        return formatter.string(from: Date())
+    }
+}
+
+struct ProbeError: Error, CustomStringConvertible {
+    let description: String
+
+    init(_ description: String) {
+        self.description = description
+    }
+}


### PR DESCRIPTION
Vendors the native mFLUX image/video engine (from jjang-ai/vmlx-flux) into vmlx-swift as in-tree SwiftPM targets so the whole vMLX stack shares one MLX runtime.

## Targets added
- `vMLXFluxKit` — protocols, FluxEngine types, requests/events, ModelRegistry, FlowMatch scheduler, VAE, WeightLoader, MLXStudioModelStore, JANG bridge
- `vMLXFluxModels` — concrete models (ZImage native, Flux1/2, Qwen, FIBO, SeedVR2)
- `vMLXFluxVideo` — WAN 2.1/2.2 (scaffold)
- `vMLXFlux` — umbrella (`import vMLXFlux`)
- `vmlxflux-probe` — scan/load/generate verification CLI
- `vMLXFluxTests` — 19 unit tests

## What works
`z-image-turbo` runs a full native pipeline (Qwen-style text encoder + patchify/RoPE/adaLN DiT with noise/context refiners + AutoencoderKL VAE + 4-bit mflux weight decode). Live-proven on the 4-bit mflux bundle:
- same-seed/same-prompt → byte-deterministic
- same-seed/different-prompt → distinct coherent prompt-accurate images
- CFG/negative-prompt path verified; seed sensitivity verified
- resolution/speed: 256²→1.3s · 512²→4.3s · 768²→10.6s · 1024²→20.8s (8-step, 4-bit, M5 Max)
- unit tests 19/19 green

Other models (qwen-image(-edit), flux2-klein, flux1-*, seedvr2, wan-2.x) register but throw `notImplemented` pending per-model text-encoder + weight-key-map ports (see `docs/QWEN_IMAGE_PORT_PLAN.md`).

## Notes
- Deps point at the in-tree MLX/MLXNN/MLXRandom/MLXLMCommon/VMLXTokenizers targets — no new external packages.
- `docs/OSAURUS_VMLX_FLUX_INTEGRATION_SPEC.md` documents the API + the required MetalGate exclusion for image-gen MLX eval (image gen is a 2nd MLX graph and races LLM eval on the shared command buffer, same hazard as the Model2Vec embedder).