### PR TITLE
Add Ideogram fp8 loader support

### DIFF
--- a/Libraries/vMLXFluxKit/WeightLoader.swift
+++ b/Libraries/vMLXFluxKit/WeightLoader.swift
@@ -116,7 +116,7 @@ public enum WeightLoader {
         if !rootShards.isEmpty {
             groups.append(ShardGroup(component: "root", shards: rootShards))
         }
-        for component in ["transformer", "text_encoder", "text_encoder_2", "vae"] {
+        for component in ["transformer", "unconditional_transformer", "text_encoder", "text_encoder_2", "vae"] {
             let componentURL = directory.appendingPathComponent(component, isDirectory: true)
             let shards = try enumerateShards(in: componentURL)
             if !shards.isEmpty {

--- a/Libraries/vMLXFluxModels/Common/MFluxQuant.swift
+++ b/Libraries/vMLXFluxModels/Common/MFluxQuant.swift
@@ -2,12 +2,14 @@
 //  MFluxQuant.swift
 //  vMLXFluxModels
 //
-//  Shared building blocks for native mFLUX model ports (flux1, flux2, qwen).
+//  Shared building blocks for native mFLUX model ports (flux1, flux2, qwen,
+//  ideogram).
 //  These mirror the MLX group-quantization format that mflux's `*-mflux-{4,8}bit`
 //  bundles use for every Linear/Embedding (`weight` + `scales` + `biases`,
-//  group-quantized, bits inferred from shapes). The proven Z-Image native
-//  pipeline uses an equivalent private store; this is the reusable extraction so
-//  flux/qwen don't re-implement quant handling. Plain (non-quantized) params
+//  group-quantized, bits inferred from shapes), plus Ideogram fp8 Linear
+//  weights (`weight` + `weight_scale`). The proven Z-Image native pipeline uses
+//  an equivalent private store; this is the reusable extraction so flux/qwen/
+//  ideogram don't re-implement quant handling. Plain (non-quantized) params
 //  (layer norms, conv bias) are loaded as-is.
 //
 
@@ -64,6 +66,7 @@ final class MFluxStore {
             weight: tensor(component, "\(prefix).weight"),
             scales: optionalTensor(component, "\(prefix).scales"),
             biases: optionalTensor(component, "\(prefix).biases"),
+            weightScale: optionalTensor(component, "\(prefix).weight_scale"),
             bias: bias ? optionalTensor(component, "\(prefix).bias") : nil,
             inputDimensions: inputDimensions,
             outputDimensions: outputDimensions,
@@ -132,12 +135,14 @@ final class MFluxStore {
 
 // MARK: - Layers
 
-/// Linear that runs quantized matmul when `scales` is present, else dense matmul.
-/// Bits + group size are inferred from the packed `weight`/`scales` shapes.
+/// Linear that runs group-quantized matmul when `scales` is present, fp8 decode
+/// when `weight_scale` is present, else dense matmul. Bits + group size are
+/// inferred from the packed `weight`/`scales` shapes.
 final class MFluxLinear {
     private let weight: MLXArray
     private let scales: MLXArray?
     private let biases: MLXArray?
+    private let weightScale: MLXArray?
     private let bias: MLXArray?
     private let groupSize: Int
     private let bits: Int
@@ -146,6 +151,7 @@ final class MFluxLinear {
         weight: MLXArray,
         scales: MLXArray?,
         biases: MLXArray?,
+        weightScale: MLXArray?,
         bias: MLXArray?,
         inputDimensions: Int,
         outputDimensions: Int,
@@ -154,11 +160,24 @@ final class MFluxLinear {
         guard weight.dim(0) == outputDimensions else {
             throw FluxError.invalidRequest("\(name) output mismatch: weight=\(weight.shape), expected output \(outputDimensions)")
         }
+        if scales != nil, weightScale != nil {
+            throw FluxError.invalidRequest("\(name) has both group quant scales and fp8 weight_scale")
+        }
         self.weight = weight
         self.scales = scales
         self.biases = biases
+        self.weightScale = weightScale
         self.bias = bias
-        if scales != nil {
+        if let weightScale {
+            guard weight.dim(1) == inputDimensions else {
+                throw FluxError.invalidRequest("\(name) fp8 input mismatch: weight=\(weight.shape), expected input \(inputDimensions)")
+            }
+            guard weightScale.shape == [outputDimensions] else {
+                throw FluxError.invalidRequest("\(name) invalid fp8 weight_scale \(weightScale.shape), expected [\(outputDimensions)]")
+            }
+            self.bits = 0
+            self.groupSize = 0
+        } else if scales != nil {
             var inferred: Int?
             for candidate in [2, 3, 4, 5, 6, 8] where weight.dim(1) * 32 / candidate == inputDimensions {
                 inferred = candidate; break
@@ -186,6 +205,9 @@ final class MFluxLinear {
         if let scales {
             y = quantizedMM(x, weight, scales: scales, biases: biases,
                             transpose: true, groupSize: groupSize, bits: bits, mode: .affine)
+        } else if let weightScale {
+            let decoded = MLX.fromFP8(weight, dtype: .float32) * weightScale.asType(.float32)[0..., .newAxis]
+            y = matmul(x.asType(.float32), decoded.T)
         } else {
             y = matmul(x, weight.T)
         }

--- a/Libraries/vMLXFluxModels/Ideogram4/Ideogram4.swift
+++ b/Libraries/vMLXFluxModels/Ideogram4/Ideogram4.swift
@@ -13,8 +13,10 @@ import vMLXFluxKit
 //
 // NOTE: ideogram-4 uses **fp8 quantization** (mflux fp8_linear) for the
 // transformer — a DIFFERENT quant path than the MLX group-quant (weight/
-// scales/biases) that flux/qwen/z-image use via MFluxStore. The port needs an
-// fp8 dequant/matmul path. STATUS: scaffold — generate throws notImplemented.
+// scales/biases) that flux/qwen/z-image use via MFluxStore. MFluxStore now has
+// fp8 `weight_scale` Linear support; STATUS: scaffold — generate throws
+// notImplemented until the Qwen3 encoder, DiT, unconditional transformer, and
+// VAE execution path are ported.
 
 public final class Ideogram4: ImageGenerator, @unchecked Sendable {
     public static let _register: Void = {
@@ -48,7 +50,7 @@ public final class Ideogram4: ImageGenerator, @unchecked Sendable {
         AsyncThrowingStream { continuation in
             continuation.finish(throwing: FluxError.notImplemented(
                 "Ideogram4.generate — port from mflux/models/ideogram4 "
-                    + "(Qwen3 encoder + 34-layer fp8 DiT). Needs an fp8 quant path."))
+                    + "(Qwen3 encoder + 34-layer fp8 DiT + unconditional transformer + VAE)."))
         }
     }
 }

--- a/Tests/vMLXFluxTests/LocalModelStoreTests.swift
+++ b/Tests/vMLXFluxTests/LocalModelStoreTests.swift
@@ -1,3 +1,4 @@
+import MLX
 import XCTest
 @testable import vMLXFlux
 @testable import vMLXFluxKit
@@ -127,6 +128,22 @@ final class LocalModelStoreTests: XCTestCase {
         } catch {
             XCTFail("wrong error: \(error)")
         }
+    }
+
+    func testWeightLoaderIncludesIdeogramUnconditionalTransformerComponent() throws {
+        let root = try makeTemporaryImageModelRoot()
+        let model = root.appendingPathComponent("ideogram-4-fp8", isDirectory: true)
+        for component in ["transformer", "text_encoder", "vae", "unconditional_transformer"] {
+            let directory = model.appendingPathComponent(component, isDirectory: true)
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            try MLX.save(
+                arrays: ["input_proj.weight": MLXArray([1, 2], [1, 2]).asType(.float32)],
+                url: directory.appendingPathComponent("diffusion_pytorch_model.safetensors"))
+        }
+
+        let loaded = try WeightLoader.load(from: model)
+
+        XCTAssertNotNil(loaded.componentWeights["unconditional_transformer"]?["input_proj.weight"])
     }
 
     private func makeTemporaryImageModelRoot() throws -> URL {

--- a/Tests/vMLXFluxTests/MFluxStoreTests.swift
+++ b/Tests/vMLXFluxTests/MFluxStoreTests.swift
@@ -29,4 +29,35 @@ final class MFluxStoreTests: XCTestCase {
         XCTAssertEqual(output[0, 0].item(Float.self), 4, accuracy: 0.001)
         XCTAssertEqual(output[0, 1].item(Float.self), 14, accuracy: 0.001)
     }
+
+    func testLinearUsesFp8WeightScaleWhenPresent() throws {
+        let rawWeight = MLXArray(Array(UInt8(1) ... UInt8(6)), [2, 3])
+        let weightScale = MLXArray([Float(0.5), Float(2.0)], [2])
+        let bias = MLXArray([Float(0.25), Float(-0.5)], [2])
+        let loaded = LoadedWeights(
+            weights: [:],
+            componentWeights: [
+                "transformer": [
+                    "fp8.weight": rawWeight,
+                    "fp8.weight_scale": weightScale,
+                    "fp8.bias": bias,
+                ]
+            ])
+        let store = MFluxStore(loaded)
+
+        let linear = try store.linear(
+            "transformer",
+            "fp8",
+            inputDimensions: 3,
+            outputDimensions: 2,
+            bias: true)
+        let x = MLXArray([Float(1), Float(2), Float(3)], [1, 3])
+        let output = linear(x)
+        let decoded = MLX.fromFP8(rawWeight, dtype: .float32) * weightScale[0..., .newAxis]
+        let expected = matmul(x, decoded.T) + bias
+        eval(output, expected)
+
+        XCTAssertEqual(output[0, 0].item(Float.self), expected[0, 0].item(Float.self), accuracy: 0.001)
+        XCTAssertEqual(output[0, 1].item(Float.self), expected[0, 1].item(Float.self), accuracy: 0.001)
+    }
 }

--- a/docs/MFLUX_HANDOFF.md
+++ b/docs/MFLUX_HANDOFF.md
@@ -5,7 +5,8 @@
 are live-proven for 4/8-bit; qwen-image 4-bit and 6-bit are live-proven; qwen-image-edit
 q4/q5 are live-proven for text-image edit after the conditioning-grid fix. qwen-edit
 q3 is incomplete (`text_encoder/3.safetensors` missing from its index), q6 is incomplete on disk, masks are
-not wired, and Ideogram has a staged fp8 mirror bundle but no native
+not wired, and Ideogram has a staged fp8 mirror bundle plus source-level fp8
+linear and unconditional-transformer loading support, but no native
 implementation/live generation proof yet. The current HF account still is not
 approved for the official `ideogram-ai/ideogram-4-nf4` or
 `ideogram-ai/ideogram-4-fp8` repos.
@@ -59,8 +60,11 @@ At that point no complete Ideogram bundle was staged. Later on 2026-06-16,
 `docs/local/vmlx-flux-probes/2026-06-16-ideogram-fp8-mirror-scan/scan.json`
 reports `ideogram-4-fp8` as `readiness=loadableScaffold`, 4 safetensors,
 27,526,985,054 bytes, with tokenizer/text_encoder/transformer/
-unconditional_transformer/vae present. Ideogram still has no live generation
-evidence because `Ideogram4.generate` throws `FluxError.notImplemented`.
+unconditional_transformer/vae present. The next source slice added
+`MFluxLinear` support for fp8 `weight` + `weight_scale` rows and taught
+`WeightLoader` to load the `unconditional_transformer` component. Ideogram still
+has no live generation evidence because `Ideogram4.generate` throws
+`FluxError.notImplemented`.
 Official `hf download --dry-run` for `ideogram-ai/ideogram-4-fp8` still returned
 `Access denied. This repository requires approval.` on 2026-06-16.
 Qwen-Image 6-bit was staged from `filipstrand/Qwen-Image-mflux-6bit` on
@@ -87,7 +91,7 @@ This is the single starting doc. Read it top to bottom, then the per-model port 
 | **flux-schnell** | ✅ proven | ✅ proven | ⬜ (not staged) | `Libraries/vMLXFluxModels/Flux1/Flux1Native.swift` |
 | **qwen-image** (txt2img) | ✅ proven; ✅ 6-bit also proven | ⬜ (public mflux 8-bit not found) | ⬜ | `Libraries/vMLXFluxModels/Common/QwenImageNative.swift` |
 | qwen-image-edit | ✅ q4/q5 text-image edit proven; q3/q6 incomplete | — | — | `Libraries/vMLXFluxModels/QwenImage/QwenImageEditSupport.swift`; masks/inpaint pending |
-| ideogram (4) | ⬜ scaffold; fp8 mirror staged/scans loadable; no live generation proof | — | — | `Libraries/vMLXFluxModels/Ideogram4/Ideogram4.swift` (fp8/nf4 path missing) |
+| ideogram (4) | ⬜ scaffold; fp8 mirror staged/scans loadable; fp8 linear + unconditional transformer loading source-supported; no live generation proof | — | — | `Libraries/vMLXFluxModels/Ideogram4/Ideogram4.swift` (native pipeline missing) |
 | flux1-dev/kontext/fill, flux2-klein, fibo, seedvr2, wan | ⬜ scaffold | — | — | registered, throw `notImplemented` |
 
 "Proven" = live-generated a coherent, prompt-accurate image that is **deterministic** (same seed+prompt -> byte-identical) and **prompt-sensitive** (different prompt same seed -> different coherent image). Per Eric's HARD RULE: *do not trust/claim a model works until you have generated and visually checked a real image.* 2026-06-16 rerun: z-image 4/8 and flux-schnell 4/8 passed live load + three-turn generate + SHA determinism/prompt-sensitivity + visual inspection. Qwen-image 4-bit also passed live load + 20-step generation + three-turn SHA determinism/prompt-sensitivity + visual inspection after the mflux guidance rescale fix; turn 1/3 apple SHA `2f1c27c68993fe9a537bca2cc019ac3d32d59818b92c606c00726104661bcea7`, turn 2 mountain SHA `2bf77ce59c8ed99c1b1aa5fb8940c9d35948b1763fbd360e14f577032b62f060`, artifact `docs/local/vmlx-flux-probes/2026-06-16-qwen-image-q4-guidance-proof/qwen-image-mflux-4bit-load.json`. Qwen-image 6-bit also passed live load + 20-step three-turn SHA determinism/prompt-sensitivity + visual inspection; turn 1/3 apple SHA `66e8187e887087e8a8e9227a99f16236c5ba15717a5e31e08a5772868b3a456a`, turn 2 mountain SHA `44069312716932d6d72181a808625a33777ed29af7723eea8f76b0ac5ba96a52`, artifact `docs/local/vmlx-flux-probes/2026-06-16-qwen-image-6bit-gen20-after-key-fix/Qwen-Image-mflux-6bit-load.json`.
@@ -95,7 +99,7 @@ This is the single starting doc. Read it top to bottom, then the per-model port 
 Qwen-image-edit q4/q5 are live-proven after fixing the source-image conditioning grid to match mflux. Source trace: mflux `qwen_image_edit.py` passes `vl_width/vl_height` into `QwenEditUtil.create_image_conditioning_latents`, and `qwen_edit_util.py` uses those VL dimensions for the source-image VAE encode when present. Swift now mirrors that in `QwenImageEditSupport.swift`: square source images encode conditioning at 384x384, pack 24x24=576 static latents, and denoise with 1024 target latents + 576 conditioning latents. q4 live proof artifact: `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-determinism-after-cond-fix/Qwen-Image-Edit-mflux-q4-load.json` (blue prompt SHA `005ab8baddfe9b7a94aa83f8ddd22d192e7e5a0275c556dcf2ead76a565e474a`, green-pear prompt SHA `815711be73a9e89599b3e97f9f15196115875103f9407d7b1b61bab33de8e3b4`, repeated blue prompt same SHA). q5 live proof artifact: `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q5-determinism/Qwen-Image-Edit-mflux-q5-load.json` (blue prompt SHA `5cd5d9197bd659bd8b59b4a2f2bca413266146ad4e08249289d5fa6a8025fa4e`, green-pear prompt SHA `d2c6c4eb4a19dcf48122b5216fc15ac37b9f5aa49c15f596acd1276a4df57034`, repeated blue prompt same SHA). Viewed q4/q5 outputs are coherent and prompt-sensitive. Boundary artifacts remain useful: `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-prompt-live/Qwen-Image-Edit-mflux-q4-load.json`, `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-vl-encode-live/Qwen-Image-Edit-mflux-q4-load.json`, `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-conditioning-after-cond-fix/Qwen-Image-Edit-mflux-q4-load.json`, and `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-denoise-after-cond-fix/Qwen-Image-Edit-mflux-q4-load.json`.
 
 **Next work, in priority order:**
-1. **Ideogram 4** — local fp8 mirror bundle is now staged; implement the **fp8/nf4 quant path** (different from the MLX group-quant used by the others) + Qwen3 encoder + 34-layer DiT + unconditional transformer + VAE, then live-prove. Official `ideogram-ai/*` approval is still needed for canonical official bundles.
+1. **Ideogram 4** — local fp8 mirror bundle is now staged; `MFluxStore` can decode fp8 linear `weight_scale` rows and `WeightLoader` now includes the `unconditional_transformer` component. Next implement the Qwen3 encoder + 34-layer DiT + unconditional transformer execution + VAE path, extend nf4 if needed, then live-prove. Official `ideogram-ai/*` approval is still needed for canonical official bundles.
 2. **qwen-image-edit follow-through** — wire real masks/inpaint semantics. Today non-null masks are rejected before the edit pipeline loads; q3/q6 need complete local bundles before they can be exposed.
 3. **Full-precision** flux-schnell + z-image (download + prove with existing pipelines — should "just work").
 4. Consolidated PR of all the new models to `osaurus-ai/vmlx-swift` main.
@@ -182,8 +186,10 @@ DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter vML
   Current account state: both repos are visible through `hf models info`, but
   `hf download --dry-run` is approval-gated (`Access denied. This repository
   requires approval.`). The third-party `cocktailpeanut/ideogram-4-fp8` mirror is
-  staged locally and scans complete; live Ideogram generation remains blocked on
-  the missing native pipeline and fp8/nf4 path, not on local mirror availability.
+  staged locally and scans complete. `MFluxStore` now covers the fp8
+  `weight_scale` linear format and `WeightLoader` loads the
+  `unconditional_transformer` shard group; live Ideogram generation remains
+  blocked on the missing native pipeline, not on local mirror availability.
 
 **TOKENIZER GOTCHA:** mflux bundles ship SLOW tokenizers (CLIP vocab.json+merges, T5 spiece.model). swift-transformers' `AutoTokenizer.from(modelFolder:)` needs `tokenizer.json` (fast). Convert once:
 ```python
@@ -285,7 +291,7 @@ Full per-model transcription specs are in `docs/FLUX_SCHNELL_PORT_PLAN.md` and `
 ## 9. How to continue (concrete next steps)
 1. **qwen-image-edit:** the q4/q5 text-image edit paths are live-proven. Source-image conditioning now follows mflux's VL-size path (`vlWidth/vlHeight`) instead of the 1024-area VAE target grid. Current proof artifacts: `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-determinism-after-cond-fix/Qwen-Image-Edit-mflux-q4-load.json`, `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q5-determinism/Qwen-Image-Edit-mflux-q5-load.json`, `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-conditioning-after-cond-fix/Qwen-Image-Edit-mflux-q4-load.json` (`latents_shape=1x576x64`, `image_ids_shape=1x576x3`), and `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-denoise-after-cond-fix/Qwen-Image-Edit-mflux-q4-load.json` (`combined_velocity_shape=1x1600x64`). Current non-null masks are rejected before pipeline load; next qwen-edit work is real masks/inpaint semantics and complete q3/q6 bundle staging if those variants matter.
    - Current staged bundle is already present at `~/.mlxstudio/models/image/Qwen-Image-Edit-mflux`; use `Qwen-Image-Edit-mflux-q4` or `Qwen-Image-Edit-mflux-q5` for current Osaurus wiring. Keep q3/q6 hidden/blocked until their indexed shards/components are complete.
-2. **Ideogram 4:** `cocktailpeanut/ideogram-4-fp8` is staged locally and scans complete; official `ideogram-ai/*` access remains approval-gated. Port = Qwen3 text encoder (close to the qwen LM encoder) + 34-layer DiT (emb 4608, 18 heads, `llm_features 4096×13` = multi-layer Qwen3 hidden states, rope θ5e6) + unconditional transformer + VAE. **Build an fp8/nf4 dequant/matmul path** in `MFluxStore` (the transformer is fp8 in the mflux canonical bundle, not group-quant). Ref: `/tmp/mflux-ref/src/mflux/models/ideogram4/`.
+2. **Ideogram 4:** `cocktailpeanut/ideogram-4-fp8` is staged locally and scans complete; official `ideogram-ai/*` access remains approval-gated. Port = Qwen3 text encoder (close to the qwen LM encoder) + 34-layer DiT (emb 4608, 18 heads, `llm_features 4096×13` = multi-layer Qwen3 hidden states, rope θ5e6) + unconditional transformer execution + VAE. `MFluxStore` already has the fp8 `weight_scale` linear path and `WeightLoader` already includes `unconditional_transformer`; remaining quant work is nf4 if that bundle is used. Ref: `/tmp/mflux-ref/src/mflux/models/ideogram4/`.
 3. **Full precision** flux/z-image: download, run the probe — existing pipelines (`MFluxLinear` handles non-quant). Should just work.
 4. **Consolidated osaurus PR:** keep `codex/mflux-qwen-edit-main` rebased on
    current `vmlx-origin/main`, keep standalone imports rewritten to

--- a/docs/OSAURUS_IMAGE_API_SPEC.md
+++ b/docs/OSAURUS_IMAGE_API_SPEC.md
@@ -19,7 +19,9 @@ contract osaurus implements server-side and the UI builds against.
 > local bundle is complete, and hide mask/inpaint controls until wired.
 > Ideogram has a complete local fp8 mirror bundle staged from
 > `cocktailpeanut/ideogram-4-fp8`, and the scanner reports it as loadable
-> scaffold. Keep it disabled because the native `Ideogram4.generate` body still
+> scaffold. The shared source can now load Ideogram's
+> `unconditional_transformer` component and decode fp8 linear `weight_scale`
+> rows. Keep it disabled because the native `Ideogram4.generate` body still
 > throws `FluxError.notImplemented`, and no live generation proof exists.
 > Official `ideogram-ai/*` downloads still require approval for the current
 > account.

--- a/docs/OSAURUS_VMLX_FLUX_INTEGRATION_SPEC.md
+++ b/docs/OSAURUS_VMLX_FLUX_INTEGRATION_SPEC.md
@@ -38,9 +38,11 @@
   because its text-encoder index references missing `text_encoder/3.safetensors`,
   q6 is incomplete, and mask/inpaint editing is not wired. A complete
   `cocktailpeanut/ideogram-4-fp8` mirror bundle is now staged locally and scans
-  as `loadableScaffold`, but Ideogram still has no native generation proof
-  because `Ideogram4.generate` is not implemented. Official `ideogram-ai/*`
-  downloads are still approval-gated for the current account. See §6 and §7b.
+  as `loadableScaffold`. The shared loader now covers fp8 linear
+  `weight_scale` rows and the `unconditional_transformer` component, but
+  Ideogram still has no native generation proof because `Ideogram4.generate` is
+  not implemented. Official `ideogram-ai/*` downloads are still approval-gated
+  for the current account. See §6 and §7b.
 
 ---
 
@@ -283,7 +285,7 @@ their 4-bit linears through scale tensors at load time inside the model.
 | flux2-klein / flux2-klein-edit | `not_implemented` | Bundle scans + loads; `FluxDiTConfig.flux2Klein` preset exists. | T5 (single-encoder) port + weight key-map + 3-axis RoPE. |
 | **flux1-schnell** | `native_pipeline_implemented` | Full native pipeline `Flux1Native.swift`: T5-XXL + CLIP-L encoders, full DiT (19 joint + 38 single blocks, 24h×128, 3-axis RoPE), AutoencoderKL VAE, mflux decode. Fresh 2026-06-16 proof: 4-bit + 8-bit live load, 3 completed turns, same-prompt SHA match, different-prompt SHA change, viewed coherent apple/mountain images. | tokenizer.json must be staged (mflux ships slow tokenizers — convert; see port plan). Full precision pending. |
 | flux1-dev/kontext/fill | `not_implemented` | dev = schnell + guidance embedder (small add); kontext/fill = edit variants. | wire guidance + edit conditioning on the working schnell pipeline. |
-| **ideogram** (Ideogram 4) | `not_implemented` (scaffold registered) | Strong text/typography renderer. mflux-compatible official weights: `ideogram-ai/ideogram-4-fp8` or `ideogram-ai/ideogram-4-nf4` (4-bit). Official HF metadata is reachable, but official downloads still require approval for the current account. A complete fp8 mirror bundle, `cocktailpeanut/ideogram-4-fp8`, is staged at `~/.mlxstudio/models/image/ideogram-4-fp8`; scan artifact `docs/local/vmlx-flux-probes/2026-06-16-ideogram-fp8-mirror-scan/scan.json` reports `readiness=loadableScaffold`, 4 safetensors, 27,526,985,054 bytes, and tokenizer/text_encoder/transformer/unconditional_transformer/vae present. | Native generation is still missing: `Ideogram4.generate` throws `FluxError.notImplemented`, so there is no live load/generation proof. Port Qwen3 text encoder (reuse Qwen LM pattern) + 34-layer DiT (emb 4608, 18 heads, llm_features 4096×13 multi-layer, rope 5e6) + unconditional transformer + VAE. **Needs an fp8/nf4 quant path** (mflux fp8_linear for the canonical fp8 bundle) — different from the MLX group-quant the others use. |
+| **ideogram** (Ideogram 4) | `not_implemented` (scaffold registered) | Strong text/typography renderer. mflux-compatible official weights: `ideogram-ai/ideogram-4-fp8` or `ideogram-ai/ideogram-4-nf4` (4-bit). Official HF metadata is reachable, but official downloads still require approval for the current account. A complete fp8 mirror bundle, `cocktailpeanut/ideogram-4-fp8`, is staged at `~/.mlxstudio/models/image/ideogram-4-fp8`; scan artifact `docs/local/vmlx-flux-probes/2026-06-16-ideogram-fp8-mirror-scan/scan.json` reports `readiness=loadableScaffold`, 4 safetensors, 27,526,985,054 bytes, and tokenizer/text_encoder/transformer/unconditional_transformer/vae present. Shared source now supports fp8 linear `weight_scale` rows and loads the `unconditional_transformer` shard group. | Native generation is still missing: `Ideogram4.generate` throws `FluxError.notImplemented`, so there is no live load/generation proof. Port Qwen3 text encoder (reuse Qwen LM pattern) + 34-layer DiT execution (emb 4608, 18 heads, llm_features 4096×13 multi-layer, rope 5e6) + unconditional transformer execution + VAE. Remaining quant work is nf4 if that bundle is used. |
 | seedvr2 | scaffold | registered | upscale arch (different family). |
 | wan-2.1 / wan-2.2 | scaffold | full pipeline scaffolded (WanVAE3D + WanDiT + MP4 writer) with random weights. | real weight key-map, real Conv3d (currently a Conv2d shim), windowed attention for >3-4s clips. |
 

--- a/tools/vMLXFluxProbe/main.swift
+++ b/tools/vMLXFluxProbe/main.swift
@@ -672,7 +672,7 @@ struct VMLXFluxProbe {
                 "Ideogram4.generate body throws FluxError.notImplemented",
                 "local ideogram-4-fp8 mirror bundle is staged and scans loadable, but live generation is blocked until the native pipeline is implemented",
                 "official ideogram-ai/ideogram-4-fp8 and ideogram-ai/ideogram-4-nf4 downloads still require approval for the current HF account",
-                "Qwen3 text encoder, 34-layer DiT key mapping, unconditional transformer, VAE, and fp8/nf4 quant path are missing",
+                "Qwen3 text encoder, 34-layer DiT execution, unconditional transformer execution, VAE, and nf4 support are missing; shared fp8 Linear weight_scale support is present",
             ]
         case "wan-2.1", "wan-2.2":
             return [


### PR DESCRIPTION
## Summary
- Add shared MFlux fp8 Linear support for Ideogram-style `weight` + `weight_scale` rows.
- Include `unconditional_transformer` in component shard loading and cover it with a regression test.
- Update Ideogram scaffold/probe/docs so Osaurus keeps Ideogram disabled until Qwen3/DiT/unconditional-transformer/VAE generation is implemented and live-proven.

## Validation
- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter MFluxStoreTests/testLinearUsesFp8WeightScaleWhenPresent`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter LocalModelStoreTests/testWeightLoaderIncludesIdeogramUnconditionalTransformerComponent`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter vMLXFluxTests` (46 tests, 0 failures)
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build --product vmlxflux-probe`
- `.build/arm64-apple-macosx/debug/vmlxflux-probe --root /Users/eric/.mlxstudio/models/image --model ideogram-4-fp8 --artifacts docs/local/vmlx-flux-probes/2026-06-16-ideogram-fp8-after-fp8-linear`

## Boundary
- Ideogram remains `not_implemented`: scan shows the staged fp8 mirror is loadable scaffold, but `Ideogram4.generate` still throws until the native pipeline is ported.