### PR TITLE
Validate Ideogram fp8 load path

### DIFF
--- a/Libraries/vMLXFluxModels/Ideogram4/Ideogram4.swift
+++ b/Libraries/vMLXFluxModels/Ideogram4/Ideogram4.swift
@@ -36,6 +36,8 @@ public final class Ideogram4: ImageGenerator, @unchecked Sendable {
 
     public let modelPath: URL
     public let quantize: Int?
+    public let loadedWeights: LoadedWeights
+    private let store: MFluxStore
 
     public init(modelPath: URL, quantize: Int?) throws {
         self.modelPath = modelPath
@@ -44,6 +46,10 @@ public final class Ideogram4: ImageGenerator, @unchecked Sendable {
         guard FileManager.default.fileExists(atPath: modelPath.path) else {
             throw FluxError.weightsNotFound(modelPath)
         }
+        let loaded = try WeightLoader.load(from: modelPath)
+        try Ideogram4BundleValidator.validate(modelPath, loaded: loaded)
+        self.loadedWeights = loaded
+        self.store = MFluxStore(loaded)
     }
 
     public func generate(_ request: ImageGenRequest) -> AsyncThrowingStream<ImageGenEvent, Error> {
@@ -51,6 +57,66 @@ public final class Ideogram4: ImageGenerator, @unchecked Sendable {
             continuation.finish(throwing: FluxError.notImplemented(
                 "Ideogram4.generate — port from mflux/models/ideogram4 "
                     + "(Qwen3 encoder + 34-layer fp8 DiT + unconditional transformer + VAE)."))
+        }
+    }
+}
+
+enum Ideogram4BundleValidator {
+    private static let requiredFiles = [
+        "tokenizer/tokenizer.json",
+    ]
+
+    private static let requiredWeightsByComponent: [String: [String]] = [
+        "text_encoder": [
+            "language_model.embed_tokens.weight",
+            "language_model.layers.0.self_attn.q_proj.weight",
+            "language_model.layers.35.mlp.down_proj.weight",
+            "language_model.norm.weight",
+        ],
+        "transformer": [
+            "input_proj.weight",
+            "input_proj.weight_scale",
+            "llm_cond_proj.weight",
+            "layers.0.attention.qkv.weight",
+            "layers.33.feed_forward.w3.weight",
+            "final_layer.linear.weight",
+        ],
+        "unconditional_transformer": [
+            "input_proj.weight",
+            "input_proj.weight_scale",
+            "layers.0.attention.qkv.weight",
+            "layers.33.feed_forward.w3.weight",
+            "final_layer.linear.weight",
+        ],
+        "vae": [
+            "decoder.conv_in.weight",
+            "decoder.conv_out.weight",
+            "post_quant_conv.weight",
+        ],
+    ]
+
+    static func validate(_ modelPath: URL, loaded: LoadedWeights) throws {
+        let fm = FileManager.default
+        var reasons: [String] = []
+        for relativePath in requiredFiles {
+            let url = modelPath.appendingPathComponent(relativePath)
+            if !fm.fileExists(atPath: url.path) {
+                reasons.append("missing \(relativePath)")
+            }
+        }
+
+        for component in requiredWeightsByComponent.keys.sorted() {
+            guard let weights = loaded.componentWeights[component], !weights.isEmpty else {
+                reasons.append("missing \(component) component")
+                continue
+            }
+            for key in requiredWeightsByComponent[component, default: []] where weights[key] == nil {
+                reasons.append("missing \(component) weight \(key)")
+            }
+        }
+
+        if !reasons.isEmpty {
+            throw FluxError.localModelIncomplete(modelPath, reasons: reasons)
         }
     }
 }

--- a/Tests/vMLXFluxTests/RegistryTests.swift
+++ b/Tests/vMLXFluxTests/RegistryTests.swift
@@ -1,3 +1,4 @@
+import MLX
 import XCTest
 @testable import vMLXFlux
 @testable import vMLXFluxKit
@@ -107,6 +108,30 @@ final class RegistryTests: XCTestCase {
         }
     }
 
+    func testIdeogramLoadRejectsBundleMissingUnconditionalTransformerKeys() async throws {
+        let model = try makeTemporaryIdeogramBundle(includeUnconditionalTransformer: false)
+        let engine = FluxEngine()
+
+        do {
+            try await engine.load(name: "ideogram", modelPath: model)
+            XCTFail("expected incomplete Ideogram bundle rejection")
+        } catch FluxError.localModelIncomplete(let url, let reasons) {
+            XCTAssertEqual(url.lastPathComponent, model.lastPathComponent)
+            XCTAssertTrue(
+                reasons.contains("missing unconditional_transformer component"),
+                "blocked reasons: \(reasons)")
+        } catch {
+            XCTFail("wrong error: \(error)")
+        }
+    }
+
+    func testIdeogramLoadAcceptsRequiredFp8Components() async throws {
+        let model = try makeTemporaryIdeogramBundle(includeUnconditionalTransformer: true)
+        let engine = FluxEngine()
+
+        try await engine.load(name: "ideogram", modelPath: model)
+    }
+
     func testEngineGenerateRequiresLoad() async {
         let engine = FluxEngine()
         let request = ImageGenRequest(
@@ -188,5 +213,72 @@ final class RegistryTests: XCTestCase {
         try data.write(to: url)
         try Data([0]).write(
             to: url.deletingLastPathComponent().appendingPathComponent("0.safetensors"))
+    }
+
+    private func makeTemporaryIdeogramBundle(includeUnconditionalTransformer: Bool) throws -> URL {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vmlx-flux-ideogram-tests-\(UUID().uuidString)", isDirectory: true)
+        addTeardownBlock {
+            try? FileManager.default.removeItem(at: root)
+        }
+        let model = root.appendingPathComponent("ideogram-4-fp8", isDirectory: true)
+        let fm = FileManager.default
+        try fm.createDirectory(
+            at: model.appendingPathComponent("tokenizer", isDirectory: true),
+            withIntermediateDirectories: true)
+        try Data("{}".utf8).write(to: model.appendingPathComponent("tokenizer/tokenizer.json"))
+
+        try writeSafetensor(
+            keys: [
+                "language_model.embed_tokens.weight",
+                "language_model.layers.0.self_attn.q_proj.weight",
+                "language_model.layers.35.mlp.down_proj.weight",
+                "language_model.norm.weight",
+            ],
+            component: "text_encoder",
+            model: model)
+        try writeSafetensor(
+            keys: [
+                "input_proj.weight",
+                "input_proj.weight_scale",
+                "llm_cond_proj.weight",
+                "layers.0.attention.qkv.weight",
+                "layers.33.feed_forward.w3.weight",
+                "final_layer.linear.weight",
+            ],
+            component: "transformer",
+            model: model)
+        if includeUnconditionalTransformer {
+            try writeSafetensor(
+                keys: [
+                    "input_proj.weight",
+                    "input_proj.weight_scale",
+                    "layers.0.attention.qkv.weight",
+                    "layers.33.feed_forward.w3.weight",
+                    "final_layer.linear.weight",
+                ],
+                component: "unconditional_transformer",
+                model: model)
+        }
+        try writeSafetensor(
+            keys: [
+                "decoder.conv_in.weight",
+                "decoder.conv_out.weight",
+                "post_quant_conv.weight",
+            ],
+            component: "vae",
+            model: model)
+        return model
+    }
+
+    private func writeSafetensor(keys: [String], component: String, model: URL) throws {
+        let directory = model.appendingPathComponent(component, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let arrays = Dictionary(uniqueKeysWithValues: keys.map {
+            ($0, MLXArray([Float(1)], [1]))
+        })
+        try MLX.save(
+            arrays: arrays,
+            url: directory.appendingPathComponent("diffusion_pytorch_model.safetensors"))
     }
 }

--- a/docs/MFLUX_HANDOFF.md
+++ b/docs/MFLUX_HANDOFF.md
@@ -6,7 +6,8 @@ are live-proven for 4/8-bit; qwen-image 4-bit and 6-bit are live-proven; qwen-im
 q4/q5 are live-proven for text-image edit after the conditioning-grid fix. qwen-edit
 q3 is incomplete (`text_encoder/3.safetensors` missing from its index), q6 is incomplete on disk, masks are
 not wired, and Ideogram has a staged fp8 mirror bundle plus source-level fp8
-linear and unconditional-transformer loading support, but no native
+linear support plus load-time sentinel validation for its conditional and
+unconditional transformer components, but no native
 implementation/live generation proof yet. The current HF account still is not
 approved for the official `ideogram-ai/ideogram-4-nf4` or
 `ideogram-ai/ideogram-4-fp8` repos.
@@ -65,6 +66,12 @@ unconditional_transformer/vae present. The next source slice added
 `WeightLoader` to load the `unconditional_transformer` component. Ideogram still
 has no live generation evidence because `Ideogram4.generate` throws
 `FluxError.notImplemented`.
+Follow-up load proof after the validation gate:
+`docs/local/vmlx-flux-probes/2026-06-16-ideogram-fp8-honest-load/ideogram-4-fp8-load.json`
+reports `load_status=loaded`, records `load_elapsed_seconds`, reports
+`native_runtime_status=not_implemented`, and confirms the same
+27,526,985,054-byte staged bundle. This proves direct engine load now reaches
+the Ideogram loader and sentinel-key validator, not only the scanner.
 Official `hf download --dry-run` for `ideogram-ai/ideogram-4-fp8` still returned
 `Access denied. This repository requires approval.` on 2026-06-16.
 Qwen-Image 6-bit was staged from `filipstrand/Qwen-Image-mflux-6bit` on
@@ -91,7 +98,7 @@ This is the single starting doc. Read it top to bottom, then the per-model port 
 | **flux-schnell** | ✅ proven | ✅ proven | ⬜ (not staged) | `Libraries/vMLXFluxModels/Flux1/Flux1Native.swift` |
 | **qwen-image** (txt2img) | ✅ proven; ✅ 6-bit also proven | ⬜ (public mflux 8-bit not found) | ⬜ | `Libraries/vMLXFluxModels/Common/QwenImageNative.swift` |
 | qwen-image-edit | ✅ q4/q5 text-image edit proven; q3/q6 incomplete | — | — | `Libraries/vMLXFluxModels/QwenImage/QwenImageEditSupport.swift`; masks/inpaint pending |
-| ideogram (4) | ⬜ scaffold; fp8 mirror staged/scans loadable; fp8 linear + unconditional transformer loading source-supported; no live generation proof | — | — | `Libraries/vMLXFluxModels/Ideogram4/Ideogram4.swift` (native pipeline missing) |
+| ideogram (4) | ⬜ scaffold; fp8 mirror staged/scans loadable; direct load validates fp8 sentinel keys; no live generation proof | — | — | `Libraries/vMLXFluxModels/Ideogram4/Ideogram4.swift` (native pipeline missing) |
 | flux1-dev/kontext/fill, flux2-klein, fibo, seedvr2, wan | ⬜ scaffold | — | — | registered, throw `notImplemented` |
 
 "Proven" = live-generated a coherent, prompt-accurate image that is **deterministic** (same seed+prompt -> byte-identical) and **prompt-sensitive** (different prompt same seed -> different coherent image). Per Eric's HARD RULE: *do not trust/claim a model works until you have generated and visually checked a real image.* 2026-06-16 rerun: z-image 4/8 and flux-schnell 4/8 passed live load + three-turn generate + SHA determinism/prompt-sensitivity + visual inspection. Qwen-image 4-bit also passed live load + 20-step generation + three-turn SHA determinism/prompt-sensitivity + visual inspection after the mflux guidance rescale fix; turn 1/3 apple SHA `2f1c27c68993fe9a537bca2cc019ac3d32d59818b92c606c00726104661bcea7`, turn 2 mountain SHA `2bf77ce59c8ed99c1b1aa5fb8940c9d35948b1763fbd360e14f577032b62f060`, artifact `docs/local/vmlx-flux-probes/2026-06-16-qwen-image-q4-guidance-proof/qwen-image-mflux-4bit-load.json`. Qwen-image 6-bit also passed live load + 20-step three-turn SHA determinism/prompt-sensitivity + visual inspection; turn 1/3 apple SHA `66e8187e887087e8a8e9227a99f16236c5ba15717a5e31e08a5772868b3a456a`, turn 2 mountain SHA `44069312716932d6d72181a808625a33777ed29af7723eea8f76b0ac5ba96a52`, artifact `docs/local/vmlx-flux-probes/2026-06-16-qwen-image-6bit-gen20-after-key-fix/Qwen-Image-mflux-6bit-load.json`.
@@ -99,7 +106,7 @@ This is the single starting doc. Read it top to bottom, then the per-model port 
 Qwen-image-edit q4/q5 are live-proven after fixing the source-image conditioning grid to match mflux. Source trace: mflux `qwen_image_edit.py` passes `vl_width/vl_height` into `QwenEditUtil.create_image_conditioning_latents`, and `qwen_edit_util.py` uses those VL dimensions for the source-image VAE encode when present. Swift now mirrors that in `QwenImageEditSupport.swift`: square source images encode conditioning at 384x384, pack 24x24=576 static latents, and denoise with 1024 target latents + 576 conditioning latents. q4 live proof artifact: `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-determinism-after-cond-fix/Qwen-Image-Edit-mflux-q4-load.json` (blue prompt SHA `005ab8baddfe9b7a94aa83f8ddd22d192e7e5a0275c556dcf2ead76a565e474a`, green-pear prompt SHA `815711be73a9e89599b3e97f9f15196115875103f9407d7b1b61bab33de8e3b4`, repeated blue prompt same SHA). q5 live proof artifact: `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q5-determinism/Qwen-Image-Edit-mflux-q5-load.json` (blue prompt SHA `5cd5d9197bd659bd8b59b4a2f2bca413266146ad4e08249289d5fa6a8025fa4e`, green-pear prompt SHA `d2c6c4eb4a19dcf48122b5216fc15ac37b9f5aa49c15f596acd1276a4df57034`, repeated blue prompt same SHA). Viewed q4/q5 outputs are coherent and prompt-sensitive. Boundary artifacts remain useful: `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-prompt-live/Qwen-Image-Edit-mflux-q4-load.json`, `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-vl-encode-live/Qwen-Image-Edit-mflux-q4-load.json`, `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-conditioning-after-cond-fix/Qwen-Image-Edit-mflux-q4-load.json`, and `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-denoise-after-cond-fix/Qwen-Image-Edit-mflux-q4-load.json`.
 
 **Next work, in priority order:**
-1. **Ideogram 4** — local fp8 mirror bundle is now staged; `MFluxStore` can decode fp8 linear `weight_scale` rows and `WeightLoader` now includes the `unconditional_transformer` component. Next implement the Qwen3 encoder + 34-layer DiT + unconditional transformer execution + VAE path, extend nf4 if needed, then live-prove. Official `ideogram-ai/*` approval is still needed for canonical official bundles.
+1. **Ideogram 4** — local fp8 mirror bundle is now staged; `MFluxStore` can decode fp8 linear `weight_scale` rows, `WeightLoader` includes `unconditional_transformer`, and direct load validates sentinel keys from text encoder/conditional transformer/unconditional transformer/VAE. Next implement the Qwen3 encoder + 34-layer DiT + unconditional transformer execution + VAE path, extend nf4 if needed, then live-prove. Official `ideogram-ai/*` approval is still needed for canonical official bundles.
 2. **qwen-image-edit follow-through** — wire real masks/inpaint semantics. Today non-null masks are rejected before the edit pipeline loads; q3/q6 need complete local bundles before they can be exposed.
 3. **Full-precision** flux-schnell + z-image (download + prove with existing pipelines — should "just work").
 4. Consolidated PR of all the new models to `osaurus-ai/vmlx-swift` main.
@@ -188,8 +195,10 @@ DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter vML
   requires approval.`). The third-party `cocktailpeanut/ideogram-4-fp8` mirror is
   staged locally and scans complete. `MFluxStore` now covers the fp8
   `weight_scale` linear format and `WeightLoader` loads the
-  `unconditional_transformer` shard group; live Ideogram generation remains
-  blocked on the missing native pipeline, not on local mirror availability.
+  `unconditional_transformer` shard group. Direct load now validates sentinel
+  keys from the text encoder, transformer, unconditional transformer, and VAE;
+  live Ideogram generation remains blocked on the missing native pipeline, not
+  on local mirror availability.
 
 **TOKENIZER GOTCHA:** mflux bundles ship SLOW tokenizers (CLIP vocab.json+merges, T5 spiece.model). swift-transformers' `AutoTokenizer.from(modelFolder:)` needs `tokenizer.json` (fast). Convert once:
 ```python
@@ -291,7 +300,7 @@ Full per-model transcription specs are in `docs/FLUX_SCHNELL_PORT_PLAN.md` and `
 ## 9. How to continue (concrete next steps)
 1. **qwen-image-edit:** the q4/q5 text-image edit paths are live-proven. Source-image conditioning now follows mflux's VL-size path (`vlWidth/vlHeight`) instead of the 1024-area VAE target grid. Current proof artifacts: `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-determinism-after-cond-fix/Qwen-Image-Edit-mflux-q4-load.json`, `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q5-determinism/Qwen-Image-Edit-mflux-q5-load.json`, `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-conditioning-after-cond-fix/Qwen-Image-Edit-mflux-q4-load.json` (`latents_shape=1x576x64`, `image_ids_shape=1x576x3`), and `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-denoise-after-cond-fix/Qwen-Image-Edit-mflux-q4-load.json` (`combined_velocity_shape=1x1600x64`). Current non-null masks are rejected before pipeline load; next qwen-edit work is real masks/inpaint semantics and complete q3/q6 bundle staging if those variants matter.
    - Current staged bundle is already present at `~/.mlxstudio/models/image/Qwen-Image-Edit-mflux`; use `Qwen-Image-Edit-mflux-q4` or `Qwen-Image-Edit-mflux-q5` for current Osaurus wiring. Keep q3/q6 hidden/blocked until their indexed shards/components are complete.
-2. **Ideogram 4:** `cocktailpeanut/ideogram-4-fp8` is staged locally and scans complete; official `ideogram-ai/*` access remains approval-gated. Port = Qwen3 text encoder (close to the qwen LM encoder) + 34-layer DiT (emb 4608, 18 heads, `llm_features 4096×13` = multi-layer Qwen3 hidden states, rope θ5e6) + unconditional transformer execution + VAE. `MFluxStore` already has the fp8 `weight_scale` linear path and `WeightLoader` already includes `unconditional_transformer`; remaining quant work is nf4 if that bundle is used. Ref: `/tmp/mflux-ref/src/mflux/models/ideogram4/`.
+2. **Ideogram 4:** `cocktailpeanut/ideogram-4-fp8` is staged locally, scans complete, and load-validates required sentinel keys; official `ideogram-ai/*` access remains approval-gated. Port = Qwen3 text encoder (close to the qwen LM encoder) + 34-layer DiT (emb 4608, 18 heads, `llm_features 4096×13` = multi-layer Qwen3 hidden states, rope θ5e6) + unconditional transformer execution + VAE. `MFluxStore` already has the fp8 `weight_scale` linear path and `WeightLoader` already includes `unconditional_transformer`; remaining quant work is nf4 if that bundle is used. Ref: `/tmp/mflux-ref/src/mflux/models/ideogram4/`.
 3. **Full precision** flux/z-image: download, run the probe — existing pipelines (`MFluxLinear` handles non-quant). Should just work.
 4. **Consolidated osaurus PR:** keep `codex/mflux-qwen-edit-main` rebased on
    current `vmlx-origin/main`, keep standalone imports rewritten to

--- a/docs/OSAURUS_IMAGE_API_SPEC.md
+++ b/docs/OSAURUS_IMAGE_API_SPEC.md
@@ -21,7 +21,9 @@ contract osaurus implements server-side and the UI builds against.
 > `cocktailpeanut/ideogram-4-fp8`, and the scanner reports it as loadable
 > scaffold. The shared source can now load Ideogram's
 > `unconditional_transformer` component and decode fp8 linear `weight_scale`
-> rows. Keep it disabled because the native `Ideogram4.generate` body still
+> rows; direct load validates required sentinel keys from text encoder,
+> conditional transformer, unconditional transformer, and VAE. Keep it disabled
+> because the native `Ideogram4.generate` body still
 > throws `FluxError.notImplemented`, and no live generation proof exists.
 > Official `ideogram-ai/*` downloads still require approval for the current
 > account.

--- a/docs/OSAURUS_VMLX_FLUX_INTEGRATION_SPEC.md
+++ b/docs/OSAURUS_VMLX_FLUX_INTEGRATION_SPEC.md
@@ -39,10 +39,11 @@
   q6 is incomplete, and mask/inpaint editing is not wired. A complete
   `cocktailpeanut/ideogram-4-fp8` mirror bundle is now staged locally and scans
   as `loadableScaffold`. The shared loader now covers fp8 linear
-  `weight_scale` rows and the `unconditional_transformer` component, but
-  Ideogram still has no native generation proof because `Ideogram4.generate` is
-  not implemented. Official `ideogram-ai/*` downloads are still approval-gated
-  for the current account. See §6 and §7b.
+  `weight_scale` rows and the `unconditional_transformer` component, and direct
+  load validates sentinel keys from text encoder/transformers/VAE, but Ideogram
+  still has no native generation proof because `Ideogram4.generate` is not
+  implemented. Official `ideogram-ai/*` downloads are still approval-gated for
+  the current account. See §6 and §7b.
 
 ---
 
@@ -285,7 +286,7 @@ their 4-bit linears through scale tensors at load time inside the model.
 | flux2-klein / flux2-klein-edit | `not_implemented` | Bundle scans + loads; `FluxDiTConfig.flux2Klein` preset exists. | T5 (single-encoder) port + weight key-map + 3-axis RoPE. |
 | **flux1-schnell** | `native_pipeline_implemented` | Full native pipeline `Flux1Native.swift`: T5-XXL + CLIP-L encoders, full DiT (19 joint + 38 single blocks, 24h×128, 3-axis RoPE), AutoencoderKL VAE, mflux decode. Fresh 2026-06-16 proof: 4-bit + 8-bit live load, 3 completed turns, same-prompt SHA match, different-prompt SHA change, viewed coherent apple/mountain images. | tokenizer.json must be staged (mflux ships slow tokenizers — convert; see port plan). Full precision pending. |
 | flux1-dev/kontext/fill | `not_implemented` | dev = schnell + guidance embedder (small add); kontext/fill = edit variants. | wire guidance + edit conditioning on the working schnell pipeline. |
-| **ideogram** (Ideogram 4) | `not_implemented` (scaffold registered) | Strong text/typography renderer. mflux-compatible official weights: `ideogram-ai/ideogram-4-fp8` or `ideogram-ai/ideogram-4-nf4` (4-bit). Official HF metadata is reachable, but official downloads still require approval for the current account. A complete fp8 mirror bundle, `cocktailpeanut/ideogram-4-fp8`, is staged at `~/.mlxstudio/models/image/ideogram-4-fp8`; scan artifact `docs/local/vmlx-flux-probes/2026-06-16-ideogram-fp8-mirror-scan/scan.json` reports `readiness=loadableScaffold`, 4 safetensors, 27,526,985,054 bytes, and tokenizer/text_encoder/transformer/unconditional_transformer/vae present. Shared source now supports fp8 linear `weight_scale` rows and loads the `unconditional_transformer` shard group. | Native generation is still missing: `Ideogram4.generate` throws `FluxError.notImplemented`, so there is no live load/generation proof. Port Qwen3 text encoder (reuse Qwen LM pattern) + 34-layer DiT execution (emb 4608, 18 heads, llm_features 4096×13 multi-layer, rope 5e6) + unconditional transformer execution + VAE. Remaining quant work is nf4 if that bundle is used. |
+| **ideogram** (Ideogram 4) | `not_implemented` (scaffold registered) | Strong text/typography renderer. mflux-compatible official weights: `ideogram-ai/ideogram-4-fp8` or `ideogram-ai/ideogram-4-nf4` (4-bit). Official HF metadata is reachable, but official downloads still require approval for the current account. A complete fp8 mirror bundle, `cocktailpeanut/ideogram-4-fp8`, is staged at `~/.mlxstudio/models/image/ideogram-4-fp8`; scan artifact `docs/local/vmlx-flux-probes/2026-06-16-ideogram-fp8-mirror-scan/scan.json` reports `readiness=loadableScaffold`, 4 safetensors, 27,526,985,054 bytes, and tokenizer/text_encoder/transformer/unconditional_transformer/vae present. Shared source now supports fp8 linear `weight_scale` rows, loads the `unconditional_transformer` shard group, and direct load validates sentinel keys from text encoder/transformers/VAE. Load artifact: `docs/local/vmlx-flux-probes/2026-06-16-ideogram-fp8-honest-load/ideogram-4-fp8-load.json` (`load_status=loaded`, `native_runtime_status=not_implemented`). | Native generation is still missing: `Ideogram4.generate` throws `FluxError.notImplemented`, so there is no live generation proof. Port Qwen3 text encoder (reuse Qwen LM pattern) + 34-layer DiT execution (emb 4608, 18 heads, llm_features 4096×13 multi-layer, rope 5e6) + unconditional transformer execution + VAE. Remaining quant work is nf4 if that bundle is used. |
 | seedvr2 | scaffold | registered | upscale arch (different family). |
 | wan-2.1 / wan-2.2 | scaffold | full pipeline scaffolded (WanVAE3D + WanDiT + MP4 writer) with random weights. | real weight key-map, real Conv3d (currently a Conv2d shim), windowed attention for >3-4s clips. |
 

--- a/tools/vMLXFluxProbe/main.swift
+++ b/tools/vMLXFluxProbe/main.swift
@@ -670,7 +670,7 @@ struct VMLXFluxProbe {
         case "ideogram":
             return [
                 "Ideogram4.generate body throws FluxError.notImplemented",
-                "local ideogram-4-fp8 mirror bundle is staged and scans loadable, but live generation is blocked until the native pipeline is implemented",
+                "local ideogram-4-fp8 mirror bundle is staged, scans loadable, and passes load-time sentinel-key validation, but live generation is blocked until the native pipeline is implemented",
                 "official ideogram-ai/ideogram-4-fp8 and ideogram-ai/ideogram-4-nf4 downloads still require approval for the current HF account",
                 "Qwen3 text encoder, 34-layer DiT execution, unconditional transformer execution, VAE, and nf4 support are missing; shared fp8 Linear weight_scale support is present",
             ]


### PR DESCRIPTION
## Summary

Adds an honest load-time validation gate for the staged Ideogram 4 fp8 mirror bundle.

- Loads Ideogram weights during `Ideogram4` initialization instead of accepting any existing directory.
- Validates required sentinel files and weights across text encoder, conditional transformer, unconditional transformer, and VAE components.
- Adds regression coverage for missing `unconditional_transformer` rejection and minimal fp8 component acceptance.
- Updates probe/spec/handoff text so Osaurus keeps Ideogram disabled until native generation exists.

## Verification

- `git diff --check`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter vMLXFluxTests`
  - 48 tests, 0 failures
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build --product vmlxflux-probe`
- `.build/arm64-apple-macosx/debug/vmlxflux-probe --root /Users/eric/.mlxstudio/models/image --model ideogram-4-fp8 --load --json --artifacts docs/local/vmlx-flux-probes/2026-06-16-ideogram-fp8-honest-load`
  - artifact: `docs/local/vmlx-flux-probes/2026-06-16-ideogram-fp8-honest-load/ideogram-4-fp8-load.json`
  - `load_status=loaded`
  - `native_runtime_status=not_implemented`
  - `total_bytes=27526985054`

## Boundary

This does not implement Ideogram image generation. `Ideogram4.generate` still throws `FluxError.notImplemented`, and there is no live Ideogram image proof yet.
