### PR TITLE
Add qwen edit multi-image support

### DIFF
--- a/Libraries/vMLXFluxKit/Requests.swift
+++ b/Libraries/vMLXFluxKit/Requests.swift
@@ -44,6 +44,7 @@ public struct ImageGenRequest: Sendable {
 public struct ImageEditRequest: Sendable {
     public var prompt: String
     public var sourceImage: URL
+    public var sourceImages: [URL]
     public var mask: URL?          // optional PNG mask — white=edit, black=keep
     public var strength: Float     // 0..1 — how much to deviate from source
     public var width: Int?         // nil → match source
@@ -69,6 +70,37 @@ public struct ImageEditRequest: Sendable {
     ) {
         self.prompt = prompt
         self.sourceImage = sourceImage
+        self.sourceImages = [sourceImage]
+        self.mask = mask
+        self.strength = strength
+        self.width = width
+        self.height = height
+        self.steps = steps
+        self.guidance = guidance
+        self.seed = seed
+        self.outputDir = outputDir
+        self.outputFormat = outputFormat
+    }
+
+    public init(
+        prompt: String,
+        sourceImages: [URL],
+        mask: URL? = nil,
+        strength: Float = 0.75,
+        width: Int? = nil,
+        height: Int? = nil,
+        steps: Int = 20,
+        guidance: Float = 3.5,
+        seed: UInt64? = nil,
+        outputDir: URL,
+        outputFormat: ImageFormat = .png
+    ) throws {
+        guard let sourceImage = sourceImages.first else {
+            throw FluxError.invalidRequest("ImageEditRequest requires at least one source image")
+        }
+        self.prompt = prompt
+        self.sourceImage = sourceImage
+        self.sourceImages = sourceImages
         self.mask = mask
         self.strength = strength
         self.width = width

--- a/Libraries/vMLXFluxModels/QwenImage/QwenImage.swift
+++ b/Libraries/vMLXFluxModels/QwenImage/QwenImage.swift
@@ -102,7 +102,7 @@ public final class QwenImageEdit: ImageEditor, @unchecked Sendable {
                     let pipeline = try QwenImageEditPipeline(modelPath: self.modelPath)
                     let image = try await pipeline.edit(
                         prompt: request.prompt,
-                        sourceImage: request.sourceImage,
+                        sourceImages: request.sourceImages,
                         width: request.width,
                         height: request.height,
                         steps: request.steps,

--- a/Libraries/vMLXFluxModels/QwenImage/QwenImageEditSupport.swift
+++ b/Libraries/vMLXFluxModels/QwenImage/QwenImageEditSupport.swift
@@ -24,6 +24,24 @@ public struct QwenImageEditPreprocessPlan: Sendable {
         steps: Int,
         guidance: Float
     ) throws {
+        try self.init(
+            sourceImages: [sourceImage],
+            requestedWidth: requestedWidth,
+            requestedHeight: requestedHeight,
+            steps: steps,
+            guidance: guidance)
+    }
+
+    public init(
+        sourceImages: [URL],
+        requestedWidth: Int?,
+        requestedHeight: Int?,
+        steps: Int,
+        guidance: Float
+    ) throws {
+        guard let sourceImage = sourceImages.last else {
+            throw FluxError.invalidRequest("Qwen edit requires at least one source image")
+        }
         let dimensions = try ImageIO.dimensions(of: sourceImage)
         try self.init(
             sourceWidth: dimensions.width,
@@ -136,21 +154,28 @@ public struct QwenImageEditPromptTokens {
 
 public struct QwenImageEditVisionFeatures {
     public let imageFeatures: MLXArray
-    public let imageGridTHW: [Int]
+    public let imageGridTHWs: [[Int]]
 
     public var imageTokenCount: Int { imageFeatures.dim(0) }
     public var hiddenSize: Int { imageFeatures.dim(1) }
+    public var imageGridTHW: [Int] { imageGridTHWs.first ?? [] }
 
     public init(imageFeatures: MLXArray, imageGridTHW: [Int]) {
+        self.init(imageFeatures: imageFeatures, imageGridTHWs: [imageGridTHW])
+    }
+
+    public init(imageFeatures: MLXArray, imageGridTHWs: [[Int]]) {
         self.imageFeatures = imageFeatures
-        self.imageGridTHW = imageGridTHW
+        self.imageGridTHWs = imageGridTHWs
     }
 
     public func validateMatches(promptImageTokenCount: Int) throws {
-        guard imageGridTHW.count == 3 else {
-            throw FluxError.invalidRequest("Qwen edit vision grid must be [t,h,w]")
+        let expected = try imageGridTHWs.reduce(0) { total, grid in
+            guard grid.count == 3 else {
+                throw FluxError.invalidRequest("Qwen edit vision grid must be [t,h,w]")
+            }
+            return total + (try QwenImageEditVisionTransformer.mergedTokenCount(imageGridTHW: grid))
         }
-        let expected = try QwenImageEditVisionTransformer.mergedTokenCount(imageGridTHW: imageGridTHW)
         guard imageTokenCount == expected else {
             throw FluxError.invalidRequest(
                 "Qwen edit vision feature count \(imageTokenCount) does not match grid-derived count \(expected)")
@@ -163,6 +188,26 @@ public struct QwenImageEditVisionFeatures {
             throw FluxError.invalidRequest(
                 "Qwen edit vision hidden size \(hiddenSize) does not match Qwen text hidden size \(QwenTextEncoder.hidden)")
         }
+    }
+
+    public func validateMatches(promptImageTokenCounts: [Int]) throws {
+        guard promptImageTokenCounts.count == imageGridTHWs.count else {
+            throw FluxError.invalidRequest(
+                "Qwen edit prompt image count \(promptImageTokenCounts.count) does not match vision image count \(imageGridTHWs.count)")
+        }
+        var expectedTotal = 0
+        for (index, grid) in imageGridTHWs.enumerated() {
+            guard grid.count == 3 else {
+                throw FluxError.invalidRequest("Qwen edit vision grid must be [t,h,w]")
+            }
+            let expected = try QwenImageEditVisionTransformer.mergedTokenCount(imageGridTHW: grid)
+            guard promptImageTokenCounts[index] == expected else {
+                throw FluxError.invalidRequest(
+                    "Qwen edit image \(index + 1) prompt token count \(promptImageTokenCounts[index]) does not match vision grid count \(expected)")
+            }
+            expectedTotal += expected
+        }
+        try validateMatches(promptImageTokenCount: expectedTotal)
     }
 }
 
@@ -217,6 +262,21 @@ public struct QwenImageEditConditioningLatents {
     public let imageIDs: MLXArray
     public let patchRows: Int
     public let patchColumns: Int
+    public let imageCount: Int
+
+    public init(
+        latents: MLXArray,
+        imageIDs: MLXArray,
+        patchRows: Int,
+        patchColumns: Int,
+        imageCount: Int = 1
+    ) {
+        self.latents = latents
+        self.imageIDs = imageIDs
+        self.patchRows = patchRows
+        self.patchColumns = patchColumns
+        self.imageCount = imageCount
+    }
 }
 
 public struct QwenImageEditImageShape {
@@ -272,10 +332,11 @@ public struct QwenImageEditTransformerInputs {
         else {
             throw FluxError.invalidRequest("Qwen edit conditioning latents must have shape 1xNx64")
         }
-        guard conditioning.patchRows > 0, conditioning.patchColumns > 0 else {
+        guard conditioning.patchRows > 0, conditioning.patchColumns > 0, conditioning.imageCount > 0 else {
             throw FluxError.invalidRequest("Qwen edit conditioning patch grid must be positive")
         }
-        guard conditioning.latents.dim(1) == conditioning.patchRows * conditioning.patchColumns else {
+        let conditioningPerImage = conditioning.patchRows * conditioning.patchColumns
+        guard conditioning.latents.dim(1) == conditioningPerImage * conditioning.imageCount else {
             throw FluxError.invalidRequest("Qwen edit conditioning latent count does not match patch grid")
         }
         guard conditioning.imageIDs.shape == [1, conditioning.latents.dim(1), 3] else {
@@ -293,10 +354,13 @@ public struct QwenImageEditTransformerInputs {
         self.hiddenStates = concatenated([targetLatents, conditioning.latents], axis: 1)
         self.targetLatentCount = targetCount
         self.conditioningLatentCount = conditioning.latents.dim(1)
-        self.imageShapes = [
-            QwenImageEditImageShape(frame: 1, height: targetPatchRows, width: targetPatchColumns),
-            QwenImageEditImageShape(frame: 1, height: conditioning.patchRows, width: conditioning.patchColumns),
-        ]
+        self.imageShapes = [QwenImageEditImageShape(frame: 1, height: targetPatchRows, width: targetPatchColumns)]
+            + Array(
+                repeating: QwenImageEditImageShape(
+                    frame: 1,
+                    height: conditioning.patchRows,
+                    width: conditioning.patchColumns),
+                count: conditioning.imageCount)
     }
 }
 
@@ -542,8 +606,16 @@ public enum QwenImageEditConditioner {
         sourceImage: URL,
         plan: QwenImageEditPreprocessPlan
     ) throws -> QwenImageEditConditioningLatents {
+        try encode(modelPath: modelPath, sourceImages: [sourceImage], plan: plan)
+    }
+
+    public static func encode(
+        modelPath: URL,
+        sourceImages: [URL],
+        plan: QwenImageEditPreprocessPlan
+    ) throws -> QwenImageEditConditioningLatents {
         let store = MFluxStore(try WeightLoader.load(from: modelPath))
-        return try encode(store: store, sourceImage: sourceImage, plan: plan)
+        return try encode(store: store, sourceImages: sourceImages, plan: plan)
     }
 
     static func encode(
@@ -551,14 +623,39 @@ public enum QwenImageEditConditioner {
         sourceImage: URL,
         plan: QwenImageEditPreprocessPlan
     ) throws -> QwenImageEditConditioningLatents {
+        try encode(store: store, sourceImages: [sourceImage], plan: plan)
+    }
+
+    static func encode(
+        store: MFluxStore,
+        sourceImages: [URL],
+        plan: QwenImageEditPreprocessPlan
+    ) throws -> QwenImageEditConditioningLatents {
+        guard !sourceImages.isEmpty else {
+            throw FluxError.invalidRequest("Qwen edit conditioning requires at least one source image")
+        }
         let encoder = try Qwen3DVAEEncoder(store: store)
-        let vaeInput = try QwenImageEditPreprocessor.vaeInput(sourceImage: sourceImage, plan: plan)
-        let encoded = encoder.encode(vaeInput.tensor)
-        eval(encoded)
-        return try QwenImageEditPreprocessor.conditioningLatents(
-            encodedLatents: encoded,
-            height: plan.vlHeight,
-            width: plan.vlWidth)
+        var latentParts: [MLXArray] = []
+        var idParts: [MLXArray] = []
+        latentParts.reserveCapacity(sourceImages.count)
+        idParts.reserveCapacity(sourceImages.count)
+        for sourceImage in sourceImages {
+            let vaeInput = try QwenImageEditPreprocessor.vaeInput(sourceImage: sourceImage, plan: plan)
+            let encoded = encoder.encode(vaeInput.tensor)
+            eval(encoded)
+            let conditioning = try QwenImageEditPreprocessor.conditioningLatents(
+                encodedLatents: encoded,
+                height: plan.vlHeight,
+                width: plan.vlWidth)
+            latentParts.append(conditioning.latents)
+            idParts.append(conditioning.imageIDs)
+        }
+        return QwenImageEditConditioningLatents(
+            latents: concatenated(latentParts, axis: 1),
+            imageIDs: concatenated(idParts, axis: 1),
+            patchRows: plan.conditioningPatchRows,
+            patchColumns: plan.conditioningPatchColumns,
+            imageCount: sourceImages.count)
     }
 }
 
@@ -568,15 +665,37 @@ public enum QwenImageEditVisionFeatureEncoder {
         sourceImage: URL,
         plan: QwenImageEditPreprocessPlan
     ) throws -> QwenImageEditVisionFeatures {
+        try encode(modelPath: modelPath, sourceImages: [sourceImage], plan: plan)
+    }
+
+    public static func encode(
+        modelPath: URL,
+        sourceImages: [URL],
+        plan: QwenImageEditPreprocessPlan
+    ) throws -> QwenImageEditVisionFeatures {
         let store = MFluxStore(try WeightLoader.load(from: modelPath))
         let vision = try QwenImageEditVisionTransformer(store: store)
-        let input = try QwenImageEditPreprocessor.visionInput(sourceImage: sourceImage, plan: plan)
-        let features = vision(pixelValues: input.pixelValues, imageGridTHW: input.imageGridTHW)
-        eval(features)
+        guard !sourceImages.isEmpty else {
+            throw FluxError.invalidRequest("Qwen edit vision encode requires at least one source image")
+        }
+        var featureParts: [MLXArray] = []
+        var grids: [[Int]] = []
+        var tokenCounts: [Int] = []
+        featureParts.reserveCapacity(sourceImages.count)
+        grids.reserveCapacity(sourceImages.count)
+        tokenCounts.reserveCapacity(sourceImages.count)
+        for sourceImage in sourceImages {
+            let input = try QwenImageEditPreprocessor.visionInput(sourceImage: sourceImage, plan: plan)
+            let features = vision(pixelValues: input.pixelValues, imageGridTHW: input.imageGridTHW)
+            eval(features)
+            featureParts.append(features)
+            grids.append(input.imageGridTHW)
+            tokenCounts.append(input.imageTokenCount)
+        }
         let result = QwenImageEditVisionFeatures(
-            imageFeatures: features,
-            imageGridTHW: input.imageGridTHW)
-        try result.validateMatches(promptImageTokenCount: input.imageTokenCount)
+            imageFeatures: concatenated(featureParts, axis: 0),
+            imageGridTHWs: grids)
+        try result.validateMatches(promptImageTokenCounts: tokenCounts)
         return result
     }
 }
@@ -594,11 +713,24 @@ public enum QwenImageEditPromptImageEncoder {
         prompt: String,
         plan: QwenImageEditPreprocessPlan
     ) async throws -> QwenImageEditVisionLanguageEncoding {
+        try await encode(
+            modelPath: modelPath,
+            sourceImages: [sourceImage],
+            prompt: prompt,
+            plan: plan)
+    }
+
+    public static func encode(
+        modelPath: URL,
+        sourceImages: [URL],
+        prompt: String,
+        plan: QwenImageEditPreprocessPlan
+    ) async throws -> QwenImageEditVisionLanguageEncoding {
         let store = MFluxStore(try WeightLoader.load(from: modelPath))
         return try await encode(
             store: store,
             modelPath: modelPath,
-            sourceImage: sourceImage,
+            sourceImages: sourceImages,
             prompt: prompt,
             plan: plan)
     }
@@ -610,22 +742,51 @@ public enum QwenImageEditPromptImageEncoder {
         prompt: String,
         plan: QwenImageEditPreprocessPlan
     ) async throws -> QwenImageEditVisionLanguageEncoding {
+        try await encode(
+            store: store,
+            modelPath: modelPath,
+            sourceImages: [sourceImage],
+            prompt: prompt,
+            plan: plan)
+    }
+
+    static func encode(
+        store: MFluxStore,
+        modelPath: URL,
+        sourceImages: [URL],
+        prompt: String,
+        plan: QwenImageEditPreprocessPlan
+    ) async throws -> QwenImageEditVisionLanguageEncoding {
+        guard !sourceImages.isEmpty else {
+            throw FluxError.invalidRequest("Qwen edit prompt-image encode requires at least one source image")
+        }
         let vision = try QwenImageEditVisionTransformer(store: store)
         let text = try QwenTextEncoder(store: store, dropIdx: QwenImageEditPreprocessor.editTemplateStartIndex)
         let tokenizer = try await QwenImageEditPromptTokenizer(modelPath: modelPath)
-        let visionInput = try QwenImageEditPreprocessor.visionInput(sourceImage: sourceImage, plan: plan)
-        let imageFeatures = vision(
-            pixelValues: visionInput.pixelValues,
-            imageGridTHW: visionInput.imageGridTHW)
-        eval(imageFeatures)
+        var featureParts: [MLXArray] = []
+        var grids: [[Int]] = []
+        var imageTokenCounts: [Int] = []
+        featureParts.reserveCapacity(sourceImages.count)
+        grids.reserveCapacity(sourceImages.count)
+        imageTokenCounts.reserveCapacity(sourceImages.count)
+        for sourceImage in sourceImages {
+            let visionInput = try QwenImageEditPreprocessor.visionInput(sourceImage: sourceImage, plan: plan)
+            let imageFeatures = vision(
+                pixelValues: visionInput.pixelValues,
+                imageGridTHW: visionInput.imageGridTHW)
+            eval(imageFeatures)
+            featureParts.append(imageFeatures)
+            grids.append(visionInput.imageGridTHW)
+            imageTokenCounts.append(visionInput.imageTokenCount)
+        }
         let features = QwenImageEditVisionFeatures(
-            imageFeatures: imageFeatures,
-            imageGridTHW: visionInput.imageGridTHW)
-        try features.validateMatches(promptImageTokenCount: visionInput.imageTokenCount)
+            imageFeatures: concatenated(featureParts, axis: 0),
+            imageGridTHWs: grids)
+        try features.validateMatches(promptImageTokenCounts: imageTokenCounts)
 
         let promptInput = try QwenImageEditPreprocessor.visionLanguagePrompt(
             prompt: prompt,
-            imageTokenCounts: [features.imageTokenCount])
+            imageTokenCounts: imageTokenCounts)
         let tokens = tokenizer.tokenize(promptInput)
         try features.validateMatches(promptImageTokenCount: tokens.imageTokenCount)
         let promptEmbeddings = try text.encodeVisionLanguage(
@@ -649,16 +810,31 @@ public enum QwenImageEditDenoiseProbe {
         plan: QwenImageEditPreprocessPlan,
         seed: UInt64?
     ) async throws -> QwenImageEditDenoiseResult {
+        try await predictVelocity(
+            modelPath: modelPath,
+            sourceImages: [sourceImage],
+            prompt: prompt,
+            plan: plan,
+            seed: seed)
+    }
+
+    public static func predictVelocity(
+        modelPath: URL,
+        sourceImages: [URL],
+        prompt: String,
+        plan: QwenImageEditPreprocessPlan,
+        seed: UInt64?
+    ) async throws -> QwenImageEditDenoiseResult {
         let store = MFluxStore(try WeightLoader.load(from: modelPath))
         let promptEncoding = try await QwenImageEditPromptImageEncoder.encode(
             store: store,
             modelPath: modelPath,
-            sourceImage: sourceImage,
+            sourceImages: sourceImages,
             prompt: prompt,
             plan: plan)
         let conditioning = try QwenImageEditConditioner.encode(
             store: store,
-            sourceImage: sourceImage,
+            sourceImages: sourceImages,
             plan: plan)
 
         let targetRows = plan.outputHeight / 16
@@ -712,8 +888,29 @@ final class QwenImageEditPipeline {
         seed: UInt64?,
         progress: (Int, Int, Double?) -> Void
     ) async throws -> MLXArray {
+        try await edit(
+            prompt: prompt,
+            sourceImages: [sourceImage],
+            width: width,
+            height: height,
+            steps: steps,
+            guidance: guidance,
+            seed: seed,
+            progress: progress)
+    }
+
+    func edit(
+        prompt: String,
+        sourceImages: [URL],
+        width: Int?,
+        height: Int?,
+        steps: Int,
+        guidance: Float,
+        seed: UInt64?,
+        progress: (Int, Int, Double?) -> Void
+    ) async throws -> MLXArray {
         let plan = try QwenImageEditPreprocessPlan(
-            sourceImage: sourceImage,
+            sourceImages: sourceImages,
             requestedWidth: width,
             requestedHeight: height,
             steps: steps,
@@ -721,18 +918,18 @@ final class QwenImageEditPipeline {
         let positive = try await QwenImageEditPromptImageEncoder.encode(
             store: store,
             modelPath: modelPath,
-            sourceImage: sourceImage,
+            sourceImages: sourceImages,
             prompt: prompt,
             plan: plan)
         let negative = try await QwenImageEditPromptImageEncoder.encode(
             store: store,
             modelPath: modelPath,
-            sourceImage: sourceImage,
+            sourceImages: sourceImages,
             prompt: "",
             plan: plan)
         let conditioning = try QwenImageEditConditioner.encode(
             store: store,
-            sourceImage: sourceImage,
+            sourceImages: sourceImages,
             plan: plan)
 
         let targetRows = plan.outputHeight / 16

--- a/Tests/vMLXFluxTests/QwenImageEditSupportTests.swift
+++ b/Tests/vMLXFluxTests/QwenImageEditSupportTests.swift
@@ -83,6 +83,54 @@ final class QwenImageEditSupportTests: XCTestCase {
         XCTAssertEqual(plan.vlHeight, 320)
     }
 
+    func testPreprocessPlanUsesLastSourceImageDimensionsForMultiImageEdit() throws {
+        let first = try makePNG(width: 1536, height: 1024)
+        let second = try makePNG(width: 480, height: 640)
+
+        let plan = try QwenImageEditPreprocessPlan(
+            sourceImages: [first, second],
+            requestedWidth: nil,
+            requestedHeight: nil,
+            steps: 20,
+            guidance: 4.0)
+
+        XCTAssertEqual(plan.outputWidth, 896)
+        XCTAssertEqual(plan.outputHeight, 1184)
+        XCTAssertEqual(plan.vlWidth, 320)
+        XCTAssertEqual(plan.vlHeight, 448)
+        XCTAssertEqual(plan.vaeWidth, 896)
+        XCTAssertEqual(plan.vaeHeight, 1184)
+    }
+
+    func testImageEditRequestPreservesMultipleSourceImages() throws {
+        let first = try makePNG(width: 64, height: 64)
+        let second = try makePNG(width: 64, height: 64, rgba: (0, 128, 255, 255))
+        let outputDir = FileManager.default.temporaryDirectory
+
+        let request = try ImageEditRequest(
+            prompt: "combine both references",
+            sourceImages: [first, second],
+            steps: 4,
+            guidance: 4.0,
+            outputDir: outputDir)
+
+        XCTAssertEqual(request.sourceImage, first)
+        XCTAssertEqual(request.sourceImages, [first, second])
+    }
+
+    func testImageEditRequestRejectsEmptySourceImages() {
+        XCTAssertThrowsError(
+            try ImageEditRequest(
+                prompt: "missing references",
+                sourceImages: [],
+                outputDir: FileManager.default.temporaryDirectory)
+        ) { error in
+            XCTAssertEqual(
+                String(describing: error),
+                "invalid request: ImageEditRequest requires at least one source image")
+        }
+    }
+
     func testVisionInputMatchesQwenVLProcessorShapeAndNormalization() throws {
         let source = try makePNG(width: 512, height: 512, rgba: (255, 128, 0, 255))
         let plan = try QwenImageEditPreprocessPlan(
@@ -196,6 +244,27 @@ final class QwenImageEditSupportTests: XCTestCase {
         XCTAssertEqual(inputs.conditioningLatentCount, 4056)
         XCTAssertEqual(inputs.imageShapes.map { [$0.frame, $0.height, $0.width] }, [[1, 52, 78], [1, 52, 78]])
         XCTAssertEqual(inputs.targetVelocitySlice.shape, [1, 4056, 64])
+    }
+
+    func testTransformerInputsAcceptMultipleConditioningImages() throws {
+        let target = MLXArray.zeros([1, 256, 64], dtype: .float32)
+        let conditioning = QwenImageEditConditioningLatents(
+            latents: MLXArray.ones([1, 12, 64], dtype: .float32),
+            imageIDs: MLXArray.zeros([1, 12, 3], dtype: .float32),
+            patchRows: 2,
+            patchColumns: 3,
+            imageCount: 2)
+
+        let inputs = try QwenImageEditTransformerInputs(
+            targetLatents: target,
+            conditioning: conditioning)
+
+        XCTAssertEqual(inputs.hiddenStates.shape, [1, 268, 64])
+        XCTAssertEqual(inputs.targetLatentCount, 256)
+        XCTAssertEqual(inputs.conditioningLatentCount, 12)
+        XCTAssertEqual(
+            inputs.imageShapes.map { [$0.frame, $0.height, $0.width] },
+            [[1, 16, 16], [1, 2, 3], [1, 2, 3]])
     }
 
     func testQwenEditRoPECombinesTargetAndConditioningImageGrids() {

--- a/docs/MFLUX_HANDOFF.md
+++ b/docs/MFLUX_HANDOFF.md
@@ -2,10 +2,12 @@
 
 **For:** the next engineer/agent continuing the native mFLUX image-generation port.
 **Date:** 2026-06-16. **Owner:** Eric. **Status:** z-image-turbo and flux-schnell
-are live-proven for 4/8-bit; qwen-image 4-bit and 6-bit are live-proven; qwen-image-edit
-q4/q5 are live-proven for text-image edit after the conditioning-grid fix. qwen-edit
-q3 is incomplete (`text_encoder/3.safetensors` missing from its index), q6 is incomplete on disk, masks are
-not wired, and Ideogram has a staged fp8 mirror bundle plus source-level fp8
+are live-proven for 4/8-bit; qwen-image 4-bit and 6-bit are live-proven;
+qwen-image-edit q4/q5 are live-proven for single-image and ordered multi-image
+text-image edit after the conditioning-grid fix. qwen-edit q3 is incomplete
+(`text_encoder/3.safetensors` missing from its index), q6 is incomplete on
+disk, qwen masks are unsupported by the current mflux qwen-edit reference, and
+Ideogram has a staged fp8 mirror bundle plus source-level fp8
 linear support plus load-time sentinel validation for its conditional and
 unconditional transformer components, but no native
 implementation/live generation proof yet. The current HF account still is not
@@ -135,7 +137,7 @@ This is the single starting doc. Read it top to bottom, then the per-model port 
 | **z-image-turbo** | ✅ proven | ✅ proven | ⬜ (weights gone) | `Libraries/vMLXFluxModels/ZImage/ZImageNative.swift` |
 | **flux-schnell** | ✅ proven | ✅ proven | ⬜ (not staged) | `Libraries/vMLXFluxModels/Flux1/Flux1Native.swift` |
 | **qwen-image** (txt2img) | ✅ proven; ✅ 6-bit also proven | ⬜ (public mflux 8-bit not found) | ⬜ | `Libraries/vMLXFluxModels/Common/QwenImageNative.swift` |
-| qwen-image-edit | ✅ q4/q5 text-image edit proven; q3/q6 incomplete | — | — | `Libraries/vMLXFluxModels/QwenImage/QwenImageEditSupport.swift`; masks/inpaint pending |
+| qwen-image-edit | ✅ q4/q5 single/multi-image text edit proven; q3/q6 incomplete | — | — | `Libraries/vMLXFluxModels/QwenImage/QwenImageEditSupport.swift`; qwen masks unsupported |
 | ideogram (4) | ⬜ scaffold; fp8 mirror staged/scans loadable; direct load validates fp8 sentinel keys; no live generation proof | — | — | `Libraries/vMLXFluxModels/Ideogram4/Ideogram4.swift` (native pipeline missing) |
 | flux1-dev/kontext/fill, flux2-klein, fibo, seedvr2, wan | ⬜ scaffold | — | — | registered, throw `notImplemented` |
 
@@ -143,14 +145,47 @@ This is the single starting doc. Read it top to bottom, then the per-model port 
 
 Qwen-image-edit q4/q5 are live-proven after fixing the source-image conditioning grid to match mflux. Source trace: mflux `qwen_image_edit.py` passes `vl_width/vl_height` into `QwenEditUtil.create_image_conditioning_latents`, and `qwen_edit_util.py` uses those VL dimensions for the source-image VAE encode when present. Swift now mirrors that in `QwenImageEditSupport.swift`: square source images encode conditioning at 384x384, pack 24x24=576 static latents, and denoise with 1024 target latents + 576 conditioning latents. q4 live proof artifact: `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-determinism-after-cond-fix/Qwen-Image-Edit-mflux-q4-load.json` (blue prompt SHA `005ab8baddfe9b7a94aa83f8ddd22d192e7e5a0275c556dcf2ead76a565e474a`, green-pear prompt SHA `815711be73a9e89599b3e97f9f15196115875103f9407d7b1b61bab33de8e3b4`, repeated blue prompt same SHA). q5 live proof artifact: `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q5-determinism/Qwen-Image-Edit-mflux-q5-load.json` (blue prompt SHA `5cd5d9197bd659bd8b59b4a2f2bca413266146ad4e08249289d5fa6a8025fa4e`, green-pear prompt SHA `d2c6c4eb4a19dcf48122b5216fc15ac37b9f5aa49c15f596acd1276a4df57034`, repeated blue prompt same SHA). Viewed q4/q5 outputs are coherent and prompt-sensitive. Boundary artifacts remain useful: `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-prompt-live/Qwen-Image-Edit-mflux-q4-load.json`, `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-vl-encode-live/Qwen-Image-Edit-mflux-q4-load.json`, `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-conditioning-after-cond-fix/Qwen-Image-Edit-mflux-q4-load.json`, and `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-denoise-after-cond-fix/Qwen-Image-Edit-mflux-q4-load.json`.
 
+Qwen-image-edit multi-image is also live-proven on q4 and q5. Source trace:
+mflux qwen-edit accepts `image_paths: list[str]`, sizes from `image_paths[-1]`,
+and concatenates per-source prompt-image features plus VAE conditioning latents.
+Swift mirrors that with ordered `ImageEditRequest.sourceImages`, repeated
+`--source-image` in `vmlxflux-probe`, last-source sizing, per-image Qwen2.5-VL
+feature/token counts, and concatenated VAE latents/IDs. q5 shape proof:
+`docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q5-multi-image-shape-proof/Qwen-Image-Edit-mflux-q5-load.json`
+(`image_count=2`, `latents_shape=[1,1152,64]`,
+`image_token_counts=[196,196]`,
+`combined_velocity_shape=[1,1728,64]`,
+`image_shapes=[[1,24,24],[1,24,24],[1,24,24]]`). q4 live proof:
+`docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-multi-image-live/Qwen-Image-Edit-mflux-q4-load.json`
+(turn 1/3 SHA
+`e43910a505ab090bfbd4ec3a00f6e58fcd97df65c6b61e6b973754511bc740be`,
+turn 2 SHA
+`16ecc1fec4bdff1e5aecb9c0875569b2bebed53a81c686bf23e806faa6e2b893`).
+q5 live proof:
+`docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q5-multi-image-live/Qwen-Image-Edit-mflux-q5-load.json`
+(turn 1/3 SHA
+`ec2e49d6f300849cb46940b793670bee007f4aae8f04e97a31289670758519c9`,
+turn 2 SHA
+`8dfacb52aa81c6e0a8a6827c4377f27bc5d9396e39a4f8662a47db93798b767a`).
+Viewed exact current-source output PNGs recorded in the q4/q5 load artifacts
+(the existing contact sheet is
+`docs/local/vmlx-flux-outputs/2026-06-16-qwen-edit-multi-image-contact-sheet.png`).
+Visual caveat: q4 is rougher than q5; q5 strongly uses the mountain and
+green-pear prompt, while its first apple prompt leans mountain-only. This is
+multi-reference text-image edit, not qwen mask/inpaint support.
+
 **Next work, in priority order:**
 1. **Ideogram 4** — local fp8 mirror bundle is now staged; `MFluxStore` can decode fp8 linear `weight_scale` rows, `WeightLoader` includes `unconditional_transformer`, and direct load validates sentinel keys from text encoder/conditional transformer/unconditional transformer/VAE. Next implement the Qwen3 encoder + 34-layer DiT + unconditional transformer execution + VAE path, extend nf4 if needed, then live-prove. Official `ideogram-ai/*` approval is still needed for canonical official bundles.
-2. **qwen-image-edit follow-through** — wire real masks/inpaint semantics. Today non-null masks are rejected before the edit pipeline loads; q3/q6 need complete local bundles before they can be exposed.
+2. **qwen-image-edit follow-through** — q4/q5 single-image and ordered
+   multi-image text-image edit are proven. q3/q6 need complete local bundles
+   before they can be exposed. Qwen masks remain unsupported unless upstream
+   mflux adds a real qwen mask path or a separate fill/inpaint model is wired;
+   do not fake masks with post-blends.
 3. **Full-precision** flux-schnell + z-image (download + prove with existing pipelines — should "just work").
 4. Osaurus app/server wiring: implement the `/v1/images/*` bridge from the
    specs below, wrap every image request in the required `MetalGate` exclusion,
    expose only proven variants, and pin Osaurus to `vmlx-origin/main`
-   `9f1faea11aee78f17041c5bed6da039e70c11d05` or a later verified main SHA.
+   `66f328322c41ce51881a9ab3bb630c1aeee114b8` or a later verified main SHA.
 
 ---
 
@@ -158,14 +193,16 @@ Qwen-image-edit q4/q5 are live-proven after fixing the source-image conditioning
 
 - **vmlx-swift integration worktree:** `/Users/eric/vmlx-swift-fluxwt` — clean
   Osaurus monorepo worktree for this lane. Current checked-out branch is
-  `main` at `vmlx-origin/main` `9f1faea11aee78f17041c5bed6da039e70c11d05`.
+  `codex/qwen-edit-multi-image`, based on `vmlx-origin/main`
+  `66f328322c41ce51881a9ab3bb630c1aeee114b8`.
 - **Dirty local dev tree:** `/Users/eric/vmlx-swift` — branch
   `codex/mimo-v25-cache-contract` carries unrelated MLXPress/MiMo/Gemma/JANG
   WIP; do not commit the image-gen integration from that dirty checkout.
 - **Pushable remotes:**
   - `jjang-ai/vmlx-flux` (standalone SwiftPM engine) — **all native work is pushed here** on branch `native-zimage-proven`. This is the durable home. Latest: branch HEAD.
   - `osaurus-ai/vmlx-swift` (the monorepo) — image engine work is merged to
-    `main` through PRs #63, #64, #65, #66, and #67. Remote name
+    `main` through PRs #63, #64, #65, #66, #67, and #68. Current qwen-edit
+    multi-image work is PR #69 on branch `codex/qwen-edit-multi-image`. Remote name
     `vmlx-origin`. (Note: the `osaurus-upstream` remote is DO_NOT_PUSH — only
     the mlx-swift fork.)
 - **Standalone clone (for vmlx-flux pushes):** `/Users/eric/vmlx-flux-push` (sibling to `../vmlx-swift-lm` so its path-deps resolve).
@@ -223,11 +260,14 @@ DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter vML
   transformer RoPE grids, and slices the target velocity
   (`combined_velocity_shape=1x1600x64`, `target_velocity_shape=1x1024x64`,
   finite stats). `ImageEditor` runs the scheduler loop, decodes, and writes
-  coherent prompt-sensitive PNGs for q4. `Qwen-Image-Edit-mflux-q5` also has
-  live same-seed text-image edit proof at
+  coherent prompt-sensitive PNGs for q4. Ordered multi-image edit is wired through
+  `ImageEditRequest.sourceImages`; repeat `--source-image` in the probe to pass
+  multiple references. `Qwen-Image-Edit-mflux-q5` also has
+  live same-seed text-image and multi-image edit proof at
   `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q5-determinism/Qwen-Image-Edit-mflux-q5-load.json`.
-  q3/q6 require complete local bundles before UI promotion. Non-null masks are
-  rejected before the edit pipeline loads; masks are not wired.
+  q3/q6 require complete local bundles before UI promotion. Non-null qwen masks are
+  rejected before the edit pipeline loads; the mflux qwen-edit reference has no
+  qwen mask/inpaint argument or path.
 
 **Downloadable mflux-compatible weights (HF):**
 - flux: `dhairyashil/FLUX.1-schnell-mflux-{4,8}bit`; full = `black-forest-labs/FLUX.1-schnell` (GATED).
@@ -267,30 +307,35 @@ AutoTokenizer.from_pretrained(dir, use_fast=True).save_pretrained(dir)   # for t
 .build/debug/vmlxflux-probe --model Qwen-Image-Edit-mflux-q4 --edit \
   --source-image <png> --turn "make the background blue" \
   --artifacts <art>
-# Current qwen-edit q4 status: live load + ImageEditor loop + PNG write +
-# coherent same-seed prompt-sensitive edit proof after the VL-grid conditioning fix.
+# Repeat --source-image for ordered multi-reference qwen edit. Current qwen-edit
+# q4/q5 status: live load + ImageEditor loop + PNG write + coherent same-seed
+# prompt-sensitive single-image and multi-image edit proof.
 # Add --mask-image <png> to prove the current unsupported-mask path emits a
 # failed event before the edit pipeline runs.
 
 .build/debug/vmlxflux-probe --model Qwen-Image-Edit-mflux-q4 --qwen-edit-prompt \
   --source-image <png> --turn "make the background blue" \
   --artifacts <art>
-# Current qwen-edit prompt status: live q4 load + real tokenizer image-pad expansion.
+# Repeat --source-image to record per-image token counts and real tokenizer
+# image-pad expansion.
 
 .build/debug/vmlxflux-probe --model Qwen-Image-Edit-mflux-q4 --qwen-edit-conditioning \
   --source-image <png> --artifacts <art>
-# Current qwen-edit conditioning status: live q4 load + source-image VAE encode + packed static latents.
+# Repeat --source-image to record one VAE encode + packed static latents per
+# source image.
 
 .build/debug/vmlxflux-probe --model Qwen-Image-Edit-mflux-q4 --qwen-edit-vision \
   --source-image <png> --turn "make the background blue" \
   --artifacts <art>
-# Current qwen-edit VL status: live q4 load + Qwen2.5-VL vision features + image-token splice into Qwen text embeddings.
+# Repeat --source-image to record per-source Qwen2.5-VL features and image-token
+# splice into Qwen text embeddings.
 
 .build/debug/vmlxflux-probe --model Qwen-Image-Edit-mflux-q4 --qwen-edit-denoise \
   --source-image <png> --width 256 --height 256 --steps 1 --seed 7 \
   --turn "make the background blue" --artifacts <art>
 # Current qwen-edit denoise status: live q4 load + prompt-image encode + VAE
-# conditioning + first transformer velocity slice.
+# conditioning + first transformer velocity slice with target+one shape per
+# conditioning image.
 ```
 - Flags: `--guidance`, `--negative` (added for CFG), `--width/height/steps/seed/turn/root/model/output-dir/artifacts/--matrix`.
 - `--model` must be the **exact directory name** (the resolution bug — §6 — is fixed so `-8bit` no longer collapses onto `-4bit`).
@@ -307,7 +352,7 @@ All on `MFluxStore` (loads safetensors via `WeightLoader`, builds quant-aware la
 - **qwen-image** (`QwenImageNative.swift`):
   - `QwenTextEncoder` = Qwen2.5 LM (28-layer, GQA 28q/4kv, standard RoPE θ1e6, SwiGLU, **causal**). Tokenize with the gen template; **drop the first 34 tokens** of the output → prompt embeds.
   - `QwenTransformer` = 60-layer MM-DiT (dual-stream `QwenBlock`: img/txt `mod_linear` 3072→18432 split into mod1(attn)/mod2(mlp), each shift/scale/gate; `QwenAttn` joint img+txt with RMSNorm q/k + complex-pair RoPE `QwenRoPE` axes[16,56,56] θ1e4 scale_rope; `QwenFF` gelu_approx 4×). img_in 64→3072, txt_norm+txt_in 3584→3072, `QwenTimeEmbed`, norm_out=`FluxAdaNormContinuous`, proj_out→64.
-  - `Qwen3DVAEEncoder`/`Qwen3DVAEDecoder` = 3D causal-conv VAE **operated in 2D since T=1** (each causal Conv3d → 2D conv on the last temporal kernel slice; decoder resamplers do spatial nearest-2× + conv; encoder downsamplers pad bottom/right then stride-2 conv). Per-channel `LATENTS_MEAN/STD` (16-vectors). Decoder channel flow 384→192→192→96→3 over 3 upsamples (8×). Qwen-edit q4/q5 VAE conditioning encode/pack and edit-loop PNG output are live-proven after the VL-grid conditioning fix; non-null masks are rejected before pipeline load; real masks and incomplete q3/q6 bundles are pending.
+  - `Qwen3DVAEEncoder`/`Qwen3DVAEDecoder` = 3D causal-conv VAE **operated in 2D since T=1** (each causal Conv3d → 2D conv on the last temporal kernel slice; decoder resamplers do spatial nearest-2× + conv; encoder downsamplers pad bottom/right then stride-2 conv). Per-channel `LATENTS_MEAN/STD` (16-vectors). Decoder channel flow 384→192→192→96→3 over 3 upsamples (8×). Qwen-edit q4/q5 VAE conditioning encode/pack and edit-loop PNG output are live-proven for single-image and ordered multi-image text-image edits after the VL-grid conditioning fix; non-null qwen masks are rejected before pipeline load because mflux has no qwen mask path; incomplete q3/q6 bundles are pending.
   - Pipeline: noise (flux-style pack, 1,hw,64) → loop[CFG: pos+neg transformer passes → mflux guidance rescale (`combined = neg + g*(pos-neg)`, then rescale to positive-noise norm) → FlowMatch step] → unpack → 5D → VAE decode → PNG. **timestep passed = RAW sigma** (`QwenTimesteps` applies ×1000 internally — see §6 bug 2). ~20 steps, guidance ~4 (CFG).
 
 Full per-model transcription specs are in `docs/FLUX_SCHNELL_PORT_PLAN.md` and `docs/QWEN_IMAGE_PORT_PLAN.md` (grounded from the mflux Python source).
@@ -318,10 +363,11 @@ Full per-model transcription specs are in `docs/FLUX_SCHNELL_PORT_PLAN.md` and `
 1. **Conv weight layout.** mflux stores conv weights in **MLX channels-last** `(out, [kt,] kh, kw, in)`, NOT PyTorch `(out, in, k...)`. Assuming PyTorch → wrong reshape/transpose → load-time crash (`reshape 442368→(1152,1)`). Linear weights ARE PyTorch `(out,in)`.
 2. **Qwen timestep double-scale.** mflux passes the raw sigma to `QwenTimesteps(scale=1000)` which multiplies internally. Passing `sigma×1000` double-scales → the transformer denoises to pure noise. Pass the **raw sigma**.
 3. **Qwen-edit conditioning grid.** mflux computes a 1024-area VAE plan for the output target but passes `vl_width/vl_height` into `QwenEditUtil.create_image_conditioning_latents`; when present, the source-image conditioning VAE encode uses those VL dimensions. Swift must use `vlWidth/vlHeight` for qwen-edit conditioning latents, not `vaeWidth/vaeHeight`. The fixed square q4 path is 384x384 -> 24x24 -> 576 static tokens, not 1024x1024 -> 64x64 -> 4096 tokens.
-4. **Indexed safetensor completeness.** A component with “some safetensors” is not enough. `Qwen-Image-Edit-mflux-q3` looked loadable until live load failed on missing `text_encoder/3.safetensors`; scanner readiness now validates `*.safetensors.index.json` shard references.
-5. **Model resolution / quant collision.** `MLXStudioModelStore.resolve` normalized away the `-Nbit` suffix → requesting `...-8bit` loaded a co-installed `...-4bit`. Fixed with a literal case-insensitive directory-name match first. **osaurus must request the exact bundle directory name.**
-6. **Tokenizer format** — see §3 (need fast `tokenizer.json`).
-7. **GPU watchdog** — MLX mmaps weights lazily; running gen with weights on a **slow volume (USB)** stalls the Metal command buffer → `kIOGPUCommandBufferCallbackErrorTimeout`. **Stage weights on the internal SSD.**
+4. **Qwen-edit multi-image semantics.** mflux accepts ordered `image_paths`, uses the last path for sizing, and concatenates per-source prompt-image features and VAE conditioning latents. Swift mirrors that with `ImageEditRequest.sourceImages`; do not collapse multiple sources into one prompt image or post-blend outputs.
+5. **Indexed safetensor completeness.** A component with “some safetensors” is not enough. `Qwen-Image-Edit-mflux-q3` looked loadable until live load failed on missing `text_encoder/3.safetensors`; scanner readiness now validates `*.safetensors.index.json` shard references.
+6. **Model resolution / quant collision.** `MLXStudioModelStore.resolve` normalized away the `-Nbit` suffix → requesting `...-8bit` loaded a co-installed `...-4bit`. Fixed with a literal case-insensitive directory-name match first. **osaurus must request the exact bundle directory name.**
+7. **Tokenizer format** — see §3 (need fast `tokenizer.json`).
+8. **GPU watchdog** — MLX mmaps weights lazily; running gen with weights on a **slow volume (USB)** stalls the Metal command buffer → `kIOGPUCommandBufferCallbackErrorTimeout`. **Stage weights on the internal SSD.**
 
 ---
 
@@ -342,7 +388,7 @@ Full per-model transcription specs are in `docs/FLUX_SCHNELL_PORT_PLAN.md` and `
 ---
 
 ## 9. How to continue (concrete next steps)
-1. **qwen-image-edit:** the q4/q5 text-image edit paths are live-proven. Source-image conditioning now follows mflux's VL-size path (`vlWidth/vlHeight`) instead of the 1024-area VAE target grid. Current proof artifacts: `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-determinism-after-cond-fix/Qwen-Image-Edit-mflux-q4-load.json`, `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q5-determinism/Qwen-Image-Edit-mflux-q5-load.json`, `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-conditioning-after-cond-fix/Qwen-Image-Edit-mflux-q4-load.json` (`latents_shape=1x576x64`, `image_ids_shape=1x576x3`), and `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-denoise-after-cond-fix/Qwen-Image-Edit-mflux-q4-load.json` (`combined_velocity_shape=1x1600x64`). Current non-null masks are rejected before pipeline load; next qwen-edit work is real masks/inpaint semantics and complete q3/q6 bundle staging if those variants matter.
+1. **qwen-image-edit:** the q4/q5 single-image and ordered multi-image text-image edit paths are live-proven. Source-image conditioning now follows mflux's VL-size path (`vlWidth/vlHeight`) instead of the 1024-area VAE target grid, and multi-image uses mflux's ordered `image_paths` semantics. Current proof artifacts: `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-determinism-after-cond-fix/Qwen-Image-Edit-mflux-q4-load.json`, `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q5-determinism/Qwen-Image-Edit-mflux-q5-load.json`, `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-conditioning-after-cond-fix/Qwen-Image-Edit-mflux-q4-load.json` (`latents_shape=1x576x64`, `image_ids_shape=1x576x3`), `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-denoise-after-cond-fix/Qwen-Image-Edit-mflux-q4-load.json` (`combined_velocity_shape=1x1600x64`), `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-multi-image-live/Qwen-Image-Edit-mflux-q4-load.json`, and `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q5-multi-image-live/Qwen-Image-Edit-mflux-q5-load.json`. Current non-null qwen masks are rejected before pipeline load; keep qwen masks hidden unless upstream mflux adds a real qwen mask path or a separate fill/inpaint model is wired.
    - Current staged bundle is already present at `~/.mlxstudio/models/image/Qwen-Image-Edit-mflux`; use `Qwen-Image-Edit-mflux-q4` or `Qwen-Image-Edit-mflux-q5` for current Osaurus wiring. Keep q3/q6 hidden/blocked until their indexed shards/components are complete.
 2. **Ideogram 4:** `cocktailpeanut/ideogram-4-fp8` is staged locally, scans complete, and load-validates required sentinel keys; official `ideogram-ai/*` access remains approval-gated. Port = Qwen3 text encoder (close to the qwen LM encoder) + 34-layer DiT (emb 4608, 18 heads, `llm_features 4096×13` = multi-layer Qwen3 hidden states, rope θ5e6) + unconditional transformer execution + VAE. `MFluxStore` already has the fp8 `weight_scale` linear path and `WeightLoader` already includes `unconditional_transformer`; remaining quant work is nf4 if that bundle is used. Ref: `/tmp/mflux-ref/src/mflux/models/ideogram4/`.
 3. **Full precision** flux/z-image: download, run the probe — existing pipelines (`MFluxLinear` handles non-quant). Should just work.
@@ -350,7 +396,7 @@ Full per-model transcription specs are in `docs/FLUX_SCHNELL_PORT_PLAN.md` and `
    `osaurus-ai/vmlx-swift` main. Next osaurus-side work is the `/v1/images/*`
    bridge, model list/capability mapping, progress SSE, output file policy, and
    `MetalGate` exclusion. Pin Osaurus to `vmlx-origin/main`
-   `9f1faea11aee78f17041c5bed6da039e70c11d05` or a later verified main SHA.
+   `66f328322c41ce51881a9ab3bb630c1aeee114b8` or a later verified main SHA.
 
 **Reference:** the mflux Python source (the source of truth for every arch + weight key) is at `/tmp/mflux-ref` (clone of `github.com/filipstrand/mflux`). Re-clone if gone.
 
@@ -367,6 +413,11 @@ Full per-model transcription specs are in `docs/FLUX_SCHNELL_PORT_PLAN.md` and `
 - `osaurus-ai/vmlx-swift` **PR #67** — Ideogram fp8 load-time sentinel
   validation merged to main. Merge commit:
   `9f1faea11aee78f17041c5bed6da039e70c11d05`.
+- `osaurus-ai/vmlx-swift` **PR #68** — current-main image proof docs merged to
+  main. Merge commit: `66f328322c41ce51881a9ab3bb630c1aeee114b8`.
+- `osaurus-ai/vmlx-swift` **PR #69** / branch
+  **`codex/qwen-edit-multi-image`** — qwen-edit ordered multi-image
+  source/docs work, pending merge.
 - `jjang-ai/vmlx-flux` branch **`native-zimage-proven`** — standalone mirror of
   the native work. Current pushed checkpoint includes Ideogram fp8 load
   validation (`6d7901d01b19f76b9d4a0754188eff1dba80b10c`).

--- a/docs/OSAURUS_IMAGE_API_SPEC.md
+++ b/docs/OSAURUS_IMAGE_API_SPEC.md
@@ -13,10 +13,12 @@ contract osaurus implements server-side and the UI builds against.
 > Status: the engine is real. `z-image-turbo` and `flux1-schnell` are
 > live-proven for 4-bit and 8-bit text-to-image; `qwen-image` is live-proven for
 > 4-bit and 6-bit text-to-image (public mflux 8-bit not found). `qwen-image-edit` q4 and q5 are live-proven for
-> text-image edit after the VL-grid conditioning fix; expose only the proven
-> q4/q5 paths for normal testing, keep q3 blocked because its text-encoder index
-> references missing `text_encoder/3.safetensors`, keep q6 blocked until its
-> local bundle is complete, and hide mask/inpaint controls until wired.
+> single-image and multi-image text-image edit after the VL-grid conditioning
+> fix; expose only the proven q4/q5 paths for normal testing, keep q3 blocked
+> because its text-encoder index references missing `text_encoder/3.safetensors`,
+> keep q6 blocked until its local bundle is complete, and hide mask/inpaint
+> controls for qwen-edit. The mflux qwen-edit reference supports one or more
+> source images, but does not expose a qwen mask/inpaint path.
 > Ideogram has a complete local fp8 mirror bundle staged from
 > `cocktailpeanut/ideogram-4-fp8`, and the scanner reports it as loadable
 > scaffold. The shared source can now load Ideogram's
@@ -33,6 +35,15 @@ contract osaurus implements server-side and the UI builds against.
 > Artifact root: `docs/local/vmlx-flux-probes/2026-06-16-current-main-*`;
 > viewed contact sheet:
 > `docs/local/vmlx-flux-outputs/2026-06-16-current-main-contact-sheet.png`.
+> Multi-image qwen-edit proof: branch `codex/qwen-edit-multi-image` adds
+> ordered `ImageEditRequest.sourceImages`. q4 artifact:
+> `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-multi-image-live/Qwen-Image-Edit-mflux-q4-load.json`;
+> q5 artifact:
+> `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q5-multi-image-live/Qwen-Image-Edit-mflux-q5-load.json`;
+> internal q5 shape proof:
+> `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q5-multi-image-shape-proof/Qwen-Image-Edit-mflux-q5-load.json`;
+> viewed contact sheet:
+> `docs/local/vmlx-flux-outputs/2026-06-16-qwen-edit-multi-image-contact-sheet.png`.
 > The HTTP surface below is the **proposed contract** for the osaurus team to
 > expose; design it once, wire all models through it.
 
@@ -44,7 +55,7 @@ contract osaurus implements server-side and the UI builds against.
 |---|---|---|
 | `GET  /v1/images/models` | List installed image models + defaults + capabilities | `MLXStudioModelStore.scan()` + `ModelRegistry` |
 | `POST /v1/images/generations` | text → image | `FluxEngine.generate` |
-| `POST /v1/images/edits` | image (+mask) + prompt → image | `FluxEngine.edit` |
+| `POST /v1/images/edits` | image(s) (+mask where supported) + prompt → image | `FluxEngine.edit` |
 | `POST /v1/images/upscale` | low-res → high-res | `FluxEngine.upscale` |
 | `POST /v1/images/cancel` | cancel an in-flight job | cancels the consuming `Task` |
 
@@ -73,6 +84,7 @@ The UI should NOT hard-code model names or limits — fetch them. Response:
         "upscale": false,
         "negative_prompt": true,           // show/hide negative field
         "mask": false,                     // show/hide mask tool
+        "multiple_source_images": false,   // show/hide multi-reference upload
         "lora": false
       },
       "defaults": { "steps": 4, "guidance": 0.0 },   // pre-fill the form
@@ -98,7 +110,8 @@ Notes for UI:
   `Qwen-Image-Edit-mflux-q5` are implemented/testable; q3/q6 remain partial or
   blocked until complete local bundles are staged and proven.
 - Use `capabilities` to show/hide fields. e.g. `negative_prompt:false` → hide the
-  negative box; `mask:false` → no mask tool.
+  negative box; `mask:false` → no mask tool;
+  `multiple_source_images:true` → allow ordered multi-reference upload.
 - Pre-fill `steps`/`guidance` from `defaults`; clamp sliders with `limits`.
 
 ---
@@ -150,13 +163,18 @@ Notes for UI:
 
 ---
 
-## 3. `POST /v1/images/edits` — image + prompt (+ optional mask)
+## 3. `POST /v1/images/edits` — image(s) + prompt (+ optional mask for models that support it)
 
 ```jsonc
 {
   "model": "Qwen-Image-Edit-mflux-q4",
   "prompt": "make the apple green",
   "image": "data:image/png;base64,....",   // REQUIRED. source image (b64 or URL)
+  "images": [
+    "data:image/png;base64,....",
+    "file:///Users/me/reference-shirt.png"
+  ],                                      // optional ordered list. If present,
+                                          // server maps this to sourceImages.
   "mask":  "data:image/png;base64,....",   // optional. white=edit, black=keep
   "strength": 0.75,               // 0..1 — how far to deviate from the source
                                   //   (0 = barely change, 1 = ignore source)
@@ -169,12 +187,24 @@ Notes for UI:
   "stream": true
 }
 ```
-Maps to `ImageEditRequest` (`sourceImage`, `mask`, `strength`, ...). Only models
+Maps to `ImageEditRequest` (`sourceImage` legacy single-image compatibility,
+`sourceImages` ordered multi-image list, `mask`, `strength`, ...). Only models
 with `capabilities.image_edit:true` accept this; else 400 `wrong model kind`.
+For qwen-edit, send either `image` or `images`; if both are present, prefer
+`images` and preserve order. The qwen-edit runtime uses the last source image for
+the mflux aspect-ratio sizing plan and all source images for Qwen-VL prompt
+features plus VAE conditioning latents.
+
 Current live-proven targets are `Qwen-Image-Edit-mflux-q4` and
-`Qwen-Image-Edit-mflux-q5` without masks; reject a non-null `mask` with 501 or
-hide the control until mask/inpaint wiring lands. The engine currently enforces
-this for Qwen edit by emitting a failed event before the edit pipeline loads;
+`Qwen-Image-Edit-mflux-q5` without masks. Both accept ordered multi-image
+inputs through `sourceImages`. q4 multi-image proof has turn 1/3 SHA
+`e43910a505ab090bfbd4ec3a00f6e58fcd97df65c6b61e6b973754511bc740be` and turn 2
+SHA `16ecc1fec4bdff1e5aecb9c0875569b2bebed53a81c686bf23e806faa6e2b893`; q5
+multi-image proof has turn 1/3 SHA
+`ec2e49d6f300849cb46940b793670bee007f4aae8f04e97a31289670758519c9` and turn 2
+SHA `8dfacb52aa81c6e0a8a6827c4377f27bc5d9396e39a4f8662a47db93798b767a`.
+Reject a non-null `mask` with 501 or hide the control for qwen-edit. The engine
+currently enforces this by emitting a failed event before the edit pipeline loads;
 `QwenImageEditSupportTests.testQwenImageEditRejectsMaskBeforePipelineLoad`
 covers that contract, and `vmlxflux-probe --edit --mask-image <png>` records the
 same failed-event behavior against staged local bundles.

--- a/docs/OSAURUS_VMLX_FLUX_INTEGRATION_SPEC.md
+++ b/docs/OSAURUS_VMLX_FLUX_INTEGRATION_SPEC.md
@@ -32,11 +32,13 @@
   live load + three-turn generate + SHA + visual proof from 2026-06-16.
   `qwen-image` 4-bit has fresh live load/generate/SHA + visual proof after the
   mflux guidance-rescale fix. `qwen-image-edit` q4 and q5 have fresh live
-  text-image edit proof after the VL-grid source-conditioning fix: same
-  prompt+seed repeats byte-identically, a different edit prompt changes the
-  image coherently, and the q4 shape probes match mflux. q3 is incomplete
-  because its text-encoder index references missing `text_encoder/3.safetensors`,
-  q6 is incomplete, and mask/inpaint editing is not wired. A complete
+  single-image and ordered multi-image text-image edit proof after the VL-grid
+  source-conditioning fix: same prompt+seed repeats byte-identically, a
+  different edit prompt changes the image, and shape probes match mflux. q3 is
+  incomplete because its text-encoder index references missing
+  `text_encoder/3.safetensors`, q6 is incomplete, and qwen masks are
+  intentionally hidden because the mflux qwen-edit reference has no qwen
+  mask/inpaint argument or path. A complete
   `cocktailpeanut/ideogram-4-fp8` mirror bundle is now staged locally and scans
   as `loadableScaffold`. The shared loader now covers fp8 linear
   `weight_scale` rows and the `unconditional_transformer` component, and direct
@@ -123,13 +125,23 @@ Notes: width/height must be divisible by 16 for Z-Image (else
 `invalidRequest`). `guidance == 0` ⇒ no CFG pass (turbo models). `seed == nil` ⇒
 nondeterministic. `numImages > 1` is not yet batched (see §6 open work).
 
-### ImageEditRequest (image[+mask]→image)
+### ImageEditRequest (image(s)[+mask where supported]→image)
 ```swift
 ImageEditRequest(prompt:, sourceImage:URL, mask:URL?, strength:0.75,
                  width:nil, height:nil, steps:20, guidance:3.5, seed:,
                  outputDir:, outputFormat:.png)
+
+try ImageEditRequest(prompt:, sourceImages:[URL], mask:URL?, strength:0.75,
+                     width:nil, height:nil, steps:20, guidance:3.5, seed:,
+                     outputDir:, outputFormat:.png)
 ```
-`mask`: white=edit, black=keep. `strength`: 0..1 deviation from source. `width/height nil`⇒match source.
+`sourceImage` is the legacy single-image path. `sourceImages` is the ordered
+multi-reference path; it throws `FluxError.invalidRequest` for an empty array.
+For qwen-image-edit, the last source image drives the mflux sizing plan and all
+source images feed Qwen-VL prompt features plus VAE conditioning latents.
+`mask`: white=edit, black=keep for models that really support masks.
+Qwen-image-edit does not; hide qwen mask controls and reject non-null qwen masks.
+`strength`: 0..1 deviation from source. `width/height nil`=>match source.
 
 ### UpscaleRequest (SeedVR2)
 ```swift
@@ -282,7 +294,7 @@ their 4-bit linears through scale tensors at load time inside the model.
 |---|---|---|---|
 | **z-image-turbo** | `native_pipeline_implemented` | Full native port: Qwen-style text encoder, patchify+caption-concat DiT (noise/context refiners + unified layers, RoPE, adaLN, timestep embed), real `AutoencoderKL` VAE decode, real 4/8-bit weight decode, PNG out. Fresh 2026-06-16 proof: 4-bit + 8-bit live load, 3 completed turns, same-prompt SHA match, different-prompt SHA change, viewed coherent apple/mountain images. | 1024px tuning. |
 | **qwen-image** | `native_pipeline_implemented` | Full native pipeline `QwenImageNative.swift`: Qwen2.5 LM text encoder (GQA), 60-layer MM-DiT (joint attention + 3-axis RoPE), 3D causal-conv VAE, mflux guidance-rescaled CFG. Fresh 2026-06-16 4-bit proof: live load, 20-step generation, same-prompt SHA match, different-prompt SHA change, viewed coherent apple/mountain outputs. Fresh 2026-06-16 6-bit proof after the mod-linear key-layout fallback: live load, 20-step generation, same-prompt SHA `66e8187e887087e8a8e9227a99f16236c5ba15717a5e31e08a5772868b3a456a`, different-prompt SHA `44069312716932d6d72181a808625a33777ed29af7723eea8f76b0ac5ba96a52`, viewed coherent apple/mountain outputs. | Public mflux 8-bit not found/staged; full not staged/proven. Three port bugs fixed: VAE conv weights are MLX channels-last (not PyTorch); qwen timestep is raw sigma (QwenTimesteps applies ×1000 internally); qwen txt2img mod-linear keys can be either `img_mod_linear`/`txt_mod_linear` or nested `img_norm1.mod_linear`/`txt_norm1.mod_linear`. |
-| qwen-image-edit | `native_pipeline_implemented` for `Qwen-Image-Edit-mflux-q4` and `Qwen-Image-Edit-mflux-q5`; `native_pipeline_partial` for incomplete q3/q6 | q4/q5 scan as loadable local bundles and have live text-image edit proof after the indexed-shard scanner fix. q3 now scans incomplete because its text-encoder index references missing `text_encoder/3.safetensors`; q6 scans incomplete because it lacks transformer/VAE shards and indexed text-encoder shards. `Qwen-Image-Edit-mflux-q4` passes manifest-gated engine load against tokenizer files, Qwen LM keys, Qwen-VL vision keys, transformer keys, and VAE encode/decode keys. Live q4 probes prove real tokenizer image-pad expansion (`input_ids_shape=1x276`, `image_token_count=196`, `template_drop_index=64`), Qwen2.5-VL prompt-image encode (`feature_shape=196x3584`, `prompt_embeds_shape=1x212x3584`, prompt tokens match features, finite stats), fixed VL-size VAE static image latents (`conditioning_width=384`, `conditioning_height=384`, `latents_shape=1x576x64`, `image_ids_shape=1x576x3`, finite stats), first edit-shaped transformer velocity (`combined_velocity_shape=1x1600x64`, `target_velocity_shape=1x1024x64`, finite stats), and ImageEditor scheduler/decode/PNG output. Same-seed q4 proof: blue edit turn 1 and turn 3 share SHA `005ab8baddfe9b7a94aa83f8ddd22d192e7e5a0275c556dcf2ead76a565e474a`; green edit turn 2 SHA `815711be73a9e89599b3e97f9f15196115875103f9407d7b1b61bab33de8e3b4`; viewed outputs are coherent and prompt-sensitive. Same-seed q5 proof: blue edit turn 1 and turn 3 share SHA `5cd5d9197bd659bd8b59b4a2f2bca413266146ad4e08249289d5fa6a8025fa4e`; green edit turn 2 SHA `d2c6c4eb4a19dcf48122b5216fc15ac37b9f5aa49c15f596acd1276a4df57034`; viewed outputs are coherent and prompt-sensitive. Non-null masks are rejected before the edit pipeline loads and covered by `QwenImageEditSupportTests.testQwenImageEditRejectsMaskBeforePipelineLoad`. | q3/q6 need complete local bundles before UI promotion; mask/inpaint edit fields are not wired; broader Osaurus production matrix still pending. |
+| qwen-image-edit | `native_pipeline_implemented` for `Qwen-Image-Edit-mflux-q4` and `Qwen-Image-Edit-mflux-q5`; `native_pipeline_partial` for incomplete q3/q6 | q4/q5 scan as loadable local bundles and have live text-image edit proof after the indexed-shard scanner fix. q3 now scans incomplete because its text-encoder index references missing `text_encoder/3.safetensors`; q6 scans incomplete because it lacks transformer/VAE shards and indexed text-encoder shards. `Qwen-Image-Edit-mflux-q4` passes manifest-gated engine load against tokenizer files, Qwen LM keys, Qwen-VL vision keys, transformer keys, and VAE encode/decode keys. Live q4 probes prove real tokenizer image-pad expansion (`input_ids_shape=1x276`, `image_token_count=196`, `template_drop_index=64`), Qwen2.5-VL prompt-image encode (`feature_shape=196x3584`, `prompt_embeds_shape=1x212x3584`, prompt tokens match features, finite stats), fixed VL-size VAE static image latents (`conditioning_width=384`, `conditioning_height=384`, `latents_shape=1x576x64`, `image_ids_shape=1x576x3`, finite stats), first edit-shaped transformer velocity (`combined_velocity_shape=1x1600x64`, `target_velocity_shape=1x1024x64`, finite stats), and ImageEditor scheduler/decode/PNG output. Same-seed q4 proof: blue edit turn 1 and turn 3 share SHA `005ab8baddfe9b7a94aa83f8ddd22d192e7e5a0275c556dcf2ead76a565e474a`; green edit turn 2 SHA `815711be73a9e89599b3e97f9f15196115875103f9407d7b1b61bab33de8e3b4`; viewed outputs are coherent and prompt-sensitive. Same-seed q5 proof: blue edit turn 1 and turn 3 share SHA `5cd5d9197bd659bd8b59b4a2f2bca413266146ad4e08249289d5fa6a8025fa4e`; green edit turn 2 SHA `d2c6c4eb4a19dcf48122b5216fc15ac37b9f5aa49c15f596acd1276a4df57034`; viewed outputs are coherent and prompt-sensitive. Non-null qwen masks are rejected before the edit pipeline loads and covered by `QwenImageEditSupportTests.testQwenImageEditRejectsMaskBeforePipelineLoad`. | q3/q6 need complete local bundles before UI promotion; qwen mask/inpaint is unsupported by the current mflux reference; broader Osaurus production matrix still pending. |
 | flux2-klein / flux2-klein-edit | `not_implemented` | Bundle scans + loads; `FluxDiTConfig.flux2Klein` preset exists. | T5 (single-encoder) port + weight key-map + 3-axis RoPE. |
 | **flux1-schnell** | `native_pipeline_implemented` | Full native pipeline `Flux1Native.swift`: T5-XXL + CLIP-L encoders, full DiT (19 joint + 38 single blocks, 24h×128, 3-axis RoPE), AutoencoderKL VAE, mflux decode. Fresh 2026-06-16 proof: 4-bit + 8-bit live load, 3 completed turns, same-prompt SHA match, different-prompt SHA change, viewed coherent apple/mountain images. | tokenizer.json must be staged (mflux ships slow tokenizers — convert; see port plan). Full precision pending. |
 | flux1-dev/kontext/fill | `not_implemented` | dev = schnell + guidance embedder (small add); kontext/fill = edit variants. | wire guidance + edit conditioning on the working schnell pipeline. |
@@ -290,13 +302,47 @@ their 4-bit linears through scale tensors at load time inside the model.
 | seedvr2 | scaffold | registered | upscale arch (different family). |
 | wan-2.1 / wan-2.2 | scaffold | full pipeline scaffolded (WanVAE3D + WanDiT + MP4 writer) with random weights. | real weight key-map, real Conv3d (currently a Conv2d shim), windowed attention for >3-4s clips. |
 
+**Qwen-image-edit multi-image addendum (2026-06-16):** branch
+`codex/qwen-edit-multi-image` adds ordered `ImageEditRequest.sourceImages` and
+the probe accepts repeated `--source-image`. Source trace: mflux qwen-edit
+accepts `image_paths: list[str]`, computes sizing from `image_paths[-1]`, and
+concatenates per-source prompt-image features and VAE conditioning latents.
+Swift mirrors that in `QwenImageEditSupport.swift`: the preprocessing plan uses
+the last source image for sizing, `QwenImageEditPromptImageEncoder` concatenates
+per-image Qwen2.5-VL features and prompt image-token runs, and
+`QwenImageEditConditioner` concatenates per-image VAE conditioning latents and
+IDs. q5 shape proof:
+`docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q5-multi-image-shape-proof/Qwen-Image-Edit-mflux-q5-load.json`
+(`image_count=2`, `latents_shape=[1,1152,64]`,
+`image_token_counts=[196,196]`,
+`combined_velocity_shape=[1,1728,64]`,
+`image_shapes=[[1,24,24],[1,24,24],[1,24,24]]`). q4 live proof:
+`docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-multi-image-live/Qwen-Image-Edit-mflux-q4-load.json`
+(turn 1/3 SHA
+`e43910a505ab090bfbd4ec3a00f6e58fcd97df65c6b61e6b973754511bc740be`,
+turn 2 SHA
+`16ecc1fec4bdff1e5aecb9c0875569b2bebed53a81c686bf23e806faa6e2b893`).
+q5 live proof:
+`docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q5-multi-image-live/Qwen-Image-Edit-mflux-q5-load.json`
+(turn 1/3 SHA
+`ec2e49d6f300849cb46940b793670bee007f4aae8f04e97a31289670758519c9`,
+turn 2 SHA
+`8dfacb52aa81c6e0a8a6827c4377f27bc5d9396e39a4f8662a47db93798b767a`).
+Viewed exact current-source output PNGs recorded in the q4/q5 load artifacts
+(the existing contact sheet is
+`docs/local/vmlx-flux-outputs/2026-06-16-qwen-edit-multi-image-contact-sheet.png`).
+Visual boundary: q4 uses both images but is rougher than q5; q5 strongly uses
+the mountain and green-pear prompt, while the first q5 apple prompt leans
+mountain-only. This is still not mask/inpaint support; qwen masks remain
+unsupported because the mflux qwen-edit reference exposes no mask path.
+
 **Shared P0 blockers for the Flux/Qwen family** (z-image already cleared these via
 its own native port): (1) safetensors→module key-map + `Module.update`, (2) T5-XXL
 text encoder (shared Flux/Qwen/Wan), (3) CLIP-L (Flux1), (4) Flux 3-axis RoPE.
 
 **mflux feature surface (scope = "mflux type, not just flux type"):**
 - ✅ Quantized mflux packaging (`*-mflux-4bit`) load + decode — implemented for z-image.
-- ✅ Image *edit* protocol (`ImageEditor`, mask/strength) — API present; per-model bodies pending.
+- ✅ Image *edit* protocol (`ImageEditor`, `sourceImage`/`sourceImages`, `mask`/`strength`) — qwen-edit q4/q5 single-image and ordered multi-image text-image paths are live-proven; expose masks only for models with a real mask path.
 - ⬜ LoRA — `ModelEntry.supportsLoRA` flag exists (false everywhere today); loader hook TBD.
 - ⬜ ControlNet / img2img strength conditioning — request fields exist (`strength`, `mask`); wiring pending per model.
 
@@ -326,14 +372,16 @@ eval hot path).
 | z-image-turbo | ✅ proven | — | ✅ proven | (not staged) |
 | flux1-schnell | ✅ proven | — | ✅ proven | (not staged) |
 | qwen-image | ✅ proven | ✅ 6-bit proven | public mflux 8-bit not found/staged | (not staged) |
-| qwen-image-edit | ✅ q4 text-image edit proven; q3 incomplete | ✅ q5 text-image edit proven; q6 incomplete | (not staged) | (not staged) |
+| qwen-image-edit | ✅ q4 single/multi-image text edit proven; q3 incomplete | ✅ q5 single/multi-image text edit proven; q6 incomplete | (not staged) | (not staged) |
 Proven rows are deterministic (same seed+prompt -> identical), prompt-sensitive,
 and coherent. z-image-turbo and flux1-schnell 8-bit and 4-bit produce visibly
 distinct images (genuine quant), ~3-4s/512px/4-step. qwen-image 4-bit and
 6-bit are live-proven text-to-image rows; qwen-image 8-bit remains unproven
 because no public mflux 8-bit bundle was found in the current HF search.
-qwen-image-edit q4/q5 are live-proven text-image edit rows after the VL-grid
-conditioning fix; q3/q6 and masks remain unpromoted as above.
+qwen-image-edit q4/q5 are live-proven single-image and ordered multi-image
+text-image edit rows after the VL-grid conditioning fix; q3/q6 remain hidden
+until local bundles are complete. Qwen masks remain unsupported unless upstream
+mflux adds a real qwen mask path or a separate fill/inpaint model is wired.
 
 Current-main refresh after PR #67: `vmlx-origin/main`
 `9f1faea11aee78f17041c5bed6da039e70c11d05` was rebuilt and live-probed from
@@ -417,27 +465,31 @@ vmlxflux-probe --root <dir> --model <name|dir> --generate --json \
 vmlxflux-probe --model Qwen-Image-Edit-mflux-q4 --edit \
   --source-image <png> --turn "make the background blue" \
   --artifacts <dir>
-# qwen-image-edit q4 records completed edit turns and writes PNGs; current proof
-# includes same-seed deterministic repeat plus prompt-sensitive viewed outputs.
+# Repeat --source-image for ordered multi-reference qwen edits; the last source
+# image drives mflux sizing and all sources feed prompt/conditioning features.
+# qwen-image-edit q4/q5 record completed edit turns and write PNGs; current
+# proof includes same-seed deterministic repeat plus prompt-sensitive viewed
+# outputs for single-image and multi-image rows.
 # Add --mask-image <png> to prove the current unsupported-mask path: the engine
 # loads the staged bundle then emits failed_event before the edit pipeline runs.
 
 vmlxflux-probe --model Qwen-Image-Edit-mflux-q4 --qwen-edit-prompt \
   --source-image <png> --turn "make the background blue" \
   --artifacts <dir>
-# qwen-image-edit prompt currently records live tokenizer image-pad expansion
-# only.
+# Repeat --source-image to record per-image token counts and concatenated
+# tokenizer image-pad expansion.
 
 vmlxflux-probe --model Qwen-Image-Edit-mflux-q4 --qwen-edit-conditioning \
   --source-image <png> \
   --artifacts <dir>
 # qwen-image-edit conditioning records the mflux-compatible VL-size VAE encode
-# and packed static latents (square source: 384x384 -> 24x24 -> 576 tokens).
+# and packed static latents per source image (square source: 384x384 -> 24x24
+# -> 576 tokens).
 
 vmlxflux-probe --model Qwen-Image-Edit-mflux-q4 --qwen-edit-vision \
   --source-image <png> --turn "make the background blue" \
   --artifacts <dir>
-# qwen-image-edit vision currently records live Qwen2.5-VL features and
+# Repeat --source-image to record per-source Qwen2.5-VL grids/features and
 # image-token splice into Qwen text embeddings.
 
 vmlxflux-probe --model Qwen-Image-Edit-mflux-q4 --qwen-edit-denoise \
@@ -445,7 +497,7 @@ vmlxflux-probe --model Qwen-Image-Edit-mflux-q4 --qwen-edit-denoise \
   --turn "make the background blue" \
   --artifacts <dir>
 # qwen-image-edit denoise records one live edit-shaped transformer velocity
-# forward and target velocity slice with target+conditioning image_shapes.
+# forward and target velocity slice with target+one shape per conditioning image.
 ```
 Per-turn seed = `--seed` if given (fixes ALL turns to one seed — use for
 same-seed/different-prompt sensitivity tests), else `turnIndex+1`. Artifacts:
@@ -496,10 +548,11 @@ seeds, and the CFG path. z-image-turbo is **production-compatible** — the May-
    exclusion around the full stream drain.
 2. Ideogram 4 native generation: Qwen3 encoder, 34-layer DiT,
    unconditional transformer execution, VAE decode, then live image proof.
-3. Qwen-Image-Edit follow-through: q4/q5 text-image edit is live-proven after
-   the VL-grid conditioning fix. Keep q3/q6 hidden/blocked until the local
-   bundles are complete, and wire masks/inpaint semantics before exposing masked
-   editing.
+3. Qwen-Image-Edit follow-through: q4/q5 single-image and ordered multi-image
+   text-image edit are live-proven after the VL-grid conditioning fix. Keep
+   q3/q6 hidden/blocked until the local bundles are complete. Keep qwen mask
+   controls hidden unless upstream mflux adds a real qwen mask path or a
+   separate fill/inpaint model is wired; do not fake masks with post-blends.
 4. Full-precision z-image/flux-schnell: stage weights, run the same current-main
    probe matrix, and visually inspect outputs before promotion.
 5. LoRA loader hook (`supportsLoRA`), img2img/controlnet conditioning.

--- a/tools/vMLXFluxProbe/main.swift
+++ b/tools/vMLXFluxProbe/main.swift
@@ -156,6 +156,7 @@ struct VMLXFluxProbe {
             "width_explicit": options.widthExplicit,
             "height_explicit": options.heightExplicit,
             "source_image": options.sourceImage?.path ?? NSNull(),
+            "source_images": options.sourceImages.map(\.path),
             "mask_image": options.maskImage?.path ?? NSNull(),
             "steps": options.steps,
             "seed": options.seed.map { $0 as Any } ?? NSNull(),
@@ -235,14 +236,14 @@ struct VMLXFluxProbe {
             }
 
             if options.edit {
-                guard let sourceImage = options.sourceImage else {
+                guard !options.sourceImages.isEmpty else {
                     throw ProbeError("--edit requires --source-image")
                 }
                 var turnRecords: [[String: Any]] = []
                 for (index, prompt) in options.turns.enumerated() {
-                    let request = ImageEditRequest(
+                    let request = try ImageEditRequest(
                         prompt: prompt,
-                        sourceImage: sourceImage,
+                        sourceImages: options.sourceImages,
                         mask: options.maskImage,
                         strength: options.strength,
                         width: options.widthExplicit ? options.width : nil,
@@ -255,7 +256,8 @@ struct VMLXFluxProbe {
                     var record: [String: Any] = [
                         "turn": index + 1,
                         "prompt": prompt,
-                        "source_image": sourceImage.path,
+                        "source_image": options.sourceImage?.path ?? NSNull(),
+                        "source_images": options.sourceImages.map(\.path),
                         "mask_image": options.maskImage?.path ?? NSNull(),
                         "started_at": isoTimestamp(turnStart),
                     ]
@@ -307,14 +309,14 @@ struct VMLXFluxProbe {
             }
 
             if options.qwenEditConditioning {
-                guard let sourceImage = options.sourceImage else {
+                guard !options.sourceImages.isEmpty else {
                     throw ProbeError("--qwen-edit-conditioning requires --source-image")
                 }
                 guard local.canonicalName == "qwen-image-edit" else {
                     throw ProbeError("--qwen-edit-conditioning requires a qwen-image-edit model")
                 }
                 let plan = try QwenImageEditPreprocessPlan(
-                    sourceImage: sourceImage,
+                    sourceImages: options.sourceImages,
                     requestedWidth: options.widthExplicit ? options.width : nil,
                     requestedHeight: options.heightExplicit ? options.height : nil,
                     steps: options.steps,
@@ -322,7 +324,7 @@ struct VMLXFluxProbe {
                 let conditioningStart = Date()
                 let conditioning = try QwenImageEditConditioner.encode(
                     modelPath: local.directory,
-                    sourceImage: sourceImage,
+                    sourceImages: options.sourceImages,
                     plan: plan)
                 payload["qwen_edit_conditioning"] = [
                     "status": "encoded",
@@ -335,6 +337,7 @@ struct VMLXFluxProbe {
                     "conditioning_height": plan.vlHeight,
                     "patch_rows": conditioning.patchRows,
                     "patch_columns": conditioning.patchColumns,
+                    "image_count": conditioning.imageCount,
                     "latents_shape": conditioning.latents.shape,
                     "image_ids_shape": conditioning.imageIDs.shape,
                     "latents_stats": mlxStats(conditioning.latents),
@@ -343,31 +346,33 @@ struct VMLXFluxProbe {
             }
 
             if options.qwenEditPrompt {
-                guard let sourceImage = options.sourceImage else {
+                guard !options.sourceImages.isEmpty else {
                     throw ProbeError("--qwen-edit-prompt requires --source-image")
                 }
                 guard local.canonicalName == "qwen-image-edit" else {
                     throw ProbeError("--qwen-edit-prompt requires a qwen-image-edit model")
                 }
                 let plan = try QwenImageEditPreprocessPlan(
-                    sourceImage: sourceImage,
+                    sourceImages: options.sourceImages,
                     requestedWidth: options.widthExplicit ? options.width : nil,
                     requestedHeight: options.heightExplicit ? options.height : nil,
                     steps: options.steps,
                     guidance: options.guidance ?? 4.0)
-                let visionInput = try QwenImageEditPreprocessor.visionInput(
-                    sourceImage: sourceImage,
-                    plan: plan)
+                let visionInputs = try options.sourceImages.map {
+                    try QwenImageEditPreprocessor.visionInput(sourceImage: $0, plan: plan)
+                }
+                let imageTokenCounts = visionInputs.map(\.imageTokenCount)
+                let totalImageTokenCount = imageTokenCounts.reduce(0, +)
                 let tokenizer = try await QwenImageEditPromptTokenizer(modelPath: local.directory)
                 var promptRecords: [[String: Any]] = []
                 for prompt in options.turns {
                     let promptInput = try QwenImageEditPreprocessor.visionLanguagePrompt(
                         prompt: prompt,
-                        imageTokenCounts: [visionInput.imageTokenCount])
+                        imageTokenCounts: imageTokenCounts)
                     let tokens = tokenizer.tokenize(promptInput)
-                    guard tokens.imageTokenCount == visionInput.imageTokenCount else {
+                    guard tokens.imageTokenCount == totalImageTokenCount else {
                         throw ProbeError(
-                            "qwen edit prompt image token count mismatch: got \(tokens.imageTokenCount), expected \(visionInput.imageTokenCount)")
+                            "qwen edit prompt image token count mismatch: got \(tokens.imageTokenCount), expected \(totalImageTokenCount)")
                     }
                     promptRecords.append([
                         "status": "tokenized",
@@ -377,23 +382,24 @@ struct VMLXFluxProbe {
                         "attention_mask_shape": tokens.attentionMask.shape,
                         "image_token_id": QwenImageEditPreprocessor.imageTokenID,
                         "image_token_count": tokens.imageTokenCount,
-                        "expected_image_token_count": visionInput.imageTokenCount,
+                        "expected_image_token_count": totalImageTokenCount,
+                        "image_token_counts": imageTokenCounts,
                         "template_drop_index": tokens.templateDropIndex,
-                        "image_grid_thw": visionInput.imageGridTHW,
+                        "image_grid_thw": visionInputs.map(\.imageGridTHW),
                     ])
                 }
                 payload["qwen_edit_prompt_tokens"] = promptRecords
             }
 
             if options.qwenEditVision {
-                guard let sourceImage = options.sourceImage else {
+                guard !options.sourceImages.isEmpty else {
                     throw ProbeError("--qwen-edit-vision requires --source-image")
                 }
                 guard local.canonicalName == "qwen-image-edit" else {
                     throw ProbeError("--qwen-edit-vision requires a qwen-image-edit model")
                 }
                 let plan = try QwenImageEditPreprocessPlan(
-                    sourceImage: sourceImage,
+                    sourceImages: options.sourceImages,
                     requestedWidth: options.widthExplicit ? options.width : nil,
                     requestedHeight: options.heightExplicit ? options.height : nil,
                     steps: options.steps,
@@ -403,14 +409,14 @@ struct VMLXFluxProbe {
                     let visionStart = Date()
                     let encoding = try await QwenImageEditPromptImageEncoder.encode(
                         modelPath: local.directory,
-                        sourceImage: sourceImage,
+                        sourceImages: options.sourceImages,
                         prompt: prompt,
                         plan: plan)
                     encodingRecords.append([
                         "status": "encoded",
                         "elapsed_seconds": Date().timeIntervalSince(visionStart),
                         "prompt": prompt,
-                        "image_grid_thw": encoding.features.imageGridTHW,
+                        "image_grid_thw": encoding.features.imageGridTHWs,
                         "feature_shape": encoding.features.imageFeatures.shape,
                         "feature_stats": mlxStats(encoding.features.imageFeatures),
                         "image_token_count": encoding.features.imageTokenCount,
@@ -428,14 +434,14 @@ struct VMLXFluxProbe {
             }
 
             if options.qwenEditDenoise {
-                guard let sourceImage = options.sourceImage else {
+                guard !options.sourceImages.isEmpty else {
                     throw ProbeError("--qwen-edit-denoise requires --source-image")
                 }
                 guard local.canonicalName == "qwen-image-edit" else {
                     throw ProbeError("--qwen-edit-denoise requires a qwen-image-edit model")
                 }
                 let plan = try QwenImageEditPreprocessPlan(
-                    sourceImage: sourceImage,
+                    sourceImages: options.sourceImages,
                     requestedWidth: options.widthExplicit ? options.width : nil,
                     requestedHeight: options.heightExplicit ? options.height : nil,
                     steps: options.steps,
@@ -446,7 +452,7 @@ struct VMLXFluxProbe {
                     let denoiseStart = Date()
                     let result = try await QwenImageEditDenoiseProbe.predictVelocity(
                         modelPath: local.directory,
-                        sourceImage: sourceImage,
+                        sourceImages: options.sourceImages,
                         prompt: prompt,
                         plan: plan,
                         seed: seed)
@@ -760,7 +766,8 @@ struct ProbeOptions {
     var seed: UInt64?
     var guidance: Float?
     var negativePrompt: String?
-    var sourceImage: URL?
+    var sourceImages: [URL] = []
+    var sourceImage: URL? { sourceImages.first }
     var maskImage: URL?
     var strength: Float = 0.75
     var turns = Self.defaultTurns
@@ -831,7 +838,7 @@ struct ProbeOptions {
             case "--negative":
                 negativePrompt = try Self.value(after: arg, in: arguments, index: &index)
             case "--source-image":
-                sourceImage = URL(fileURLWithPath: try Self.value(after: arg, in: arguments, index: &index))
+                sourceImages.append(URL(fileURLWithPath: try Self.value(after: arg, in: arguments, index: &index)))
             case "--mask-image":
                 maskImage = URL(fileURLWithPath: try Self.value(after: arg, in: arguments, index: &index))
             case "--strength":


### PR DESCRIPTION
## What changed
- Added ordered multi-image qwen-edit support through `ImageEditRequest.sourceImages` while preserving the legacy `sourceImage` initializer.
- Mirrored mflux qwen-edit semantics: last source image drives sizing, every source image contributes Qwen-VL prompt features and VAE conditioning latents.
- Updated `vmlxflux-probe` so repeated `--source-image` drives edit, prompt, conditioning, vision, and denoise probes.
- Updated Osaurus image API/integration docs and the handoff with the real multi-image contract and the qwen mask boundary.

## Source trace
- mflux qwen edit accepts `image_paths: list[str]`, uses `image_paths[-1]` for sizing, and iterates all image paths for prompt/conditioning work.
- The mflux qwen-edit reference has no qwen mask/inpaint argument or path, so qwen masks stay hidden/rejected rather than faked.

## Verification
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter QwenImageEditSupportTests` -> 22 tests, 0 failures.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter vMLXFluxTests` -> 52 tests, 0 failures.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build --product vmlxflux-probe` -> build complete.
- q5 shape proof: `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q5-multi-image-shape-proof/Qwen-Image-Edit-mflux-q5-load.json` (`image_count=2`, `latents_shape=[1,1152,64]`, `image_token_counts=[196,196]`, `combined_velocity_shape=[1,1728,64]`).
- q4 live proof: `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q4-multi-image-live/Qwen-Image-Edit-mflux-q4-load.json` (three completed turns; turn 1/3 SHA `e43910a505ab090bfbd4ec3a00f6e58fcd97df65c6b61e6b973754511bc740be`; turn 2 SHA `16ecc1fec4bdff1e5aecb9c0875569b2bebed53a81c686bf23e806faa6e2b893`).
- q5 live proof: `docs/local/vmlx-flux-probes/2026-06-16-qwen-edit-q5-multi-image-live/Qwen-Image-Edit-mflux-q5-load.json` (three completed turns; turn 1/3 SHA `ec2e49d6f300849cb46940b793670bee007f4aae8f04e97a31289670758519c9`; turn 2 SHA `8dfacb52aa81c6e0a8a6827c4377f27bc5d9396e39a4f8662a47db93798b767a`).
- Visually opened the exact current-source q4/q5 PNGs recorded in those load artifacts.

## Boundaries
- qwen-edit q3/q6 remain hidden/blocked until local bundles are complete.
- qwen mask/inpaint remains unsupported because the reference has no real qwen mask path.
- Osaurus `/v1/images/*` app/server bridge is still a separate app-side integration task.