### PR TITLE
[WIP] MiniMax-M3 runtime: sparse MSA cache + indexer decode

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -104,6 +104,10 @@ public enum LLMTypeRegistry {
             "mimo_v2": create(MiMoV2FlashConfiguration.self, MiMoV2FlashModel.init),
             "mimo_v2_flash": create(MiMoV2FlashConfiguration.self, MiMoV2FlashModel.init),
             "minimax": create(MiniMaxConfiguration.self, MiniMaxModel.init),
+            // MiniMax-M3 (MSA / Lightning-Indexer). The text decoder is shared by
+            // the plain and VL outer types; text-only sanitize drops vision keys.
+            "minimax_m3": create(MiniMaxM3Configuration.self, MiniMaxM3Model.init),
+            "minimax_m3_vl": create(MiniMaxM3Configuration.self, MiniMaxM3Model.init),
             "minimax_m2": { data in
                 // Peek at weight_format — "mxtq" routes to the JANGTQ variant,
                 // which swaps the MoE SwitchGLU for TurboQuantSwitchGLU so the

--- a/Libraries/MLXLLM/Models/MiniMaxM3.swift
+++ b/Libraries/MLXLLM/Models/MiniMaxM3.swift
@@ -1,0 +1,606 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// MiniMax-M3 (minimax_m3 / minimax_m3_vl) text runtime — full MSA decode.
+//
+// Port of vllm-mlx `models/minimax_m3/minimax_m3.py`. M3 is a GQA MoE decoder
+// (n_kv=4, head_dim=128) with two attention regimes:
+//   * layers 0-2  — dense full causal attention (stock `KVCacheSimple`)
+//   * layers 3-59 — MiniMax Sparse Attention (MSA): a Lightning Indexer picks the
+//     top-k 128-token key blocks per query and the main branch attends only those
+//     via an additive block mask. Indexer keys live in `MiniMaxM3SparseCache`
+//     alongside K/V; selection is recomputed every step.
+// Below topk*block (=2048) tokens every block is visible, so MSA reduces to full
+// causal attention. Quant is standard affine (per-module from config.json); the
+// Load path quantizes only modules whose checkpoint carries `.scales`, so the
+// indexer projections, router gate, and all norms stay fp16 with no custom
+// predicate.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+// MARK: - gpt_oss SwiGLU (clamped, alpha-scaled) — gate+up fused activation
+
+/// gpt_oss swiglu: `(xLinear+1) * (clamp(xGlu) * sigmoid(alpha*clamp(xGlu)))`,
+/// with xGlu clamped to `max=limit` and xLinear to `[-limit, limit]`. Matches
+/// `mlx_lm.models.gpt_oss.swiglu`. Caller convention: `xLinear` = up, `xGlu` = gate.
+private func minimaxM3Swiglu(
+    xLinear: MLXArray, xGlu: MLXArray, alpha: Float = 1.702, limit: Float = 7.0
+) -> MLXArray {
+    let glu = clip(xGlu, max: MLXArray(limit, dtype: xGlu.dtype))
+    let lin = clip(
+        xLinear, min: MLXArray(-limit, dtype: xLinear.dtype),
+        max: MLXArray(limit, dtype: xLinear.dtype))
+    let outGlu = glu * sigmoid(alpha * glu)
+    return outGlu * (lin + 1)
+}
+
+/// Dense / shared-expert MLP using the gpt_oss clamped swiglu.
+private class SwiGLUOAIMLP: Module, UnaryLayer {
+    @ModuleInfo(key: "gate_proj") var gateProj: Linear
+    @ModuleInfo(key: "up_proj") var upProj: Linear
+    @ModuleInfo(key: "down_proj") var downProj: Linear
+    let alpha: Float
+    let limit: Float
+
+    init(dimensions: Int, hiddenDimensions: Int, alpha: Float, limit: Float) {
+        self._gateProj.wrappedValue = Linear(dimensions, hiddenDimensions, bias: false)
+        self._upProj.wrappedValue = Linear(dimensions, hiddenDimensions, bias: false)
+        self._downProj.wrappedValue = Linear(hiddenDimensions, dimensions, bias: false)
+        self.alpha = alpha
+        self.limit = limit
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        downProj(minimaxM3Swiglu(xLinear: upProj(x), xGlu: gateProj(x), alpha: alpha, limit: limit))
+    }
+}
+
+// MARK: - Lightning Indexer (block selection)
+
+/// Scores `idx_q` against cached `idx_k`, max-pools per `block`-token block,
+/// selects top-k blocks per query, and returns an additive mask `[B, 1, Sq, Sk]`
+/// (0 on allowed keys, -inf elsewhere) that composes with the causal mask.
+/// Returns `nil` when every block is visible (short context) → caller uses the
+/// plain causal mask (full attention).
+private class MiniMaxM3Indexer: Module {
+    let nh: Int
+    let d: Int
+    let block: Int
+    let topk: Int
+    let local: Int
+
+    @ModuleInfo(key: "index_q_proj") var indexQProj: Linear
+    @ModuleInfo(key: "index_k_proj") var indexKProj: Linear
+    @ModuleInfo(key: "index_q_norm") var indexQNorm: GemmaRMSNorm
+    @ModuleInfo(key: "index_k_norm") var indexKNorm: GemmaRMSNorm
+    let rope: RoPE
+
+    init(_ args: MiniMaxM3Configuration) {
+        self.nh = args.indexNHeads
+        self.d = args.indexHeadDim
+        self.block = args.indexBlockSize
+        self.topk = args.indexTopkBlocks
+        self.local = args.indexLocalBlocks
+        self._indexQProj.wrappedValue = Linear(args.hiddenSize, nh * d, bias: false)
+        self._indexKProj.wrappedValue = Linear(args.hiddenSize, d, bias: false)
+        self._indexQNorm.wrappedValue = GemmaRMSNorm(dimensions: d, eps: args.rmsNormEps)
+        self._indexKNorm.wrappedValue = GemmaRMSNorm(dimensions: d, eps: args.rmsNormEps)
+        self.rope = RoPE(dimensions: args.rotaryDim, traditional: false, base: args.ropeTheta)
+    }
+
+    func callAsFunction(_ x: MLXArray, cache: MiniMaxM3SparseCache, offset: Int) -> MLXArray? {
+        let (B, Sq) = (x.dim(0), x.dim(1))
+        var idxQ = indexQNorm(indexQProj(x).reshaped(B, Sq, nh, d)).transposed(0, 2, 1, 3)
+        var idxK = indexKNorm(indexKProj(x).reshaped(B, Sq, 1, d)).transposed(0, 2, 1, 3)
+        idxQ = rope(idxQ, offset: offset)
+        idxK = rope(idxK, offset: offset)
+        idxK = cache.updateIndex(idxK)  // [B, 1, Sk, d], lockstep with K/V
+        let Sk = idxK.dim(2)
+
+        // scores [B, nh, Sq, Sk] in fp32, masked causal
+        var scores = matmul(idxQ.asType(.float32), idxK.asType(.float32).transposed(0, 1, 3, 2))
+        let qPos = MLXArray(offset ..< (offset + Sq)).reshaped(1, 1, Sq, 1)
+        let kPos = MLXArray(0 ..< Sk).reshaped(1, 1, 1, Sk)
+        let negInf = MLXArray(-Float.infinity, dtype: .float32)
+        scores = MLX.where(kPos .> qPos, negInf, scores)
+
+        // pad Sk to a block multiple, max-pool per block, max over heads
+        let nBlocks = (Sk + block - 1) / block
+        let pad = nBlocks * block - Sk
+        if pad > 0 {
+            let padTensor = MLX.full([B, nh, Sq, pad], values: negInf, dtype: .float32)
+            scores = concatenated([scores, padTensor], axis: -1)
+        }
+        scores = scores.reshaped(B, nh, Sq, nBlocks, block)
+        var blockScores = scores.max(axis: -1).max(axis: 1)  // [B, Sq, nBlocks]
+
+        // force each query's own (local) block(s) to always win
+        let qBlock = (MLXArray(offset ..< (offset + Sq)) / MLXArray(Int32(block)))  // [Sq]
+        if local > 0 {
+            let loc = MLXArray(0 ..< local).reshaped(1, 1, local)
+            var localIdx = MLX.maximum(qBlock.reshaped(1, Sq, 1) - loc, MLXArray(Int32(0)))
+            localIdx = broadcast(localIdx, to: [B, Sq, local])
+            blockScores = putAlong(
+                blockScores, localIdx, values: MLXArray(Float.infinity, dtype: .float32), axis: -1)
+        }
+
+        let keep = min(topk, nBlocks)
+        if keep >= nBlocks {
+            return nil  // all blocks visible → only causal matters
+        }
+
+        // top-k blocks per query → [B,1,Sq,Sk] keep-bias (0 kept / -inf else)
+        let topIdx = argPartition(-blockScores, kth: keep - 1, axis: -1)[.ellipsis, ..<keep]
+        var blockKeep = MLX.full([B, Sq, nBlocks], values: negInf, dtype: .float32)
+        blockKeep = putAlong(
+            blockKeep, topIdx, values: MLXArray(Float(0), dtype: .float32), axis: -1)
+        var keyBias = repeated(blockKeep, count: block, axis: -1)[0..., 0..., 0 ..< Sk]  // [B,Sq,Sk]
+        keyBias = keyBias.reshaped(B, 1, Sq, Sk)
+        keyBias = MLX.where(kPos .> qPos, negInf, keyBias)  // re-enforce causal
+        return keyBias
+    }
+}
+
+// MARK: - Attention (dense + MSA)
+
+private class MiniMaxM3Attention: Module {
+    let nHeads: Int
+    let nKV: Int
+    let headDim: Int
+    let scale: Float
+
+    @ModuleInfo(key: "q_proj") var qProj: Linear
+    @ModuleInfo(key: "k_proj") var kProj: Linear
+    @ModuleInfo(key: "v_proj") var vProj: Linear
+    @ModuleInfo(key: "o_proj") var oProj: Linear
+    @ModuleInfo(key: "q_norm") var qNorm: GemmaRMSNorm
+    @ModuleInfo(key: "k_norm") var kNorm: GemmaRMSNorm
+    let rope: RoPE
+    @ModuleInfo(key: "indexer") var indexer: MiniMaxM3Indexer?
+
+    init(_ args: MiniMaxM3Configuration, layerIdx: Int) {
+        self.nHeads = args.attentionHeads
+        self.nKV = args.kvHeads
+        self.headDim = args.headDim
+        self.scale = pow(Float(headDim), -0.5)
+        let d = args.hiddenSize
+        self._qProj.wrappedValue = Linear(d, nHeads * headDim, bias: false)
+        self._kProj.wrappedValue = Linear(d, nKV * headDim, bias: false)
+        self._vProj.wrappedValue = Linear(d, nKV * headDim, bias: false)
+        self._oProj.wrappedValue = Linear(nHeads * headDim, d, bias: false)
+        self._qNorm.wrappedValue = GemmaRMSNorm(dimensions: headDim, eps: args.rmsNormEps)
+        self._kNorm.wrappedValue = GemmaRMSNorm(dimensions: headDim, eps: args.rmsNormEps)
+        self.rope = RoPE(dimensions: args.rotaryDim, traditional: false, base: args.ropeTheta)
+        self._indexer.wrappedValue = args.isSparse(layerIdx) ? MiniMaxM3Indexer(args) : nil
+    }
+
+    func callAsFunction(
+        _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
+    ) -> MLXArray {
+        let (B, L) = (x.dim(0), x.dim(1))
+        let off = cache?.offset ?? 0
+
+        var q = qNorm(qProj(x).reshaped(B, L, nHeads, headDim)).transposed(0, 2, 1, 3)
+        var k = kNorm(kProj(x).reshaped(B, L, nKV, headDim)).transposed(0, 2, 1, 3)
+        var v = vProj(x).reshaped(B, L, nKV, headDim).transposed(0, 2, 1, 3)
+        q = rope(q, offset: off)
+        k = rope(k, offset: off)
+
+        // Append K/V FIRST (upstream M3 ordering) so the indexer sees the
+        // completed post-append Sk. `off` (captured pre-append) stays the correct
+        // RoPE position. Manual update→SDPA (not attentionWithCacheUpdate) because
+        // the indexer must run between the append and the SDPA. M3 forces TQ-KV
+        // off, so the cache is always KVCacheSimple / MiniMaxM3SparseCache.
+        if let cache {
+            (k, v) = cache.update(keys: k, values: v)
+        }
+
+        var attnMask = mask
+        if let indexer, let sparseCache = cache as? MiniMaxM3SparseCache {
+            if let blockBias = indexer(x, cache: sparseCache, offset: off) {
+                // 0.0/-inf are exact in bf16; SDPA requires the mask to promote to
+                // the bf16 compute dtype once the indexer fires past 2048 tokens.
+                attnMask = .array(blockBias.asType(q.dtype))
+            }
+        }
+
+        let o = MLXFast.scaledDotProductAttention(
+            queries: q, keys: k, values: v, scale: scale, mask: attnMask
+        )
+        .transposed(0, 2, 1, 3)
+        .reshaped(B, L, -1)
+        return oProj(o)
+    }
+}
+
+// MARK: - Sparse MoE block (routed + shared experts)
+
+private class MiniMaxM3SparseMoeBlock: Module, UnaryLayer {
+    let topK: Int
+    let normTopkProb: Bool
+    let routedScalingFactor: Float
+
+    @ModuleInfo(key: "gate") var gate: Linear
+    @ParameterInfo(key: "e_score_correction_bias") var eScoreCorrectionBias: MLXArray
+    @ModuleInfo(key: "switch_mlp") var switchMLP: SwitchGLU
+    @ModuleInfo(key: "shared_experts") var sharedExperts: SwiGLUOAIMLP
+
+    init(_ args: MiniMaxM3Configuration) {
+        self.topK = args.numExpertsPerTok
+        self.normTopkProb = args.normTopkProb
+        self.routedScalingFactor = args.routedScalingFactor
+
+        self._gate.wrappedValue = Linear(args.hiddenSize, args.numLocalExperts, bias: false)
+        self._eScoreCorrectionBias.wrappedValue = MLXArray.zeros([args.numLocalExperts])
+        // Routed experts use the gpt_oss clamped swiglu via the `glue` override
+        // (gate, up) -> swiglu(up, gate). The Load path swaps in
+        // QuantizedSwitchLinear from the checkpoint's `.scales`.
+        let alpha = args.swigluAlpha
+        let limit = args.swigluLimit
+        self._switchMLP.wrappedValue = SwitchGLU(
+            inputDims: args.hiddenSize,
+            hiddenDims: args.intermediateSize,
+            numExperts: args.numLocalExperts,
+            glue: { gateActivation, up in
+                minimaxM3Swiglu(xLinear: up, xGlu: gateActivation, alpha: alpha, limit: limit)
+            }
+        )
+        self._sharedExperts.wrappedValue = SwiGLUOAIMLP(
+            dimensions: args.hiddenSize,
+            hiddenDimensions: args.sharedIntermediateSize,
+            alpha: alpha, limit: limit)
+    }
+
+    /// deepseek_v3 group_expert_select with n_group = topk_group = 1 (group logic
+    /// collapses): sigmoid(gate)+bias → top-k → gather original sigmoid scores →
+    /// normalize → scale by routedScalingFactor.
+    private func route(_ x: MLXArray) -> (MLXArray, MLXArray) {
+        let gates = gate(x)
+        let origScores = sigmoid(gates.asType(.float32))
+        let scoresForChoice = origScores + eScoreCorrectionBias
+        let inds = argPartition(-scoresForChoice, kth: topK - 1, axis: -1)[.ellipsis, ..<topK]
+        var scores = takeAlong(origScores, inds, axis: -1)
+        if topK > 1, normTopkProb {
+            scores = scores / (scores.sum(axis: -1, keepDims: true) + MLXArray(Float(1e-20)))
+        }
+        scores = scores * routedScalingFactor
+        return (inds, scores)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let (inds, scores) = route(x)
+        let routed = (switchMLP(x, inds) * scores[.ellipsis, .newAxis]).sum(axis: -2)
+        // route() returns fp32 scores → promote the residual stream; cast back to
+        // x's dtype so downstream matmuls stay bf16 (matches the Python fix).
+        return (routed + sharedExperts(x)).asType(x.dtype)
+    }
+}
+
+// MARK: - Decoder layer
+
+private class MiniMaxM3DecoderLayer: Module {
+    @ModuleInfo(key: "self_attn") var selfAttn: MiniMaxM3Attention
+    @ModuleInfo(key: "input_layernorm") var inputLayerNorm: GemmaRMSNorm
+    @ModuleInfo(key: "post_attention_layernorm") var postAttentionLayerNorm: GemmaRMSNorm
+    fileprivate let mlp: UnaryLayer
+
+    init(_ args: MiniMaxM3Configuration, layerIdx: Int) {
+        self._selfAttn.wrappedValue = MiniMaxM3Attention(args, layerIdx: layerIdx)
+        self._inputLayerNorm.wrappedValue = GemmaRMSNorm(
+            dimensions: args.hiddenSize, eps: args.rmsNormEps)
+        self._postAttentionLayerNorm.wrappedValue = GemmaRMSNorm(
+            dimensions: args.hiddenSize, eps: args.rmsNormEps)
+        if args.isMoe(layerIdx) {
+            self.mlp = MiniMaxM3SparseMoeBlock(args)
+        } else {
+            self.mlp = SwiGLUOAIMLP(
+                dimensions: args.hiddenSize, hiddenDimensions: args.denseIntermediateSize,
+                alpha: args.swigluAlpha, limit: args.swigluLimit)
+        }
+    }
+
+    func callAsFunction(
+        _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
+    ) -> MLXArray {
+        let h = x + selfAttn(inputLayerNorm(x), mask: mask, cache: cache)
+        return h + mlp(postAttentionLayerNorm(h))
+    }
+}
+
+// MARK: - Model
+
+private class MiniMaxM3ModelInner: Module {
+    @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
+    fileprivate let layers: [MiniMaxM3DecoderLayer]
+    @ModuleInfo(key: "norm") var norm: GemmaRMSNorm
+
+    init(_ args: MiniMaxM3Configuration) {
+        precondition(args.vocabularySize > 0)
+        self._embedTokens.wrappedValue = Embedding(
+            embeddingCount: args.vocabularySize, dimensions: args.hiddenSize)
+        self.layers = (0 ..< args.hiddenLayers).map { MiniMaxM3DecoderLayer(args, layerIdx: $0) }
+        self._norm.wrappedValue = GemmaRMSNorm(dimensions: args.hiddenSize, eps: args.rmsNormEps)
+    }
+
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        var h = embedTokens(inputs)
+        // Dense layers (0-2) use this causal mask; sparse layers build their own
+        // block mask but fall back to it below the 2048-token threshold.
+        let mask = createAttentionMask(h: h, cache: cache?.first)
+        for (i, layer) in layers.enumerated() {
+            h = layer(h, mask: mask, cache: cache?[i])
+        }
+        return norm(h)
+    }
+}
+
+public class MiniMaxM3Model: Module, LLMModel, KVCacheDimensionProvider {
+    public let vocabularySize: Int
+    public let kvHeads: [Int]
+
+    fileprivate let model: MiniMaxM3ModelInner
+    let configuration: MiniMaxM3Configuration
+
+    @ModuleInfo(key: "lm_head") var lmHead: Linear?
+
+    public init(_ args: MiniMaxM3Configuration) {
+        self.configuration = args
+        self.vocabularySize = args.vocabularySize
+        self.kvHeads = (0 ..< args.hiddenLayers).map { _ in args.kvHeads }
+        self.model = MiniMaxM3ModelInner(args)
+        if !args.tieWordEmbeddings {
+            self._lmHead.wrappedValue = Linear(args.hiddenSize, args.vocabularySize, bias: false)
+        }
+    }
+
+    public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        var out = model(inputs, cache: cache)
+        if let lmHead {
+            out = lmHead(out)
+        } else {
+            out = model.embedTokens.asLinear(out)
+        }
+        return out
+    }
+
+    /// Sparse layers (3-59) carry the 3-lane `MiniMaxM3SparseCache`; dense layers
+    /// (0-2) use a stock `KVCacheSimple`. The cache list must stay heterogeneous —
+    /// downcasting the sparse entry to a plain KVCache drops `idx_keys` and loops.
+    public func newCache(parameters: GenerateParameters?) -> [KVCache] {
+        (0 ..< configuration.hiddenLayers).map { li -> KVCache in
+            configuration.isSparse(li)
+                ? MiniMaxM3SparseCache(indexDim: configuration.indexHeadDim)
+                : KVCacheSimple()
+        }
+    }
+
+    public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        var out: [String: MLXArray] = [:]
+        out.reserveCapacity(weights.count)
+        for (rawKey, value) in weights {
+            if rawKey.hasPrefix("mtp") { continue }
+            // Text-only build: drop the VL vision stack + projector.
+            if rawKey.hasPrefix("vision_tower.") || rawKey.hasPrefix("multi_modal_projector.")
+                || rawKey.hasPrefix("patch_merge_mlp.")
+            {
+                continue
+            }
+            var key = rawKey
+            if key.hasPrefix("language_model.model.") {
+                key = "model." + key.dropFirst("language_model.model.".count)
+            } else if key.hasPrefix("language_model.lm_head") {
+                key = "lm_head" + key.dropFirst("language_model.lm_head".count)
+            }
+            key = key.replacingOccurrences(of: ".block_sparse_moe.", with: ".mlp.")
+            // Indexer projections are flat on self_attn in the checkpoint; the
+            // model nests them under the `indexer` submodule.
+            key = key.replacingOccurrences(
+                of: ".self_attn.index_", with: ".self_attn.indexer.index_")
+            out[key] = value
+        }
+        if configuration.tieWordEmbeddings {
+            out["lm_head.weight"] = nil
+        }
+        return out
+    }
+}
+
+extension MiniMaxM3Model: LoRAModel {
+    public var loraLayers: [Module] {
+        model.layers
+    }
+}
+
+// MARK: - Configuration
+
+public struct MiniMaxM3Configuration: Codable, Sendable {
+    var modelType: String = "minimax_m3"
+    var hiddenSize: Int = 6144
+    var hiddenLayers: Int = 60
+    var intermediateSize: Int = 3072
+    var denseIntermediateSize: Int = 12288
+    var sharedIntermediateSize: Int = 3072
+    var attentionHeads: Int = 64
+    var kvHeads: Int = 4
+    var headDim: Int = 128
+    var rotaryDim: Int = 64
+    var ropeTheta: Float = 5_000_000
+    var rmsNormEps: Float = 1e-6
+    var vocabularySize: Int = 200064
+    var numLocalExperts: Int = 100
+    var numExpertsPerTok: Int = 4
+    var nSharedExperts: Int = 1
+    var routedScalingFactor: Float = 2.0
+    var normTopkProb: Bool = true
+    var swigluAlpha: Float = 1.702
+    var swigluLimit: Float = 7.0
+    var moeLayerFreq: [Int]? = nil
+    // MSA indexer
+    var indexNHeads: Int = 4
+    var indexHeadDim: Int = 128
+    var indexBlockSize: Int = 128
+    var indexTopkBlocks: Int = 16
+    var indexLocalBlocks: Int = 1
+    var sparseAttentionFreq: [Int]? = nil
+    var tieWordEmbeddings: Bool = false
+
+    func isMoe(_ li: Int) -> Bool {
+        if let freq = moeLayerFreq { return freq[li] != 0 }
+        return li >= 3
+    }
+
+    func isSparse(_ li: Int) -> Bool {
+        if let freq = sparseAttentionFreq { return freq[li] != 0 }
+        return li >= 3
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case hiddenSize = "hidden_size"
+        case hiddenLayers = "num_hidden_layers"
+        case intermediateSize = "intermediate_size"
+        case denseIntermediateSize = "dense_intermediate_size"
+        case sharedIntermediateSize = "shared_intermediate_size"
+        case attentionHeads = "num_attention_heads"
+        case kvHeads = "num_key_value_heads"
+        case headDim = "head_dim"
+        case rotaryDim = "rotary_dim"
+        case ropeTheta = "rope_theta"
+        case rmsNormEps = "rms_norm_eps"
+        case vocabularySize = "vocab_size"
+        case numLocalExperts = "num_local_experts"
+        case numExpertsPerTok = "num_experts_per_tok"
+        case nSharedExperts = "n_shared_experts"
+        case routedScalingFactor = "routed_scaling_factor"
+        case normTopkProb = "norm_topk_prob"
+        case swigluAlpha = "swiglu_alpha"
+        case swigluLimit = "swiglu_limit"
+        case moeLayerFreq = "moe_layer_freq"
+        case tieWordEmbeddings = "tie_word_embeddings"
+        case sparseAttentionConfig = "sparse_attention_config"
+        // Indexer fields are decoded from the nested sparse_attention_config
+        // (SparseKeys); listed here only so Encodable auto-synthesizes.
+        case indexNHeads = "index_n_heads"
+        case indexHeadDim = "index_head_dim"
+        case indexBlockSize = "index_block_size"
+        case indexTopkBlocks = "index_topk_blocks"
+        case indexLocalBlocks = "index_local_blocks"
+        case sparseAttentionFreq = "sparse_attention_freq"
+    }
+
+    enum SparseKeys: String, CodingKey {
+        case sparseNumIndexHeads = "sparse_num_index_heads"
+        case sparseIndexDim = "sparse_index_dim"
+        case sparseBlockSize = "sparse_block_size"
+        case sparseTopkBlocks = "sparse_topk_blocks"
+        case sparseLocalBlock = "sparse_local_block"
+        case sparseAttentionFreq = "sparse_attention_freq"
+    }
+
+    enum OuterKeys: String, CodingKey {
+        case textConfig = "text_config"
+        case modelType = "model_type"
+        case numLocalExperts = "num_local_experts"
+    }
+
+    // Configs are only ever decoded by the factory; encode is required for the
+    // `create<C: Codable, M>` constraint but never exercised. Emit the flat fields.
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(modelType, forKey: .modelType)
+        try c.encode(hiddenSize, forKey: .hiddenSize)
+        try c.encode(hiddenLayers, forKey: .hiddenLayers)
+        try c.encode(intermediateSize, forKey: .intermediateSize)
+        try c.encode(denseIntermediateSize, forKey: .denseIntermediateSize)
+        try c.encode(sharedIntermediateSize, forKey: .sharedIntermediateSize)
+        try c.encode(attentionHeads, forKey: .attentionHeads)
+        try c.encode(kvHeads, forKey: .kvHeads)
+        try c.encode(headDim, forKey: .headDim)
+        try c.encode(rotaryDim, forKey: .rotaryDim)
+        try c.encode(ropeTheta, forKey: .ropeTheta)
+        try c.encode(rmsNormEps, forKey: .rmsNormEps)
+        try c.encode(vocabularySize, forKey: .vocabularySize)
+        try c.encode(numLocalExperts, forKey: .numLocalExperts)
+        try c.encode(numExpertsPerTok, forKey: .numExpertsPerTok)
+        try c.encode(nSharedExperts, forKey: .nSharedExperts)
+        try c.encode(routedScalingFactor, forKey: .routedScalingFactor)
+        try c.encode(normTopkProb, forKey: .normTopkProb)
+        try c.encode(swigluAlpha, forKey: .swigluAlpha)
+        try c.encode(swigluLimit, forKey: .swigluLimit)
+        try c.encodeIfPresent(moeLayerFreq, forKey: .moeLayerFreq)
+        try c.encode(tieWordEmbeddings, forKey: .tieWordEmbeddings)
+        try c.encode(indexNHeads, forKey: .indexNHeads)
+        try c.encode(indexHeadDim, forKey: .indexHeadDim)
+        try c.encode(indexBlockSize, forKey: .indexBlockSize)
+        try c.encode(indexTopkBlocks, forKey: .indexTopkBlocks)
+        try c.encode(indexLocalBlocks, forKey: .indexLocalBlocks)
+        try c.encodeIfPresent(sparseAttentionFreq, forKey: .sparseAttentionFreq)
+    }
+
+    public init(from decoder: Decoder) throws {
+        let outer = try decoder.container(keyedBy: OuterKeys.self)
+        // The JANG bundle nests real fields under `text_config`; fall back to the
+        // top level for plain (non-VL) configs.
+        let c: KeyedDecodingContainer<CodingKeys>
+        if outer.contains(.textConfig) {
+            c = try outer.nestedContainer(keyedBy: CodingKeys.self, forKey: .textConfig)
+        } else {
+            c = try decoder.container(keyedBy: CodingKeys.self)
+        }
+
+        func i(_ k: CodingKeys, _ d: Int) -> Int {
+            ((try? c.decodeIfPresent(Int.self, forKey: k)) ?? nil) ?? d
+        }
+        func f(_ k: CodingKeys, _ d: Float) -> Float {
+            ((try? c.decodeIfPresent(Float.self, forKey: k)) ?? nil) ?? d
+        }
+
+        self.modelType =
+            (try? outer.decodeIfPresent(String.self, forKey: .modelType))
+            ?? (try? c.decodeIfPresent(String.self, forKey: .modelType)) ?? "minimax_m3"
+        self.hiddenSize = i(.hiddenSize, 6144)
+        self.hiddenLayers = i(.hiddenLayers, 60)
+        self.intermediateSize = i(.intermediateSize, 3072)
+        self.denseIntermediateSize = i(.denseIntermediateSize, 12288)
+        self.sharedIntermediateSize = i(.sharedIntermediateSize, 3072)
+        self.attentionHeads = i(.attentionHeads, 64)
+        self.kvHeads = i(.kvHeads, 4)
+        self.headDim = i(.headDim, 128)
+        self.rotaryDim = i(.rotaryDim, 64)
+        self.ropeTheta = f(.ropeTheta, 5_000_000)
+        self.rmsNormEps = f(.rmsNormEps, 1e-6)
+        self.vocabularySize = i(.vocabularySize, 200064)
+        // num_local_experts can sit at the top level (REAP-pruned bundles).
+        self.numLocalExperts =
+            (try? outer.decodeIfPresent(Int.self, forKey: .numLocalExperts))
+            ?? (try? c.decodeIfPresent(Int.self, forKey: .numLocalExperts)) ?? 100
+        self.numExpertsPerTok = i(.numExpertsPerTok, 4)
+        self.nSharedExperts = i(.nSharedExperts, 1)
+        self.routedScalingFactor = f(.routedScalingFactor, 2.0)
+        self.normTopkProb = (try? c.decodeIfPresent(Bool.self, forKey: .normTopkProb)) ?? true
+        self.swigluAlpha = f(.swigluAlpha, 1.702)
+        self.swigluLimit = f(.swigluLimit, 7.0)
+        self.moeLayerFreq = try? c.decodeIfPresent([Int].self, forKey: .moeLayerFreq)
+        self.tieWordEmbeddings =
+            (try? c.decodeIfPresent(Bool.self, forKey: .tieWordEmbeddings)) ?? false
+
+        // sparse_attention_config (nested under text_config)
+        if let sca = try? c.nestedContainer(keyedBy: SparseKeys.self, forKey: .sparseAttentionConfig)
+        {
+            self.indexNHeads =
+                (try? sca.decodeIfPresent(Int.self, forKey: .sparseNumIndexHeads)) ?? 4
+            self.indexHeadDim = (try? sca.decodeIfPresent(Int.self, forKey: .sparseIndexDim)) ?? 128
+            self.indexBlockSize =
+                (try? sca.decodeIfPresent(Int.self, forKey: .sparseBlockSize)) ?? 128
+            self.indexTopkBlocks =
+                (try? sca.decodeIfPresent(Int.self, forKey: .sparseTopkBlocks)) ?? 16
+            self.indexLocalBlocks =
+                (try? sca.decodeIfPresent(Int.self, forKey: .sparseLocalBlock)) ?? 1
+            self.sparseAttentionFreq = try? sca.decodeIfPresent(
+                [Int].self, forKey: .sparseAttentionFreq)
+        }
+    }
+}

--- a/Libraries/MLXLLM/Models/MiniMaxM3.swift
+++ b/Libraries/MLXLLM/Models/MiniMaxM3.swift
@@ -58,6 +58,17 @@ private class SwiGLUOAIMLP: Module, UnaryLayer {
     }
 }
 
+// MARK: - MSA trace (opt-in, one-shot)
+
+/// Set `MM3_MSA_TRACE=1` to emit a single stderr line the first time the
+/// Lightning Indexer falls back to full attention and the first time it fires
+/// real block-sparse selection (context past `topk*block` = 2048 tokens). This
+/// is the conclusive GO signal for the MSA decode path during live validation —
+/// one-shot so it never floods the 57 sparse layers × N steps decode loop.
+private let mm3MSATrace = ProcessInfo.processInfo.environment["MM3_MSA_TRACE"] != nil
+nonisolated(unsafe) private var mm3FullAttnLogged = false
+nonisolated(unsafe) private var mm3SparseFiredLogged = false
+
 // MARK: - Lightning Indexer (block selection)
 
 /// Scores `idx_q` against cached `idx_k`, max-pools per `block`-token block,
@@ -129,7 +140,17 @@ private class MiniMaxM3Indexer: Module {
 
         let keep = min(topk, nBlocks)
         if keep >= nBlocks {
+            if mm3MSATrace, !mm3FullAttnLogged {
+                mm3FullAttnLogged = true
+                FileHandle.standardError.write(
+                    Data("[MM3-MSA] full attention (offset=\(offset) Sk=\(Sk) nBlocks=\(nBlocks) <= topk=\(topk)); indexer not yet firing\n".utf8))
+            }
             return nil  // all blocks visible → only causal matters
+        }
+        if mm3MSATrace, !mm3SparseFiredLogged {
+            mm3SparseFiredLogged = true
+            FileHandle.standardError.write(
+                Data("[MM3-MSA] SPARSE SELECTION FIRED (offset=\(offset) Sk=\(Sk) nBlocks=\(nBlocks) keep=\(keep) of topk=\(topk)); block-sparse MSA active\n".utf8))
         }
 
         // top-k blocks per query → [B,1,Sq,Sk] keep-bias (0 kept / -inf else)

--- a/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
@@ -93,7 +93,15 @@ public func cacheRequiresDiskBackedCoordinatorRestore(_ cache: [any KVCache]) ->
             layer is RotatingKVCache ||
             layer is RotatingKVCacheWrapper ||
             layer is TurboQuantKVCache ||
-            layer is QuantizedKVCache
+            layer is QuantizedKVCache ||
+            // MiniMax-M3 MSA: the paged tier stores only full-history KV blocks
+            // and cannot round-trip the idx_keys lane. Force restore through the
+            // disk serializer (which carries all 3 lanes via `state`) so block
+            // selection is never recomputed against a cache missing idx_keys.
+            // Deliberately NOT in `cacheContainsPathDependentState`: M3 has no
+            // SSM/conv companion — idx_keys rides the standard state round-trip,
+            // so it must not trigger SSM-state extraction.
+            layer is MiniMaxM3SparseCache
     }
 }
 
@@ -568,6 +576,15 @@ private func restoreFromV2Arrays(
                 totalTokens = comp.offset
             }
 
+        case .miniMaxM3Sparse(let comp):
+            // MiniMax-M3 MSA: restore keys, values, AND idx_keys together. A
+            // KV-only restore would be a false hit because block selection is
+            // recomputed from idx_keys every step.
+            restoreMiniMaxM3Layer(comp, into: cache[i])
+            if totalTokens == 0 {
+                totalTokens = comp.offset
+            }
+
         case .cacheList(let subLayers):
             // CacheList composite (BaichuanM1, FalconH1, MiMoV2Flash
             // hybrid stacks). Dispatch each sub-LayerData via the
@@ -606,7 +623,7 @@ private func restoreFromV2Arrays(
                         totalTokens = comp.offset
                     }
 
-                case .tq, .qkv, .deepseekV4, .zayaCCA, .cacheList, .skip:
+                case .tq, .qkv, .deepseekV4, .zayaCCA, .miniMaxM3Sparse, .cacheList, .skip:
                     // .skip is a per-sub no-op (sub-cache had no
                     // persistable state). The other cases are not
                     // currently emitted as sub-cache kinds — see
@@ -986,6 +1003,18 @@ private func restoreZayaCCALayer(
 ) {
     guard let zaya = layer as? ZayaCCACache else { return }
     zaya.state = [comp.keys, comp.values, comp.convState, comp.prevHS]
+}
+
+/// Restore a full `MiniMaxM3SparseCache` layer — keys, values, idx_keys — as
+/// one unit. The cache's `state` setter handles zero-seq sentinels (empty
+/// source) and re-derives `offset` from the keys length. No-ops on type
+/// mismatch so the caller falls back to fresh prefill.
+private func restoreMiniMaxM3Layer(
+    _ comp: TQDiskSerializer.MiniMaxM3SparseLayerComponents,
+    into layer: any KVCache
+) {
+    guard let m3 = layer as? MiniMaxM3SparseCache else { return }
+    m3.state = [comp.keys, comp.values, comp.idxKeys]
 }
 
 /// Helper: restore Mamba SSM state into a `MambaCache` layer (or a

--- a/Libraries/MLXLMCommon/Cache/MiniMaxM3SparseCache.swift
+++ b/Libraries/MLXLMCommon/Cache/MiniMaxM3SparseCache.swift
@@ -31,7 +31,7 @@
 
 import Foundation
 import MLX
-import MLXFast
+import MLXNN
 
 public final class MiniMaxM3SparseCache: KVCache {
 
@@ -58,6 +58,9 @@ public final class MiniMaxM3SparseCache: KVCache {
     public var offset: Int { kv.offset }
     public var maxSize: Int? { nil }
     public var isTrimmable: Bool { true }
+
+    /// Compile-traceable inner state — the same 3-lane view as `state`.
+    public func innerState() -> [MLXArray] { state }
 
     /// Standard GQA K/V append. The attention forward calls this BEFORE
     /// `updateIndex` (upstream ordering), so after both appends `idxKeys`'

--- a/Libraries/MLXLMCommon/Cache/MiniMaxM3SparseCache.swift
+++ b/Libraries/MLXLMCommon/Cache/MiniMaxM3SparseCache.swift
@@ -1,0 +1,189 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// MiniMax-M3 (MSA / Lightning-Indexer) sparse-attention cache.
+//
+// M3 attention is GQA on every layer. Layers 0-2 are full attention and use a
+// stock `KVCacheSimple`. Layers 3-59 are sparse MSA: they carry TWO append-only
+// caches in lockstep —
+//   * the standard GQA KV cache         keys/values  [B, n_kv(=4), S, head_dim(=128)]
+//   * the Lightning-Indexer key cache   idx_keys      [B, 1, S, index_dim(=128)]
+//
+// The indexer scores the current step's idx_q against ALL cached idx_keys,
+// max-pools per 128-token block, and selects top-k blocks; the main branch then
+// attends the selected K/V blocks. SELECTION IS RECOMPUTED EVERY STEP from
+// idx_keys — it is never cached. Blocks are anchored to ABSOLUTE position
+// (block = pos / 128), so the cache is append-only / trim-and-replay only: never
+// shift, rotate, or evict mid-stream (that moves block boundaries and corrupts
+// selection). Trimming to N slices BOTH lanes on the sequence axis in lockstep.
+//
+// CONTRACT (mirrors vllm-mlx `models/minimax_m3/cache.py`; lesson from the v1.5.62
+// repetition-loop postmortem): this type must stay FIRST-CLASS through every
+// reuse path — copy / fetch / trim / store / snapshot. `keys`, `values`,
+// `idx_keys`, and `offset` move together. Never downcast to a plain KVCache: the
+// generic helpers copy only (keys,values) and drop idx_keys → the indexer scores
+// against corrupt keys → loops. `copy()` returns a `MiniMaxM3SparseCache`, and
+// `state` carries all three tensors so the disk/prefix tiers round-trip the lane.
+//
+// Composite-cache precedent: `ZayaCCACache` (one inner `KVCacheSimple` + extra
+// persistent lanes serialized through `state`/`metaState`). M3 is the simplest of
+// the composite family — one extra tensor, no conv/SSM state, no compressor pool.
+
+import Foundation
+import MLX
+import MLXFast
+
+public final class MiniMaxM3SparseCache: KVCache {
+
+    /// Standard GQA K/V half. Inherits the exact update / trim / step-growth
+    /// semantics the runtime already relies on.
+    private let kv: KVCacheSimple
+
+    /// Lightning-Indexer key history `[B, 1, S, indexDim]`, append-only, grown in
+    /// lockstep with `kv` so both share `offset`. `nil` until the first append.
+    private var idxKeys: MLXArray?
+
+    /// Indexer key width (e.g. 128). Carried in `metaState` for round-trip.
+    public let indexDim: Int
+    public let batchSize: Int
+
+    public init(indexDim: Int = 128, batchSize: Int = 1) {
+        self.kv = KVCacheSimple()
+        self.indexDim = indexDim
+        self.batchSize = batchSize
+    }
+
+    // MARK: KVCache conformance
+
+    public var offset: Int { kv.offset }
+    public var maxSize: Int? { nil }
+    public var isTrimmable: Bool { true }
+
+    /// Standard GQA K/V append. The attention forward calls this BEFORE
+    /// `updateIndex` (upstream ordering), so after both appends `idxKeys`'
+    /// sequence length equals `offset`.
+    public func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray) {
+        kv.update(keys: keys, values: values)
+    }
+
+    public func makeMask(
+        n: Int, windowSize: Int?, returnArray: Bool
+    ) -> MLXFast.ScaledDotProductAttentionMaskMode {
+        kv.makeMask(n: n, windowSize: windowSize, returnArray: returnArray)
+    }
+
+    /// Append-only trim: slice BOTH lanes to the same logical length. Returns the
+    /// number of tokens actually trimmed.
+    @discardableResult
+    public func trim(_ n: Int) -> Int {
+        let trimmed = kv.trim(n)
+        if trimmed > 0, idxKeys != nil {
+            idxKeys = sliceSeq(idxKeys!, to: kv.offset)
+        }
+        assertLanesAligned()
+        return trimmed
+    }
+
+    // MARK: Lightning-Indexer lane (called by the MSA attention each step)
+
+    /// Append this step's indexer keys `idx_k [B, 1, T, indexDim]` and return the
+    /// full indexer history sliced to the current KV `offset` so `Sk` matches the
+    /// SDPA K length. Grows in lockstep with the K/V side.
+    @discardableResult
+    public func updateIndex(_ idxK: MLXArray) -> MLXArray {
+        if let prev = idxKeys {
+            idxKeys = concatenated([prev, idxK], axis: 2)
+        } else {
+            idxKeys = idxK
+        }
+        assertLanesAligned()
+        return readIndex()
+    }
+
+    /// The indexer history sliced to the current KV `offset`.
+    public func readIndex() -> MLXArray {
+        guard let idx = idxKeys else {
+            return MLXArray.zeros([batchSize, 1, 0, indexDim], dtype: .bfloat16)
+        }
+        return offset > 0 ? sliceSeq(idx, to: offset) : idx
+    }
+
+    // MARK: Serialization — [keys, values, idx_keys]
+
+    public var state: [MLXArray] {
+        get {
+            let kvState = kv.state
+            let k: MLXArray
+            let v: MLXArray
+            if kvState.count == 2 {
+                k = kvState[0]
+                v = kvState[1]
+            } else {
+                // Empty KV — sentinels with a zero-length sequence axis.
+                k = MLXArray.zeros([batchSize, 1, 0, 1], dtype: .bfloat16)
+                v = MLXArray.zeros([batchSize, 1, 0, 1], dtype: .bfloat16)
+            }
+            let idx = idxKeys ?? MLXArray.zeros([batchSize, 1, 0, indexDim], dtype: .bfloat16)
+            return [k, v, idx]
+        }
+        set {
+            precondition(
+                newValue.count == 3,
+                "MiniMaxM3SparseCache.state requires [keys, values, idx_keys]")
+            let k = newValue[0]
+            let v = newValue[1]
+            let idx = newValue[2]
+            if k.ndim >= 3 && k.dim(2) == 0 {
+                // Leave kv empty — offset stays 0.
+            } else {
+                kv.state = [k, v]
+            }
+            // Zero-length sequence axis ⇒ no indexer history yet.
+            idxKeys = (idx.ndim >= 3 && idx.dim(2) == 0) ? nil : idx
+            assertLanesAligned()
+        }
+    }
+
+    /// metaState: kv's trailer + an M3 sentinel carrying `indexDim`.
+    public var metaState: [String] {
+        get { kv.metaState + ["minimax_m3_v1", String(indexDim), String(batchSize)] }
+        set {
+            let trailer = 3
+            if newValue.count >= trailer,
+                newValue[newValue.count - trailer] == "minimax_m3_v1"
+            {
+                kv.metaState = Array(newValue[0 ..< (newValue.count - trailer)])
+            } else {
+                kv.metaState = newValue
+            }
+        }
+    }
+
+    /// Deep copy that PRESERVES the sparse type AND all three lanes — the single
+    /// safe path for prefix/disk/snapshot reuse. Never returns a plain KVCache.
+    public func copy() -> any KVCache {
+        let dup = MiniMaxM3SparseCache(indexDim: indexDim, batchSize: batchSize)
+        dup.state = self.state.map { $0[.ellipsis] }
+        dup.metaState = self.metaState
+        return dup
+    }
+
+    // MARK: helpers
+
+    /// Slice a `[B, H, S, D]` tensor to the first `n` positions on the sequence axis.
+    private func sliceSeq(_ a: MLXArray, to n: Int) -> MLXArray {
+        a[0..., 0..., 0 ..< n, 0...]
+    }
+
+    /// DEBUG-only invariant: a wrong restored offset corrupts attention even when
+    /// shapes look right (postmortem). idx_keys length must equal `offset`.
+    private func assertLanesAligned() {
+        #if DEBUG
+        if let idx = idxKeys {
+            assert(
+                idx.dim(2) == kv.offset,
+                "MiniMaxM3SparseCache lanes desynced: idx_keys S=\(idx.dim(2)) != kv.offset=\(kv.offset)")
+        }
+        #endif
+    }
+}

--- a/Libraries/MLXLMCommon/Cache/TQDiskSerializer.swift
+++ b/Libraries/MLXLMCommon/Cache/TQDiskSerializer.swift
@@ -122,6 +122,13 @@ public enum TQDiskSerializer {
         /// CCA state is a false hit per the Zyphra runtime contract, so
         /// the four arrays round-trip together. Added 2026-05-06.
         case zayaCCA = 9
+        /// `MiniMaxM3SparseCache` — rolling KV plus the Lightning-Indexer key
+        /// lane (`idx_keys`). The paged tier stores only full KV history and
+        /// cannot round-trip idx_keys, so M3 forces disk restore (see
+        /// `cacheRequiresDiskBackedCoordinatorRestore`). The three state arrays
+        /// (keys, values, idx_keys) round-trip together; a KV-only restore is a
+        /// false hit because MSA block selection is recomputed from idx_keys.
+        case miniMaxM3Sparse = 10
         /// Cache type we don't know how to persist. On restore, treated as
         /// a forced miss for the affected layer only.
         case skip = 4
@@ -223,6 +230,9 @@ public enum TQDiskSerializer {
                 // ZAYA CCA-attention: round-trip the four-slot state
                 // (keys, values, conv_state, prev_hs) as one unit.
                 serializeZayaCCALayer(zaya, index: i, into: &result)
+            } else if let m3 = layer as? MiniMaxM3SparseCache {
+                // MiniMax-M3 MSA: round-trip keys, values, AND idx_keys together.
+                serializeMiniMaxM3Layer(m3, index: i, into: &result)
             } else if let hybrid = layer as? HybridPoolCache {
                 // 2026-05-04 (DSV4 SWA/CSA/HSA correctness pass):
                 // serialize the rotating window AND the compressor +
@@ -610,6 +620,32 @@ public enum TQDiskSerializer {
         result[kindKey(for: i)] = kindArray(.zayaCCA)
     }
 
+    /// Serialize a single `MiniMaxM3SparseCache` layer — keys, values, AND the
+    /// idx_keys lane — as one unit, plus `(offset, indexDim, batchSize)` meta so
+    /// restore rebuilds without the model. KV-only restore is a false hit since
+    /// MSA block selection recomputes from idx_keys every step. `.skip` if the
+    /// 3-array state shape is unexpectedly wrong.
+    private static func serializeMiniMaxM3Layer(
+        _ m3: MiniMaxM3SparseCache,
+        index i: Int,
+        into result: inout [String: MLXArray]
+    ) {
+        let s = m3.state
+        guard s.count == 3 else {
+            result[kindKey(for: i)] = kindArray(.skip)
+            return
+        }
+        result["mm3_\(i)_keys"] = s[0]
+        result["mm3_\(i)_values"] = s[1]
+        result["mm3_\(i)_idx_keys"] = s[2]
+        result["__mm3_\(i)_meta__"] = MLXArray([
+            Int32(m3.offset),
+            Int32(m3.indexDim),
+            Int32(m3.batchSize),
+        ])
+        result[kindKey(for: i)] = kindArray(.miniMaxM3Sparse)
+    }
+
     /// Serialize a single QuantizedKVCache layer's state (4 or 6 arrays
     /// covering qweight/scales/[biases] for both keys and values), plus
     /// group size, bit width and offset metadata so the restore path can
@@ -728,6 +764,17 @@ public enum TQDiskSerializer {
         public let batchSize: Int
     }
 
+    /// MiniMax-M3 MSA layer: keys, values, idx_keys + (offset, indexDim,
+    /// batchSize). The three arrays restore together as a `MiniMaxM3SparseCache`.
+    public struct MiniMaxM3SparseLayerComponents {
+        public let keys: MLXArray
+        public let values: MLXArray
+        public let idxKeys: MLXArray
+        public let offset: Int
+        public let indexDim: Int
+        public let batchSize: Int
+    }
+
     /// Result of deserializing one cache layer from a dict.
     public indirect enum LayerData {
         case tq(TQLayerComponents)
@@ -737,6 +784,7 @@ public enum TQDiskSerializer {
         case rotating(RotatingLayerComponents)
         case deepseekV4(DeepseekV4LayerComponents)
         case zayaCCA(ZayaCCALayerComponents)
+        case miniMaxM3Sparse(MiniMaxM3SparseLayerComponents)
         /// `CacheList` composite: ordered per-sub-cache LayerData. Each
         /// sub-element carries its own kind (`.standard`, `.mamba`,
         /// `.rotating`, etc.). Restore walks the array and dispatches
@@ -886,6 +934,12 @@ public enum TQDiskSerializer {
             case .zayaCCA:
                 if let comp = deserializeZayaCCALayer(index: i, from: arrays) {
                     out.append(IndexedLayerData(index: i, data: .zayaCCA(comp)))
+                } else {
+                    out.append(IndexedLayerData(index: i, data: .skip))
+                }
+            case .miniMaxM3Sparse:
+                if let comp = deserializeMiniMaxM3Layer(index: i, from: arrays) {
+                    out.append(IndexedLayerData(index: i, data: .miniMaxM3Sparse(comp)))
                 } else {
                     out.append(IndexedLayerData(index: i, data: .skip))
                 }
@@ -1162,7 +1216,7 @@ public enum TQDiskSerializer {
                 }
             case .skip, .unknown:
                 subs.append(.skip)
-            case .tq, .qkv, .deepseekV4, .cacheList, .zayaCCA:
+            case .tq, .qkv, .deepseekV4, .cacheList, .zayaCCA, .miniMaxM3Sparse:
                 // Not currently emitted as sub-cache types — see
                 // serializeCacheListLayer. If a future bundle ships
                 // these we'll need to extend serialize too. Skip for
@@ -1242,6 +1296,30 @@ public enum TQDiskSerializer {
             convChannels: Int(m[1]),
             hiddenSize: Int(m[2]),
             batchSize: Int(m[3]))
+    }
+
+    /// Deserialize a single `MiniMaxM3SparseCache` layer. Reads three state
+    /// arrays (keys, values, idx_keys) plus the 3-element `__mm3_{i}_meta__`
+    /// tuple `(offset, index_dim, batch_size)`.
+    private static func deserializeMiniMaxM3Layer(
+        index i: Int,
+        from arrays: [String: MLXArray]
+    ) -> MiniMaxM3SparseLayerComponents? {
+        guard let keys = arrays["mm3_\(i)_keys"],
+              let values = arrays["mm3_\(i)_values"],
+              let idxKeys = arrays["mm3_\(i)_idx_keys"],
+              let metaArr = arrays["__mm3_\(i)_meta__"]
+        else { return nil }
+        guard !metaArr.shape.isEmpty, metaArr.shape[0] == 3 else { return nil }
+        let m = metaArr.asArray(Int32.self)
+        guard m.count == 3 else { return nil }
+        return MiniMaxM3SparseLayerComponents(
+            keys: keys,
+            values: values,
+            idxKeys: idxKeys,
+            offset: Int(m[0]),
+            indexDim: Int(m[1]),
+            batchSize: Int(m[2]))
     }
 
     // MARK: - Helpers

--- a/Libraries/MLXLMCommon/JangLoader.swift
+++ b/Libraries/MLXLMCommon/JangLoader.swift
@@ -1915,7 +1915,7 @@ public struct JangLoader: Sendable {
 
             let packedDim = weightArray.shape.last ?? 0
             let numGroups = scalesArray.shape.last ?? 1
-            let (bits, inferredGroupSize): (Int, Int)
+            var (bits, inferredGroupSize): (Int, Int)
 
             let isHiddenAnchor =
                 basePath.hasSuffix("embed_tokens")
@@ -2149,6 +2149,29 @@ public struct JangLoader: Sendable {
 
             let mode = weights[basePath + ".biases"] == nil ? defaultMode : .affine
             let declaredForLayer = declaredQuantization(for: basePath)
+
+            // Resolve shape ambiguity in favor of the authoritative config.
+            // `bits * group_size` is invariant under affine packing, so e.g.
+            // (bits=6, gs=64) and (bits=3, gs=128) yield IDENTICAL weight/scales
+            // shapes (embed_tokens here: 1152 packed cols, 96 groups). The scales
+            // tensor cannot tell them apart — only the true input dim can. When
+            // config.json declares a per-module (bits, gs) that is itself
+            // shape-consistent with the observed tensors, trust it over the shape
+            // walk; otherwise embed_tokens (6-bit/gs64) is mis-read as 3-bit/gs128,
+            // doubling the input dim (12288 vs 6144) and crashing quantized_matmul.
+            // A declared value that is INconsistent with the shapes (a genuinely
+            // wrong "lying config") still falls through to the inferred value.
+            if let declared = declaredForLayer,
+               declared.bits > 0, declared.groupSize > 0,
+               numGroups > 0,
+               (packedDim * 32) % declared.bits == 0,
+               (packedDim * 32) / declared.bits == numGroups * declared.groupSize,
+               (bits != declared.bits || inferredGroupSize != declared.groupSize)
+            {
+                bits = declared.bits
+                inferredGroupSize = declared.groupSize
+            }
+
             let declaredMatches =
                 declaredForLayer?.bits == bits
                 && declaredForLayer?.groupSize == inferredGroupSize

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -1384,6 +1384,13 @@ public func savePromptCache(
     // Use Python-compatible class names for cross-platform compatibility
     let cacheClasses = cache.map { cache -> String in
         switch cache {
+        case is MiniMaxM3SparseCache:
+            // M3 sparse layers carry a 3-lane composite cache (keys, values,
+            // idx_keys). Must precede the KVCacheSimple/default arms: it is NOT a
+            // KVCacheSimple subclass, so it would otherwise fall through to the
+            // "KVCache" default, drop idx_keys, and load back as a 2-array cache
+            // (state setter fatals on the 3-array payload). Keep it first-class.
+            return "MiniMaxM3SparseCache"
         case is ChunkedKVCache:
             return "ChunkedKVCache"  // Must precede KVCacheSimple because of inheritance
         case is KVCacheSimple:
@@ -1473,6 +1480,11 @@ public func loadPromptCache(
         switch className {
         case "KVCache", "KVCacheSimple":  // Handle both Python and Swift names
             cache = KVCacheSimple()
+        case "MiniMaxM3SparseCache":
+            // indexDim is recovered from the 3-lane `state` payload (the idx
+            // tensor's last dim); the default-constructed cache only needs a
+            // placeholder until `state`/`metaState` are applied below.
+            cache = MiniMaxM3SparseCache()
         case "RotatingKVCache":
             // Parse metaState first to get maxSize, then create cache
             let info = i < cacheInfo.count ? cacheInfo[i] : []
@@ -1764,7 +1776,10 @@ public func quantizedScaledDotProductAttention(
 ///   Returns float arrays — models need zero changes.
 ///
 /// Only converts `KVCacheSimple` layers. `RotatingKVCache`, `DeepseekV4Cache`,
-/// `MambaCache`, and already-converted caches are skipped automatically.
+/// `MambaCache`, `MiniMaxM3SparseCache` (native MSA — its idx_keys lane cannot be
+/// TQ/affine-encoded), and already-converted caches are skipped automatically.
+/// For MiniMax-M3 this means the 57 sparse MSA layers are never compressed; only
+/// the 3 dense full-attention `KVCacheSimple` layers are eligible.
 ///
 /// - Parameters:
 ///   - cache: Array of KV caches to potentially quantize/compress

--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -637,6 +637,27 @@ public func loadWeights(
             let quantBiases =
                 (mode == .mxfp4 || mode == .mxfp8) ? nil : weights[biasesKey]
 
+            // Disambiguate (bits, group_size) from the placeholder module's TRUE
+            // input dim. Pre-quantized shapes alone are ambiguous: `bits*group_size`
+            // is invariant under affine packing, so e.g. (bits=6, gs=64) and
+            // (bits=3, gs=128) produce IDENTICAL weight/scales shapes (the scales
+            // tensor has the same column count either way). Only the real input dim
+            // resolves it. The placeholder Linear/SwitchLinear/Embedding carries
+            // that dim, so this is unconditional and module-local — no reliance on
+            // config defaults or shape-walk candidate ordering, which mis-read
+            // MiniMax-M3's mixed 6/8-bit modules as 3-bit/gs128 and crashed
+            // quantized_matmul. Affine only; MXFP modes pack differently.
+            func resolveAffineBitsGS(inputDim: Int) -> (bits: Int, groupSize: Int)? {
+                guard mode == .affine, inputDim > 0 else { return nil }
+                let packed = loadedWeight.dim(-1)
+                let groups = loadedScales.dim(-1)
+                guard groups > 0, inputDim % groups == 0, (packed * 32) % inputDim == 0
+                else { return nil }
+                let derivedBits = (packed * 32) / inputDim
+                guard derivedBits > 0 else { return nil }
+                return (derivedBits, inputDim / groups)
+            }
+
             // Pre-quantized safetensors already provide `.weight` +
             // `.scales` (+ optional quant `.biases`). Build the quantized
             // module from those arrays directly instead of quantizing the
@@ -645,15 +666,17 @@ public func loadWeights(
             // especially important for routed-MoE `SwitchLinear`, where the
             // placeholder can be tens of GB on Ling/DSV4-class bundles.
             if let linear = m as? Linear {
+                let (rb, rgs) = resolveAffineBitsGS(inputDim: linear.weight.dim(-1)) ?? (b, gs)
                 return (path, QuantizedLinear(
                     weight: loadedWeight,
                     bias: weights[biasKey] ?? linear.bias,
                     scales: loadedScales,
                     biases: quantBiases,
-                    groupSize: gs, bits: b, mode: mode))
+                    groupSize: rgs, bits: rb, mode: mode))
             }
 
             if let switchLinear = m as? SwitchLinear {
+                let (rb, rgs) = resolveAffineBitsGS(inputDim: switchLinear.inputDims) ?? (b, gs)
                 return (path, QuantizedSwitchLinear(
                     inputDims: switchLinear.inputDims,
                     outputDims: switchLinear.outputDims,
@@ -662,16 +685,17 @@ public func loadWeights(
                     bias: weights[biasKey] ?? switchLinear.bias,
                     scales: loadedScales,
                     biases: quantBiases,
-                    groupSize: gs, bits: b, mode: mode))
+                    groupSize: rgs, bits: rb, mode: mode))
             }
 
-            if m is Embedding {
+            if let embedding = m as? Embedding {
+                let (rb, rgs) = resolveAffineBitsGS(inputDim: embedding.weight.dim(-1)) ?? (b, gs)
                 return (path, QuantizedEmbedding(
                     weight: loadedWeight,
                     scales: loadedScales,
                     biases: quantBiases,
-                    groupSize: gs,
-                    bits: b,
+                    groupSize: rgs,
+                    bits: rb,
                     mode: mode))
             }
 

--- a/Libraries/MLXLMCommon/ModelContainer.swift
+++ b/Libraries/MLXLMCommon/ModelContainer.swift
@@ -27,6 +27,13 @@ public struct ModelCacheTopologySnapshot: Codable, Sendable, Equatable {
     public var arraysLayerCount: Int
     public var zayaCCALayerCount: Int
     public var cacheListLayerCount: Int
+    /// MiniMax-M3 MSA layers carry a `MiniMaxM3SparseCache` (KV + an idx_keys
+    /// lane). Counted separately so reuse tiers preserve the composite (never a
+    /// plain KV copy that drops idx_keys) and the coordinator marks it
+    /// paged-incompatible — dynamic block selection has no page format. This is
+    /// NOT an SSM companion (no conv/recurrent state); see
+    /// `requiresMiniMaxM3SparseState`.
+    public var miniMaxM3SparseLayerCount: Int
 
     public init(
         layerCount: Int = 0,
@@ -44,7 +51,8 @@ public struct ModelCacheTopologySnapshot: Codable, Sendable, Equatable {
         compilableMambaLayerCount: Int = 0,
         arraysLayerCount: Int = 0,
         zayaCCALayerCount: Int = 0,
-        cacheListLayerCount: Int = 0
+        cacheListLayerCount: Int = 0,
+        miniMaxM3SparseLayerCount: Int = 0
     ) {
         self.layerCount = layerCount
         self.kvLayerCount = kvLayerCount
@@ -62,6 +70,7 @@ public struct ModelCacheTopologySnapshot: Codable, Sendable, Equatable {
         self.arraysLayerCount = arraysLayerCount
         self.zayaCCALayerCount = zayaCCALayerCount
         self.cacheListLayerCount = cacheListLayerCount
+        self.miniMaxM3SparseLayerCount = miniMaxM3SparseLayerCount
     }
 
     public init(cache: [any KVCache]) {
@@ -80,12 +89,20 @@ public struct ModelCacheTopologySnapshot: Codable, Sendable, Equatable {
         zayaCCALayerCount > 0
     }
 
+    /// True when any layer is a MiniMax-M3 sparse (MSA) cache. The reuse tiers
+    /// must keep that cache first-class (preserve the idx_keys lane) and the
+    /// coordinator must run paged-incompatible for it.
+    public var requiresMiniMaxM3SparseState: Bool {
+        miniMaxM3SparseLayerCount > 0
+    }
+
     public var requiresRecurrentSSMCompanionState: Bool {
         mambaLayerCount > 0 || arraysLayerCount > 0
     }
 
     public var requiresDiskBackedCoordinatorRestore: Bool {
         requiresSSMCompanionState
+            || requiresMiniMaxM3SparseState
             || rotatingKVLayerCount > 0
             || compilableRotatingKVLayerCount > 0
             || rotatingWrapperLayerCount > 0
@@ -115,6 +132,7 @@ public struct ModelCacheTopologySnapshot: Codable, Sendable, Equatable {
         if compilableMambaLayerCount > 0 { tags.append("compilableMambaLayers=\(compilableMambaLayerCount)") }
         if arraysLayerCount > 0 { tags.append("arraysLayers=\(arraysLayerCount)") }
         if zayaCCALayerCount > 0 { tags.append("zayaCCALayers=\(zayaCCALayerCount)") }
+        if miniMaxM3SparseLayerCount > 0 { tags.append("minimaxM3SparseLayers=\(miniMaxM3SparseLayerCount)") }
         if cacheListLayerCount > 0 { tags.append("cacheListLayers=\(cacheListLayerCount)") }
         if requiresRecurrentSSMCompanionState { tags.append("companion=ssm") }
         if requiresZayaCCACompanionState { tags.append("companion=zaya-cca") }
@@ -146,6 +164,12 @@ public struct ModelCacheTopologySnapshot: Codable, Sendable, Equatable {
             rotatingWrapperLayerCount += 1
         case is ZayaCCACache:
             zayaCCALayerCount += 1
+        case is MiniMaxM3SparseCache:
+            // KV + idx_keys composite. Distinct bucket so it is NOT miscounted as
+            // a plain KV layer (which would let a reuse path drop the idx_keys
+            // lane and loop). Drives requiresMiniMaxM3SparseState / disk-backed
+            // restore / paged-incompatible.
+            miniMaxM3SparseLayerCount += 1
         case is CompilableMambaCache:
             compilableMambaLayerCount += 1
             mambaLayerCount += 1

--- a/Libraries/MLXLMCommon/ReasoningParser.swift
+++ b/Libraries/MLXLMCommon/ReasoningParser.swift
@@ -653,6 +653,23 @@ extension ReasoningParser {
                 startInReasoning: false)
         }
 
+        if compact.hasPrefix("minimaxm3") {
+            // MiniMax-M3 native reasoning envelope is <mm:think>…</mm:think>,
+            // NOT minimax_m2's <think>. The template's default (adaptive) and
+            // disabled modes do NOT prefill the open tag — the model emits its
+            // own <mm:think> — so start in content and flip on the open tag.
+            // The explicit thinking_mode="enabled" path prefills <mm:think> at
+            // the prompt tail (model starts mid-reasoning); the runtime sets
+            // startInReasoning per-request for that case (matrix B13). With the
+            // generic "minimax" stamp the <think> tag never matches <mm:think>
+            // and the whole CoT leaks into visible content (verified live
+            // 2026-06-19). minimax_m2 stays on <think> via the switch below.
+            return ReasoningParser(
+                startTag: "<mm:think>",
+                endTag: "</mm:think>",
+                startInReasoning: false)
+        }
+
         if normalized.hasPrefix("qwen3_vl")
             || normalized.hasPrefix("qwen3_5_vl")
             || normalized.hasPrefix("qwen3_6_vl")
@@ -924,6 +941,14 @@ public func reasoningStampFromModelType(_ modelType: String?) -> String {
     // Harmony marker leak.
     if compact.hasPrefix("gptoss") {
         return "harmony"
+    }
+
+    // MiniMax-M3 emits <mm:think>…</mm:think>, not minimax_m2's <think>. Route
+    // to a dedicated stamp so fromCapabilityName builds the <mm:think> parser;
+    // the generic "minimax" think_xml stamp leaves <mm:think> unmatched → CoT
+    // leaks into content. minimax_m2 keeps the "minimax" stamp below.
+    if compact.hasPrefix("minimaxm3") {
+        return "minimax_m3"
     }
 
     // ZAYA1-VL is a sibling multimodal architecture, not the text

--- a/Libraries/MLXLMCommon/Tool/Parsers/MiniMaxM3ToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/MiniMaxM3ToolCallParser.swift
@@ -1,0 +1,176 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// MiniMax-M3 tool-call parser — a faithful port of vllm-mlx
+// `tool_parsers/minimax_m3_tool_parser.py` (the authoritative M3 format).
+//
+// M3 emits Anthropic-style XML where the PARAMETER NAME IS THE TAG (not a
+// `name=` attribute), wrapped in `<tool_call>...</tool_call>`, with the literal
+// namespace token `]<]minimax[>[` prefixed before every element, and reasoning in
+// `<mm:think>...</mm:think>`. Rendered shape (ns shown as · , stripped first):
+//
+//     <tool_call>
+//     ·<invoke name="get_weather">
+//     ·<location>San Francisco·</location>
+//     ·<opts>·<unit>celsius·</unit>·</opts>          (nested object)
+//     ·<days>·<item>mon·</item>·<item>tue·</item>·</days>  (array)
+//     ·</invoke>
+//     </tool_call>
+//
+// Value mapping:  scalar -> coerced (JSON-parsed else string); `<item>` repeats ->
+// array; other nested tags -> object. This is NOT minimax_m2's `<minimax:tool_call>`
+// + `<parameter name=>` form, so M3 needs its own parser/route.
+
+import Foundation
+
+public struct MiniMaxM3ToolCallParser: ToolCallParser, Sendable {
+    private static let ns = "]<]minimax[>["
+
+    public let startTag: String? = "<tool_call>"
+    public let endTag: String? = "</tool_call>"
+    /// The model prefixes the namespace token before the envelope; accept it too.
+    public var startTagAliases: [String] { ["\(MiniMaxM3ToolCallParser.ns)<tool_call>"] }
+    public var endTagAliases: [String] { ["\(MiniMaxM3ToolCallParser.ns)</tool_call>"] }
+
+    public init() {}
+
+    // MARK: noise stripping (ns token + reasoning block)
+
+    private func stripNoise(_ text: String) -> String {
+        var t = text.replacingOccurrences(of: Self.ns, with: "")
+        // Remove <mm:think>...</mm:think> blocks (DOTALL).
+        while let open = t.range(of: "<mm:think>"),
+            let close = t.range(of: "</mm:think>", range: open.upperBound ..< t.endIndex) {
+            t.removeSubrange(open.lowerBound ..< close.upperBound)
+        }
+        return t
+    }
+
+    // MARK: recursive tag parsing (mirrors _next_tag / _children / _parse_value)
+
+    /// Next top-level `<tag>...</tag>` at/after `pos`, with correct nesting of
+    /// same-named tags. Returns (tag, inner, endIndex) or nil if none complete.
+    private func nextTag(_ s: String, _ pos: String.Index)
+        -> (tag: String, inner: String, end: String.Index)? {
+        guard let openLt = s.range(of: "<", range: pos ..< s.endIndex),
+            let openGt = s.range(of: ">", range: openLt.upperBound ..< s.endIndex)
+        else { return nil }
+        let rawTag = String(s[openLt.upperBound ..< openGt.lowerBound])
+            .trimmingCharacters(in: .whitespaces)
+        // Skip closing tags / attributes-bearing openers (only bare `<tag>` here).
+        guard !rawTag.isEmpty, !rawTag.hasPrefix("/"),
+            rawTag.allSatisfy({ $0.isLetter || $0.isNumber || "_-.:".contains($0) })
+        else {
+            return nextTag(s, openGt.upperBound)
+        }
+        let openTag = "<\(rawTag)>"
+        let closeTag = "</\(rawTag)>"
+        var depth = 1
+        var scan = openGt.upperBound
+        while true {
+            let nextOpen = s.range(of: openTag, range: scan ..< s.endIndex)
+            guard let nextClose = s.range(of: closeTag, range: scan ..< s.endIndex) else {
+                return nil  // unterminated
+            }
+            if let nextOpen, nextOpen.lowerBound < nextClose.lowerBound {
+                depth += 1
+                scan = nextOpen.upperBound
+            } else {
+                depth -= 1
+                scan = nextClose.upperBound
+                if depth == 0 {
+                    return (rawTag, String(s[openGt.upperBound ..< nextClose.lowerBound]), scan)
+                }
+            }
+        }
+    }
+
+    private func children(_ s: String) -> [(tag: String, inner: String)] {
+        var out: [(String, String)] = []
+        var pos = s.startIndex
+        while let nxt = nextTag(s, pos) {
+            out.append((nxt.tag, nxt.inner))
+            pos = nxt.end
+        }
+        return out
+    }
+
+    private func coerce(_ value: String) -> any Sendable {
+        let v = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if v.isEmpty { return v }
+        if v == "true" { return true }
+        if v == "false" { return false }
+        if v == "null" { return NSNull() }
+        if let i = Int(v) { return i }
+        if let d = Double(v) { return d }
+        // Nested objects/arrays arrive as XML tags (handled by parseValue), not
+        // JSON-in-a-leaf, so a leaf value is returned as its coerced scalar/string.
+        return v
+    }
+
+    private func parseValue(_ inner: String) -> any Sendable {
+        let kids = children(inner)
+        if kids.isEmpty { return coerce(inner) }
+        if kids.allSatisfy({ $0.tag == "item" }) {
+            return kids.map { parseValue($0.inner) } as [any Sendable]
+        }
+        var obj: [String: any Sendable] = [:]
+        for (tag, ci) in kids { obj[tag] = parseValue(ci) }
+        return obj
+    }
+
+    private func argsFromInvoke(_ body: String) -> [String: any Sendable] {
+        var args: [String: any Sendable] = [:]
+        for (tag, inner) in children(body) { args[tag] = parseValue(inner) }
+        return args
+    }
+
+    // MARK: ToolCallParser
+
+    public func isValidPartialContent(_ toolCallBuffer: String) -> Bool {
+        let cleaned = stripNoise(toolCallBuffer)
+        guard !cleaned.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return true }
+        // Building toward a <tool_call> or <invoke ...> opener.
+        return cleaned.contains("<tool_call")
+            || cleaned.contains("<invoke")
+            || "<tool_call>".hasPrefix(cleaned)
+            || "<invoke".hasPrefix(cleaned)
+    }
+
+    public func parse(content: String, tools: [[String: any Sendable]]?) -> ToolCall? {
+        let cleaned = stripNoise(content)
+        guard cleaned.contains("<invoke") else { return nil }
+
+        // Search inside <tool_call>...</tool_call> if present; else whole text
+        // (covers truncation / wrapper-less invoke).
+        var searchSpace = cleaned
+        if let open = cleaned.range(of: "<tool_call>") {
+            let afterOpen = open.upperBound
+            if let close = cleaned.range(of: "</tool_call>", range: afterOpen ..< cleaned.endIndex) {
+                searchSpace = String(cleaned[afterOpen ..< close.lowerBound])
+            } else {
+                searchSpace = String(cleaned[afterOpen...])  // truncated, no closer
+            }
+        }
+
+        // First <invoke name=...>...</invoke>. Name may be "x" / 'x' / bare.
+        guard let invokeOpen = searchSpace.range(of: "<invoke") else { return nil }
+        guard let nameEq = searchSpace.range(
+            of: "name=", range: invokeOpen.upperBound ..< searchSpace.endIndex)
+        else { return nil }
+        guard let headerEnd = searchSpace.range(
+            of: ">", range: nameEq.upperBound ..< searchSpace.endIndex)
+        else { return nil }
+        let rawName = String(searchSpace[nameEq.upperBound ..< headerEnd.lowerBound])
+            .trimmingCharacters(in: .whitespaces)
+        let funcName = rawName.trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+        guard !funcName.isEmpty else { return nil }
+
+        guard let invokeClose = searchSpace.range(
+            of: "</invoke>", range: headerEnd.upperBound ..< searchSpace.endIndex)
+        else { return nil }
+        let body = String(searchSpace[headerEnd.upperBound ..< invokeClose.lowerBound])
+
+        return ToolCall(function: .init(name: funcName, arguments: argsFromInvoke(body)))
+    }
+}

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -158,6 +158,13 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
     /// Example: `<invoke name="f"><parameter name="k">v</parameter></invoke>`
     case minimaxM2 = "minimax_m2"
 
+    /// MiniMax M3 namespaced XML invoke format. The template prefixes every tag
+    /// with `]<]minimax[>[` and uses BARE `<key>value</key>` arg tags inside a
+    /// `<tool_call>` wrapper — distinct from M2's `<minimax:tool_call>` +
+    /// `<parameter name=>`. Example:
+    /// `]<]minimax[>[<tool_call>]<]minimax[>[<invoke name="f">]<]minimax[>[<k>v]<]minimax[>[</k>]<]minimax[>[</invoke>]<]minimax[>[</tool_call>`
+    case minimaxM3 = "minimax_m3"
+
     /// Mistral V11+ format with [TOOL_CALLS] and [ARGS] delimiters.
     /// Example: `[TOOL_CALLS]get_weather [ARGS]{"location": "Tokyo"}`
     case mistral
@@ -218,6 +225,8 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
             return KimiK2ToolCallParser()
         case .minimaxM2:
             return MiniMaxM2ToolCallParser()
+        case .minimaxM3:
+            return MiniMaxM3ToolCallParser()
         case .mistral:
             return MistralToolCallParser()
         case .llama3:
@@ -263,7 +272,7 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
     /// residue once a native tool call is extracted.
     public var preservesReasoningTextAroundToolCalls: Bool {
         switch self {
-        case .minimaxM2:
+        case .minimaxM2, .minimaxM3:
             return true
         default:
             return false
@@ -346,6 +355,11 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
             return .gemma
         }
 
+        // MiniMax-M3 (minimax_m3 / minimax_m3_vl) uses a DIFFERENT tool envelope
+        // than M2 — must be checked first so it doesn't fall into the M2 arm.
+        if compact.hasPrefix("minimaxm3") {
+            return .minimaxM3
+        }
         // MiniMax family (minimax, minimax_m2)
         if compact.hasPrefix("minimax") {
             return .minimaxM2
@@ -596,6 +610,8 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
         // MiniMax — JANG converter stamps `minimax`; older artifacts use
         // the canonical `minimax_m2`. Future M2.5 variants use
         // `minimax_m2_5` per the converter.
+        case "minimax_m3", "minimax_m3_vl":
+            return .minimaxM3
         case "minimax", "minimax_m2_5":
             return .minimaxM2
         // GLM 4.x / 5 / DeepSeek tool format (arg_key / arg_value tags).

--- a/Tests/MLXLMTests/MiniMaxM3SmokeTests.swift
+++ b/Tests/MLXLMTests/MiniMaxM3SmokeTests.swift
@@ -1,0 +1,259 @@
+// MiniMax-M3 REAP/JANG live smoke (gated on the bundle present at the canonical
+// path; override with VMLX_MM3_BUNDLE). Deliberately ONE model load: loading a
+// 60-layer REAP MoE bundle is RAM/time heavy, so every signal is harvested from a
+// single `loadModel`.
+//
+// PROOF STANDARD (not math): the load/forward shape checks only prove the runtime
+// doesn't crash and produces finite numbers. Coherence is proven by SCANNING each
+// generated turn for leaked reasoning/tool/special tokens, non-printable/weird
+// characters, repetition loops, and emptiness — see `scanResponse`. The test
+// drives a VARYING multiturn session (thinking_mode disabled→enabled→adaptive)
+// using CODE prompts, because this REAP bundle keeps coding/agentic experts but
+// has barely any math experts (better math-capable builds exist elsewhere; this
+// local copy does not — do not gate on arithmetic).
+//
+// Set MM3_MSA_TRACE=1 to see the one-shot stderr line when block-sparse MSA fires.
+
+import BenchmarkHelpers
+import Foundation
+import MLX
+@preconcurrency import VMLXTokenizers
+@testable import MLXHuggingFace
+@testable import MLXLLM
+@testable import MLXLMCommon
+import Testing
+
+@Suite("MiniMax-M3 REAP JANG live smoke", .serialized)
+struct MiniMaxM3SmokeTests {
+    static let bundlePath: String = {
+        if let override = ProcessInfo.processInfo.environment["VMLX_MM3_BUNDLE"],
+           !override.isEmpty {
+            return override
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("models/JANGQ-AI/MiniMax-M3-REAP40-d3-JANG_2L").path
+    }()
+
+    static var bundlePresent: Bool {
+        FileManager.default.fileExists(atPath: bundlePath + "/config.json")
+    }
+
+    // MARK: response scanner (the real proof)
+
+    /// Returns a list of violations; empty == clean. Flags leaked reasoning/tool/
+    /// special tokens in visible content, non-printable/weird characters,
+    /// repetition loops, emptiness, and reasoning-channel mismatches.
+    static func scanResponse(
+        content: String, reasoning: String, label: String, reasoningExpected: Bool
+    ) -> [String] {
+        var v: [String] = []
+
+        // Leaked reasoning / tool / chat-template special tokens in CONTENT.
+        let leaks = [
+            "<mm:think>", "</mm:think>", "<think>", "</think>",
+            "<|im_start|>", "<|im_end|>", "<|endoftext|>",
+            "<tool_call>", "</tool_call>", "<mm:tool", "<thinking_instructions>",
+            // M3 ACTUALLY emits this tool envelope at inference (NOT the template's
+            // <tool_call><invoke> form) — unparsed tool syntax must never leak.
+            "<|tool>", "<tool|>", "]<]minimax[>[",
+        ]
+        for tag in leaks where content.contains(tag) {
+            v.append("\(label): leaked token '\(tag)' in visible content")
+        }
+
+        // Non-printable / weird characters.
+        if content.unicodeScalars.contains(where: { $0.value == 0 }) {
+            v.append("\(label): NUL byte in content")
+        }
+        if content.contains("\u{FFFD}") {
+            v.append("\(label): U+FFFD replacement char (mojibake)")
+        }
+        let controls = content.unicodeScalars.filter {
+            $0.value < 0x20 && $0 != "\n" && $0 != "\r" && $0 != "\t"
+        }
+        if !controls.isEmpty {
+            v.append("\(label): \(controls.count) C0 control char(s)")
+        }
+
+        // Repetition loop (the classic degeneration signature) — in EITHER channel.
+        if let loop = detectLoop(content) {
+            v.append("\(label): repetition loop in content \"\(loop)\"")
+        }
+        if let loop = detectLoop(reasoning) {
+            v.append("\(label): repetition loop in reasoning \"\(loop)\"")
+        }
+
+        // Weird characters in the reasoning channel too (it is user-visible).
+        if reasoning.unicodeScalars.contains(where: { $0.value == 0 })
+            || reasoning.contains("\u{FFFD}") {
+            v.append("\(label): NUL/U+FFFD in reasoning channel")
+        }
+        // Reasoning text must not still contain its own envelope tags (parser
+        // should have consumed them).
+        for tag in ["<mm:think>", "</mm:think>"] where reasoning.contains(tag) {
+            v.append("\(label): unconsumed '\(tag)' inside reasoning channel")
+        }
+        _ = reasoningExpected
+        return v
+    }
+
+    /// Detect a consecutive n-gram (n=3..5 words) repeated >=4 times in a row.
+    static func detectLoop(_ s: String) -> String? {
+        let words = s.split(whereSeparator: { $0 == " " || $0 == "\n" }).map(String.init)
+        guard words.count >= 12 else { return nil }
+        for size in [3, 4, 5] {
+            var i = 0
+            while i + size * 4 <= words.count {
+                let gram = Array(words[i ..< i + size])
+                var reps = 1
+                var j = i + size
+                while j + size <= words.count && Array(words[j ..< j + size]) == gram {
+                    reps += 1
+                    j += size
+                }
+                if reps >= 4 { return gram.joined(separator: " ") }
+                i += 1
+            }
+        }
+        return nil
+    }
+
+    // MARK: the single-load live proof
+
+    @Test("Single load: cache layout, short/long(>2048 MSA) forward, varying multiturn scanned clean",
+          .enabled(if: MiniMaxM3SmokeTests.bundlePresent))
+    func liveProof() async throws {
+        let url = URL(fileURLWithPath: Self.bundlePath)
+        let context = try await MLXLMCommon.loadModel(
+            from: url, using: #huggingFaceTokenizerLoader())
+        nonisolated(unsafe) let ctx = context
+
+        // (0) The engine stamps M3's OWN tool-call format (not minimax_m2's) from
+        // model_type, so tool calls parse with the <mm:think>/`<invoke>` family.
+        #expect(context.configuration.toolCallFormat == .minimaxM3)
+
+        // (1) Heterogeneous cache: dense 0-2 plain KV, sparse 3-59 composite.
+        let cache = ctx.model.newCache(parameters: nil)
+        #expect(cache.count == 60)
+        #expect(cache[0] is KVCacheSimple)
+        #expect(!(cache[0] is MiniMaxM3SparseCache))
+        #expect(cache[2] is KVCacheSimple)
+        #expect(cache[3] is MiniMaxM3SparseCache)
+        #expect(cache[59] is MiniMaxM3SparseCache)
+
+        // (2) Short forward (<2048, full attention). Finite logits = no crash.
+        let shortTokens = MLXArray((0 ..< 8).map { Int32($0 + 1) }).reshaped([1, 8])
+        let shortLogits = ctx.model(shortTokens, cache: cache)
+        MLX.eval(shortLogits)
+        #expect(shortLogits.dim(1) == 8)
+        #expect(shortLogits.abs().max().item(Float.self).isFinite)
+
+        // (3) Long forward >2048 → Lightning Indexer fires; 3-lane lockstep.
+        let longCache = ctx.model.newCache(parameters: nil)
+        let n = 2304
+        let longTokens = MLXArray((0 ..< n).map { Int32($0 % 200_000) }).reshaped([1, n])
+        let longLogits = ctx.model(longTokens, cache: longCache)
+        MLX.eval(longLogits)
+        #expect(longLogits.abs().max().item(Float.self).isFinite)
+        #expect(longCache[3].offset == n)
+
+        // (4) Varying multiturn with CODE prompts, scanned per turn. thinking_mode
+        // (NOT enable_thinking) is M3's reasoning knob; default-unset == adaptive.
+        let engine = BatchEngine(context: ctx, maxBatchSize: 1)
+        let turns: [(mode: String, prompt: String, reasoningExpected: Bool)] = [
+            ("disabled",
+             "Write a Swift function `reverseString(_ s: String) -> String` that returns its input reversed. Code only, no explanation.",
+             false),
+            ("enabled",
+             "Now extend it to also trim leading/trailing whitespace, and briefly explain your reasoning.",
+             true),
+            ("adaptive",
+             "Write a Swift Testing unit test (`@Test`) that checks reverseString on a normal string and an empty string.",
+             false),
+        ]
+        var chat: [Chat.Message] = []
+        for (idx, turn) in turns.enumerated() {
+            chat.append(.user(turn.prompt))
+            let input = try await context.processor.prepare(input: UserInput(
+                chat: chat, additionalContext: ["thinking_mode": turn.mode]))
+            nonisolated(unsafe) let send = input
+            // Generous budget so reasoning turns can finish thinking AND emit
+            // content (this REAP build over-reasons on simple asks).
+            let params = GenerateParameters(maxTokens: 1024, temperature: 0, prefillStepSize: 512)
+            let stream = await engine.generate(input: send, parameters: params)
+            let r = await Self.collect(stream)
+
+            let label = "T\(idx + 1)/\(turn.mode)"
+            let truncatedByLength: Bool = { if case .length = r.stopReason { return true } else { return false } }()
+            FileHandle.standardError.write(Data(
+                "[MM3-\(label)] stop=\(r.stopReason) unclosed=\(r.unclosed) content=<<<\(r.text.prefix(240))>>>\n[MM3-\(label)] reasoning(\(r.reasoning.count))=<<<\(r.reasoning.prefix(160))>>>\n".utf8))
+
+            // Hygiene scan (leaks / weird chars / loops) — ALWAYS hard.
+            var violations = Self.scanResponse(
+                content: r.text, reasoning: r.reasoning,
+                label: label, reasoningExpected: turn.reasoningExpected)
+
+            // Empty visible content: a real failure (empty bubble) UNLESS the turn
+            // was cut off mid-reasoning by the length cap (out of token budget),
+            // which is a truncation artifact, not incoherence. Not a fake guard:
+            // we still log it and it would fail if the model stopped (eos) empty.
+            let contentEmpty = r.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            if contentEmpty {
+                if truncatedByLength && (r.unclosed || !r.reasoning.isEmpty) {
+                    FileHandle.standardError.write(Data(
+                        "[MM3-\(label)] NOTE: truncated mid-reasoning at maxTokens (raise budget); not a coherence failure\n".utf8))
+                } else {
+                    violations.append("\(label): empty visible content with stop=\(r.stopReason) (empty bubble)")
+                }
+            }
+            // Reasoning expectation: enabled/adaptive turns that DID think must have
+            // surfaced it in the reasoning channel, not swallowed it.
+            if turn.reasoningExpected
+                && r.reasoning.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                && !contentEmpty {
+                violations.append("\(label): reasoning expected but channel empty (CoT may have leaked)")
+            }
+
+            #expect(violations.isEmpty, "\(violations)")
+            // Feed back the visible content (+ reasoning if no content) so multiturn
+            // context stays non-empty even on a truncated reasoning turn.
+            chat.append(.assistant(r.text.isEmpty ? r.reasoning : r.text))
+        }
+        await engine.shutdown()
+
+        // NOTE: a LIVE tool-call turn is intentionally NOT asserted here. This
+        // local REAP build is pruned of the experts that emit valid M3 tool
+        // syntax — it produces cross-family garbage (Gemma-4 `<|tool>declaration:`
+        // tokens) instead of M3's `<tool_call><invoke>` XML, so a live tool turn
+        // can't pass on this model (same limitation as its missing math experts).
+        // The tool-call parser is instead proven for correctness in
+        // `MiniMaxM3ToolCallParserTests` against the authoritative vllm-mlx
+        // `minimax_m3_tool_parser.py` (routing + namespaced/bare envelopes +
+        // nested object/array args + <mm:think> stripping). The engine wiring is
+        // covered by the `.minimaxM3` stamping assertion at the top of this test.
+    }
+
+    private static func collect(_ stream: AsyncStream<Generation>)
+        async -> (text: String, reasoning: String, stopReason: GenerateStopReason,
+                  unclosed: Bool, toolCalls: [(name: String, args: [String: JSONValue])])
+    {
+        var text = ""
+        var reasoning = ""
+        var stopReason: GenerateStopReason = .cancelled
+        var unclosed = false
+        var toolCalls: [(name: String, args: [String: JSONValue])] = []
+        for await event in stream {
+            switch event {
+            case .chunk(let chunk): text += chunk
+            case .reasoning(let chunk): reasoning += chunk
+            case .toolCall(let call):
+                toolCalls.append((call.function.name, call.function.arguments))
+            case .info(let info):
+                stopReason = info.stopReason
+                unclosed = info.unclosedReasoning
+            default: break
+            }
+        }
+        return (text, reasoning, stopReason, unclosed, toolCalls)
+    }
+}

--- a/Tests/MLXLMTests/MiniMaxM3SparseCacheTests.swift
+++ b/Tests/MLXLMTests/MiniMaxM3SparseCacheTests.swift
@@ -1,0 +1,201 @@
+// MiniMaxM3SparseCache contract tests — the 3-lane (keys, values, idx_keys)
+// reuse primitive that every osaurus cache tier (prefix/SSD/snapshot/trim) leans
+// on. No model load required: pure cache logic. These prove the lanes grow,
+// trim, copy, and serialize in lockstep so a reuse path can NEVER silently drop
+// idx_keys (the root cause of the historical repetition-loop saga).
+
+import Foundation
+import MLX
+@testable import MLXLMCommon
+import Testing
+
+@Suite("MiniMaxM3SparseCache contract", .serialized)
+struct MiniMaxM3SparseCacheTests {
+    private static let nKV = 4
+    private static let headDim = 128
+    private static let indexDim = 128
+
+    private func kv(_ s: Int) -> (MLXArray, MLXArray) {
+        (
+            MLXArray.zeros([1, Self.nKV, s, Self.headDim], dtype: .bfloat16),
+            MLXArray.zeros([1, Self.nKV, s, Self.headDim], dtype: .bfloat16)
+        )
+    }
+    private func idx(_ s: Int) -> MLXArray {
+        MLXArray.zeros([1, 1, s, Self.indexDim], dtype: .bfloat16)
+    }
+
+    @Test("Append grows all 3 lanes in lockstep; idx history == offset")
+    func appendLockstep() {
+        let c = MiniMaxM3SparseCache(indexDim: Self.indexDim)
+        let (k, v) = kv(4)
+        _ = c.update(keys: k, values: v)            // K/V first (upstream order)
+        #expect(c.offset == 4)
+        let hist = c.updateIndex(idx(4))             // then indexer lane
+        #expect(hist.dim(2) == 4)                    // sliced to offset
+
+        let (k2, v2) = kv(1)
+        _ = c.update(keys: k2, values: v2)
+        #expect(c.offset == 5)
+        let hist2 = c.updateIndex(idx(1))
+        #expect(hist2.dim(2) == 5)
+        #expect(c.readIndex().dim(2) == 5)
+    }
+
+    @Test("Trim slices K/V AND idx_keys to the same length")
+    func trimLockstep() {
+        let c = MiniMaxM3SparseCache(indexDim: Self.indexDim)
+        let (k, v) = kv(10)
+        _ = c.update(keys: k, values: v)
+        _ = c.updateIndex(idx(10))
+        #expect(c.offset == 10)
+
+        let trimmed = c.trim(3)
+        #expect(trimmed == 3)
+        #expect(c.offset == 7)
+        #expect(c.readIndex().dim(2) == 7)           // idx lane trimmed lockstep
+    }
+
+    @Test("copy() preserves the sparse TYPE and all 3 lanes")
+    func copyPreservesTypeAndLanes() {
+        let c = MiniMaxM3SparseCache(indexDim: Self.indexDim)
+        let (k, v) = kv(6)
+        _ = c.update(keys: k, values: v)
+        _ = c.updateIndex(idx(6))
+
+        let dup = c.copy()
+        #expect(dup is MiniMaxM3SparseCache)         // never a plain KVCache
+        #expect(dup.offset == 6)
+        let dupSparse = try! #require(dup as? MiniMaxM3SparseCache)
+        #expect(dupSparse.readIndex().dim(2) == 6)
+    }
+
+    @Test("state round-trip carries the idx_keys lane")
+    func stateRoundTrip() {
+        let c = MiniMaxM3SparseCache(indexDim: Self.indexDim)
+        let (k, v) = kv(5)
+        _ = c.update(keys: k, values: v)
+        _ = c.updateIndex(idx(5))
+
+        let s = c.state
+        #expect(s.count == 3)                        // [keys, values, idx_keys]
+        let m = c.metaState
+
+        let restored = MiniMaxM3SparseCache(indexDim: Self.indexDim)
+        restored.state = s.map { $0[.ellipsis] }
+        restored.metaState = m
+        #expect(restored.offset == 5)
+        #expect(restored.readIndex().dim(2) == 5)
+    }
+
+    @Test("Topology classifies M3 sparse layers as composite (not plain KV)")
+    func topologyClassification() {
+        var caches: [any KVCache] = []
+        for _ in 0 ..< 3 { caches.append(KVCacheSimple()) }                     // dense 0-2
+        for _ in 0 ..< 57 { caches.append(MiniMaxM3SparseCache(indexDim: Self.indexDim)) }  // sparse 3-59
+        let topo = ModelCacheTopologySnapshot(cache: caches)
+        #expect(topo.layerCount == 60)
+        #expect(topo.kvLayerCount == 3)                       // only the 3 dense layers
+        #expect(topo.miniMaxM3SparseLayerCount == 57)         // NOT folded into kv
+        #expect(topo.requiresMiniMaxM3SparseState)
+        #expect(!topo.requiresSSMCompanionState)              // M3 is not an SSM hybrid
+        #expect(topo.requiresDiskBackedCoordinatorRestore)    // composite must disk-restore
+        #expect(topo.topologyTags.contains("minimaxM3SparseLayers=57"))
+    }
+
+    @Test("M3 cache list flips paged-incompatible (disk restore) but is NOT SSM path-dependent")
+    func autoFlipHelpers() {
+        var caches: [any KVCache] = [KVCacheSimple(), KVCacheSimple(), KVCacheSimple()]
+        for _ in 0 ..< 57 { caches.append(MiniMaxM3SparseCache(indexDim: Self.indexDim)) }
+        // Must restore through the disk serializer (idx_keys can't ride the paged tier)…
+        #expect(cacheRequiresDiskBackedCoordinatorRestore(caches))
+        // …but must NOT be treated as SSM/conv path-dependent (no companion extraction).
+        #expect(!cacheContainsPathDependentState(caches))
+
+        // A purely dense KV list triggers neither.
+        let dense: [any KVCache] = [KVCacheSimple(), KVCacheSimple()]
+        #expect(!cacheRequiresDiskBackedCoordinatorRestore(dense))
+        #expect(!cacheContainsPathDependentState(dense))
+    }
+
+    @Test("TQDiskSerializer round-trips M3 sparse layers with idx_keys intact")
+    func diskSerializerRoundTrip() {
+        // Source: 3 dense + 2 M3 sparse, all populated to 7 tokens.
+        var src: [any KVCache] = [KVCacheSimple(), KVCacheSimple(), KVCacheSimple()]
+        for i in 0 ..< 3 { let (k, v) = kv(7); _ = src[i].update(keys: k, values: v) }
+        for _ in 0 ..< 2 {
+            let c = MiniMaxM3SparseCache(indexDim: Self.indexDim)
+            let (k, v) = kv(7)
+            _ = c.update(keys: k, values: v)
+            _ = c.updateIndex(idx(7))
+            src.append(c)
+        }
+
+        let arrays = TQDiskSerializer.serialize(cache: src)
+        // M3 layers must serialize as their own kind, not skip.
+        #expect(arrays["mm3_3_idx_keys"] != nil)
+        #expect(arrays["mm3_4_idx_keys"] != nil)
+
+        // Restore into a fresh typed list (as `newCache()` would build).
+        var dst: [any KVCache] = [
+            KVCacheSimple(), KVCacheSimple(), KVCacheSimple(),
+            MiniMaxM3SparseCache(indexDim: Self.indexDim),
+            MiniMaxM3SparseCache(indexDim: Self.indexDim),
+        ]
+        _ = restoreFromDiskArrays(arrays, into: &dst)
+
+        for i in 3 ..< 5 {
+            let m3 = try! #require(dst[i] as? MiniMaxM3SparseCache)
+            #expect(m3.offset == 7)
+            #expect(m3.readIndex().dim(2) == 7)   // idx_keys survived the round-trip
+        }
+    }
+
+    @Test("maybeQuantizeKVCache never TQ/affine-encodes an M3 sparse layer (B6)")
+    func tqKvSkipsM3Sparse() {
+        // Dense KVCacheSimple + M3 sparse, both populated well past any threshold.
+        let dense = KVCacheSimple()
+        let (dk, dv) = kv(2048)
+        _ = dense.update(keys: dk, values: dv)
+        let m3 = MiniMaxM3SparseCache(indexDim: Self.indexDim)
+        let (mk, mv) = kv(2048)
+        _ = m3.update(keys: mk, values: mv)
+        _ = m3.updateIndex(idx(2048))
+
+        var cache: [KVCache] = [dense, m3]
+        maybeQuantizeKVCache(
+            cache: &cache, kvBits: nil, quantizedKVStart: 8,
+            kvMode: .turboQuant(keyBits: 3, valueBits: 3))
+        // The MSA layer is never converted — its idx_keys lane can't be encoded.
+        #expect(cache[1] is MiniMaxM3SparseCache)
+        #expect(!(cache[1] is TurboQuantKVCache))
+
+        // Same for affine mode.
+        var cache2: [KVCache] = [KVCacheSimple(), m3]
+        let (k0, v0) = kv(2048); _ = (cache2[0] as! KVCacheSimple).update(keys: k0, values: v0)
+        maybeQuantizeKVCache(cache: &cache2, kvBits: 4, quantizedKVStart: 8)
+        #expect(cache2[1] is MiniMaxM3SparseCache)
+    }
+
+    @Test("innerState() returns all 3 lanes so eval(cache) materializes idx_keys (B7)")
+    func innerStateCoversIdxKeys() {
+        let c = MiniMaxM3SparseCache(indexDim: Self.indexDim)
+        let (k, v) = kv(5)
+        _ = c.update(keys: k, values: v)
+        _ = c.updateIndex(idx(5))
+        // eval(cache) drives Evaluatable.innerState(); 3 lanes ⇒ idx_keys can't lag K/V.
+        #expect(c.innerState().count == 3)
+        #expect(c.innerState()[2].dim(2) == 5)
+    }
+
+    @Test("empty cache state has a zero-length idx sentinel, round-trips to empty")
+    func emptyRoundTrip() {
+        let c = MiniMaxM3SparseCache(indexDim: Self.indexDim)
+        let s = c.state
+        #expect(s.count == 3)
+        #expect(s[2].dim(2) == 0)                     // empty idx sentinel
+        let restored = MiniMaxM3SparseCache(indexDim: Self.indexDim)
+        restored.state = s.map { $0[.ellipsis] }
+        #expect(restored.offset == 0)
+    }
+}

--- a/Tests/MLXLMTests/MiniMaxM3ToolCallParserTests.swift
+++ b/Tests/MLXLMTests/MiniMaxM3ToolCallParserTests.swift
@@ -1,0 +1,79 @@
+// MiniMax-M3 tool-call parser + routing tests (no model load).
+// Proves minimax_m3 routes to its OWN format (not minimax_m2's) and that the
+// namespaced `<tool_call><invoke name><key>v</key></invoke></tool_call>` envelope
+// parses — including the bare form when the detokenizer elides the namespace
+// token. Also pins that minimax_m2 routing is unchanged (M2/M2.7 regression).
+
+import Foundation
+@testable import MLXLMCommon
+import Testing
+
+@Suite("MiniMax-M3 tool-call parser")
+struct MiniMaxM3ToolCallParserTests {
+    private static let ns = "]<]minimax[>["
+
+    @Test("minimax_m3 routes to .minimaxM3; minimax_m2 stays .minimaxM2")
+    func routing() {
+        #expect(ToolCallFormat.infer(from: "minimax_m3") == .minimaxM3)
+        #expect(ToolCallFormat.infer(from: "minimax_m3_vl") == .minimaxM3)
+        #expect(ToolCallFormat.infer(from: "minimax_m2") == .minimaxM2)
+        #expect(ToolCallFormat.fromCapabilityName("minimax_m3") == .minimaxM3)
+        #expect(ToolCallFormat.fromCapabilityName("minimax") == .minimaxM2)
+    }
+
+    @Test("parses the namespaced <tool_call><invoke><key> envelope")
+    func parsesNamespaced() {
+        let ns = Self.ns
+        let raw = "\(ns)<tool_call>\n\(ns)<invoke name=\"read_file\">"
+            + "\(ns)<path>/tmp/main.swift\(ns)</path>"
+            + "\(ns)<max_lines>50\(ns)</max_lines>"
+            + "\(ns)</invoke>\n\(ns)</tool_call>"
+        let call = ToolCallFormat.minimaxM3.createParser().parse(content: raw, tools: nil)
+        #expect(call?.function.name == "read_file")
+        #expect(call?.function.arguments["path"] == .string("/tmp/main.swift"))
+        #expect(call?.function.arguments["max_lines"] != nil)
+    }
+
+    @Test("parses the bare envelope when the namespace token is elided")
+    func parsesBare() {
+        let raw = "<tool_call><invoke name=\"list_dir\"><path>/src</path></invoke></tool_call>"
+        let call = ToolCallFormat.minimaxM3.createParser().parse(content: raw, tools: nil)
+        #expect(call?.function.name == "list_dir")
+        #expect(call?.function.arguments["path"] == .string("/src"))
+    }
+
+    @Test("parses nested object + array args (parity with the Python authority's example)")
+    func parsesNestedArgs() {
+        let raw = """
+            <tool_call>
+            <invoke name="get_weather">
+            <location>San Francisco</location>
+            <opts><unit>celsius</unit></opts>
+            <days><item>mon</item><item>tue</item></days>
+            </invoke>
+            </tool_call>
+            """
+        let call = ToolCallFormat.minimaxM3.createParser().parse(content: raw, tools: nil)
+        #expect(call?.function.name == "get_weather")
+        #expect(call?.function.arguments["location"] == .string("San Francisco"))
+        #expect(call?.function.arguments["opts"] == .object(["unit": .string("celsius")]))
+        #expect(call?.function.arguments["days"] == .array([.string("mon"), .string("tue")]))
+    }
+
+    @Test("strips a leading <mm:think> reasoning block before the tool_call")
+    func stripsReasoningBlock() {
+        let raw = "<mm:think>I should call the tool.</mm:think>"
+            + "<tool_call><invoke name=\"f\"><n>3</n></invoke></tool_call>"
+        let call = ToolCallFormat.minimaxM3.createParser().parse(content: raw, tools: nil)
+        #expect(call?.function.name == "f")
+        #expect(call?.function.arguments["n"] == .int(3))   // scalar coerced via JSON
+    }
+
+    @Test("the M2 parser does NOT parse M3 args (confirms the gap was real)")
+    func m2CannotParseM3Args() {
+        let raw = "<tool_call><invoke name=\"f\"><k>v</k></invoke></tool_call>"
+        let m2 = ToolCallFormat.minimaxM2.createParser().parse(content: raw, tools: nil)
+        // M2 looks for <parameter name=>; M3's bare <k>v</k> yields no such arg.
+        #expect(m2?.function.arguments["k"] == nil)
+    }
+}

--- a/docs/MM3_E2E_VERIFICATION.md
+++ b/docs/MM3_E2E_VERIFICATION.md
@@ -1,0 +1,214 @@
+# MiniMax-M3 (mm3) — E2E Verification & Confirmation Spec
+
+How to confirm and live-prove the MiniMax-M3 engine + osaurus integration end-to-end before merge.
+Paired PRs: **vmlx-swift #75** (`codex/mm3-runtime`, engine) + **osaurus #1576** (`codex/minimax-m3-integration`).
+Model: `MiniMax-M3-REAP40-d3-JANG_2L` (REAP 128→77 experts, 95 GB) at `~/models/JANGQ-AI/MiniMax-M3-REAP40-d3-JANG_2L`.
+REAP-pruned → gate is **coherent non-garbled text + correct mechanics**, NOT answer correctness.
+
+---
+
+## 0. Architecture recap (what makes M3 special — drives the test matrix)
+
+- **60 decoder layers, two attention regimes:**
+  - **Layers 0–2:** dense full-causal attention → stock `KVCacheSimple`.
+  - **Layers 3–59:** **MiniMax Sparse Attention (MSA)** via a **Lightning Indexer** → `MiniMaxM3SparseCache`.
+- **GQA:** `n_kv=4`, `head_dim=128`. **Partial RoPE** (`rotaryDim=64`, `traditional:false`/NeoX half-split, base=`ropeTheta`); manual `rope→SDPA` (not `attentionWithCacheUpdate`).
+- **Lightning Indexer / MSA:** scores fresh `idx_q` against ALL cached `idx_k`, **max-pools per 128-token block**, **max over heads**, selects **top-k blocks** per query → additive `[B,1,Sq,Sk]` keep-bias (0 kept / −inf else). The query's **own (local) block always wins**.
+  - **Below `topk*block = 2048` tokens:** every block visible → indexer returns `nil` → caller uses plain causal (full attention). **Past 2048:** sparse selection fires.
+  - `idx_q` is **recomputed every step, never cached**. Only `idx_keys` are cached.
+  - **Blocks anchored to ABSOLUTE position** (`block = pos/128`) → cache is **append-only / trim-and-replay only** (never re-key on reuse).
+- **`MiniMaxM3SparseCache` = 3 lanes that MUST move together:** `keys [B,4,S,128]`, `values [B,4,S,128]`, `idx_keys [B,1,S,128]`, sharing one `offset`. `copy()` returns a `MiniMaxM3SparseCache`; `state`/`metaState` round-trip all three through disk/prefix tiers. **DEBUG asserts `idx_keys.len == offset`.**
+  - **THE failure mode:** any reuse layer that downcasts to a plain KVCache copies only `(keys,values)` and **drops `idx_keys`** → indexer scores against corrupt/empty keys → **decode loops**. (This was the Python loop bug.) Every cache path must keep it first-class.
+- **Reasoning envelope:** `<mm:think>…</mm:think>` (NOT m2's `<think>`) → dedicated `minimax_m3` reasoning stamp (`ReasoningParser.swift`).
+- **Tool calls:** `MiniMaxM3ToolCallParser` (registered in `ToolCallFormat`).
+- **Quant (mixed, all gs=64):** embed=6, attn/lm_head=8, routed gate/up=2, routed/shared down=3 or 6, indexer/router-gate/norms fp16. Loader resolves `(bits,gs)` from each module's true input dim (see [[mm3-quant-bits-gs-ambiguity-fix]]).
+- **Runtime constraints for M3 (must be enforced + verified):** **paged OFF**, **TurboQuant-KV skip**, **JIT/compile OFF**. Gated via `ModelContainer.requiresMiniMaxM3SparseState`.
+
+---
+
+## 1. Pre-flight (do before any live test)
+
+| # | Step | Pass criteria |
+|---|------|---------------|
+| P1 | **Rebase `codex/mm3-runtime` onto current vmlx main** (now includes the merged disk-cache B1/B2 fixes, commit `1b7d3ef`). MM3 touches `CacheHelpers/TQDiskSerializer/KVCache/Load/ModelContainer`; B1/B2 touched `DiskCache/Evaluate/BatchEngine` → **no file overlap, expect clean rebase**. | rebase applies with no conflicts; `git diff --name-only` overlap check = none |
+| P2 | **Build vmlx** (Xcode toolchain) | compiles clean |
+| P3 | **Autodetect / load** — model appears in `/v1/models`; loads without the bits×gs crash | listed; `loadModel` succeeds; no `[quantized_matmul] ... does not match` fatal |
+| P4 | **Cache layout** assertion | 60 caches: layers 0–2 = `KVCacheSimple`, layers 3–59 = `MiniMaxM3SparseCache` |
+| P5 | **Constraints enforced** | paged off, TQ-KV skipped, JIT off for M3 (assert via the coordinator config / `requiresMiniMaxM3SparseState`) |
+| P6 | **RAM safety** — 95 GB model on 128 GB box; single residency; no OOM | loads; RSS/unified-mem within budget; no eviction thrash |
+
+---
+
+## 2. Engine smoke (vmlx, gated test) — load once, harvest all
+
+Run `MiniMaxM3SmokeTests` (one `loadModel`, RAM-heavy):
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer MM3_MSA_TRACE=1 \
+  swift test --filter MiniMaxM3SmokeTests
+```
+(metallib gotcha: copy `mlx/default.metallib` into the `.build` lookup sites — see [[mm3-live-test-recipe]].)
+
+| # | Signal | Pass criteria |
+|---|--------|---------------|
+| S1 | Short forward (< 2048 ctx) | runs; indexer returns `nil` (full attention); coherent logits |
+| S2 | **MSA fires past 2048** | `MM3_MSA_TRACE` prints `[MM3-MSA] full attention …` then `[MM3-MSA] SPARSE SELECTION FIRED (… keep=N of topk=…)`; proven before at Sk≈2304 (16/18 blocks) |
+| S3 | BatchEngine generation | `[MM3-GEN] visible=<<<…>>>` is coherent, no garble, no loop |
+| S4 | **SparseCache round-trip** (`MiniMaxM3SparseCacheTests`) | `copy()/state/metaState/trim` preserve `idx_keys`; DEBUG assert `idx_keys.len == offset` holds across append/trim/restore |
+| S5 | **Tool parser** (`MiniMaxM3ToolCallParserTests`) | parses the M3 tool envelope; no false positives on prose |
+
+---
+
+## 3. LIVE E2E MATRIX (osaurus, the real chat-engine path) — the gate
+
+Drive headless via osaurus `/v1/chat/completions` + `/agents/default/run`. Read **every** response for: garble, looping, incoherency, markup leak, and **streaming content-delta correctness**. Varying prompt per turn.
+
+### A. iRoPE / partial-rope + position correctness
+- **A1** Short prompt → coherent (rope correct at low positions).
+- **A2** Long prompt that crosses 2048 → coherent (positions stay absolute & monotonic across the full→sparse transition; partial-rotary 64/128 applied to the right dims).
+- **A3** After cache trim/reuse, positions resume correctly (no off-by-one at the prefill→decode or reuse boundary).
+- **Pass:** no degradation/repetition as context grows; the full→sparse crossover at ~2048 produces no discontinuity.
+
+### B. MSA / Lightning-Indexer (block-sparse attention)
+- **B1** Force context > 2048 (long system prompt or multi-turn) and confirm **`SPARSE SELECTION FIRED`** in the engine trace AND output stays coherent (sparse selection didn't drop needed context).
+- **B2** **Local-block-wins:** the most recent tokens are always attended (the model can quote/continue the immediately preceding text verbatim past 2048).
+- **B3** **Recall across the sparse window:** a fact placed early (block 0) and queried after >2048 tokens is still retrievable (top-k selects the right block) — within REAP capability.
+- **Pass:** indexer fires, no loop, coherent recall of both local and selected-distant blocks.
+
+### C. Reasoning matrix (`<mm:think>`)
+- **C1** reasoning ON → `<mm:think>…</mm:think>` is parsed to `reasoning_content` (NOT leaked into `content`); content is the post-think answer; coherent.
+- **C2** reasoning OFF → no think envelope; coherent answer.
+- **C3** reasoning across **multiturn** (think on turn 2 after a cache-hit turn 1) → think still parsed, no `<mm:think>` leak, no loop.
+- **Pass:** `<mm:think>` always routed to reasoning_content; never the `<think>` (m2) mis-stamp; no CoT leak; no loop.
+
+### D. Tool-call matrix
+- **D1** with tools → emits a structured tool_call (M3 envelope parsed by `MiniMaxM3ToolCallParser`); no markup leak into content.
+- **D2** **tool round-trip:** model calls tool → tool result fed back → model produces coherent final answer.
+- **D3** **reasoning + tool** (think then call) → `<mm:think>` parsed AND tool_call parsed in the same turn; correct order; no leak/loop.
+- **D4** tool_choice=required → valid call; no-tools → coherent prose (no spurious tool markup).
+- **Pass:** structured calls, clean round-trip, reasoning+tool coexist.
+
+### E. System-prompt injection
+- **E1** Custom system prompt is injected correctly for M3 (osaurus chat-context compose) and honored in output.
+- **E2** With tools, the tool block + system prompt render in the right order (no duplication, single BOS, correct M3 turn markers).
+- **E3** Capture the **rendered prompt** (debug dump) and confirm: one BOS, correct M3 chat template, tools in the M3 format, reasoning prefill correct for the reasoning toggle.
+- **Pass:** rendered prompt is well-formed; output reflects the system prompt.
+
+### F. Prefix / disk-L2 cache reuse — **the critical 3-lane invariant**
+- **F1** **Multiturn warm reuse:** turn 1 (cold) → turn 2 (same session, growing) reuses turn-1 prefix. Confirm a cache hit AND that the restored cache is a `MiniMaxM3SparseCache` with `idx_keys` intact (NOT downcast). **Output coherent, zero loops.**
+- **F2** **idx_keys round-trip through disk:** after an unload/reload (or cross-process disk hit), the restored sparse cache still carries `idx_keys` (state/metaState serialized all 3 lanes). The indexer past 2048 still selects correctly post-restore.
+- **F3** **Trim-replay:** a reuse that requires trimming to a history boundary replays append-only (blocks stay absolute-positioned); no re-keying; coherent.
+- **F4** **Negative guard:** confirm NO generic reuse path downcasts the sparse cache to plain KVCache (the loop bug). Greppable invariant + live: a warm sparse-context turn does not loop.
+- **Pass:** warm reuse on M3 = coherent, idx_keys preserved on every path (paged-off, disk, trim).
+
+### G. Cache syncing — between layers, processes, and rederive type
+- **G1** **Cross-layer sync:** dense layers (0–2, KVCacheSimple) and sparse layers (3–59, MiniMaxM3SparseCache) advance on a **shared offset**; a restore lands ALL 60 layers at the same boundary (no dense/sparse desync → would corrupt).
+- **G2** **Cross-process / disk sync:** an entry stored in one run is fetched in another (disk-L2) and both lanes (dense KV + sparse 3-lane) restore consistently; modelKey isolation holds (no cross-model alias).
+- **G3** **Async / rederive type:** M3 sparse cache is **append-only / trim-replay** — confirm there is **no async detached rederive** racing decode (unlike SSM); the trim path is synchronous/actor-serialized. (M3 has no conv/SSM state; verify nothing schedules a background rederive that could read half-written `idx_keys`.)
+- **G4** **Multi-cache-type coexistence:** the 60-layer cache (mixed KVCacheSimple + MiniMaxM3SparseCache) is handled first-class by the coordinator (protocol-driven, no type allow-list); store/fetch/trim treat the composite correctly.
+- **Pass:** all 60 layers stay synced through every reuse; no desync, no race, no allow-list drop.
+
+### H. osaurus cache-window processing + wiring
+- **H1** **KV window/cap:** the osaurus memory-safety slider / KV cap governs M3's live context correctly (the resolved cap reaches the coordinator); a long session respects the window without garbling.
+- **H2** **Constraints wired osaurus-side:** paged OFF, TQ-KV skip, JIT off are applied for M3 via the runtime config (not just engine-side); confirm `/health` / coordinator tags reflect it.
+- **H3** **Reasoning/tool wiring:** osaurus surfaces M3 `reasoning_content` + `tool_calls` correctly (picks up the engine's minimax_m3 stamps via jang_config/capabilities); model autodetect sets the right reasoning + tool format.
+- **H4** **Prefill-progress / streaming:** prefill counter + streaming deltas behave for M3 (no frozen counter, monotonic, content deltas contiguous).
+- **Pass:** osaurus drives M3 with correct window, constraints, reasoning/tool surfacing, and streaming.
+
+### I. THE MERGE GATE — multiturn cache-reuse, zero loops, coherent
+A ≥6-turn session on `MiniMax-M3-REAP40-d3-JANG_2L` (paged off, TQ-KV skip, JIT off) that interleaves: a long turn crossing 2048 (MSA fires), a reasoning turn (`<mm:think>`), a tool round-trip, and cache-hit (warm) turns. **Every cache-hit turn must be coherent, zero loops, zero incoherency, no markup leak.** Scan all deltas.
+- **Pass = the whole session is loop-free and coherent, with the sparse cache reused (idx_keys preserved) on the warm turns.** This is the not-to-main bar.
+
+### J. Streaming-delta + stress + RAM
+- **J1** Streaming content deltas are contiguous/monotonic, no dup/garble, reasoning vs content split correct.
+- **J2** Per-turn-varied multirun (≥10) at non-zero temperature → scan every output for loop/garble/leak (catch non-deterministic faults).
+- **J3** RAM: sustained session → no leak, no crash, disk-L2 bounded (ties to B1 orphan-row fix already on main).
+
+---
+
+## 4. Run-book (commands)
+
+- **Engine smoke / MSA trace / sparse-cache / tool-parser tests:** §2 command above.
+- **Live osaurus matrix:** build osaurus against the rebased vmlx (repin `codex/minimax-m3-integration` → the mm3 vmlx commit), launch with a test root, drive `/v1/chat/completions` (reasoning toggle via `enable_thinking`/`reasoning_effort`, tools via `tools`) and `/agents/default/run`; capture rendered prompt with the `VMLX_DUMP_PROMPT` env (swift-transformers Tokenizer render site) for §E; inspect the disk-cache SQLite for §F/§G accounting; `MM3_MSA_TRACE=1` for §B.
+- **Cache accounting helper:** `cacheq.sh <root>` (rows vs files vs SUM(file_size), delta=0).
+
+## 5. Definition of done (both PRs out of WIP)
+- [ ] P1–P6 pre-flight green (rebase clean, builds, loads, layout, constraints, RAM).
+- [ ] S1–S5 engine smoke green (MSA fires, sparse-cache round-trip, tool parser).
+- [ ] A–H live matrix green on the real model (iRoPE, MSA, reasoning, tools, sys-prompt, prefix/disk reuse with idx_keys preserved, cross-layer/process sync, osaurus window/wiring/streaming).
+- [ ] **I merge gate**: ≥6-turn multiturn, zero loops, coherent, sparse cache reused warm.
+- [ ] J streaming/stress/RAM green.
+- [ ] vmlx #75 + osaurus #1576 rebased onto current mains, CI green, flipped out of `[WIP]`, repin osaurus → merged mm3 vmlx commit.
+
+---
+
+## 6. CONCRETE multiturn live script (drive this exact session, same `session_id`)
+
+Run on `MiniMax-M3-REAP40-d3-JANG_2L`, paged off / TQ-KV skip / JIT off. **Read every turn deeply per §7.** Vary the prompt TYPE each turn; keep one long system prompt so context crosses 2048 by mid-session.
+
+System prompt (long, ~600+ tokens so the session crosses the 2048 MSA threshold by turn 3-4): a detailed assistant persona + a planted fact: *"Remember this session key: ORBIT-7731."*
+
+| Turn | Type | Prompt (vary each run) | What it exercises | Specific pass check |
+|---|---|---|---|---|
+| 1 | short text, reason OFF | "In one sentence, what is photosynthesis?" | cold prefill, rope@low-pos, baseline | 1 coherent sentence; no `<mm:think>` leak; no junk |
+| 2 | text, **reason ON** | "Explain why the sky is blue. Think first." | `<mm:think>` parse, warm reuse of turn-1 prefix | think→reasoning_content (NOT content); answer coherent; **warm cache hit** (TTFT drop); no loop |
+| 3 | **long-form, reason OFF** | "Write ~400 words on the history of computing, with specifics." | crosses 2048 → **MSA fires**; long coherent gen | `MM3_MSA_TRACE` shows SPARSE SELECTION FIRED; text stays coherent to the end (no late-context degeneration/repetition) |
+| 4 | **tool + reason ON** | "What's the weather in Tokyo? Think, then use the get_weather tool." | reasoning + tool same turn; M3 tool parse | `<mm:think>` parsed AND a structured `get_weather` tool_call; no markup leak; correct order |
+| 5 | **tool round-trip** | (feed tool result `{"temp":"18C"}` back) | tool result consumed → final answer | coherent final answer using 18C; no re-loop of the call; no leak |
+| 6 | **recall, reason OFF** | "What was the session key I gave you at the start?" | cross-turn recall past 2048 (idx_keys preserved + local/distant block selection) | returns **ORBIT-7731** (top-k selected block 0) AND warm reuse coherent; **proves sparse cache reused, idx_keys intact** |
+| 7 | **code, reason ON** | "Write a Python function to reverse a linked list. Think about edge cases." | reasoning + code formatting, warm reuse | think parsed; valid code in content; no `<mm:think>`/backtick-fence corruption; no loop |
+| 8 | **long + tool, reason ON** | "Summarize our whole conversation, then use get_weather for London." | deep context + sparse reuse + tool, max stress | coherent summary referencing earlier turns; structured tool_call; no loop/leak across the longest context |
+
+**Repeat the whole 8-turn session ≥3×** at temperature 0.7-0.9 (sampling) with **different prompts each run** to catch non-deterministic faults. Then a **≥10-iteration single-turn multirun** mixing all types at temp 0.9.
+
+## 7. DEEP output scanning (apply to EVERY turn — this is the crucial gate)
+
+For each response, scan `content` AND `reasoning_content` AND the raw stream:
+
+**A. Looping** (any → FAIL):
+- Repeated n-gram: any 12–40 char window appearing ≥4× (excluding legit list bullets/markdown).
+- Repeated sentence/line ≥3×.
+- Repeated special/reasoning token: `<mm:think>`, `</mm:think>`, `<|`, channel/think markers ≥3×.
+- Degenerate tail: the last 20% is near-identical repetition of earlier text.
+- **M3-specific:** the indexer-loop signature — generation that stalls into repeating the same phrase past 2048 tokens = the idx_keys-dropped bug. Treat as CRITICAL.
+
+**B. Incoherency** (any → FAIL):
+- Non-ASCII junk: control/garbage chars beyond legit unicode (count > a few).
+- **Broken words / char corruption:** inserted/dropped letters (e.g. `stateFcile`, `Amerin`, `rtificial`) — scan for mid-word breaks, impossible letter runs. (This was the gemma symptom; watch for it on M3 too, esp. after a cache hit or past 2048.)
+- Abrupt topic break / non-sequitur mid-response.
+- Empty content with `finish=length` (all output went to a discarded bucket — reasoning/special).
+
+**C. Leaking** (any → FAIL):
+- `<mm:think>` / `</mm:think>` appearing in **content** (reasoning leaked) — must be in reasoning_content only.
+- Tool envelope markup (the M3 tool tags / `<tool…`) in content instead of a parsed `tool_calls`.
+- Special tokens (`<|`, BOS/EOS literals, turn markers) in content.
+- The wrong reasoning tag: `<think>` (m2) instead of `<mm:think>` (m3) → indicates the minimax (not minimax_m3) stamp fired = wiring bug.
+
+**D. Streaming-delta correctness:**
+- Content deltas concatenate to a clean string (no dup/overlap/gap between chunks).
+- reasoning_content vs content split is clean (no bleed at the `</mm:think>` boundary).
+- Monotonic; finish_reason present; no truncated UTF-8 mid-grapheme.
+
+**E. Cache/mechanics (per warm turn):**
+- Warm turn shows a TTFT drop (cache hit) vs the equivalent cold.
+- `cacheq.sh` accounting delta = 0 across the session (no orphan rows — B1).
+- No `[MM3] downcast`/plain-KVCache restore in logs (idx_keys preserved).
+- `MM3_MSA_TRACE`: full→sparse transition fires once, cleanly.
+
+## 8. Fix playbook (what each failure points to)
+
+| Symptom | Most-likely cause | Where to look |
+|---|---|---|
+| Loop/repeat past 2048, esp. after warm reuse | idx_keys dropped (sparse cache downcast to plain KVCache on a reuse path) | `MiniMaxM3SparseCache.copy()/state/metaState`; the coordinator fetch/restore path; assert `idx_keys.len==offset` |
+| `<think>` instead of `<mm:think>` parsed / CoT leak | minimax (m2) stamp instead of minimax_m3 | engine `ReasoningParser` stamp (`minimax_m3`); osaurus `isMiniMaxFamily` sites (OpenAIAPI:155, MLXBatchAdapter:829) — verify M3 isn't forced to m2 handling |
+| Tool markup leaks / not parsed | M3 tool format not resolved | `ToolCallFormat.infer(model_type=minimax_m3)`; osaurus `supportsLocalToolCalling`/`resolvedToolCallFormat` (jang_config tool_parser=None → infer path) |
+| Char corruption / junk (esp. past 2048 or post-hit) | quant (bits×gs) or RoPE/MSA numeric | quant resolve at `Load.swift` (mm3 mixed bits); partial-rope dims; indexer max-pool/top-k math |
+| Garble only on cache-hit turns | trim-replay / restore mis-keys sparse blocks (absolute pos) | sparse cache `trim`; disk round-trip of all 3 lanes; cross-layer (dense 0-2 vs sparse 3-59) offset sync |
+| Empty content, finish=length | everything routed to reasoning (open `<mm:think>` never closed) | template reasoning prefill + the `<mm:think>` close; reasoning parser tail-aware init |
+| Late-context degeneration | KV window/cap too small OR MSA dropping needed blocks | osaurus memory-safety slider → coordinator KV cap for M3; indexer top-k `keep` value; local-block-wins |
+| Cross-process garble | disk-L2 didn't round-trip all 3 lanes / modelKey alias | `MiniMaxM3SparseCache.state`/`metaState` serialize; disk modelKey tag includes M3 topology |
+
+## 9. osaurus wiring status (this PR)
+- vmlx `codex/mm3-runtime` rebased onto main (`5139e84a`, includes merged cache B1/B2). osaurus `codex/minimax-m3-integration` rebased + repinned (Package.swift + 2 Package.resolved + RuntimePolicySource hardening test all → `5139e84a`).
+- Engine owns: model, MSA/indexer, sparse cache, `minimax_m3` reasoning + tool parsers, quant resolve, registration.
+- osaurus family handling for M3 (verify live, do NOT speculatively change): `isMiniMaxFamily` → `shouldEnableCompiledBatchDecode=false` (matches JIT-off ✅), `enable_thinking` toggle (MLXBatchAdapter:829), architecture metadata (OpenAIAPI:155). jang_config has reasoning_parser/tool_parser = None → engine infers from `model_type=minimax_m3`.
+- **Open verification (live, RAM-gated, user-run): the entire §3 matrix + §6 script + §7 scan.** Build (Release) compiling now = the static integration check.

--- a/docs/MM3_E2E_VERIFICATION.md
+++ b/docs/MM3_E2E_VERIFICATION.md
@@ -1,5 +1,11 @@
 # MiniMax-M3 (mm3) — E2E Verification & Confirmation Spec
 
+> **STATUS (2026-06-21):** WIRED + BUILD GREEN, ready for user live testing.
+> vmlx `codex/mm3-runtime`@`409d2c47` rebased on main (incl cache B1/B2). osaurus
+> `codex/minimax-m3-integration` rebased + repinned to `5139e84a`; Release build
+> SUCCEEDED (MM3 engine integrates). The §6 script + §7 scan against the 95 GB
+> model is the remaining merge gate — RAM-gated, user-run.
+
 How to confirm and live-prove the MiniMax-M3 engine + osaurus integration end-to-end before merge.
 Paired PRs: **vmlx-swift #75** (`codex/mm3-runtime`, engine) + **osaurus #1576** (`codex/minimax-m3-integration`).
 Model: `MiniMax-M3-REAP40-d3-JANG_2L` (REAP 128→77 experts, 95 GB) at `~/models/JANGQ-AI/MiniMax-M3-REAP40-d3-JANG_2L`.


### PR DESCRIPTION
**WIP — engine lane for MiniMax-M3 (mm3).** Built in lockstep with the osaurus integration PR (osaurus-ai/osaurus#1576). Do not merge until the multiturn-no-loop gate is met.

## Why M3 is special
Layers 0-2 dense full-attn (stock KV); layers 3-59 block-sparse MSA / Lightning-Indexer (GQA n_kv=4, head_dim=128). Sparse layers carry a 3rd append-only cache lane `idx_keys [B,1,S,128]`; the indexer max-pools per 128-token block and selects top-k blocks, recomputed every step. Blocks anchored to absolute `pos/128` → append-only / trim-replay only.

## This PR so far
- `MiniMaxM3SparseCache` (`Libraries/MLXLMCommon/Cache/`): self-cloning 3-lane composite cache mirroring `ZayaCCACache`. `copy()`/`state`/`trim`/`metaState` carry `keys,values,idx_keys` together so the cache stays first-class through every reuse path (the Python loop bug was a reuse layer downcasting it to plain KVCache and dropping `idx_keys`). DEBUG asserts `idx_keys.len == offset`.

## Next (in lockstep with osaurus#1576)
- MSA / Lightning-Indexer attention + block selection; MoE; RoPE/iRoPE; `make_cache` dispatch.
- Decode loop; reasoning/tool parser hooks.
- Cache reuse stays protocol-driven (no type allow-lists) so M3 is first-class by construction.

## Gate
Multiturn cache-reuse on `MiniMax-M3-REAP40-d3-JANG_2L`: zero loops, zero incoherency, cache-hit turns coherent. (Paged off, TQ-KV skip, JIT off for M3.)