### PR TITLE
Parse Gemma nested object tool-call arguments

### DIFF
--- a/Libraries/MLXLMCommon/Tool/Parsers/GemmaFunctionParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/GemmaFunctionParser.swift
@@ -124,8 +124,58 @@ public struct GemmaFunctionParser: ToolCallParser, Sendable {
             return parseArray(from: &text)
         }
 
+        if text.hasPrefix("{") {
+            return parseObject(from: &text)
+        }
+
         let value = takeRawValue(from: &text, terminators: [","])
         return decodeRawValue(value)
+    }
+
+    /// Parse a nested object value: `{key:value,k:<escape>str<escape>}`.
+    ///
+    /// Gemma emits nested object arguments (e.g. a `target:{mark:1}` field, or
+    /// any tool whose schema declares an `object` parameter) in the same
+    /// `key:value` body syntax as the top-level call. Without an explicit
+    /// object branch, `parseValue` fell through to `takeRawValue` /
+    /// `decodeRawValue`, which captured the brace span as an undecodable string
+    /// (`"{mark:1}"`) and lost the nested structure — so a tool expecting an
+    /// object received a string and rejected the call. Keys and scalar/escaped
+    /// values reuse the same decoding as the top level, so a nested object is
+    /// parsed identically (and recursively for objects/arrays inside it).
+    private func parseObject(from text: inout String) -> [String: any Sendable]? {
+        guard text.hasPrefix("{") else { return nil }
+        text = String(text.dropFirst())
+        var object: [String: any Sendable] = [:]
+
+        while true {
+            text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            if text.hasPrefix("}") {
+                text = String(text.dropFirst())
+                return object
+            }
+            if text.isEmpty { return nil }
+
+            guard let colonIdx = text.firstIndex(of: ":") else { return nil }
+            let key = normalizeArgumentKey(
+                String(text[..<colonIdx])
+                    .trimmingCharacters(in: .whitespacesAndNewlines))
+            text = String(text[text.index(after: colonIdx)...])
+
+            guard let value = parseValue(from: &text) else { return nil }
+            object[key] = value
+
+            text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            if text.hasPrefix(",") {
+                text = String(text.dropFirst())
+                continue
+            }
+            if text.hasPrefix("}") {
+                text = String(text.dropFirst())
+                return object
+            }
+            return nil
+        }
     }
 
     private func parseArray(from text: inout String) -> [any Sendable]? {
@@ -165,7 +215,10 @@ public struct GemmaFunctionParser: ToolCallParser, Sendable {
         var index = text.startIndex
         while index < text.endIndex {
             let character = text[index]
-            if terminators.contains(character) || character == "]" {
+            // `]` and `}` always terminate a raw scalar so an element inside a
+            // nested array/object (e.g. the `1` in `{mark:1}`) stops at the
+            // closing bracket rather than swallowing it into the value.
+            if terminators.contains(character) || character == "]" || character == "}" {
                 break
             }
             index = text.index(after: index)

--- a/Package.swift
+++ b/Package.swift
@@ -816,6 +816,7 @@ let package = Package(
                 "DeepseekV4IndexerCausalTopKTests.swift",
                 "DeepseekV4ReasoningPolicyTests.swift",
                 "Gemma4ZyphraToolParserFocusedTests.swift",
+                "GemmaNestedObjectArgumentFocusedTests.swift",
                 "Gemma4ThoughtChannelParserFocusedTests.swift",
                 "Gemma3nTextSanitizeFocusedTests.swift",
                 "MediaCachePlaceholderTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/GemmaNestedObjectArgumentFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/GemmaNestedObjectArgumentFocusedTests.swift
@@ -1,0 +1,155 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Testing
+@testable import MLXLMCommon
+
+/// Regression contracts for nested object arguments in the Gemma function-call
+/// format (`call:name{key:{nested:value}}`).
+///
+/// Gemma emits a nested object argument (e.g. an agentic `target:{mark:1}`
+/// field, or any tool whose schema declares an `object` parameter) in the same
+/// `key:value` body syntax as the top-level call. Before the fix `parseValue`
+/// had branches only for escaped strings and arrays, so a `{...}` value fell
+/// through to the raw-scalar path and was captured as an undecodable string
+/// (`"{mark:1}"`). A tool expecting an object then received a string and
+/// rejected the call. These tests pin the object branch (and the matching
+/// `}` raw-scalar terminator) so nested objects parse as real objects.
+@Suite("Gemma nested object argument contracts")
+struct GemmaNestedObjectArgumentFocusedTests {
+    @Test("Gemma4 parses a nested object argument as an object, not a string")
+    func gemma4ParsesNestedObjectArgument() throws {
+        let output =
+            #"<|tool_call>call:agent_action{note:<|"|>Type into Title<|"|>,target:{mark:1},text:<|"|>hello world<|"|>,verb:<|"|>type<|"|>}<tool_call|>"#
+        let call = try #require(
+            ToolCallFormat.gemma4.createParser().parse(
+                content: output,
+                tools: [agentActionToolSpec()]
+            )
+        )
+
+        #expect(call.function.name == "agent_action")
+        // The nested object survives as an object. Scalar typing (the `1`) is
+        // intentionally left to the same downstream schema-aware coercion that
+        // already types top-level scalars — the parser keeps bare scalars as
+        // strings everywhere for consistency.
+        #expect(call.function.arguments["target"] == .object(["mark": .string("1")]))
+        #expect(call.function.arguments["text"] == .string("hello world"))
+        #expect(call.function.arguments["verb"] == .string("type"))
+        #expect(call.function.arguments["note"] == .string("Type into Title"))
+    }
+
+    @Test("Gemma4 parses an escaped string value inside a nested object")
+    func gemma4ParsesEscapedStringInsideNestedObject() throws {
+        let output =
+            #"<|tool_call>call:agent_action{target:{describe:<|"|>the Send button<|"|>},verb:<|"|>click<|"|>}<tool_call|>"#
+        let call = try #require(
+            ToolCallFormat.gemma4.createParser().parse(
+                content: output,
+                tools: [agentActionToolSpec()]
+            )
+        )
+
+        #expect(call.function.name == "agent_action")
+        #expect(
+            call.function.arguments["target"] == .object(["describe": .string("the Send button")]))
+        #expect(call.function.arguments["verb"] == .string("click"))
+    }
+
+    @Test("Gemma4 parses a nested object with multiple keys")
+    func gemma4ParsesNestedObjectWithMultipleKeys() throws {
+        let output = #"<|tool_call>call:move{from:{x:1,y:2},to:{x:3,y:4}}<tool_call|>"#
+        let call = try #require(
+            ToolCallFormat.gemma4.createParser().parse(content: output, tools: nil))
+
+        #expect(call.function.name == "move")
+        #expect(call.function.arguments["from"] == .object(["x": .string("1"), "y": .string("2")]))
+        #expect(call.function.arguments["to"] == .object(["x": .string("3"), "y": .string("4")]))
+    }
+
+    @Test("Gemma4 parses a nested object as the final argument")
+    func gemma4ParsesNestedObjectAsFinalArgument() throws {
+        let output = #"<|tool_call>call:agent_action{verb:<|"|>click<|"|>,target:{mark:2}}<tool_call|>"#
+        let call = try #require(
+            ToolCallFormat.gemma4.createParser().parse(
+                content: output,
+                tools: [agentActionToolSpec()]
+            )
+        )
+
+        #expect(call.function.arguments["verb"] == .string("click"))
+        #expect(call.function.arguments["target"] == .object(["mark": .string("2")]))
+    }
+
+    @Test("Gemma3 native format also parses nested object arguments")
+    func gemma3ParsesNestedObjectArgument() throws {
+        let output = "<start_function_call>call:agent_action{target:{mark:1}}<end_function_call>"
+        let call = try #require(
+            ToolCallFormat.gemma.createParser().parse(
+                content: output,
+                tools: [agentActionToolSpec()]
+            )
+        )
+
+        #expect(call.function.arguments["target"] == .object(["mark": .string("1")]))
+    }
+
+    @Test("Gemma4 still parses flat scalar/array/string arguments unchanged")
+    func gemma4StillParsesFlatArgumentsUnchanged() throws {
+        let output =
+            #"<|tool_call>call:line_count{text:<|"|>one\ntwo<|"|>,tags:[<|"|>a<|"|>,<|"|>b<|"|>]}<tool_call|>"#
+        let call = try #require(
+            ToolCallFormat.gemma4.createParser().parse(
+                content: output,
+                tools: [lineCountToolSpec()]
+            )
+        )
+
+        #expect(call.function.arguments["text"] == .string("one\ntwo"))
+        #expect(call.function.arguments["tags"] == .array([.string("a"), .string("b")]))
+    }
+
+    private func agentActionToolSpec() -> [String: any Sendable] {
+        [
+            "type": "function",
+            "function": [
+                "name": "agent_action",
+                "parameters": [
+                    "type": "object",
+                    "properties": [
+                        "verb": ["type": "string"] as [String: any Sendable],
+                        "text": ["type": "string"] as [String: any Sendable],
+                        "note": ["type": "string"] as [String: any Sendable],
+                        "target": [
+                            "type": "object",
+                            "properties": [
+                                "mark": ["type": "integer"] as [String: any Sendable],
+                                "describe": ["type": "string"] as [String: any Sendable],
+                            ] as [String: any Sendable],
+                        ] as [String: any Sendable],
+                    ] as [String: any Sendable],
+                    "required": ["verb"],
+                ] as [String: any Sendable],
+            ] as [String: any Sendable],
+        ]
+    }
+
+    private func lineCountToolSpec() -> [String: any Sendable] {
+        [
+            "type": "function",
+            "function": [
+                "name": "line_count",
+                "parameters": [
+                    "type": "object",
+                    "properties": [
+                        "text": ["type": "string"] as [String: any Sendable],
+                        "tags": [
+                            "type": "array",
+                            "items": ["type": "string"] as [String: any Sendable],
+                        ] as [String: any Sendable],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable],
+            ] as [String: any Sendable],
+        ]
+    }
+}


### PR DESCRIPTION
## Summary

`GemmaFunctionParser` (used by `.gemma` and, via `Gemma4ToolCallParser`, by `.gemma4`) did not parse **nested object** values in tool-call arguments. A call like:

```
<|tool_call>call:agent_action{verb:<|"|>click<|"|>,target:{mark:1}}<tool_call|>
```

decoded `target` as the **string** `"{mark:1}"` instead of an object `{ "mark": "1" }`. Any tool whose schema declares an `object` parameter therefore received a string and rejected the call.

## Root cause

`parseValue(from:)` branched only on the escaped-string marker and `[` (arrays). A `{...}` value fell through to `takeRawValue` / `decodeRawValue`, which captured the brace span as raw text. `decodeRawValue` then failed to JSON-decode `{mark:1}` (unquoted keys/values aren't valid JSON) and returned it verbatim as a string.

## Fix

- Add a `parseObject(from:)` branch in `parseValue` for `{`. It decodes the `{key:value,...}` body with the **same** key/value handling as the top-level call, so nested objects (and objects/arrays nested inside them) parse identically and recursively.
- Make `}` terminate a raw scalar in `takeRawValue`, so a scalar inside a nested object (the `1` in `{mark:1}`) stops at the closing brace rather than swallowing it.

Scalar typing inside objects is intentionally left to the same downstream schema-aware coercion that already types top-level scalars — the parser keeps bare scalars as strings everywhere for consistency, so this is a structural fix only (no value normalization, sampler, prompt, or template changes).

## Validation

- **End-to-end** in [Osaurus](https://github.com/osaurus-ai) Computer Use evals (which compile this exact parser): Gemma tool-use scenarios went from **2/7 → 7/7** (gemma-4 E4B) and **2/7 → 6/7** (gemma-4 12B MXFP4). Before the fix the failures were all `Property 'target' must be an object`.
- **Standalone harness** compiling the real `GemmaFunctionParser.swift` + `ParserUtilities.swift`: 12/12 assertions pass (nested object, escaped string inside object, multiple/trailing nested objects, Gemma-3 envelope, and a flat-args regression check).
- **Focused unit test** added: `Tests/MLXLMCommonFocusedTests/GemmaNestedObjectArgumentFocusedTests.swift` (registered in `Package.swift`), mirroring the conventions of `Gemma4ZyphraToolParserFocusedTests`.

## Test plan

- [ ] `swift test --filter GemmaNestedObjectArgumentFocusedTests`
- [ ] Existing `Gemma4ZyphraToolParserFocusedTests` still pass (no regression in flat scalar/array/escaped-string parsing)

Made with [Cursor](https://cursor.com)