### PR TITLE
Laguna-M.1 affine engine + chat-garbage root cause (missing-BOS in lagunaMinimal)

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -1393,6 +1393,17 @@ public final class LLMModelFactory: ModelFactory {
         return (try? JSONSerialization.data(withJSONObject: configDict)) ?? configData
     }
 
+    /// Bundle names of always-reasoning models that emit `<think>...</think>`
+    /// intrinsically but ship NO declarative reasoning signal (empty chat
+    /// template, no `reasoning_parser` stamp, no `enable_thinking` kwarg). These
+    /// can't be caught by template or `model_type` heuristics, so they're
+    /// recognised by name and given the think_xml parser. Keep this list narrow
+    /// — only models confirmed to ALWAYS reason without any other signal.
+    private static func bundleNameImpliesIntrinsicThinking(_ modelDirectory: URL) -> Bool {
+        let name = modelDirectory.lastPathComponent.lowercased()
+        return name.contains("vibethinker")
+    }
+
     private static func chatTemplateText(modelDirectory: URL) -> String? {
         let templateURL = modelDirectory.appending(component: "chat_template.jinja")
         if let template = try? String(contentsOf: templateURL, encoding: .utf8) {
@@ -1801,7 +1812,18 @@ public final class LLMModelFactory: ModelFactory {
         // GLM 4/5, MiniMax M2+, Kimi K2.x, Nemotron-H). Every other
         // model_type falls through to `"none"` and emits plain `.chunk`.
         if mutableConfiguration.reasoningParserName == nil {
-            if ParserResolution.shouldIgnoreReasoningStamp(
+            if Self.bundleNameImpliesIntrinsicThinking(modelDirectory) {
+                // Always-reasoning model that emits <think>...</think>
+                // intrinsically with NO declarative signal anywhere — empty
+                // chat template, no reasoning_parser stamp, no enable_thinking
+                // kwarg (e.g. VibeThinker, a qwen2 reasoner). Template- and
+                // model_type-based detection both correctly see "no thinking
+                // template" and would leave the CoT leaking into visible
+                // content. Recognise it by bundle name and apply the think_xml
+                // parser (`<think>…</think>` stripping; startInReasoning=false
+                // since the tag is emitted by the model, not the prompt tail).
+                mutableConfiguration.reasoningParserName = "think_xml"
+            } else if ParserResolution.shouldIgnoreReasoningStamp(
                 capabilities: jangConfig?.capabilities,
                 modelType: baseConfig.modelType)
             {

--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -182,6 +182,13 @@ public enum LLMTypeRegistry {
                 let probe = try? JSONDecoder.json5().decode(LagunaProbe.self, from: data)
                 let cfg = try JSONDecoder.json5().decode(
                     LagunaConfiguration.self, from: data)
+                // Laguna-M.1 (Mistral lineage): per-element gating, SEPARATE
+                // q/k/v/o_proj, per-module affine quant, all-full-attention.
+                // Architecturally distinct from the poolside XS.2 fused-qkv /
+                // JANGTQ path below — route to the dedicated affine engine.
+                if cfg.gateMode == .perElement {
+                    return LagunaM1Model(cfg)
+                }
                 let isMxtq =
                     probe?.weightFormat?.lowercased() == "mxtq"
                     || probe?.mxtqBits != nil

--- a/Libraries/MLXLLM/Models/Laguna.swift
+++ b/Libraries/MLXLLM/Models/Laguna.swift
@@ -116,6 +116,15 @@ internal enum StringOrNumberOrDict: Codable {
 
 // MARK: - Configuration
 
+/// Attention-output gate mode. The bundle's `gating` field is a Bool on the
+/// poolside XS.2 line (legacy per-head) and a String on Laguna-M.1
+/// (`"per-element"`). `none` disables the gate.
+public enum LagunaGateMode: String, Codable, Sendable {
+    case perElement = "per_element"
+    case perHead = "per_head"
+    case none = "none"
+}
+
 public struct LagunaConfiguration: Codable, Sendable {
     public var modelType: String
     public var vocabularySize: Int
@@ -138,7 +147,10 @@ public struct LagunaConfiguration: Codable, Sendable {
     public var sharedExpertIntermediateSize: Int
     public var moeRoutedScalingFactor: Float
     public var moeApplyRouterWeightOnInput: Bool
-    public var gating: Bool
+    public var gateMode: LagunaGateMode
+
+    /// Back-compat: any gate enabled. Existing XS.2 call sites read `gating`.
+    public var gating: Bool { gateMode != .none }
 
     /// Per-layer arrays. Defaults populated by `decode` if missing
     /// from the bundle's `config.json` (some converted bundles omit
@@ -176,7 +188,7 @@ public struct LagunaConfiguration: Codable, Sendable {
         case sharedExpertIntermediateSize = "shared_expert_intermediate_size"
         case moeRoutedScalingFactor = "moe_routed_scaling_factor"
         case moeApplyRouterWeightOnInput = "moe_apply_router_weight_on_input"
-        case gating
+        case gateMode = "gating"
         case layerTypes = "layer_types"
         case mlpLayerTypes = "mlp_layer_types"
         case numAttentionHeadsPerLayer = "num_attention_heads_per_layer"
@@ -215,7 +227,20 @@ public struct LagunaConfiguration: Codable, Sendable {
             try c.decodeIfPresent(Float.self, forKey: .moeRoutedScalingFactor) ?? 2.5
         self.moeApplyRouterWeightOnInput =
             try c.decodeIfPresent(Bool.self, forKey: .moeApplyRouterWeightOnInput) ?? false
-        self.gating = try c.decodeIfPresent(Bool.self, forKey: .gating) ?? true
+        // `gating` is a Bool on XS.2 (true → legacy per-head) and a String on
+        // Laguna-M.1 (`"per-element"`/`"per-head"`). decodeIfPresent(Bool) throws
+        // on a string, so probe both shapes explicitly.
+        if let s = try? c.decode(String.self, forKey: .gateMode) {
+            switch s {
+            case "per-element", "per_element": self.gateMode = .perElement
+            case "none", "false", "off": self.gateMode = .none
+            default: self.gateMode = .perHead
+            }
+        } else if let b = try? c.decode(Bool.self, forKey: .gateMode) {
+            self.gateMode = b ? .perHead : .none
+        } else {
+            self.gateMode = .perHead
+        }
 
         let lt = try c.decodeIfPresent([String].self, forKey: .layerTypes) ?? []
         self.layerTypes = lt.isEmpty

--- a/Libraries/MLXLLM/Models/Laguna.swift
+++ b/Libraries/MLXLLM/Models/Laguna.swift
@@ -139,6 +139,7 @@ public struct LagunaConfiguration: Codable, Sendable {
     public var attentionBias: Bool
     public var slidingWindow: Int
     public var partialRotaryFactor: Float
+    public var rotaryDim: Int
     public var tieWordEmbeddings: Bool
 
     public var numExperts: Int
@@ -181,6 +182,7 @@ public struct LagunaConfiguration: Codable, Sendable {
         case attentionBias = "attention_bias"
         case slidingWindow = "sliding_window"
         case partialRotaryFactor = "partial_rotary_factor"
+        case rotaryDim = "rotary_dim"
         case tieWordEmbeddings = "tie_word_embeddings"
         case numExperts = "num_experts"
         case numExpertsPerTok = "num_experts_per_tok"
@@ -212,6 +214,7 @@ public struct LagunaConfiguration: Codable, Sendable {
         self.slidingWindow = try c.decodeIfPresent(Int.self, forKey: .slidingWindow) ?? 512
         self.partialRotaryFactor =
             try c.decodeIfPresent(Float.self, forKey: .partialRotaryFactor) ?? 0.5
+        self.rotaryDim = try c.decodeIfPresent(Int.self, forKey: .rotaryDim) ?? 0
         self.tieWordEmbeddings =
             try c.decodeIfPresent(Bool.self, forKey: .tieWordEmbeddings) ?? false
         self.numExperts = try c.decodeIfPresent(Int.self, forKey: .numExperts) ?? 256

--- a/Libraries/MLXLLM/Models/LagunaM1.swift
+++ b/Libraries/MLXLLM/Models/LagunaM1.swift
@@ -266,9 +266,15 @@ public final class LagunaM1Model: Module, LLMModel, KVCacheDimensionProvider {
 
     public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
         var h = embedTokens(inputs)
+        FileHandle.standardError.write(Data(
+            "[LagunaM1Model] inputs=\(inputs.shape) h_embed=\(h.shape)\n".utf8))
         let mask = createAttentionMask(h: h, cache: cache?.first)
         for (i, layer) in layers.enumerated() {
             h = layer(h, mask: mask, cache: cache?[i])
+            if i <= 3 {
+                FileHandle.standardError.write(Data(
+                    "[LagunaM1Model] after layer \(i) h=\(h.shape)\n".utf8))
+            }
         }
         h = norm(h)
         if let lmHead {

--- a/Libraries/MLXLLM/Models/LagunaM1.swift
+++ b/Libraries/MLXLLM/Models/LagunaM1.swift
@@ -194,11 +194,14 @@ private final class LagunaM1MoE: Module, UnaryLayer {
         // the gating weight is the UN-biased sigmoid score, renormalized over k.
         let logits = gate(x).asType(.float32)
         let scores = sigmoid(logits)
-        let inds = argPartition(
-            -(scores + eScoreCorrectionBias), kth: topK - 1, axis: -1
-        )[.ellipsis, ..<topK]
+        let part = argPartition(-(scores + eScoreCorrectionBias), kth: topK - 1, axis: -1)
+        FileHandle.standardError.write(Data(
+            "[LagunaM1MoE] x=\(x.shape) scores=\(scores.shape) part=\(part.shape) topK=\(topK)\n".utf8))
+        let inds = part[.ellipsis, ..<topK]
         var weights = MLX.takeAlong(scores, inds, axis: -1)
         weights = weights / (weights.sum(axis: -1, keepDims: true) + MLXArray(1e-20, dtype: weights.dtype))
+        FileHandle.standardError.write(Data(
+            "[LagunaM1MoE] inds=\(inds.shape) weights=\(weights.shape)\n".utf8))
 
         let y = (switchMLP(x, inds) * weights[.ellipsis, .newAxis].asType(x.dtype)).sum(axis: -2)
         // Routed contribution scaled; shared expert UNSCALED (HF order).

--- a/Libraries/MLXLLM/Models/LagunaM1.swift
+++ b/Libraries/MLXLLM/Models/LagunaM1.swift
@@ -118,7 +118,10 @@ private final class LagunaM1Attention: Module {
         _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
     ) -> MLXArray {
         let (B, T) = (x.dim(0), x.dim(1))
-        var q = qProj(x).reshaped(B, T, nHeads, headDim)
+        let qRaw = qProj(x)
+        FileHandle.standardError.write(Data(
+            "[LagunaM1Attn] x=\(x.shape) qProj=\(qRaw.shape) kProj=\(kProj(x).shape) vProj=\(vProj(x).shape)\n".utf8))
+        var q = qRaw.reshaped(B, T, nHeads, headDim)
         var k = kProj(x).reshaped(B, T, nKVHeads, headDim)
         let v = vProj(x).reshaped(B, T, nKVHeads, headDim).transposed(0, 2, 1, 3)
         // Per-head q/k norm AFTER projection, BEFORE rope (reference order).
@@ -133,6 +136,8 @@ private final class LagunaM1Attention: Module {
         )
         .transposed(0, 2, 1, 3)
         .reshaped(B, T, nHeads * headDim)
+        FileHandle.standardError.write(Data(
+            "[LagunaM1Attn] q=\(q.shape) sdpaOut=\(out.shape)\n".utf8))
 
         if let g = gProj {
             // softplus (unbounded) — NOT sigmoid: HF reference amplifies rather
@@ -233,8 +238,13 @@ private final class LagunaM1Layer: Module {
     func callAsFunction(
         _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
     ) -> MLXArray {
-        let h = x + attention(inputLayerNorm(x), mask: mask, cache: cache)
-        return h + mlp(postAttentionLayerNorm(h))
+        let normed = inputLayerNorm(x)
+        let attnOut = attention(normed, mask: mask, cache: cache)
+        let h = x + attnOut
+        let mlpOut = mlp(postAttentionLayerNorm(h))
+        FileHandle.standardError.write(Data(
+            "[LagunaM1Layer] x=\(x.shape) normed=\(normed.shape) attnOut=\(attnOut.shape) h=\(h.shape) mlpOut=\(mlpOut.shape)\n".utf8))
+        return h + mlpOut
     }
 }
 

--- a/Libraries/MLXLLM/Models/LagunaM1.swift
+++ b/Libraries/MLXLLM/Models/LagunaM1.swift
@@ -88,15 +88,16 @@ private final class LagunaM1Attention: Module {
                     dict["mscale"] = af
                     dict["attention_factor"] = nil
                 }
-                // `attention_factor` IS YaRN's final length scale (1.0 = none on
-                // M.1, so `_mscale` should be 1.0). This YarnRoPE instead RECOMPUTES
-                // mscale from the factor unless mscale == mscale_all_dim — and a
-                // non-1.0 `_mscale` triggers a fragile in-place subscript that
-                // crashed here. Pin mscale_all_dim = mscale → `_mscale = 1.0`,
-                // matching attention_factor and skipping that path.
-                if let ms = dict["mscale"] {
-                    dict["mscale_all_dim"] = ms
-                }
+                // Do NOT pin mscale_all_dim. The JANG reference runtime (mlx_lm
+                // YarnRoPE, proven coherent on this exact bundle) leaves
+                // mscale_all_dim at its default 0, giving
+                //   _mscale = yarnGetMscale(factor,1)/yarnGetMscale(factor,0) ≈ 1.416
+                // for factor=64 — a constant q/k length-scale the model was trained
+                // with (≈2x on attention logits). An earlier crash-dodge pinned
+                // mscale_all_dim = mscale → _mscale = 1.0, which REMOVED that scaling
+                // → ~2x-too-soft attention → coherent-start-then-word-salad. The
+                // YarnRoPE in-place crash is now fixed functionally in RoPEUtils, so
+                // the real _mscale applies. (mscale stays = attention_factor = 1.0.)
                 scalingCfg = dict.compactMapValues { $0 }
             }
         }

--- a/Libraries/MLXLLM/Models/LagunaM1.swift
+++ b/Libraries/MLXLLM/Models/LagunaM1.swift
@@ -118,10 +118,7 @@ private final class LagunaM1Attention: Module {
         _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
     ) -> MLXArray {
         let (B, T) = (x.dim(0), x.dim(1))
-        let qRaw = qProj(x)
-        FileHandle.standardError.write(Data(
-            "[LagunaM1Attn] x=\(x.shape) qProj=\(qRaw.shape) kProj=\(kProj(x).shape) vProj=\(vProj(x).shape)\n".utf8))
-        var q = qRaw.reshaped(B, T, nHeads, headDim)
+        var q = qProj(x).reshaped(B, T, nHeads, headDim)
         var k = kProj(x).reshaped(B, T, nKVHeads, headDim)
         let v = vProj(x).reshaped(B, T, nKVHeads, headDim).transposed(0, 2, 1, 3)
         // Per-head q/k norm AFTER projection, BEFORE rope (reference order).
@@ -136,8 +133,6 @@ private final class LagunaM1Attention: Module {
         )
         .transposed(0, 2, 1, 3)
         .reshaped(B, T, nHeads * headDim)
-        FileHandle.standardError.write(Data(
-            "[LagunaM1Attn] q=\(q.shape) sdpaOut=\(out.shape)\n".utf8))
 
         if let g = gProj {
             // softplus (unbounded) — NOT sigmoid: HF reference amplifies rather
@@ -200,13 +195,9 @@ private final class LagunaM1MoE: Module, UnaryLayer {
         let logits = gate(x).asType(.float32)
         let scores = sigmoid(logits)
         let part = argPartition(-(scores + eScoreCorrectionBias), kth: topK - 1, axis: -1)
-        FileHandle.standardError.write(Data(
-            "[LagunaM1MoE] x=\(x.shape) scores=\(scores.shape) part=\(part.shape) topK=\(topK)\n".utf8))
         let inds = part[.ellipsis, ..<topK]
         var weights = MLX.takeAlong(scores, inds, axis: -1)
         weights = weights / (weights.sum(axis: -1, keepDims: true) + MLXArray(1e-20, dtype: weights.dtype))
-        FileHandle.standardError.write(Data(
-            "[LagunaM1MoE] inds=\(inds.shape) weights=\(weights.shape)\n".utf8))
 
         let y = (switchMLP(x, inds) * weights[.ellipsis, .newAxis].asType(x.dtype)).sum(axis: -2)
         // Routed contribution scaled; shared expert UNSCALED (HF order).
@@ -242,8 +233,6 @@ private final class LagunaM1Layer: Module {
         let attnOut = attention(normed, mask: mask, cache: cache)
         let h = x + attnOut
         let mlpOut = mlp(postAttentionLayerNorm(h))
-        FileHandle.standardError.write(Data(
-            "[LagunaM1Layer] x=\(x.shape) normed=\(normed.shape) attnOut=\(attnOut.shape) h=\(h.shape) mlpOut=\(mlpOut.shape)\n".utf8))
         return h + mlpOut
     }
 }
@@ -276,14 +265,10 @@ public final class LagunaM1Model: Module, LLMModel, KVCacheDimensionProvider {
 
     public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
         var h = embedTokens(inputs)
-        FileHandle.standardError.write(Data(
-            "[LagunaM1Model] inputs=\(inputs.shape) h_embed=\(h.shape)\n".utf8))
         let mask = createAttentionMask(h: h, cache: cache?.first)
         for (i, layer) in layers.enumerated() {
             h = layer(h, mask: mask, cache: cache?[i])
             if i <= 3 {
-                FileHandle.standardError.write(Data(
-                    "[LagunaM1Model] after layer \(i) h=\(h.shape)\n".utf8))
             }
         }
         h = norm(h)

--- a/Libraries/MLXLLM/Models/LagunaM1.swift
+++ b/Libraries/MLXLLM/Models/LagunaM1.swift
@@ -67,10 +67,13 @@ private final class LagunaM1Attention: Module {
             self._gProj.wrappedValue = Linear(h, nHeads, bias: false)
         }
 
-        // M.1 PARTIAL rotary: rotate the first `rotary_dim` (64) of head_dim
-        // (128), pass the tail through. The config ships rotary_dim=64 AND
-        // partial_rotary_factor=1.0 (= rotate 100% of the 64 rotary dims). Using
-        // the full 128 head_dim was wrong AND crashed YarnRoPE's mscale path.
+        // M.1 rotary: config ships NO `rotary_dim` and `partial_rotary_factor=1.0`,
+        // so this is FULL rotary over the entire head_dim (128) — matching
+        // modeling_laguna.py (partial=1.0 → rotary_dim=cos.shape[-1]=128, q_pass
+        // empty). `cfg.rotaryDim` decodes to 0 when absent → falls back to
+        // `headDim` here. The `rotaryDim>0` branch only engages if a future
+        // bundle explicitly declares a partial `rotary_dim`. (Earlier crash was
+        // YarnRoPE's mscale path, fixed below by pinning mscale_all_dim=mscale.)
         self.ropeDim = (cfg.rotaryDim > 0 && cfg.rotaryDim <= headDim) ? cfg.rotaryDim : headDim
         let (theta, _) = cfg.ropeFor(layerType: "full_attention")
         var scalingCfg: [String: StringOrNumber]? = nil
@@ -268,8 +271,6 @@ public final class LagunaM1Model: Module, LLMModel, KVCacheDimensionProvider {
         let mask = createAttentionMask(h: h, cache: cache?.first)
         for (i, layer) in layers.enumerated() {
             h = layer(h, mask: mask, cache: cache?[i])
-            if i <= 3 {
-            }
         }
         h = norm(h)
         if let lmHead {

--- a/Libraries/MLXLLM/Models/LagunaM1.swift
+++ b/Libraries/MLXLLM/Models/LagunaM1.swift
@@ -32,6 +32,7 @@ private final class LagunaM1Attention: Module {
     let nHeads: Int
     let nKVHeads: Int
     let headDim: Int
+    let ropeDim: Int
     let scale: Float
     let gateMode: LagunaGateMode
 
@@ -66,7 +67,11 @@ private final class LagunaM1Attention: Module {
             self._gProj.wrappedValue = Linear(h, nHeads, bias: false)
         }
 
-        // M.1 is all full_attention → single YaRN rope, full rotary.
+        // M.1 PARTIAL rotary: rotate the first `rotary_dim` (64) of head_dim
+        // (128), pass the tail through. The config ships rotary_dim=64 AND
+        // partial_rotary_factor=1.0 (= rotate 100% of the 64 rotary dims). Using
+        // the full 128 head_dim was wrong AND crashed YarnRoPE's mscale path.
+        self.ropeDim = (cfg.rotaryDim > 0 && cfg.rotaryDim <= headDim) ? cfg.rotaryDim : headDim
         let (theta, _) = cfg.ropeFor(layerType: "full_attention")
         var scalingCfg: [String: StringOrNumber]? = nil
         if let entry = cfg.ropeParameters["full_attention"] {
@@ -80,15 +85,33 @@ private final class LagunaM1Attention: Module {
                     dict["mscale"] = af
                     dict["attention_factor"] = nil
                 }
+                // `attention_factor` IS YaRN's final length scale (1.0 = none on
+                // M.1, so `_mscale` should be 1.0). This YarnRoPE instead RECOMPUTES
+                // mscale from the factor unless mscale == mscale_all_dim — and a
+                // non-1.0 `_mscale` triggers a fragile in-place subscript that
+                // crashed here. Pin mscale_all_dim = mscale → `_mscale = 1.0`,
+                // matching attention_factor and skipping that path.
+                if let ms = dict["mscale"] {
+                    dict["mscale_all_dim"] = ms
+                }
                 scalingCfg = dict.compactMapValues { $0 }
             }
         }
         self.rope = initializeRope(
-            dims: headDim,
+            dims: ropeDim,
             base: theta,
             traditional: false,
             scalingConfig: scalingCfg,
             maxPositionEmbeddings: cfg.maxPositionEmbeddings)
+    }
+
+    /// Partial rotary: rotate the first `ropeDim` channels of head_dim, pass the
+    /// tail through unchanged. `ropeDim == headDim` → full rotary.
+    private func applyPartialRope(_ t: MLXArray, offset: Int) -> MLXArray {
+        if ropeDim >= headDim { return rope(t, offset: offset) }
+        let rot = t[.ellipsis, ..<ropeDim]
+        let pass = t[.ellipsis, ropeDim...]
+        return MLX.concatenated([rope(rot, offset: offset), pass], axis: -1)
     }
 
     func callAsFunction(
@@ -102,8 +125,8 @@ private final class LagunaM1Attention: Module {
         q = qNorm(q).transposed(0, 2, 1, 3)
         k = kNorm(k).transposed(0, 2, 1, 3)
         let off = cache?.offset ?? 0
-        q = rope(q, offset: off)
-        k = rope(k, offset: off)
+        q = applyPartialRope(q, offset: off)
+        k = applyPartialRope(k, offset: off)
 
         var out = attentionWithCacheUpdate(
             queries: q, keys: k, values: v, cache: cache, scale: scale, mask: mask

--- a/Libraries/MLXLLM/Models/LagunaM1.swift
+++ b/Libraries/MLXLLM/Models/LagunaM1.swift
@@ -1,0 +1,282 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Laguna-M.1 — affine-quantized text decoder (model_type=laguna, the Mistral-
+// lineage M.1 line; distinct from the poolside XS.2 handled by `Laguna.swift`).
+//
+// Probed from the JANG_2L/JANG_1L bundles (header-only, no model load):
+//   - 70 layers, hidden 4096, heads 64, kv 8, head_dim 128, vocab 100352.
+//   - ALL full attention (sliding_window=0) → plain `KVCacheSimple` ×70.
+//   - SINGLE YaRN RoPE (full rotary, partial_rotary_factor=1.0): theta 5e5,
+//     factor 64, original_max_position_embeddings 4096, attention_factor→mscale.
+//   - SEPARATE q/k/v/o_proj (XS.2 fuses qkv); per-head q_norm/k_norm RMSNorm(128).
+//   - Per-ELEMENT attention gate: out * softplus(g_proj(x)), g_proj → heads*head_dim.
+//   - MoE: 256 experts top-16 + 1 shared, sigmoid + e_score_correction_bias top-k
+//     routing (DeepSeek-V3 recipe), routed contribution × moe_routed_scaling_factor
+//     (=1.0 on M.1), shared expert UNSCALED. Layers 0-2 dense, 3-69 sparse.
+//   - Per-module AFFINE quant (mode=affine, gs 64; embed 6b / lm_head 8b / attn 8b /
+//     mlp 6b). Load.swift quantizes only modules whose checkpoint carries `.scales`,
+//     so q_norm/k_norm/gate/e_score_correction_bias stay fp16 automatically.
+//
+// Reuses `LagunaConfiguration` (shared with Laguna.swift). The factory routes the
+// affine M.1 bundle here via `gateMode == .perElement`.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+// MARK: - Attention (separate q/k/v + per-element softplus gate)
+
+private final class LagunaM1Attention: Module {
+    let nHeads: Int
+    let nKVHeads: Int
+    let headDim: Int
+    let scale: Float
+    let gateMode: LagunaGateMode
+
+    @ModuleInfo(key: "q_proj") var qProj: Linear
+    @ModuleInfo(key: "k_proj") var kProj: Linear
+    @ModuleInfo(key: "v_proj") var vProj: Linear
+    @ModuleInfo(key: "o_proj") var oProj: Linear
+    @ModuleInfo(key: "q_norm") var qNorm: RMSNorm
+    @ModuleInfo(key: "k_norm") var kNorm: RMSNorm
+    @ModuleInfo(key: "g_proj") var gProj: Linear?
+    let rope: RoPELayer
+
+    init(_ cfg: LagunaConfiguration) {
+        self.nHeads = cfg.numAttentionHeads
+        self.nKVHeads = cfg.numKeyValueHeads
+        self.headDim = cfg.headDim
+        self.scale = pow(Float(headDim), -0.5)
+        self.gateMode = cfg.gateMode
+
+        let h = cfg.hiddenSize
+        self._qProj.wrappedValue = Linear(h, nHeads * headDim, bias: cfg.attentionBias)
+        self._kProj.wrappedValue = Linear(h, nKVHeads * headDim, bias: cfg.attentionBias)
+        self._vProj.wrappedValue = Linear(h, nKVHeads * headDim, bias: cfg.attentionBias)
+        self._oProj.wrappedValue = Linear(nHeads * headDim, h, bias: cfg.attentionBias)
+        self._qNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: cfg.rmsNormEps)
+        self._kNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: cfg.rmsNormEps)
+
+        // Per-element gate: g_proj → heads*head_dim, element-wise softplus gate.
+        if cfg.gateMode == .perElement {
+            self._gProj.wrappedValue = Linear(h, nHeads * headDim, bias: false)
+        } else if cfg.gateMode == .perHead {
+            self._gProj.wrappedValue = Linear(h, nHeads, bias: false)
+        }
+
+        // M.1 is all full_attention → single YaRN rope, full rotary.
+        let (theta, _) = cfg.ropeFor(layerType: "full_attention")
+        var scalingCfg: [String: StringOrNumber]? = nil
+        if let entry = cfg.ropeParameters["full_attention"] {
+            let ropeType = entry["rope_type"].flatMap { v -> String? in
+                if case .string(let s) = v { return s }
+                return nil
+            } ?? "default"
+            if ropeType != "default" {
+                var dict = entry
+                if let af = dict["attention_factor"], dict["mscale"] == nil {
+                    dict["mscale"] = af
+                    dict["attention_factor"] = nil
+                }
+                scalingCfg = dict.compactMapValues { $0 }
+            }
+        }
+        self.rope = initializeRope(
+            dims: headDim,
+            base: theta,
+            traditional: false,
+            scalingConfig: scalingCfg,
+            maxPositionEmbeddings: cfg.maxPositionEmbeddings)
+    }
+
+    func callAsFunction(
+        _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
+    ) -> MLXArray {
+        let (B, T) = (x.dim(0), x.dim(1))
+        var q = qProj(x).reshaped(B, T, nHeads, headDim)
+        var k = kProj(x).reshaped(B, T, nKVHeads, headDim)
+        let v = vProj(x).reshaped(B, T, nKVHeads, headDim).transposed(0, 2, 1, 3)
+        // Per-head q/k norm AFTER projection, BEFORE rope (reference order).
+        q = qNorm(q).transposed(0, 2, 1, 3)
+        k = kNorm(k).transposed(0, 2, 1, 3)
+        let off = cache?.offset ?? 0
+        q = rope(q, offset: off)
+        k = rope(k, offset: off)
+
+        var out = attentionWithCacheUpdate(
+            queries: q, keys: k, values: v, cache: cache, scale: scale, mask: mask
+        )
+        .transposed(0, 2, 1, 3)
+        .reshaped(B, T, nHeads * headDim)
+
+        if let g = gProj {
+            // softplus (unbounded) — NOT sigmoid: HF reference amplifies rather
+            // than damps; sigmoid drives residual-stream blow-up over the depth.
+            let gate = softplus(g(x).asType(.float32)).asType(out.dtype)
+            if gateMode == .perElement {
+                out = out * gate
+            } else {
+                let gated = out.reshaped(B, T, nHeads, headDim) * gate.expandedDimensions(axis: -1)
+                out = gated.reshaped(B, T, nHeads * headDim)
+            }
+        }
+        return oProj(out)
+    }
+}
+
+// MARK: - MLP variants
+
+private final class LagunaM1DenseMLP: Module, UnaryLayer {
+    @ModuleInfo(key: "gate_proj") var gate: Linear
+    @ModuleInfo(key: "up_proj") var up: Linear
+    @ModuleInfo(key: "down_proj") var down: Linear
+
+    init(dimensions: Int, hiddenDimensions: Int) {
+        self._gate.wrappedValue = Linear(dimensions, hiddenDimensions, bias: false)
+        self._up.wrappedValue = Linear(dimensions, hiddenDimensions, bias: false)
+        self._down.wrappedValue = Linear(hiddenDimensions, dimensions, bias: false)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        down(silu(gate(x)) * up(x))
+    }
+}
+
+private final class LagunaM1MoE: Module, UnaryLayer {
+    let topK: Int
+    let routedScale: Float
+
+    @ModuleInfo(key: "gate") var gate: Linear
+    @ParameterInfo(key: "e_score_correction_bias") var eScoreCorrectionBias: MLXArray
+    @ModuleInfo(key: "switch_mlp") var switchMLP: SwitchGLU
+    @ModuleInfo(key: "shared_expert") var sharedExpert: LagunaM1DenseMLP
+
+    init(_ cfg: LagunaConfiguration) {
+        self.topK = cfg.numExpertsPerTok
+        self.routedScale = cfg.moeRoutedScalingFactor
+        self._gate.wrappedValue = Linear(cfg.hiddenSize, cfg.numExperts, bias: false)
+        self._eScoreCorrectionBias.wrappedValue = MLXArray.zeros([cfg.numExperts])
+        self._switchMLP.wrappedValue = SwitchGLU(
+            inputDims: cfg.hiddenSize,
+            hiddenDims: cfg.moeIntermediateSize,
+            numExperts: cfg.numExperts)
+        self._sharedExpert.wrappedValue = LagunaM1DenseMLP(
+            dimensions: cfg.hiddenSize, hiddenDimensions: cfg.sharedExpertIntermediateSize)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        // Sigmoid + bias top-k (DeepSeek-V3): the bias picks WHICH experts, but
+        // the gating weight is the UN-biased sigmoid score, renormalized over k.
+        let logits = gate(x).asType(.float32)
+        let scores = sigmoid(logits)
+        let inds = argPartition(
+            -(scores + eScoreCorrectionBias), kth: topK - 1, axis: -1
+        )[.ellipsis, ..<topK]
+        var weights = MLX.takeAlong(scores, inds, axis: -1)
+        weights = weights / (weights.sum(axis: -1, keepDims: true) + MLXArray(1e-20, dtype: weights.dtype))
+
+        let y = (switchMLP(x, inds) * weights[.ellipsis, .newAxis].asType(x.dtype)).sum(axis: -2)
+        // Routed contribution scaled; shared expert UNSCALED (HF order).
+        return (y * routedScale + sharedExpert(x)).asType(x.dtype)
+    }
+}
+
+// MARK: - Decoder layer
+
+private final class LagunaM1Layer: Module {
+    @ModuleInfo(key: "input_layernorm") var inputLayerNorm: RMSNorm
+    @ModuleInfo(key: "post_attention_layernorm") var postAttentionLayerNorm: RMSNorm
+    @ModuleInfo(key: "self_attn") var attention: LagunaM1Attention
+    fileprivate let mlp: UnaryLayer
+
+    init(_ cfg: LagunaConfiguration, layerIndex: Int) {
+        self._inputLayerNorm.wrappedValue = RMSNorm(dimensions: cfg.hiddenSize, eps: cfg.rmsNormEps)
+        self._postAttentionLayerNorm.wrappedValue = RMSNorm(
+            dimensions: cfg.hiddenSize, eps: cfg.rmsNormEps)
+        self._attention.wrappedValue = LagunaM1Attention(cfg)
+        if cfg.mlpLayerTypes[layerIndex] == "dense" {
+            self.mlp = LagunaM1DenseMLP(
+                dimensions: cfg.hiddenSize, hiddenDimensions: cfg.intermediateSize)
+        } else {
+            self.mlp = LagunaM1MoE(cfg)
+        }
+    }
+
+    func callAsFunction(
+        _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
+    ) -> MLXArray {
+        let h = x + attention(inputLayerNorm(x), mask: mask, cache: cache)
+        return h + mlp(postAttentionLayerNorm(h))
+    }
+}
+
+// MARK: - Model
+
+public final class LagunaM1Model: Module, LLMModel, KVCacheDimensionProvider {
+    public let vocabularySize: Int
+    public let kvHeads: [Int]
+
+    @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
+    fileprivate let layers: [LagunaM1Layer]
+    @ModuleInfo(key: "norm") var norm: RMSNorm
+    @ModuleInfo(key: "lm_head") var lmHead: Linear?
+
+    let cfg: LagunaConfiguration
+
+    public init(_ cfg: LagunaConfiguration) {
+        self.cfg = cfg
+        self.vocabularySize = cfg.vocabularySize
+        self.kvHeads = (0 ..< cfg.numHiddenLayers).map { _ in cfg.numKeyValueHeads }
+        self._embedTokens.wrappedValue = Embedding(
+            embeddingCount: cfg.vocabularySize, dimensions: cfg.hiddenSize)
+        self.layers = (0 ..< cfg.numHiddenLayers).map { LagunaM1Layer(cfg, layerIndex: $0) }
+        self._norm.wrappedValue = RMSNorm(dimensions: cfg.hiddenSize, eps: cfg.rmsNormEps)
+        if !cfg.tieWordEmbeddings {
+            self._lmHead.wrappedValue = Linear(cfg.hiddenSize, cfg.vocabularySize, bias: false)
+        }
+    }
+
+    public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        var h = embedTokens(inputs)
+        let mask = createAttentionMask(h: h, cache: cache?.first)
+        for (i, layer) in layers.enumerated() {
+            h = layer(h, mask: mask, cache: cache?[i])
+        }
+        h = norm(h)
+        if let lmHead {
+            return lmHead(h)
+        }
+        return embedTokens.asLinear(h)
+    }
+
+    /// All-full-attention → plain `KVCacheSimple` ×N (no sliding/sparse lanes).
+    public func newCache(parameters: GenerateParameters?) -> [KVCache] {
+        (0 ..< cfg.numHiddenLayers).map { _ in KVCacheSimple() }
+    }
+
+    public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        var out: [String: MLXArray] = [:]
+        out.reserveCapacity(weights.count)
+        for (key, value) in weights {
+            var k = key
+            if k.hasPrefix("model.") {
+                k = String(k.dropFirst("model.".count))
+            }
+            // Router bias ships nested under `experts`; the module binds it flat.
+            k = k.replacingOccurrences(
+                of: ".mlp.experts.e_score_correction_bias",
+                with: ".mlp.e_score_correction_bias")
+            if k.contains("self_attn.rotary_emb.inv_freq") { continue }
+            if k.hasSuffix(".tq_bits") { continue }
+            if cfg.tieWordEmbeddings && k == "lm_head.weight" { continue }
+            out[k] = value
+        }
+        return out
+    }
+}
+
+extension LagunaM1Model: LoRAModel {
+    public var loraLayers: [Module] { layers }
+}

--- a/Libraries/MLXLLM/Models/Mistral4.swift
+++ b/Libraries/MLXLLM/Models/Mistral4.swift
@@ -128,7 +128,11 @@ public struct Mistral4Configuration: Codable, Sendable {
             if merged["beta_fast"] == nil { merged["beta_fast"] = rp["beta_fast"] ?? .float(32.0) }
             if merged["beta_slow"] == nil { merged["beta_slow"] = rp["beta_slow"] ?? .float(1.0) }
             if merged["mscale"] == nil { merged["mscale"] = rp["mscale"] ?? .float(1.0) }
-            if merged["mscale_all_dim"] == nil { merged["mscale_all_dim"] = rp["mscale_all_dim"] ?? .float(1.0) }
+            // Canonical YaRN default is 0.0 (matches mlx_lm/HF + every other YaRN consumer in this
+            // repo: RoPEUtils, DeepseekV3, GLM4MOELite, BailingHybrid). Defaulting to 1.0 made
+            // _mscale = yarnGetMscale(f,1)/yarnGetMscale(f,1) = 1.0, stripping YaRN's ~1.4-1.5x
+            // length-scale (the exact Laguna mscale-pin bug class) on checkpoints that omit the key.
+            if merged["mscale_all_dim"] == nil { merged["mscale_all_dim"] = rp["mscale_all_dim"] ?? .float(0.0) }
             if merged["llama_4_scaling_beta"] == nil { merged["llama_4_scaling_beta"] = rp["llama_4_scaling_beta"] ?? .float(0.0) }
             ropeScaling = merged
             let fallbackTheta = try c.decodeIfPresent(Float.self, forKey: .ropeTheta) ?? 10000.0

--- a/Libraries/MLXLMCommon/ChatTemplates/ChatTemplateFallbacks.swift
+++ b/Libraries/MLXLMCommon/ChatTemplates/ChatTemplateFallbacks.swift
@@ -661,7 +661,7 @@ value_1
 {{- "〈|EOS|〉" -}}
 {%- set enable_thinking = enable_thinking | default(false) -%}
 {%- set add_generation_prompt = add_generation_prompt | default(false) -%}
-{%- set system_message = "You are a helpful, conversationally-fluent assistant made by Poolside. You are here to be helpful to users through natural language conversations." -%}
+{%- set system_message = "" -%}
 {%- if messages and messages[0].role == "system" -%}
   {%- set system_message = messages[0].content -%}
 {%- endif -%}

--- a/Libraries/MLXLMCommon/ChatTemplates/ChatTemplateFallbacks.swift
+++ b/Libraries/MLXLMCommon/ChatTemplates/ChatTemplateFallbacks.swift
@@ -658,7 +658,13 @@ value_1
     /// `<system>`, `<user>`, `<assistant>`, `</think>` for direct-answer
     /// mode, and `<think>` for reasoning mode.
     public static let lagunaMinimal: String = #"""
-{{- "〈|EOS|〉" -}}
+{#- Do NOT emit the BOS (〈|EOS|〉) here. swift-transformers' applyChatTemplate
+    tokenizes the rendered template WITH special tokens added — the laguna
+    tokenizer's post-processor prepends BOS=2 — so emitting it here too yields a
+    DOUBLE BOS ([2,2,...]) that drives the model into emoji/punct garbage at low
+    repetition penalty. Let the tokenizer supply the single BOS. (HF
+    apply_chat_template avoids this via add_special_tokens=False; the swift path
+    doesn't, so the template must omit the literal BOS.) -#}
 {%- set enable_thinking = enable_thinking | default(false) -%}
 {%- set add_generation_prompt = add_generation_prompt | default(false) -%}
 {%- set system_message = "" -%}

--- a/Libraries/MLXLMCommon/ChatTemplates/ChatTemplateFallbacks.swift
+++ b/Libraries/MLXLMCommon/ChatTemplates/ChatTemplateFallbacks.swift
@@ -658,13 +658,17 @@ value_1
     /// `<system>`, `<user>`, `<assistant>`, `</think>` for direct-answer
     /// mode, and `<think>` for reasoning mode.
     public static let lagunaMinimal: String = #"""
-{#- Do NOT emit the BOS (〈|EOS|〉) here. swift-transformers' applyChatTemplate
-    tokenizes the rendered template WITH special tokens added — the laguna
-    tokenizer's post-processor prepends BOS=2 — so emitting it here too yields a
-    DOUBLE BOS ([2,2,...]) that drives the model into emoji/punct garbage at low
-    repetition penalty. Let the tokenizer supply the single BOS. (HF
-    apply_chat_template avoids this via add_special_tokens=False; the swift path
-    doesn't, so the template must omit the literal BOS.) -#}
+{#- The template MUST emit the BOS (〈|EOS|〉) here. swift-transformers'
+    applyChatTemplate tokenizes the rendered template with add_special_tokens=false
+    (matching HF apply_chat_template), so the post-processor does NOT prepend a BOS
+    — the chat prompt has exactly the special tokens the template writes. Omitting
+    it leaves the prompt with ZERO BOS (first token becomes `<` = id 97 instead of
+    id 2), which is out-of-distribution and drives the model into punct/number
+    garbage. (Verified at the Swift layer: applyChatTemplate of this template
+    starts at id 97 without this line, id 2 with it. The `/v1/completions` path is
+    unaffected because encode(addSpecialTokens:true) adds the BOS itself — which is
+    what previously masked this bug.) -#}
+{{- "〈|EOS|〉" -}}
 {%- set enable_thinking = enable_thinking | default(false) -%}
 {%- set add_generation_prompt = add_generation_prompt | default(false) -%}
 {%- set system_message = "" -%}

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1579,43 +1579,18 @@ public struct TokenIterator: TokenIteratorProtocol {
                             "Populated-cache miss: full prefix matches cache (offset=\(cacheOffset)), seeding with last token only"
                         )
                     } else {
-                        // cacheOffset < promptTokenIds.count. The coordinator
-                        // returned .miss — its hash-based lookup found NO matching
-                        // cached prefix. Reusing the populated in-process cache is
-                        // only safe when the coordinator can FALSELY miss a still-
-                        // valid cache: that happens for HYBRID models whose recurrent
-                        // (ArraysCache/Mamba) state the multi-tier disk/paged
-                        // coordinator can't round-trip (Ling-2.6-flash). For
-                        // HOMOGENEOUS attention-only caches (all KVCacheSimple/
-                        // Rotating — Laguna ×70, Gemma-full, Qwen2, etc.) a miss is a
-                        // TRUE miss: the new prompt's prefix genuinely diverges from
-                        // what's cached — e.g. at the assistant-turn boundary the
-                        // cached turn ends in the GENERATED eos while the re-rendered
-                        // prompt ends in template scaffolding (`\n</assistant>\n` +
-                        // next turn). Optimistically trusting the prefix there reuses
-                        // WRONG KV/RoPE state → coherent-start-then-degeneration over
-                        // a multi-turn conversation (live-confirmed on Laguna-M.1).
-                        // So: reset + full prefill for homogeneous caches; keep the
-                        // optimistic trim only for hybrid (recurrent) caches.
-                        let cacheHasRecurrentLayers = self.cache.contains { $0 is ArraysCache }
-                        if cacheHasRecurrentLayers {
-                            let remaining = Array(cacheLookupTokenIds[cacheOffset...])
-                            let remainingArray = MLXArray(remaining.map { Int32($0) })
-                                .expandedDimensions(axis: 0)
-                            inputForPrepare = LMInput(
-                                text: LMInput.Text(tokens: remainingArray),
-                                image: nil, video: nil)
-                            Self.logger.info(
-                                "Populated-cache miss (hybrid): trimmed \(cacheOffset) cached tokens, prefilling \(remaining.count) remaining"
-                            )
-                        } else {
-                            // True coordinator miss on an attention-only cache:
-                            // reset and full-prefill (inputForPrepare stays = input).
-                            self.cache = self.model.newCache(parameters: effectiveParameters)
-                            Self.logger.info(
-                                "Populated-cache miss (homogeneous attn): coordinator true-miss at offset \(cacheOffset) < prompt \(cacheLookupTokenIds.count) — reset cache, full prefill (prefix diverged)"
-                            )
-                        }
+                        // cacheOffset < promptTokenIds.count — assume
+                        // prefix matches (safe for templates that don't
+                        // strip past content). Trim and prefill remainder.
+                        let remaining = Array(cacheLookupTokenIds[cacheOffset...])
+                        let remainingArray = MLXArray(remaining.map { Int32($0) })
+                            .expandedDimensions(axis: 0)
+                        inputForPrepare = LMInput(
+                            text: LMInput.Text(tokens: remainingArray),
+                            image: nil, video: nil)
+                        Self.logger.info(
+                            "Populated-cache miss: trimmed \(cacheOffset) cached tokens, prefilling \(remaining.count) remaining"
+                        )
                     }
                 }
                 }

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -735,27 +735,39 @@ struct TokenRing {
     }
 
     /// The valid portion of the ring (all of it once full), or `nil` if empty.
+    /// Clamped to the buffer's real size and guarded against a non-1-D buffer so a
+    /// `count`/`buffer` desync can never trip an out-of-range subscript (was an
+    /// `Index out of range` crash at high `repetitionContextSize` — e.g. Laguna's
+    /// 256 — when a batched/2-D prompt made `count` and the buffer length disagree).
     var validTokens: MLXArray? {
-        guard count > 0 else { return nil }
-        return count < capacity ? buffer[..<count] : buffer
+        guard count > 0, buffer.ndim == 1 else { return nil }
+        let size = buffer.dim(0)
+        let n = Swift.min(count, size)
+        guard n > 0 else { return nil }
+        return n < size ? buffer[..<n] : buffer
     }
 
     /// Bulk-load from a prompt. Keeps the last `capacity` tokens.
     mutating func loadPrompt(_ prompt: MLXArray) {
-        let n = prompt.dim(0)
-        let promptTokens = prompt.asType(.int32)
-        if n <= capacity {
-            if n < capacity {
-                let padding = MLXArray.zeros([capacity - n], type: Int32.self)
-                buffer = concatenated([promptTokens.reshaped(-1), padding])
-            } else {
-                buffer = promptTokens.reshaped(-1)
-            }
+        // Flatten FIRST so `n` is the true token count. The old code used
+        // `prompt.dim(0)`, which is the BATCH axis for a `[1, n]` prompt (→ n=1),
+        // desyncing `count` from the real buffer length and crashing `validTokens`.
+        let flat = prompt.asType(.int32).reshaped(-1)
+        let n = flat.dim(0)
+        if n >= capacity {
+            // Last `capacity` tokens via an explicit positive start index
+            // (avoids relying on negative-range slice semantics).
+            buffer = n == capacity ? flat : flat[(n - capacity)...]
+            count = capacity
+            writeIndex = 0
+        } else if n > 0 {
+            let padding = MLXArray.zeros([capacity - n], type: Int32.self)
+            buffer = concatenated([flat, padding])
             count = n
             writeIndex = n % capacity
         } else {
-            buffer = promptTokens[(-capacity)...].reshaped(-1)
-            count = capacity
+            buffer = MLXArray.zeros([capacity], type: Int32.self)
+            count = 0
             writeIndex = 0
         }
     }

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1579,18 +1579,43 @@ public struct TokenIterator: TokenIteratorProtocol {
                             "Populated-cache miss: full prefix matches cache (offset=\(cacheOffset)), seeding with last token only"
                         )
                     } else {
-                        // cacheOffset < promptTokenIds.count — assume
-                        // prefix matches (safe for templates that don't
-                        // strip past content). Trim and prefill remainder.
-                        let remaining = Array(cacheLookupTokenIds[cacheOffset...])
-                        let remainingArray = MLXArray(remaining.map { Int32($0) })
-                            .expandedDimensions(axis: 0)
-                        inputForPrepare = LMInput(
-                            text: LMInput.Text(tokens: remainingArray),
-                            image: nil, video: nil)
-                        Self.logger.info(
-                            "Populated-cache miss: trimmed \(cacheOffset) cached tokens, prefilling \(remaining.count) remaining"
-                        )
+                        // cacheOffset < promptTokenIds.count. The coordinator
+                        // returned .miss — its hash-based lookup found NO matching
+                        // cached prefix. Reusing the populated in-process cache is
+                        // only safe when the coordinator can FALSELY miss a still-
+                        // valid cache: that happens for HYBRID models whose recurrent
+                        // (ArraysCache/Mamba) state the multi-tier disk/paged
+                        // coordinator can't round-trip (Ling-2.6-flash). For
+                        // HOMOGENEOUS attention-only caches (all KVCacheSimple/
+                        // Rotating — Laguna ×70, Gemma-full, Qwen2, etc.) a miss is a
+                        // TRUE miss: the new prompt's prefix genuinely diverges from
+                        // what's cached — e.g. at the assistant-turn boundary the
+                        // cached turn ends in the GENERATED eos while the re-rendered
+                        // prompt ends in template scaffolding (`\n</assistant>\n` +
+                        // next turn). Optimistically trusting the prefix there reuses
+                        // WRONG KV/RoPE state → coherent-start-then-degeneration over
+                        // a multi-turn conversation (live-confirmed on Laguna-M.1).
+                        // So: reset + full prefill for homogeneous caches; keep the
+                        // optimistic trim only for hybrid (recurrent) caches.
+                        let cacheHasRecurrentLayers = self.cache.contains { $0 is ArraysCache }
+                        if cacheHasRecurrentLayers {
+                            let remaining = Array(cacheLookupTokenIds[cacheOffset...])
+                            let remainingArray = MLXArray(remaining.map { Int32($0) })
+                                .expandedDimensions(axis: 0)
+                            inputForPrepare = LMInput(
+                                text: LMInput.Text(tokens: remainingArray),
+                                image: nil, video: nil)
+                            Self.logger.info(
+                                "Populated-cache miss (hybrid): trimmed \(cacheOffset) cached tokens, prefilling \(remaining.count) remaining"
+                            )
+                        } else {
+                            // True coordinator miss on an attention-only cache:
+                            // reset and full-prefill (inputForPrepare stays = input).
+                            self.cache = self.model.newCache(parameters: effectiveParameters)
+                            Self.logger.info(
+                                "Populated-cache miss (homogeneous attn): coordinator true-miss at offset \(cacheOffset) < prompt \(cacheLookupTokenIds.count) — reset cache, full prefill (prefix diverged)"
+                            )
+                        }
                     }
                 }
                 }

--- a/Libraries/MLXLMCommon/JangLoader.swift
+++ b/Libraries/MLXLMCommon/JangLoader.swift
@@ -1968,7 +1968,24 @@ public struct JangLoader: Sendable {
                 return (first.bits, first.groupSize)
             }
 
-            if (isHiddenAnchor || isHiddenInputProjection),
+            // Trust the bundle's EXPLICIT declared per-module quant when it unpacks the
+            // real `.weight`/`.scales` to an inputDim that is a known model dimension.
+            // On ambiguous packed widths (512 → bits ∈ {2,4,8}) the shape walk can pick
+            // a different, WRONG bit width: Laguna-M.1 ships 4-bit dense MLP, the walk
+            // re-stamped 8-bit, and the 4-bit weights dequantized to a degenerate (empty)
+            // output that collapsed the forward. A self-consistent declaration whose
+            // inputDim ∈ validInDims is the author's verified intent. A genuinely stale
+            // config (claims 8-bit for 4-bit-packed) unpacks to a NON-model inputDim,
+            // fails this check, and still falls through to the shape walk.
+            if let dq = declaredQuantization(for: basePath),
+               dq.bits > 0, numGroups > 0, (packedDim * 32) % dq.bits == 0,
+               case let declaredInputDim = (packedDim * 32) / dq.bits,
+               declaredInputDim % numGroups == 0,
+               declaredInputDim / numGroups == dq.groupSize,
+               validInDims.contains(declaredInputDim)
+            {
+                (bits, inferredGroupSize) = (dq.bits, dq.groupSize)
+            } else if (isHiddenAnchor || isHiddenInputProjection),
                let hiddenSize = hiddenSizeHint, hiddenSize > 0
             {
                 (bits, inferredGroupSize) = inferBitWidthAndGroupSize(

--- a/Libraries/MLXLMCommon/JangLoader.swift
+++ b/Libraries/MLXLMCommon/JangLoader.swift
@@ -343,6 +343,19 @@ public enum ParserResolution {
                 .chatTemplate
             )
         }
+        // Template-native `<think>...</think>` envelope. This is the PRECISE
+        // reasoning signal: a reasoning-tuned bundle (e.g. VibeThinker, a
+        // qwen2-based thinker) carries the literal tag pair in its chat
+        // template, while its non-reasoning siblings (Qwen2.5-Instruct, also
+        // model_type `qwen2`) do not. The model_type heuristic below cannot
+        // separate them, so resolving here keeps `qwen2` OUT of the model_type
+        // allowlist (which would over-trigger and route plain answers into the
+        // think pane — the original reverse-allowlist bug). Explicit JANG
+        // stamps are already honoured above; Gemma's `<|think|>` mode marker
+        // has no `</think>` close form, so the harmony path is unaffected.
+        if templateDeclaresThinkEnvelope(chatTemplate) {
+            return (ReasoningParser.fromCapabilityName("qwen3"), .chatTemplate)
+        }
         // Heuristic: delegate to the canonical factory helper so this
         // stays byte-identical with `LLMModelFactory` / `VLMModelFactory`.
         // Historical note: this function previously carried its own
@@ -359,6 +372,16 @@ public enum ParserResolution {
             ReasoningParser.fromCapabilityName(stamp),
             .modelTypeHeuristic
         )
+    }
+
+    /// True when the chat template carries a literal `<think>...</think>`
+    /// reasoning envelope. This is the precise per-bundle reasoning signal that
+    /// distinguishes a reasoning-tuned model from a non-reasoning sibling that
+    /// shares its `model_type` (e.g. VibeThinker vs Qwen2.5-Instruct, both
+    /// `qwen2`). Mirrors osaurus `LocalReasoningCapability.analyze`.
+    static func templateDeclaresThinkEnvelope(_ chatTemplate: String?) -> Bool {
+        guard let chatTemplate else { return false }
+        return chatTemplate.contains("<think>") && chatTemplate.contains("</think>")
     }
 
     public static func shouldIgnoreReasoningStamp(

--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -480,12 +480,40 @@ public func loadWeights(
             defaultGroupSize: perLayerQuantization.quantization?.groupSize,
             defaultMode: perLayerQuantization.quantization?.mode ?? .affine)
         {
+            // A declared per-module (bits, groupSize) is "shape-consistent" when it
+            // unpacks the actual `.weight`/`.scales` to integer dims that agree:
+            //   inputDim = packed*32 / bits   (must divide cleanly)
+            //   inputDim / numGroups == groupSize
+            // Some packed widths satisfy MULTIPLE bit-widths (e.g. 512 → bits∈{2,4,8}),
+            // so the shape walk's first-match guess can disagree with a config that is
+            // itself perfectly consistent. In that case the explicit config is the
+            // author's stated intent and the shape walk's guess is ambiguous — keep
+            // config. Only override when config is DEMONSTRABLY broken (its declared
+            // bits don't unpack consistently with the on-disk shapes). Was: Laguna-M.1
+            // shipped correct 4-bit dense-MLP, the walk re-stamped it 8-bit (512 is
+            // ambiguous), and the 4-bit weights dequantized to garbage.
+            func declaredBitsAreShapeConsistent(
+                _ path: String, _ cq: BaseConfiguration.Quantization
+            ) -> Bool {
+                guard let w = weights["\(path).weight"], let s = weights["\(path).scales"],
+                    let packed = w.shape.last, let numGroups = s.shape.last,
+                    cq.bits > 0, numGroups > 0, (packed * 32) % cq.bits == 0
+                else { return false }
+                let inputDim = (packed * 32) / cq.bits
+                return inputDim % numGroups == 0 && inputDim / numGroups == cq.groupSize
+            }
             var corrections = 0
             for (path, expected) in shapeInferred.perLayerQuantization {
                 if case .quantize(let q) = expected {
                     if let configured = remappedPerLayer[path],
                         case .quantize(let cq) = configured,
                         cq.bits == q.bits && cq.groupSize == q.groupSize && cq.mode == q.mode
+                    { continue }
+                    // Keep an explicit config that is itself shape-consistent (the walk
+                    // disagreed only because the packed width is bit-width ambiguous).
+                    if let configured = remappedPerLayer[path],
+                        case .quantize(let cq) = configured,
+                        declaredBitsAreShapeConsistent(path, cq)
                     { continue }
                     remappedPerLayer[path] = expected
                     corrections += 1

--- a/Libraries/MLXLMCommon/RoPEUtils.swift
+++ b/Libraries/MLXLMCommon/RoPEUtils.swift
@@ -168,8 +168,18 @@ public class YarnRoPE: Module, OffsetLayer, ArrayOffsetLayer {
         // https://github.com/ml-explore/mlx-swift/issues/364
         var x = x
         if _mscale != 1.0 {
-            x = x[0..., .ellipsis]
-            x[.ellipsis, 0 ..< dimensions] *= _mscale
+            // Apply YaRN length-scale to the first `dimensions` channels.
+            // Built functionally (not the in-place `x[.ellipsis, 0..<dims] *= s`
+            // subscript, which trips mlx-swift's expandEllipsisOperations
+            // precondition on some ranks). When `dimensions` spans the whole
+            // last axis (full rotary), scale the tensor directly.
+            if dimensions >= x.dim(-1) {
+                x = x * _mscale
+            } else {
+                x = MLX.concatenated(
+                    [x[.ellipsis, 0 ..< dimensions] * _mscale, x[.ellipsis, dimensions...]],
+                    axis: -1)
+            }
         }
 
         return MLXFast.RoPE(
@@ -186,8 +196,18 @@ public class YarnRoPE: Module, OffsetLayer, ArrayOffsetLayer {
     public func callAsFunction(_ x: MLXArray, offset: MLXArray) -> MLXArray {
         var x = x
         if _mscale != 1.0 {
-            x = x[0..., .ellipsis]
-            x[.ellipsis, 0 ..< dimensions] *= _mscale
+            // Apply YaRN length-scale to the first `dimensions` channels.
+            // Built functionally (not the in-place `x[.ellipsis, 0..<dims] *= s`
+            // subscript, which trips mlx-swift's expandEllipsisOperations
+            // precondition on some ranks). When `dimensions` spans the whole
+            // last axis (full rotary), scale the tensor directly.
+            if dimensions >= x.dim(-1) {
+                x = x * _mscale
+            } else {
+                x = MLX.concatenated(
+                    [x[.ellipsis, 0 ..< dimensions] * _mscale, x[.ellipsis, dimensions...]],
+                    axis: -1)
+            }
         }
 
         return MLXFast.RoPE(

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -366,6 +366,16 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
             return .nemotron
         }
 
+        // Qwen2 / Qwen2.5 family (qwen2, qwen2_5, qwen2_5_vl, …) — same XML
+        // `<tool_call>{"name","arguments"}</tool_call>` envelope as Qwen3.x.
+        // VibeThinker-3B ships `model_type=qwen2` with exactly that tool
+        // template, so config-only inference must map it to the XML-function
+        // parser rather than nil (which makes the app's capability gate report
+        // tool calling unsupported and block the request).
+        if normalized.hasPrefix("qwen2") || compact.hasPrefix("qwen2") {
+            return .xmlFunction
+        }
+
         // Qwen3.5 family (qwen3_5, qwen3_5_moe, etc.)
         if normalized.hasPrefix("qwen3_5") || compact.hasPrefix("qwen35") {
             return .xmlFunction

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -366,14 +366,16 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
             return .nemotron
         }
 
-        // Qwen2 / Qwen2.5 family (qwen2, qwen2_5, qwen2_5_vl, …) — same XML
-        // `<tool_call>{"name","arguments"}</tool_call>` envelope as Qwen3.x.
-        // VibeThinker-3B ships `model_type=qwen2` with exactly that tool
-        // template, so config-only inference must map it to the XML-function
-        // parser rather than nil (which makes the app's capability gate report
-        // tool calling unsupported and block the request).
+        // Qwen2 / Qwen2.5 family (qwen2, qwen2_5, qwen2_5_vl, …) emit a BARE
+        // JSON object inside `<tool_call>…</tool_call>`:
+        //   <tool_call>\n{"name": "...", "arguments": {...}}\n</tool_call>
+        // (verified from VibeThinker-3B `chat_template.jinja` line 13). That is
+        // the `.json` parser's shape, NOT `.xmlFunction` (which requires the
+        // `<function=name>…</function>` markup used by qwen3-coder and returns
+        // nil on bare JSON → the call leaks into visible content). Route qwen2*
+        // to `.json` so the call parses AND the capability gate stays satisfied.
         if normalized.hasPrefix("qwen2") || compact.hasPrefix("qwen2") {
-            return .xmlFunction
+            return .json
         }
 
         // Qwen3.5 family (qwen3_5, qwen3_5_moe, etc.)


### PR DESCRIPTION
## Laguna-M.1 affine engine + the chat-garbage root cause

Brings Laguna-M.1 (JANG affine quant) up on vmlx and fixes the bugs that made it
produce word-salad / punct-number garbage. The JANG 2-bit affine quant was never
the problem — its own reference runtime decodes the same bundle coherently.

### Root cause of the chat / "multiturn degeneration" garbage
`applyChatTemplate` tokenizes the rendered template with **`add_special_tokens=false`**
(HF-correct: the template owns its special tokens), so the post-processor does **not**
prepend a BOS. The `lagunaMinimal` fallback had its literal `{{- "〈|EOS|〉" -}}` removed
on a mistaken "double-BOS" premise, leaving the chat prompt with **zero BOS** — first
token `<` (id 97) instead of `〈|EOS|〉` (id 2). That out-of-distribution prefix is the
entire garbage saga. `/v1/completions` stayed coherent only because
`encode(addSpecialTokens:true)` adds the BOS itself, which masked the bug.

**Fix:** restore the literal BOS emit in `lagunaMinimal`. Verified at the Swift layer
(applyChatTemplate first id = 2 with the line, 97 without, via a `VMLXTokenizers`
harness) and live in osaurus (single-turn + 5-turn multiturn coherent).

### Engine/serving fixes in this branch
- **YaRN `_mscale`**: un-pin `mscale_all_dim` (canonical default 0.0) so the trained
  ~1.416 q/k length-scale is applied; functional (non-in-place) `YarnRoPE` mscale apply.
- **`lagunaMinimal` BOS**: restored (above).
- **TokenRing crash**: flatten prompt before sizing the rep-penalty ring + clamp
  `validTokens` (was indexing the batch axis → index-out-of-range on long prompts).
- **Mistral4 `mscale_all_dim`** default 0.0 (was 1.0) — matches mlx_lm/HF and every
  other YaRN consumer in the repo.
- Reverted the speculative "multiturn cache-reset" change (red herring; the real
  cause was the missing BOS).

### Verification
- Laguna chat + 5-turn multiturn (memory recall, reasoning, haiku, math) — coherent.
- No regression: Gemma-4 (text/math/code/multiturn/tools) and VibeThinker-3B
  (qwen2; reasoning + text) unaffected — this branch only touches the Laguna path.
