### PR TITLE
Recover tool-call format for non-JANG Qwen3 from the chat template

### DIFF
--- a/Libraries/MLXLMCommon/JangLoader.swift
+++ b/Libraries/MLXLMCommon/JangLoader.swift
@@ -469,12 +469,35 @@ public enum ParserResolution {
         if let modelType, let inferred = ToolCallFormat.infer(from: modelType) {
             return (inferred, .modelTypeHeuristic)
         }
+        // Non-JANG bundle whose `model_type` the heuristic doesn't recognise.
+        // The canonical example is plain Qwen3: `infer` deliberately leaves
+        // `qwen3` / `qwen3_moe` nil because `qwen3_moe` is shared by BOTH the
+        // instruct line (Hermes `<tool_call>{"name":…,"arguments":…}` → .json)
+        // and Qwen3-Coder (`<tool_call><function=…><parameter=…>` → .xmlFunction),
+        // so model_type alone cannot disambiguate them. Read the model's OWN
+        // chat template — the ground truth for what it emits — to recover the
+        // format instead of guessing or returning "tools unsupported".
+        if let templateFormat = templateDeclaredToolCallFormat(chatTemplate) {
+            return (templateFormat, .chatTemplate)
+        }
         return (nil, .none)
     }
 
     private static func templateDeclaredToolCallFormat(_ chatTemplate: String?) -> ToolCallFormat? {
         guard let chatTemplate else { return nil }
         let lower = chatTemplate.lowercased()
+        // XML-function envelope: `<tool_call><function=name><parameter=key>…`
+        // (Qwen3-Coder, Qwen3.5/3.6, Nemotron-style). Checked BEFORE the bare-JSON
+        // rule because a coder template still contains `<tool_call>` but carries
+        // `<function=>`/`<parameter=>` bodies rather than a `{"name":…,"arguments":…}`
+        // object. Verified against real Qwen3-Coder-30B-A3B `chat_template`.
+        if lower.contains("<function=") && lower.contains("<parameter=") {
+            return .xmlFunction
+        }
+        // Hermes bare-JSON envelope: `<tool_call>\n{"name":…,"arguments":…}\n</tool_call>`.
+        // Verified against real Qwen3-4B (qwen3) and Qwen3-30B-A3B (qwen3_moe)
+        // instruct `chat_template`. The `<arg_key>` exclusion keeps GLM/Ling-style
+        // `<arg_key>`/`<arg_value>` templates from matching here.
         if lower.contains("<tool_call>")
             && lower.contains("\"name\"")
             && lower.contains("\"arguments\"")

--- a/Tests/MLXLMTests/Qwen3ToolFormatTemplateDetectTests.swift
+++ b/Tests/MLXLMTests/Qwen3ToolFormatTemplateDetectTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import MLXLMCommon
+import Testing
+
+/// Regression coverage for non-JANG Qwen3 tool-call detection.
+///
+/// Symptom (2026-06-19, reporter tpae): a plain Qwen3 bundle errored with
+/// "tool calling as unsupported" because `ParserResolution.toolCall` skipped the
+/// chat-template signal for non-JANG models and `ToolCallFormat.infer("qwen3" /
+/// "qwen3_moe")` returns nil (qwen3_moe is shared by instruct=Hermes/.json and
+/// Qwen3-Coder=.xmlFunction, so model_type alone cannot disambiguate).
+///
+/// The fragments below are the REAL tool-call envelopes copied from upstream
+/// Hugging Face `chat_template`s:
+///   - Qwen/Qwen3-4B (model_type=qwen3) and Qwen/Qwen3-30B-A3B (qwen3_moe):
+///       <tool_call>\n{"name": <function-name>, "arguments": <args-json-object>}\n</tool_call>
+///   - Qwen/Qwen3-Coder-30B-A3B-Instruct (qwen3_moe):
+///       <tool_call>\n<function=name>\n<parameter=key>\nvalue\n</parameter>\n</function>\n</tool_call>
+struct Qwen3ToolFormatTemplateDetectTests {
+    private let qwen3InstructTemplate = """
+        You are a helpful assistant. For each function call return a json object \
+        with function name and arguments within <tool_call></tool_call> XML tags:
+        <tool_call>
+        {"name": <function-name>, "arguments": <args-json-object>}
+        </tool_call>
+        """
+
+    private let qwen3CoderTemplate = """
+        Make tool calls inside <tool_call> tags using the function/parameter form:
+        <tool_call>
+        <function=example_function_name>
+        <parameter=example_parameter_1>
+        value_1
+        </parameter>
+        </function>
+        </tool_call>
+        """
+
+    @Test("qwen3 dense instruct template → .json via chatTemplate")
+    func qwen3DenseInstruct() {
+        let r = ParserResolution.toolCall(
+            capabilities: nil, modelType: "qwen3", chatTemplate: qwen3InstructTemplate)
+        #expect(r.format == .json)
+        #expect(r.source == .chatTemplate)
+    }
+
+    @Test("qwen3_moe instruct template → .json via chatTemplate")
+    func qwen3MoeInstruct() {
+        let r = ParserResolution.toolCall(
+            capabilities: nil, modelType: "qwen3_moe", chatTemplate: qwen3InstructTemplate)
+        #expect(r.format == .json)
+        #expect(r.source == .chatTemplate)
+    }
+
+    @Test("qwen3_moe coder template → .xmlFunction via chatTemplate")
+    func qwen3MoeCoder() {
+        let r = ParserResolution.toolCall(
+            capabilities: nil, modelType: "qwen3_moe", chatTemplate: qwen3CoderTemplate)
+        #expect(r.format == .xmlFunction)
+        #expect(r.source == .chatTemplate)
+    }
+
+    @Test("recognised model_type still wins over template (no behaviour change)")
+    func recognisedModelTypeUnchanged() {
+        // qwen2 is resolved by the model_type heuristic; the template fallback must
+        // not be consulted (source stays .modelTypeHeuristic).
+        let r = ParserResolution.toolCall(
+            capabilities: nil, modelType: "qwen2", chatTemplate: qwen3CoderTemplate)
+        #expect(r.format == .json)
+        #expect(r.source == .modelTypeHeuristic)
+    }
+
+    @Test("no template + unrecognised model_type stays unresolved")
+    func unresolvedWithoutTemplate() {
+        let r = ParserResolution.toolCall(
+            capabilities: nil, modelType: "qwen3", chatTemplate: nil)
+        #expect(r.format == nil)
+        #expect(r.source == .none)
+    }
+}

--- a/Tests/MLXLMTests/ToolTests.swift
+++ b/Tests/MLXLMTests/ToolTests.swift
@@ -1068,9 +1068,12 @@ struct ToolTests {
         #expect(ToolCallFormat.infer(from: "zaya_text") == .zayaXml)
         #expect(ToolCallFormat.infer(from: "zyphra_zaya") == .zayaXml)
 
+        // Qwen2 / Qwen2.5 family emit Hermes bare-JSON inside <tool_call> → .json.
+        #expect(ToolCallFormat.infer(from: "qwen2") == .json)
+        #expect(ToolCallFormat.infer(from: "qwen2_5") == .json)
+
         // Unknown models should return nil (use default JSON format)
         #expect(ToolCallFormat.infer(from: "llama") == nil)
-        #expect(ToolCallFormat.infer(from: "qwen2") == nil)
         #expect(ToolCallFormat.infer(from: "mistral") == nil)
     }
 


### PR DESCRIPTION
## Recover tool-calling for non-JANG Qwen3 (and any non-JANG model) from the chat template

Fixes a "Model capability detection reports tool calling as unsupported" 400 for
plain (non-JANG) Qwen3 bundles, reported by tpae on the team.

### Root cause (verified, not assumed)
`ParserResolution.toolCall` only consulted the chat-template signal to *override* a
JANG stamp; for non-JANG models it fell straight to `ToolCallFormat.infer(model_type)`,
which deliberately leaves `qwen3` / `qwen3_moe` **nil** — `qwen3_moe` is shared by
the instruct line (Hermes `<tool_call>{"name":…,"arguments":…}` → `.json`) and
Qwen3-Coder (`<tool_call><function=…><parameter=…>` → `.xmlFunction`), so model_type
alone cannot disambiguate them. nil format → capability snapshot marks tools
unsupported → osaurus 400s.

Verified against **real upstream chat_templates**: Qwen3-4B (`qwen3`) and
Qwen3-30B-A3B (`qwen3_moe`) instruct emit Hermes `.json`; Qwen3-Coder-30B
(`qwen3_moe`) emits `.xmlFunction`; the two MoE configs differ only in
`max_position_embeddings`/`rope_theta` (version artifacts, not a coder signal).

### Fix
- `ParserResolution.toolCall`: non-JANG path now falls back to
  `templateDeclaredToolCallFormat(chatTemplate)` after `infer()` returns nil — the
  model's own template is the ground truth for what it emits.
- `templateDeclaredToolCallFormat`: also recognise `.xmlFunction` (`<function=` AND
  `<parameter=`), checked before the bare-JSON `.json` rule.

Only fires when `infer()` returns nil, so every recognised model_type resolves
exactly as before (verified live: gemma4/laguna/qwen2/qwen3.6-JANG unchanged).

### Proof
- Unit: `Qwen3ToolFormatTemplateDetectTests` (5) — qwen3 dense→.json, qwen3_moe
  instruct→.json, qwen3_moe coder→.xmlFunction, qwen2 still .modelTypeHeuristic,
  no-template→nil. Existing tool/parser suite green (also corrected a stale
  `ToolTests` assertion that pre-dated the qwen2→.json change).
- Live (osaurus dev app): reproduced the 400 on a real mlx-community/Qwen3-4B-4bit,
  then with this fix qwen3-4b + qwen3-8b emit and parse tool calls + tool-result
  round-trips; gemma-4 / laguna / vibethinker / qwen3.6-JANG all regression-free.
