### PR TITLE
Fix L2 disk-cache orphan rows and solo-path seed-boundary leak

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -953,6 +953,9 @@ public actor BatchEngine {
         let disableDiskBackedRequiredToolRestore = shouldDisableDiskBackedRequiredToolRestore(
             toolSchemas: toolSchemas,
             disablesGeneratedCacheBoundary: false)
+        let skipDiskBackedToolPromptSeedBoundary = shouldSkipDiskBackedToolPromptSeedBoundary(
+            toolSchemas: toolSchemas,
+            disablesGeneratedCacheBoundary: false)
         let fastPathID = UUID()
         var soloParameters = parameters
         soloParameters.extraStopStrings = mergeStopStrings(
@@ -1063,6 +1066,7 @@ public actor BatchEngine {
                 let promptTokenIdsForTail = input.text.tokens.reshaped(-1).asArray(Int.self)
                 let deferredParameters = soloParameters
                 let deferredDisableRestore = disableDiskBackedRequiredToolRestore
+                let deferredSkipSeedBoundary = skipDiskBackedToolPromptSeedBoundary
                 let deferredInputs = SendableBox(
                     (input, context.model, cacheCoordinator))
                 let deferredContinuation = continuation
@@ -1076,6 +1080,7 @@ public actor BatchEngine {
                         parameters: deferredParameters,
                         cacheCoordinator: deferredCoordinator,
                         disableDiskBackedRequiredToolRestore: deferredDisableRestore,
+                        skipDiskBackedToolPromptSeedBoundary: deferredSkipSeedBoundary,
                         prefillProgressHandler: { progress in
                             deferredContinuation.yield(.prefillProgress(prefillGate.clamp(progress)))
                         })

--- a/Libraries/MLXLMCommon/Cache/DiskCache.swift
+++ b/Libraries/MLXLMCommon/Cache/DiskCache.swift
@@ -259,6 +259,12 @@ public final class DiskCache: @unchecked Sendable {
                 "[vmlx][cache/disk] fetch corrupt entry at \(url.lastPathComponent): \(error) — removing\n"
                 .utf8))
             try? FileManager.default.removeItem(at: url)
+            // Drop the SQLite row too. Removing only the file orphans the
+            // `cache_entries` row, whose `file_size` then permanently inflates
+            // the `SUM(file_size)` eviction quota (unbounded on-disk growth and
+            // premature eviction of live entries). The fetch path already holds
+            // `lock`, so delete in-place.
+            _deleteEntryLocked(hash: hash)
             return nil
         }
     }
@@ -397,6 +403,25 @@ public final class DiskCache: @unchecked Sendable {
             sqlite3_bind_text(stmt, 1, cStr, -1, nil)
             sqlite3_bind_int64(stmt, 2, Int64(tokenCount))
             sqlite3_bind_int64(stmt, 3, Int64(fileSize))
+            sqlite3_step(stmt)
+        }
+        sqlite3_finalize(stmt)
+    }
+
+    /// Delete a single `cache_entries` row by hash. Caller MUST hold `lock`.
+    ///
+    /// Used when the on-disk file for an entry is removed (corrupt/truncated
+    /// payload) so the row's `file_size` stops counting toward the eviction
+    /// quota. Removing only the file would orphan the row and permanently
+    /// inflate `SUM(file_size)`.
+    private func _deleteEntryLocked(hash: String) {
+        guard let db else { return }
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(db, "DELETE FROM cache_entries WHERE hash = ?", -1, &stmt, nil)
+            == SQLITE_OK
+        else { return }
+        hash.withCString { cStr in
+            sqlite3_bind_text(stmt, 1, cStr, -1, nil)
             sqlite3_step(stmt)
         }
         sqlite3_finalize(stmt)

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1164,6 +1164,13 @@ public struct TokenIterator: TokenIteratorProtocol {
     /// warm restore can pollute prompt boundaries before tool selection.
     let disableDiskBackedRequiredToolRestore: Bool
 
+    /// Caller-proven policy gate that suppresses storing the `promptLen-1`
+    /// seed-boundary disk entry for disk-backed required-tool prompts whose
+    /// warm restore is not proven safe. Mirrors the batched-path
+    /// `shouldSkipDiskBackedToolPromptSeedBoundary` so the solo path does not
+    /// persist a seed entry the batched path deliberately skips.
+    let skipDiskBackedToolPromptSeedBoundary: Bool
+
     /// Prompt token IDs captured at init for cache store after generation.
     public private(set) var promptTokenIds: [Int]
 
@@ -1238,6 +1245,7 @@ public struct TokenIterator: TokenIteratorProtocol {
 
         self.cacheCoordinator = nil
         self.disableDiskBackedRequiredToolRestore = false
+        self.skipDiskBackedToolPromptSeedBoundary = false
         self.promptTokenIds = []
         self.cachePrefixTokenCounts = []
         self.originalInput = LMInput(text: y)
@@ -1274,6 +1282,7 @@ public struct TokenIterator: TokenIteratorProtocol {
         parameters: GenerateParameters,
         cacheCoordinator: CacheCoordinator? = nil,
         disableDiskBackedRequiredToolRestore: Bool = false,
+        skipDiskBackedToolPromptSeedBoundary: Bool = false,
         prefillProgressHandler: (@Sendable (PrefillProgress) -> Void)? = nil
     ) throws {
         _ = try AccelerationRuntime.resolveTextDecode(parameters.accelerationMode)
@@ -1282,6 +1291,7 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.y = input.text
         self.cacheCoordinator = cacheCoordinator
         self.disableDiskBackedRequiredToolRestore = disableDiskBackedRequiredToolRestore
+        self.skipDiskBackedToolPromptSeedBoundary = skipDiskBackedToolPromptSeedBoundary
         let promptTokenCount = input.text.tokens.size
         var effectiveParameters = parameters
         if let coordinator = cacheCoordinator {
@@ -1680,6 +1690,7 @@ public struct TokenIterator: TokenIteratorProtocol {
 
         self.cacheCoordinator = nil
         self.disableDiskBackedRequiredToolRestore = false
+        self.skipDiskBackedToolPromptSeedBoundary = false
         self.promptTokenIds = []
         self.cachePrefixTokenCounts = input.cachePrefixTokenCounts
         self.originalInput = input
@@ -2006,6 +2017,7 @@ public struct TokenIterator: TokenIteratorProtocol {
                 let requiresDiskBackedRestore =
                     cacheRequiresDiskBackedCoordinatorRestore(promptCacheSnapshot)
                 if requiresDiskBackedRestore,
+                   !skipDiskBackedToolPromptSeedBoundary,
                    promptTokenIds.count > 1,
                    let boundarySnapshot = cacheSnapshotForBoundary(
                         tokens: Array(promptTokenIds.dropLast()),


### PR DESCRIPTION
Two cache-correctness fixes, both verified live.

## B1 — DiskCache orphan rows (unbounded on-disk growth)
`DiskCache.fetch` deletes a corrupt/undeserializable safetensors file but left its `cache_entries` row, so the row's `file_size` permanently inflated the `SUM(file_size)` eviction quota → unbounded on-disk growth + premature eviction of live entries. Now also deletes the row (new `_deleteEntryLocked`; fetch already holds the lock).

## B2 — solo-path seed-boundary leak
The required-tool disk-backed seed-boundary suppression (`shouldSkipDiskBackedToolPromptSeedBoundary`) existed only on the batched `BatchEngine` path. The **solo `TokenIterator` path — the default for single-user serving** — still persisted the `promptLen-1` seed entry the batched path deliberately skips. Plumbs a precomputed `skipDiskBackedToolPromptSeedBoundary` flag through `TokenIterator` (parallel to the existing fetch gate) and guards the `dropLast()` seed store.

## Verified live
- disk-cache accounting delta stays 0 (no orphan rows) across multi-model load/switch/multiturn
- gemma-4-mxfp4 **with** tools stores only the full prompt boundary (seed skipped); **without** tools stores full+seed
- prefix reuse + multiturn unaffected (gemma-4 long-context warm reuse ~10x); no crash