### PR TITLE
Support deepseek_v3 q_lora=null + qwen JSON tool-call wire form

### DIFF
--- a/Libraries/MLXLLM/Models/DeepseekV3.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV3.swift
@@ -19,7 +19,12 @@ public struct DeepseekV3Configuration: Codable, Sendable {
     var nRoutedExperts: Int?
     var routedScalingFactor: Float
     var kvLoraRank: Int
-    var qLoraRank: Int
+    /// Optional: DeepSeek-V3 671B compresses Q via a LoRA (`q_a_proj`/`q_b_proj`),
+    /// but smaller deepseek_v3-arch bundles (e.g. Kanana-2-30B-A3B) set
+    /// `q_lora_rank: null` and use a direct `q_proj`. The attention already
+    /// branches on `qLoraRank == nil`; the config must accept null/absent too
+    /// or Codable throws "Missing value at 'q_lora_rank'" on load.
+    var qLoraRank: Int?
     var qkRopeHeadDim: Int
     var vHeadDim: Int
     var qkNopeHeadDim: Int

--- a/Libraries/MLXLMCommon/Tool/Parsers/XMLFunctionParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/XMLFunctionParser.swift
@@ -27,7 +27,19 @@ public struct XMLFunctionParser: ToolCallParser, Sendable {
         guard
             let funcMatch = content.range(
                 of: #"<function=([\s\S]*?)</function>"#, options: .regularExpression)
-        else { return nil }
+        else {
+            // The `qwen` capability stamp covers two wire formats: Qwen3-Coder
+            // emits the `<function=…><parameter=…>` XML handled above, but
+            // Qwen3 (non-coder) and deepseek_v3-arch bundles such as
+            // Kanana-2-30B-A3B emit a JSON object inside the `<tool_call>` tags
+            // (`<tool_call>\n{"name": …, "arguments": …}\n</tool_call>`) per their
+            // chat template. The XML pattern never matches that, so the call
+            // would be silently dropped. Fall back to JSON decoding — only when
+            // no `<function=>` block is present and the body is a JSON object —
+            // so the same stamp drives both forms with no regression to the XML
+            // path (it is still tried first) and no risk to non-tool prose.
+            return parseJSONToolCallFallback(content)
+        }
 
         let funcContent = String(content[funcMatch])
 
@@ -128,6 +140,26 @@ public struct XMLFunctionParser: ToolCallParser, Sendable {
         }
 
         return ToolCall(function: .init(name: funcName, arguments: arguments))
+    }
+
+    /// Qwen JSON wire form fallback: `<tool_call>{"name": …, "arguments": …}</tool_call>`.
+    /// Strips the surrounding start/end tags (if present) and decodes the body as a
+    /// `ToolCall.Function`, mirroring `JSONToolCallParser`. Returns nil unless the body
+    /// is a JSON object so ordinary prose is never misread as a tool call.
+    private func parseJSONToolCallFallback(_ content: String) -> ToolCall? {
+        var text = content
+        if let startTag, let r = text.range(of: startTag) {
+            text = String(text[r.upperBound...])
+        }
+        if let endTag, let r = text.range(of: endTag) {
+            text = String(text[..<r.lowerBound])
+        }
+        let jsonStr = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard jsonStr.hasPrefix("{"), jsonStr.hasSuffix("}"),
+            let data = jsonStr.data(using: .utf8),
+            let function = try? JSONDecoder().decode(ToolCall.Function.self, from: data)
+        else { return nil }
+        return ToolCall(function: function)
     }
 
     private func schemaValidationFailure(

--- a/Tests/MLXLMTests/ToolTests.swift
+++ b/Tests/MLXLMTests/ToolTests.swift
@@ -131,6 +131,39 @@ struct ToolTests {
         #expect(toolCall.function.arguments["query"] == .string("swift programming"))
     }
 
+    // MARK: - XMLFunctionParser dual-format (qwen XML + qwen JSON)
+
+    @Test("XMLFunctionParser - Qwen3-Coder <function=> XML form still parses")
+    func testXMLFunctionParserXMLForm() throws {
+        let parser = XMLFunctionParser(startTag: "<tool_call>", endTag: "</tool_call>")
+        let content =
+            "<function=get_weather><parameter=location>Paris</parameter></function>"
+        let toolCall = try #require(parser.parse(content: content, tools: nil))
+        #expect(toolCall.function.name == "get_weather")
+        #expect(toolCall.function.arguments["location"] == .string("Paris"))
+    }
+
+    @Test("XMLFunctionParser - Qwen JSON form (Kanana/Qwen3) parses via fallback")
+    func testXMLFunctionParserJSONFallback() throws {
+        // Kanana-2-30B-A3B (deepseek_v3) and Qwen3 (non-coder) stamp
+        // tool_parser: "qwen" → .xmlFunction but emit the JSON wire form per
+        // their chat template. The fallback must decode it (regression: was
+        // silently dropped → no structured tool call).
+        let parser = XMLFunctionParser(startTag: "<tool_call>", endTag: "</tool_call>")
+        // The processor strips the leading <tool_call> tag before parse(); the
+        // segment retains the trailing close tag + the model's newlines.
+        let content = "\n{\"name\": \"get_weather\", \"arguments\": {\"location\": \"Tokyo\"}}\n</tool_call>"
+        let toolCall = try #require(parser.parse(content: content, tools: nil))
+        #expect(toolCall.function.name == "get_weather")
+        #expect(toolCall.function.arguments["location"] == .string("Tokyo"))
+    }
+
+    @Test("XMLFunctionParser - prose is not misread as a tool call")
+    func testXMLFunctionParserIgnoresProse() throws {
+        let parser = XMLFunctionParser(startTag: "<tool_call>", endTag: "</tool_call>")
+        #expect(parser.parse(content: "I will check the weather for you.", tools: nil) == nil)
+    }
+
     // MARK: - Pythonic Format Tests (LFM2/LFM2.5)
 
     @Test("Test Pythonic Tool Call Parser - Basic")


### PR DESCRIPTION
Two engine fixes to run deepseek_v3-arch JANG bundles (e.g. Kanana-2-30B-A3B-Instruct-JANG_4M — MLA + 128-expert MoE, `tool_parser: "qwen"`).

## 1. `DeepseekV3Configuration.qLoraRank: Int -> Int?`
DeepSeek-V3 671B compresses Q via a LoRA (`q_a_proj`/`q_b_proj`), but smaller deepseek_v3 bundles set `q_lora_rank: null` and use a direct `q_proj`. The attention already branches on `qLoraRank == nil`; the config must accept null/absent or Codable throws "Missing value at 'q_lora_rank'" on load.

## 2. XMLFunctionParser JSON-form fallback
The `qwen` capability stamp maps to `.xmlFunction`, whose parser only matched the Qwen3-Coder `<function=name><parameter=...>` XML form. Qwen3 (non-coder) and deepseek_v3 bundles emit the JSON wire form per their chat template:

    <tool_call>\n{"name": ..., "arguments": ...}\n</tool_call>

The XML pattern never matched, so a well-formed call was silently dropped (no structured `.toolCall` event). `parse` now falls back to JSON decoding when no `<function=>` block is present and the body is a JSON object — XML form is still tried first (no qwen-coder regression), scoped to inside the tool tags, prose never misread.

Adds ToolTests coverage for both wire forms + a prose-negative case.

## Proof
- Engine (RunBench): q_lora=null loads; coherent EN/KO; tool call `get_weather({"location":"Tokyo"})` emitted at temp 0; L2 disk-cache restore 8.4x prompt-eval speedup.
- Live in osaurus.app (repinned to this commit): loads default settings, 17+28->45, multiturn recall, tool-call round-trip (call->result->final), reasoning-in-content, default native fp16 KV (no TurboQuant).

Confined to `DeepseekV3.swift` (standard model — Ling/DSV4/MiniMax use separate files) + `XMLFunctionParser.swift` (XML path unchanged).