### PR TITLE
Fix VMLXHub Swift 6 concurrency build

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -106,7 +106,8 @@ import PackageDescription
 #endif
 
 let transformersSwiftSettings: [SwiftSetting] = [
-    .enableExperimentalFeature("StrictConcurrency")
+    .enableExperimentalFeature("StrictConcurrency"),
+    .swiftLanguageMode(.v5),
 ]
 
 let mlxLMCommonExcludedFiles: [String] = [


### PR DESCRIPTION
## Summary
- Compile vendored swift-transformers targets in Swift 5 language mode while keeping strict concurrency enabled.
- Fixes Swift 6/Xcode beta builds failing in VMLXHub/HubApi with a sendability diagnostic for repo access.

## Verification
- Used by PeykaCore via fork revision f647dc959f486c2322d863a3dceb3721b403c84a.
- Clean PeykaCore focused test build reached and passed the cloud employee/provider tests after pinning this revision.