### PR TITLE
Fix concurrent-GPU crash drain + load standalone chat_template.jinja

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -2673,6 +2673,22 @@ public actor BatchEngine {
             }
         }
 
+        // Drain the GPU before signaling end-of-stream. Everything above —
+        // the decode tail and the end-of-turn cache store (`MLX.eval` on
+        // trimmed/boundary snapshots, hybrid-SSM re-derive forward passes) —
+        // only SUBMITS work; MLX completes it asynchronously on its stream
+        // thread. The host releases the process-wide GPU gate (osaurus'
+        // MetalGate) when this stream finishes, so if the next exclusive
+        // producer (image generation via a second MLX graph, the embedder, a
+        // model load) starts while this cache-store eval is still in flight,
+        // the two race on the shared Metal command buffer and crash
+        // (EXC_BAD_ACCESS in `tryCoalescingPreviousComputeCommandEncoder`, or
+        // `addCompletedHandler: provided after commit call`). Synchronizing on
+        // THIS thread — which owns the command buffers — drains them in order
+        // with no foreign-commit hazard, so "stream finished" provably means
+        // "GPU idle." Mirrors the solo-fast-path drain in `finishSoloFastPath`.
+        Stream().synchronize()
+
         slot.continuation.finish()
 
         // Long-context pressure relief: the global memoryPurgeInterval (256

--- a/Libraries/MLXLMCommon/JangLoader.swift
+++ b/Libraries/MLXLMCommon/JangLoader.swift
@@ -985,7 +985,30 @@ public struct JangLoader: Sendable {
             return template
         }()
 
-        guard zayaToolAware || lfm2ToolAware || sidecarTemplate != nil else {
+        // Modern-HuggingFace fallback: current `transformers` ships the chat
+        // template as a standalone `chat_template.jinja` text file and leaves
+        // `tokenizer_config.json` without an inline `chat_template`. swift-
+        // transformers only reads the inline field, so such a model is prompted
+        // with no turn structure — an instruct model then emits EOS/pad
+        // immediately and the response detokenizes to empty (observed on
+        // LFM2.5 mxfp4/mxfp8 and VibeThinker-3B mxfp4/mxfp8/jang). When there is
+        // no usable inline template and no more-specific substitution above
+        // applies, inject the model's own `.jinja` template verbatim.
+        let genericJinjaTemplate: String? = {
+            if let currentTemplate, !currentTemplate.isEmpty { return nil }
+            let jinjaURL = directory.appendingPathComponent("chat_template.jinja")
+            guard fileManager.fileExists(atPath: jinjaURL.path),
+                  let text = try? String(contentsOf: jinjaURL, encoding: .utf8),
+                  !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            else {
+                return nil
+            }
+            return text
+        }()
+
+        guard zayaToolAware || lfm2ToolAware || sidecarTemplate != nil
+            || genericJinjaTemplate != nil
+        else {
             return directory
         }
         if !zayaToolAware,
@@ -1001,8 +1024,10 @@ public struct JangLoader: Sendable {
             effectiveTemplate = ChatTemplateFallbacks.zayaVLVisionToolMinimal
         } else if lfm2ToolAware {
             effectiveTemplate = ChatTemplateFallbacks.lfm2ToolMinimal
+        } else if let sidecarTemplate {
+            effectiveTemplate = sidecarTemplate
         } else {
-            effectiveTemplate = sidecarTemplate!
+            effectiveTemplate = genericJinjaTemplate!
         }
         configJSON["chat_template"] = effectiveTemplate
 


### PR DESCRIPTION
Two runtime fixes proven via exhaustive 18-model live E2E (osaurus dev app).

## 1. BatchEngine: drain GPU before finishing the stream
`finishSlot` released the host GPU gate (`continuation.finish()`) while the async MLX eval tail (decode + cache store + SSM re-derive) was still in flight. When a chat turn was immediately followed by image generation (a second MLX graph on the shared Metal device), the two producers raced → SIGSEGV in `AGXG17XFamilyCommandBuffer` / SIGABRT "addCompletedHandler after commit". Adding a `Stream().synchronize()` before finishing the stream drains the tail first. Verified: 0 crashes across all 18 models (incl. 35b/31b/30b + minimax) under repeated chat↔image handoff.

## 2. JangLoader: load standalone chat_template.jinja
Modern `transformers` ships the chat template as a standalone `chat_template.jinja` text file and leaves `tokenizer_config.json` without an inline `chat_template`. swift-transformers only reads the inline field, so affected models (LFM2.5 mxfp4/mxfp8, VibeThinker-3B mxfp4/mxfp8/jang) got no turn structure → the instruct model emitted EOS/pad immediately → empty output. `resolveChatTemplateSidecarSubstitution` now falls back to the model's own `.jinja` file when no inline template and no more-specific substitution applies. Verified: both families now coherent, lfm2 tool-calls correctly.

Both apply cleanly on top of main (4453909e).