### PR TITLE
fix mistral3 vlm crash on flat rope_theta configs

### DIFF
--- a/Libraries/MLXVLM/Models/Mistral3.swift
+++ b/Libraries/MLXVLM/Models/Mistral3.swift
@@ -335,16 +335,16 @@ private enum Language {
             self._wv.wrappedValue = Linear(dim, nKVHeads * headDim, bias: false)
             self._wo.wrappedValue = Linear(nHeads * headDim, dim, bias: false)
 
-            // Initialize RoPE using rope_parameters - rope_theta is required like in Python
-            guard let ropeParams = config.ropeParameters,
-                let ropeTheta = ropeParams["rope_theta"]?.asFloat()
-            else {
-                fatalError("rope_parameters['rope_theta'] is required")
-            }
+            // RoPE base: prefer the nested rope_parameters["rope_theta"]
+            // (Ministral-3.x layout), else the flat top-level rope_theta
+            // (standard Mistral/Ministral configs). Both are parsed by
+            // the config; only the nested dict drives scaling.
+            let ropeTheta = config.ropeParameters?["rope_theta"]?.asFloat()
+                ?? config.ropeTheta
             self.rope = initializeRope(
                 dims: headDim,
                 base: ropeTheta,
-                traditional: false,
+                traditional: config.ropeTraditional,
                 scalingConfig: config.ropeParameters,
                 maxPositionEmbeddings: config.maxPositionEmbeddings
             )


### PR DESCRIPTION
- Fixed a fatal crash at model-load time when loading Mistral3 / Ministral VLM bundles whose `text_config` specifies `rope_theta` as a flat top-level field instead of a nested `rope_parameters` dict.
- Removed the hard `fatalError` in the language attention initializer that aborted the entire app when `rope_parameters` was absent.
- Fell back to the top-level `rope_theta` value (already parsed by the config, with a sane default) when the nested `rope_parameters` dict is not present, keeping the nested layout authoritative when it exists.
- Wired the RoPE `traditional` flag to the parsed `rope_traditional` config value rather than a hardcoded `false`.
- Resolved the production crash reported for standard Mistral and Ministral config layouts that previously could not be loaded.