### PR TITLE
Fix Mistral3/Pixtral VLM load on flat-rope and split-processor configs

### DIFF
--- a/Libraries/MLXVLM/Models/Mistral3.swift
+++ b/Libraries/MLXVLM/Models/Mistral3.swift
@@ -335,16 +335,16 @@ private enum Language {
             self._wv.wrappedValue = Linear(dim, nKVHeads * headDim, bias: false)
             self._wo.wrappedValue = Linear(nHeads * headDim, dim, bias: false)
 
-            // Initialize RoPE using rope_parameters - rope_theta is required like in Python
-            guard let ropeParams = config.ropeParameters,
-                let ropeTheta = ropeParams["rope_theta"]?.asFloat()
-            else {
-                fatalError("rope_parameters['rope_theta'] is required")
-            }
+            // RoPE base: prefer the nested rope_parameters["rope_theta"]
+            // (Ministral-3.x layout), else the flat top-level rope_theta
+            // (standard Mistral/Ministral configs). Both are parsed by
+            // the config; only the nested dict drives scaling.
+            let ropeTheta = config.ropeParameters?["rope_theta"]?.asFloat()
+                ?? config.ropeTheta
             self.rope = initializeRope(
                 dims: headDim,
                 base: ropeTheta,
-                traditional: false,
+                traditional: config.ropeTraditional,
                 scalingConfig: config.ropeParameters,
                 maxPositionEmbeddings: config.maxPositionEmbeddings
             )
@@ -988,6 +988,31 @@ public struct Mistral3VLMProcessorConfiguration: Codable, Sendable {
     public let imageEndToken: String?
     public let patchSize: Int
     public let spatialMergeSize: Int?
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        // Image-processor params live under a nested `image_processor` key in
+        // osaurus's combined bundles, but at the top level in the split HF
+        // layout (preprocessor_config.json — e.g. PixtralImageProcessorFast,
+        // as shipped by mlx-community Mistral-Small-3.1/3.2). Accept both so
+        // externally-packaged Mistral3/Pixtral VLMs load, not just combined ones.
+        if let nested = try c.decodeIfPresent(ImageProcessorConfig.self, forKey: .imageProcessor) {
+            self.imageProcessor = nested
+        } else {
+            self.imageProcessor = try ImageProcessorConfig(from: decoder)
+        }
+        // Pixtral/Mistral3 image tokens are standardized; the split layout keeps
+        // them in processor_config.json, which the preprocessor-preferring loader
+        // does not read — fall back to the canonical values when absent.
+        self.imageToken = try c.decodeIfPresent(String.self, forKey: .imageToken) ?? "[IMG]"
+        self.imageBreakToken =
+            try c.decodeIfPresent(String.self, forKey: .imageBreakToken) ?? "[IMG_BREAK]"
+        self.imageEndToken =
+            try c.decodeIfPresent(String.self, forKey: .imageEndToken) ?? "[IMG_END]"
+        self.patchSize =
+            try c.decodeIfPresent(Int.self, forKey: .patchSize) ?? imageProcessor.patchSize
+        self.spatialMergeSize = try c.decodeIfPresent(Int.self, forKey: .spatialMergeSize)
+    }
 
     public struct ImageProcessorConfig: Codable, Sendable {
         public let imageMean: [CGFloat]

--- a/Libraries/MLXVLM/Models/Mistral3VLMJANGTQ.swift
+++ b/Libraries/MLXVLM/Models/Mistral3VLMJANGTQ.swift
@@ -58,15 +58,15 @@ internal final class Mistral3JANGTQAttention: Module {
             inFeatures: nHeads * headDim, outFeatures: dim,
             bits: bits, seed: seed, bias: false)
 
-        guard let ropeParams = config.ropeParameters,
-            let ropeTheta = ropeParams["rope_theta"]?.asFloat()
-        else {
-            fatalError("rope_parameters['rope_theta'] is required")
-        }
+        // RoPE base: prefer nested rope_parameters["rope_theta"] (Ministral-3.x
+        // layout), else the flat top-level rope_theta (standard Mistral/Ministral).
+        // Mirrors the fp Mistral3 path; only the nested dict drives scaling.
+        let ropeTheta = config.ropeParameters?["rope_theta"]?.asFloat()
+            ?? config.ropeTheta
         self.rope = initializeRope(
             dims: headDim,
             base: ropeTheta,
-            traditional: false,
+            traditional: config.ropeTraditional,
             scalingConfig: config.ropeParameters,
             maxPositionEmbeddings: config.maxPositionEmbeddings
         )

--- a/Libraries/MLXVLM/Models/Pixtral.swift
+++ b/Libraries/MLXVLM/Models/Pixtral.swift
@@ -954,6 +954,25 @@ public struct PixtralProcessorConfiguration: Codable, Sendable {
     public let imageEndToken: String?
     public let patchSize: Int
 
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        // Accept both the nested `image_processor` layout (combined bundles) and
+        // the flat top-level layout (split HF preprocessor_config.json, e.g.
+        // mlx-community Pixtral). Mirrors Mistral3VLMProcessorConfiguration.
+        if let nested = try c.decodeIfPresent(ImageProcessorConfig.self, forKey: .imageProcessor) {
+            self.imageProcessor = nested
+        } else {
+            self.imageProcessor = try ImageProcessorConfig(from: decoder)
+        }
+        self.imageToken = try c.decodeIfPresent(String.self, forKey: .imageToken) ?? "[IMG]"
+        self.imageBreakToken =
+            try c.decodeIfPresent(String.self, forKey: .imageBreakToken) ?? "[IMG_BREAK]"
+        self.imageEndToken =
+            try c.decodeIfPresent(String.self, forKey: .imageEndToken) ?? "[IMG_END]"
+        self.patchSize =
+            try c.decodeIfPresent(Int.self, forKey: .patchSize) ?? imageProcessor.patchSize
+    }
+
     public struct ImageProcessorConfig: Codable, Sendable {
         public let imageMean: [CGFloat]
         public let imageStd: [CGFloat]


### PR DESCRIPTION
## Problem
Loading a Mistral3 / Ministral / Pixtral **VLM** bundle packaged in the standard Hugging Face layout fatally crashes the app at model-load time. Two distinct root causes:

1. **Flat `rope_theta`** — the language attention hard-required a nested `rope_parameters['rope_theta']` and called `fatalError` otherwise. Standard Mistral/Ministral configs put `rope_theta` flat at the top level. This is the Sentry crash `EXC_BREAKPOINT … Mistral3.swift: rope_parameters['rope_theta'] is required`. Present in **both** `Mistral3.swift` (fp) and `Mistral3VLMJANGTQ.swift` (quantized).
2. **Split processor config** — the VLM processor decoded image-processor fields only from a nested `image_processor` key. The split HF layout keeps image params flat in `preprocessor_config.json` and tokens in `processor_config.json`; the preprocessor-preferring loader then threw `DecodingError.keyNotFound: image_processor`. Present in `Mistral3.swift` and the structurally identical `Pixtral.swift`.

The crash-triggering external models (e.g. `mlx-community/Mistral-Small-3.1/3.2`, Pixtral) ship **both** layouts, so fix #1 alone only moves the crash downstream — both are required.

## Fix
- RoPE: fall back to flat `config.ropeTheta` when `rope_parameters['rope_theta']` is absent; wire `rope_traditional`. (`Mistral3.swift`, `Mistral3VLMJANGTQ.swift`)
- Processor: tolerant `init(from:)` accepting nested **or** flat top-level image-processor fields, defaulting the standard Pixtral image tokens when absent. (`Mistral3.swift`, `Pixtral.swift`)
- `Gemma4` ships `processor_config.json` (nested) and is unaffected — left untouched.

## Proof
On `mlx-community/Mistral-Small-3.1-24B-Instruct-2503-4bit` (unmodified, split layout):
- **Pre-fix:** `Mistral3.swift: Fatal error: rope_parameters['rope_theta'] is required`.
- **Post-fix:** loads as `Mistral3VLM` (~0.9s), coherent multi-turn ("blue" recalled across turns), image preprocessing produces the correct patch-token count and the vision tower runs. No regression on combined-layout bundles (nested branch is taken first).

Supersedes #83 — that PR fixed only the fp rope path; this also covers the JANGTQ twin and the split-processor blocker #83 left unresolved.