### PR TITLE
Mistral tools/reasoning/vision native: complete template + JSON-array tool parser

### DIFF
--- a/Libraries/MLXLMCommon/ChatTemplates/ChatTemplateFallbacks.swift
+++ b/Libraries/MLXLMCommon/ChatTemplates/ChatTemplateFallbacks.swift
@@ -852,6 +852,76 @@ value_1
 {%- endfor -%}
 """#
 
+    /// Complete Mistral 3.x chat template for bundles that ship only the
+    /// vision-only `chat_template.json` (e.g. mlx-community Mistral-Small-3.1 /
+    /// 3.2): `[SYSTEM_PROMPT]` + `[INST]` + `[IMG]` but NO tool support, and a
+    /// `raise_exception` on a `tool` role. Mistral-Small-3.x does tools natively
+    /// via the tekken `[TOOL_CALLS]name[ARGS]{json}` format (see
+    /// MistralToolCallParser); the HF chat_template never rendered it, so tools
+    /// went ungrounded and the model hallucinated a foreign format.
+    ///
+    /// This template preserves the native Mistral surface and adds the missing
+    /// pieces, so reasoning / tools / vision all work natively:
+    /// - `[SYSTEM_PROMPT]` (passthrough or a Mistral default),
+    /// - `[MODEL_SETTINGS]{"reasoning_effort": ...}` ONLY when a meaningful
+    ///   `reasoning_effort` is set (Magistral / 3.5); omitted for non-reasoning
+    ///   2503 so its prompt is byte-native,
+    /// - `[AVAILABLE_TOOLS]<tools json>[/AVAILABLE_TOOLS]` rendered immediately
+    ///   before the last user turn (Mistral's canonical placement),
+    /// - `[INST]...[/INST]` with `[IMG]` for image blocks (vision preserved),
+    /// - assistant tool calls as `[TOOL_CALLS]name[ARGS]{args}` (tekken-native,
+    ///   round-trips with the parser), and `[TOOL_RESULTS]...[/TOOL_RESULTS]`
+    ///   for the tool role.
+    public static let mistral3CompleteMinimal: String = #"""
+{%- set ns = namespace(last_user_index=-1) -%}
+{%- for message in messages -%}
+{%- if message['role'] == 'user' -%}{%- set ns.last_user_index = loop.index0 -%}{%- endif -%}
+{%- endfor -%}
+{%- set default_system = "You are Mistral Small, a Large Language Model (LLM) created by Mistral AI, a French startup headquartered in Paris.\nWhen you're not sure about some information, you say that you don't have the information and don't make up anything." -%}
+{{- bos_token -}}
+{%- if messages and messages[0]['role'] == 'system' -%}
+{{- '[SYSTEM_PROMPT]' -}}
+{%- if messages[0]['content'] is string -%}{{- messages[0]['content'] -}}
+{%- else -%}{%- for item in messages[0]['content'] -%}{%- if item['type'] == 'text' -%}{{- item['text'] -}}{%- endif -%}{%- endfor -%}{%- endif -%}
+{{- '[/SYSTEM_PROMPT]' -}}
+{%- else -%}
+{{- '[SYSTEM_PROMPT]' + default_system + '[/SYSTEM_PROMPT]' -}}
+{%- endif -%}
+{%- set effort = reasoning_effort | default('') -%}
+{%- if effort and effort != 'none' and effort != 'default' -%}
+{{- '[MODEL_SETTINGS]{"reasoning_effort": "' + effort + '"}[/MODEL_SETTINGS]' -}}
+{%- endif -%}
+{%- for message in messages -%}
+{%- if message['role'] == 'system' -%}
+{%- elif message['role'] == 'user' -%}
+{%- if tools and loop.index0 == ns.last_user_index -%}
+{{- '[AVAILABLE_TOOLS]' + (tools | tojson) + '[/AVAILABLE_TOOLS]' -}}
+{%- endif -%}
+{{- '[INST]' -}}
+{%- if message['content'] is string -%}{{- message['content'] -}}
+{%- else -%}{%- for item in message['content'] -%}{%- if item['type'] == 'text' -%}{{- item['text'] -}}{%- elif item['type'] == 'image' or item['type'] == 'image_url' -%}{{- '[IMG]' -}}{%- endif -%}{%- endfor -%}{%- endif -%}
+{{- '[/INST]' -}}
+{%- elif message['role'] == 'assistant' -%}
+{%- if message['tool_calls'] -%}
+{%- for tc in message['tool_calls'] -%}
+{%- set fn = tc['function'] if tc['function'] is defined else tc -%}
+{{- '[TOOL_CALLS]' + fn['name'] + '[ARGS]' -}}
+{%- if fn['arguments'] is string -%}{{- fn['arguments'] -}}{%- else -%}{{- fn['arguments'] | tojson -}}{%- endif -%}
+{%- endfor -%}
+{{- eos_token -}}
+{%- else -%}
+{%- if message['content'] is string -%}{{- message['content'] -}}
+{%- else -%}{%- for item in message['content'] -%}{%- if item['type'] == 'text' -%}{{- item['text'] -}}{%- endif -%}{%- endfor -%}{%- endif -%}
+{{- eos_token -}}
+{%- endif -%}
+{%- elif message['role'] == 'tool' -%}
+{{- '[TOOL_RESULTS]' -}}
+{%- if message['content'] is string -%}{{- message['content'] -}}{%- else -%}{{- message['content'] | tojson -}}{%- endif -%}
+{{- '[/TOOL_RESULTS]' -}}
+{%- endif -%}
+{%- endfor -%}
+"""#
+
     /// MiniMax-M2 minimal chat template that honors `enable_thinking`.
     /// The bundle-shipped native template ignores the flag and always
     /// prefills `<think>\n` at the assistant tail. That makes the model

--- a/Libraries/MLXLMCommon/JangLoader.swift
+++ b/Libraries/MLXLMCommon/JangLoader.swift
@@ -1035,13 +1035,37 @@ public struct JangLoader: Sendable {
             return template
         }()
 
+        // Mistral 3.x packs whose template (inline OR chat_template.json) is the
+        // vision/text `[INST]` format with NO tool support (e.g. mlx-community
+        // Mistral-Small-3.1/3.2 ship only the HF vision template). Mistral does
+        // tools natively via the tekken `[TOOL_CALLS]name[ARGS]{}` format, but
+        // the shipped template never renders `[AVAILABLE_TOOLS]`, so tools go
+        // ungrounded. Swap in the complete Mistral template, which preserves the
+        // native `[INST]`/`[IMG]` surface and adds tools + conditional reasoning.
+        // Data-driven (`[INST]` present, `[AVAILABLE_TOOLS]` absent), not by name.
+        let mistralCompleteTemplate: String? = {
+            let existing: String? = {
+                if let currentTemplate, !currentTemplate.isEmpty { return currentTemplate }
+                return sidecarTemplate ?? genericJsonTemplate
+            }()
+            guard let existing,
+                  existing.contains("[INST]"),
+                  !existing.contains("[AVAILABLE_TOOLS]")
+            else {
+                return nil
+            }
+            return ChatTemplateFallbacks.mistral3CompleteMinimal
+        }()
+
         guard zayaToolAware || lfm2ToolAware || sidecarTemplate != nil
             || genericJinjaTemplate != nil || genericJsonTemplate != nil
+            || mistralCompleteTemplate != nil
         else {
             return directory
         }
         if !zayaToolAware,
            !lfm2ToolAware,
+           mistralCompleteTemplate == nil,
            let currentTemplate,
            isVisionChatTemplate(currentTemplate)
         {
@@ -1053,6 +1077,8 @@ public struct JangLoader: Sendable {
             effectiveTemplate = ChatTemplateFallbacks.zayaVLVisionToolMinimal
         } else if lfm2ToolAware {
             effectiveTemplate = ChatTemplateFallbacks.lfm2ToolMinimal
+        } else if let mistralCompleteTemplate {
+            effectiveTemplate = mistralCompleteTemplate
         } else if let sidecarTemplate {
             effectiveTemplate = sidecarTemplate
         } else if let genericJinjaTemplate {

--- a/Libraries/MLXLMCommon/Tool/Parsers/MistralToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/MistralToolCallParser.swift
@@ -66,10 +66,6 @@ public struct MistralToolCallParser: ToolCallParser, Sendable {
     public func parseEOS(
         _ toolCallBuffer: String, tools: [[String: any Sendable]]?
     ) -> [ToolCall] {
-        if ProcessInfo.processInfo.environment["VMLX_TOOL_DEBUG"] == "1" {
-            try? ("BUFFER>>>" + toolCallBuffer + "<<<\n")
-                .write(toFile: "/tmp/vmlx_tool_buffer.log", atomically: true, encoding: .utf8)
-        }
         // Each `[TOOL_CALLS]` segment is either a single `name[ARGS]{json}` call
         // (V13) or a JSON array/object that may itself carry multiple calls (V7).
         let segments =

--- a/Libraries/MLXLMCommon/Tool/Parsers/MistralToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/MistralToolCallParser.swift
@@ -2,22 +2,27 @@
 
 import Foundation
 
-/// Parser for Mistral V13 tool call format: `[TOOL_CALLS]name[ARGS]{"json_args"}`
+/// Parser for the Mistral tekken tool-call formats.
 ///
-/// This format is used by Mistral3/Ministral-3 2512 models and Devstral 2.
-/// The special tokens `[TOOL_CALLS]` (token ID 9) and `[ARGS]` (ID 32) are used
-/// as delimiters. Multiple tool calls use repeated `[TOOL_CALLS]` tokens.
+/// Mistral has shipped two on-the-wire encodings, both opened by the
+/// `[TOOL_CALLS]` special token (ID 9) and ended at EOS (no end tag):
 ///
-/// Also handles the older V11 format which includes an optional `[CALL_ID]`
-/// between the function name and `[ARGS]` (V13 does not use `[CALL_ID]`).
+/// - V7 / V11 (Mistral-Small-3.1/3.2 2503/2506, Pixtral): a JSON array of
+///   call objects — `[TOOL_CALLS][{"name": "get_weather", "arguments": {...}}]`.
+///   These tokenizers do NOT contain an `[ARGS]` token.
+/// - V13 (Mistral-3 2512, Devstral 2): `[TOOL_CALLS]name[ARGS]{json}`, with an
+///   optional `[CALL_ID]` between the name and `[ARGS]` (the V11 variant).
+///
+/// This parser accepts both: it uses `[ARGS]` when present, otherwise decodes
+/// the remainder as a JSON array (or single object) of `{name, arguments}`.
+/// Since stop tokens are intercepted at the token-ID level before
+/// detokenization, the buffered tool body is handed to `parseEOS()` at the end
+/// of generation.
 ///
 /// Examples:
+/// - `[TOOL_CALLS][{"name": "get_weather", "arguments": {"city": "Tokyo"}}]`
 /// - `[TOOL_CALLS]get_weather[ARGS]{"location": "Tokyo"}`
 /// - `[TOOL_CALLS]fn1[ARGS]{...}[TOOL_CALLS]fn2[ARGS]{...}` (multiple calls)
-///
-/// Mistral does not use an end tag — tool calls end at EOS. Since stop tokens
-/// are intercepted at the token ID level before detokenization, tool calls are
-/// extracted via `ToolCallProcessor.processEOS()` at generation end.
 public struct MistralToolCallParser: ToolCallParser, Sendable {
     public let startTag: String? = "[TOOL_CALLS]"
     public let endTag: String? = nil
@@ -33,31 +38,94 @@ public struct MistralToolCallParser: ToolCallParser, Sendable {
             text = String(text.dropFirst(start.count))
             text = text.trimmingCharacters(in: .whitespacesAndNewlines)
         }
-        // Split on [ARGS] to get function name and arguments
-        guard let argsRange = text.range(of: "[ARGS]") else {
-            return nil
-        }
 
-        var namePart = String(text[..<argsRange.lowerBound])
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        let argsPart = String(text[argsRange.upperBound...])
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-
-        // Handle optional [CALL_ID] between name and [ARGS]
-        if let callIdRange = namePart.range(of: "[CALL_ID]") {
-            namePart = String(namePart[..<callIdRange.lowerBound])
+        // V13 / V11: `[name][CALL_ID?][ARGS]{json}`
+        if let argsRange = text.range(of: "[ARGS]") {
+            var namePart = String(text[..<argsRange.lowerBound])
                 .trimmingCharacters(in: .whitespacesAndNewlines)
+            let argsPart = String(text[argsRange.upperBound...])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+
+            // Handle optional [CALL_ID] between name and [ARGS]
+            if let callIdRange = namePart.range(of: "[CALL_ID]") {
+                namePart = String(namePart[..<callIdRange.lowerBound])
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+
+            guard !namePart.isEmpty else { return nil }
+            guard let argsDict = tryParseJSON(argsPart) as? [String: any Sendable] else {
+                return nil
+            }
+            return ToolCall(function: ToolCall.Function(name: namePart, arguments: argsDict))
         }
 
-        guard !namePart.isEmpty else { return nil }
+        // V7 / V11 (2503/2506): JSON array or single object of {name, arguments}.
+        return Self.firstToolCall(fromJSON: text)
+    }
 
-        // Parse arguments as JSON using tryParseJSON from ParserUtilities
-        guard let argsDict = tryParseJSON(argsPart) as? [String: any Sendable] else {
-            return nil
+    public func parseEOS(
+        _ toolCallBuffer: String, tools: [[String: any Sendable]]?
+    ) -> [ToolCall] {
+        if ProcessInfo.processInfo.environment["VMLX_TOOL_DEBUG"] == "1" {
+            try? ("BUFFER>>>" + toolCallBuffer + "<<<\n")
+                .write(toFile: "/tmp/vmlx_tool_buffer.log", atomically: true, encoding: .utf8)
         }
+        // Each `[TOOL_CALLS]` segment is either a single `name[ARGS]{json}` call
+        // (V13) or a JSON array/object that may itself carry multiple calls (V7).
+        let segments =
+            toolCallBuffer
+            .components(separatedBy: startTag ?? "[TOOL_CALLS]")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
 
-        return ToolCall(
-            function: ToolCall.Function(name: namePart, arguments: argsDict)
-        )
+        var calls: [ToolCall] = []
+        for segment in segments {
+            if segment.range(of: "[ARGS]") != nil {
+                if let call = parse(content: segment, tools: tools) {
+                    calls.append(call)
+                }
+            } else if let parsed = tryParseJSON(segment) as? [Any] {
+                for element in parsed {
+                    if let call = Self.toolCall(fromObject: element) {
+                        calls.append(call)
+                    }
+                }
+            } else if let call = Self.firstToolCall(fromJSON: segment) {
+                calls.append(call)
+            }
+        }
+        return calls
+    }
+
+    /// Decode a JSON array (first element) or single object into a `ToolCall`.
+    private static func firstToolCall(fromJSON text: String) -> ToolCall? {
+        let parsed = tryParseJSON(text)
+        if let array = parsed as? [Any] {
+            return array.lazy.compactMap { toolCall(fromObject: $0) }.first
+        }
+        return toolCall(fromObject: parsed)
+    }
+
+    /// Map a `{"name": ..., "arguments": ...}` (or `parameters`) object to a
+    /// `ToolCall`. Accepts string-encoded arguments as well as objects.
+    private static func toolCall(fromObject object: Any?) -> ToolCall? {
+        guard let dict = object as? [String: any Sendable] else { return nil }
+        // Some encodings nest under `function`.
+        if let fn = dict["function"] as? [String: any Sendable] {
+            return toolCall(fromObject: fn)
+        }
+        guard let name = (dict["name"] as? String), !name.isEmpty else { return nil }
+        let rawArgs = dict["arguments"] ?? dict["parameters"]
+        let args: [String: any Sendable]
+        if let mapping = rawArgs as? [String: any Sendable] {
+            args = mapping
+        } else if let string = rawArgs as? String,
+            let mapping = tryParseJSON(string) as? [String: any Sendable]
+        {
+            args = mapping
+        } else {
+            args = [:]
+        }
+        return ToolCall(function: ToolCall.Function(name: name, arguments: args))
     }
 }


### PR DESCRIPTION
Makes Mistral 3.x (Mistral-Small-3.1/3.2, Pixtral) tools, reasoning, and vision all work natively, not just load.

## Problem
mlx-community Mistral packs ship only the HF **vision** chat_template (`[SYSTEM_PROMPT]`/`[INST]`/`[IMG]`, **no tool support**, `raise_exception` on `tool` role). With tools passed the model was ungrounded and emitted a foreign ChatML/Hermes format that leaked `<|im_start|>`. And even when grounded, `MistralToolCallParser` only handled the V13 `[TOOL_CALLS]name[ARGS]{json}` format — but 2503/2506 tekken has **no `[ARGS]` token** and emits the JSON-array `[TOOL_CALLS][{"name":..,"arguments":..}]`, so calls were buffered then dropped (empty output, 0 visible tokens).

## Fix
1. `ChatTemplateFallbacks.mistral3CompleteMinimal` — native Mistral template: `[SYSTEM_PROMPT]` + `[INST]` + `[IMG]` (vision) + `[AVAILABLE_TOOLS]` before the last user turn + `[TOOL_CALLS]`/`[TOOL_RESULTS]` + `[MODEL_SETTINGS]` reasoning gated to a meaningful effort (omitted for non-reasoning 2503).
2. `JangLoader.resolveChatTemplateSidecarSubstitution` — data-driven wiring (Mistral `[INST]` template lacking `[AVAILABLE_TOOLS]` → use the complete template). (The osaurus-side tokenizer bridge has the matching selector.)
3. `MistralToolCallParser` — accept the JSON-array format (and string-encoded args / nested `function`) in addition to `[ARGS]`; `parseEOS` returns all array calls.

## Proof (live dev app, Mistral-Small-3.1-24B)
- Raw buffer confirmed: model emits `[TOOL_CALLS][{"name":"get_weather","arguments":{"city":"Tokyo"}}]`.
- Tools: `tool_calls` populated, finish=`tool_calls`. Tool round-trip → *"The weather in Tokyo is sunny with a temperature of 22°C."*
- Multi-turn (context), single-image VL (reads image correctly), reasoning (no `<think>`/`<|im_start|>`/`[INST]` leaks) — all native.
- Regression: qwen3-4b tools still work (Mistral-gated, no impact).

Builds on #84 (load crash) and #85 (chat_template.json loading).