### PR TITLE
JangLoader: tighten Mistral complete-template gating to [INST]+[SYSTEM_PROMPT]

### DIFF
--- a/Libraries/MLXLMCommon/JangLoader.swift
+++ b/Libraries/MLXLMCommon/JangLoader.swift
@@ -1048,8 +1048,13 @@ public struct JangLoader: Sendable {
                 if let currentTemplate, !currentTemplate.isEmpty { return currentTemplate }
                 return sidecarTemplate ?? genericJsonTemplate
             }()
+            // Require BOTH Mistral-family markers: `[INST]` alone is also used
+            // by Llama-2-family templates (which use `<<SYS>>`, not
+            // `[SYSTEM_PROMPT]`), so gate on `[SYSTEM_PROMPT]` too to avoid
+            // mis-applying the Mistral template to a non-Mistral `[INST]` model.
             guard let existing,
                   existing.contains("[INST]"),
+                  existing.contains("[SYSTEM_PROMPT]"),
                   !existing.contains("[AVAILABLE_TOOLS]")
             else {
                 return nil


### PR DESCRIPTION
Defensive follow-up to #86. The mistralCompleteTemplate selector matched on `[INST]` alone, which is also a Llama-2-family marker (Llama-2 uses `<<SYS>>`, not `[SYSTEM_PROMPT]`). Gate on `[SYSTEM_PROMPT]` too so a non-Mistral `[INST]` template is never swapped for the Mistral template via osaurus's bridge native path. No currently-served model was affected (only Mistral has `[INST]`, and it has `[SYSTEM_PROMPT]`); surfaced by questioning regressions. Mirrors the osaurus bridge's `[INST]+[SYSTEM_PROMPT]+[AVAILABLE_TOOLS]` gating.