### PR TITLE
DeepSeek-OCR / Unlimited-OCR support (DeepseekOCRForCausalLM) — engine verified

### DIFF
--- a/Libraries/MLXVLM/Models/DeepseekOCR.swift
+++ b/Libraries/MLXVLM/Models/DeepseekOCR.swift
@@ -110,6 +110,20 @@ public class DeepseekOCR: Module, VLMModel, KVCacheDimensionProvider {
         self._viewSeparator.wrappedValue = MLXArray.zeros([nEmbed])
     }
 
+    /// Debug: print mean/std/shape of an intermediate tensor when DSOCR_DUMP=1.
+    /// Used to localize numerical divergence vs the PyTorch reference (SAM /
+    /// CLIP / fused / projector ranges). No-op in normal operation.
+    static func dumpStat(_ name: String, _ x: MLXArray) {
+        guard ProcessInfo.processInfo.environment["DSOCR_DUMP"] == "1" else { return }
+        let xf = x.asType(.float32)
+        let m = xf.mean().item(Float.self)
+        let s = sqrt((xf * xf).mean().item(Float.self) - m * m)
+        let mn = xf.min().item(Float.self)
+        let mx = xf.max().item(Float.self)
+        FileHandle.standardError.write(Data(
+            "[stat] \(name): shape=\(x.shape) mean=\(m) std=\(s) min=\(mn) max=\(mx)\n".utf8))
+    }
+
     // MARK: get_input_embeddings
 
     /// Port of deepseekocr.py `Model.get_input_embeddings`.
@@ -166,15 +180,19 @@ public class DeepseekOCR: Module, VLMModel, KVCacheDimensionProvider {
 
             if let imagePatches, imagePatches.sum().item(Float.self) != 0 {
                 // --- local crop features ---
+                Self.dumpStat("crop.imagePatches", imagePatches)
                 let localFeatures1 = samModel(imagePatches.transposed(0, 2, 3, 1))
+                Self.dumpStat("crop.sam_out", localFeatures1)
                 let localFeatures2 = visionModel(
                     imagePatches.transposed(0, 2, 3, 1), patchEmbeds: localFeatures1)
+                Self.dumpStat("crop.clip_out", localFeatures2)
                 var localFeatures = concatenated(
                     [
                         localFeatures2[0..., 1...],
                         flattened(localFeatures1, start: 1, end: 2),
                     ], axis: -1)
                 localFeatures = projector(localFeatures)
+                Self.dumpStat("crop.localProjected", localFeatures)
 
                 // --- global view features ---
                 let globalFeatures1 = samModel(imageOriSingle.transposed(0, 2, 3, 1))
@@ -236,7 +254,14 @@ public class DeepseekOCR: Module, VLMModel, KVCacheDimensionProvider {
                         globalFeatures2[0..., 1...],
                         flattened(globalFeatures1, start: 1, end: 2),
                     ], axis: -1)
+                Self.dumpStat("imageOri", imageOriSingle)
+                Self.dumpStat("sam_out(globalFeatures1)", globalFeatures1)
+                Self.dumpStat("clip_out(globalFeatures2)", globalFeatures2)
+                Self.dumpStat("fused", globalFeatures)
                 globalFeatures = projector(globalFeatures)
+                Self.dumpStat("projected", globalFeatures)
+                Self.dumpStat("image_newline", imageNewline)
+                Self.dumpStat("view_separator", viewSeparator)
 
                 globalFeatures = globalFeatures[0]
                 let hw = globalFeatures.dim(0)
@@ -323,9 +348,14 @@ public class DeepseekOCR: Module, VLMModel, KVCacheDimensionProvider {
     public func prepare(_ input: LMInput, cache: [any KVCache], windowSize: Int?) throws
         -> PrepareResult
     {
-        // SAM's PatchEmbed is `private` in its component file, so derive the
-        // working dtype from a reachable weight (the text embedding table).
-        let dtype = languageModel.model.embedTokens.weight.dtype
+        // Working float dtype for the pixel buffer. Must NOT be taken from the
+        // text embedding table: under quantization that weight is uint32 (a
+        // QuantizedEmbedding), and casting normalized [-1,1] pixels to uint32
+        // truncates every value to 0 (the whole global view became zero, which
+        // tripped the `imageOri.sum()==0` guard and silently dropped image
+        // injection). `image_newline` is a plain learned parameter in the
+        // embedding space (bf16), so it gives the correct float dtype.
+        let dtype = imageNewline.dtype
 
         let inputIds = input.text.tokens
         let seqMask = input.text.mask

--- a/Libraries/MLXVLM/Models/DeepseekOCR.swift
+++ b/Libraries/MLXVLM/Models/DeepseekOCR.swift
@@ -1,0 +1,406 @@
+//
+//  DeepseekOCR.swift
+//  mlx-swift-lm
+//
+//  Top-level DeepSeek-OCR / Unlimited-OCR VLM (DeepseekOCRForCausalLM, top
+//  model_type "deepseek_vl_v2"). Wires together the four already-ported
+//  component towers:
+//
+//    - `vision_model`   (DeepseekOCRVisionModel)   CLIP-L/14 ViT
+//    - `sam_model`      (DeepseekOCRSAMEncoder)     SAM-ViT-B
+//    - `language_model` (DeepseekOCRLanguageModel)  DeepSeek-V2 MoE decoder
+//    - `projector`      (MlpProjector)              vision feat dim -> n_embed
+//
+//  plus the two formatting parameters `image_newline` and `view_separator`.
+//
+//  Faithful port of mlx-vlm's deepseekocr/deepseekocr.py — the orchestration in
+//  `get_input_embeddings` (SAM+CLIP fusion, projector, 2D image tiling with
+//  per-row image_newline and trailing view_separator, scatter into the text
+//  embeddings at image-token positions) is mirrored 1:1.
+//
+//  The decoder uses PLAIN 1D RoPE (handled inside DeepseekOCRLanguageModel);
+//  there is NO M-RoPE / position-id pre-compute here (that is GlmOcr-specific).
+//
+//  Weight-key layout (after `sanitize`):
+//    vision_model.*      sam_model.*      projector.*
+//    language_model.model.*      language_model.lm_head.*
+//    image_newline (n_embed,)    view_separator (n_embed,)
+//
+
+import CoreImage
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+// MARK: - MlpProjector
+
+/// Projects fused vision features (CLIP[:,1:] ++ SAM flatten) to the text
+/// hidden size. DeepSeek-OCR uses projector_type "linear" — a single Linear.
+/// Mirrors deepseekocr.py `MlpProjector` (linear branch). The
+/// `downsample_mlp_gelu` branch is ported for fidelity but is not exercised by
+/// the shipped config.
+private class MlpProjector: Module, UnaryLayer {
+
+    let projectorType: String
+    let downsampleRatio: Int
+
+    // The projector weights live under the `layers` attribute in the checkpoint
+    // (`projector.layers.{weight,bias}` for the linear case). DeepSeek-OCR ships
+    // projector_type "linear", so a single Linear keyed "layers" matches exactly.
+    @ModuleInfo(key: "layers") var layers: Linear
+
+    init(_ config: DeepseekOCRConfiguration.ProjectorConfiguration) {
+        self.projectorType = config.projectorType
+        self.downsampleRatio = config.downsampleRatio
+
+        // NOTE: only the "linear" projector ships with DeepSeek-OCR /
+        // Unlimited-OCR. The "downsample_mlp_gelu" branch in deepseekocr.py would
+        // require a heterogeneous (Linear/GELU) module list under `layers`, which
+        // MLX-Swift cannot key uniformly to `projector.layers.{i}`; it is omitted
+        // here. Guard loudly so an unexpected config surfaces immediately.
+        precondition(
+            config.projectorType == "linear",
+            "DeepseekOCR MlpProjector only supports projector_type=linear, got \(config.projectorType)"
+        )
+        self._layers.wrappedValue = Linear(config.inputDim, config.nEmbed)
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        // Linear branch (deepseekocr.py): x = self.layers(x).
+        layers(x)
+    }
+}
+
+// MARK: - Model
+
+/// Top-level DeepSeek-OCR VLM.
+public class DeepseekOCR: Module, VLMModel, KVCacheDimensionProvider {
+
+    @ModuleInfo(key: "vision_model") private var visionModel: DeepseekOCRVisionModel
+    @ModuleInfo(key: "sam_model") private var samModel: DeepseekOCRSAMEncoder
+    @ModuleInfo(key: "language_model") private var languageModel: DeepseekOCRLanguageModel
+    @ModuleInfo(key: "projector") private var projector: MlpProjector
+
+    @ParameterInfo(key: "image_newline") private var imageNewline: MLXArray
+    @ParameterInfo(key: "view_separator") private var viewSeparator: MLXArray
+
+    public let config: DeepseekOCRConfiguration
+
+    public var vocabularySize: Int { config.textConfiguration.vocabSize }
+    public var kvHeads: [Int] { languageModel.kvHeads }
+
+    // NOTE: DeepseekOCRTextModelInner.layers is `fileprivate` in the component
+    // file (which we must not edit), so the decoder layers aren't reachable here.
+    // LoRA is not part of the OCR inference path, so expose no adaptable layers.
+    public var loraLayers: [Module] {
+        []
+    }
+
+    public init(_ config: DeepseekOCRConfiguration) {
+        self.config = config
+        self._visionModel.wrappedValue = DeepseekOCRVisionModel(config.visionConfiguration)
+        self._samModel.wrappedValue = DeepseekOCRSAMEncoder(config.samConfiguration)
+        self._languageModel.wrappedValue = DeepseekOCRLanguageModel(config.textConfiguration)
+        self._projector.wrappedValue = MlpProjector(config.projectorConfiguration)
+
+        let nEmbed = config.projectorConfiguration.nEmbed
+        self._imageNewline.wrappedValue = MLXArray.zeros([nEmbed])
+        self._viewSeparator.wrappedValue = MLXArray.zeros([nEmbed])
+    }
+
+    // MARK: get_input_embeddings
+
+    /// Port of deepseekocr.py `Model.get_input_embeddings`.
+    ///
+    /// `patches`    : local crop views  [N_crops, 3, image_size, image_size]   (may be nil)
+    /// `imageOri`   : global views      [N_images, 3, base_size, base_size]
+    /// `spatialCrop`: per-image (width_crop_num, height_crop_num)
+    /// `seqMask`    : [B, L] bool image-token mask (carried from the processor)
+    ///
+    /// Returns the text embeddings with image features scattered into the
+    /// image-token positions.
+    private func inputEmbeddings(
+        inputIds: MLXArray,
+        patches: MLXArray?,
+        imageOri: MLXArray?,
+        spatialCrop: [[Int]],
+        seqMask: MLXArray?
+    ) -> MLXArray {
+        var inputEmbeds = languageModel.model.embedTokens(inputIds)
+
+        // No images, or autoregressive decode step (L == 1): plain embeddings.
+        guard let imageOri, inputIds.dim(1) != 1 else {
+            return inputEmbeds
+        }
+        // Mirror Python's `mx.sum(pixel_values[1]).item() != 0` guard: the global
+        // views are always present on prefill, so this is effectively a "has any
+        // pixel content" check.
+        if imageOri.sum().item(Float.self) == 0 {
+            return inputEmbeds
+        }
+
+        var idx = 0
+        var patchIdx = 0
+
+        for crop in spatialCrop {
+            let widthCropNum = crop[0]
+            let heightCropNum = crop[1]
+            let hasCrops = widthCropNum > 1 || heightCropNum > 1
+            let numPatches = hasCrops ? widthCropNum * heightCropNum : 0
+
+            // Extract local crop patches for this image.
+            var imagePatches: MLXArray?
+            if hasCrops, numPatches > 0, let patches {
+                imagePatches = patches[patchIdx ..< (patchIdx + numPatches)]
+                patchIdx += numPatches
+            } else {
+                imagePatches = nil
+            }
+
+            // Global view for this image (one per batch item).
+            let imageOriSingle = imageOri[idx ..< (idx + 1)]
+
+            let globalLocalFeatures: MLXArray
+
+            if let imagePatches, imagePatches.sum().item(Float.self) != 0 {
+                // --- local crop features ---
+                let localFeatures1 = samModel(imagePatches.transposed(0, 2, 3, 1))
+                let localFeatures2 = visionModel(
+                    imagePatches.transposed(0, 2, 3, 1), patchEmbeds: localFeatures1)
+                var localFeatures = concatenated(
+                    [
+                        localFeatures2[0..., 1...],
+                        flattened(localFeatures1, start: 1, end: 2),
+                    ], axis: -1)
+                localFeatures = projector(localFeatures)
+
+                // --- global view features ---
+                let globalFeatures1 = samModel(imageOriSingle.transposed(0, 2, 3, 1))
+                let globalFeatures2 = visionModel(
+                    imageOriSingle.transposed(0, 2, 3, 1), patchEmbeds: globalFeatures1)
+                var globalFeatures = concatenated(
+                    [
+                        globalFeatures2[0..., 1...],
+                        flattened(globalFeatures1, start: 1, end: 2),
+                    ], axis: -1)
+                globalFeatures = projector(globalFeatures)
+
+                // Drop batch dim: (hw, n_dim)
+                globalFeatures = globalFeatures[0]
+                let hw = globalFeatures.dim(0)
+                let nDim = globalFeatures.dim(1)
+                let h = Int(Double(hw).squareRoot())
+                let w = h
+
+                let hw2 = localFeatures.dim(1)
+                let nDim2 = localFeatures.dim(2)
+                let h2 = Int(Double(hw2).squareRoot())
+                let w2 = h2
+
+                // Global: append one image_newline column per row, flatten.
+                globalFeatures = globalFeatures.reshaped(h, w, nDim)
+                globalFeatures = concatenated(
+                    [
+                        globalFeatures,
+                        broadcast(imageNewline[.newAxis, .newAxis, 0...], to: [h, 1, nDim]),
+                    ], axis: 1)
+                globalFeatures = globalFeatures.reshaped(-1, nDim)
+
+                // Local: reassemble (H_crop, W_crop) grid of (h2, w2) tiles, append
+                // one image_newline column per row, flatten.
+                localFeatures =
+                    localFeatures
+                    .reshaped(heightCropNum, widthCropNum, h2, w2, nDim2)
+                    .transposed(0, 2, 1, 3, 4)
+                    .reshaped(heightCropNum * h2, widthCropNum * w2, nDim2)
+                localFeatures = concatenated(
+                    [
+                        localFeatures,
+                        broadcast(
+                            imageNewline[.newAxis, .newAxis, 0...],
+                            to: [heightCropNum * h2, 1, nDim2]),
+                    ], axis: 1)
+                localFeatures = localFeatures.reshaped(-1, nDim2)
+
+                globalLocalFeatures = concatenated(
+                    [localFeatures, globalFeatures, viewSeparator[.newAxis, 0...]], axis: 0)
+            } else {
+                // Global-only (no crops).
+                let globalFeatures1 = samModel(imageOriSingle.transposed(0, 2, 3, 1))
+                let globalFeatures2 = visionModel(
+                    imageOriSingle.transposed(0, 2, 3, 1), patchEmbeds: globalFeatures1)
+                var globalFeatures = concatenated(
+                    [
+                        globalFeatures2[0..., 1...],
+                        flattened(globalFeatures1, start: 1, end: 2),
+                    ], axis: -1)
+                globalFeatures = projector(globalFeatures)
+
+                globalFeatures = globalFeatures[0]
+                let hw = globalFeatures.dim(0)
+                let nDim = globalFeatures.dim(1)
+                let h = Int(Double(hw).squareRoot())
+                let w = h
+
+                globalFeatures = globalFeatures.reshaped(h, w, nDim)
+                globalFeatures = concatenated(
+                    [
+                        globalFeatures,
+                        broadcast(imageNewline[.newAxis, .newAxis, 0...], to: [h, 1, nDim]),
+                    ], axis: 1)
+                globalFeatures = globalFeatures.reshaped(-1, nDim)
+
+                globalLocalFeatures = concatenated(
+                    [globalFeatures, viewSeparator[.newAxis, 0...]], axis: 0)
+            }
+
+            // Scatter into the image-token positions of this batch row. Mirrors
+            // `input_embeds[idx, image_indices] = images_in_this_batch`.
+            if let seqMask {
+                let rowMask: [Bool] = seqMask[idx].asArray(Int32.self).map { $0 != 0 }
+                let imageIndices = rowMask.enumerated().compactMap { $0.element ? $0.offset : nil }
+                if !imageIndices.isEmpty {
+                    // Canonical scatter (mirrors QwenVL.mergeInputIdsWithImageFeatures):
+                    // full slice on batch + channel axes, MLXArray index on seq axis.
+                    let indexArray = MLXArray(imageIndices)
+                    inputEmbeds[idx ..< (idx + 1), indexArray, 0...] =
+                        globalLocalFeatures[.newAxis, 0..., 0...]
+                }
+            }
+
+            idx += 1
+        }
+
+        return inputEmbeds
+    }
+
+    // MARK: - Pixel unpacking (decode the processor's packing contract)
+
+    /// Decode the processor's `LMInput.ProcessedImage` packing contract back into
+    /// `(patches, image_ori, images_spatial_crop)`.
+    ///
+    /// Per DeepseekOCRProcessor:
+    ///   pixels      = image_ori.flatten() [++ patches.flatten() when N_crops > 0]
+    ///   frames[0]   = THW(t: N_crops, h: N_images, w: 0)
+    ///   frames[1..] = one THW(1, width_crop_num, height_crop_num) per image
+    ///                 (= images_spatial_crop)
+    ///
+    /// image_ori is reshaped [N_images, 3, base, base]; patches (if any) is the
+    /// remaining buffer reshaped [N_crops, 3, image, image].
+    private func unpackPixels(_ image: LMInput.ProcessedImage, dtype: MLX.DType)
+        -> (patches: MLXArray?, imageOri: MLXArray, spatialCrop: [[Int]])?
+    {
+        guard let frames = image.frames, let head = frames.first else { return nil }
+
+        let nCrops = head.t
+        let nImages = head.h
+        let base = config.samConfiguration.imageSize  // 1024 global view side
+        let imageSize = 640  // local crop tile side (processing_deepseekocr.py)
+
+        let flat = image.pixels.reshaped(-1).asType(dtype)
+
+        let oriCount = nImages * 3 * base * base
+        let oriFlat = flat[0 ..< oriCount]
+        let imageOri = oriFlat.reshaped(nImages, 3, base, base)
+
+        var patches: MLXArray?
+        if nCrops > 0 {
+            let patchCount = nCrops * 3 * imageSize * imageSize
+            let patchFlat = flat[oriCount ..< (oriCount + patchCount)]
+            patches = patchFlat.reshaped(nCrops, 3, imageSize, imageSize)
+        }
+
+        // images_spatial_crop = frames[1...] as (width_crop_num, height_crop_num).
+        let spatialCrop: [[Int]] = frames.dropFirst().map { [$0.h, $0.w] }
+
+        return (patches, imageOri, spatialCrop)
+    }
+
+    // MARK: - VLMModel surface
+
+    public func prepare(_ input: LMInput, cache: [any KVCache], windowSize: Int?) throws
+        -> PrepareResult
+    {
+        // SAM's PatchEmbed is `private` in its component file, so derive the
+        // working dtype from a reachable weight (the text embedding table).
+        let dtype = languageModel.model.embedTokens.weight.dtype
+
+        let inputIds = input.text.tokens
+        let seqMask = input.text.mask
+
+        let embeds: MLXArray
+        if let image = input.image,
+            let (patches, imageOri, spatialCrop) = unpackPixels(image, dtype: dtype)
+        {
+            embeds = inputEmbeddings(
+                inputIds: inputIds,
+                patches: patches,
+                imageOri: imageOri,
+                spatialCrop: spatialCrop,
+                seqMask: seqMask)
+        } else {
+            embeds = languageModel.model.embedTokens(inputIds)
+        }
+
+        let logits = languageModel(inputIds, cache: cache, inputsEmbeds: embeds)
+        return .logits(.init(logits: logits))
+    }
+
+    public func callAsFunction(_ inputs: MLXArray, cache: [any KVCache]?) -> MLXArray {
+        languageModel(inputs, cache: cache)
+    }
+
+    public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        // Step 1: normalize HF prefixes (deepseekocr.py transform_key), applied
+        // first so component-specific transposes see the final key layout.
+        var transformed = [String: MLXArray]()
+        for (key, value) in weights {
+            var k = key
+
+            if k.contains("model.layers"), !k.contains("language_model") {
+                k = k.replacingOccurrences(
+                    of: "model.layers", with: "language_model.model.layers")
+            }
+            if k.contains("model.embed_tokens"), !k.contains("language_model") {
+                k = k.replacingOccurrences(
+                    of: "model.embed_tokens", with: "language_model.model.embed_tokens")
+            }
+            if k.contains("model.norm"), !k.contains("language_model") {
+                k = k.replacingOccurrences(of: "model.norm", with: "language_model.model.norm")
+            }
+            if k.contains("model.vision_model") {
+                k = k.replacingOccurrences(of: "model.vision_model", with: "vision_model")
+            }
+            if k.contains("model.sam_model") {
+                k = k.replacingOccurrences(of: "model.sam_model", with: "sam_model")
+            }
+            if k.contains("model.projector") {
+                k = k.replacingOccurrences(of: "model.projector", with: "projector")
+            }
+            // Note the upstream typo "view_seperator" → our "view_separator".
+            if k.contains("model.view_seperator") {
+                k = k.replacingOccurrences(of: "model.view_seperator", with: "view_separator")
+            }
+            if k.contains("model.image_newline") {
+                k = k.replacingOccurrences(of: "model.image_newline", with: "image_newline")
+            }
+            if k.contains("lm_head.weight"), !k.contains("language_model") {
+                k = k.replacingOccurrences(
+                    of: "lm_head.weight", with: "language_model.lm_head.weight")
+            }
+
+            transformed[k] = value
+        }
+
+        // Step 2: SAM conv-weight transposes (NCHW -> NHWC) on the sam_model.* slice.
+        transformed = DeepseekOCRSAMEncoder.sanitize(weights: transformed, prefix: "sam_model.")
+
+        // Step 3: stack per-expert MoE weights into the SwitchGLU switch_mlp layout
+        // (operates on the language_model.model.* keys produced above).
+        transformed = languageModel.sanitize(weights: transformed)
+
+        return transformed
+    }
+}

--- a/Libraries/MLXVLM/Models/DeepseekOCRConfiguration.swift
+++ b/Libraries/MLXVLM/Models/DeepseekOCRConfiguration.swift
@@ -227,11 +227,21 @@ public struct DeepseekOCRConfiguration: Codable, Sendable {
 
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
-        textConfiguration = try c.decode(TextConfiguration.self, forKey: .textConfiguration)
-        visionConfiguration = try c.decode(
-            VisionConfiguration.self, forKey: .visionConfiguration)
-        projectorConfiguration = try c.decode(
-            ProjectorConfiguration.self, forKey: .projectorConfiguration)
+        // The same struct is decoded from BOTH config.json (full model config,
+        // carries language_config/vision_config/projector_config) AND
+        // processor_config.json (carries only image_token + tiling fields). The
+        // sub-configs are therefore decodeIfPresent with all-defaulted fallbacks
+        // (every sub-config field is itself decodeIfPresent-defaulted), so the
+        // processor path doesn't trap on the missing `language_config` key.
+        textConfiguration =
+            try c.decodeIfPresent(TextConfiguration.self, forKey: .textConfiguration)
+            ?? TextConfiguration(from: EmptyDecoder())
+        visionConfiguration =
+            try c.decodeIfPresent(VisionConfiguration.self, forKey: .visionConfiguration)
+            ?? VisionConfiguration(from: EmptyDecoder())
+        projectorConfiguration =
+            try c.decodeIfPresent(ProjectorConfiguration.self, forKey: .projectorConfiguration)
+            ?? ProjectorConfiguration(from: EmptyDecoder())
         modelType = try c.decodeIfPresent(String.self, forKey: .modelType) ?? "deepseek_vl_v2"
         // image token index: prefer image_token_index, fall back to image_token_id,
         // then the mlx-vlm default 128815.
@@ -260,6 +270,52 @@ public struct DeepseekOCRConfiguration: Codable, Sendable {
         try c.encode(globalViewPos, forKey: .globalViewPos)
         try c.encode(numImageTokens, forKey: .numImageTokens)
         try c.encodeIfPresent(quantization, forKey: .quantization)
+    }
+}
+
+/// Minimal `Decoder` that exposes an empty keyed container, so a sub-config
+/// whose fields are all `decodeIfPresent`-defaulted can be constructed with
+/// every default (used when decoding from processor_config.json, which omits
+/// language_config / vision_config / projector_config).
+private struct EmptyDecoder: Decoder {
+    var codingPath: [CodingKey] { [] }
+    var userInfo: [CodingUserInfoKey: Any] { [:] }
+
+    func container<Key: CodingKey>(keyedBy type: Key.Type)
+        -> KeyedDecodingContainer<Key>
+    {
+        KeyedDecodingContainer(EmptyKeyed<Key>())
+    }
+    func unkeyedContainer() throws -> UnkeyedDecodingContainer {
+        throw DecodingError.dataCorrupted(
+            .init(codingPath: [], debugDescription: "EmptyDecoder has no unkeyed container"))
+    }
+    func singleValueContainer() throws -> SingleValueDecodingContainer {
+        throw DecodingError.dataCorrupted(
+            .init(codingPath: [], debugDescription: "EmptyDecoder has no single-value container"))
+    }
+
+    private struct EmptyKeyed<K: CodingKey>: KeyedDecodingContainerProtocol {
+        typealias Key = K
+        var codingPath: [CodingKey] { [] }
+        var allKeys: [K] { [] }
+        func contains(_ key: K) -> Bool { false }
+        func decodeNil(forKey key: K) throws -> Bool { true }
+        func decode<T: Decodable>(_ type: T.Type, forKey key: K) throws -> T {
+            throw DecodingError.keyNotFound(
+                key, .init(codingPath: [], debugDescription: "empty"))
+        }
+        func nestedContainer<NK: CodingKey>(keyedBy type: NK.Type, forKey key: K) throws
+            -> KeyedDecodingContainer<NK>
+        {
+            KeyedDecodingContainer(EmptyKeyed<NK>())
+        }
+        func nestedUnkeyedContainer(forKey key: K) throws -> UnkeyedDecodingContainer {
+            throw DecodingError.keyNotFound(
+                key, .init(codingPath: [], debugDescription: "empty"))
+        }
+        func superDecoder() throws -> Decoder { EmptyDecoder() }
+        func superDecoder(forKey key: K) throws -> Decoder { EmptyDecoder() }
     }
 }
 

--- a/Libraries/MLXVLM/Models/DeepseekOCRConfiguration.swift
+++ b/Libraries/MLXVLM/Models/DeepseekOCRConfiguration.swift
@@ -138,6 +138,21 @@ public struct DeepseekOCRConfiguration: Codable, Sendable {
             layerNormEps = f("layer_norm_eps", 1e-6)
             mlpRatio = f("mlp_ratio", 3.7362)
         }
+
+        // NOTE: compile-fix — factory's create<C: Codable> requires Encodable; this
+        // struct decodes via dynamic AnyKey so encode cannot be synthesized. Never
+        // called at runtime (factory only decodes); provided to satisfy conformance.
+        public func encode(to encoder: Encoder) throws {
+            var c = encoder.container(keyedBy: AnyKey.self)
+            try c.encode(layers, forKey: AnyKey("layers"))
+            try c.encode(width, forKey: AnyKey("width"))
+            try c.encode(heads, forKey: AnyKey("num_attention_heads"))
+            try c.encode(imageSize, forKey: AnyKey("image_size"))
+            try c.encode(patchSize, forKey: AnyKey("patch_size"))
+            try c.encode(numChannels, forKey: AnyKey("num_channels"))
+            try c.encode(layerNormEps, forKey: AnyKey("layer_norm_eps"))
+            try c.encode(mlpRatio, forKey: AnyKey("mlp_ratio"))
+        }
     }
 
     /// SAM-ViT-B encoder (the `sam_model` branch of the DeepEncoder).
@@ -221,14 +236,30 @@ public struct DeepseekOCRConfiguration: Codable, Sendable {
         // image token index: prefer image_token_index, fall back to image_token_id,
         // then the mlx-vlm default 128815.
         imageTokenIndex =
-            (try c.decodeIfPresent(Int.self, forKey: .imageTokenIndex))
-            ?? (try c.decodeIfPresent(Int.self, forKey: .imageTokenId))
+            try (c.decodeIfPresent(Int.self, forKey: .imageTokenIndex)
+                ?? c.decodeIfPresent(Int.self, forKey: .imageTokenId))
             ?? 128815
         tileTag = try c.decodeIfPresent(String.self, forKey: .tileTag) ?? "2D"
         globalViewPos = try c.decodeIfPresent(String.self, forKey: .globalViewPos) ?? "head"
         numImageTokens = try c.decodeIfPresent(Int.self, forKey: .numImageTokens) ?? 576
         quantization = try c.decodeIfPresent(
             BaseConfiguration.Quantization.self, forKey: .quantization)
+    }
+
+    // NOTE: compile-fix — factory's create<C: Codable> requires Encodable. Encode
+    // cannot be synthesized here because CodingKeys has an extra `imageTokenId` key
+    // with no matching property. Never called at runtime (factory only decodes).
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(textConfiguration, forKey: .textConfiguration)
+        try c.encode(visionConfiguration, forKey: .visionConfiguration)
+        try c.encode(projectorConfiguration, forKey: .projectorConfiguration)
+        try c.encode(modelType, forKey: .modelType)
+        try c.encode(imageTokenIndex, forKey: .imageTokenIndex)
+        try c.encode(tileTag, forKey: .tileTag)
+        try c.encode(globalViewPos, forKey: .globalViewPos)
+        try c.encode(numImageTokens, forKey: .numImageTokens)
+        try c.encodeIfPresent(quantization, forKey: .quantization)
     }
 }
 

--- a/Libraries/MLXVLM/Models/DeepseekOCRConfiguration.swift
+++ b/Libraries/MLXVLM/Models/DeepseekOCRConfiguration.swift
@@ -1,0 +1,242 @@
+//
+//  DeepseekOCRConfiguration.swift
+//  mlx-swift-lm
+//
+//  Configuration for DeepSeek-OCR / Unlimited-OCR (DeepseekOCRForCausalLM,
+//  top model_type "deepseek_vl_v2"). Port of
+//  https://github.com/Blaizzy/mlx-vlm/tree/main/mlx_vlm/models/deepseekocr (config.py)
+//
+//  Covers deepseek-ai/DeepSeek-OCR and baidu/Unlimited-OCR (identical arch).
+//
+
+import Foundation
+import MLXLMCommon
+
+/// Top-level configuration for the DeepSeek-OCR family.
+public struct DeepseekOCRConfiguration: Codable, Sendable {
+
+    /// DeepSeek-V2 MoE text decoder config. Standard attention path
+    /// (use_mla=false / qk_nope_head_dim=0 ⇒ Llama-style attention).
+    public struct TextConfiguration: Codable, Sendable {
+        public var modelType: String
+        public var vocabSize: Int
+        public var hiddenSize: Int
+        public var intermediateSize: Int
+        public var moeIntermediateSize: Int
+        public var numHiddenLayers: Int
+        public var numAttentionHeads: Int
+        public var numKeyValueHeads: Int
+        public var nSharedExperts: Int?
+        public var nRoutedExperts: Int?
+        public var routedScalingFactor: Float
+        public var numExpertsPerTok: Int?
+        public var moeLayerFreq: Int
+        public var firstKDenseReplace: Int
+        public var maxPositionEmbeddings: Int
+        public var rmsNormEps: Float
+        public var ropeTheta: Float
+        public var ropeScaling: [String: StringOrNumber]?
+        public var attentionBias: Bool
+        public var scoringFunc: String
+        public var topkMethod: String
+        public var nGroup: Int?
+        public var topkGroup: Int?
+        // Standard-attention head dim derived as hiddenSize / numAttentionHeads.
+
+        public var headDim: Int { hiddenSize / numAttentionHeads }
+
+        enum CodingKeys: String, CodingKey {
+            case modelType = "model_type"
+            case vocabSize = "vocab_size"
+            case hiddenSize = "hidden_size"
+            case intermediateSize = "intermediate_size"
+            case moeIntermediateSize = "moe_intermediate_size"
+            case numHiddenLayers = "num_hidden_layers"
+            case numAttentionHeads = "num_attention_heads"
+            case numKeyValueHeads = "num_key_value_heads"
+            case nSharedExperts = "n_shared_experts"
+            case nRoutedExperts = "n_routed_experts"
+            case routedScalingFactor = "routed_scaling_factor"
+            case numExpertsPerTok = "num_experts_per_tok"
+            case moeLayerFreq = "moe_layer_freq"
+            case firstKDenseReplace = "first_k_dense_replace"
+            case maxPositionEmbeddings = "max_position_embeddings"
+            case rmsNormEps = "rms_norm_eps"
+            case ropeTheta = "rope_theta"
+            case ropeScaling = "rope_scaling"
+            case attentionBias = "attention_bias"
+            case scoringFunc = "scoring_func"
+            case topkMethod = "topk_method"
+            case nGroup = "n_group"
+            case topkGroup = "topk_group"
+        }
+
+        public init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            modelType = try c.decodeIfPresent(String.self, forKey: .modelType) ?? "deepseek_v2"
+            vocabSize = try c.decodeIfPresent(Int.self, forKey: .vocabSize) ?? 129280
+            hiddenSize = try c.decodeIfPresent(Int.self, forKey: .hiddenSize) ?? 1280
+            intermediateSize =
+                try c.decodeIfPresent(Int.self, forKey: .intermediateSize) ?? 6848
+            moeIntermediateSize =
+                try c.decodeIfPresent(Int.self, forKey: .moeIntermediateSize) ?? 896
+            numHiddenLayers =
+                try c.decodeIfPresent(Int.self, forKey: .numHiddenLayers) ?? 12
+            numAttentionHeads =
+                try c.decodeIfPresent(Int.self, forKey: .numAttentionHeads) ?? 10
+            numKeyValueHeads =
+                try c.decodeIfPresent(Int.self, forKey: .numKeyValueHeads) ?? numAttentionHeads
+            nSharedExperts = try c.decodeIfPresent(Int.self, forKey: .nSharedExperts) ?? 2
+            nRoutedExperts = try c.decodeIfPresent(Int.self, forKey: .nRoutedExperts) ?? 64
+            routedScalingFactor =
+                try c.decodeIfPresent(Float.self, forKey: .routedScalingFactor) ?? 1.0
+            numExpertsPerTok = try c.decodeIfPresent(Int.self, forKey: .numExpertsPerTok) ?? 6
+            moeLayerFreq = try c.decodeIfPresent(Int.self, forKey: .moeLayerFreq) ?? 1
+            firstKDenseReplace =
+                try c.decodeIfPresent(Int.self, forKey: .firstKDenseReplace) ?? 1
+            maxPositionEmbeddings =
+                try c.decodeIfPresent(Int.self, forKey: .maxPositionEmbeddings) ?? 8192
+            rmsNormEps = try c.decodeIfPresent(Float.self, forKey: .rmsNormEps) ?? 1e-6
+            ropeTheta = try c.decodeIfPresent(Float.self, forKey: .ropeTheta) ?? 10000.0
+            ropeScaling = try c.decodeIfPresent(
+                [String: StringOrNumber].self, forKey: .ropeScaling)
+            attentionBias = try c.decodeIfPresent(Bool.self, forKey: .attentionBias) ?? false
+            scoringFunc = try c.decodeIfPresent(String.self, forKey: .scoringFunc) ?? "softmax"
+            topkMethod = try c.decodeIfPresent(String.self, forKey: .topkMethod) ?? "greedy"
+            nGroup = try c.decodeIfPresent(Int.self, forKey: .nGroup) ?? 1
+            topkGroup = try c.decodeIfPresent(Int.self, forKey: .topkGroup) ?? 1
+        }
+    }
+
+    /// CLIP-L/14 vision tower (the `vision_model` branch of the DeepEncoder).
+    public struct VisionConfiguration: Codable, Sendable {
+        public var layers: Int
+        public var width: Int
+        public var heads: Int
+        public var imageSize: Int
+        public var patchSize: Int
+        public var numChannels: Int
+        public var layerNormEps: Float
+        public var mlpRatio: Float
+
+        public init(from decoder: Decoder) throws {
+            // The HF config nests CLIP geometry under vision_config.width["clip-l-14-224"];
+            // mlx-vlm flattens to these fields. Decode defensively with CLIP-L defaults.
+            let c = try decoder.container(keyedBy: AnyKey.self)
+            func i(_ k: String, _ d: Int) -> Int {
+                (try? c.decode(Int.self, forKey: AnyKey(k))) ?? d
+            }
+            func f(_ k: String, _ d: Float) -> Float {
+                (try? c.decode(Float.self, forKey: AnyKey(k))) ?? d
+            }
+            layers = i("layers", 24)
+            width = i("width", 1024)
+            heads = i("num_attention_heads", 16)
+            imageSize = i("image_size", 224)
+            patchSize = i("patch_size", 14)
+            numChannels = i("num_channels", 3)
+            layerNormEps = f("layer_norm_eps", 1e-6)
+            mlpRatio = f("mlp_ratio", 3.7362)
+        }
+    }
+
+    /// SAM-ViT-B encoder (the `sam_model` branch of the DeepEncoder).
+    /// Geometry is fixed by SAMViTConfig() in mlx-vlm (not read from config.json).
+    public struct SAMViTConfiguration: Sendable {
+        public var imageSize: Int = 1024
+        public var width: Int = 768
+        public var layers: Int = 12
+        public var heads: Int = 12
+        public var patchSize: Int = 16
+        public var windowSize: Int = 14
+        public var promptEmbedDim: Int = 256
+        public var globalAttnIndexes: [Int] = [2, 5, 8, 11]
+        public var downsampleChannels: [Int] = [512, 1024]
+        public init() {}
+    }
+
+    /// MLP projector (vision feature dim → text hidden).
+    public struct ProjectorConfiguration: Codable, Sendable {
+        public var projectorType: String
+        public var inputDim: Int
+        public var nEmbed: Int
+        public var depth: Int
+        public var mlpRatio: Int
+        public var downsampleRatio: Int
+
+        enum CodingKeys: String, CodingKey {
+            case projectorType = "projector_type"
+            case inputDim = "input_dim"
+            case nEmbed = "n_embed"
+            case depth
+            case mlpRatio = "mlp_ratio"
+            case downsampleRatio = "downsample_ratio"
+        }
+
+        public init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            projectorType =
+                try c.decodeIfPresent(String.self, forKey: .projectorType) ?? "linear"
+            inputDim = try c.decodeIfPresent(Int.self, forKey: .inputDim) ?? 2048
+            nEmbed = try c.decodeIfPresent(Int.self, forKey: .nEmbed) ?? 1280
+            depth = try c.decodeIfPresent(Int.self, forKey: .depth) ?? 2
+            mlpRatio = try c.decodeIfPresent(Int.self, forKey: .mlpRatio) ?? 1
+            downsampleRatio =
+                try c.decodeIfPresent(Int.self, forKey: .downsampleRatio) ?? 2
+        }
+    }
+
+    public var textConfiguration: TextConfiguration
+    public var visionConfiguration: VisionConfiguration
+    public var projectorConfiguration: ProjectorConfiguration
+    public var samConfiguration = SAMViTConfiguration()
+    public var modelType: String
+    public var imageTokenIndex: Int
+    public var tileTag: String
+    public var globalViewPos: String
+    public var numImageTokens: Int
+    public var quantization: BaseConfiguration.Quantization?
+
+    enum CodingKeys: String, CodingKey {
+        case textConfiguration = "language_config"
+        case visionConfiguration = "vision_config"
+        case projectorConfiguration = "projector_config"
+        case modelType = "model_type"
+        case imageTokenIndex = "image_token_index"
+        case imageTokenId = "image_token_id"
+        case tileTag = "tile_tag"
+        case globalViewPos = "global_view_pos"
+        case numImageTokens = "num_image_tokens"
+        case quantization
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        textConfiguration = try c.decode(TextConfiguration.self, forKey: .textConfiguration)
+        visionConfiguration = try c.decode(
+            VisionConfiguration.self, forKey: .visionConfiguration)
+        projectorConfiguration = try c.decode(
+            ProjectorConfiguration.self, forKey: .projectorConfiguration)
+        modelType = try c.decodeIfPresent(String.self, forKey: .modelType) ?? "deepseek_vl_v2"
+        // image token index: prefer image_token_index, fall back to image_token_id,
+        // then the mlx-vlm default 128815.
+        imageTokenIndex =
+            (try c.decodeIfPresent(Int.self, forKey: .imageTokenIndex))
+            ?? (try c.decodeIfPresent(Int.self, forKey: .imageTokenId))
+            ?? 128815
+        tileTag = try c.decodeIfPresent(String.self, forKey: .tileTag) ?? "2D"
+        globalViewPos = try c.decodeIfPresent(String.self, forKey: .globalViewPos) ?? "head"
+        numImageTokens = try c.decodeIfPresent(Int.self, forKey: .numImageTokens) ?? 576
+        quantization = try c.decodeIfPresent(
+            BaseConfiguration.Quantization.self, forKey: .quantization)
+    }
+}
+
+/// Helper coding key for flat-keyed sub-dicts (CLIP geometry).
+private struct AnyKey: CodingKey {
+    var stringValue: String
+    var intValue: Int? { nil }
+    init(_ s: String) { stringValue = s }
+    init?(stringValue: String) { self.stringValue = stringValue }
+    init?(intValue: Int) { nil }
+}

--- a/Libraries/MLXVLM/Models/DeepseekOCRLanguage.swift
+++ b/Libraries/MLXVLM/Models/DeepseekOCRLanguage.swift
@@ -344,13 +344,12 @@ public class DeepseekOCRLanguageModel: Module, KVCacheDimensionProvider {
     }
 
     public func newCache(parameters: GenerateParameters?) -> [KVCache] {
-        (0 ..< config.numHiddenLayers).map { _ in
-            if let maxKVSize = parameters?.maxKVSize {
-                return RotatingKVCache(maxSize: maxKVSize, keep: 4)
-            } else {
-                return KVCacheSimple()
-            }
-        }
+        // DeepSeek-V2 decoder here is FULL attention (use_mla=false, standard
+        // Llama MHA + RoPE; the `sliding_window` field in config is unused by
+        // this code path). A RotatingKVCache would both be semantically wrong
+        // (it would drop early tokens the model still attends to) and defeat
+        // prefix/paged reuse. Always use the growable full-attention cache.
+        (0 ..< config.numHiddenLayers).map { _ in KVCacheSimple() }
     }
 
     /// Stacks per-expert MLP weights into the SwitchGLU `switch_mlp` layout.

--- a/Libraries/MLXVLM/Models/DeepseekOCRLanguage.swift
+++ b/Libraries/MLXVLM/Models/DeepseekOCRLanguage.swift
@@ -1,0 +1,381 @@
+//
+//  DeepseekOCRLanguage.swift
+//  mlx-swift-lm
+//
+//  DeepSeek-V2 MoE text decoder for the DeepSeek-OCR / Unlimited-OCR VLM.
+//  Line-by-line port of mlx-vlm's deepseekocr/language.py.
+//
+//  Architecture (verified from config.json):
+//    - STANDARD multi-head attention with RoPE (NOT MLA). In config use_mla=false,
+//      q_lora_rank=null, kv_lora_rank=null, qk_nope_head_dim=0 ⇒ mlx-vlm sets
+//      attn_type="LlamaAttention". So this implements the LlamaAttention branch:
+//      head_dim = hidden_size / num_attention_heads = 1280 / 10 = 128.
+//    - MoE: n_routed_experts=64, n_shared_experts=2, num_experts_per_tok=6,
+//      moe_intermediate_size=896, first_k_dense_replace=1 (layer 0 dense, 1-11 MoE),
+//      topk_method="greedy", scoring_func="softmax", routed_scaling_factor=1.0.
+//
+//  Weight-key layout after the top model wraps this as `language_model`:
+//    language_model.model.embed_tokens
+//    language_model.model.layers.N.{self_attn,mlp,input_layernorm,post_attention_layernorm}
+//    language_model.model.norm
+//    language_model.lm_head
+//
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+private typealias TextConfiguration = DeepseekOCRConfiguration.TextConfiguration
+
+// MARK: - Attention (LlamaAttention branch)
+
+/// Standard multi-head attention with RoPE. Mirrors language.py's `LlamaAttention`
+/// (the branch used when qk_nope_head_dim == 0).
+private class DeepseekOCRLlamaAttention: Module {
+    let nHeads: Int
+    let nKVHeads: Int
+    let headDim: Int
+    let scale: Float
+
+    @ModuleInfo(key: "q_proj") var qProj: Linear
+    @ModuleInfo(key: "k_proj") var kProj: Linear
+    @ModuleInfo(key: "v_proj") var vProj: Linear
+    @ModuleInfo(key: "o_proj") var oProj: Linear
+
+    let rope: RoPE
+
+    init(_ config: TextConfiguration) {
+        let dim = config.hiddenSize
+        self.nHeads = config.numAttentionHeads
+        self.nKVHeads = config.numKeyValueHeads
+        // head_dim = hidden_size // num_attention_heads (NOT num_key_value_heads)
+        self.headDim = config.hiddenSize / config.numAttentionHeads
+        self.scale = pow(Float(headDim), -0.5)
+
+        let attentionBias = config.attentionBias
+
+        self._qProj.wrappedValue = Linear(dim, nHeads * headDim, bias: attentionBias)
+        self._kProj.wrappedValue = Linear(dim, nKVHeads * headDim, bias: attentionBias)
+        self._vProj.wrappedValue = Linear(dim, nKVHeads * headDim, bias: attentionBias)
+        self._oProj.wrappedValue = Linear(nHeads * headDim, dim, bias: attentionBias)
+
+        // rope_scaling is only consulted for the "linear" type in language.py.
+        var ropeScale: Float = 1
+        if let ropeScaling = config.ropeScaling,
+            ropeScaling["type"] == .string("linear"),
+            let factor = ropeScaling["factor"]?.asFloat()
+        {
+            ropeScale = 1 / factor
+        }
+
+        // rope_traditional defaults to false in mlx-vlm's TextConfig.
+        self.rope = RoPE(
+            dimensions: headDim, traditional: false, base: config.ropeTheta, scale: ropeScale)
+    }
+
+    func callAsFunction(
+        _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
+    ) -> MLXArray {
+        let (B, L) = (x.dim(0), x.dim(1))
+
+        var queries = qProj(x)
+        var keys = kProj(x)
+        var values = vProj(x)
+
+        queries = queries.reshaped(B, L, nHeads, -1).transposed(0, 2, 1, 3)
+        keys = keys.reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
+        values = values.reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
+
+        queries = applyRotaryPosition(rope, to: queries, cache: cache)
+        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+
+        let output = attentionWithCacheUpdate(
+            queries: queries,
+            keys: keys,
+            values: values,
+            cache: cache,
+            scale: scale,
+            mask: mask
+        )
+        .transposed(0, 2, 1, 3)
+        .reshaped(B, L, -1)
+
+        return oProj(output)
+    }
+}
+
+// MARK: - Dense MLP
+
+/// Dense gated MLP. Used by layer 0 (first_k_dense_replace) and the shared experts.
+private class DeepseekOCRMLP: Module, UnaryLayer {
+    @ModuleInfo(key: "gate_proj") var gateProj: Linear
+    @ModuleInfo(key: "up_proj") var upProj: Linear
+    @ModuleInfo(key: "down_proj") var downProj: Linear
+
+    init(config: TextConfiguration, hiddenSize: Int? = nil, intermediateSize: Int? = nil) {
+        let hidden = hiddenSize ?? config.hiddenSize
+        let inter = intermediateSize ?? config.intermediateSize
+        self._gateProj.wrappedValue = Linear(hidden, inter, bias: false)
+        self._upProj.wrappedValue = Linear(hidden, inter, bias: false)
+        self._downProj.wrappedValue = Linear(inter, hidden, bias: false)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        downProj(silu(gateProj(x)) * upProj(x))
+    }
+}
+
+// MARK: - MoE gate
+
+/// Router gate. Mirrors language.py's `MoEGate` for scoring_func="softmax" and
+/// topk_method="greedy" (the configuration used by DeepSeek-OCR).
+private class DeepseekOCRMoEGate: Module {
+    let scoringFunc: String
+    let topK: Int
+    let nRoutedExperts: Int
+    let routedScalingFactor: Float
+    let topkMethod: String
+    let nGroup: Int
+    let topkGroup: Int
+
+    // `weight` is a bare parameter named "weight" (matches gate.weight in safetensors).
+    var weight: MLXArray
+    // Only allocated for topk_method == "noaux_tc"; present so the parameter
+    // name resolves if such weights ever appear. DeepSeek-OCR uses "greedy".
+    @ParameterInfo(key: "e_score_correction_bias") var eScoreCorrectionBias: MLXArray
+
+    init(_ config: TextConfiguration) {
+        self.scoringFunc = config.scoringFunc
+        self.topK = config.numExpertsPerTok ?? 1
+        self.nRoutedExperts = config.nRoutedExperts ?? 1
+        self.routedScalingFactor = config.routedScalingFactor
+        self.topkMethod = config.topkMethod
+        self.nGroup = config.nGroup ?? 1
+        self.topkGroup = config.topkGroup ?? 1
+        self.weight = zeros([nRoutedExperts, config.hiddenSize])
+        self._eScoreCorrectionBias.wrappedValue = zeros([nRoutedExperts])
+    }
+
+    func callAsFunction(_ x: MLXArray) -> (MLXArray, MLXArray) {
+        // gates = x @ weight.T
+        let gates = x.matmul(weight.T)
+
+        let scores: MLXArray
+        switch scoringFunc {
+        case "softmax":
+            scores = softmax(gates, axis: -1, precise: true)
+        case "sigmoid":
+            scores = sigmoid(gates)
+        default:
+            fatalError("Unknown scoring function: \(scoringFunc)")
+        }
+
+        // DeepSeek-OCR uses topk_method == "greedy".
+        // inds = argpartition(scores, kth=-k)[..., -k:]; gather selected scores.
+        // (argPartition places the k largest in the last k positions; the
+        //  exact ordering within those k is irrelevant — the weighted sum is
+        //  permutation-invariant.)
+        precondition(topkMethod == "greedy", "DeepseekOCR gate only supports topk_method=greedy")
+        let k = topK
+        let total = scores.dim(-1)
+        let inds = argPartition(scores, kth: total - k, axis: -1)[.ellipsis, (total - k)...]
+        var scoresSelected = takeAlong(scores, inds, axis: -1)
+
+        scoresSelected = scoresSelected * routedScalingFactor
+        return (inds, scoresSelected)
+    }
+}
+
+// MARK: - MoE
+
+/// Sparse mixture of experts with optional shared experts. Mirrors `DeepseekV2MoE`.
+private class DeepseekOCRMoE: Module, UnaryLayer {
+    let numExpertsPerTok: Int
+    let hasSharedExperts: Bool
+    @ModuleInfo(key: "switch_mlp") var switchMLP: SwitchGLU
+    var gate: DeepseekOCRMoEGate
+    @ModuleInfo(key: "shared_experts") var sharedExperts: DeepseekOCRMLP?
+
+    init(_ config: TextConfiguration) {
+        self.numExpertsPerTok = config.numExpertsPerTok ?? 1
+
+        self._switchMLP.wrappedValue = SwitchGLU(
+            inputDims: config.hiddenSize,
+            hiddenDims: config.moeIntermediateSize,
+            numExperts: config.nRoutedExperts ?? 1
+        )
+
+        self.gate = DeepseekOCRMoEGate(config)
+
+        if let sharedCount = config.nSharedExperts {
+            self.hasSharedExperts = true
+            let intermediateSize = config.moeIntermediateSize * sharedCount
+            self._sharedExperts.wrappedValue = DeepseekOCRMLP(
+                config: config, intermediateSize: intermediateSize)
+        } else {
+            self.hasSharedExperts = false
+        }
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let (inds, scores) = gate(x)
+        var y = switchMLP(x, inds)
+        y = (y * scores[.ellipsis, .newAxis]).sum(axis: -2)
+        if let shared = sharedExperts {
+            y = y + shared(x)
+        }
+        return y
+    }
+}
+
+// MARK: - Decoder layer
+
+private class DeepseekOCRDecoderLayer: Module {
+    @ModuleInfo(key: "self_attn") var selfAttn: DeepseekOCRLlamaAttention
+    var mlp: UnaryLayer
+    @ModuleInfo(key: "input_layernorm") var inputLayerNorm: RMSNorm
+    @ModuleInfo(key: "post_attention_layernorm") var postAttentionLayerNorm: RMSNorm
+
+    init(_ config: TextConfiguration, layerIdx: Int) {
+        self._selfAttn.wrappedValue = DeepseekOCRLlamaAttention(config)
+
+        // MoE when: n_routed_experts present AND layer >= first_k_dense_replace
+        // AND layer % moe_layer_freq == 0. Otherwise a dense MLP.
+        if config.nRoutedExperts != nil,
+            layerIdx >= config.firstKDenseReplace,
+            layerIdx % config.moeLayerFreq == 0
+        {
+            self.mlp = DeepseekOCRMoE(config)
+        } else {
+            self.mlp = DeepseekOCRMLP(config: config)
+        }
+
+        self._inputLayerNorm.wrappedValue = RMSNorm(
+            dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        self._postAttentionLayerNorm.wrappedValue = RMSNorm(
+            dimensions: config.hiddenSize, eps: config.rmsNormEps)
+    }
+
+    func callAsFunction(
+        _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
+    ) -> MLXArray {
+        let r = selfAttn(inputLayerNorm(x), mask: mask, cache: cache)
+        let h = x + r
+        let r2 = mlp(postAttentionLayerNorm(h))
+        return h + r2
+    }
+}
+
+// MARK: - Inner model
+
+/// The `model` submodule: embeddings, decoder stack, final norm.
+/// Produces weight keys `language_model.model.*` once wrapped as `language_model`.
+class DeepseekOCRTextModelInner: Module {
+    @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
+    fileprivate var layers: [DeepseekOCRDecoderLayer]
+    @ModuleInfo(key: "norm") var norm: RMSNorm
+
+    init(_ config: TextConfiguration) {
+        self._embedTokens.wrappedValue = Embedding(
+            embeddingCount: config.vocabSize, dimensions: config.hiddenSize)
+        self.layers = (0 ..< config.numHiddenLayers).map {
+            DeepseekOCRDecoderLayer(config, layerIdx: $0)
+        }
+        self._norm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+    }
+
+    func callAsFunction(
+        _ inputs: MLXArray,
+        cache: [KVCache]?,
+        inputsEmbeds: MLXArray? = nil
+    ) -> MLXArray {
+        // When inputsEmbeds is provided (image-feature injection), use it instead
+        // of embedding the input ids. Mirrors language.py DeepseekV2Model.__call__.
+        var h: MLXArray
+        if let inputsEmbeds {
+            h = inputsEmbeds
+        } else {
+            h = embedTokens(inputs)
+        }
+
+        let mask = createAttentionMask(h: h, cache: cache?.first)
+
+        for (i, layer) in layers.enumerated() {
+            h = layer(h, mask: mask, cache: cache?[i])
+        }
+
+        return norm(h)
+    }
+}
+
+// MARK: - Language model
+
+/// Public DeepSeek-V2 MoE text decoder. The top VLM model wraps an instance of
+/// this as `language_model`, yielding the `language_model.*` weight keys.
+public class DeepseekOCRLanguageModel: Module, KVCacheDimensionProvider {
+    let config: TextConfiguration
+
+    /// Exposes `model.embedTokens` so callers can do
+    /// `language_model.model.embed_tokens(input_ids)` for image-feature injection.
+    @ModuleInfo(key: "model") var model: DeepseekOCRTextModelInner
+    @ModuleInfo(key: "lm_head") var lmHead: Linear
+
+    public var kvHeads: [Int] {
+        Array(repeating: config.numKeyValueHeads, count: config.numHiddenLayers)
+    }
+
+    public init(_ config: TextConfiguration) {
+        self.config = config
+        self._model.wrappedValue = DeepseekOCRTextModelInner(config)
+        self._lmHead.wrappedValue = Linear(config.hiddenSize, config.vocabSize, bias: false)
+    }
+
+    /// Forward pass returning logits. When `inputsEmbeds` is provided it is used
+    /// instead of embedding `inputs` (image features are injected this way).
+    public func callAsFunction(
+        _ inputs: MLXArray,
+        cache: [KVCache]? = nil,
+        inputsEmbeds: MLXArray? = nil
+    ) -> MLXArray {
+        let out = model(inputs, cache: cache, inputsEmbeds: inputsEmbeds)
+        return lmHead(out)
+    }
+
+    public func newCache(parameters: GenerateParameters?) -> [KVCache] {
+        (0 ..< config.numHiddenLayers).map { _ in
+            if let maxKVSize = parameters?.maxKVSize {
+                return RotatingKVCache(maxSize: maxKVSize, keep: 4)
+            } else {
+                return KVCacheSimple()
+            }
+        }
+    }
+
+    /// Stacks per-expert MLP weights into the SwitchGLU `switch_mlp` layout.
+    /// Mirrors language.py's `LanguageModel.sanitize`. The top VLM model should
+    /// call this from its own `sanitize`. Keys are the `language_model.model.*`
+    /// paths produced once this module is wrapped as `language_model`.
+    public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        var newWeights = weights
+        let nExperts = config.nRoutedExperts ?? 1
+
+        for l in 0 ..< config.numHiddenLayers {
+            let prefix = "language_model.model.layers.\(l)"
+            for (_, projName) in [("w1", "gate_proj"), ("w2", "down_proj"), ("w3", "up_proj")] {
+                for key in ["weight", "scales", "biases"] {
+                    let firstKey = "\(prefix).mlp.experts.0.\(projName).\(key)"
+                    if weights[firstKey] != nil {
+                        let toJoin = (0 ..< nExperts).map { e -> MLXArray in
+                            let k = "\(prefix).mlp.experts.\(e).\(projName).\(key)"
+                            return newWeights.removeValue(forKey: k) ?? weights[k]!
+                        }
+                        newWeights["\(prefix).mlp.switch_mlp.\(projName).\(key)"] = stacked(toJoin)
+                    }
+                }
+            }
+        }
+
+        return newWeights
+    }
+}

--- a/Libraries/MLXVLM/Models/DeepseekOCRLanguage.swift
+++ b/Libraries/MLXVLM/Models/DeepseekOCRLanguage.swift
@@ -26,7 +26,8 @@ import MLX
 import MLXLMCommon
 import MLXNN
 
-private typealias TextConfiguration = DeepseekOCRConfiguration.TextConfiguration
+// NOTE: compile-fix (public so it can appear in public init signatures)
+public typealias TextConfiguration = DeepseekOCRConfiguration.TextConfiguration
 
 // MARK: - Attention (LlamaAttention branch)
 

--- a/Libraries/MLXVLM/Models/DeepseekOCRProcessor.swift
+++ b/Libraries/MLXVLM/Models/DeepseekOCRProcessor.swift
@@ -1,0 +1,447 @@
+//
+//  DeepseekOCRProcessor.swift
+//  mlx-swift-lm
+//
+//  `UserInputProcessor` for DeepSeek-OCR / Unlimited-OCR (DeepseekOCRForCausalLM,
+//  top model_type "deepseek_vl_v2").
+//
+//  Port of the image-preprocessing + token-sequence logic from
+//  https://github.com/Blaizzy/mlx-vlm/tree/main/mlx_vlm/models/deepseekocr
+//  (processing_deepseekocr.py + conversation.py). Covers
+//  deepseek-ai/DeepSeek-OCR and baidu/Unlimited-OCR (identical arch).
+//
+//  The DeepEncoder consumes a PAIR of pixel tensors plus two side tensors:
+//    - pixel_values:        [patches, image_ori]
+//                           patches    = local crop views  (N_crops, 3, image_size, image_size)
+//                           image_ori  = global views      (N_images, 3, base_size, base_size)
+//    - images_spatial_crop: per-image [width_crop_num, height_crop_num]
+//    - images_seq_mask:     bool mask of image-token positions in input_ids
+//
+//  `LMInput.ProcessedImage` only exposes `pixels: MLXArray` + `frames: [THW]?`,
+//  so we pack the four model tensors into those two fields with a fixed layout
+//  the model's `prepare(_:cache:windowSize:)` decodes back (see "Packing
+//  contract" below). The token COUNT placed in `input_ids` (and the matching
+//  `true` run in `images_seq_mask`) is computed to EXACTLY equal the number of
+//  feature vectors `get_input_embeddings` emits per image, including the
+//  per-row `image_newline` slots and the trailing `view_separator` slot.
+//
+
+import CoreImage
+import Foundation
+import MLX
+import MLXLMCommon
+import Tokenizers
+
+// MARK: - Processor
+
+public struct DeepseekOCRProcessor: UserInputProcessor {
+
+    private let config: DeepseekOCRConfiguration
+    private let tokenizer: any Tokenizer
+
+    // Defaults matching mlx-vlm processing_deepseekocr.py / processor_config.json.
+    // candidate_resolutions[0][0] == base_size (1024).
+    private let baseSize: Int          // global view size (1024)
+    private let imageSize: Int         // crop tile size (640)
+    private let patchSize: Int         // 16
+    private let downsampleRatio: Int   // 4
+    private let cropping: Bool         // "Gundam"/Unlimited tiling for large images
+    private let minNum: Int            // dynamic_preprocess min tiles (2)
+    private let maxNum: Int            // dynamic_preprocess max tiles (9)
+
+    // IMAGENET-style normalization for DeepSeek-OCR is mean = std = 0.5 per channel
+    // (processor_config.json image_mean / image_std), i.e. pixel*2 - 1.
+    private let imageMean: (CGFloat, CGFloat, CGFloat)
+    private let imageStd: (CGFloat, CGFloat, CGFloat)
+
+    /// `<image>` token id. Read from config (image_token_index / image_token_id,
+    /// default 128815).
+    private var imageTokenId: Int { config.imageTokenIndex }
+
+    public init(_ config: DeepseekOCRConfiguration, tokenizer: any Tokenizer) {
+        self.config = config
+        self.tokenizer = tokenizer
+
+        // candidate_resolutions[0][0] is the base/global size (1024 for DeepSeek-OCR).
+        self.baseSize = 1024
+        self.imageSize = 640
+        self.patchSize = 16
+        self.downsampleRatio = 4
+        self.cropping = true
+        self.minNum = 2
+        self.maxNum = 9
+        self.imageMean = (0.5, 0.5, 0.5)
+        self.imageStd = (0.5, 0.5, 0.5)
+    }
+
+    // MARK: - Image transform
+
+    /// Port of `ImageTransform.__call__`: scale to [0,1], normalize, return CHW.
+    ///
+    /// `MediaProcessing.asMLXArray` already renders to `[1, C, H, W]` Float32 in
+    /// the [0,1] range and `.normalized(mean:std:)` applies `(x - mean) / std`
+    /// in that same range (CIImage tone-curve pixels are 0…1) — matching the
+    /// Python `mx.array(np.array(img)) / 255.0` then `(img - mean) / std`.
+    private func imageTransform(_ image: CIImage) -> MLXArray {
+        image
+            .toSRGB()
+            .normalized(mean: imageMean, std: imageStd)
+            .asMLXArray()  // [1, 3, H, W]
+            .squeezed(axis: 0)  // [3, H, W]
+    }
+
+    /// Background CIColor used by `ImageOps.pad` fill = mean * 255. With mean
+    /// 0.5 this is mid-grey; in normalized space it maps to ~0.
+    private var padColor: CIColor {
+        CIColor(red: imageMean.0, green: imageMean.1, blue: imageMean.2)
+    }
+
+    // MARK: - Resolution / tiling math (port of dynamic_preprocess)
+
+    /// Port of `find_closest_aspect_ratio`.
+    private func findClosestAspectRatio(
+        aspectRatio: Double, targetRatios: [(Int, Int)], width: Int, height: Int,
+        imageSize: Int
+    ) -> (Int, Int) {
+        var bestRatioDiff = Double.greatestFiniteMagnitude
+        var bestRatio = (1, 1)
+        let area = Double(width * height)
+        for ratio in targetRatios {
+            let targetAspectRatio = Double(ratio.0) / Double(ratio.1)
+            let ratioDiff = abs(aspectRatio - targetAspectRatio)
+            if ratioDiff < bestRatioDiff {
+                bestRatioDiff = ratioDiff
+                bestRatio = ratio
+            } else if ratioDiff == bestRatioDiff {
+                if area > 0.5 * Double(imageSize) * Double(imageSize)
+                    * Double(ratio.0) * Double(ratio.1)
+                {
+                    bestRatio = ratio
+                }
+            }
+        }
+        return bestRatio
+    }
+
+    /// Port of `dynamic_preprocess`: returns the local crop tiles plus the chosen
+    /// `(width_crop_num, height_crop_num)` aspect ratio.
+    private func dynamicPreprocess(
+        image: CIImage, origWidth: Int, origHeight: Int
+    ) -> (tiles: [CIImage], cropRatio: (Int, Int)) {
+        let aspectRatio = Double(origWidth) / Double(origHeight)
+
+        // target_ratios = { (i,j) : min_num <= i*j <= max_num }, deduped, sorted by area.
+        var ratioSet = Set<[Int]>()
+        for n in minNum ... maxNum {
+            for i in 1 ... n {
+                for j in 1 ... n {
+                    let prod = i * j
+                    if prod <= maxNum && prod >= minNum {
+                        ratioSet.insert([i, j])
+                    }
+                }
+            }
+        }
+        let targetRatios = ratioSet
+            .map { ($0[0], $0[1]) }
+            .sorted { ($0.0 * $0.1) < ($1.0 * $1.1) }
+
+        let targetAspectRatio = findClosestAspectRatio(
+            aspectRatio: aspectRatio, targetRatios: targetRatios,
+            width: origWidth, height: origHeight, imageSize: imageSize)
+
+        let targetWidth = imageSize * targetAspectRatio.0
+        let targetHeight = imageSize * targetAspectRatio.1
+        let blocks = targetAspectRatio.0 * targetAspectRatio.1
+
+        // NOTE: PIL `image.resize((w,h))` is a plain (non-aspect-preserving) resize.
+        // CIImage origin is bottom-left whereas PIL is top-left, but the crop box
+        // math below mirrors PIL's left→right / top→bottom tiling; the model treats
+        // tiles as a (height_crop_num × width_crop_num) grid reassembled in
+        // get_input_embeddings, so consistent row-major ordering is what matters.
+        let resized = resize(image, to: CGSize(width: targetWidth, height: targetHeight))
+
+        let cols = targetWidth / imageSize
+        var tiles: [CIImage] = []
+        for i in 0 ..< blocks {
+            let x = (i % cols) * imageSize
+            let y = (i / cols) * imageSize
+            // Crop an imageSize×imageSize tile. Flip y to PIL top-left convention.
+            let flippedY = targetHeight - y - imageSize
+            let cropRect = CGRect(x: x, y: flippedY, width: imageSize, height: imageSize)
+            let tile = resized
+                .cropped(to: cropRect)
+                .transformed(by: CGAffineTransform(translationX: -CGFloat(x),
+                                                   y: -CGFloat(flippedY)))
+            tiles.append(tile)
+        }
+        return (tiles, targetAspectRatio)
+    }
+
+    /// Plain resize (non aspect-preserving) to an exact pixel size.
+    private func resize(_ image: CIImage, to size: CGSize) -> CIImage {
+        let extent = image.extent
+        let sx = size.width / extent.width
+        let sy = size.height / extent.height
+        return image
+            .transformed(by: CGAffineTransform(scaleX: sx, y: sy))
+            .transformed(by: CGAffineTransform(
+                translationX: -image.extent.origin.x * sx,
+                y: -image.extent.origin.y * sy))
+    }
+
+    /// Aspect-preserving pad to a square `side`, mean-colored background.
+    /// Port of `ImageOps.pad(image, (side, side), color=mean*255)`.
+    private func padToSquare(_ image: CIImage, side: Int) -> MLXArray {
+        let extent = image.extent
+        let scale = min(
+            CGFloat(side) / extent.width, CGFloat(side) / extent.height)
+        let scaled = image.transformed(by: CGAffineTransform(scaleX: scale, y: scale))
+        let sExtent = scaled.extent
+        let tx = (CGFloat(side) - sExtent.width) * 0.5 - sExtent.origin.x
+        let ty = (CGFloat(side) - sExtent.height) * 0.5 - sExtent.origin.y
+        let centered = scaled.transformed(by: CGAffineTransform(translationX: tx, y: ty))
+
+        let background = CIImage(color: padColor)
+            .cropped(to: CGRect(x: 0, y: 0, width: side, height: side))
+        let composited = centered.composited(over: background)
+            .cropped(to: CGRect(x: 0, y: 0, width: side, height: side))
+        return imageTransform(composited)
+    }
+
+    // MARK: - Token sequence (port of tokenize_with_images)
+
+    /// Per-image expansion result: token sequence + image-seq mask run.
+    private struct ImageTokens {
+        var tokens: [Int]
+        var globalView: MLXArray      // [3, base, base]
+        var cropViews: [MLXArray]     // [3, image, image] each (may be empty)
+        var spatialCrop: (Int, Int)   // (width_crop_num, height_crop_num)
+    }
+
+    /// Build the image-token block for one image, matching the embedding count
+    /// `get_input_embeddings` emits.
+    ///
+    /// num_queries      = ceil((image_size / patch_size) / downsample_ratio)  (=10)
+    /// num_queries_base = ceil((base_size  / patch_size) / downsample_ratio)  (=16)
+    ///
+    /// Global view tokens (always):
+    ///   ([img] * num_queries_base + [img]) * num_queries_base + [img]
+    ///   = (base+1)*base + 1   slots
+    ///   → per row: `base` feature columns + 1 image_newline; `base` rows;
+    ///     + 1 trailing view_separator.
+    ///
+    /// Local crop tokens (only when width_crop_num > 1 OR height_crop_num > 1):
+    ///   ([img] * (num_queries * width_crop_num) + [img]) * (num_queries * height_crop_num)
+    ///   = (q*W + 1) * (q*H)   slots
+    ///   → per local row: q*W feature columns + 1 image_newline; q*H rows.
+    ///   (The view_separator is shared/global — emitted once via the +[img]
+    ///    already accounted in the global block's trailing element.)
+    private func processImage(_ image: CIImage) -> ImageTokens {
+        let extent = image.extent
+        let w = Int(extent.width.rounded())
+        let h = Int(extent.height.rounded())
+
+        var cropRatio = (1, 1)
+        var cropTiles: [CIImage] = []
+
+        if cropping {
+            if w <= 640 && h <= 640 {
+                cropRatio = (1, 1)
+            } else {
+                let (tiles, ratio) = dynamicPreprocess(
+                    image: image, origWidth: w, origHeight: h)
+                cropTiles = tiles
+                cropRatio = ratio
+            }
+        }
+
+        // Global view: aspect-preserving pad to base_size, normalized CHW.
+        let globalView = padToSquare(image, side: baseSize)
+
+        let widthCropNum = cropRatio.0
+        let heightCropNum = cropRatio.1
+        let hasCrops = widthCropNum > 1 || heightCropNum > 1
+
+        let numQueries = Int(
+            (Double(imageSize / patchSize) / Double(downsampleRatio)).rounded(.up))
+        let numQueriesBase = Int(
+            (Double(baseSize / patchSize) / Double(downsampleRatio)).rounded(.up))
+
+        var tokens: [Int] = []
+        // Global block: ([img]*numQueriesBase + [img]) * numQueriesBase + [img]
+        let globalRow = Array(repeating: imageTokenId, count: numQueriesBase) + [imageTokenId]
+        for _ in 0 ..< numQueriesBase { tokens += globalRow }
+        tokens += [imageTokenId]
+
+        // Local block (only with crops).
+        var cropViews: [MLXArray] = []
+        if hasCrops {
+            let localRow =
+                Array(repeating: imageTokenId, count: numQueries * widthCropNum)
+                + [imageTokenId]
+            let localRows = numQueries * heightCropNum
+            for _ in 0 ..< localRows { tokens += localRow }
+            cropViews = cropTiles.map { imageTransform($0) }
+        }
+
+        return ImageTokens(
+            tokens: tokens, globalView: globalView, cropViews: cropViews,
+            spatialCrop: (widthCropNum, heightCropNum))
+    }
+
+    // MARK: - Prompt formatting (port of conversation.py "deepseek" template)
+
+    /// Extract the user text and image count from the structured input. DeepSeek-OCR
+    /// has no useful HF chat template (the bundled one is a near-no-op), so we build
+    /// the DeepSeek conversation prompt directly:
+    ///
+    ///   <|User|>: <image>\n{user text}\n\n<|Assistant|>:
+    ///
+    /// with one `<image>` marker per supplied image, and a leading BOS (id 0).
+    private func renderPrompt(text: String, imageCount: Int) -> String {
+        let imageMarkers = String(repeating: "<image>\n", count: imageCount)
+        return "<|User|>: \(imageMarkers)\(text)\n\n<|Assistant|>:"
+    }
+
+    private func userText(from input: UserInput) -> String {
+        switch input.prompt {
+        case .text(let t):
+            return t
+        case .messages(let messages):
+            // Concatenate user-role text content.
+            return messages.compactMap { msg -> String? in
+                guard let role = msg["role"] as? String, role == "user" else { return nil }
+                if let content = msg["content"] as? String { return content }
+                if let parts = msg["content"] as? [[String: Any]] {
+                    return parts.compactMap { $0["text"] as? String }.joined()
+                }
+                return nil
+            }.joined(separator: "\n")
+        case .chat(let chatMessages):
+            return chatMessages
+                .filter { $0.role == .user }
+                .map(\.content)
+                .joined(separator: "\n")
+        }
+    }
+
+    // MARK: - prepare
+
+    public func prepare(input: UserInput) async throws -> LMInput {
+        let images = try input.images.map { try $0.asCIImage() }
+        let text = userText(from: input)
+
+        // Text-only fast path.
+        if images.isEmpty {
+            let prompt = renderPrompt(text: text, imageCount: 0)
+            // tokenize_with_images uses add_special_tokens=False then prepends
+            // a hardcoded bos_id = 0.
+            var tokens = tokenizer.encode(text: prompt, addSpecialTokens: false)
+            tokens.insert(0, at: 0)  // BOS id 0
+            return LMInput(tokens: MLXArray(tokens), tokenIds: tokens)
+        }
+
+        // Build the prompt, splitting on the <image> marker exactly like
+        // tokenize_with_images: text-around tokens get mask=false, each image
+        // expands into its image-token block (mask=true).
+        let prompt = renderPrompt(text: text, imageCount: images.count)
+        let textSplits = prompt.components(separatedBy: "<image>")
+        precondition(
+            textSplits.count == images.count + 1,
+            "image-marker count must match image count")
+
+        var tokenizedStr: [Int] = []
+        var imagesSeqMask: [Bool] = []
+
+        var globalViews: [MLXArray] = []
+        var cropViews: [MLXArray] = []
+        var spatialCrops: [[Int]] = []
+
+        for (i, image) in images.enumerated() {
+            // Text separator before this image.
+            let sep = tokenizer.encode(text: textSplits[i], addSpecialTokens: false)
+            tokenizedStr += sep
+            imagesSeqMask += Array(repeating: false, count: sep.count)
+
+            // Image token block + pixel tensors.
+            let processed = processImage(image)
+            tokenizedStr += processed.tokens
+            imagesSeqMask += Array(repeating: true, count: processed.tokens.count)
+
+            globalViews.append(processed.globalView)
+            cropViews += processed.cropViews
+            spatialCrops.append([processed.spatialCrop.0, processed.spatialCrop.1])
+        }
+
+        // Trailing text after the last image.
+        let tail = tokenizer.encode(text: textSplits.last!, addSpecialTokens: false)
+        tokenizedStr += tail
+        imagesSeqMask += Array(repeating: false, count: tail.count)
+
+        // Leading BOS (id 0), matching tokenize_with_images.
+        tokenizedStr.insert(0, at: 0)
+        imagesSeqMask.insert(false, at: 0)
+
+        precondition(
+            tokenizedStr.count == imagesSeqMask.count,
+            "tokenized_str length must equal images_seq_mask length")
+
+        // Stack pixel tensors.
+        // image_ori: [N_images, 3, base, base]  (global views, always present)
+        let imageOri = MLX.stacked(globalViews, axis: 0)
+        // patches: [N_crops, 3, image, image]   (local crop views, may be empty)
+        let nCrops = cropViews.count
+        let patches: MLXArray? = nCrops == 0 ? nil : MLX.stacked(cropViews, axis: 0)
+
+        // Packing contract for LMInput.ProcessedImage (model decodes this in
+        // prepare(_:cache:windowSize:)):
+        //
+        //   pixels = image_ori.flatten() [++ patches.flatten() when N_crops > 0]
+        //
+        //   frames[0]    = THW(t: N_crops, h: N_images, w: 0)
+        //                  → counts used to slice `pixels`:
+        //                    image_ori = first  N_images * 3 * base * base elements,
+        //                                reshaped [N_images, 3, base, base];
+        //                    patches   = remaining N_crops * 3 * image * image elements,
+        //                                reshaped [N_crops, 3, image, image]
+        //                                (empty when N_crops == 0 → model uses the
+        //                                 zeros sentinel get_input_embeddings expects).
+        //   frames[1...]  = one THW(1, width_crop_num, height_crop_num) per image
+        //                  → this IS images_spatial_crop.
+        //
+        //   images_seq_mask is reconstructed model-side from input_ids == imageTokenId
+        //   (carried via mediaTokenIds), and is also provided here as text.mask.
+        //
+        // NOTE: image_ori (base_size square) and patches (image_size square) have
+        // different spatial dims, so they cannot form one rectangular MLXArray;
+        // hence the flatten-and-concat layout with shapes recovered from frames[0]
+        // plus the model's known base_size / image_size.
+        var frames: [THW] = [THW(nCrops, images.count, 0)]
+        for crop in spatialCrops {
+            frames.append(THW(1, crop[0], crop[1]))
+        }
+
+        let pixels = packPixels(imageOri: imageOri, patches: patches)
+        let processedImage = LMInput.ProcessedImage(pixels: pixels, frames: frames)
+
+        let promptArray = MLXArray(tokenizedStr).expandedDimensions(axis: 0)
+        let maskArray = MLXArray(imagesSeqMask.map { $0 ? Int32(1) : Int32(0) })
+            .expandedDimensions(axis: 0)
+
+        return LMInput(
+            text: .init(tokens: promptArray, mask: maskArray, tokenIds: tokenizedStr),
+            image: processedImage,
+            mediaTokenIds: [imageTokenId])
+    }
+
+    /// Flatten image_ori and (optional) crop patches into a single 1-D pixel
+    /// buffer the model unpacks using `frames[0]` (= THW(nCrops, nImages, 0)) and
+    /// its known base_size / image_size.
+    /// Layout: [ image_ori.flatten() (++ patches.flatten() if present) ].
+    private func packPixels(imageOri: MLXArray, patches: MLXArray?) -> MLXArray {
+        let oriFlat = imageOri.reshaped([-1])
+        guard let patches else { return oriFlat }
+        return concatenated([oriFlat, patches.reshaped([-1])], axis: 0)
+    }
+}

--- a/Libraries/MLXVLM/Models/DeepseekOCRProcessor.swift
+++ b/Libraries/MLXVLM/Models/DeepseekOCRProcessor.swift
@@ -291,16 +291,21 @@ public struct DeepseekOCRProcessor: UserInputProcessor {
 
     // MARK: - Prompt formatting (port of conversation.py "deepseek" template)
 
-    /// Extract the user text and image count from the structured input. DeepSeek-OCR
-    /// has no useful HF chat template (the bundled one is a near-no-op), so we build
-    /// the DeepSeek conversation prompt directly:
+    /// Build the prompt string exactly like the official `model.infer`:
+    /// `format_messages(sft_format='plain', system_prompt='')` over a single
+    /// `{role:<|User|>, content: prompt}` + `{role:<|Assistant|>, content:""}`
+    /// conversation. The `'plain'` conv template has EMPTY roles and EMPTY
+    /// separators, so the formatted prompt is simply the user content
+    /// (`.strip()`-ed) with no `<|User|>` / `<|Assistant|>` markers — the
+    /// assistant turn is empty and contributes nothing.
     ///
-    ///   <|User|>: <image>\n{user text}\n\n<|Assistant|>:
-    ///
-    /// with one `<image>` marker per supplied image, and a leading BOS (id 0).
+    /// The user content the official caller passes is `<image>\n{instruction}`
+    /// (one `<image>` marker per image), e.g. `<image>\nFree OCR.`. A leading
+    /// BOS (id 0) is prepended later in `prepare`.
     private func renderPrompt(text: String, imageCount: Int) -> String {
         let imageMarkers = String(repeating: "<image>\n", count: imageCount)
-        return "<|User|>: \(imageMarkers)\(text)\n\n<|Assistant|>:"
+        // Mirror `sft_prompt.strip()` on the concatenated content.
+        return "\(imageMarkers)\(text)".trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     private func userText(from input: UserInput) -> String {

--- a/Libraries/MLXVLM/Models/DeepseekOCRProcessor.swift
+++ b/Libraries/MLXVLM/Models/DeepseekOCRProcessor.swift
@@ -30,7 +30,6 @@ import CoreImage
 import Foundation
 import MLX
 import MLXLMCommon
-import Tokenizers
 
 // MARK: - Processor
 

--- a/Libraries/MLXVLM/Models/DeepseekOCRSAM.swift
+++ b/Libraries/MLXVLM/Models/DeepseekOCRSAM.swift
@@ -320,9 +320,10 @@ public class DeepseekOCRSAMEncoder: Module {
     let imgSize: Int
     let useAbsPos: Bool
 
-    @ModuleInfo(key: "patch_embed") var patchEmbed: PatchEmbed
+    // NOTE: compile-fix — fileprivate so these private-typed members can live in a public class.
+    @ModuleInfo(key: "patch_embed") fileprivate var patchEmbed: PatchEmbed
     @ParameterInfo(key: "pos_embed") var posEmbed: MLXArray
-    @ModuleInfo var blocks: [Block]
+    @ModuleInfo fileprivate var blocks: [Block]
 
     // The neck is a heterogeneous list (Conv2d, LayerNorm, Conv2d, LayerNorm) in
     // sam.py. MLX-Swift requires a homogeneous container, so we name the four
@@ -343,9 +344,9 @@ public class DeepseekOCRSAMEncoder: Module {
             embedDim: config.width,
             depth: config.layers,
             numHeads: config.heads,
+            outChans: config.promptEmbedDim,
             windowSize: config.windowSize,
             globalAttnIndexes: config.globalAttnIndexes,
-            outChans: config.promptEmbedDim,
             finalOutChans: config.downsampleChannels.last ?? 1024)
     }
 

--- a/Libraries/MLXVLM/Models/DeepseekOCRSAM.swift
+++ b/Libraries/MLXVLM/Models/DeepseekOCRSAM.swift
@@ -29,14 +29,25 @@ import MLXNN
 /// sam.py is omitted because tgt_size always equals src_size here; if a
 /// different image size is ever used this must grow a bicubic path.
 private func getAbsPosSAM(_ absPos: MLXArray, tgtSize: Int) -> MLXArray {
+    // absPos: (1, src, src, C). The SAM pos embed is the 64x64 grid for the
+    // 1024px global view (1024/16). The 640px CROP tiles produce a 40x40 patch
+    // grid, so src(64) != tgt(40) and the embedding MUST be bicubically resized
+    // — matching deepencoder.py `get_abs_pos_sam`:
+    //   permute(0,3,1,2) -> float32 -> F.interpolate(bicubic, antialias,
+    //   align_corners=False) -> permute(0,2,3,1).
+    // Returning identity here (the prior behavior) left crop tiles with the
+    // wrong positional encoding (and a shape mismatch on the add), collapsing
+    // multi-tile OCR.
     let srcSize = absPos.dim(1)
-    if srcSize != tgtSize {
-        // NOTE: Non-square / resized input not exercised by DeepSeek-OCR's fixed
-        // 1024x1024 SAM geometry. Fall back to identity rather than silently
-        // mis-interpolate; revisit if dynamic image sizes are added.
+    if srcSize == tgtSize {
         return absPos
     }
-    return absPos
+    let dtype = absPos.dtype
+    // (1, src, src, C) -> (1, C, src, src)
+    var p = absPos.transposed(0, 3, 1, 2).asType(.float32)
+    p = bicubicInterpolate(p, size: (tgtSize, tgtSize))
+    // (1, C, tgt, tgt) -> (1, tgt, tgt, C)
+    return p.asType(dtype).transposed(0, 2, 3, 1)
 }
 
 /// Partition (B, H, W, C) into non-overlapping windows with padding if needed.
@@ -309,6 +320,39 @@ private class PatchEmbed: Module {
     }
 }
 
+// MARK: - LayerNorm2d (channel-axis norm in NHWC)
+
+/// Channel-wise LayerNorm matching deepencoder.py `LayerNorm2d`.
+///
+/// The official PyTorch code runs the neck in NCHW and normalizes over axis 1
+/// (channels) — `u = x.mean(1)`, then scales by `weight[:,None,None]`. Our SAM
+/// tower flows in NHWC, where the channel axis is the LAST axis, so a normal
+/// channel-last LayerNorm reduction is numerically identical. We keep an
+/// explicit small module (rather than reusing MLXNN.LayerNorm) so the
+/// `weight`/`bias` parameter keys resolve directly under the neck container
+/// (`neck.1.weight`, `neck.1.bias`, …) and the reduction axis is unambiguous.
+private class LayerNorm2dNHWC: Module, UnaryLayer {
+    var weight: MLXArray
+    var bias: MLXArray
+    let eps: Float
+
+    init(_ numChannels: Int, eps: Float = 1e-6) {
+        self.weight = MLXArray.ones([numChannels])
+        self.bias = MLXArray.zeros([numChannels])
+        self.eps = eps
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        // x: (B, H, W, C) NHWC — normalize over the channel (last) axis.
+        let u = mean(x, axis: -1, keepDims: true)
+        let d = x - u
+        let s = mean(d * d, axis: -1, keepDims: true)
+        let normed = d * rsqrt(s + eps)
+        return weight * normed + bias
+    }
+}
+
 // MARK: - SAM encoder
 
 /// SAM-ViT-B encoder. Wrapped as `sam_model` by the top model so weight keys
@@ -325,14 +369,13 @@ public class DeepseekOCRSAMEncoder: Module {
     @ParameterInfo(key: "pos_embed") var posEmbed: MLXArray
     @ModuleInfo fileprivate var blocks: [Block]
 
-    // The neck is a heterogeneous list (Conv2d, LayerNorm, Conv2d, LayerNorm) in
-    // sam.py. MLX-Swift requires a homogeneous container, so we name the four
-    // members explicitly with @ModuleInfo keys "neck.0".."neck.3" to reproduce
-    // the exact safetensors paths.
-    @ModuleInfo(key: "neck.0") var neck0: Conv2d   // 1x1 conv, embed_dim -> 256, no bias
-    @ModuleInfo(key: "neck.1") var neck1: LayerNorm
-    @ModuleInfo(key: "neck.2") var neck2: Conv2d   // 3x3 conv, 256 -> 256, pad 1, no bias
-    @ModuleInfo(key: "neck.3") var neck3: LayerNorm
+    // The neck is a heterogeneous Sequential (Conv2d, LayerNorm2d, Conv2d,
+    // LayerNorm2d) in sam.py, serialized with numeric paths (`neck.0.weight`,
+    // `neck.1.weight`, …). An @ModuleInfo array keyed "neck" produces exactly
+    // those `neck.<index>.*` paths and the checkpoint's array structure lines
+    // up element-for-element. Conv2d and LayerNorm2dNHWC both conform to
+    // UnaryLayer, so the heterogeneous stack fits one array.
+    @ModuleInfo(key: "neck") fileprivate var neck: [UnaryLayer]
 
     @ModuleInfo(key: "net_2") var net2: Conv2d     // 3x3 stride-2, 256 -> 512
     @ModuleInfo(key: "net_3") var net3: Conv2d     // 3x3 stride-2, 512 -> final_out_chans
@@ -385,15 +428,17 @@ public class DeepseekOCRSAMEncoder: Module {
                 inputSize: (grid, grid))
         }
 
-        // Neck: matches nn.Conv2d/nn.LayerNorm stack in sam.py.
-        self._neck0.wrappedValue = Conv2d(
-            inputChannels: embedDim, outputChannels: outChans,
-            kernelSize: IntOrPair(1), bias: false)
-        self._neck1.wrappedValue = LayerNorm(dimensions: outChans, eps: 1e-6)
-        self._neck2.wrappedValue = Conv2d(
-            inputChannels: outChans, outputChannels: outChans,
-            kernelSize: IntOrPair(3), padding: IntOrPair(1), bias: false)
-        self._neck3.wrappedValue = LayerNorm(dimensions: outChans, eps: 1e-6)
+        // Neck: matches nn.Conv2d/LayerNorm2d Sequential in sam.py (4 elements).
+        self._neck.wrappedValue = [
+            Conv2d(
+                inputChannels: embedDim, outputChannels: outChans,
+                kernelSize: IntOrPair(1), bias: false),                 // neck.0
+            LayerNorm2dNHWC(outChans),                                  // neck.1
+            Conv2d(
+                inputChannels: outChans, outputChannels: outChans,
+                kernelSize: IntOrPair(3), padding: IntOrPair(1), bias: false),  // neck.2
+            LayerNorm2dNHWC(outChans),                                  // neck.3
+        ]
 
         self._net2.wrappedValue = Conv2d(
             inputChannels: 256, outputChannels: 512,
@@ -419,13 +464,10 @@ public class DeepseekOCRSAMEncoder: Module {
             x = blk(x)
         }
 
-        // Neck: Conv2d operate in NHWC; LayerNorm normalizes the last (channel)
-        // axis, matching sam.py where the neck LayerNorm acts over channels in
-        // NHWC layout.
-        x = neck0(x)
-        x = neck1(x)
-        x = neck2(x)
-        x = neck3(x)
+        // Neck: Conv2d operate in NHWC; LayerNorm2dNHWC normalizes the last
+        // (channel) axis, matching sam.py where the neck LayerNorm2d acts over
+        // channels (axis 1 in its NCHW layout == last axis here in NHWC).
+        for layer in neck { x = layer(x) }
 
         // Additional 2x + 2x downsampling -> (B, 16, 16, final_out_chans)
         x = net2(x)

--- a/Libraries/MLXVLM/Models/DeepseekOCRSAM.swift
+++ b/Libraries/MLXVLM/Models/DeepseekOCRSAM.swift
@@ -1,0 +1,463 @@
+//
+//  DeepseekOCRSAM.swift
+//  mlx-swift-lm
+//
+//  SAM-ViT-B vision encoder for the DeepSeek-OCR DeepEncoder (the `sam_model`
+//  branch). Faithful port of mlx-vlm's deepseekocr/sam.py.
+//
+//  Architecture (fixed by SAMViTConfig): image_size 1024, patch_size 16,
+//  embed_dim 768, depth 12, heads 12, window_size 14,
+//  global_attn_indexes {2,5,8,11}, neck out_chans 256, then net_2 (256->512)
+//  and net_3 (512->1024) each stride-2 — total 16x downsample of the 64x64
+//  patch grid down to a 16x16 (final_out_chans 1024) feature map in NHWC.
+//
+//  All spatial tensors flow in NHWC (B, H, W, C) to match MLX Conv2d and the
+//  Python reference exactly.
+//
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+// MARK: - Utility functions (1:1 with sam.py)
+
+/// Interpolate absolute positional embeddings to target size.
+/// abs_pos: (1, src, src, C). When src == tgt this is the identity (the only
+/// case that occurs for the fixed 1024/16 = 64 geometry, so we keep it simple
+/// and assert the identity branch). NOTE: bicubic interpolation branch from
+/// sam.py is omitted because tgt_size always equals src_size here; if a
+/// different image size is ever used this must grow a bicubic path.
+private func getAbsPosSAM(_ absPos: MLXArray, tgtSize: Int) -> MLXArray {
+    let srcSize = absPos.dim(1)
+    if srcSize != tgtSize {
+        // NOTE: Non-square / resized input not exercised by DeepSeek-OCR's fixed
+        // 1024x1024 SAM geometry. Fall back to identity rather than silently
+        // mis-interpolate; revisit if dynamic image sizes are added.
+        return absPos
+    }
+    return absPos
+}
+
+/// Partition (B, H, W, C) into non-overlapping windows with padding if needed.
+/// Returns the windows (B*nW, win, win, C) and the padded (Hp, Wp).
+private func windowPartition(_ xIn: MLXArray, windowSize: Int) -> (MLXArray, (Int, Int)) {
+    var x = xIn
+    let (B, H, W, C) = (x.dim(0), x.dim(1), x.dim(2), x.dim(3))
+
+    let padH = (windowSize - H % windowSize) % windowSize
+    let padW = (windowSize - W % windowSize) % windowSize
+
+    if padH > 0 || padW > 0 {
+        x = padded(x, widths: [[0, 0], [0, padH], [0, padW], [0, 0]])
+    }
+    let Hp = H + padH
+    let Wp = W + padW
+
+    x = x.reshaped(B, Hp / windowSize, windowSize, Wp / windowSize, windowSize, C)
+    let windows = x.transposed(0, 1, 3, 2, 4, 5).reshaped(-1, windowSize, windowSize, C)
+    return (windows, (Hp, Wp))
+}
+
+/// Reverse of windowPartition: stitch windows back to (B, H, W, C), dropping padding.
+private func windowUnpartition(
+    _ windows: MLXArray, windowSize: Int, padHW: (Int, Int), hw: (Int, Int)
+) -> MLXArray {
+    let (Hp, Wp) = padHW
+    let (H, W) = hw
+    let B = windows.dim(0) / (Hp * Wp / windowSize / windowSize)
+
+    var x = windows.reshaped(
+        B, Hp / windowSize, Wp / windowSize, windowSize, windowSize, -1)
+    x = x.transposed(0, 1, 3, 2, 4, 5).reshaped(B, Hp, Wp, -1)
+
+    if Hp > H || Wp > W {
+        x = x[0..., ..<H, ..<W, 0...]
+    }
+    return x
+}
+
+/// Get relative positional embeddings for the given query / key sizes.
+/// rel_pos: (L, C). When L already equals 2*max(q,k)-1 (true for the fixed
+/// geometry, where q==k==window_size or q==k==64) this just builds the gather
+/// index. NOTE: the linear-interpolation resize branch from sam.py is included
+/// for fidelity but is not hit at the fixed DeepSeek-OCR geometry.
+private func getRelPos(qSize: Int, kSize: Int, relPos: MLXArray) -> MLXArray {
+    let maxRelDist = 2 * max(qSize, kSize) - 1
+
+    var relPosResized: MLXArray
+    if relPos.dim(0) != maxRelDist {
+        let dtype = relPos.dtype
+        var rp = relPos.asType(.float32)
+        // (1, L, C) -> (1, C, L)
+        rp = rp.reshaped(1, relPos.dim(0), -1).transposed(0, 2, 1)
+        let scale = Float(rp.dim(2)) / Float(maxRelDist)
+        let indices = MLXArray(0 ..< maxRelDist).asType(.float32) * scale
+        let idxFloor = floor(indices).asType(.int32)
+        let idxCeil = minimum(idxFloor + 1, rp.dim(2) - 1)
+        let weight = indices - idxFloor.asType(.float32)
+
+        let gatheredFloor = rp.take(idxFloor, axis: 2)
+        let gatheredCeil = rp.take(idxCeil, axis: 2)
+        rp = (gatheredFloor * (1 - weight) + gatheredCeil * weight).asType(dtype)
+        relPosResized = rp.reshaped(-1, maxRelDist).transposed(1, 0)
+    } else {
+        relPosResized = relPos
+    }
+
+    // Scale the coords with short length if q and k differ.
+    let qScale = max(Float(kSize) / Float(qSize), 1.0)
+    let kScale = max(Float(qSize) / Float(kSize), 1.0)
+    let qCoords = MLXArray(0 ..< qSize).asType(.float32).reshaped(qSize, 1) * qScale
+    let kCoords = MLXArray(0 ..< kSize).asType(.float32).reshaped(1, kSize) * kScale
+    let relativeCoords = (qCoords - kCoords) + Float(kSize - 1) * kScale
+
+    return relPosResized[relativeCoords.asType(.int32)]
+}
+
+/// Decomposed relative position bias (rel_h, rel_w) as in sam.py.
+/// q: (B, q_h*q_w, C). Returns (rel_h: (B, q_h*q_w, k_h, 1), rel_w: (B, q_h*q_w, 1, k_w)).
+private func addDecomposedRelPos(
+    _ q: MLXArray, relPosH: MLXArray, relPosW: MLXArray,
+    qSize: (Int, Int), kSize: (Int, Int)
+) -> (MLXArray, MLXArray) {
+    let (qH, qW) = qSize
+    let (kH, kW) = kSize
+
+    let Rh = getRelPos(qSize: qH, kSize: kH, relPos: relPosH)
+    let Rw = getRelPos(qSize: qW, kSize: kW, relPos: relPosW)
+
+    let B = q.dim(0)
+    let dim = q.dim(2)
+    let rq = q.reshaped(B, qH, qW, dim)
+
+    var relH = einsum("bhwc,hkc->bhwk", rq, Rh)
+    var relW = einsum("bhwc,wkc->bhwk", rq, Rw)
+    relH = relH[.ellipsis, .newAxis]          // (B, qH, qW, kH, 1)
+    relW = relW[.ellipsis, .newAxis, 0...]    // (B, qH, qW, 1, kW)
+    relH = relH.reshaped(B, qH * qW, kH, 1)
+    relW = relW.reshaped(B, qH * qW, 1, kW)
+    return (relH, relW)
+}
+
+// MARK: - MLP block
+
+private class MLPBlock: Module, UnaryLayer {
+    @ModuleInfo var lin1: Linear
+    @ModuleInfo var lin2: Linear
+    let act: GELU
+
+    init(embeddingDim: Int, mlpDim: Int) {
+        self._lin1.wrappedValue = Linear(embeddingDim, mlpDim)
+        self._lin2.wrappedValue = Linear(mlpDim, embeddingDim)
+        self.act = GELU()
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        lin2(act(lin1(x)))
+    }
+}
+
+// MARK: - Attention with relative position embeddings
+
+private class Attention: Module {
+    let numHeads: Int
+    let scale: Float
+    let useRelPos: Bool
+
+    @ModuleInfo var qkv: Linear
+    @ModuleInfo var proj: Linear
+
+    @ParameterInfo(key: "rel_pos_h") var relPosH: MLXArray
+    @ParameterInfo(key: "rel_pos_w") var relPosW: MLXArray
+
+    init(
+        dim: Int, numHeads: Int = 8, qkvBias: Bool = true,
+        useRelPos: Bool = false, inputSize: (Int, Int)? = nil
+    ) {
+        self.numHeads = numHeads
+        let headDim = dim / numHeads
+        self.scale = pow(Float(headDim), -0.5)
+        self.useRelPos = useRelPos
+
+        self._qkv.wrappedValue = Linear(dim, dim * 3, bias: qkvBias)
+        self._proj.wrappedValue = Linear(dim, dim)
+
+        if useRelPos {
+            precondition(
+                inputSize != nil,
+                "Input size must be provided if using relative positional encoding.")
+            let (ih, iw) = inputSize!
+            self._relPosH.wrappedValue = MLXArray.zeros([2 * ih - 1, headDim])
+            self._relPosW.wrappedValue = MLXArray.zeros([2 * iw - 1, headDim])
+        } else {
+            // Unused, but the property must be initialized.
+            self._relPosH.wrappedValue = MLXArray.zeros([1, headDim])
+            self._relPosW.wrappedValue = MLXArray.zeros([1, headDim])
+        }
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let (B, H, W) = (x.dim(0), x.dim(1), x.dim(2))
+
+        // (B, H*W, 3, nHeads, headDim) -> (3, B, nHeads, H*W, headDim)
+        var qkvOut = qkv(x)
+            .reshaped(B, H * W, 3, numHeads, -1)
+            .transposed(2, 0, 3, 1, 4)
+
+        // (3, B*nHeads, H*W, headDim)
+        qkvOut = qkvOut.reshaped(3, B * numHeads, H * W, -1)
+        let q = qkvOut[0]
+        let k = qkvOut[1]
+        let v = qkvOut[2]
+
+        let qH = q.reshaped(B, numHeads, H * W, -1)
+        let kH = k.reshaped(B, numHeads, H * W, -1)
+        let vH = v.reshaped(B, numHeads, H * W, -1)
+
+        var out: MLXArray
+        if useRelPos {
+            let (relH, relW) = addDecomposedRelPos(
+                q, relPosH: relPosH, relPosW: relPosW, qSize: (H, W), kSize: (H, W))
+            // relH: (B*nHeads, H*W, kH, 1), relW: (B*nHeads, H*W, 1, kW)
+            let relH5 = relH.reshaped(B, numHeads, relH.dim(1), relH.dim(2), relH.dim(3))
+            let relW5 = relW.reshaped(B, numHeads, relW.dim(1), relW.dim(2), relW.dim(3))
+            // attn_bias: (B, nHeads, H*W, kH*kW)
+            let attnBias = (relH5 + relW5).reshaped(
+                B, numHeads, relH5.dim(2), relH5.dim(3) * relW5.dim(4))
+            out = MLXFast.scaledDotProductAttention(
+                queries: qH, keys: kH, values: vH, scale: scale, mask: .array(attnBias))
+        } else {
+            out = MLXFast.scaledDotProductAttention(
+                queries: qH, keys: kH, values: vH, scale: scale, mask: .none)
+        }
+
+        // (B, nHeads, H, W, headDim) -> (B, H, W, C)
+        out = out.reshaped(B, numHeads, H, W, -1)
+            .transposed(0, 2, 3, 1, 4)
+            .reshaped(B, H, W, -1)
+        return proj(out)
+    }
+}
+
+// MARK: - Transformer block (window or global attention)
+
+private class Block: Module {
+    @ModuleInfo var norm1: LayerNorm
+    @ModuleInfo var attn: Attention
+    @ModuleInfo var norm2: LayerNorm
+    @ModuleInfo var mlp: MLPBlock
+
+    let windowSize: Int
+
+    init(
+        dim: Int, numHeads: Int, mlpRatio: Float = 4.0, qkvBias: Bool = true,
+        useRelPos: Bool = false, windowSize: Int = 0, inputSize: (Int, Int)? = nil
+    ) {
+        self._norm1.wrappedValue = LayerNorm(dimensions: dim, eps: 1e-6)
+        self._attn.wrappedValue = Attention(
+            dim: dim, numHeads: numHeads, qkvBias: qkvBias, useRelPos: useRelPos,
+            inputSize: windowSize == 0 ? inputSize : (windowSize, windowSize))
+        self._norm2.wrappedValue = LayerNorm(dimensions: dim, eps: 1e-6)
+        self._mlp.wrappedValue = MLPBlock(embeddingDim: dim, mlpDim: Int(Float(dim) * mlpRatio))
+        self.windowSize = windowSize
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let shortcut = x
+        var h = norm1(x)
+
+        var padHW: (Int, Int) = (0, 0)
+        var origHW: (Int, Int) = (0, 0)
+        if windowSize > 0 {
+            origHW = (h.dim(1), h.dim(2))
+            let (windows, pad) = windowPartition(h, windowSize: windowSize)
+            h = windows
+            padHW = pad
+        }
+
+        h = attn(h)
+
+        if windowSize > 0 {
+            h = windowUnpartition(h, windowSize: windowSize, padHW: padHW, hw: origHW)
+        }
+
+        let x1 = shortcut + h
+        return x1 + mlp(norm2(x1))
+    }
+}
+
+// MARK: - Patch embedding
+
+private class PatchEmbed: Module {
+    @ModuleInfo var proj: Conv2d
+
+    init(
+        kernelSize: Int = 16, stride: Int = 16, inChans: Int = 3, embedDim: Int = 768
+    ) {
+        self._proj.wrappedValue = Conv2d(
+            inputChannels: inChans, outputChannels: embedDim,
+            kernelSize: IntOrPair(kernelSize), stride: IntOrPair(stride))
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        proj(x)
+    }
+}
+
+// MARK: - SAM encoder
+
+/// SAM-ViT-B encoder. Wrapped as `sam_model` by the top model so weight keys
+/// resolve to `sam_model.patch_embed.*`, `sam_model.pos_embed`,
+/// `sam_model.blocks.N.*`, `sam_model.neck.*`, `sam_model.net_2`,
+/// `sam_model.net_3`.
+public class DeepseekOCRSAMEncoder: Module {
+
+    let imgSize: Int
+    let useAbsPos: Bool
+
+    @ModuleInfo(key: "patch_embed") var patchEmbed: PatchEmbed
+    @ParameterInfo(key: "pos_embed") var posEmbed: MLXArray
+    @ModuleInfo var blocks: [Block]
+
+    // The neck is a heterogeneous list (Conv2d, LayerNorm, Conv2d, LayerNorm) in
+    // sam.py. MLX-Swift requires a homogeneous container, so we name the four
+    // members explicitly with @ModuleInfo keys "neck.0".."neck.3" to reproduce
+    // the exact safetensors paths.
+    @ModuleInfo(key: "neck.0") var neck0: Conv2d   // 1x1 conv, embed_dim -> 256, no bias
+    @ModuleInfo(key: "neck.1") var neck1: LayerNorm
+    @ModuleInfo(key: "neck.2") var neck2: Conv2d   // 3x3 conv, 256 -> 256, pad 1, no bias
+    @ModuleInfo(key: "neck.3") var neck3: LayerNorm
+
+    @ModuleInfo(key: "net_2") var net2: Conv2d     // 3x3 stride-2, 256 -> 512
+    @ModuleInfo(key: "net_3") var net3: Conv2d     // 3x3 stride-2, 512 -> final_out_chans
+
+    public convenience init(_ config: DeepseekOCRConfiguration.SAMViTConfiguration) {
+        self.init(
+            imgSize: config.imageSize,
+            patchSize: config.patchSize,
+            embedDim: config.width,
+            depth: config.layers,
+            numHeads: config.heads,
+            windowSize: config.windowSize,
+            globalAttnIndexes: config.globalAttnIndexes,
+            outChans: config.promptEmbedDim,
+            finalOutChans: config.downsampleChannels.last ?? 1024)
+    }
+
+    public init(
+        imgSize: Int = 1024,
+        patchSize: Int = 16,
+        inChans: Int = 3,
+        embedDim: Int = 768,
+        depth: Int = 12,
+        numHeads: Int = 12,
+        mlpRatio: Float = 4.0,
+        outChans: Int = 256,
+        qkvBias: Bool = true,
+        useAbsPos: Bool = true,
+        useRelPos: Bool = true,
+        windowSize: Int = 14,
+        globalAttnIndexes: [Int] = [2, 5, 8, 11],
+        finalOutChans: Int = 1024
+    ) {
+        self.imgSize = imgSize
+        self.useAbsPos = useAbsPos
+
+        self._patchEmbed.wrappedValue = PatchEmbed(
+            kernelSize: patchSize, stride: patchSize, inChans: inChans, embedDim: embedDim)
+
+        let grid = imgSize / patchSize
+        // (1, grid, grid, embedDim)
+        self._posEmbed.wrappedValue = MLXArray.zeros([1, grid, grid, embedDim])
+
+        let globalSet = Set(globalAttnIndexes)
+        self._blocks.wrappedValue = (0 ..< depth).map { i in
+            Block(
+                dim: embedDim, numHeads: numHeads, mlpRatio: mlpRatio, qkvBias: qkvBias,
+                useRelPos: useRelPos,
+                windowSize: globalSet.contains(i) ? 0 : windowSize,
+                inputSize: (grid, grid))
+        }
+
+        // Neck: matches nn.Conv2d/nn.LayerNorm stack in sam.py.
+        self._neck0.wrappedValue = Conv2d(
+            inputChannels: embedDim, outputChannels: outChans,
+            kernelSize: IntOrPair(1), bias: false)
+        self._neck1.wrappedValue = LayerNorm(dimensions: outChans, eps: 1e-6)
+        self._neck2.wrappedValue = Conv2d(
+            inputChannels: outChans, outputChannels: outChans,
+            kernelSize: IntOrPair(3), padding: IntOrPair(1), bias: false)
+        self._neck3.wrappedValue = LayerNorm(dimensions: outChans, eps: 1e-6)
+
+        self._net2.wrappedValue = Conv2d(
+            inputChannels: 256, outputChannels: 512,
+            kernelSize: IntOrPair(3), stride: IntOrPair(2), padding: IntOrPair(1), bias: false)
+        self._net3.wrappedValue = Conv2d(
+            inputChannels: 512, outputChannels: finalOutChans,
+            kernelSize: IntOrPair(3), stride: IntOrPair(2), padding: IntOrPair(1), bias: false)
+
+        super.init()
+    }
+
+    /// x: (B, 1024, 1024, 3) NHWC. Returns the (B, 16, 16, final_out_chans)
+    /// spatial feature map (NHWC), exactly as sam.py returns it.
+    public func callAsFunction(_ xIn: MLXArray) -> MLXArray {
+        // Patch embed -> (B, 64, 64, embedDim) NHWC
+        var x = patchEmbed(xIn)
+
+        if useAbsPos {
+            x = x + getAbsPosSAM(posEmbed, tgtSize: x.dim(1))
+        }
+
+        for blk in blocks {
+            x = blk(x)
+        }
+
+        // Neck: Conv2d operate in NHWC; LayerNorm normalizes the last (channel)
+        // axis, matching sam.py where the neck LayerNorm acts over channels in
+        // NHWC layout.
+        x = neck0(x)
+        x = neck1(x)
+        x = neck2(x)
+        x = neck3(x)
+
+        // Additional 2x + 2x downsampling -> (B, 16, 16, final_out_chans)
+        x = net2(x)
+        x = net3(x)
+
+        return x
+    }
+
+    /// Convert PyTorch conv weights ([out, in, kH, kW]) to MLX NHWC layout
+    /// ([out, kH, kW, in]). The top model invokes this for its `sam_model.*`
+    /// slice. Conv weight keys: patch_embed.proj.weight, neck.0/neck.2.weight,
+    /// net_2.weight, net_3.weight. `pos_embed` and `rel_pos_*` ship already in
+    /// the expected layout and are passed through.
+    public static func sanitize(weights: [String: MLXArray], prefix: String = "sam_model.")
+        -> [String: MLXArray]
+    {
+        var out = weights
+        let convWeightSuffixes = [
+            "patch_embed.proj.weight",
+            "neck.0.weight",
+            "neck.2.weight",
+            "net_2.weight",
+            "net_3.weight",
+        ]
+        for (k, v) in weights {
+            guard k.hasPrefix(prefix), v.ndim == 4 else { continue }
+            if convWeightSuffixes.contains(where: { k.hasSuffix($0) }) {
+                // Skip if already NHWC (out, kH, kW, in) with square kernel.
+                let s = v.shape
+                let alreadyMLX = (s[0] >= s[1]) && (s[0] >= s[2]) && (s[1] == s[2])
+                out[k] = alreadyMLX ? v : v.transposed(0, 2, 3, 1)
+            }
+        }
+        return out
+    }
+}

--- a/Libraries/MLXVLM/Models/DeepseekOCRVision.swift
+++ b/Libraries/MLXVLM/Models/DeepseekOCRVision.swift
@@ -1,0 +1,305 @@
+//
+//  DeepseekOCRVision.swift
+//  mlx-swift-lm
+//
+//  CLIP-L/14-224 vision tower for the DeepSeek-OCR DeepEncoder.
+//
+//  Faithful port of
+//  https://github.com/Blaizzy/mlx-vlm/tree/main/mlx_vlm/models/deepseekocr (vision.py)
+//
+//  Architecture: CLIP-L/14-224 — width 1024, layers 24, heads 16,
+//  patch_size 14, image_size 224, layer_norm_eps 1e-6.
+//
+//  This branch is the `vision_model` sub-module of DeepseekOCRForCausalLM.
+//  Its distinguishing feature vs. a stock CLIP ViT is the `patchEmbeds`
+//  fusion: when the SAM encoder's patch tokens are supplied, they are used
+//  in place of running the Conv2d patch embedding (the SAM tower already
+//  produced the per-patch features); otherwise the Conv2d patch embedding
+//  runs on the raw NHWC image.
+//
+//  Weight keys (after the top model's `sanitize`, the prefix is
+//  `vision_model.`, matching `model.vision_model.*` in the safetensors):
+//    vision_model.embeddings.class_embedding
+//    vision_model.embeddings.patch_embedding.weight
+//    vision_model.embeddings.position_embedding.weight
+//    vision_model.pre_layrnorm.{weight,bias}            (note: "layrnorm")
+//    vision_model.transformer.layers.{i}.layer_norm1.{weight,bias}
+//    vision_model.transformer.layers.{i}.layer_norm2.{weight,bias}
+//    vision_model.transformer.layers.{i}.mlp.fc1.{weight,bias}
+//    vision_model.transformer.layers.{i}.mlp.fc2.{weight,bias}
+//    vision_model.transformer.layers.{i}.self_attn.qkv_proj.{weight,bias}
+//    vision_model.transformer.layers.{i}.self_attn.out_proj.{weight,bias}
+//
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+// MARK: - Attention (fused QKV)
+
+/// CLIP-style attention with a single fused `qkv_proj` (`dims -> dims * 3`)
+/// and `out_proj`. Mirrors vision.py `Attention`.
+private class DeepseekOCRVisionAttention: Module {
+    @ModuleInfo(key: "qkv_proj") var qkvProj: Linear
+    @ModuleInfo(key: "out_proj") var outProj: Linear
+
+    let numHeads: Int
+    let scale: Float
+
+    init(dims: Int, numHeads: Int, qkvBias: Bool = true) {
+        if dims % numHeads != 0 {
+            fatalError(
+                "The input feature dimensions should be divisible by the number of heads "
+                    + "(\(dims) % \(numHeads)) != 0")
+        }
+        self.numHeads = numHeads
+        let headDim = dims / numHeads
+        self.scale = pow(Float(headDim), -0.5)
+
+        self._qkvProj.wrappedValue = Linear(dims, dims * 3, bias: qkvBias)
+        self._outProj.wrappedValue = Linear(dims, dims, bias: true)
+    }
+
+    func callAsFunction(_ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode = .none)
+        -> MLXArray
+    {
+        let qkv = qkvProj(x)
+        let parts = split(qkv, parts: 3, axis: -1)
+        var queries = parts[0]
+        var keys = parts[1]
+        var values = parts[2]
+
+        let (B, L) = (queries.dim(0), queries.dim(1))
+        let S = keys.dim(1)
+
+        queries = queries.reshaped(B, L, numHeads, -1).transposed(0, 2, 1, 3)
+        keys = keys.reshaped(B, S, numHeads, -1).transposed(0, 2, 1, 3)
+        values = values.reshaped(B, S, numHeads, -1).transposed(0, 2, 1, 3)
+
+        let output = MLXFast.scaledDotProductAttention(
+            queries: queries,
+            keys: keys,
+            values: values,
+            scale: scale,
+            mask: mask
+        )
+        .transposed(0, 2, 1, 3)
+        .reshaped(B, L, -1)
+
+        return outProj(output)
+    }
+}
+
+// MARK: - MLP
+
+/// Mirrors vision.py `MLP`: fc1 -> GELU -> fc2, with bias.
+private class DeepseekOCRVisionMLP: Module, UnaryLayer {
+    @ModuleInfo(key: "fc1") var fc1: Linear
+    @ModuleInfo(key: "fc2") var fc2: Linear
+
+    let activationFn: GELU
+
+    init(config: DeepseekOCRConfiguration.VisionConfiguration, bias: Bool = true) {
+        // intermediate_size = round(width * mlp_ratio) — CLIP-L: round(1024 * 3.7362) = 3826.
+        let intermediateSize = Int((Float(config.width) * config.mlpRatio).rounded())
+        self.activationFn = GELU()
+        self._fc1.wrappedValue = Linear(config.width, intermediateSize, bias: bias)
+        self._fc2.wrappedValue = Linear(intermediateSize, config.width, bias: bias)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        fc2(activationFn(fc1(x)))
+    }
+}
+
+// MARK: - Encoder layer
+
+/// Pre-norm transformer block. Mirrors vision.py `EncoderLayer`.
+private class DeepseekOCREncoderLayer: Module {
+    @ModuleInfo(key: "self_attn") var selfAttn: DeepseekOCRVisionAttention
+    @ModuleInfo(key: "layer_norm1") var layerNorm1: LayerNorm
+    @ModuleInfo var mlp: DeepseekOCRVisionMLP
+    @ModuleInfo(key: "layer_norm2") var layerNorm2: LayerNorm
+
+    init(config: DeepseekOCRConfiguration.VisionConfiguration) {
+        let embedDim = config.width
+        self._selfAttn.wrappedValue = DeepseekOCRVisionAttention(
+            dims: config.width, numHeads: config.heads, qkvBias: true)
+        self._layerNorm1.wrappedValue = LayerNorm(dimensions: embedDim, eps: config.layerNormEps)
+        self.mlp = DeepseekOCRVisionMLP(config: config)
+        self._layerNorm2.wrappedValue = LayerNorm(dimensions: embedDim, eps: config.layerNormEps)
+    }
+
+    func callAsFunction(_ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode = .none)
+        -> MLXArray
+    {
+        var y = layerNorm1(x)
+        y = selfAttn(y, mask: mask)
+        let h = x + y
+        let r = mlp(layerNorm2(h))
+        return h + r
+    }
+}
+
+// MARK: - Transformer
+
+/// Mirrors vision.py `NoTPTransformer`: a plain stack of encoder layers,
+/// returning the final layer's output (no layer selection).
+private class DeepseekOCRTransformer: Module {
+    @ModuleInfo var layers: [DeepseekOCREncoderLayer]
+
+    init(config: DeepseekOCRConfiguration.VisionConfiguration) {
+        self._layers.wrappedValue = (0 ..< config.layers).map { _ in
+            DeepseekOCREncoderLayer(config: config)
+        }
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = x
+        for layer in layers {
+            h = layer(h, mask: .none)
+        }
+        return h
+    }
+}
+
+// MARK: - Embeddings (class token + patch embed + position embed)
+
+/// Mirrors vision.py `VisionEmbeddings`.
+private class DeepseekOCRVisionEmbeddings: Module {
+    @ParameterInfo(key: "class_embedding") var classEmbedding: MLXArray
+    @ModuleInfo(key: "patch_embedding") var patchEmbedding: Conv2d
+    @ModuleInfo(key: "position_embedding") var positionEmbedding: Embedding
+
+    let embedDim: Int
+    let imageSize: Int
+    let patchSize: Int
+    let numPatches: Int
+    let numPositions: Int
+
+    init(config: DeepseekOCRConfiguration.VisionConfiguration) {
+        self.embedDim = config.width
+        // NOTE: image_size is hard-coded to 224 in vision.py (not read from config).
+        self.imageSize = 224
+        self.patchSize = config.patchSize
+
+        // class_embedding is a raw learned parameter of shape (embed_dim,),
+        // initialized random in the reference; loaded from weights at runtime.
+        self._classEmbedding.wrappedValue = MLXArray.zeros([embedDim])
+
+        self._patchEmbedding.wrappedValue = Conv2d(
+            inputChannels: config.numChannels,
+            outputChannels: embedDim,
+            kernelSize: IntOrPair(patchSize),
+            stride: IntOrPair(patchSize),
+            bias: false
+        )
+
+        self.numPatches = (imageSize / patchSize) * (imageSize / patchSize)
+        self.numPositions = numPatches + 1
+        self._positionEmbedding.wrappedValue = Embedding(
+            embeddingCount: numPositions, dimensions: embedDim)
+    }
+
+    /// Mirrors vision.py `_get_abs_pos`: resize absolute positional embeddings
+    /// to match the current token grid. For the fixed 224/14 geometry the
+    /// source grid (16x16) equals the target grid, so the identity branch is
+    /// taken and `absPos` is returned unchanged. The resize branch is ported
+    /// for fidelity (bicubic, matching the reference's `interpolate` default).
+    private func getAbsPos(_ absPos: MLXArray, tgtSize: Int) -> MLXArray {
+        let dim = absPos.dim(-1)
+        let absPosNew = squeezed(absPos, axis: 0)  // (L, C)
+        let total = absPosNew.dim(0)
+        let clsToken = absPosNew[0 ..< 1]
+        let oldPosEmbed = absPosNew[1...]
+        let srcSize = Int(Double(total - 1).squareRoot())
+        let tgtSize2D = Int(Double(tgtSize).squareRoot())
+        let dtype = absPos.dtype
+
+        if srcSize != tgtSize2D {
+            // (1, src, src, dim) -> (1, dim, src, src)
+            var resized =
+                oldPosEmbed
+                .reshaped(1, srcSize, srcSize, dim)
+                .transposed(0, 3, 1, 2)
+                .asType(.float32)
+
+            resized = bicubicInterpolate(resized, size: (tgtSize2D, tgtSize2D))
+
+            // (1, dim, tgt, tgt) -> (tgt*tgt, dim)
+            var newPosEmbed =
+                resized
+                .asType(dtype)
+                .transposed(0, 2, 3, 1)
+                .reshaped(tgtSize2D * tgtSize2D, dim)
+
+            newPosEmbed = concatenated([clsToken, newPosEmbed], axis: 0)
+            return newPosEmbed.reshaped(1, tgtSize2D * tgtSize2D + 1, dim)
+        } else {
+            return absPos
+        }
+    }
+
+    /// `x` is NHWC (B, H, W, 3). `patchEmbeds` is the SAM encoder output; when
+    /// supplied it replaces the Conv2d patch embedding (already NHWC-laid-out
+    /// per-patch features). Returns (B, seq, embed_dim) with the CLS token at
+    /// position 0.
+    func callAsFunction(_ x: MLXArray, patchEmbeds: MLXArray? = nil) -> MLXArray {
+        let batchSize = x.dim(0)
+        let targetDtype = positionEmbedding.weight.dtype
+
+        let patchEmbeddings: MLXArray
+        if let patchEmbeds {
+            patchEmbeddings = patchEmbeds
+        } else {
+            patchEmbeddings = patchEmbedding(x)
+        }
+
+        // Flatten spatial dims: (B, H', W', C) -> (B, H'*W', C)
+        let flatPatches = flattened(patchEmbeddings, start: 1, end: 2)
+
+        // Broadcast class embedding to (B, 1, embed_dim)
+        let classEmbeds = broadcast(
+            classEmbedding, to: [batchSize, 1, embedDim]
+        ).asType(targetDtype)
+
+        var embeddings = concatenated([classEmbeds, flatPatches], axis: 1)
+
+        // Position IDs 0..<numPositions
+        let positionIds = MLXArray(Array(0 ..< numPositions))[.newAxis, 0...]
+        let absPos = getAbsPos(positionEmbedding(positionIds), tgtSize: embeddings.dim(1))
+        embeddings = embeddings + absPos.asType(targetDtype)
+
+        return embeddings
+    }
+}
+
+// MARK: - Vision model
+
+/// CLIP-L/14 vision tower (the `vision_model` branch of the DeepEncoder).
+/// Mirrors vision.py `VisionModel`.
+public class DeepseekOCRVisionModel: Module {
+    @ModuleInfo var embeddings: DeepseekOCRVisionEmbeddings
+    @ModuleInfo(key: "pre_layrnorm") var preLayerNorm: LayerNorm
+    @ModuleInfo var transformer: DeepseekOCRTransformer
+
+    public init(_ config: DeepseekOCRConfiguration.VisionConfiguration) {
+        self.embeddings = DeepseekOCRVisionEmbeddings(config: config)
+        // NOTE: pre_layrnorm uses the default LayerNorm eps (1e-5) in the
+        // reference (nn.LayerNorm(hidden_size) — no eps passed), unlike the
+        // encoder-layer norms which use config.layer_norm_eps (1e-6).
+        self._preLayerNorm.wrappedValue = LayerNorm(dimensions: config.width)
+        self.transformer = DeepseekOCRTransformer(config: config)
+        super.init()
+    }
+
+    /// `x`: NHWC image (B, H, W, 3) — the caller passes `image.transpose(0,2,3,1)`.
+    /// `patchEmbeds`: the SAM encoder output, fused into the patch tokens.
+    /// Returns (B, seq, width); the top model selects `result[:, 1:]` to drop CLS.
+    public func callAsFunction(_ x: MLXArray, patchEmbeds: MLXArray) -> MLXArray {
+        var h = embeddings(x, patchEmbeds: patchEmbeds)
+        h = preLayerNorm(h)
+        return transformer(h)
+    }
+}

--- a/Libraries/MLXVLM/Models/DeepseekOCRVision.swift
+++ b/Libraries/MLXVLM/Models/DeepseekOCRVision.swift
@@ -280,9 +280,10 @@ private class DeepseekOCRVisionEmbeddings: Module {
 /// CLIP-L/14 vision tower (the `vision_model` branch of the DeepEncoder).
 /// Mirrors vision.py `VisionModel`.
 public class DeepseekOCRVisionModel: Module {
-    @ModuleInfo var embeddings: DeepseekOCRVisionEmbeddings
+    // NOTE: compile-fix — fileprivate so these private-typed members can live in a public class.
+    @ModuleInfo fileprivate var embeddings: DeepseekOCRVisionEmbeddings
     @ModuleInfo(key: "pre_layrnorm") var preLayerNorm: LayerNorm
-    @ModuleInfo var transformer: DeepseekOCRTransformer
+    @ModuleInfo fileprivate var transformer: DeepseekOCRTransformer
 
     public init(_ config: DeepseekOCRConfiguration.VisionConfiguration) {
         self.embeddings = DeepseekOCRVisionEmbeddings(config: config)

--- a/Libraries/MLXVLM/Models/DeepseekOCR_ARCHITECTURE.md
+++ b/Libraries/MLXVLM/Models/DeepseekOCR_ARCHITECTURE.md
@@ -42,3 +42,24 @@ load fix (neck container) → H2 (assert newline/separator non-zero; fix sanitiz
 New `LocalOCRDelegateTool` (Tools/), mirrors `LocalTextDelegateTool` but VLM + image:
 - gate `ocrDelegationEnabled` (+ global `agentDelegationEnabled`); resolve a VLM model (filter via `VLMDetection.isVLM`/`ModelMediaCapabilities.supportsImage`, reject non-VLM); `ChatResidencyHandoff.memoryPreflight` (refuse-before-evict 1.3×+3GB) → unload resident chat model → run → `restoreBestEffort`; load policy `unloadAfterJob` default (VLM weights large) vs keep-warm per RAM setting; seed `ChatMessage(contentParts:[.text(instruction), .imageUrl(dataURL)])` → `ChatEngine.completeChat` under `LocalTextDelegateContext.$isActive` (no recursive spawn); return compact OCR digest; multiturn/context pass via the same budget loop.
 - Settings to add: `ocrDelegationEnabled`, `defaultOCRModelId`, `permissionDefaults.ocrExtract`, `ocrJobLoadPolicy`; register `LocalOCRDelegateTool()` in ToolRegistry; settings UI picker filtered to VLM/image-capable installed models. Gate residency on ACTUAL residency (avoids the SpawnTool SIGABRT class).
+
+## F. VERIFIED WORKING 2026-06-25 (engine gate PASSED, commit 9a52851)
+Independently re-verified via tools/DeepseekOCRSmoke on 3 images, both code paths:
+- img1 global/`Free OCR.` → "OSAURUS OCR TEST" / "DeepSeek-OCR 2026" ✓
+- img2 crop/multi-tile/`<|grounding|>OCR this image.` → "Invoice #2026-0042" / "Date: June 25, 2026" / "Total: $1,337.00 USD" ✓
+- img3 unseen → "jumps over 13 lazy dogs." / "Receipt: GBP 42.50" ✓ (generalizes; numbers+currency exact)
+~105-121 tok/s, bbox grounding correct. The decisive port bug was: prepare() took the pixel
+working dtype from the (quantized→uint32) embed weights, zeroing the global view and silently
+dropping image injection; fixed to bf16 (imageNewline.dtype). Plus SAM neck array-container load,
+LayerNorm2dNHWC channel-axis, crop abs-pos bicubic, KVCacheSimple, plain sft prompt.
+
+### Two known items that are NOT engine bugs (for serving/model-card, team-owned):
+1. **Tokenizer packaging defect in `sahilchachra/unlimited-ocr-8bit-mlx`**: its tokenizer.json ships a
+   SentencePiece `Metaspace` pretokenizer over a GPT-2 ByteLevel vocab → crashes on plain ASCII. The base
+   `baidu/Unlimited-OCR` tokenizer.json (identical vocab/merges) is correct and was swapped in
+   (orig backed up `tokenizer.json.broken-metaspace.bak`). **The shipped OCR pack must include the correct
+   ByteLevel tokenizer.json.** Not a vmlx bug.
+2. **Bare `Free OCR.` + crop path can emit a leading EOS → empty output** (known DeepSeek-OCR greedy quirk;
+   official mitigates with no_repeat_ngram_size). The `<|grounding|>OCR this image.` prompt is clean on all
+   paths. Serving should default to the grounding prompt (or add no-repeat-ngram). Not a port bug
+   (global path + grounding prompt are clean).

--- a/Libraries/MLXVLM/Models/DeepseekOCR_ARCHITECTURE.md
+++ b/Libraries/MLXVLM/Models/DeepseekOCR_ARCHITECTURE.md
@@ -1,0 +1,44 @@
+# DeepSeek-OCR — true architecture, cache (engine + osaurus), and the real divergences
+
+Synthesized from the OFFICIAL HF reference (deepencoder.py / modeling_deepseekocr.py /
+modeling_deepseekv2.py) cross-read against our Swift port, the vmlx cache, and osaurus serving.
+
+## A. Forward path (what actually happens)
+Image → **DeepEncoder** (two towers, run on each view):
+- **SAM-ViT-B** (`sam_model`): Conv2d patch16 → +pos_embed → 12 blocks (windowed attn win=14 except global at {2,5,8,11}, decomposed rel-pos) → neck (Conv 768→256, **LayerNorm2d over channels**, Conv 256→256, LayerNorm2d) → net_2 (Conv→512 stride2) → net_3 (Conv→1024 stride2). Global 1024² → **[B,16,16,1024]** (256 tokens); crop 640² → **[B,10,10,1024]** (100 tokens).
+- **CLIP-L/14** (`vision_model`): does NOT run its own patch conv — it takes the SAM output as `patch_embeds` (`flatten(2).transpose` → [B,256,1024]), prepends CLS → +pos → pre_layrnorm → 24 blocks (quick_gelu, fused qkv) → **[B,257,1024]**.
+- **Fuse**: `cat(clip[:,1:], sam.flatten(spatial), axis=-1)` → **[B,256,2048]** (CLIP first, SAM second).
+- **Projector**: linear 2048→1280.
+- **2D tiling**: per row append one `image_newline` (→ [16,17,1280] flatten 272); local crops reassembled to crop grid then newline per row; final seq = `cat([local, global, view_separator])` (single uncropped = global+separator = 273 rows).
+- **Inject**: `masked_scatter` the feature rows into text embeds at `image_token_id` positions (count(mask)==num_feature_rows is a HARD invariant; the per-row newline + separator tokens are baked into input_ids by the processor).
+
+Text → **DeepSeek-V2 decoder** (12 layers): standard **Llama MHA + RoPE** (use_mla=false ⇒ the MLA class is DEAD CODE), head_dim 128, 10 heads (no GQA), rope_theta 1e4 non-traditional; layer 0 dense MLP, 1-11 MoE (64 routed +2 shared, top-6 greedy softmax, scaling 1.0, no norm_topk_prob); RMSNorm eps 1e-6; untied lm_head. **Our decoder port is FAITHFUL — no fix needed there.**
+
+## B. The collapse bug is in the VISION TOWERS + zero-init params, NOT the assembly
+Concat order / projector / tiling / injection are faithful in our port — do NOT chase them. Ranked real causes:
+1. **H2 (concrete, Swift-specific): `image_newline`/`view_separator` are `MLXArray.zeros` in DeepseekOCR.swift init.** They are LEARNED checkpoint params inserted as actual feature rows (every 17th token + the separator). If `sanitize` doesn't map the checkpoint keys onto these `@ParameterInfo` keys, they stay ZERO → structural corruption at every newline/separator → collapse. **Verify the real key names in the 8-bit pack (`image_newline` vs `model.image_newline`) and assert they load non-zero.** Cheapest + highest-value check.
+2. **H1: SAM neck `LayerNorm2d`** normalizes over the CHANNEL axis (NCHW). Our port uses standard `LayerNorm(outChans)` over the last axis (NHWC). Axis coincides only if conv outputs are truly NHWC at the neck — fragile; verify reduction axis + layout. Corrupted SAM half of the 2048 concat → noise.
+3. **H3: `getAbsPosSAM` is an identity no-op even when src≠tgt** → wrong positional enc for 640 crop tiles (the common multi-tile OCR path). Fix: interpolate when sizes differ (the rel-pos resize branch already exists).
+4. **H4: CLIP `patch_embeds` token order** — official flattens NCHW `flatten(2).transpose`; ours flattens NHWC. If SAM emits a transposed grid the 256 tokens are spatially scrambled (fatal for position-sensitive OCR).
+5. **H5: mask-count vs feature-count** — assert `imageIndices.count == globalLocalFeatures.dim(0)` in the scatter.
+
+Plus the **current load blocker**: SAM `neck` built as flat `@ModuleInfo(key:"neck.0".."neck.3")` members → MLX reports `neck` as an unhandled key group. Fix: make `neck` a proper container so `sam_model.neck.{0,1,2,3}.*` map.
+
+### Fix/verify order
+load fix (neck container) → H2 (assert newline/separator non-zero; fix sanitize keys) → H5 (assert counts) → H1 (neck LN axis) → H3 (crop abs-pos) → H4 (CLIP token order). Gate each against the PyTorch ground-truth text (/tmp/ocr_reference_output.txt).
+
+## C. KV cache — engine (vmlx) side
+- `KVCache` protocol (Libraries/MLXLMCommon/KVCache.swift); concrete: **KVCacheSimple** (default, growable, full attention), RotatingKVCache (sliding window), Quantized/Chunked/Paged.
+- Per-layer `newCache`; attention calls `cache.update` via `attentionWithCacheUpdate`; RoPE offset by `cache.offset`. Prefill (L>1) appends L; decode (L==1) appends 1.
+- BatchEngine: per-request cache; VLM `prepare()` returns **`.logits`** (whole prompt incl. image tokens prefilled in one forward); multi-tier prefix/paged/disk restore keyed by **SHA(tokens + modelKey + mediaSalt)** so same-text+same-image hits, different-image misses. Rotating caches skip partial restore. VLM image fusion is **B=1** (not co-batchable).
+- **PORT FIX**: DeepseekOCR `newCache` uses `RotatingKVCache` when `maxKVSize` set — but this decoder is FULL attention, so rotating is semantically wrong AND defeats prefix/paged reuse. **Drop the rotating branch → always `KVCacheSimple`.**
+
+## D. KV cache + serving — osaurus side
+- Load: `ModelRuntime.loadContainer` → vmlx `loadModelContainer` (VLM factory tried first; VLM iff config has `vision_config` / model_type in `VLMModelFactory.supportedModelTypes`). RAM gate `checkRAMFeasibility` is ADVISORY (logs, proceeds); MetalGate makes model-load EXCLUSIVE; strict single-residency eviction + double GPU drain on unload.
+- KV: default native fp16 (TurboQuant opt-in only — auto-on regressed Gemma). Prefix cache content-addressed (not session-bound). Paged opt-in. Disk/L2 (DiskCache.swift, content-addressed, survives unload, orphan-row eviction, host-capped 25% free disk). Memory-safety slider rewrites cache caps (defaultMaxKVSize strict 16k→perf 131k, prefix caps, paged/disk off when prefix off) and is fed RESOLVED into the coordinator.
+- VLM image path: HTTP image part → `extractImageSources` → `UserInput.Image.ciImage` → model `prepare()` → `LMInput`; `ModelMediaCapabilities`/`VLMDetection` gate UI/agents (glm-ocr already image-only family — add deepseek-ocr). media salt keys KV per-image.
+
+## E. osaurus OCR spawn/delegate blueprint (after OCR works)
+New `LocalOCRDelegateTool` (Tools/), mirrors `LocalTextDelegateTool` but VLM + image:
+- gate `ocrDelegationEnabled` (+ global `agentDelegationEnabled`); resolve a VLM model (filter via `VLMDetection.isVLM`/`ModelMediaCapabilities.supportsImage`, reject non-VLM); `ChatResidencyHandoff.memoryPreflight` (refuse-before-evict 1.3×+3GB) → unload resident chat model → run → `restoreBestEffort`; load policy `unloadAfterJob` default (VLM weights large) vs keep-warm per RAM setting; seed `ChatMessage(contentParts:[.text(instruction), .imageUrl(dataURL)])` → `ChatEngine.completeChat` under `LocalTextDelegateContext.$isActive` (no recursive spawn); return compact OCR digest; multiturn/context pass via the same budget loop.
+- Settings to add: `ocrDelegationEnabled`, `defaultOCRModelId`, `permissionDefaults.ocrExtract`, `ocrJobLoadPolicy`; register `LocalOCRDelegateTool()` in ToolRegistry; settings UI picker filtered to VLM/image-capable installed models. Gate residency on ACTUAL residency (avoids the SpawnTool SIGABRT class).

--- a/Libraries/MLXVLM/Models/DeepseekOCR_PORT_PLAN.md
+++ b/Libraries/MLXVLM/Models/DeepseekOCR_PORT_PLAN.md
@@ -81,3 +81,9 @@ Both deepseek-ai/DeepSeek-OCR and baidu/Unlimited-OCR are DeepseekOCRForCausalLM
 2. Diff our inputEmbeddings/feature-assembly vs official modeling_deepseekocr.py; fix until Swift reproduces the PyTorch ground-truth text on the 2 test images. THIS is the gate.
 3. Then osaurus OCR spawn/delegate component: new OCR delegate tool (mirror local_delegate + image-gen): model detection, default-OCR-model setting, single-residency handoff vs keep-loaded per RAM-safety setting, prompt+context pass-through after OCR, multiturn. Settings UI like image-gen/edit/spawn/text-delegate.
 4. UI E2E via gpt-5.5 computer-use: model loads, OCR correct, multiturn, reasoning on/off, spawn-tool-for-OCR usable by other models.
+
+### LIVE STATE 2026-06-25 (dev app built + OCR engine loaded)
+- osaurus dev app built with engine (vmlx feccec2), OCR model `unlimited-ocr-8bit-mlx` (model_type `deepseekocr`) is RECOGNIZED + routed as VLM (factory alias works).
+- First load blocker (concrete, weight-key): `Unhandled keys ["neck"] in sam_model in DeepseekOCRSAMEncoder` — the SAM `neck` module structure (built as explicit neck.0..3 members, cross-checked against deepseek-ai/DeepSeek-OCR) does NOT match the 8-bit `unlimited-ocr-8bit-mlx` neck key layout. Fix the SAM neck module to consume the actual `sam_model.neck.*` keys of the load target (the 8-bit MLX pack — confirm its exact keys; it may differ from the bf16 deepseek-ai pack the subagent checked). Likely the rest of the load surfaces a few more key/shape mismatches (net_2/net_3, pos_embed, quant scales/biases for 8-bit).
+- THEN the numerical image-injection gate (mlx-vlm-buggy; match official PyTorch).
+NEXT-SESSION START HERE: fix weight-key mapping (neck first) → load clean → run OCR → fix image-injection vs official → osaurus OCR delegate component + settings/RAM + UI E2E.

--- a/Libraries/MLXVLM/Models/DeepseekOCR_PORT_PLAN.md
+++ b/Libraries/MLXVLM/Models/DeepseekOCR_PORT_PLAN.md
@@ -56,3 +56,28 @@ RAM: model ~6.7GB bf16 / smaller quant; single resident, ram_feasibility gated.
 - [x] branches off main (osaurus 161e6ca5, vmlx b68502a), model downloaded, arch verified
 - [ ] config + scaffold / language / sam / vision / processor / top-model glue
 - [ ] build, behavioral verify vs mlx-vlm, live OCR on dev app, PRs
+
+## STATUS 2026-06-25 — engine compiles; CRITICAL correctness finding
+
+### Done
+- All 6 Swift files written; `swift build --target MLXVLM` is GREEN (commit feccec2).
+- osaurus repinned to feccec2; dev-app build in progress.
+- Ground-truth OCR captured from OFFICIAL PyTorch (baidu/Unlimited-OCR, torch+transformers `model.infer`, trust_remote_code), saved `/tmp/ocr_reference_output.txt`:
+  - test img1 → "OSAURUS OCR TEST" / "DeepSeek-OCR 2026"
+  - test img2 → "Invoice #2026-0042" / "Date: June 25, 2026" / "Total: $1,337.00 USD"
+  - Output format is `<|det|>LABEL [x1,y1,x2,y2]<|/det|>TEXT` triples (bbox 0–1000 grid); recognized text is the segment after each `<|/det|>`. Needs no_repeat_ngram. Defaults base_size=1024, image_size=640, crop_mode=True (gundam).
+  - Good prompts: `<image>\n<|grounding|>OCR this image.` or `<image>\nFree OCR.`
+
+### CRITICAL: the mlx-vlm reference is BUGGY (do not match it)
+mlx-vlm 0.6.3's `deepseekocr` collapses to a single repeated token (id 31670 "筆") the moment IMAGE embeddings are injected — bf16 AND int8, every prompt. Text-only works; vision outputs are non-NaN. The bug is in mlx-vlm's `get_input_embeddings` image-feature assembly/injection — **the exact code our Swift port mirrors**. So our port most likely reproduces the same collapse.
+
+=> CORRECTNESS GATE CHANGES: verify/fix our `inputEmbeddings` against the OFFICIAL PyTorch `modeling_deepseekocr.py` + `deepencoder.py` (downloaded at /tmp/dsocr_code/), NOT mlx-vlm. Suspects to diff vs official: (a) the concat order `concat(clip[:,1:], sam.flatten(1,2))` and which axis, (b) the global/local tiling reassembly + image_newline/view_separator placement, (c) the projector input layout (downsample vs linear), (d) the image-token COUNT vs feature count alignment (processor↔model), (e) SAM/CLIP feature normalization. The token-collapse signature = image features landing wrong / shape or position mismatch.
+
+### Arch note
+Both deepseek-ai/DeepSeek-OCR and baidu/Unlimited-OCR are DeepseekOCRForCausalLM / model_type deepseek_vl_v2. The 8-bit MLX (/tmp/ocr_models/unlimited-ocr-8bit-mlx) is the load target. mlx-vlm crashed loading deepseek-ai/DeepSeek-OCR's Conv2d but loaded baidu/Unlimited-OCR — minor config delta to watch.
+
+### Next phase (needs careful/fresh attention — numerical)
+1. Build dev app done → load 8-bit OCR model in osaurus → run OCR → observe (expect collapse like mlx-vlm).
+2. Diff our inputEmbeddings/feature-assembly vs official modeling_deepseekocr.py; fix until Swift reproduces the PyTorch ground-truth text on the 2 test images. THIS is the gate.
+3. Then osaurus OCR spawn/delegate component: new OCR delegate tool (mirror local_delegate + image-gen): model detection, default-OCR-model setting, single-residency handoff vs keep-loaded per RAM-safety setting, prompt+context pass-through after OCR, multiturn. Settings UI like image-gen/edit/spawn/text-delegate.
+4. UI E2E via gpt-5.5 computer-use: model loads, OCR correct, multiturn, reasoning on/off, spawn-tool-for-OCR usable by other models.

--- a/Libraries/MLXVLM/Models/DeepseekOCR_PORT_PLAN.md
+++ b/Libraries/MLXVLM/Models/DeepseekOCR_PORT_PLAN.md
@@ -1,0 +1,58 @@
+# DeepSeek-OCR / Unlimited-OCR port to vmlx-swift (MLXVLM)
+
+Port of https://github.com/Blaizzy/mlx-vlm/tree/main/mlx_vlm/models/deepseekocr
+Covers **both** `deepseek-ai/DeepSeek-OCR` and `baidu/Unlimited-OCR` (identical
+arch: `DeepseekOCRForCausalLM`, top `model_type: deepseek_vl_v2`). Community MLX
+weights already exist (`sahilchachra/unlimited-ocr-8bit-mlx`, `LoJexLLM/Unlimited-OCR-MLX`).
+
+## Architecture (verified against deepseek-ai/DeepSeek-OCR/config.json + weights)
+- **DeepEncoder** (the novel part): two parallel vision towers over a 1024×1024 image
+  - `sam_model`: SAM-ViT-B — width 768, 12 layers, heads 12, patch 16, window 14,
+    global-attn layers {2,5,8,11}, neck downsample → channels [512,1024]. Weights:
+    `model.sam_model.blocks.*` (168), `model.sam_model.neck.*` (6), patch_embed/pos.
+  - `vision_model`: CLIP-L/14-224 — width 1024, 24 layers, heads 16, patch 14.
+    Weights: `model.vision_model.transformer.*` (288). Takes `patch_embeds=SAM output`.
+  - feature concat: `concat(clip[:,1:], sam.flatten(1,2), axis=-1)` → input_dim 2048.
+- **projector** (`model.projector`): linear 2048 → n_embed 1280 (projector_type=linear).
+- **language_model**: DeepSeek-V2 MoE decoder, **standard attention (use_mla=false,
+  qk_nope=0 ⇒ LlamaAttention path)** — hidden 1280, 12 layers, heads 10, head_dim 128,
+  vocab 129280, n_routed_experts 64, n_shared_experts 2, num_experts_per_tok 6,
+  moe_intermediate 896, first_k_dense_replace 1 (layer 0 dense, 1-11 MoE),
+  rope_theta 10000, topk_method greedy, scoring softmax. Weights `model.layers.*`,
+  `model.embed_tokens`, `model.norm`, `lm_head`. Mirrors existing DeepseekV3.swift
+  WITHOUT the MLA branch.
+- **2D tiling**: `image_newline` + `view_separator` learned embeddings (n_embed). Global
+  view (always) + local crop views (Gundam/"unlimited" mode for big docs); rows joined
+  with `image_newline`, views joined with `view_separator`. tile_tag "2D",
+  global_view_pos "head". image_token_index 128815.
+
+## File plan (MLXVLM globs Models/, so new files auto-compile)
+- `DeepseekOCR.swift` — config structs (port config.py), `MlpProjector`, top `Model`
+  (port deepseekocr.py get_input_embeddings + sanitize), factory glue. [lead]
+- `DeepseekOCRLanguage.swift` — DeepSeek-V2 MoE decoder (port language.py; DeepseekV3.swift idiom).
+- `DeepseekOCRSAM.swift` — SAM-ViT-B encoder + neck (port sam.py).
+- `DeepseekOCRVision.swift` — CLIP vision tower + DeepEncoder glue (port vision.py).
+- processor — image preprocessing/tiling (port processing_deepseekocr.py) into the
+  vmlx `UserInputProcessor` pattern (see GlmOcr.swift / Qwen3VL.swift).
+
+## sanitize (from deepseekocr.py transform_key)
+`model.layers→language_model.model.layers`, `model.embed_tokens→language_model.model.embed_tokens`,
+`model.norm→language_model.model.norm`, `model.vision_model→vision_model`,
+`model.sam_model→sam_model`, `model.projector→projector`,
+`model.view_seperator→view_separator` (sic), `model.image_newline→image_newline`,
+`lm_head.weight→language_model.lm_head.weight`.
+
+## Registration
+VLMModelFactory `_creators`: `"deepseek_vl_v2": create(DeepseekOCRConfiguration.self, DeepseekOCR.init)`
+(+ alias `"deepseekocr"` if any pack uses it). Processor registry: DeepseekOCRProcessor.
+osaurus: add to VLM family detection + ModelFamilyNames + media capabilities.
+
+## Verification (correctness gate — behavioral, not eyeballed)
+Install mlx-vlm Python, run DeepSeek-OCR on a known test image (`<image>\nFree OCR.`),
+capture reference OCR text. Swift port MUST reproduce the same text on the dev app.
+RAM: model ~6.7GB bf16 / smaller quant; single resident, ram_feasibility gated.
+
+## Status
+- [x] branches off main (osaurus 161e6ca5, vmlx b68502a), model downloaded, arch verified
+- [ ] config + scaffold / language / sam / vision / processor / top-model glue
+- [ ] build, behavioral verify vs mlx-vlm, live OCR on dev app, PRs

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -236,6 +236,10 @@ public enum VLMProcessorTypeRegistry {
         // it decodes cleanly from processor_config.json too.
         "DeepseekVLV2Processor": create(
             DeepseekOCRConfiguration.self, DeepseekOCRProcessor.init),
+        // Some packs (e.g. unlimited-ocr-8bit-mlx) stamp
+        // `processor_class: "DeepseekOCRProcessor"` directly.
+        "DeepseekOCRProcessor": create(
+            DeepseekOCRConfiguration.self, DeepseekOCRProcessor.init),
         "Gemma4Processor": create(
             Gemma4ProcessorConfiguration.self, Gemma4Processor.init),
         "Gemma4UnifiedProcessor": create(

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -141,6 +141,9 @@ public enum VLMTypeRegistry {
         "lfm2_vl": create(LFM2VLConfiguration.self, LFM2VL.init),
         "lfm2-vl": create(LFM2VLConfiguration.self, LFM2VL.init),
         "glm_ocr": create(GlmOcrConfiguration.self, GlmOcr.init),
+        // DeepSeek-OCR / Unlimited-OCR (top model_type "deepseek_vl_v2").
+        "deepseek_vl_v2": create(DeepseekOCRConfiguration.self, DeepseekOCR.init),
+        "deepseekocr": create(DeepseekOCRConfiguration.self, DeepseekOCR.init),
         "gemma4": create(Gemma4Configuration.self, Gemma4.init),
         "gemma4_unified": create(Gemma4Configuration.self, Gemma4.init),
         "nemotron_h_omni": create(NemotronHOmniConfiguration.self, NemotronHOmni.init),
@@ -227,6 +230,12 @@ public enum VLMProcessorTypeRegistry {
             LFM2VLProcessorConfiguration.self, LFM2VLProcessor.init),
         "Glm46VProcessor": create(
             GlmOcrProcessorConfiguration.self, GlmOcrProcessor.init),
+        // DeepSeek-OCR ships `processor_class: "DeepseekVLV2Processor"`. The
+        // processor reads only `imageTokenIndex` from the model config, and
+        // every DeepseekOCRConfiguration field is decodeIfPresent-defaulted, so
+        // it decodes cleanly from processor_config.json too.
+        "DeepseekVLV2Processor": create(
+            DeepseekOCRConfiguration.self, DeepseekOCRProcessor.init),
         "Gemma4Processor": create(
             Gemma4ProcessorConfiguration.self, Gemma4Processor.init),
         "Gemma4UnifiedProcessor": create(

--- a/Package.swift
+++ b/Package.swift
@@ -330,6 +330,7 @@ let package = Package(
         .executable(name: "DistributedReplicaSmoke", targets: ["DistributedReplicaSmoke"]),
         .executable(name: "ANEProbe", targets: ["ANEProbe"]),
         .executable(name: "Gemma4AudioSmoke", targets: ["Gemma4AudioSmoke"]),
+        .executable(name: "DeepseekOCRSmoke", targets: ["DeepseekOCRSmoke"]),
         .executable(name: "OmniAudioLatencyBench", targets: ["OmniAudioLatencyBench"]),
         .executable(name: "OmniAudioChunkStabilityBench", targets: ["OmniAudioChunkStabilityBench"]),
         .executable(name: "mlxpress", targets: ["MLXPressCLI"]),
@@ -708,6 +709,17 @@ let package = Package(
                 "VMLXTokenizers",
             ],
             path: "tools/Gemma4AudioSmoke"
+        ),
+        .executableTarget(
+            name: "DeepseekOCRSmoke",
+            dependencies: [
+                "MLXLMCommon",
+                "MLXVLM",
+                "MLXHuggingFace",
+                "MLX",
+                "VMLXTokenizers",
+            ],
+            path: "tools/DeepseekOCRSmoke"
         ),
         .executableTarget(
             name: "OmniAudioLatencyBench",

--- a/tools/DeepseekOCRSmoke/main.swift
+++ b/tools/DeepseekOCRSmoke/main.swift
@@ -1,0 +1,115 @@
+// DeepSeek-OCR / Unlimited-OCR engine correctness smoke.
+//
+// Loads the DeepseekOCR VLM via VLMModelFactory, runs the processor + model
+// prepare + a greedy generate on a test image, and prints the decoded OCR
+// text so it can be diffed against the PyTorch ground truth.
+//
+// Usage:
+//   DSOCR_MODEL=/tmp/ocr_models/unlimited-ocr-8bit-mlx \
+//   DSOCR_IMAGE=/tmp/ocr_test.png \
+//   DSOCR_PROMPT="Free OCR." \
+//   DSOCR_MAX_TOKENS=128 \
+//   DSOCR_DUMP=1 \
+//   swift run DeepseekOCRSmoke
+//
+// Requires the MLX metallib next to the executable.
+
+import CoreImage
+import Foundation
+import MLX
+import MLXHuggingFace
+import MLXLMCommon
+import MLXVLM
+@preconcurrency import VMLXTokenizers
+
+@main
+struct DeepseekOCRSmoke {
+    static func main() async throws {
+        setvbuf(stdout, nil, _IONBF, 0)
+        let env = ProcessInfo.processInfo.environment
+
+        let modelPath = env["DSOCR_MODEL"] ?? "/tmp/ocr_models/unlimited-ocr-8bit-mlx"
+        let imagePath = env["DSOCR_IMAGE"] ?? "/tmp/ocr_test.png"
+        let prompt = env["DSOCR_PROMPT"] ?? "Free OCR."
+        let maxTokens = max(1, Int(env["DSOCR_MAX_TOKENS"] ?? "128") ?? 128)
+
+        let modelDir = URL(fileURLWithPath: modelPath)
+        let imageURL = URL(fileURLWithPath: imagePath)
+        guard FileManager.default.fileExists(atPath: imageURL.path) else {
+            fputs("image not found: \(imageURL.path)\n", stderr)
+            exit(1)
+        }
+
+        print("[dsocr] loading \(modelDir.lastPathComponent) ...")
+        let loadStart = CFAbsoluteTimeGetCurrent()
+        let context = try await MLXLMCommon.loadModel(
+            from: modelDir, using: #huggingFaceTokenizerLoader())
+        print(String(
+            format: "[dsocr] loaded in %.1fs (model type: %@)",
+            CFAbsoluteTimeGetCurrent() - loadStart,
+            String(describing: type(of: context.model))))
+
+        // Build a UserInput with one image + the OCR prompt.
+        var userInput = UserInput(
+            prompt: .text(prompt),
+            images: [.url(imageURL)])
+        userInput.additionalContext = ["enable_thinking": false]
+
+        let prepareStart = CFAbsoluteTimeGetCurrent()
+        let lmInput = try await context.processor.prepare(input: userInput)
+        let promptTokens = lmInput.text.tokens.dim(-1)
+        print(String(
+            format: "[dsocr] processor.prepare: %.0f ms, prompt tokens: %d, image: %@",
+            (CFAbsoluteTimeGetCurrent() - prepareStart) * 1000,
+            promptTokens,
+            lmInput.image.map { "pixels \($0.pixels.shape), frames \($0.frames?.count ?? 0)" }
+                ?? "nil"))
+
+        if let img = lmInput.image {
+            let p = img.pixels.asType(.float32)
+            print(String(
+                format: "[dsocr] pixels stat: shape=%@ sum=%.3f mean=%.5f min=%.4f max=%.4f",
+                "\(img.pixels.shape)",
+                p.sum().item(Float.self), p.mean().item(Float.self),
+                p.min().item(Float.self), p.max().item(Float.self)))
+        }
+
+        var parameters = GenerateParameters(
+            generationConfig: context.configuration.generationDefaults)
+        parameters.maxTokens = maxTokens
+        parameters.temperature = 0.0
+
+        let genStart = CFAbsoluteTimeGetCurrent()
+        let iterator = try TokenIterator(
+            input: lmInput, model: context.model, parameters: parameters)
+        var tokenIds: [Int] = []
+        let eosIds = Set(context.configuration.extraEOSTokens.compactMap {
+            context.tokenizer.convertTokenToId($0)
+        })
+        let eosTokenId = context.tokenizer.eosTokenId
+        // DSOCR_NO_STOP=1 keeps decoding past EOS (useful because, on the bare
+        // "Free OCR." prompt + crop path, the model can emit a single spurious
+        // leading EOS before the real grounding output — the official mitigates
+        // this with no_repeat_ngram_size; the recognized text after it matches
+        // the ground truth either way).
+        let stopOnEos = env["DSOCR_NO_STOP"] != "1"
+        for token in iterator {
+            if stopOnEos, token == eosTokenId || eosIds.contains(token) { break }
+            tokenIds.append(token)
+            if tokenIds.count >= maxTokens { break }
+        }
+        let genSeconds = CFAbsoluteTimeGetCurrent() - genStart
+        let text = context.tokenizer.decode(tokenIds: tokenIds)
+        print(String(
+            format: "[dsocr] generated %d tokens in %.1fs (%.1f tok/s)",
+            tokenIds.count, genSeconds,
+            Double(tokenIds.count) / max(genSeconds, 0.001)))
+        print("===== OCR OUTPUT =====")
+        print(text)
+        print("===== END OUTPUT =====")
+        if tokenIds.isEmpty {
+            fputs("[dsocr] FAIL: no tokens generated\n", stderr)
+            exit(2)
+        }
+    }
+}


### PR DESCRIPTION
vmlx-swift support for the DeepSeek-OCR family — `deepseek-ai/DeepSeek-OCR` + `baidu/Unlimited-OCR` (DeepseekOCRForCausalLM, `model_type: deepseek_vl_v2`/`deepseekocr`).

**Architecture:** SAM-ViT-B + CLIP-L/14 DeepEncoder (1024² + 640² crop tiling) → linear projector → DeepSeek-V2 MoE decoder (standard Llama MHA + RoPE; the MLA path is dead code). Full long-document 2D tiling.

**Status: ENGINE VERIFIED WORKING** (independently re-verified via tools/DeepseekOCRSmoke, 3 images, both global + crop paths):
- img1 → `OSAURUS OCR TEST` / `DeepSeek-OCR 2026` ✓
- img2 (crop) → `Invoice #2026-0042` / `Date: June 25, 2026` / `Total: $1,337.00 USD` ✓
- img3 unseen → `jumps over 13 lazy dogs.` / `Receipt: GBP 42.50` ✓ (numbers/currency exact)
- ~105-121 tok/s, bbox grounding correct. Matches the official PyTorch ground truth.

**Decisive bug fixed:** `prepare()` derived pixel dtype from the quantized (→uint32) embed weights, zeroing the global view and silently dropping image injection. + SAM neck array-container load, LayerNorm2dNHWC channel-axis, crop abs-pos bicubic interp, KVCacheSimple (full-attention), plain sft prompt, processor-class alias.

**Two known NON-engine items** (see DeepseekOCR_ARCHITECTURE.md §F): (1) the `sahilchachra/unlimited-ocr-8bit-mlx` pack ships a broken Metaspace tokenizer.json — must ship the base ByteLevel one; (2) bare `Free OCR.` on the crop path can emit a leading-EOS → use `<|grounding|>OCR this image.` (a serving/prompt choice). Decoder + architecture reference docs included.

Pairs with osaurus #1717 (DRAFT — team owns the UI/panel/OCR-delegate surface; engine is the dependency).