### PR TITLE
LFM2: restore native 'List of tools: [JSON]' tool format (fixes broken tool calls)

### DIFF
--- a/Libraries/MLXLMCommon/ChatTemplates/ChatTemplateFallbacks.swift
+++ b/Libraries/MLXLMCommon/ChatTemplates/ChatTemplateFallbacks.swift
@@ -1401,17 +1401,12 @@ value_1
 {%- endmacro -%}
 
 {%- macro render_tool_summary() -%}
-    {{- 'Available functions:' -}}
-    {%- for tool in tools -%}
-        {%- set fn = tool['function'] if tool['function'] is defined else tool -%}
-        {{- '\n- ' ~ fn['name'] -}}
-        {%- if fn['description'] is defined and fn['description'] -%}
-            {{- ': ' ~ (fn['description'] | trim) -}}
-        {%- endif -%}
-        {%- if fn['parameters'] is defined and fn['parameters']['required'] is defined -%}
-            {{- '\n  required arguments: ' ~ (fn['parameters']['required'] | join(', ')) -}}
-        {%- endif -%}
-    {%- endfor -%}
+    {#- LFM2 native tool-list format: the model is trained on the full JSON
+        tool schemas under `List of tools: [...]`, NOT a bare name/desc summary.
+        Restoring this (removed in 46973d1 'Remove LFM tool schema markup', which
+        silently broke auto tool-calling for ALL lfm2/lfm2_moe models) is what lets
+        the model actually emit <|tool_call_start|> calls. -#}
+    {{- 'List of tools: ' ~ (tools | tojson) -}}
 {%- endmacro -%}
 
 {%- macro render_required_tool_choice_instruction(latest_user_content='') -%}


### PR DESCRIPTION
## Problem
LFM2 models don't pick up tools — they answer in prose instead of emitting tool calls. Reproduced on `OsaurusAI/LFM2.5-230M-MXFP8`, but it affects **all** LFM2 models.

## Root cause (regression dated)
The `lfm2ToolMinimal` fallback (applied by the osaurus tokenizer bridge for `lfm2`/`lfm2_moe`/`lfm2-vl` whenever tools are present) rendered tools as a bare summary:
```
Available functions:
- get_weather: Get weather for a city
  required arguments: city
```
But every LFM2 model (verified: LFM2.5-230M **and** LFM2.5-8B-A1B) is trained on the native Liquid format — the **full JSON tool schemas** under `List of tools: [ ... ]` plus `<|tool_call_start|>` emission. With only a name/description summary (no parameter schema), the model doesn't recognize callable tools and replies in prose.

Introduced **2026-05-29 in `46973d1` "Remove LFM tool schema markup"**, which replaced `'List of tools: ' ~ (tools | tojson)` with the summary macro. So tool-calling has been broken for LFM2 since then (auto/normal tool use; the `tool_choice=required` path limped along via its explicit bracketed-call instruction).

## Fix
Restore the native `List of tools: [<JSON>]` rendering in `render_tool_summary()` (one macro). Required-tool-choice guidance untouched.

## Proven live (osaurus dev app, lfm2.5-230m-mxfp8)
| case | before | after |
|---|---|---|
| auto | prose, no call | `get_weather{city:Tokyo}`, finish=tool_calls |
| required | (limped) | `get_weather{city:Paris}` |
| multi-turn | — | consumes tool result: "sunny … 22°C" |

Pairs with an osaurus repin PR.