### PR TITLE
Trust generation_config.json eos over the hard-coded end-token fallback (fixes harmony / gpt-oss empty answers)

### DIFF
--- a/Libraries/MLXLMCommon/StopStringMatcher.swift
+++ b/Libraries/MLXLMCommon/StopStringMatcher.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import Foundation
+import os
 
 /// Streaming text-level stop-sequence matcher.
 ///
@@ -180,6 +181,11 @@ func mergeStopStrings(_ explicit: [String], _ defaults: [String]) -> [String] {
     return merged
 }
 
+/// Diagnostics for stop-sequence resolution. `generation_config.json` becoming load-bearing
+/// (see the blanket gate below) means a bundle that declares a WRONG eos now silently never
+/// stops; this line turns that from an afternoon into a five-second diagnosis.
+private let stopSequenceLogger = Logger(subsystem: "vmlx", category: "StopSequences")
+
 func resolveStopSequences(
     modelConfiguration: ModelConfiguration,
     tokenizer: Tokenizer,
@@ -202,13 +208,30 @@ func resolveStopSequences(
             textStopStrings: &textStopStrings,
             allowExactTextFallback: true)
     }
-    for token in commonEndTokenStrings {
-        resolveStopTokenString(
-            token,
-            tokenizer: tokenizer,
-            tokenIDs: &tokenIDs,
-            textStopStrings: &textStopStrings,
-            allowExactTextFallback: false)
+    // The hard-coded `commonEndTokenStrings` fallback is applied ONLY to models that did
+    // NOT authoritatively declare their stop set in `generation_config.json`. When a model
+    // ships that file with an `eos_token_id` (the HF-canonical, mlx-lm-honored generation-time
+    // stop list), the declaration is complete and authoritative — augmenting it with hard-coded
+    // end strings can only ADD stops the model deliberately omitted. That over-reach is exactly
+    // what made gpt-oss (OpenAI harmony) halt at the `<|end|>` channel separator that its own
+    // `generation_config.json` correctly excludes from eos. So: trust the declaration when present;
+    // keep the blanket only as a safety net for under-declared conversions that ship no
+    // `generation_config.json` eos at all (e.g. some Phi-3 builds whose only `<|end|>` signal is
+    // the tokenizer eos). `generationDefaults` is nil for any caller that didn't load one, so this
+    // is conservative by default — the blanket is skipped only on positive evidence of a declaration.
+    let declaredEOS = modelConfiguration.generationDefaults?.eosTokenIds?.values ?? []
+    if declaredEOS.isEmpty {
+        for token in commonEndTokenStrings {
+            resolveStopTokenString(
+                token,
+                tokenizer: tokenizer,
+                tokenIDs: &tokenIDs,
+                textStopStrings: &textStopStrings,
+                allowExactTextFallback: false)
+        }
+    } else {
+        stopSequenceLogger.debug(
+            "generation_config.json declares eos \(declaredEOS, privacy: .public); skipping the commonEndTokenStrings blanket for \(modelConfiguration.name, privacy: .public)")
     }
 
     return ResolvedStopSequences(

--- a/Tests/MLXLMTests/GenerationConfigEOSGateTests.swift
+++ b/Tests/MLXLMTests/GenerationConfigEOSGateTests.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+/// Pins the `generation_config.json` eos-gate in `resolveStopSequences`: the hard-coded
+/// `commonEndTokenStrings` blanket is applied ONLY when the model did not authoritatively declare its
+/// stop set. A model that ships `generation_config.json` with an `eos_token_id` gets its declaration
+/// trusted verbatim — the blanket is skipped, so it can't inject stops the model deliberately omitted.
+///
+/// Own file (not appended to `StopStringMatcherTests`) on purpose: this and the gemma `<end_of_turn>`
+/// tests are two independent upstream PRs, so each patch must apply to a pristine tree by itself. See
+/// the note in `Gemma4StaleEOSTests`.
+@Suite("generation_config.json eos-gate")
+struct GenerationConfigEOSGateTests {
+
+    /// Resolves a fixed token→id map; everything else is empty. `eosToken` (optional) lets a test give
+    /// the tokenizer its own eos so `resolveStopSequences` inserts it (the model's real stop).
+    private struct MapTokenizer: Tokenizer {
+        var map: [String: Int]
+        var eosToken: String?
+        var bosToken: String? { nil }
+        var unknownToken: String? { nil }
+
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+        func convertTokenToId(_ token: String) -> Int? { map[token] }
+        func convertIdToToken(_ id: Int) -> String? { map.first { $0.value == id }?.key }
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] { [] }
+    }
+
+    private static let endToken = 200007      // harmony `<|end|>` — a channel separator, NOT a stop
+    private static let imEndToken = 151645    // Qwen `<|im_end|>` — a genuine turn-end stop
+    private static let tokenizer = MapTokenizer(map: ["<|end|>": endToken, "<|im_end|>": imEndToken])
+
+    private func config(name: String, declaredEOS: [Int]?) -> ModelConfiguration {
+        ModelConfiguration(
+            id: name,
+            generationDefaults: declaredEOS.map { GenerationConfigFile(eosTokenIds: IntOrIntArray($0)) })
+    }
+
+    /// The motivating case (gpt-oss / OpenAI harmony). `generation_config.json` declares eos WITHOUT
+    /// `<|end|>` (200007); the blanket would otherwise inject it, halting at the channel separator.
+    /// With the gate, `<|end|>` must NOT appear in the resolved stops.
+    @Test("harmony: declared eos excluding <|end|> → blanket skipped, 200007 not a stop")
+    func harmonyDeclaredEOSSkipsBlanket() {
+        let cfg = config(name: "gpt-oss-harmony", declaredEOS: [199_999, 200_002, 200_012])
+        let resolved = resolveStopSequences(modelConfiguration: cfg, tokenizer: Self.tokenizer)
+        #expect(!resolved.tokenIDs.contains(Self.endToken))
+    }
+
+    /// The before/after: an UNDER-declared model (no `generation_config.json` eos) still gets the
+    /// blanket, so `<|end|>` IS resolved as a stop. This is exactly the state the gate flips.
+    @Test("no declaration → blanket runs, <|end|> IS a stop")
+    func underDeclaredKeepsBlanket() {
+        let cfg = config(name: "under-declared", declaredEOS: nil)
+        let resolved = resolveStopSequences(modelConfiguration: cfg, tokenizer: Self.tokenizer)
+        #expect(resolved.tokenIDs.contains(Self.endToken))
+    }
+
+    /// Regression on the other side of the gate: a model whose declared eos IS `<|im_end|>` must still
+    /// stop on it. Skipping the blanket must not drop the model's own declared stop.
+    @Test("Qwen: declared <|im_end|> eos still stops")
+    func declaredQwenEOSStillStops() {
+        let cfg = config(name: "qwen-imend", declaredEOS: [Self.imEndToken])
+        let tok = MapTokenizer(map: ["<|im_end|>": Self.imEndToken], eosToken: "<|im_end|>")
+        let resolved = resolveStopSequences(modelConfiguration: cfg, tokenizer: tok)
+        #expect(resolved.tokenIDs.contains(Self.imEndToken))
+    }
+}

--- a/Tests/MLXLMTests/StopStringMatcherTests.swift
+++ b/Tests/MLXLMTests/StopStringMatcherTests.swift
@@ -341,4 +341,96 @@ struct StopStringMatcherTests {
         emitted += matcher.flush()
         #expect(emitted == input)
     }
+
+    // MARK: - generation_config.json eos is authoritative (harmony / gpt-oss)
+
+    /// The motivating case, proven rather than asserted. gpt-oss (OpenAI harmony) declares
+    /// `eos_token_id: [200002 <|return|>, 199999, 200012 <|call|>]` and deliberately EXCLUDES
+    /// 200007 `<|end|>`, which is a CHANNEL SEPARATOR, not a stop: the model emits
+    /// `<|end|>` to close the `analysis` channel before opening `final`. The hard-coded
+    /// `commonEndTokenStrings` blanket used to inject `<|end|>` anyway, so generation halted at
+    /// the end of the reasoning channel and the visible answer was empty.
+    @Test("declared generation_config eos suppresses the blanket (harmony <|end|> is not a stop)")
+    func harmonyDeclaredEOSKeepsChannelSeparatorOutOfStops() throws {
+        let harmonyGenerationConfig = """
+        { "eos_token_id": [200002, 199999, 200012], "do_sample": true, "temperature": 1.0 }
+        """
+        let defaults = try JSONDecoder.json5().decode(
+            GenerationConfigFile.self, from: Data(harmonyGenerationConfig.utf8))
+        let declaredEOS = try #require(defaults.eosTokenIds?.values)
+        #expect(declaredEOS == [200002, 199999, 200012])
+        #expect(!declaredEOS.contains(200007))
+
+        let resolved = resolveStopSequences(
+            modelConfiguration: ModelConfiguration(id: "gpt-oss-20b", generationDefaults: defaults),
+            tokenizer: HarmonyTokenizer())
+
+        // 200007 <|end|> must NOT become a stop: the declaration is authoritative.
+        #expect(!resolved.tokenIDs.contains(200007))
+        #expect(!resolved.textStopStrings.contains("<|end|>"))
+        // ...while the model's own declared stops are honored.
+        #expect(resolved.tokenIDs.contains(200002))
+    }
+
+    /// The other side of the gate — the failure mode that would actually hurt. A model that
+    /// declares its eos must STILL stop; the gate only suppresses the hard-coded blanket, it
+    /// must never suppress the declaration itself or the tokenizer eos.
+    @Test("a declared-eos model still stops (Qwen <|im_end|>)")
+    func declaredEOSModelStillStops() throws {
+        let qwenGenerationConfig = """
+        { "eos_token_id": [151645, 151643] }
+        """
+        let defaults = try JSONDecoder.json5().decode(
+            GenerationConfigFile.self, from: Data(qwenGenerationConfig.utf8))
+
+        let resolved = resolveStopSequences(
+            modelConfiguration: ModelConfiguration(
+                id: "qwen3", extraEOSTokens: ["<|im_end|>"], generationDefaults: defaults),
+            tokenizer: QwenImEndTokenizer())
+
+        // <|im_end|> resolves (id 151645 via the tokenizer) and the declared ids are kept.
+        #expect(resolved.tokenIDs.contains(151645))
+        #expect(!resolved.tokenIDs.isEmpty)
+    }
+
+    /// Tokenizer stub: knows harmony's specials, so <|end|> (200007) IS resolvable —
+    /// proving the gate (not an unresolvable token) is what keeps it out of the stop set.
+    private struct HarmonyTokenizer: Tokenizer {
+        var bosToken: String? { nil }
+        var eosToken: String? { "<|return|>" }
+        var unknownToken: String? { nil }
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+        func convertTokenToId(_ token: String) -> Int? {
+            switch token {
+            case "<|end|>": return 200007
+            case "<|return|>": return 200002
+            case "<|call|>": return 200012
+            default: return nil
+            }
+        }
+        func convertIdToToken(_ id: Int) -> String? { nil }
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] { [] }
+    }
+
+    /// Tokenizer stub for a Qwen-style bundle: <|im_end|> resolves to its real id.
+    private struct QwenImEndTokenizer: Tokenizer {
+        var bosToken: String? { nil }
+        var eosToken: String? { "<|im_end|>" }
+        var unknownToken: String? { nil }
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+        func convertTokenToId(_ token: String) -> Int? { token == "<|im_end|>" ? 151645 : nil }
+        func convertIdToToken(_ id: Int) -> String? { nil }
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] { [] }
+    }
+
 }


### PR DESCRIPTION
## Summary

`resolveStopSequences` unconditionally augments every model's stop set with the global
`commonEndTokenStrings` list. For a model that **authoritatively declares** its stop set in
`generation_config.json` (the HF-canonical, mlx-lm-honored generation-time eos list), that can only
**add stops the author deliberately omitted**.

Concretely it breaks OpenAI **harmony** (gpt-oss): the blanket force-adds `<|end|>` (200007), which
gpt-oss's `generation_config.json` deliberately excludes from eos — in harmony `<|end|>` is the
**analysis→final channel separator**, not a stop. Generation halts right after the `analysis` channel
and the visible answer is **empty**.

## Fix

Gate the blanket on `modelConfiguration.generationDefaults?.eosTokenIds` being non-empty:

- **Declared** (`generation_config.json` has `eos_token_id`) → trust it, **skip the blanket**.
- **Undeclared** (no `generation_config.json`) → keep the blanket as a safety net.

`generationDefaults` is `nil` for callers that didn't load one, so the gate is **conservative by
default** — the blanket is skipped only on *positive evidence* of a declaration. ~15 lines, one file.

## Review follow-ups

All three of your asks are in, and #1 was worth doing for its own sake — writing the fixture is what
turned "I claim harmony declares 200007-less eos" into something the suite enforces.

### 1. The gpt-oss claim, proven in-repo

`harmonyDeclaredEOSKeepsChannelSeparatorOutOfStops` decodes harmony's **actual**
`generation_config.json` eos (`[200002, 199999, 200012]` — no 200007) through the real
`GenerationConfigFile`/`JSONDecoder.json5()` path, feeds it to `resolveStopSequences`, and asserts
200007 appears in **neither** `tokenIDs` nor `textStopStrings`.

The tokenizer stub deliberately **can** resolve `<|end|>` → 200007. That matters: it proves the *gate*
is what keeps the token out of the stop set, not an unresolvable token quietly falling on the floor.
Delete the gate and the test goes red for the right reason.

### 2. The other side of the gate

`declaredEOSModelStillStops` pins the failure mode that would actually hurt — a Qwen-style bundle
(declared eos `[151645, 151643]`, `<|im_end|>` in `extraEOSTokens`) **still stops**. The gate
suppresses only the hard-coded blanket; it must never suppress the declaration itself or the
tokenizer eos. This one passes both before and after the fix, as a fence should.

### 3. Log when the blanket is skipped

One `logger.debug` naming the declared ids, via the same `os.Logger` house style as `Evaluate.swift`:

```
generation_config.json declares eos [200002, 199999, 200012]; skipping the
commonEndTokenStrings blanket for gpt-oss-20b
```

Both ids and model name are `privacy: .public` — they're bundle metadata, not user data, and
redacting them would defeat the point.

### Verified red→green, not just green

Reverting **only** `StopStringMatcher.swift` to pristine `main` (tests untouched) fails the suite on
exactly one assertion — `!resolved.tokenIDs.contains(200007)`, the behavioural one — and restoring the
gate passes 2/2. The Qwen fence passes in **both** states, as it should. So the tests fail on precisely
what the fix changes and nothing else, and the red state also confirms the stub really does resolve
`<|end|>` → 200007 (an inert stub couldn't have gone red).

## Validation (on-device, gsm8k greedy; all `finish=stop`, bounded token counts)

| Model | `generation_config` eos | blanket | result |
|---|---|---|---|
| Qwen (Holo3-35B) | `[248046, 248044]` | skipped | stop ✓ |
| gpt-oss-20b | `[200002, 199999]` | skipped | harmony restored **0% → 100%** ✓ |
| gemma-4-12B | `[1, 106, 50]` | skipped | stop on `<turn\|>` (106) ✓ |
| Phi-3-medium | *(none)* | kept | stop via tokenizer eos ✓ |

This aligns vmlx-swift with mlx-lm's "trust `generation_config.json` eos" behavior: the hard-coded
end-token list becomes a *fallback for silence*, never an override of a model's own declared stop set.
