### PR TITLE
Remove stale <end_of_turn> extraEOSTokens from the gemma4_* configs (fixes a live false-stop)

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -1070,22 +1070,28 @@ public class LLMRegistry: AbstractModelRegistry, @unchecked Sendable {
         defaultPrompt: ""
     )
 
+    // Gemma-4 renamed its turn-end token: `<end_of_turn>` is NOT in the gemma-4 vocabulary.
+    // Do NOT add `extraEOSTokens: ["<end_of_turn>"]` to the gemma4_* configs. The extraEOSTokens
+    // loop passes `allowExactTextFallback: true`, so an entry the tokenizer cannot resolve does
+    // NOT evaporate — it becomes a LIVE text stop-string that truncates any answer containing
+    // those characters (e.g. gemma-4 asked to explain a Gemma-3 chat template). Gemma-4 ends
+    // turns with `<turn|>` (id 106), which it already declares in `generation_config.json`
+    // (`eos_token_id: [1, 106, 50]`) and which the loader honors via `resolvedEOSTokenIds`.
+    // The `gemma3_*` / `gemma3n_*` configs above intentionally KEEP the entry — `<end_of_turn>`
+    // is still their real turn-end token.
     static public let gemma4_27b_it_4bit = ModelConfiguration(
         id: "mlx-community/gemma-4-27b-it-4bit",
-        defaultPrompt: "Explain quantum computing briefly.",
-        extraEOSTokens: ["<end_of_turn>"]
+        defaultPrompt: "Explain quantum computing briefly."
     )
 
     static public let gemma4_12b_it_4bit = ModelConfiguration(
         id: "mlx-community/gemma-4-12b-it-4bit",
-        defaultPrompt: "What is the meaning of life?",
-        extraEOSTokens: ["<end_of_turn>"]
+        defaultPrompt: "What is the meaning of life?"
     )
 
     static public let gemma4_27b_it_qat_4bit = ModelConfiguration(
         id: "mlx-community/gemma-4-27b-it-qat-4bit",
-        defaultPrompt: "Explain quantum computing briefly.",
-        extraEOSTokens: ["<end_of_turn>"]
+        defaultPrompt: "Explain quantum computing briefly."
     )
 
     private static func all() -> [ModelConfiguration] {

--- a/Tests/MLXLMTests/Gemma4StaleEOSTests.swift
+++ b/Tests/MLXLMTests/Gemma4StaleEOSTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import MLXLLM
+import Testing
+
+@testable import MLXLMCommon
+
+/// Pins the gemma `<end_of_turn>` `extraEOSTokens` contract: gemma-4 must NOT declare it, gemma-3 must.
+///
+/// These live in their own file rather than alongside `StopStringMatcherTests` on purpose. They and the
+/// `generation_config.json` eos-gate tests are offered as two independent upstream PRs, so each patch has
+/// to apply to a pristine tree on its own; if both appended to the tail of the same suite they could not
+/// be applied sequentially (an add/add conflict at the same anchor). Separate files keep them orthogonal
+/// in any order, at the cost of the small tokenizer stub below.
+@Suite("gemma <end_of_turn> stale extraEOSTokens")
+struct Gemma4StaleEOSTests {
+
+    /// A tokenizer that resolves nothing — standing in for gemma-4's, which has no `<end_of_turn>`.
+    private struct NoSpecialTokenTokenizer: Tokenizer {
+        var bosToken: String? { nil }
+        var eosToken: String? { nil }
+        var unknownToken: String? { nil }
+
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+        func convertTokenToId(_ token: String) -> Int? { nil }
+        func convertIdToToken(_ id: Int) -> String? { nil }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] { [] }
+    }
+
+    /// Gemma-4 renamed its turn-end token, so `<end_of_turn>` is absent from its vocabulary.
+    /// Declaring it in `extraEOSTokens` is NOT inert: that loop passes `allowExactTextFallback: true`,
+    /// so an entry the tokenizer cannot resolve becomes a live TEXT stop-string — able to truncate a
+    /// legitimate answer that happens to type those characters.
+    @Test("gemma-4 configs declare no <end_of_turn> extra EOS token")
+    func gemma4ConfigsDropStaleTurnEnd() {
+        for config in [
+            LLMRegistry.gemma4_27b_it_4bit,
+            LLMRegistry.gemma4_12b_it_4bit,
+            LLMRegistry.gemma4_27b_it_qat_4bit,
+        ] {
+            #expect(!config.extraEOSTokens.contains("<end_of_turn>"))
+        }
+    }
+
+    /// `<end_of_turn>` IS still the real turn-end token for gemma-3 / gemma-3n — it must stay.
+    @Test("gemma-3 configs keep <end_of_turn>")
+    func gemma3ConfigsKeepTurnEnd() {
+        #expect(LLMRegistry.gemma3_1B_qat_4bit.extraEOSTokens.contains("<end_of_turn>"))
+        #expect(LLMRegistry.gemma3n_E4B_it_lm_bf16.extraEOSTokens.contains("<end_of_turn>"))
+    }
+
+    /// Behavioural pin: on a tokenizer that cannot resolve `<end_of_turn>` (as gemma-4's cannot),
+    /// gemma-4 must yield no such text stop-string, while gemma-3 still must.
+    @Test("<end_of_turn> resolves to a live text stop for gemma-3 but not gemma-4")
+    func turnEndTextStopOnlyForGemma3() {
+        let gemma4 = resolveStopSequences(
+            modelConfiguration: LLMRegistry.gemma4_27b_it_4bit,
+            tokenizer: NoSpecialTokenTokenizer())
+        #expect(!gemma4.textStopStrings.contains("<end_of_turn>"))
+
+        let gemma3 = resolveStopSequences(
+            modelConfiguration: LLMRegistry.gemma3_1B_qat_4bit,
+            tokenizer: NoSpecialTokenTokenizer())
+        #expect(gemma3.textStopStrings.contains("<end_of_turn>"))
+    }
+}


### PR DESCRIPTION
## Summary

Per review: **taking you up on the actual removal — and reframing this as a false-stop *fix*, not a cleanup.** My original framing ("inert, can never fire") was wrong, and your trace is right.

Gemma-4 renamed its turn-end token — `<end_of_turn>` is **not in the gemma-4 vocabulary**. But the entry does **not** evaporate:

- `convertTokenToId("<end_of_turn>")` returns the **`<unk>` id** — it's not a nil-on-missing API;
- the `id == unknownID` branch falls through to `textFallbackStopStrings(...)`;
- and the `extraEOSTokens` loop passes **`allowExactTextFallback: true`**, so the fallback returns `[token]` for anything starting with `<`.

Net effect on gemma-4: a **live text stop-string `"<end_of_turn>"`**. It can't fire as a token, but it *will* halt generation the moment the model emits those literal characters — not hypothetical for a model people use for coding and agent work. Ask gemma-4 to explain a Gemma-3 chat template, or to diff two templates, and the answer gets truncated mid-sentence with `stop`.

(For contrast, the `commonEndTokenStrings` blanket passes `allowExactTextFallback: false`, so *that* copy of the same string genuinely **is** inert. Only the `extraEOSTokens` one is live — the two loops are eight lines apart and differ by one argument. Easy to miss; I did.)

## What changed

- **Removed** `extraEOSTokens: ["<end_of_turn>"]` from the three `gemma4_*` configs.
- **Left `gemma3_*` / `gemma3n_*` untouched** — `<end_of_turn>` is still their real turn-end token.
- Added a tombstone comment at the gemma4 block so it doesn't get re-added, naming the `allowExactTextFallback: true` mechanism.

Nothing is lost: gemma-4 ends turns with `<turn|>` (id 106), which it already declares in `generation_config.json` (`eos_token_id: [1, 106, 50]`) and which the loader honors via `resolvedEOSTokenIds`.

## Tests

`Tests/MLXLMTests/Gemma4StaleEOSTests.swift` (new file):

- `gemma-4 configs declare no <end_of_turn> extra EOS token`
- `gemma-3 configs keep <end_of_turn>` (the fence you asked for)
- `<end_of_turn> resolves to a live text stop for gemma-3 but not gemma-4` — the behavioural pin

**Verified red→green**, not just green: against an unpatched factory the two gemma-4 tests fail on exactly
their own assertions (3 issues — one per gemma4 config), and the gemma-3 fence passes in *both* states, as
a fence should. With the fix: 3/3.

**Why a new file rather than appending to `StopStringMatcherTests`** (which is where I'd originally put
them, to reuse its private `NoSpecialTokenTokenizer`): #91 adds its tests to the tail of that same suite.
Since these are two independent PRs, each patch has to apply to a pristine tree on its own — but two
patches that both append at the same anchor cannot then be applied *sequentially*, in either order. A
separate file makes them orthogonal for any order and any base, at the cost of the small tokenizer stub
duplicated at the top. Happy to fold them back together if you'd rather merge one and rebase the other.

## Unrelated observation, take it or leave it

`jamba_3b` also declares `extraEOSTokens: ["<end_of_turn>"]`. I have no idea whether that's correct for
Jamba's vocabulary, so I've left it alone — but if `<end_of_turn>` isn't a real Jamba token, it's the same
live-text-stop shape as this bug and worth a look.
