### PR TITLE
Vendored swift-transformers: add Sendable to Hub.Repo / Hub.RepoType (Swift 6 build fix)

### DIFF
--- a/Vendors/swift-transformers/Sources/Hub/Hub.swift
+++ b/Vendors/swift-transformers/Sources/Hub/Hub.swift
@@ -77,7 +77,7 @@ public extension Hub {
     }
 
     /// The type of repository on the Hugging Face Hub.
-    enum RepoType: String, Codable {
+    enum RepoType: String, Codable, Sendable {
         /// Model repositories containing machine learning models.
         case models
         /// Dataset repositories containing training and evaluation data.
@@ -90,7 +90,7 @@ public extension Hub {
     ///
     /// A repository is identified by its unique ID and type, allowing access to
     /// different kinds of resources hosted on the Hub platform.
-    struct Repo: Codable {
+    struct Repo: Codable, Sendable {
         /// The unique identifier for the repository (e.g., "microsoft/DialoGPT-medium").
         public let id: String
         /// The type of repository (models, datasets, or spaces).


### PR DESCRIPTION
## Summary

Under Swift 6 strict concurrency, `Hub.RepoType` and `Hub.Repo` (in the vendored `swift-transformers`
copy under `Vendors/`) need `Sendable` to cross actor/task boundaries; without it, builds that touch
these types from concurrent contexts fail.

Both are trivially sendable (a `String`-raw enum and an all-`let` struct of `Sendable` fields). This
adds the conformance to the **vendored copy** so vmlx-swift builds clean under Swift 6 now, without
waiting on an upstream `swift-transformers` release + a vendor bump.

The same fix is now **merged upstream** at huggingface/swift-transformers#374 (merged 2026-06-28) — so
this vendored stopgap matches the accepted upstream change, and can be dropped on the next vendor sync
that picks it up. No behavior change.
