### PR TITLE
Llama: strip stray language_model.lm_head. prefix in sanitize() so prefixed checkpoints load

### DIFF
--- a/Libraries/MLXLLM/Models/Llama.swift
+++ b/Libraries/MLXLLM/Models/Llama.swift
@@ -185,10 +185,14 @@ public class LlamaModel: Module, LLMModel, KVCacheDimensionProvider {
     }
 
     public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
-        // Remove unused precomputed rotary frequencies
-        weights.filter {
-            !$0.key.contains("self_attn.rotary_emb.inv_freq")
-        }
+        // Some quantized checkpoints (e.g. vMLX JANG_6M conversions of text-only Llama bodies) emit
+        // the output projection under a VLM-style `language_model.lm_head.*` prefix while the body
+        // stays at `model.*`. This model binds the head at the top-level `lm_head`, so absorb that
+        // stray prefix rather than failing with "Unhandled keys [language_model]". Scoped to the head:
+        // a genuine nested `language_model.*` body is not ours to rewrite.
+        Weights.stripLanguageModelPrefix(weights, only: ["lm_head."])
+            // Remove unused precomputed rotary frequencies
+            .filter { !$0.key.contains("self_attn.rotary_emb.inv_freq") }
     }
 
     public func messageGenerator(tokenizer: any Tokenizer) -> any MessageGenerator {

--- a/Libraries/MLXLMCommon/Weights.swift
+++ b/Libraries/MLXLMCommon/Weights.swift
@@ -1,0 +1,89 @@
+// Copyright © 2025 Apple Inc.
+
+import Foundation
+import MLX
+import os
+
+private let weightsLogger = Logger(subsystem: "vmlx", category: "Weights")
+
+/// Helpers for normalizing a checkpoint's weight keys before they are bound to modules.
+public enum Weights {
+
+    /// Strips the VLM-style `language_model.` prefix that some conversions emit onto text-only bodies.
+    ///
+    /// The prefix is a **converter artifact, not a checkpoint convention**: a conversion that wraps a
+    /// text-only model in the VLM key layout leaves the body — or, in the wild, just the output head —
+    /// under `language_model.*`, while the text model binds its modules at the top level. Loading such
+    /// a bundle otherwise fails with `Unhandled keys [language_model]`. Being tolerant here is
+    /// deliberate: refusing to load a bundle someone already downloaded is worse than absorbing the
+    /// artifact.
+    ///
+    /// Both spellings are handled: `model.language_model.foo` → `model.foo`, and
+    /// `language_model.foo` → `foo`.
+    ///
+    /// - Parameters:
+    ///   - weights: the checkpoint keys, as loaded.
+    ///   - only: when non-`nil`, only keys whose **stripped** form begins with one of these strings are
+    ///     rewritten; every other key passes through untouched. Use it when a checkpoint is known to
+    ///     misplace exactly one module (e.g. `only: ["lm_head."]`) so the strip cannot silently absorb
+    ///     an unrelated, genuine `language_model.*` key. `nil` strips wherever the prefix appears.
+    /// - Returns: the weights with the prefix removed.
+    ///
+    /// ## Collisions are resolved deterministically
+    ///
+    /// A mixed-provenance re-bake can carry **both** spellings of a key — a converter writes the
+    /// prefixed head while something upstream leaves the unprefixed one behind. Both then want the same
+    /// destination. Resolving that by last-write-wins would make the bind depend on `Dictionary`'s
+    /// iteration order, which is **seeded per process**: the model would silently load a different
+    /// tensor from run to run. That is the worst failure shape available — it loads fine, generates
+    /// fine-ish, and is wrong some fraction of the time.
+    ///
+    /// So: an unprefixed key already sitting at the destination always wins, and any remaining tie is
+    /// broken by lexicographically smallest source key. The choice is arbitrary but *fixed*; the point
+    /// is that it never varies between runs. Losing keys are logged.
+    public static func stripLanguageModelPrefix(
+        _ weights: [String: MLXArray], only: [String]? = nil
+    ) -> [String: MLXArray] {
+        // Pass 1: map every key to the destination it wants. Grouping first (rather than writing as we
+        // go) is what makes collisions visible instead of order-dependent.
+        var sourcesByDestination = [String: [String]](minimumCapacity: weights.count)
+        for key in weights.keys {
+            sourcesByDestination[strippedKey(key, only: only) ?? key, default: []].append(key)
+        }
+
+        // Pass 2: bind, resolving any contested destination by a rule that does not depend on
+        // iteration order.
+        var result = [String: MLXArray](minimumCapacity: sourcesByDestination.count)
+        for (destination, sources) in sourcesByDestination {
+            guard sources.count > 1 else {
+                result[destination] = weights[sources[0]]
+                continue
+            }
+            let winner = sources.contains(destination) ? destination : (sources.min() ?? destination)
+            weightsLogger.warning(
+                """
+                checkpoint carries \(sources.count, privacy: .public) spellings of \
+                \(destination, privacy: .public) (\(sources.sorted().joined(separator: ", "), privacy: .public)); \
+                binding \(winner, privacy: .public) and dropping the rest. This bundle is malformed — \
+                the weights should be re-converted.
+                """)
+            result[destination] = weights[winner]
+        }
+        return result
+    }
+
+    /// The destination `key` would be rewritten to, or `nil` if it carries no prefix (or `only`
+    /// excludes it) and should pass through untouched.
+    private static func strippedKey(_ key: String, only: [String]?) -> String? {
+        let stripped: String
+        if key.hasPrefix("model.language_model.") {
+            stripped = "model." + key.dropFirst("model.language_model.".count)
+        } else if key.hasPrefix("language_model.") {
+            stripped = String(key.dropFirst("language_model.".count))
+        } else {
+            return nil
+        }
+        guard let only else { return stripped }
+        return only.contains(where: stripped.hasPrefix) ? stripped : nil
+    }
+}

--- a/Tests/MLXLMTests/WeightsTests.swift
+++ b/Tests/MLXLMTests/WeightsTests.swift
@@ -1,0 +1,167 @@
+import Foundation
+import MLX
+import Testing
+
+@testable import MLXLMCommon
+
+/// Tests for `Weights.stripLanguageModelPrefix`, the single home for absorbing the
+/// `language_model.` converter artifact.
+///
+/// Tensors are tagged by SHAPE rather than by value: this function routes KEYS and never inspects
+/// tensor contents, so a distinct extent per tensor is enough to catch a mis-bind, and no assertion
+/// has to force an evaluation.
+@Suite("Weights.stripLanguageModelPrefix")
+struct WeightsTests {
+
+    /// Distinct shape per tensor, so a mis-bind is visible as the wrong extent.
+    private static func tagged(_ tag: Int) -> MLXArray { MLXArray.zeros([tag]) }
+
+    // MARK: - The motivating case
+
+    @Test("a prefixed head lands on the top-level key while the body is untouched")
+    func stripsPrefixedHeadOntoTopLevelKey() {
+        let weights: [String: MLXArray] = [
+            "language_model.lm_head.weight": Self.tagged(7),
+            "model.embed_tokens.weight": Self.tagged(3),
+            "model.layers.0.self_attn.q_proj.weight": Self.tagged(4),
+        ]
+
+        let result = Weights.stripLanguageModelPrefix(weights, only: ["lm_head."])
+
+        #expect(result["lm_head.weight"]?.shape == [7])
+        #expect(result["language_model.lm_head.weight"] == nil)
+        // the body is not this function's business
+        #expect(result["model.embed_tokens.weight"]?.shape == [3])
+        #expect(result["model.layers.0.self_attn.q_proj.weight"]?.shape == [4])
+        #expect(result.count == weights.count)
+    }
+
+    @Test("quant sidecars travel with the head")
+    func stripsQuantSidecars() {
+        let weights: [String: MLXArray] = [
+            "language_model.lm_head.weight": Self.tagged(1),
+            "language_model.lm_head.scales": Self.tagged(2),
+            "language_model.lm_head.biases": Self.tagged(3),
+        ]
+
+        let result = Weights.stripLanguageModelPrefix(weights, only: ["lm_head."])
+
+        #expect(result["lm_head.weight"]?.shape == [1])
+        #expect(result["lm_head.scales"]?.shape == [2])
+        #expect(result["lm_head.biases"]?.shape == [3])
+    }
+
+    // MARK: - The collision guard (the nondeterminism this function exists to prevent)
+
+    @Test("both spellings present: the unprefixed key wins, deterministically")
+    func collisionPrefersUnprefixedKey() {
+        let weights: [String: MLXArray] = [
+            "lm_head.weight": Self.tagged(11),  // the one that must win
+            "language_model.lm_head.weight": Self.tagged(22),
+            "model.embed_tokens.weight": Self.tagged(3),
+        ]
+
+        let result = Weights.stripLanguageModelPrefix(weights, only: ["lm_head."])
+
+        #expect(result["lm_head.weight"]?.shape == [11])
+        #expect(result["language_model.lm_head.weight"] == nil)
+    }
+
+    /// The stronger case the naive `guard weights[stripped] == nil` misses: TWO prefixed spellings
+    /// contend for one destination and NEITHER is present unprefixed, so there is no existing key to
+    /// guard against. Last-write-wins would pick by dictionary iteration order here.
+    @Test("two prefixed spellings contend: resolved by a fixed rule, not iteration order")
+    func collisionBetweenTwoPrefixedSpellings() {
+        let weights: [String: MLXArray] = [
+            "language_model.model.embed_tokens.weight": Self.tagged(11),
+            "model.language_model.embed_tokens.weight": Self.tagged(22),
+        ]
+
+        let result = Weights.stripLanguageModelPrefix(weights)
+
+        // Both want `model.embed_tokens.weight`; the rule is lexicographically smallest source.
+        #expect(result["model.embed_tokens.weight"]?.shape == [11])
+        #expect(result.count == 1)
+    }
+
+    /// The real guard against order-dependence, and the reason it is shaped like this.
+    ///
+    /// An order-dependent bug cannot be caught reliably by ONE colliding key set: for a fixed set of
+    /// keys, `Dictionary`'s iteration order is decided by the per-process hash seed, so a
+    /// last-write-wins implementation lands on the right answer roughly half the time and the test is
+    /// a coin flip. (Varying *insertion* order does not help either — same keys, same seed, same
+    /// iteration order.)
+    ///
+    /// So vary the KEY SETS instead. Each one hashes independently, so a broken implementation has to
+    /// win every coin flip to pass. Measured against the `guard weights[stripped] == nil` form, a
+    /// single set passed 14 of 25 runs; across 200 sets that survives with probability ~2^-200.
+    @Test("collision resolution holds across many independently-hashing key sets")
+    func collisionResolutionIsStableAcrossKeySets() {
+        for i in 0 ..< 200 {
+            let tail = "layers.\(i).mlp.down_proj.weight"
+            // Both spellings want `model.<tail>`, and NEITHER exists unprefixed — so there is no
+            // pre-existing key to guard against and only a fixed rule can decide this.
+            let weights: [String: MLXArray] = [
+                "language_model.model." + tail: Self.tagged(11),
+                "model.language_model." + tail: Self.tagged(22),
+            ]
+
+            let result = Weights.stripLanguageModelPrefix(weights)
+
+            // Documented rule: lexicographically smallest source wins ("language_model." < "model.").
+            #expect(
+                result["model." + tail]?.shape == [11],
+                "key set \(i) bound the wrong spelling — resolution is order-dependent")
+        }
+    }
+
+    // MARK: - `only:` scoping
+
+    @Test("only: leaves unrelated language_model keys alone")
+    func onlyFilterLeavesOtherKeysAlone() {
+        let weights: [String: MLXArray] = [
+            "language_model.lm_head.weight": Self.tagged(7),
+            "language_model.model.embed_tokens.weight": Self.tagged(3),
+        ]
+
+        let result = Weights.stripLanguageModelPrefix(weights, only: ["lm_head."])
+
+        #expect(result["lm_head.weight"]?.shape == [7])
+        // NOT ours to touch: a genuine nested body key stays exactly as it was.
+        #expect(result["language_model.model.embed_tokens.weight"]?.shape == [3])
+        #expect(result["model.embed_tokens.weight"] == nil)
+    }
+
+    @Test("nil only: strips both spellings wherever they appear")
+    func nilOnlyStripsEverywhere() {
+        let weights: [String: MLXArray] = [
+            "language_model.lm_head.weight": Self.tagged(7),
+            "language_model.model.embed_tokens.weight": Self.tagged(3),
+            "model.language_model.layers.0.mlp.gate.weight": Self.tagged(4),
+            "model.layers.0.self_attn.q_proj.weight": Self.tagged(5),
+        ]
+
+        let result = Weights.stripLanguageModelPrefix(weights)
+
+        #expect(result["lm_head.weight"]?.shape == [7])
+        #expect(result["model.embed_tokens.weight"]?.shape == [3])
+        #expect(result["model.layers.0.mlp.gate.weight"]?.shape == [4])
+        // a key with no prefix is passed through untouched
+        #expect(result["model.layers.0.self_attn.q_proj.weight"]?.shape == [5])
+        #expect(result.keys.allSatisfy { !$0.contains("language_model.") })
+    }
+
+    @Test("a checkpoint with no prefix at all is returned unchanged")
+    func noPrefixIsIdentity() {
+        let weights: [String: MLXArray] = [
+            "lm_head.weight": Self.tagged(1),
+            "model.embed_tokens.weight": Self.tagged(2),
+        ]
+
+        let result = Weights.stripLanguageModelPrefix(weights)
+
+        #expect(result.count == 2)
+        #expect(result["lm_head.weight"]?.shape == [1])
+        #expect(result["model.embed_tokens.weight"]?.shape == [2])
+    }
+}


### PR DESCRIPTION
## Summary

Per review: **taking both asks, and taking you up on the shared helper.** This PR is now two commits —
the helper, then the Llama call site.

Some quantized text-only Llama checkpoints emit the output projection under a VLM-style
`language_model.lm_head.*` prefix while the body stays at `model.*`. `LlamaModel` binds the head at the
top-level key `lm_head`, so these fail to load with `Unhandled keys [language_model]`.

## Your converter diagnosis is confirmed from this side

You wrote that the JANG conversion path emits VLM-style `language_model.*` on text-only bodies and that
it's a known open bug on your side. I can confirm that independently: on
`cais/HarmBench-Llama-2-13b-cls-Jang_6M` the **bf16 source is flat `lm_head.*`**, and the JANG output
has **zero** flat `lm_head.*` keys and exactly three prefixed ones:

```
language_model.lm_head.weight
language_model.lm_head.scales
language_model.lm_head.biases
```

927 keys in the bundle; those 3 are the only `language_model.*` in it. The body is untouched at
`model.*`. So the prefix is introduced by the conversion, on exactly one module, and the quant itself is
fine (the shape walk produced 282 per-layer overrides and the classifier discriminates correctly once
it loads). That's what makes "absorb the artifact" the right call rather than "reject the bundle".

The same three keys, in the same shape, appear on a **Mixtral** JANG bundle in #96 — different
architecture, identical artifact. Which is the argument for your helper better than I could make it.

## 1. The collision guard — measured, including one case the suggested version doesn't cover

Taken, and it's the right catch: a nondeterministic weight bind is worse than the load error it
replaces.

One note on the shape of it. The suggested guard —

```swift
guard weights[stripped] == nil else { continue }
```

— covers a prefixed key colliding with an **existing unprefixed** key. It does **not** cover **two
prefixed spellings colliding with each other**: `language_model.model.x` and `model.language_model.x`
both want `model.x`, and neither exists unprefixed, so there is no existing key to guard against and
last-write-wins still picks by iteration order.

I didn't want to just assert that at you, so I measured it. Implementing your guard verbatim and running
the suite in **25 separate processes** (fresh hash seed each):

| implementation | result |
|---|---|
| `guard weights[stripped] == nil else { continue }` | **14 passed / 11 failed of 25** |
| grouping by destination + fixed rule | 25 / 25 |

So on that one input the suggested form binds the wrong tensor in ~44% of runs — the exact
loads-fine-wrong-sometimes shape you're guarding against.

The helper therefore groups by destination first and resolves by a fixed rule: an unprefixed key already
at the destination wins; any remaining tie goes to the lexicographically smallest source. Arbitrary, but
*fixed* — the point is only that it never varies between runs. Losers are logged at `warning` with the
full source list, since a bundle that hits this is malformed and wants re-converting.

**Two honest caveats.**

*The hazard is latent, not observed.* Neither witness bundle actually collides — both have zero flat
`lm_head.*`, so the guard never fires on them in practice.

*My first version of this test was junk, and the 44% is why.* It tried to catch order-dependence by
building the same dictionary in two insertion orders — which cannot work: for a fixed key set and a
fixed seed, `Dictionary` iterates the same way regardless of insertion order. It passed against the
broken implementation, which is what gave it away. The test now varies the **key sets** (200 of them),
each hashing independently, so a last-write-wins implementation has to win 200 coin flips:

| new test vs | result |
|---|---|
| suggested guard | **0 passed / 10 failed** |
| this PR's guard | 10 / 10 |

## 2. The shared helper

`Weights.stripLanguageModelPrefix(_:only:)` in `MLXLMCommon`, called by both this PR and #96:

```swift
Weights.stripLanguageModelPrefix(weights, only: ["lm_head."])
    .filter { !$0.key.contains("self_attn.rotary_emb.inv_freq") }
```

`only:` scopes the rewrite to keys whose **stripped** form starts with one of the given prefixes. That
keeps this call site's semantics exactly as they were — only the stray head is absorbed, and a genuine
nested `language_model.*` body key is left alone — while #96 passes `nil` to strip wherever the prefix
appears. That parameter is what lets one function serve call sites whose semantics differ, which was the
thing making eleven copies diverge.

I did **not** migrate the other eleven strip sites. You said you weren't asking for it, and each has its
own semantics that deserve their own reading; this just stops the count going up. If you want them
folded in, happy to do it as a separate PR.

## 3. Tests

`Tests/MLXLMTests/WeightsTests.swift` — the motivating strip, quant sidecars travelling with the head,
**both** collision shapes, resolution stability across 200 independently-hashing key sets, `only:`
scoping in both directions, and identity on an unprefixed checkpoint.

Tensors are tagged by **shape** rather than value: this function routes keys and never inspects tensor
contents, so a distinct extent per tensor is enough to catch a mis-bind and no assertion has to force an
evaluation.

## Note on the branch

The helper commit is deliberately in **both** this PR and #96, identical in both, so neither has to wait
on the other. Whichever you merge first, the other rebases cleanly and its copy collapses. Happy to
restructure if you'd rather have it standalone.
