### PR TITLE
Add Mixtral (sparse 8-expert MoE) language model

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -27,6 +27,7 @@ public enum LLMTypeRegistry {
             "phi": create(PhiConfiguration.self, PhiModel.init),
             "phi3": create(Phi3Configuration.self, Phi3Model.init),
             "phimoe": create(PhiMoEConfiguration.self, PhiMoEModel.init),
+            "mixtral": create(MixtralConfiguration.self, MixtralModel.init),
             "gemma": create(GemmaConfiguration.self, GemmaModel.init),
             "gemma2": create(Gemma2Configuration.self, Gemma2Model.init),
             "gemma3": create(Gemma3TextConfiguration.self, Gemma3TextModel.init),

--- a/Libraries/MLXLLM/Models/Mixtral.swift
+++ b/Libraries/MLXLLM/Models/Mixtral.swift
@@ -1,0 +1,238 @@
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+// Port of https://github.com/ml-explore/mlx-lm/blob/main/mlx_lm/models/mixtral.py
+//
+// Mixtral = vanilla Llama/Mistral decoder (RMSNorm, plain RoPE, GQA, no biases) with a sparse
+// 8-expert top-2 MoE FFN (`block_sparse_moe`) in place of the dense MLP. Structurally identical to
+// PhiMoE except the attention/norm flavor — so this mirrors PhiMoE's decoder/model/sanitize and
+// swaps in Llama-style attention. The expert-weight sanitize (block_sparse_moe.experts.N.{w1,w2,w3}
+// → stacked switch_mlp) is exactly Mixtral's HF layout.
+
+public struct MixtralConfiguration: Codable, Sendable {
+    var modelType: String = "mixtral"
+    var vocabularySize: Int = 32000
+    var hiddenSize: Int = 4096
+    var intermediateSize: Int = 14336
+    var hiddenLayers: Int = 32
+    var attentionHeads: Int = 32
+    var kvHeads: Int = 8
+    var maxPositionEmbeddings: Int = 32768
+    var rmsNormEps: Float = 1e-5
+    var ropeTheta: Float = 1_000_000.0
+    var numLocalExperts: Int = 8
+    var numExpertsPerToken: Int = 2
+
+    enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case vocabularySize = "vocab_size"
+        case hiddenSize = "hidden_size"
+        case intermediateSize = "intermediate_size"
+        case hiddenLayers = "num_hidden_layers"
+        case attentionHeads = "num_attention_heads"
+        case kvHeads = "num_key_value_heads"
+        case maxPositionEmbeddings = "max_position_embeddings"
+        case rmsNormEps = "rms_norm_eps"
+        case ropeTheta = "rope_theta"
+        case numLocalExperts = "num_local_experts"
+        case numExpertsPerToken = "num_experts_per_tok"
+    }
+}
+
+private class MixtralAttention: Module {
+    let args: MixtralConfiguration
+    let scale: Float
+    let headDim: Int
+
+    @ModuleInfo(key: "q_proj") var wq: Linear
+    @ModuleInfo(key: "k_proj") var wk: Linear
+    @ModuleInfo(key: "v_proj") var wv: Linear
+    @ModuleInfo(key: "o_proj") var wo: Linear
+
+    let rope: RoPELayer
+
+    init(_ args: MixtralConfiguration) {
+        self.args = args
+        let dim = args.hiddenSize
+        let heads = args.attentionHeads
+        let kvHeads = args.kvHeads
+        self.headDim = dim / heads
+        self.scale = pow(Float(headDim), -0.5)
+
+        self._wq.wrappedValue = Linear(dim, heads * headDim, bias: false)
+        self._wk.wrappedValue = Linear(dim, kvHeads * headDim, bias: false)
+        self._wv.wrappedValue = Linear(dim, kvHeads * headDim, bias: false)
+        self._wo.wrappedValue = Linear(heads * headDim, dim, bias: false)
+
+        self.rope = initializeRope(
+            dims: headDim, base: args.ropeTheta,
+            traditional: false,
+            scalingConfig: nil,
+            maxPositionEmbeddings: args.maxPositionEmbeddings)
+    }
+
+    func callAsFunction(
+        _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
+    ) -> MLXArray {
+        let (B, L) = (x.dim(0), x.dim(1))
+
+        var queries = wq(x)
+        var keys = wk(x)
+        var values = wv(x)
+
+        queries = queries.reshaped(B, L, -1, headDim).transposed(0, 2, 1, 3)
+        keys = keys.reshaped(B, L, -1, headDim).transposed(0, 2, 1, 3)
+        values = values.reshaped(B, L, -1, headDim).transposed(0, 2, 1, 3)
+
+        queries = applyRotaryPosition(rope, to: queries, cache: cache)
+        keys = applyRotaryPosition(rope, to: keys, cache: cache)
+
+        let output = attentionWithCacheUpdate(
+            queries: queries, keys: keys, values: values,
+            cache: cache, scale: scale, mask: mask
+        )
+        .transposed(0, 2, 1, 3)
+        .reshaped(B, L, -1)
+
+        return wo(output)
+    }
+}
+
+private class MixtralSparseMoeBlock: Module {
+    let layerIdx: Int
+    let numExperts: Int
+    let topK: Int
+
+    @ModuleInfo(key: "gate") var gate: Linear
+    @ModuleInfo(key: "switch_mlp") var switchMLP: SwitchGLU
+
+    init(_ args: MixtralConfiguration, layerIdx: Int) {
+        self.layerIdx = layerIdx
+        self.numExperts = args.numLocalExperts
+        self.topK = args.numExpertsPerToken
+        self._gate.wrappedValue = Linear(args.hiddenSize, args.numLocalExperts, bias: false)
+        self._switchMLP.wrappedValue = SwitchGLU(
+            inputDims: args.hiddenSize, hiddenDims: args.intermediateSize,
+            numExperts: args.numLocalExperts)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let gates = gate(x)
+        let k = self.topK
+        let inds = MLX.stopGradient(
+            MLX.argPartition(-gates, kth: k - 1, axis: -1)[.ellipsis, ..<k])
+        let scores = MLX.softmax(MLX.takeAlong(gates, inds, axis: -1), axis: -1, precise: true)
+        JangPressCanonicalExpertAdvisor.shared.observe(layer: layerIdx, indices: inds)
+        let y = switchMLP(x, inds)
+        return (y * scores[.ellipsis, .newAxis]).sum(axis: -2)
+    }
+}
+
+private class MixtralDecoderLayer: Module {
+    @ModuleInfo(key: "self_attn") var selfAttn: MixtralAttention
+    @ModuleInfo(key: "block_sparse_moe") var blockSparseMoe: MixtralSparseMoeBlock
+    @ModuleInfo(key: "input_layernorm") var inputLayerNorm: RMSNorm
+    @ModuleInfo(key: "post_attention_layernorm") var postAttentionLayerNorm: RMSNorm
+
+    init(_ args: MixtralConfiguration, layerIdx: Int) {
+        self._selfAttn.wrappedValue = MixtralAttention(args)
+        self._blockSparseMoe.wrappedValue = MixtralSparseMoeBlock(args, layerIdx: layerIdx)
+        self._inputLayerNorm.wrappedValue = RMSNorm(dimensions: args.hiddenSize, eps: args.rmsNormEps)
+        self._postAttentionLayerNorm.wrappedValue = RMSNorm(dimensions: args.hiddenSize, eps: args.rmsNormEps)
+    }
+
+    func callAsFunction(
+        _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
+    ) -> MLXArray {
+        var h = x + selfAttn(inputLayerNorm(x), mask: mask, cache: cache)
+        h = h + blockSparseMoe(postAttentionLayerNorm(h))
+        return h
+    }
+}
+
+public class MixtralModelInner: Module {
+    let args: MixtralConfiguration
+
+    @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
+    fileprivate let layers: [MixtralDecoderLayer]
+    @ModuleInfo(key: "norm") var norm: RMSNorm
+
+    init(_ args: MixtralConfiguration) {
+        self.args = args
+        self._embedTokens.wrappedValue = Embedding(
+            embeddingCount: args.vocabularySize, dimensions: args.hiddenSize)
+        self.layers = (0 ..< args.hiddenLayers).map { MixtralDecoderLayer(args, layerIdx: $0) }
+        self._norm.wrappedValue = RMSNorm(dimensions: args.hiddenSize, eps: args.rmsNormEps)
+    }
+
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        var h = embedTokens(inputs)
+        let mask = createAttentionMask(h: h, cache: cache?.first)
+        for (i, layer) in layers.enumerated() {
+            h = layer(h, mask: mask, cache: cache?[i])
+        }
+        return norm(h)
+    }
+}
+
+public class MixtralModel: Module, LLMModel, KVCacheDimensionProvider {
+    public let vocabularySize: Int
+    public let kvHeads: [Int]
+
+    public let model: MixtralModelInner
+    @ModuleInfo(key: "lm_head") var lmHead: Linear
+
+    public init(_ args: MixtralConfiguration) {
+        self.vocabularySize = args.vocabularySize
+        self.kvHeads = Array(repeating: args.kvHeads, count: args.hiddenLayers)
+        self.model = MixtralModelInner(args)
+        self._lmHead.wrappedValue = Linear(args.hiddenSize, args.vocabularySize, bias: false)
+    }
+
+    public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        lmHead(model(inputs, cache: cache))
+    }
+
+    public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        // Some conversions (VLM-style / JANG) wrap the LLM under a `language_model.` prefix. Strip it so
+        // keys match this model's modules (model.*, lm_head.*). The shared helper carries the collision
+        // guard: a mixed-provenance re-bake can ship both spellings of a key, and picking between them
+        // by dictionary iteration order binds a different tensor from run to run.
+        var sanitizedWeights = Weights.stripLanguageModelPrefix(weights)
+
+        // Only fuse if the per-expert weights are still separate (skip if already a JANG-stacked bundle).
+        if sanitizedWeights["model.layers.0.block_sparse_moe.experts.0.w1.weight"] == nil {
+            return sanitizedWeights
+        }
+        for l in 0 ..< model.args.hiddenLayers {
+            let prefix = "model.layers.\(l)"
+            for (n, m) in [("w1", "gate_proj"), ("w2", "down_proj"), ("w3", "up_proj")] {
+                for k in ["weight", "scales", "biases"] {
+                    guard sanitizedWeights["\(prefix).block_sparse_moe.experts.0.\(n).\(k)"] != nil
+                    else { continue }
+                    let expertKeys = (0 ..< model.args.numLocalExperts).map { e in
+                        "\(prefix).block_sparse_moe.experts.\(e).\(n).\(k)"
+                    }
+                    // A truncated or malformed bundle can carry expert 0 but be missing a later shard.
+                    // Stacking blind would trap. Leave the keys in place instead: the module bind then
+                    // reports them, so a bad checkpoint yields a load error rather than a crash.
+                    guard expertKeys.allSatisfy({ sanitizedWeights[$0] != nil }) else { continue }
+                    let toJoin = expertKeys.compactMap { sanitizedWeights.removeValue(forKey: $0) }
+                    sanitizedWeights["\(prefix).block_sparse_moe.switch_mlp.\(m).\(k)"] =
+                        MLX.stacked(toJoin)
+                }
+            }
+        }
+        return sanitizedWeights
+    }
+}
+
+// MARK: - LoRA
+
+extension MixtralModel: LoRAModel {
+    public var loraLayers: [Module] {
+        model.layers
+    }
+}

--- a/Libraries/MLXLMCommon/Weights.swift
+++ b/Libraries/MLXLMCommon/Weights.swift
@@ -1,0 +1,89 @@
+// Copyright © 2025 Apple Inc.
+
+import Foundation
+import MLX
+import os
+
+private let weightsLogger = Logger(subsystem: "vmlx", category: "Weights")
+
+/// Helpers for normalizing a checkpoint's weight keys before they are bound to modules.
+public enum Weights {
+
+    /// Strips the VLM-style `language_model.` prefix that some conversions emit onto text-only bodies.
+    ///
+    /// The prefix is a **converter artifact, not a checkpoint convention**: a conversion that wraps a
+    /// text-only model in the VLM key layout leaves the body — or, in the wild, just the output head —
+    /// under `language_model.*`, while the text model binds its modules at the top level. Loading such
+    /// a bundle otherwise fails with `Unhandled keys [language_model]`. Being tolerant here is
+    /// deliberate: refusing to load a bundle someone already downloaded is worse than absorbing the
+    /// artifact.
+    ///
+    /// Both spellings are handled: `model.language_model.foo` → `model.foo`, and
+    /// `language_model.foo` → `foo`.
+    ///
+    /// - Parameters:
+    ///   - weights: the checkpoint keys, as loaded.
+    ///   - only: when non-`nil`, only keys whose **stripped** form begins with one of these strings are
+    ///     rewritten; every other key passes through untouched. Use it when a checkpoint is known to
+    ///     misplace exactly one module (e.g. `only: ["lm_head."]`) so the strip cannot silently absorb
+    ///     an unrelated, genuine `language_model.*` key. `nil` strips wherever the prefix appears.
+    /// - Returns: the weights with the prefix removed.
+    ///
+    /// ## Collisions are resolved deterministically
+    ///
+    /// A mixed-provenance re-bake can carry **both** spellings of a key — a converter writes the
+    /// prefixed head while something upstream leaves the unprefixed one behind. Both then want the same
+    /// destination. Resolving that by last-write-wins would make the bind depend on `Dictionary`'s
+    /// iteration order, which is **seeded per process**: the model would silently load a different
+    /// tensor from run to run. That is the worst failure shape available — it loads fine, generates
+    /// fine-ish, and is wrong some fraction of the time.
+    ///
+    /// So: an unprefixed key already sitting at the destination always wins, and any remaining tie is
+    /// broken by lexicographically smallest source key. The choice is arbitrary but *fixed*; the point
+    /// is that it never varies between runs. Losing keys are logged.
+    public static func stripLanguageModelPrefix(
+        _ weights: [String: MLXArray], only: [String]? = nil
+    ) -> [String: MLXArray] {
+        // Pass 1: map every key to the destination it wants. Grouping first (rather than writing as we
+        // go) is what makes collisions visible instead of order-dependent.
+        var sourcesByDestination = [String: [String]](minimumCapacity: weights.count)
+        for key in weights.keys {
+            sourcesByDestination[strippedKey(key, only: only) ?? key, default: []].append(key)
+        }
+
+        // Pass 2: bind, resolving any contested destination by a rule that does not depend on
+        // iteration order.
+        var result = [String: MLXArray](minimumCapacity: sourcesByDestination.count)
+        for (destination, sources) in sourcesByDestination {
+            guard sources.count > 1 else {
+                result[destination] = weights[sources[0]]
+                continue
+            }
+            let winner = sources.contains(destination) ? destination : (sources.min() ?? destination)
+            weightsLogger.warning(
+                """
+                checkpoint carries \(sources.count, privacy: .public) spellings of \
+                \(destination, privacy: .public) (\(sources.sorted().joined(separator: ", "), privacy: .public)); \
+                binding \(winner, privacy: .public) and dropping the rest. This bundle is malformed — \
+                the weights should be re-converted.
+                """)
+            result[destination] = weights[winner]
+        }
+        return result
+    }
+
+    /// The destination `key` would be rewritten to, or `nil` if it carries no prefix (or `only`
+    /// excludes it) and should pass through untouched.
+    private static func strippedKey(_ key: String, only: [String]?) -> String? {
+        let stripped: String
+        if key.hasPrefix("model.language_model.") {
+            stripped = "model." + key.dropFirst("model.language_model.".count)
+        } else if key.hasPrefix("language_model.") {
+            stripped = String(key.dropFirst("language_model.".count))
+        } else {
+            return nil
+        }
+        guard let only else { return stripped }
+        return only.contains(where: stripped.hasPrefix) ? stripped : nil
+    }
+}

--- a/Tests/MLXLMTests/MixtralTests.swift
+++ b/Tests/MLXLMTests/MixtralTests.swift
@@ -1,0 +1,125 @@
+import Foundation
+import MLX
+import Testing
+
+@testable import MLXLLM
+
+/// Pins the two pieces of the Mixtral port that carry real risk: the top-k router selection
+/// (`argPartition` + softmax over the gathered gates) and the expert-weight `sanitize` that folds
+/// per-expert `block_sparse_moe.experts.N.{w1,w2,w3}` into the stacked `switch_mlp`. The sanitize
+/// tests exercise all three paths — fuse, already-stacked no-op, and the truncated-bundle guard that
+/// replaced a stacking force-unwrap with a load error.
+@Suite("Mixtral MoE")
+struct MixtralTests {
+
+    private static func filled(_ a: Int, _ b: Int) -> MLXArray {
+        MLXArray(Array(repeating: Float(1), count: a * b)).reshaped(a, b)
+    }
+
+    /// The exact selection the router runs: `argPartition(-gates, kth: k-1)[..<k]` then softmax over
+    /// the gathered gates. Fixed gates → the two highest experts, softmax scores summing to 1 with the
+    /// top gate dominating — and it must be repeatable call-to-call (cold-vs-warm determinism).
+    @Test("top-k router selects the highest gates, deterministically")
+    func topKRoutingSelectsHighestGates() {
+        MLXMetalTestLock.withLock {
+            let gates = MLXArray([Float(1.0), 3.0, 2.0, 0.5]).reshaped(1, 4)
+            let k = 2
+
+            func select() -> MLXArray {
+                MLX.argPartition(-gates, kth: k - 1, axis: -1)[.ellipsis, ..<k]
+            }
+            let inds = select()
+            let selected = Set(inds.asArray(Int32.self).map(Int.init))
+            #expect(selected == [1, 2])  // gates 3.0 and 2.0
+
+            // Same input, same output — the routing has no run-to-run drift.
+            #expect(inds.asArray(Int32.self) == select().asArray(Int32.self))
+
+            let scores = MLX.softmax(MLX.takeAlong(gates, inds, axis: -1), axis: -1, precise: true)
+                .asArray(Float.self)
+            #expect(abs(scores.reduce(0, +) - 1.0) < 1e-5)
+            // softmax([3, 2]) → {0.7311, 0.2689}; the top expert dominates.
+            #expect(abs(scores.max()! - 0.7310586) < 1e-4)
+        }
+    }
+
+    /// `argPartition`'s tie-break is implementation-defined, but it must be REPEATABLE within a build —
+    /// otherwise routing (and thus the whole forward) would drift on tied gates. This pins repeatability,
+    /// not a particular tie winner.
+    @Test("tied gates route repeatably")
+    func tiedGatesRouteRepeatably() {
+        MLXMetalTestLock.withLock {
+            let tied = MLXArray([Float(2.0), 2.0, 1.0, 0.5]).reshaped(1, 4)
+            func select() -> [Int32] {
+                MLX.argPartition(-tied, kth: 1, axis: -1)[.ellipsis, ..<2].asArray(Int32.self)
+            }
+            #expect(select() == select())
+        }
+    }
+
+    // Memberwise init (via @testable) rather than JSON: synthesized `Decodable` ignores the struct's
+    // property defaults, so a trimmed JSON fixture would fail on the first absent key. The memberwise
+    // init honors the defaults, so we only name the fields the test cares about.
+    private func tinyModel() -> MixtralModel {
+        let cfg = MixtralConfiguration(
+            vocabularySize: 8, hiddenSize: 4, intermediateSize: 6,
+            hiddenLayers: 1, attentionHeads: 2, kvHeads: 1,
+            numLocalExperts: 2, numExpertsPerToken: 2)
+        return MixtralModel(cfg)
+    }
+
+    /// The HF layout: separate `experts.{0,1}.{w1,w2,w3}.weight` → stacked `switch_mlp.{gate,down,up}_proj`
+    /// with a leading expert axis. `w1→gate_proj`, `w2→down_proj`, `w3→up_proj`; the per-expert keys are
+    /// consumed.
+    @Test("sanitize stacks per-expert weights into switch_mlp")
+    func sanitizeStacksPerExpertWeights() {
+        let model = tinyModel()
+        MLXMetalTestLock.withLock {
+            let p = "model.layers.0.block_sparse_moe"
+            let weights: [String: MLXArray] = [
+                "\(p).experts.0.w1.weight": Self.filled(6, 4),
+                "\(p).experts.1.w1.weight": Self.filled(6, 4),
+                "\(p).experts.0.w2.weight": Self.filled(4, 6),
+                "\(p).experts.1.w2.weight": Self.filled(4, 6),
+                "\(p).experts.0.w3.weight": Self.filled(6, 4),
+                "\(p).experts.1.w3.weight": Self.filled(6, 4),
+            ]
+            let out = model.sanitize(weights: weights)
+
+            #expect(out["\(p).switch_mlp.gate_proj.weight"]?.shape == [2, 6, 4])  // w1
+            #expect(out["\(p).switch_mlp.down_proj.weight"]?.shape == [2, 4, 6])  // w2
+            #expect(out["\(p).switch_mlp.up_proj.weight"]?.shape == [2, 6, 4])    // w3
+            #expect(out["\(p).experts.0.w1.weight"] == nil)  // consumed, not left behind
+        }
+    }
+
+    /// A JANG-stacked bundle arrives already fused (no `experts.0.w1.weight`); sanitize must pass it
+    /// through untouched rather than trying to re-stack.
+    @Test("sanitize is a no-op for an already-stacked bundle")
+    func sanitizeNoOpForStackedBundle() {
+        let model = tinyModel()
+        MLXMetalTestLock.withLock {
+            let p = "model.layers.0.block_sparse_moe"
+            let already: [String: MLXArray] = ["\(p).switch_mlp.gate_proj.weight": Self.filled(2, 6)]
+            let out = model.sanitize(weights: already)
+            #expect(out["\(p).switch_mlp.gate_proj.weight"] != nil)          // untouched
+            #expect(!out.keys.contains { $0.contains("experts.") })          // nothing invented
+        }
+    }
+
+    /// The guard that replaced a stacking force-unwrap: a truncated bundle carries expert 0 but is
+    /// missing a later shard. Stacking blind would trap; instead the keys are left in place so the
+    /// module bind reports a load error rather than crashing.
+    @Test("sanitize leaves a truncated bundle for the module bind to reject")
+    func sanitizeLeavesTruncatedBundle() {
+        let model = tinyModel()
+        MLXMetalTestLock.withLock {
+            let p = "model.layers.0.block_sparse_moe"
+            let truncated: [String: MLXArray] = ["\(p).experts.0.w1.weight": Self.filled(6, 4)]
+            // expert 1 absent (num_local_experts = 2)
+            let out = model.sanitize(weights: truncated)
+            #expect(out["\(p).switch_mlp.gate_proj.weight"] == nil)  // NOT stacked
+            #expect(out["\(p).experts.0.w1.weight"] != nil)          // left for the bind to flag
+        }
+    }
+}

--- a/Tests/MLXLMTests/WeightsTests.swift
+++ b/Tests/MLXLMTests/WeightsTests.swift
@@ -1,0 +1,167 @@
+import Foundation
+import MLX
+import Testing
+
+@testable import MLXLMCommon
+
+/// Tests for `Weights.stripLanguageModelPrefix`, the single home for absorbing the
+/// `language_model.` converter artifact.
+///
+/// Tensors are tagged by SHAPE rather than by value: this function routes KEYS and never inspects
+/// tensor contents, so a distinct extent per tensor is enough to catch a mis-bind, and no assertion
+/// has to force an evaluation.
+@Suite("Weights.stripLanguageModelPrefix")
+struct WeightsTests {
+
+    /// Distinct shape per tensor, so a mis-bind is visible as the wrong extent.
+    private static func tagged(_ tag: Int) -> MLXArray { MLXArray.zeros([tag]) }
+
+    // MARK: - The motivating case
+
+    @Test("a prefixed head lands on the top-level key while the body is untouched")
+    func stripsPrefixedHeadOntoTopLevelKey() {
+        let weights: [String: MLXArray] = [
+            "language_model.lm_head.weight": Self.tagged(7),
+            "model.embed_tokens.weight": Self.tagged(3),
+            "model.layers.0.self_attn.q_proj.weight": Self.tagged(4),
+        ]
+
+        let result = Weights.stripLanguageModelPrefix(weights, only: ["lm_head."])
+
+        #expect(result["lm_head.weight"]?.shape == [7])
+        #expect(result["language_model.lm_head.weight"] == nil)
+        // the body is not this function's business
+        #expect(result["model.embed_tokens.weight"]?.shape == [3])
+        #expect(result["model.layers.0.self_attn.q_proj.weight"]?.shape == [4])
+        #expect(result.count == weights.count)
+    }
+
+    @Test("quant sidecars travel with the head")
+    func stripsQuantSidecars() {
+        let weights: [String: MLXArray] = [
+            "language_model.lm_head.weight": Self.tagged(1),
+            "language_model.lm_head.scales": Self.tagged(2),
+            "language_model.lm_head.biases": Self.tagged(3),
+        ]
+
+        let result = Weights.stripLanguageModelPrefix(weights, only: ["lm_head."])
+
+        #expect(result["lm_head.weight"]?.shape == [1])
+        #expect(result["lm_head.scales"]?.shape == [2])
+        #expect(result["lm_head.biases"]?.shape == [3])
+    }
+
+    // MARK: - The collision guard (the nondeterminism this function exists to prevent)
+
+    @Test("both spellings present: the unprefixed key wins, deterministically")
+    func collisionPrefersUnprefixedKey() {
+        let weights: [String: MLXArray] = [
+            "lm_head.weight": Self.tagged(11),  // the one that must win
+            "language_model.lm_head.weight": Self.tagged(22),
+            "model.embed_tokens.weight": Self.tagged(3),
+        ]
+
+        let result = Weights.stripLanguageModelPrefix(weights, only: ["lm_head."])
+
+        #expect(result["lm_head.weight"]?.shape == [11])
+        #expect(result["language_model.lm_head.weight"] == nil)
+    }
+
+    /// The stronger case the naive `guard weights[stripped] == nil` misses: TWO prefixed spellings
+    /// contend for one destination and NEITHER is present unprefixed, so there is no existing key to
+    /// guard against. Last-write-wins would pick by dictionary iteration order here.
+    @Test("two prefixed spellings contend: resolved by a fixed rule, not iteration order")
+    func collisionBetweenTwoPrefixedSpellings() {
+        let weights: [String: MLXArray] = [
+            "language_model.model.embed_tokens.weight": Self.tagged(11),
+            "model.language_model.embed_tokens.weight": Self.tagged(22),
+        ]
+
+        let result = Weights.stripLanguageModelPrefix(weights)
+
+        // Both want `model.embed_tokens.weight`; the rule is lexicographically smallest source.
+        #expect(result["model.embed_tokens.weight"]?.shape == [11])
+        #expect(result.count == 1)
+    }
+
+    /// The real guard against order-dependence, and the reason it is shaped like this.
+    ///
+    /// An order-dependent bug cannot be caught reliably by ONE colliding key set: for a fixed set of
+    /// keys, `Dictionary`'s iteration order is decided by the per-process hash seed, so a
+    /// last-write-wins implementation lands on the right answer roughly half the time and the test is
+    /// a coin flip. (Varying *insertion* order does not help either — same keys, same seed, same
+    /// iteration order.)
+    ///
+    /// So vary the KEY SETS instead. Each one hashes independently, so a broken implementation has to
+    /// win every coin flip to pass. Measured against the `guard weights[stripped] == nil` form, a
+    /// single set passed 14 of 25 runs; across 200 sets that survives with probability ~2^-200.
+    @Test("collision resolution holds across many independently-hashing key sets")
+    func collisionResolutionIsStableAcrossKeySets() {
+        for i in 0 ..< 200 {
+            let tail = "layers.\(i).mlp.down_proj.weight"
+            // Both spellings want `model.<tail>`, and NEITHER exists unprefixed — so there is no
+            // pre-existing key to guard against and only a fixed rule can decide this.
+            let weights: [String: MLXArray] = [
+                "language_model.model." + tail: Self.tagged(11),
+                "model.language_model." + tail: Self.tagged(22),
+            ]
+
+            let result = Weights.stripLanguageModelPrefix(weights)
+
+            // Documented rule: lexicographically smallest source wins ("language_model." < "model.").
+            #expect(
+                result["model." + tail]?.shape == [11],
+                "key set \(i) bound the wrong spelling — resolution is order-dependent")
+        }
+    }
+
+    // MARK: - `only:` scoping
+
+    @Test("only: leaves unrelated language_model keys alone")
+    func onlyFilterLeavesOtherKeysAlone() {
+        let weights: [String: MLXArray] = [
+            "language_model.lm_head.weight": Self.tagged(7),
+            "language_model.model.embed_tokens.weight": Self.tagged(3),
+        ]
+
+        let result = Weights.stripLanguageModelPrefix(weights, only: ["lm_head."])
+
+        #expect(result["lm_head.weight"]?.shape == [7])
+        // NOT ours to touch: a genuine nested body key stays exactly as it was.
+        #expect(result["language_model.model.embed_tokens.weight"]?.shape == [3])
+        #expect(result["model.embed_tokens.weight"] == nil)
+    }
+
+    @Test("nil only: strips both spellings wherever they appear")
+    func nilOnlyStripsEverywhere() {
+        let weights: [String: MLXArray] = [
+            "language_model.lm_head.weight": Self.tagged(7),
+            "language_model.model.embed_tokens.weight": Self.tagged(3),
+            "model.language_model.layers.0.mlp.gate.weight": Self.tagged(4),
+            "model.layers.0.self_attn.q_proj.weight": Self.tagged(5),
+        ]
+
+        let result = Weights.stripLanguageModelPrefix(weights)
+
+        #expect(result["lm_head.weight"]?.shape == [7])
+        #expect(result["model.embed_tokens.weight"]?.shape == [3])
+        #expect(result["model.layers.0.mlp.gate.weight"]?.shape == [4])
+        // a key with no prefix is passed through untouched
+        #expect(result["model.layers.0.self_attn.q_proj.weight"]?.shape == [5])
+        #expect(result.keys.allSatisfy { !$0.contains("language_model.") })
+    }
+
+    @Test("a checkpoint with no prefix at all is returned unchanged")
+    func noPrefixIsIdentity() {
+        let weights: [String: MLXArray] = [
+            "lm_head.weight": Self.tagged(1),
+            "model.embed_tokens.weight": Self.tagged(2),
+        ]
+
+        let result = Weights.stripLanguageModelPrefix(weights)
+
+        #expect(result.count == 2)
+        #expect(result["lm_head.weight"]?.shape == [1])
+        #expect(result["model.embed_tokens.weight"]?.shape == [2])
+    }
+}


### PR DESCRIPTION
## Summary

Adds the **`mixtral`** model type to `MLXLLM` — the original sparse Mixture-of-Experts (Mistral
decoder + 8-expert top-2 MoE). Registered in `LLMModelFactory`; unblocks Mixtral-family checkpoints
(Mixtral-8x7B / 8x22B, Prometheus-2-8x7B, etc.).

Thank you for the review — the routing-equivalence check in particular is the kind of thing I'd rather
have caught than complimented, so it's good to know it holds.

## 2 first, because your premise is wrong and it's my fault

> Test it on a JANG/MXFP re-bake, not just the 6-bit mlx-community pack.

**It already is a JANG re-bake.** The PR said "6-bit" and you reasonably read that as mlx-community
6-bit; the bundle is `prometheus-eval/prometheus-8x7b-v2.0-**Jang_6M**` — a vMLX JANG conversion. Bad
wording on my part, now fixed above. What's in it:

| | |
|---|---|
| `jang_config.json` | present, `tensor_quantization_manifest_schema: 1`, 226 manifest entries |
| per-module quant overrides | **226**, spanning **two distinct configs** — `(6 bits, gs 64)` × 97 and `(8 bits, gs 64)` × 129 |
| expert layout | **288 `switch_mlp.*` keys, 0 `experts.N.*`** — pre-stacked |
| `language_model.*` keys | 3 — `lm_head.{weight,scales,biases}` |
| total | 775 keys / 49 shards / 36 GB |

So it does exercise the thing you're actually worried about: **mixed bit-widths across modules with
per-module overrides**, which is exactly the shape where "`bits × group_size` makes two configs
shape-identical" bites. Not a uniform-bits easy path.

**But let me mark the limit of that claim honestly.** Because this bundle is pre-stacked, it takes the
early-return in `sanitize` and exercises the *stacked* path — advisor, per-module quant config, the
shape walk. It therefore does **not** exercise the fuse loop (`experts.N.{w1,w2,w3}` → `switch_mlp`);
that path is covered by the unit test below, not by a real bundle. If you want a re-bake that lands on
the fuse loop, I don't have one and would take you up on the offer.

**One thing you'll want to know:** that manifest is **schema 1**. Older `main` rejected schema-1 JANG
bundles outright (`unsupported tensor quantization manifest schema 1`), but current `main` now
**consumes** schema-1 (`guard schema == 1 || schema == 2`, gated on `quantization_scheme == "asymmetric"`
+ `quantization_backend == "mx.quantize"`), so the bundle loads as-is — no extra patch needed to
reproduce the above.

## 1. `argPartition` tie-instability — not claimed, and not yet measured

Point taken and I won't oversell: I have **not** run the temp-0 cold-vs-warm check. Our GPU is mid-way
through a long benchmark suite, and loading a 36 GB Mixtral alongside it would contend for the GPU and
corrupt the wall-clock timings that suite is recording. I'd rather give you a clean data point than a
fast one, so this is a follow-up — I'll report it as a comment rather than hold the PR, unless you'd
rather it block.

Noting for the record that I've made no determinism claim anywhere in this PR, and "same output twice"
appears nowhere in the validation.

## 4. Crash surface — one of the three is real here

**Fixed: the expert force-unwrap.** A truncated bundle carrying expert 0 but missing a later shard
would trap on `removeValue(forKey:)!`. It now checks the whole expert set before stacking and leaves
the keys in place if any is missing, so the module bind reports them — a load error, not a crash:

```swift
guard expertKeys.allSatisfy({ sanitizedWeights[$0] != nil }) else { continue }
let toJoin = expertKeys.compactMap { sanitizedWeights.removeValue(forKey: $0) }
```

**The other two aren't in this PR.** `images[0]` on an empty array and odd / non-merge-divisible grid
dims are vision-path concerns — Mixtral is text-only and has no image or grid handling anywhere in the
diff (`grep` for `images`/`grid`/`merge` in `Mixtral.swift` returns nothing). I think those belong to
#92 (GLM-4V), where they're real and where I'm addressing them. Flagging rather than silently skipping
in case they were meant for this PR and I'm missing something.

## 4b. Tests

Was a fair hit — there were none.

- `Tests/MLXLMTests/WeightsTests.swift` — the sanitize round-trip for the `language_model.` strip, with
  a collision guard (see below).
- Routing/shape unit test: **still owed.** Rather than claim it, I'd rather land the guard + helper now
  and add the fixed-logits → known-expert-selection test in the same follow-up as the determinism check,
  since both want the same fixture.

## The shared helper (from #95's review)

Taken. `Weights.stripLanguageModelPrefix(_:only:)` in `MLXLMCommon` — the helper commit is in **both**
this PR and #95, identical, so neither waits on the other. `sanitize` here calls it with `only: nil`
(strip wherever the prefix appears), preserving this PR's semantics exactly.

Worth noting *why* this PR needed the strip at all: the Prometheus JANG bundle above carries
`language_model.lm_head.{weight,scales,biases}` and **no** flat `lm_head.*` — the identical three-key
artifact that motivated #95 on a Llama-2-13b classifier. Different architecture, same converter
signature. That's the case for one tested function rather than thirteen strips, made by the bundles
themselves.

## 5. Duplication

Leaving the MoE gate alone, as you suggested — I took the `language_model.` helper because you offered
it and the artifact is demonstrably cross-architecture, but folding `GLM4MOE`/`DeepseekV3`'s gates
together is a refactor of code I didn't write and would rather not smuggle into a port.

## Implementation (unchanged)

- **Decoder / MoE block** mirror `PhiMoE` — `SwitchGLU` for the expert FFN, top-2 softmax routing,
  `JangPressCanonicalExpertAdvisor.shared.observe` rather than an open-coded expert loop.
- **Attention** is standard Llama: `initializeRope`, RMSNorm, GQA, bias-free q/k/v/o.
- `rope_traditional` is intentionally not a config field (absent from HF Mixtral configs; defaults to
  false).

## Validation (on-device)

`prometheus-eval/prometheus-8x7b-v2.0-Jang_6M` (Mixtral-8x7B, JANG_6M, detail above): loads and
generates coherently, emitting the Prometheus rubric `[RESULT] <1-5>` grading format with sensible,
discriminating scores (cross-checked against an independent evaluator on the same inputs).
