### PR TITLE
Add Rampart PII NER MLX library

### DIFF
--- a/Libraries/RampartPII/RampartModel.swift
+++ b/Libraries/RampartPII/RampartModel.swift
@@ -1,0 +1,203 @@
+// Rampart PII NER — encoder-only BERT (MiniLM-L6) token classifier.
+//
+// Module tree is named so its flattened parameter paths match the
+// HuggingFace-style keys in `model.safetensors` exactly
+// (e.g. `bert.encoder.layer.0.attention.self.query.weight`), so weights
+// load with no remapping.
+
+import Foundation
+import MLX
+import MLXNN
+
+public struct RampartConfig: Codable, Sendable {
+    public let hiddenSize: Int
+    public let numHiddenLayers: Int
+    public let numAttentionHeads: Int
+    public let intermediateSize: Int
+    public let vocabSize: Int
+    public let maxPositionEmbeddings: Int
+    public let typeVocabSize: Int
+    public let layerNormEps: Float
+    public let id2label: [String: String]
+
+    enum CodingKeys: String, CodingKey {
+        case hiddenSize = "hidden_size"
+        case numHiddenLayers = "num_hidden_layers"
+        case numAttentionHeads = "num_attention_heads"
+        case intermediateSize = "intermediate_size"
+        case vocabSize = "vocab_size"
+        case maxPositionEmbeddings = "max_position_embeddings"
+        case typeVocabSize = "type_vocab_size"
+        case layerNormEps = "layer_norm_eps"
+        case id2label
+    }
+
+    public var numLabels: Int { id2label.count }
+
+    public func label(_ index: Int) -> String { id2label[String(index)] ?? "O" }
+
+    public static func load(from url: URL) throws -> RampartConfig {
+        try JSONDecoder().decode(RampartConfig.self, from: Data(contentsOf: url))
+    }
+}
+
+// MARK: - bert.embeddings
+
+private final class Embeddings: Module {
+    @ModuleInfo(key: "word_embeddings") var word: Embedding
+    @ModuleInfo(key: "position_embeddings") var position: Embedding
+    @ModuleInfo(key: "token_type_embeddings") var tokenType: Embedding
+    @ModuleInfo(key: "LayerNorm") var layerNorm: LayerNorm
+
+    init(_ c: RampartConfig) {
+        _word.wrappedValue = Embedding(embeddingCount: c.vocabSize, dimensions: c.hiddenSize)
+        _position.wrappedValue = Embedding(
+            embeddingCount: c.maxPositionEmbeddings, dimensions: c.hiddenSize)
+        _tokenType.wrappedValue = Embedding(
+            embeddingCount: c.typeVocabSize, dimensions: c.hiddenSize)
+        _layerNorm.wrappedValue = LayerNorm(dimensions: c.hiddenSize, eps: c.layerNormEps)
+    }
+
+    func callAsFunction(_ inputIds: MLXArray, _ tokenTypeIds: MLXArray) -> MLXArray {
+        let seq = inputIds.dim(1)
+        let posIds = MLXArray.arange(seq).reshaped(1, seq)
+        let h = word(inputIds) + position(posIds) + tokenType(tokenTypeIds)
+        return layerNorm(h)
+    }
+}
+
+// MARK: - one encoder layer (bert.encoder.layer.N)
+
+private final class SelfAttention: Module {
+    @ModuleInfo(key: "query") var query: Linear
+    @ModuleInfo(key: "key") var key: Linear
+    @ModuleInfo(key: "value") var value: Linear
+
+    init(_ c: RampartConfig) {
+        _query.wrappedValue = Linear(c.hiddenSize, c.hiddenSize)
+        _key.wrappedValue = Linear(c.hiddenSize, c.hiddenSize)
+        _value.wrappedValue = Linear(c.hiddenSize, c.hiddenSize)
+    }
+}
+
+private final class SelfOutput: Module {
+    @ModuleInfo(key: "dense") var dense: Linear
+    @ModuleInfo(key: "LayerNorm") var layerNorm: LayerNorm
+
+    init(_ c: RampartConfig) {
+        _dense.wrappedValue = Linear(c.hiddenSize, c.hiddenSize)
+        _layerNorm.wrappedValue = LayerNorm(dimensions: c.hiddenSize, eps: c.layerNormEps)
+    }
+}
+
+private final class Attention: Module {
+    @ModuleInfo(key: "self") var selfAttn: SelfAttention
+    @ModuleInfo(key: "output") var output: SelfOutput
+
+    init(_ c: RampartConfig) {
+        _selfAttn.wrappedValue = SelfAttention(c)
+        _output.wrappedValue = SelfOutput(c)
+    }
+}
+
+private final class Intermediate: Module {
+    @ModuleInfo(key: "dense") var dense: Linear
+    init(_ c: RampartConfig) { _dense.wrappedValue = Linear(c.hiddenSize, c.intermediateSize) }
+}
+
+private final class OutputFFN: Module {
+    @ModuleInfo(key: "dense") var dense: Linear
+    @ModuleInfo(key: "LayerNorm") var layerNorm: LayerNorm
+
+    init(_ c: RampartConfig) {
+        _dense.wrappedValue = Linear(c.intermediateSize, c.hiddenSize)
+        _layerNorm.wrappedValue = LayerNorm(dimensions: c.hiddenSize, eps: c.layerNormEps)
+    }
+}
+
+private final class EncoderLayer: Module {
+    @ModuleInfo(key: "attention") var attention: Attention
+    @ModuleInfo(key: "intermediate") var intermediate: Intermediate
+    @ModuleInfo(key: "output") var output: OutputFFN
+
+    let numHeads: Int
+    let headDim: Int
+
+    init(_ c: RampartConfig) {
+        _attention.wrappedValue = Attention(c)
+        _intermediate.wrappedValue = Intermediate(c)
+        _output.wrappedValue = OutputFFN(c)
+        numHeads = c.numAttentionHeads
+        headDim = c.hiddenSize / c.numAttentionHeads
+    }
+
+    func callAsFunction(_ x: MLXArray, mask: MLXArray) -> MLXArray {
+        let (b, s) = (x.dim(0), x.dim(1))
+        func split(_ t: MLXArray) -> MLXArray {
+            t.reshaped(b, s, numHeads, headDim).transposed(0, 2, 1, 3)
+        }
+        let q = split(attention.selfAttn.query(x))
+        let k = split(attention.selfAttn.key(x))
+        let v = split(attention.selfAttn.value(x))
+
+        var scores = matmul(q, k.transposed(0, 1, 3, 2)) / Float(Foundation.sqrt(Double(headDim)))
+        scores = scores + mask
+        let probs = softmax(scores, axis: -1)
+        let ctx = matmul(probs, v).transposed(0, 2, 1, 3).reshaped(b, s, numHeads * headDim)
+
+        let attnOut = attention.output.layerNorm(attention.output.dense(ctx) + x)
+        let inter = gelu(intermediate.dense(attnOut))
+        return output.layerNorm(output.dense(inter) + attnOut)
+    }
+}
+
+// MARK: - bert.encoder
+
+private final class Encoder: Module {
+    @ModuleInfo(key: "layer") var layer: [EncoderLayer]
+    init(_ c: RampartConfig) {
+        _layer.wrappedValue = (0 ..< c.numHiddenLayers).map { _ in EncoderLayer(c) }
+    }
+}
+
+// MARK: - bert
+
+private final class Bert: Module {
+    @ModuleInfo(key: "embeddings") var embeddings: Embeddings
+    @ModuleInfo(key: "encoder") var encoder: Encoder
+    init(_ c: RampartConfig) {
+        _embeddings.wrappedValue = Embeddings(c)
+        _encoder.wrappedValue = Encoder(c)
+    }
+}
+
+// MARK: - top-level token classifier
+
+public final class RampartModel: Module {
+    @ModuleInfo(key: "bert") fileprivate var bert: Bert
+    @ModuleInfo(key: "classifier") fileprivate var classifier: Linear
+
+    public let config: RampartConfig
+
+    public init(_ c: RampartConfig) {
+        config = c
+        _bert.wrappedValue = Bert(c)
+        _classifier.wrappedValue = Linear(c.hiddenSize, c.numLabels)
+        super.init()
+    }
+
+    /// - Parameters:
+    ///   - inputIds: `[batch, seq]` Int32 token ids.
+    ///   - attentionMask: `[batch, seq]` 1 for real tokens, 0 for padding.
+    /// - Returns: logits `[batch, seq, numLabels]`.
+    public func callAsFunction(_ inputIds: MLXArray, attentionMask: MLXArray) -> MLXArray {
+        let tokenTypeIds = MLXArray.zeros(like: inputIds)
+        var h = bert.embeddings(inputIds, tokenTypeIds)
+        let additive =
+            (1.0 - attentionMask.asType(.float32)).expandedDimensions(axes: [1, 2]) * -1e9
+        for layer in bert.encoder.layer {
+            h = layer(h, mask: additive)
+        }
+        return classifier(h)
+    }
+}

--- a/Libraries/RampartPII/RampartModel.swift
+++ b/Libraries/RampartPII/RampartModel.swift
@@ -19,6 +19,18 @@ public struct RampartConfig: Codable, Sendable {
     public let typeVocabSize: Int
     public let layerNormEps: Float
     public let id2label: [String: String]
+    /// Present when the checkpoint ships MLX-quantized weights (e.g. the
+    /// published 4-bit `sledgedev/rampart-mlx`). Absent ⇒ float weights.
+    public let quantization: Quantization?
+
+    public struct Quantization: Codable, Sendable {
+        public let groupSize: Int
+        public let bits: Int
+        enum CodingKeys: String, CodingKey {
+            case groupSize = "group_size"
+            case bits
+        }
+    }
 
     enum CodingKeys: String, CodingKey {
         case hiddenSize = "hidden_size"
@@ -30,6 +42,7 @@ public struct RampartConfig: Codable, Sendable {
         case typeVocabSize = "type_vocab_size"
         case layerNormEps = "layer_norm_eps"
         case id2label
+        case quantization
     }
 
     public var numLabels: Int { id2label.count }

--- a/Libraries/RampartPII/RampartPII.swift
+++ b/Libraries/RampartPII/RampartPII.swift
@@ -1,0 +1,100 @@
+// Public entry point: load the Rampart PII model from a directory and detect
+// PII entity spans in text.
+
+import Foundation
+import MLX
+import MLXNN
+
+public struct PIISpan: Sendable, Equatable {
+    public let type: String          // e.g. "EMAIL", "GIVEN_NAME"
+    public let text: String
+    public let range: Range<Int>     // character-index range into the input
+    public let score: Float          // mean softmax confidence over the span
+}
+
+public final class RampartPII {
+    private let model: RampartModel
+    private let tokenizer: RampartTokenizer
+    private let config: RampartConfig
+
+    /// Load from a directory containing `model.safetensors`, `config.json`,
+    /// and `vocab.txt`.
+    public init(directory: URL) throws {
+        let config = try RampartConfig.load(from: directory.appendingPathComponent("config.json"))
+        let model = RampartModel(config)
+        let weights = try loadArrays(url: directory.appendingPathComponent("model.safetensors"))
+        try model.update(parameters: ModuleParameters.unflattened(weights), verify: [.all])
+        eval(model)
+
+        self.config = config
+        self.model = model
+        self.tokenizer = try RampartTokenizer(
+            vocabURL: directory.appendingPathComponent("vocab.txt"),
+            maxLength: config.maxPositionEmbeddings)
+    }
+
+    /// Detect PII spans. Adjacent same-type tokens are merged (the model emits
+    /// `B-` on most subwords), using BIO tags and the tokenizer's char offsets.
+    public func detect(_ text: String) -> [PIISpan] {
+        let tokens = tokenizer.encode(text)
+        let ids = MLXArray(tokens.map { Int32($0.id) }).reshaped(1, tokens.count)
+        let mask = MLXArray(Array(repeating: Int32(1), count: tokens.count)).reshaped(1, tokens.count)
+
+        let logits = model(ids, attentionMask: mask)[0]   // [seq, numLabels]
+        let probs = softmax(logits, axis: -1)
+        let labelIds = logits.argMax(axis: -1)
+        eval(labelIds, probs)
+
+        let chars = Array(text)
+        var spans: [PIISpan] = []
+        var current: (type: String, lo: Int, hi: Int, scoreSum: Float, count: Int)?
+
+        func flush() {
+            guard let c = current else { return }
+            spans.append(PIISpan(
+                type: c.type,
+                text: String(chars[c.lo..<c.hi]),
+                range: c.lo..<c.hi,
+                score: c.scoreSum / Float(c.count)))
+            current = nil
+        }
+
+        for (i, tok) in tokens.enumerated() {
+            guard let range = tok.range else { continue }  // skip [CLS]/[SEP]
+            let labelIndex = labelIds[i].item(Int.self)
+            let label = config.label(labelIndex)
+            if label == "O" { flush(); continue }
+
+            let entityType = String(label.dropFirst(2))   // strip "B-"/"I-"
+            let score = probs[i, labelIndex].item(Float.self)
+
+            if var c = current, c.type == entityType, range.lowerBound <= c.hi + 1 {
+                c.hi = range.upperBound
+                c.scoreSum += score
+                c.count += 1
+                current = c
+            } else {
+                flush()
+                current = (entityType, range.lowerBound, range.upperBound, score, 1)
+            }
+        }
+        flush()
+        return spans
+    }
+
+    /// Replace each detected span with `[TYPE]` (simple redaction helper).
+    public func redact(_ text: String) -> String {
+        let chars = Array(text)
+        var out = ""
+        var cursor = 0
+        for span in detect(text).sorted(by: { $0.range.lowerBound < $1.range.lowerBound }) {
+            if span.range.lowerBound > cursor {
+                out += String(chars[cursor..<span.range.lowerBound])
+            }
+            out += "[\(span.type)]"
+            cursor = span.range.upperBound
+        }
+        if cursor < chars.count { out += String(chars[cursor...]) }
+        return out
+    }
+}

--- a/Libraries/RampartPII/RampartPII.swift
+++ b/Libraries/RampartPII/RampartPII.swift
@@ -22,6 +22,14 @@ public final class RampartPII {
     public init(directory: URL) throws {
         let config = try RampartConfig.load(from: directory.appendingPathComponent("config.json"))
         let model = RampartModel(config)
+        // The published checkpoint (e.g. `sledgedev/rampart-mlx`) ships MLX
+        // affine-quantized weights: every Linear/Embedding (and the classifier)
+        // is stored as packed U32 `weight` + `scales`/`biases`. Convert the
+        // matching modules to their quantized form before loading so the keys
+        // and shapes line up; LayerNorms are left dense (quantize() skips them).
+        if let q = config.quantization {
+            quantize(model: model, groupSize: q.groupSize, bits: q.bits)
+        }
         let weights = try loadArrays(url: directory.appendingPathComponent("model.safetensors"))
         try model.update(parameters: ModuleParameters.unflattened(weights), verify: [.all])
         eval(model)

--- a/Libraries/RampartPII/RampartTokenizer.swift
+++ b/Libraries/RampartPII/RampartTokenizer.swift
@@ -1,13 +1,15 @@
 // Offset-aware WordPiece tokenizer for Rampart (BERT uncased).
 //
-// The vendored `BertTokenizer` only returns token ids; PII redaction needs the
-// character span each token covers in the original string, so this carries
-// offsets through basic + wordpiece tokenization. Lowercases for vocab lookup
-// while keeping original-string indices.
+// Faithfully mirrors HuggingFace `BertTokenizer` (BasicTokenizer +
+// WordpieceTokenizer) for `do_lower_case=True`: text cleaning, CJK spacing,
+// lowercasing, accent stripping, and punctuation splitting — while carrying the
+// character span each token covers in the ORIGINAL string, which PII redaction
+// needs.
 //
-// Note: accent stripping is intentionally omitted so character offsets stay
-// 1:1 with the input (combining marks would shift indices). PII tokens
-// (emails, numbers, IDs, ASCII names) are unaffected.
+// Offsets are character indices into `Array(text)` (matching how `RampartPII`
+// slices the text). Normalization that expands a character (e.g. accent
+// decomposition or multi-char lowercasing) maps every produced character back
+// to its single origin index, so spans stay aligned to the input.
 
 import Foundation
 
@@ -18,10 +20,17 @@ public struct RampartTokenizer: Sendable {
         public let range: Range<Int>?
     }
 
+    /// A normalized character tagged with its origin index in the input.
+    private struct NormChar {
+        let ch: Character
+        let origin: Int
+    }
+
     private let vocab: [String: Int]
     private let unkId: Int
     private let clsId: Int
     private let sepId: Int
+    private let maxInputCharsPerWord = 100
     public let maxLength: Int
 
     public init(vocabURL: URL, maxLength: Int = 512) throws {
@@ -29,9 +38,9 @@ public struct RampartTokenizer: Sendable {
         var v: [String: Int] = [:]
         var i = 0
         for line in text.split(separator: "\n", omittingEmptySubsequences: false) {
-            let tok = String(line)
-            if tok.isEmpty && i == v.count { continue }
-            v[tok] = i
+            // vocab.txt is one token per line, index == line number.
+            if i == 0 && line.isEmpty { continue }
+            v[String(line)] = i
             i += 1
         }
         vocab = v
@@ -41,59 +50,132 @@ public struct RampartTokenizer: Sendable {
         self.maxLength = maxLength
     }
 
-    private static func isPunctuation(_ c: Character) -> Bool {
-        if c.isPunctuation || c.isSymbol { return true }
-        guard let v = c.unicodeScalars.first?.value else { return false }
-        switch v {
-        case 33...47, 58...64, 91...96, 123...126: return true
+    // MARK: - Character classification (HF parity)
+
+    private static func isControl(_ c: Character) -> Bool {
+        if c == "\t" || c == "\n" || c == "\r" { return false }
+        guard let s = c.unicodeScalars.first else { return false }
+        switch s.properties.generalCategory {
+        case .control, .format: return true
         default: return false
         }
     }
 
+    private static func isWhitespace(_ c: Character) -> Bool {
+        if c == "\t" || c == "\n" || c == "\r" { return true }
+        return c.isWhitespace
+    }
+
+    /// HF `_is_punctuation`: the ASCII punctuation ranges plus Unicode P*.
+    /// Deliberately excludes symbols (S* categories).
+    private static func isPunctuation(_ c: Character) -> Bool {
+        if let v = c.unicodeScalars.first?.value {
+            switch v {
+            case 33...47, 58...64, 91...96, 123...126: return true
+            default: break
+            }
+        }
+        return c.isPunctuation
+    }
+
+    private static func isCJK(_ v: UInt32) -> Bool {
+        (0x4E00...0x9FFF).contains(v) || (0x3400...0x4DBF).contains(v)
+            || (0x20000...0x2A6DF).contains(v) || (0x2A700...0x2B73F).contains(v)
+            || (0x2B740...0x2B81F).contains(v) || (0x2B820...0x2CEAF).contains(v)
+            || (0xF900...0xFAFF).contains(v) || (0x2F800...0x2FA1F).contains(v)
+    }
+
+    // MARK: - Normalization (clean + CJK space + lowercase + strip accents)
+
+    private func normalize(_ chars: [Character]) -> [NormChar] {
+        var out: [NormChar] = []
+        out.reserveCapacity(chars.count + 8)
+        for (i, c) in chars.enumerated() {
+            guard let scalar = c.unicodeScalars.first else { continue }
+            let v = scalar.value
+            if v == 0 || v == 0xFFFD || Self.isControl(c) { continue }
+            if Self.isWhitespace(c) {
+                out.append(NormChar(ch: " ", origin: i))
+                continue
+            }
+            if Self.isCJK(v) {
+                out.append(NormChar(ch: " ", origin: i))
+                out.append(NormChar(ch: c, origin: i))
+                out.append(NormChar(ch: " ", origin: i))
+                continue
+            }
+            // lowercase, then strip accents (drop Mn combining marks)
+            let lowered = String(c).lowercased().decomposedStringWithCanonicalMapping
+            for s in lowered.unicodeScalars where s.properties.generalCategory != .nonspacingMark {
+                out.append(NormChar(ch: Character(s), origin: i))
+            }
+        }
+        return out
+    }
+
+    // MARK: - Encode
+
     /// Encode into ids + offsets with [CLS] ... [SEP], truncated to `maxLength`.
     public func encode(_ text: String) -> [Token] {
         let chars = Array(text)
-        var pieces: [Token] = [Token(id: clsId, range: nil)]
+        let norm = normalize(chars)
 
-        var i = 0
-        let bodyLimit = maxLength - 1  // reserve room for [SEP]
-        outer: while i < chars.count {
-            if chars[i].isWhitespace { i += 1; continue }
-
-            // word boundary: punctuation is its own single-char word
-            let start = i
-            if Self.isPunctuation(chars[i]) {
-                i += 1
+        // Split into words on whitespace, with punctuation as its own word.
+        var words: [[NormChar]] = []
+        var current: [NormChar] = []
+        func endWord() {
+            if !current.isEmpty { words.append(current); current = [] }
+        }
+        for nc in norm {
+            if nc.ch == " " {
+                endWord()
+            } else if Self.isPunctuation(nc.ch) {
+                endWord()
+                words.append([nc])
             } else {
-                while i < chars.count, !chars[i].isWhitespace, !Self.isPunctuation(chars[i]) {
-                    i += 1
-                }
+                current.append(nc)
             }
-            let wordChars = Array(chars[start..<i]).map { Character($0.lowercased()) }
+        }
+        endWord()
+
+        var pieces: [Token] = [Token(id: clsId, range: nil)]
+        let bodyLimit = maxLength - 1  // reserve room for [SEP]
+
+        for word in words {
+            let wordRange = word.first!.origin..<(word.last!.origin + 1)
+            if word.count > maxInputCharsPerWord {
+                pieces.append(Token(id: unkId, range: wordRange))
+                if pieces.count >= bodyLimit { break }
+                continue
+            }
 
             // greedy longest-match wordpiece, carrying offsets
             var s = 0
             var sub: [Token] = []
             var bad = false
-            while s < wordChars.count {
-                var e = wordChars.count
-                var match: String?
+            while s < word.count {
+                var e = word.count
+                var matchId: Int?
+                var matchEnd = e
                 while s < e {
-                    var cand = String(wordChars[s..<e])
+                    var cand = String(word[s..<e].map { $0.ch })
                     if s > 0 { cand = "##" + cand }
-                    if vocab[cand] != nil { match = cand; break }
+                    if let id = vocab[cand] { matchId = id; matchEnd = e; break }
                     e -= 1
                 }
-                guard let m = match else { bad = true; break }
-                sub.append(Token(id: vocab[m]!, range: (start + s)..<(start + e)))
-                s = e
+                guard let id = matchId else { bad = true; break }
+                let lo = word[s].origin
+                let hi = word[matchEnd - 1].origin + 1
+                sub.append(Token(id: id, range: lo..<hi))
+                s = matchEnd
             }
+
             if bad {
-                pieces.append(Token(id: unkId, range: start..<i))
+                pieces.append(Token(id: unkId, range: wordRange))
             } else {
                 pieces.append(contentsOf: sub)
             }
-            if pieces.count >= bodyLimit { break outer }
+            if pieces.count >= bodyLimit { break }
         }
 
         pieces.append(Token(id: sepId, range: nil))

--- a/Libraries/RampartPII/RampartTokenizer.swift
+++ b/Libraries/RampartPII/RampartTokenizer.swift
@@ -178,6 +178,13 @@ public struct RampartTokenizer: Sendable {
             if pieces.count >= bodyLimit { break }
         }
 
+        // A single word can emit several subwords past `bodyLimit` in one
+        // `append(contentsOf:)`, so hard-cap before [SEP]. Without this the
+        // sequence can exceed `maxPositionEmbeddings`, indexing the position
+        // embedding out of bounds on long inputs.
+        if pieces.count > bodyLimit {
+            pieces = Array(pieces.prefix(bodyLimit))
+        }
         pieces.append(Token(id: sepId, range: nil))
         return pieces
     }

--- a/Libraries/RampartPII/RampartTokenizer.swift
+++ b/Libraries/RampartPII/RampartTokenizer.swift
@@ -1,0 +1,102 @@
+// Offset-aware WordPiece tokenizer for Rampart (BERT uncased).
+//
+// The vendored `BertTokenizer` only returns token ids; PII redaction needs the
+// character span each token covers in the original string, so this carries
+// offsets through basic + wordpiece tokenization. Lowercases for vocab lookup
+// while keeping original-string indices.
+//
+// Note: accent stripping is intentionally omitted so character offsets stay
+// 1:1 with the input (combining marks would shift indices). PII tokens
+// (emails, numbers, IDs, ASCII names) are unaffected.
+
+import Foundation
+
+public struct RampartTokenizer: Sendable {
+    public struct Token: Sendable {
+        public let id: Int
+        /// Character-index range into the original text, or nil for [CLS]/[SEP].
+        public let range: Range<Int>?
+    }
+
+    private let vocab: [String: Int]
+    private let unkId: Int
+    private let clsId: Int
+    private let sepId: Int
+    public let maxLength: Int
+
+    public init(vocabURL: URL, maxLength: Int = 512) throws {
+        let text = try String(contentsOf: vocabURL, encoding: .utf8)
+        var v: [String: Int] = [:]
+        var i = 0
+        for line in text.split(separator: "\n", omittingEmptySubsequences: false) {
+            let tok = String(line)
+            if tok.isEmpty && i == v.count { continue }
+            v[tok] = i
+            i += 1
+        }
+        vocab = v
+        unkId = v["[UNK]"] ?? 100
+        clsId = v["[CLS]"] ?? 101
+        sepId = v["[SEP]"] ?? 102
+        self.maxLength = maxLength
+    }
+
+    private static func isPunctuation(_ c: Character) -> Bool {
+        if c.isPunctuation || c.isSymbol { return true }
+        guard let v = c.unicodeScalars.first?.value else { return false }
+        switch v {
+        case 33...47, 58...64, 91...96, 123...126: return true
+        default: return false
+        }
+    }
+
+    /// Encode into ids + offsets with [CLS] ... [SEP], truncated to `maxLength`.
+    public func encode(_ text: String) -> [Token] {
+        let chars = Array(text)
+        var pieces: [Token] = [Token(id: clsId, range: nil)]
+
+        var i = 0
+        let bodyLimit = maxLength - 1  // reserve room for [SEP]
+        outer: while i < chars.count {
+            if chars[i].isWhitespace { i += 1; continue }
+
+            // word boundary: punctuation is its own single-char word
+            let start = i
+            if Self.isPunctuation(chars[i]) {
+                i += 1
+            } else {
+                while i < chars.count, !chars[i].isWhitespace, !Self.isPunctuation(chars[i]) {
+                    i += 1
+                }
+            }
+            let wordChars = Array(chars[start..<i]).map { Character($0.lowercased()) }
+
+            // greedy longest-match wordpiece, carrying offsets
+            var s = 0
+            var sub: [Token] = []
+            var bad = false
+            while s < wordChars.count {
+                var e = wordChars.count
+                var match: String?
+                while s < e {
+                    var cand = String(wordChars[s..<e])
+                    if s > 0 { cand = "##" + cand }
+                    if vocab[cand] != nil { match = cand; break }
+                    e -= 1
+                }
+                guard let m = match else { bad = true; break }
+                sub.append(Token(id: vocab[m]!, range: (start + s)..<(start + e)))
+                s = e
+            }
+            if bad {
+                pieces.append(Token(id: unkId, range: start..<i))
+            } else {
+                pieces.append(contentsOf: sub)
+            }
+            if pieces.count >= bodyLimit { break outer }
+        }
+
+        pieces.append(Token(id: sepId, range: nil))
+        return pieces
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -307,6 +307,7 @@ let package = Package(
         .library(name: "MLXLLM", targets: ["MLXLLM"]),
         .library(name: "MLXVLM", targets: ["MLXVLM"]),
         .library(name: "MLXEmbedders", targets: ["MLXEmbedders"]),
+        .library(name: "RampartPII", targets: ["RampartPII"]),
         .library(name: "MLXHuggingFace", targets: ["MLXHuggingFace"]),
         .library(name: "BenchmarkHelpers", targets: ["BenchmarkHelpers"]),
         .library(name: "IntegrationTestHelpers", targets: ["IntegrationTestHelpers"]),
@@ -331,6 +332,7 @@ let package = Package(
         .executable(name: "ANEProbe", targets: ["ANEProbe"]),
         .executable(name: "Gemma4AudioSmoke", targets: ["Gemma4AudioSmoke"]),
         .executable(name: "DeepseekOCRSmoke", targets: ["DeepseekOCRSmoke"]),
+        .executable(name: "RampartSmoke", targets: ["RampartSmoke"]),
         .executable(name: "OmniAudioLatencyBench", targets: ["OmniAudioLatencyBench"]),
         .executable(name: "OmniAudioChunkStabilityBench", targets: ["OmniAudioChunkStabilityBench"]),
         .executable(name: "mlxpress", targets: ["MLXPressCLI"]),
@@ -507,6 +509,11 @@ let package = Package(
             dependencies: ["MLX", "MLXNN", "MLXLMCommon"],
             path: "Libraries/MLXEmbedders",
             exclude: ["README.md"]
+        ),
+        .target(
+            name: "RampartPII",
+            dependencies: ["MLX", "MLXNN"],
+            path: "Libraries/RampartPII"
         ),
         .target(
             name: "MLXDistributedCore",
@@ -720,6 +727,11 @@ let package = Package(
                 "VMLXTokenizers",
             ],
             path: "tools/DeepseekOCRSmoke"
+        ),
+        .executableTarget(
+            name: "RampartSmoke",
+            dependencies: ["RampartPII", "MLX"],
+            path: "tools/RampartSmoke"
         ),
         .executableTarget(
             name: "OmniAudioLatencyBench",

--- a/tools/RampartSmoke/main.swift
+++ b/tools/RampartSmoke/main.swift
@@ -1,0 +1,59 @@
+// Rampart PII NER correctness smoke.
+//
+// Loads the Rampart MLX model, runs detection on a few strings (or one passed
+// via RAMPART_TEXT), and prints detected PII spans + a redacted line.
+//
+// Usage:
+//   RAMPART_MODEL=/path/to/rampart-mlx swift run RampartSmoke
+//   RAMPART_MODEL=/path/to/rampart-mlx RAMPART_TEXT="email me at a@b.com" swift run RampartSmoke
+//
+// Requires the MLX metallib next to the executable (see VMLX_README).
+
+import Foundation
+import RampartPII
+
+@main
+struct RampartSmoke {
+    static func main() throws {
+        setvbuf(stdout, nil, _IONBF, 0)
+        let env = ProcessInfo.processInfo.environment
+        let modelPath = env["RAMPART_MODEL"] ?? "/tmp/rampart-mlx"
+
+        let dir = URL(fileURLWithPath: modelPath)
+        guard FileManager.default.fileExists(atPath: dir.appendingPathComponent("model.safetensors").path)
+        else {
+            fputs("model.safetensors not found in \(dir.path)\n", stderr)
+            exit(1)
+        }
+
+        print("[rampart] loading \(dir.lastPathComponent) ...")
+        let start = CFAbsoluteTimeGetCurrent()
+        let pii = try RampartPII(directory: dir)
+        print(String(format: "[rampart] loaded in %.2fs", CFAbsoluteTimeGetCurrent() - start))
+
+        let texts: [String]
+        if let one = env["RAMPART_TEXT"] {
+            texts = [one]
+        } else {
+            texts = [
+                "My name is John Smith and my email is john.smith@example.com",
+                "Call me at (555) 123-4567 or visit 42 Main Street, Springfield, IL 62704",
+                "The meeting is at 3pm in the main conference room.",
+            ]
+        }
+
+        for text in texts {
+            print("\n>>> \(text)")
+            let spans = pii.detect(text)
+            if spans.isEmpty {
+                print("    (no PII)")
+            }
+            for s in spans {
+                print(String(format: "    %@  %@  [%d:%d]  %.2f",
+                    s.type.padding(toLength: 16, withPad: " ", startingAt: 0),
+                    s.text, s.range.lowerBound, s.range.upperBound, s.score))
+            }
+            print("    redacted: \(pii.redact(text))")
+        }
+    }
+}

--- a/tools/RampartSmoke/main.swift
+++ b/tools/RampartSmoke/main.swift
@@ -26,6 +26,20 @@ struct RampartSmoke {
             exit(1)
         }
 
+        // Tokenizer parity dump: prints `id:start:end` per token so the
+        // Swift WordPiece can be diffed against the HF fast tokenizer.
+        if let dumpText = env["RAMPART_DUMP"] {
+            let tokenizer = try RampartTokenizer(
+                vocabURL: dir.appendingPathComponent("vocab.txt"))
+            let toks = tokenizer.encode(dumpText)
+            let parts = toks.map { t -> String in
+                if let r = t.range { return "\(t.id):\(r.lowerBound):\(r.upperBound)" }
+                return "\(t.id):-:-"
+            }
+            print(parts.joined(separator: " "))
+            return
+        }
+
         print("[rampart] loading \(dir.lastPathComponent) ...")
         let start = CFAbsoluteTimeGetCurrent()
         let pii = try RampartPII(directory: dir)


### PR DESCRIPTION
- Added an MLX library for the Rampart PII model, an encoder-only BERT token classifier that detects personally identifiable information
- Implemented the model, an offset-aware WordPiece tokenizer matched to the reference tokenizer, and a detection API returning merged entity spans plus a redaction helper
- Added a smoke command for loading the model and printing detected spans, with a mode for dumping tokenization
- Verified detections against the original reference and confirmed exact tokenizer parity on ids and offsets across accented text, urls, punctuation, and whitespace cases