### PR TITLE
Fix Mistral chat looping/incoherence: round-trip special-token sentinel checks

### DIFF
--- a/Libraries/MLXHuggingFaceMacros/HuggingFaceIntegrationMacros.swift
+++ b/Libraries/MLXHuggingFaceMacros/HuggingFaceIntegrationMacros.swift
@@ -145,10 +145,10 @@ public struct TokenizerAdaptorMacro: ExpressionMacro {
                         let hasLagunaSentinel =
                             upstream.bosToken == lagunaEos
                             && upstream.eosToken == lagunaEos
-                            && upstream.convertTokenToId("<assistant>") != nil
-                            && upstream.convertTokenToId("</assistant>") != nil
-                            && upstream.convertTokenToId("<think>") != nil
-                            && upstream.convertTokenToId("</think>") != nil
+                            && (upstream.convertTokenToId("<assistant>").flatMap { upstream.convertIdToToken($0) } == "<assistant>")
+                            && (upstream.convertTokenToId("</assistant>").flatMap { upstream.convertIdToToken($0) } == "</assistant>")
+                            && (upstream.convertTokenToId("<think>").flatMap { upstream.convertIdToToken($0) } == "<think>")
+                            && (upstream.convertTokenToId("</think>").flatMap { upstream.convertIdToToken($0) } == "</think>")
                         if hasLagunaSentinel
                             && (env["VMLX_CHAT_TEMPLATE_FALLBACK_DISABLE"] ?? "0") != "1" {
                             if (env["VMLX_CHAT_TEMPLATE_FALLBACK_LOG"] ?? "0") == "1" {
@@ -169,8 +169,8 @@ public struct TokenizerAdaptorMacro: ExpressionMacro {
                         let hasLFM2NativeToolSentinels =
                             upstream.bosToken == "<|startoftext|>"
                             && upstream.eosToken == "<|im_end|>"
-                            && upstream.convertTokenToId("<|tool_call_start|>") != nil
-                            && upstream.convertTokenToId("<|tool_call_end|>") != nil
+                            && (upstream.convertTokenToId("<|tool_call_start|>").flatMap { upstream.convertIdToToken($0) } == "<|tool_call_start|>")
+                            && (upstream.convertTokenToId("<|tool_call_end|>").flatMap { upstream.convertIdToToken($0) } == "<|tool_call_end|>")
                         if !(tools?.isEmpty ?? true),
                            hasLFM2NativeToolSentinels,
                            (env["VMLX_CHAT_TEMPLATE_FALLBACK_DISABLE"] ?? "0") != "1" {
@@ -190,11 +190,11 @@ public struct TokenizerAdaptorMacro: ExpressionMacro {
                                     additionalContext: additionalContext)
                         }
                         let hasGemma4NativeToolSentinels =
-                            upstream.convertTokenToId("<|tool_call>") != nil
-                            && upstream.convertTokenToId("<|turn>") != nil
+                            (upstream.convertTokenToId("<|tool_call>").flatMap { upstream.convertIdToToken($0) } == "<|tool_call>")
+                            && (upstream.convertTokenToId("<|turn>").flatMap { upstream.convertIdToToken($0) } == "<|turn>")
                         if !(tools?.isEmpty ?? true),
                            upstream.bosToken == "<s>",
-                           upstream.convertTokenToId("<|im_end|>") != nil,
+                           (upstream.convertTokenToId("<|im_end|>").flatMap { upstream.convertIdToToken($0) } == "<|im_end|>"),
                            (env["VMLX_CHAT_TEMPLATE_FALLBACK_DISABLE"] ?? "0") != "1" {
                             if (env["VMLX_CHAT_TEMPLATE_FALLBACK_LOG"] ?? "0") == "1" {
                                 FileHandle.standardError.write(
@@ -239,9 +239,9 @@ public struct TokenizerAdaptorMacro: ExpressionMacro {
                         let hasStep37Sentinels =
                             upstream.bosToken == step37Bos
                             && upstream.eosToken == "<|im_end|>"
-                            && upstream.convertTokenToId("<|im_start|>") != nil
-                            && upstream.convertTokenToId("<tool_call>") != nil
-                            && upstream.convertTokenToId("<im_patch>") != nil
+                            && (upstream.convertTokenToId("<|im_start|>").flatMap { upstream.convertIdToToken($0) } == "<|im_start|>")
+                            && (upstream.convertTokenToId("<tool_call>").flatMap { upstream.convertIdToToken($0) } == "<tool_call>")
+                            && (upstream.convertTokenToId("<im_patch>").flatMap { upstream.convertIdToToken($0) } == "<im_patch>")
                         let step37NeedsFallback =
                             hasStep37Sentinels
                             && (env["VMLX_CHAT_TEMPLATE_FALLBACK_DISABLE"] ?? "0") != "1"
@@ -315,7 +315,7 @@ public struct TokenizerAdaptorMacro: ExpressionMacro {
                         // "Mistral 4 effort not normalized").
                         var mistral4AdjustedContext = additionalContext
                         if mistral4AdjustedContext?["reasoning_effort"] == nil,
-                           upstream.convertTokenToId("[MODEL_SETTINGS]") != nil,
+                           (upstream.convertTokenToId("[MODEL_SETTINGS]").flatMap { upstream.convertIdToToken($0) } == "[MODEL_SETTINGS]"),
                            let enableThinking = mistral4AdjustedContext?["enable_thinking"] as? Bool {
                             var ctx = mistral4AdjustedContext ?? [:]
                             ctx["reasoning_effort"] = enableThinking ? "high" : "none"
@@ -335,7 +335,7 @@ public struct TokenizerAdaptorMacro: ExpressionMacro {
                         }
                         if !(tools?.isEmpty ?? true),
                            upstream.bosToken == "<s>",
-                           upstream.convertTokenToId("<|im_end|>") != nil,
+                           (upstream.convertTokenToId("<|im_end|>").flatMap { upstream.convertIdToToken($0) } == "<|im_end|>"),
                            (env["VMLX_CHAT_TEMPLATE_FALLBACK_DISABLE"] ?? "0") != "1" {
                             if (env["VMLX_CHAT_TEMPLATE_FALLBACK_LOG"] ?? "0") == "1" {
                                 FileHandle.standardError.write(
@@ -429,7 +429,7 @@ public struct TokenizerAdaptorMacro: ExpressionMacro {
                                         additionalContext: additionalContext)
                                 }
                                 if upstream.bosToken == "<s>",
-                                   upstream.convertTokenToId("<|im_end|>") != nil {
+                                   (upstream.convertTokenToId("<|im_end|>").flatMap { upstream.convertIdToToken($0) } == "<|im_end|>") {
                                     if (env["VMLX_CHAT_TEMPLATE_FALLBACK_LOG"] ?? "0") == "1" {
                                         FileHandle.standardError.write(
                                             "[vmlx] chat-template missing -> NemotronMinimal fallback engaged\\n"
@@ -469,8 +469,8 @@ public struct TokenizerAdaptorMacro: ExpressionMacro {
                             // sentinel tokens are not in vocab.
                             let isGemma = upstream.bosToken == "<bos>"
                             let hasNemotronSentinel =
-                                upstream.convertTokenToId("<|im_start|>") != nil
-                                || upstream.convertTokenToId("<|im_end|>") != nil
+                                (upstream.convertTokenToId("<|im_start|>").flatMap { upstream.convertIdToToken($0) } == "<|im_start|>")
+                                || (upstream.convertTokenToId("<|im_end|>").flatMap { upstream.convertIdToToken($0) } == "<|im_end|>")
                             let ordered: [(label: String, template: String)]
                             if hasLagunaSentinel {
                                 ordered = [
@@ -544,10 +544,10 @@ public struct TokenizerAdaptorMacro: ExpressionMacro {
                         let hasLagunaSentinel =
                             upstream.bosToken == lagunaEos
                             && upstream.eosToken == lagunaEos
-                            && upstream.convertTokenToId("<assistant>") != nil
-                            && upstream.convertTokenToId("</assistant>") != nil
-                            && upstream.convertTokenToId("<think>") != nil
-                            && upstream.convertTokenToId("</think>") != nil
+                            && (upstream.convertTokenToId("<assistant>").flatMap { upstream.convertIdToToken($0) } == "<assistant>")
+                            && (upstream.convertTokenToId("</assistant>").flatMap { upstream.convertIdToToken($0) } == "</assistant>")
+                            && (upstream.convertTokenToId("<think>").flatMap { upstream.convertIdToToken($0) } == "<think>")
+                            && (upstream.convertTokenToId("</think>").flatMap { upstream.convertIdToToken($0) } == "</think>")
                         if hasLagunaSentinel
                             && (env["VMLX_CHAT_TEMPLATE_FALLBACK_DISABLE"] ?? "0") != "1" {
                             return try upstream.applyChatTemplate(
@@ -563,8 +563,8 @@ public struct TokenizerAdaptorMacro: ExpressionMacro {
                         let hasLFM2NativeToolSentinels =
                             upstream.bosToken == "<|startoftext|>"
                             && upstream.eosToken == "<|im_end|>"
-                            && upstream.convertTokenToId("<|tool_call_start|>") != nil
-                            && upstream.convertTokenToId("<|tool_call_end|>") != nil
+                            && (upstream.convertTokenToId("<|tool_call_start|>").flatMap { upstream.convertIdToToken($0) } == "<|tool_call_start|>")
+                            && (upstream.convertTokenToId("<|tool_call_end|>").flatMap { upstream.convertIdToToken($0) } == "<|tool_call_end|>")
                         if !(tools?.isEmpty ?? true),
                            hasLFM2NativeToolSentinels,
                            (env["VMLX_CHAT_TEMPLATE_FALLBACK_DISABLE"] ?? "0") != "1" {
@@ -584,11 +584,11 @@ public struct TokenizerAdaptorMacro: ExpressionMacro {
                                     additionalContext: additionalContext)
                         }
                         let hasGemma4NativeToolSentinels =
-                            upstream.convertTokenToId("<|tool_call>") != nil
-                            && upstream.convertTokenToId("<|turn>") != nil
+                            (upstream.convertTokenToId("<|tool_call>").flatMap { upstream.convertIdToToken($0) } == "<|tool_call>")
+                            && (upstream.convertTokenToId("<|turn>").flatMap { upstream.convertIdToToken($0) } == "<|turn>")
                         if !(tools?.isEmpty ?? true),
                            upstream.bosToken == "<s>",
-                           upstream.convertTokenToId("<|im_end|>") != nil,
+                           (upstream.convertTokenToId("<|im_end|>").flatMap { upstream.convertIdToToken($0) } == "<|im_end|>"),
                            (env["VMLX_CHAT_TEMPLATE_FALLBACK_DISABLE"] ?? "0") != "1" {
                             return try upstream.applyChatTemplate(
                                 messages: messages,
@@ -628,9 +628,9 @@ public struct TokenizerAdaptorMacro: ExpressionMacro {
                         let hasStep37Sentinels =
                             upstream.bosToken == step37Bos
                             && upstream.eosToken == "<|im_end|>"
-                            && upstream.convertTokenToId("<|im_start|>") != nil
-                            && upstream.convertTokenToId("<tool_call>") != nil
-                            && upstream.convertTokenToId("<im_patch>") != nil
+                            && (upstream.convertTokenToId("<|im_start|>").flatMap { upstream.convertIdToToken($0) } == "<|im_start|>")
+                            && (upstream.convertTokenToId("<tool_call>").flatMap { upstream.convertIdToToken($0) } == "<tool_call>")
+                            && (upstream.convertTokenToId("<im_patch>").flatMap { upstream.convertIdToToken($0) } == "<im_patch>")
                         let step37NeedsFallback =
                             hasStep37Sentinels
                             && (env["VMLX_CHAT_TEMPLATE_FALLBACK_DISABLE"] ?? "0") != "1"
@@ -671,7 +671,7 @@ public struct TokenizerAdaptorMacro: ExpressionMacro {
                         }
                         var mistral4AdjustedContext = additionalContext
                         if mistral4AdjustedContext?["reasoning_effort"] == nil,
-                           upstream.convertTokenToId("[MODEL_SETTINGS]") != nil,
+                           (upstream.convertTokenToId("[MODEL_SETTINGS]").flatMap { upstream.convertIdToToken($0) } == "[MODEL_SETTINGS]"),
                            let enableThinking = mistral4AdjustedContext?["enable_thinking"] as? Bool {
                             var ctx = mistral4AdjustedContext ?? [:]
                             ctx["reasoning_effort"] = enableThinking ? "high" : "none"
@@ -691,7 +691,7 @@ public struct TokenizerAdaptorMacro: ExpressionMacro {
                         }
                         if !(tools?.isEmpty ?? true),
                            upstream.bosToken == "<s>",
-                           upstream.convertTokenToId("<|im_end|>") != nil,
+                           (upstream.convertTokenToId("<|im_end|>").flatMap { upstream.convertIdToToken($0) } == "<|im_end|>"),
                            (env["VMLX_CHAT_TEMPLATE_FALLBACK_DISABLE"] ?? "0") != "1" {
                             return try upstream.applyChatTemplate(
                                 messages: messages,
@@ -750,7 +750,7 @@ public struct TokenizerAdaptorMacro: ExpressionMacro {
                                         additionalContext: additionalContext)
                                 }
                                 if upstream.bosToken == "<s>",
-                                   upstream.convertTokenToId("<|im_end|>") != nil {
+                                   (upstream.convertTokenToId("<|im_end|>").flatMap { upstream.convertIdToToken($0) } == "<|im_end|>") {
                                     return try upstream.applyChatTemplate(
                                         messages: messages,
                                         chatTemplate: VMLXTokenizers.ChatTemplateArgument.literal(
@@ -781,8 +781,8 @@ public struct TokenizerAdaptorMacro: ExpressionMacro {
                             }
                             let isGemma = upstream.bosToken == "<bos>"
                             let hasNemotronSentinel =
-                                upstream.convertTokenToId("<|im_start|>") != nil
-                                || upstream.convertTokenToId("<|im_end|>") != nil
+                                (upstream.convertTokenToId("<|im_start|>").flatMap { upstream.convertIdToToken($0) } == "<|im_start|>")
+                                || (upstream.convertTokenToId("<|im_end|>").flatMap { upstream.convertIdToToken($0) } == "<|im_end|>")
                             let ordered: [(label: String, template: String)]
                             if hasLagunaSentinel {
                                 ordered = [


### PR DESCRIPTION
Mistral models (Mistral-Small-3.x / 4, Pixtral) loop and go incoherent in chat — **especially with tools**, i.e. essentially all osaurus agent use.

## Root cause
The chat-template auto-correction in `HuggingFaceIntegrationMacros.swift` detects model family with `convertTokenToId("<|im_end|>") != nil` (and `<|im_start|>`, `<|tool_call>`, `<|turn>`, `<tool_call>`, `<im_patch>`, `[MODEL_SETTINGS]`, `<think>`, …). That is **not** an existence test: `convertTokenToId` returns the `<unk>` id for *any* absent token, so it is non-nil even for models that lack the token (the documented unk-id pitfall).

A tool-bearing Mistral request (bos `<s>`, **no** `<|im_end|>`) therefore matched the Nemotron reroute — and, once that is guarded, the Gemma reroute — so the engine fed the Mistral model a **ChatML / Gemma** prompt (`<|im_start|>`, `<|turn>`, `<think>`, `<tool_call>`) for tokens it doesn’t have. The model produced incoherent text and never stopped (`<|im_end|>` isn’t its EOS) → looping.

## Fix
Replace every sentinel existence check with a round-trip: `convertIdToToken(convertTokenToId(t)) == t`. Strictly more correct — models that genuinely have the token still round-trip and reroute exactly as before (Nemotron-Cascade, Gemma4, LFM2, Step37); models that lack it (Mistral) no longer false-match. Same pitfall previously fixed for the bridge detection (Mistral-on-Gemma-CRACK misfire).

## Proof (`BENCH_TEMPLATE_SMOKE` on Mistral-Small-3.1-24B-2503, no weights)
Before → tool cases rendered ChatML: `…<|im_end|>\n<|im_start|>user\n…<|im_start|>assistant<think>`.
After → tool cases render **native Mistral**:
```
tools_thinking_true  PASS chars==directChars  tail=…[/AVAILABLE_TOOLS][INST]Call get_weather…[/INST]
osaurus_sized_tools  PASS                       tail=…[/AVAILABLE_TOOLS][INST]Now answer again briefly.[/INST]
```
`thinkOpen=false` (spurious `<think>` gone), **no** `<|im_start|>`/`<|turn>`, no fallback reroute engaged. Non-tool multiturn unchanged (still `<s>[SYSTEM_PROMPT]…[INST]…[/INST]…</s>[INST]…[/INST]`).

Note for review: this touches the shared family-detection path. The round-trip only changes behavior for tokenizers where `convertTokenToId` returned a non-nil id that does not decode back to the same token (absent special tokens) — intended reroute targets are unaffected.