### PR TITLE
Mistral chat hardening: catch-path fallback arm + VLM image-token round-trip (follow-ups to #100)

### DIFF
--- a/Libraries/MLXHuggingFaceMacros/HuggingFaceIntegrationMacros.swift
+++ b/Libraries/MLXHuggingFaceMacros/HuggingFaceIntegrationMacros.swift
@@ -481,6 +481,17 @@ public struct TokenizerAdaptorMacro: ExpressionMacro {
                                     ("Gemma4WithTools", MLXLMCommon.ChatTemplateFallbacks.gemma4WithTools),
                                     ("Gemma4Minimal",   MLXLMCommon.ChatTemplateFallbacks.gemma4Minimal),
                                 ]
+                            } else if (upstream.convertTokenToId("[INST]").flatMap { upstream.convertIdToToken($0) } == "[INST]")
+                                && (upstream.convertTokenToId("[SYSTEM_PROMPT]").flatMap { upstream.convertIdToToken($0) } == "[SYSTEM_PROMPT]") {
+                                // Mistral-family native template threw in swift-jinja. Use the
+                                // complete Mistral template, NOT the Gemma/Nemotron default in
+                                // orderedFallbacks — feeding a Mistral model a ChatML/Gemma prompt
+                                // (<|im_start|>/<|turn|>) for tokens it lacks loops/incoheres.
+                                // (Round-trip the [INST]/[SYSTEM_PROMPT] sentinels — convertTokenToId
+                                // alone returns the <unk> id for absent tokens.)
+                                ordered = [
+                                    ("Mistral3CompleteMinimal", MLXLMCommon.ChatTemplateFallbacks.mistral3CompleteMinimal),
+                                ]
                             } else if hasNemotronSentinel {
                                 ordered = [
                                     ("NemotronMinimal", MLXLMCommon.ChatTemplateFallbacks.nemotronMinimal),
@@ -792,6 +803,17 @@ public struct TokenizerAdaptorMacro: ExpressionMacro {
                                 ordered = [
                                     ("Gemma4WithTools", MLXLMCommon.ChatTemplateFallbacks.gemma4WithTools),
                                     ("Gemma4Minimal",   MLXLMCommon.ChatTemplateFallbacks.gemma4Minimal),
+                                ]
+                            } else if (upstream.convertTokenToId("[INST]").flatMap { upstream.convertIdToToken($0) } == "[INST]")
+                                && (upstream.convertTokenToId("[SYSTEM_PROMPT]").flatMap { upstream.convertIdToToken($0) } == "[SYSTEM_PROMPT]") {
+                                // Mistral-family native template threw in swift-jinja. Use the
+                                // complete Mistral template, NOT the Gemma/Nemotron default in
+                                // orderedFallbacks — feeding a Mistral model a ChatML/Gemma prompt
+                                // (<|im_start|>/<|turn|>) for tokens it lacks loops/incoheres.
+                                // (Round-trip the [INST]/[SYSTEM_PROMPT] sentinels — convertTokenToId
+                                // alone returns the <unk> id for absent tokens.)
+                                ordered = [
+                                    ("Mistral3CompleteMinimal", MLXLMCommon.ChatTemplateFallbacks.mistral3CompleteMinimal),
                                 ]
                             } else if hasNemotronSentinel {
                                 ordered = [

--- a/Libraries/MLXVLM/Models/Mistral3.swift
+++ b/Libraries/MLXVLM/Models/Mistral3.swift
@@ -1101,8 +1101,12 @@ public struct Mistral3VLMProcessor: UserInputProcessor {
         self.config = config
         self.tokenizer = tokenizer
         self.imageToken = config.imageToken
-        // Get image token ID from tokenizer, fallback to 10 (default for Mistral3)
-        if let vocabTokenId = tokenizer.convertTokenToId(config.imageToken) {
+        // Get image token ID from tokenizer, fallback to 10 (default for Mistral3).
+        // Round-trip the lookup: convertTokenToId returns the <unk> id for an
+        // ABSENT token, so a bare non-nil check would use the unk id as the image
+        // placeholder. Only accept an id that decodes back to the image token.
+        if let vocabTokenId = tokenizer.convertTokenToId(config.imageToken),
+            tokenizer.convertIdToToken(vocabTokenId) == config.imageToken {
             self.imageTokenId = vocabTokenId
         } else {
             self.imageTokenId = 10

--- a/Libraries/MLXVLM/Models/Pixtral.swift
+++ b/Libraries/MLXVLM/Models/Pixtral.swift
@@ -1034,8 +1034,12 @@ public struct PixtralProcessor: UserInputProcessor {
     public init(_ config: PixtralProcessorConfiguration, tokenizer: any Tokenizer) {
         self.config = config
         self.tokenizer = tokenizer
-        // Get image token ID from tokenizer, fallback to 10 (default for Pixtral)
-        if let vocabTokenId = tokenizer.convertTokenToId(config.imageToken) {
+        // Get image token ID from tokenizer, fallback to 10 (default for Pixtral).
+        // Round-trip the lookup: convertTokenToId returns the <unk> id for an
+        // ABSENT token, so a bare non-nil check would use the unk id as the image
+        // placeholder. Only accept an id that decodes back to the image token.
+        if let vocabTokenId = tokenizer.convertTokenToId(config.imageToken),
+            tokenizer.convertIdToToken(vocabTokenId) == config.imageToken {
             self.imageTokenId = vocabTokenId
         } else {
             self.imageTokenId = 10


### PR DESCRIPTION
Two follow-ups to #100, found by an audit of the recent template overhaul.

**F1 (HIGH, same class as #100):** when a Mistral native template *throws* in swift-jinja, the catch-block family-sniff had no Mistral arm → fell to `orderedFallbacks` (Gemma/Nemotron/DSV4) → tried **Gemma4WithTools first** → a Mistral model got a Gemma/ChatML prompt → looping/incoherence. Reachable for Mistral-3 2512 / Devstral packs that ship `[AVAILABLE_TOOLS]` (so JangLoader keeps their native template instead of swapping in `mistral3CompleteMinimal`). Fix: add a Mistral arm (round-trip `[INST]`+`[SYSTEM_PROMPT]` sentinels → `mistral3CompleteMinimal`), both macro copies.

**F2 (low, same pitfall):** Mistral3/Pixtral image-token resolution used `convertTokenToId(imageToken) != nil` whose else-branch is dead (returns the `<unk>` id for an absent token). Round-tripped so an absent `[IMG]` falls back to id 10 instead of using the unk id as the image placeholder. (Practically inert — `[IMG]` is always present — but it’s the same fragile pattern.)

**No regression** (BENCH_TEMPLATE_SMOKE): Mistral-Small-3.1-2503 still renders native `[SYSTEM_PROMPT]`/`[INST]`; Gemma-4 still routes `Gemma4WithTools`.

Note: F1 is code-proven (the catch-block had no Mistral arm; `orderedFallbacks` has no Mistral) and the fix is symmetric with the already-live-proven #100 reroute-ladder fix; I could not live-trigger the swift-jinja throw without a 2512/Devstral pack on hand.