### PR TITLE
Qwen3.5: make the (1+weight) RMSNorm shift deterministic (fix intermittent ~7.5% degenerate loads)

### DIFF
--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -50,6 +50,9 @@ public struct Qwen35TextConfiguration: Codable, Sendable {
     var ropeScaling: [String: StringOrNumber]?
     var fullAttentionInterval: Int = 4
     var mtpNumHiddenLayers: Int = 0
+    /// Authoritative RMSNorm convention declared by the bundle (config.json `norm_convention`).
+    /// When set it overrides the architecture default; nil when the bundle declares none.
+    var normConvention: String? = nil
 
     // MoE fields
     var numExperts: Int = 0
@@ -82,6 +85,7 @@ public struct Qwen35TextConfiguration: Codable, Sendable {
         case ropeScaling = "rope_scaling"
         case fullAttentionInterval = "full_attention_interval"
         case mtpNumHiddenLayers = "mtp_num_hidden_layers"
+        case normConvention = "norm_convention"
         case numExperts = "num_experts"
         case numExpertsPerTok = "num_experts_per_tok"
         case decoderSparseStep = "decoder_sparse_step"
@@ -130,6 +134,8 @@ public struct Qwen35TextConfiguration: Codable, Sendable {
             try container.decodeIfPresent(Int.self, forKey: .fullAttentionInterval) ?? 4
         self.mtpNumHiddenLayers =
             try container.decodeIfPresent(Int.self, forKey: .mtpNumHiddenLayers) ?? 0
+        self.normConvention =
+            try container.decodeIfPresent(String.self, forKey: .normConvention)
 
         // MoE fields
         self.numExperts = try container.decodeIfPresent(Int.self, forKey: .numExperts) ?? 0
@@ -1022,13 +1028,18 @@ public class Qwen35TextModel: Module, LLMModel, KVCacheDimensionProvider, Hidden
     {
         let loadNativeMTP = configuration.mtpNumHiddenLayers > 0
         var weights = loadNativeMTP ? weights : weights.filter { !Self.isMTPWeightKey($0.key) }
-        let hasUnsanitizedConv1d = weights.contains { key, value in
-            !Self.isMTPWeightKey(key) && key.contains("conv1d.weight") && value.dim(-1) != 1
-        }
-        let explicitNormConvention = normConvention != nil
-        let shouldShiftNormWeights = Self.usesQwenPlusOneNormConvention(normConvention)
-            || (!explicitNormConvention
-                && (hasUnsanitizedConv1d || Self.baseNormWeightsNeedShift(weights)))
+        // Resolve the (1 + weight) RMSNorm shift via the shared resolver: a per-bundle
+        // metadata/config declaration wins; otherwise (this arch uses the convention) the
+        // order-independent majority vote decides raw (→ shift) vs already-shifted (→ leave it).
+        // The same architecture ships both — JangQ stores raw, MXFP4 stores already-shifted — so
+        // this MUST be measured per bundle, not declared as always-on.
+        let shouldShiftNormWeights = NormConventionResolver.shouldApplyPlusOneShift(
+            metadataConvention: normConvention,
+            configConvention: configuration.normConvention,
+            declaredConvention: declaredNormConvention,
+            weights: weights,
+            probeSuffixes: [".input_layernorm.weight", ".post_attention_layernorm.weight"],
+            excluding: Self.isMTPWeightKey)
         let shouldShiftMTPNormWeights = loadNativeMTP
             && (shouldShiftNormWeights || Self.mtpNormWeightsNeedShift(weights))
 
@@ -1089,11 +1100,13 @@ public class Qwen35TextModel: Module, LLMModel, KVCacheDimensionProvider, Hidden
         return value?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 
-    private static func usesQwenPlusOneNormConvention(_ value: String?) -> Bool {
-        value == "qwen3_5_language_mlx_plus_one"
-            || value == "qwen35_language_mlx_plus_one"
-            || value == "mlx_plus_one"
-    }
+    // NB: qwen3.5 deliberately does NOT declare a class-level `norm_convention`. This architecture
+    // uses the (1 + weight) convention, but its bundles are stored in BOTH states — JangQ stores the
+    // norms raw (needs +1), MXFP4 stores them already-shifted (must not be shifted again) — so no
+    // truthful architecture-level claim exists. A per-bundle `config.json` / metadata declaration or,
+    // failing that, the order-independent vote decides. Do NOT override `declaredNormConvention`
+    // here: an authoritative class declaration would wrongly short-circuit the vote and degrade one
+    // of the two storage states. See ``NormConventionResolver``.
 
     private static func isMTPWeightKey(_ key: String) -> Bool {
         key.hasPrefix("mtp.")
@@ -1102,22 +1115,9 @@ public class Qwen35TextModel: Module, LLMModel, KVCacheDimensionProvider, Hidden
             || key.contains(".mtp_layers.")
     }
 
-    private static func baseNormWeightsNeedShift(_ weights: [String: MLXArray]) -> Bool {
-        let probeSuffixes = [
-            ".input_layernorm.weight",
-            ".post_attention_layernorm.weight",
-        ]
-        for (key, value) in weights where value.ndim == 1 {
-            guard !Self.isMTPWeightKey(key),
-                  probeSuffixes.contains(where: { key.hasSuffix($0) }) else {
-                continue
-            }
-            let mean = value.asType(.float32).mean().item(Float.self)
-            if mean < 0.5 { return true }
-            if mean > 0.5 { return false }
-        }
-        return false
-    }
+    // The order-independent "are these norms already shifted?" fallback now lives in
+    // `NormConventionResolver.weightsAppearUnshifted` (MLXLMCommon), invoked via
+    // `shouldApplyPlusOneShift` above. Architectures share that one implementation.
 }
 
 extension Qwen35TextModel: LoRAModel {

--- a/Libraries/MLXLMCommon/LanguageModel.swift
+++ b/Libraries/MLXLMCommon/LanguageModel.swift
@@ -353,6 +353,13 @@ public protocol LanguageModel: Module {
     /// Models can override this to inspect metadata (e.g. check `metadata["format"] == "mlx"`)
     /// and skip or customize sanitization accordingly.
     func sanitize(weights: [String: MLXArray], metadata: [String: String]) -> [String: MLXArray]
+
+    /// The architecture's authoritative RMSNorm "(1 + weight)" convention marker (e.g.
+    /// `"mlx_plus_one"`), consulted when neither bundle metadata nor `config.json` declares one.
+    /// `nil` (the default) means the architecture declares no such convention. Architectures that
+    /// store RMSNorm weights as the deviation-from-1 should override this; see
+    /// ``NormConventionResolver`` and `Qwen35` for the template.
+    var declaredNormConvention: String? { get }
 }
 
 extension LanguageModel {
@@ -369,6 +376,9 @@ extension LanguageModel {
 }
 
 extension LanguageModel {
+    /// Default: the architecture declares no `(1 + weight)` convention. Override per architecture.
+    public var declaredNormConvention: String? { nil }
+
     public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
         weights
     }

--- a/Libraries/MLXLMCommon/NormConventionResolver.swift
+++ b/Libraries/MLXLMCommon/NormConventionResolver.swift
@@ -1,0 +1,81 @@
+// Architecture-agnostic resolution of the RMSNorm "(1 + weight)" shift convention.
+//
+// Several architectures (qwen3.5, qwen3-next, gemma-family, …) store RMSNorm weights as the
+// deviation from 1 and apply `(1 + weight)` at load. Whether a given bundle needs that shift is
+// authoritative information that should be *declared* — by the bundle (safetensors `metadata` or
+// `config.json` `norm_convention`) or by the architecture itself — never guessed from the weights.
+//
+// This type centralizes that resolution so every model shares one correct implementation instead of
+// hand-rolling its own. The hand-rolled version this replaces (in qwen3.5) returned on the FIRST
+// probe norm in (per-process randomized) Swift `Dictionary` iteration order, which silently
+// degenerated ~7.5% of loads when a few raw norms legitimately had mean > 0.5. New `(1 + weight)`
+// architectures should adopt `shouldApplyPlusOneShift(...)` rather than re-implementing this.
+
+import Foundation
+import MLX
+
+public enum NormConventionResolver {
+
+    /// Accepted markers for the "(1 + weight)" RMSNorm convention.
+    public static func usesPlusOne(_ value: String?) -> Bool {
+        switch value?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "qwen3_5_language_mlx_plus_one", "qwen35_language_mlx_plus_one", "mlx_plus_one":
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Order-independent detection of whether 1-D RMSNorm weights look UNSHIFTED (raw, mean ≈ 0 →
+    /// need `+1`) vs already shifted (mean ≈ 1). Decides by MAJORITY VOTE over all probe norms, so it
+    /// never depends on `Dictionary` iteration order. Returns `nil` when no probe norm is found.
+    public static func weightsAppearUnshifted(
+        _ weights: [String: MLXArray],
+        probeSuffixes: [String],
+        excluding isExcluded: (String) -> Bool = { _ in false }
+    ) -> Bool? {
+        var below = 0, above = 0
+        for (key, value) in weights where value.ndim == 1 {
+            guard !isExcluded(key),
+                probeSuffixes.contains(where: { key.hasSuffix($0) }) else { continue }
+            let mean = value.asType(.float32).mean().item(Float.self)
+            if mean < 0.5 { below += 1 } else if mean > 0.5 { above += 1 }
+        }
+        if below + above == 0 { return nil }
+        return below >= above
+    }
+
+    /// Resolve whether to apply the `(1 + weight)` shift, with deterministic precedence:
+    /// per-bundle declaration → architecture declaration → order-independent vote.
+    ///
+    /// A DECLARATION is authoritative — it states the storage state outright and short-circuits the
+    /// vote. A per-bundle declaration (safetensors metadata → `config.json`) wins first; then an
+    /// architecture-level declaration (`declaredConvention`). Crucially, an architecture may declare
+    /// only when ALL its bundles share one storage state. An architecture that ships the SAME class
+    /// both raw (norm mean ≈ 0, deviation-from-1 → needs +1) AND already-shifted (mean ≈ 1 → must NOT
+    /// be shifted again) — e.g. qwen3.5, where JangQ stores raw and MXFP4 stores pre-shifted — can
+    /// make no truthful class-level claim, so it must declare `nil` and let the per-bundle config or
+    /// the vote decide. The order-independent majority vote is the per-bundle measurement used when
+    /// nothing is declared; it discriminates the cleanly bimodal signal (≈0 vs ≈1) regardless of
+    /// `Dictionary` iteration order.
+    public static func shouldApplyPlusOneShift(
+        metadataConvention: String?,
+        configConvention: String?,
+        declaredConvention: String?,
+        weights: [String: MLXArray],
+        probeSuffixes: [String],
+        excluding isExcluded: (String) -> Bool = { _ in false },
+        fallbackWhenNoProbe: () -> Bool = { false }
+    ) -> Bool {
+        // Any declaration is authoritative and overrides the vote: per-bundle metadata/config first
+        // (states THIS bundle's storage state), then an architecture-level declaration (valid only
+        // for architectures with a uniform storage state across all their bundles).
+        if let explicit = metadataConvention ?? configConvention ?? declaredConvention {
+            return usesPlusOne(explicit)
+        }
+        // Nothing declared (the qwen3.5 reality: one class, mixed storage across bundles). Measure
+        // THIS bundle, order-independently.
+        return weightsAppearUnshifted(weights, probeSuffixes: probeSuffixes, excluding: isExcluded)
+            ?? fallbackWhenNoProbe()
+    }
+}

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -420,6 +420,9 @@ public struct Qwen35Configuration: Codable, Sendable {
         public var fullAttentionInterval: Int = 4
         public var mtpNumHiddenLayers: Int = 0
         public var weightFormat: String = ""
+        /// Authoritative RMSNorm convention declared by the bundle (config.json `norm_convention`).
+        /// When set it overrides the architecture default; nil when the bundle declares none.
+        public var normConvention: String? = nil
         public var mxtqBits: Int = 2
         public var mxtqGateUpBits: Int = 2
         public var mxtqDownBits: Int = 2
@@ -457,6 +460,7 @@ public struct Qwen35Configuration: Codable, Sendable {
             case fullAttentionInterval = "full_attention_interval"
             case mtpNumHiddenLayers = "mtp_num_hidden_layers"
             case weightFormat = "weight_format"
+            case normConvention = "norm_convention"
             case mxtqBits = "mxtq_bits"
             case mxtqGateUpBits = "mxtq_gate_up_bits"
             case mxtqDownBits = "mxtq_down_bits"
@@ -506,6 +510,8 @@ public struct Qwen35Configuration: Codable, Sendable {
                 try container.decodeIfPresent(Int.self, forKey: .mtpNumHiddenLayers) ?? 0
             self.weightFormat =
                 try container.decodeIfPresent(String.self, forKey: .weightFormat) ?? ""
+            self.normConvention =
+                try container.decodeIfPresent(String.self, forKey: .normConvention)
             if let flatBits = try? container.decodeIfPresent(Int.self, forKey: .mxtqBits) {
                 self.mxtqBits = flatBits
             }
@@ -2037,14 +2043,22 @@ public class Qwen35: Module, VLMModel, HiddenStateCaptureModel, TokenEmbedderMod
     ) -> [String: MLXArray] {
         let loadNativeMTP = config.textConfiguration.mtpNumHiddenLayers > 0
         var weights = loadNativeMTP ? weights : weights.filter { !Self.isMTPWeightKey($0.key) }
-
         let hasUnsanitizedConv1d = weights.contains { key, value in
             key.contains("conv1d.weight") && value.dim(-1) != 1
         }
-        let explicitNormConvention = normConvention != nil
-        let shouldShiftNormWeights = Self.usesQwenPlusOneNormConvention(normConvention)
-            || (!explicitNormConvention
-                && (hasUnsanitizedConv1d || Self.baseNormWeightsNeedShift(weights)))
+
+        // Resolve the (1 + weight) RMSNorm shift via the shared resolver: a per-bundle
+        // metadata/config declaration wins; otherwise (this arch uses the convention) the
+        // order-independent majority vote decides raw (→ shift) vs already-shifted (→ leave it).
+        // The same architecture ships both — JangQ stores raw, MXFP4 stores already-shifted — so
+        // this MUST be measured per bundle, not declared as always-on.
+        let shouldShiftNormWeights = NormConventionResolver.shouldApplyPlusOneShift(
+            metadataConvention: normConvention,
+            configConvention: config.textConfiguration.normConvention,
+            declaredConvention: declaredNormConvention,
+            weights: weights,
+            probeSuffixes: [".input_layernorm.weight", ".post_attention_layernorm.weight"],
+            fallbackWhenNoProbe: { !Self.isMLXFormatLike(weights) })
         let shouldShiftMTPNormWeights = loadNativeMTP
             && (shouldShiftNormWeights || Self.mtpNormWeightsNeedShift(weights))
 
@@ -2139,11 +2153,13 @@ public class Qwen35: Module, VLMModel, HiddenStateCaptureModel, TokenEmbedderMod
         return value?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     }
 
-    private static func usesQwenPlusOneNormConvention(_ value: String?) -> Bool {
-        value == "qwen3_5_language_mlx_plus_one"
-            || value == "qwen35_language_mlx_plus_one"
-            || value == "mlx_plus_one"
-    }
+    // NB: qwen3.5 deliberately does NOT declare a class-level `norm_convention`. This architecture
+    // uses the (1 + weight) convention, but its bundles are stored in BOTH states — JangQ stores the
+    // norms raw (needs +1), MXFP4 stores them already-shifted (must not be shifted again) — so no
+    // truthful architecture-level claim exists. A per-bundle `config.json` / metadata declaration or,
+    // failing that, the order-independent vote decides. Do NOT override `declaredNormConvention`
+    // here: an authoritative class declaration would wrongly short-circuit the vote and degrade one
+    // of the two storage states. See ``NormConventionResolver``.
 
     private static func isMTPWeightKey(_ key: String) -> Bool {
         key.hasPrefix("mtp.")
@@ -2152,21 +2168,9 @@ public class Qwen35: Module, VLMModel, HiddenStateCaptureModel, TokenEmbedderMod
             || key.contains(".mtp_layers.")
     }
 
-    private static func baseNormWeightsNeedShift(_ weights: [String: MLXArray]) -> Bool {
-        let probeSuffixes = [
-            ".input_layernorm.weight",
-            ".post_attention_layernorm.weight",
-        ]
-        for (key, value) in weights where value.ndim == 1 {
-            guard probeSuffixes.contains(where: { key.hasSuffix($0) }) else {
-                continue
-            }
-            let mean = value.asType(.float32).mean().item(Float.self)
-            if mean < 0.5 { return true }
-            if mean > 0.5 { return false }
-        }
-        return !isMLXFormatLike(weights)
-    }
+    // The order-independent "are these norms already shifted?" fallback now lives in
+    // `NormConventionResolver.weightsAppearUnshifted` (MLXLMCommon), invoked via
+    // `shouldApplyPlusOneShift` above. Architectures share that one implementation.
 
     private static func isMLXFormatLike(_ weights: [String: MLXArray]) -> Bool {
         weights.keys.contains { key in


### PR DESCRIPTION
## Summary

Qwen3.5 (`qwen3_5` / `qwen3_5_moe`) intermittently loads a **silently degenerate
model** — flat logits, garbage output — on roughly **1 in 13 loads of the same
bundle**, with no error and no log. The RMSNorm `(1 + weight)` shift decision was
made by a `Dictionary`-iteration-order coin flip. This replaces it with an
**order-independent, per-bundle** decision and factors the mechanism into a
shared resolver so other `(1 + weight)` architectures can adopt it.

The underlying gap is upstream of vmlx and worth stating plainly (see *Why this
is really a metadata gap* below): **no converter records whether a bundle's norms
are stored raw or already shifted**, so every runtime is forced to guess. This PR
makes the guess robust; it does not remove the need for the declaration.

## Symptom

Loading the *same* qwen3.5 bundle repeatedly, a fraction of loads (~7.5% on the
bundle that surfaced this) come up degenerate: every RMSNorm weight is near
zero, the hidden state flat-lines, logits are flat (~−15), and the model picks
one answer for everything / rambles to max tokens. It is per-process and baked
at load — reload and it is usually fine.

## Root cause — why it failed *probabilistically*

Qwen3.5 stores RMSNorm weights as the deviation from 1 and applies `(1 + weight)`
during `sanitize`. Whether to apply the shift was decided by
`baseNormWeightsNeedShift`, which **returned on the first
`.input_layernorm` / `.post_attention_layernorm` weight it found while iterating
a Swift `Dictionary`**:

```swift
for (key, value) in weights where value.ndim == 1 {
    guard probeSuffixes.contains(where: { key.hasSuffix($0) }) else { continue }
    let mean = value.asType(.float32).mean().item(Float.self)
    if mean < 0.5 { return true }    // raw → shift
    if mean > 0.5 { return false }   // already shifted → don't
}
```

Swift randomizes `Dictionary` iteration order per process. A raw bundle has
*most* norm weights near 0 (mean < 0.5) but a few legitimately above 0.5 — e.g.
**6 of 80** on the bundle here. When the random first pick lands on one of those
six (~7.5%), the function returns `false`, the `+1` shift is skipped for **all**
norms, and the model is degenerate. Probabilistic *whether*, deterministic
*where*: the same two outcomes every process, decided by a coin flip. A
single-sample decision over a noisy signal is the bug — the fix is to make the
decision over the *whole population*, order-independently.

## Why "just always shift when declared" is wrong (and would regress)

The obvious fix — declare the architecture and always apply `+1` — **breaks a
different set of bundles**. The *same* `qwen3_5` architecture ships in two storage
states:

| bundle | norm Σx² at load | stored as | needs `+1`? |
|---|---|---|---|
| `Ornith-1.0-35B-JANG_6M` (raw) | ≈ 64 (mean ≈ 0) | deviation-from-1 | **yes** |
| `Holo3-35B-A3B-mxfp4` (pre-shifted) | ≈ 2106 (mean ≈ 1) | already `1 + w` | **no** |

Force-shifting the pre-shifted MXFP4 bundle double-applies the offset
(Σx² 2106 → 4154, mean ≈ 2) → degenerate, exactly the failure we started with,
now on a *different* model. So whether to shift is a **per-bundle storage
property, not an architecture constant.** The two states are cleanly bimodal
(mean ≈ 0 vs ≈ 1), which is what makes an order-independent majority vote a
reliable discriminator.

## Fix

Resolve the convention with a deterministic precedence — **a declaration is
authoritative and short-circuits the vote; the vote runs only when nothing can be
declared:**

- **`NormConventionResolver` (new, `MLXLMCommon`)** — one shared resolver.
  Precedence: **per-bundle declaration** (safetensors `metadata` → `config.json`
  `norm_convention`) → **architecture declaration** → **order-independent majority
  vote** (`weightsAppearUnshifted`: count mean<0.5 vs mean>0.5 over all probe
  norms). A declaration wins outright because it states the storage state
  authoritatively; the vote is the per-bundle measurement used only when nothing
  is declared.
- **`LanguageModel.declaredNormConvention`** — new protocol property
  (default `nil`); the per-architecture declaration seam, **valid only for
  architectures whose bundles all share one storage state**. Non-breaking for
  existing conformers.
- **Qwen35** (both the `MLXLLM` text model and the `MLXVLM` model) **deliberately
  declares nothing** — the same class ships raw (JangQ, needs `+1`) *and*
  already-shifted (MXFP4, must not) bundles, so no truthful class-level claim
  exists; an authoritative class declaration would wrongly short-circuit the vote
  and degrade one of the two states. It adds a `norm_convention` config field for
  a per-bundle override and routes `sanitize` through the resolver, relying on
  that field or the vote. The duplicated per-copy first-element heuristic and
  convention constants are **deleted**.

The fragile first-element probe is gone; when no declaration applies, the
population-level decision lives in exactly one place.

## Validation — both storage states, on device

`qwen3_5_moe`, `mmlu` (logprob), tracing the norm Σx² through `sanitize`:

| bundle | Σx² in → out | decision | mmlu |
|---|---|---|---|
| `Ornith-1.0-35B-JANG_6M` (raw) | 64 → **2112** | **shifted** ✓ | **80%** |
| `Holo3-35B-A3B-mxfp4` (pre-shifted) | 2106 → **2106** | **left alone** ✓ | **75%** |
| `Ornith-1.0-35B-MXFP4` (pre-shifted) | 2112 → **2112** | **left alone** ✓ | **80%** |

Both MXFP4 bundles — which a declare-and-always-shift fix regresses to ~25%
random — stay healthy, and the raw JangQ bundle is correctly shifted. Separately,
idle loop-until-collapse on the raw bundle across both implementations:
**160 loads / 0 degenerate** (vs. ~12 expected at the old ~7.5%). Deterministic
across processes.

## Why this is really a metadata gap (upstream context)

This whole class of bug exists because **the model files don't declare their norm
storage state, and nothing in the format requires them to.** safetensors'
`__metadata__` is free-form `string→string` and mandates no semantic keys;
`config.json` has no field for it. The `(1 + weight)` convention *is* a documented
architecture feature (it's Gemma's; see huggingface/transformers), but *which
storage state a given converted bundle is in* is recorded nowhere — so every
runtime guesses, and the same guess has already shipped as the analogous `+1`
misapplication bug in mlx-examples (Gemma). `norm_convention` is a vmlx-coined
key, not a standard.

The resolver already honors a declaration the moment one appears, so the clean
long-term fix is for converters to emit it. We're filing an enhancement request
upstream (mlx-lm) proposing a mandatory metadata/config key so runtimes can stop
guessing; this PR is the robust interim.

## Template / follow-up

Qwen35 is the worked template for any `(1 + weight)` architecture: declare
`declaredNormConvention`, call `shouldApplyPlusOneShift(...)`. Natural follow-up:
adopt the resolver in the other `(1 + weight)` archs (e.g. Qwen3-Next) so they
share the same order-independent path — each with its own on-device check.
