### PR TITLE
fix writePNG blocking the main thread

### DIFF
--- a/Libraries/vMLXFluxKit/ImageIO.swift
+++ b/Libraries/vMLXFluxKit/ImageIO.swift
@@ -125,7 +125,10 @@ public enum ImageIO {
 
     /// Save an image tensor to `dir/<prefix>-<uuid>.png`.
     /// Returns the URL of the written file.
-    @MainActor
+    ///
+    /// Not `@MainActor`: `.asArray(UInt8.self)` forces the MLX compute
+    /// graph to evaluate, which can block for seconds on a large image.
+    /// Callers must not run this on the main actor.
     public static func writePNG(
         _ tensor: MLXArray,
         outputDir: URL,

--- a/Libraries/vMLXFluxModels/Flux1/Flux1.swift
+++ b/Libraries/vMLXFluxModels/Flux1/Flux1.swift
@@ -63,9 +63,7 @@ public final class Flux1Schnell: ImageGenerator, @unchecked Sendable {
                     ) { step, total, eta in
                         continuation.yield(.step(step: step, total: total, etaSeconds: eta))
                     }
-                    let outURL = try await MainActor.run {
-                        try ImageIO.writePNG(image, outputDir: request.outputDir, prefix: "flux1-schnell")
-                    }
+                    let outURL = try ImageIO.writePNG(image, outputDir: request.outputDir, prefix: "flux1-schnell")
                     continuation.yield(.completed(url: outURL, seed: request.seed ?? 0))
                     continuation.finish()
                 } catch {

--- a/Libraries/vMLXFluxModels/Ideogram4/Ideogram4.swift
+++ b/Libraries/vMLXFluxModels/Ideogram4/Ideogram4.swift
@@ -72,9 +72,7 @@ public final class Ideogram4: ImageGenerator, @unchecked Sendable {
                     ) { step, total, eta in
                         continuation.yield(.step(step: step, total: total, etaSeconds: eta))
                     }
-                    let outURL = try await MainActor.run {
-                        try ImageIO.writePNG(image, outputDir: request.outputDir, prefix: "ideogram")
-                    }
+                    let outURL = try ImageIO.writePNG(image, outputDir: request.outputDir, prefix: "ideogram")
                     continuation.yield(.completed(url: outURL, seed: request.seed ?? 0))
                     continuation.finish()
                 } catch {

--- a/Libraries/vMLXFluxModels/QwenImage/QwenImage.swift
+++ b/Libraries/vMLXFluxModels/QwenImage/QwenImage.swift
@@ -48,9 +48,7 @@ public final class QwenImage: ImageGenerator, @unchecked Sendable {
                     ) { step, total, eta in
                         continuation.yield(.step(step: step, total: total, etaSeconds: eta))
                     }
-                    let outURL = try await MainActor.run {
-                        try ImageIO.writePNG(image, outputDir: request.outputDir, prefix: "qwen-image")
-                    }
+                    let outURL = try ImageIO.writePNG(image, outputDir: request.outputDir, prefix: "qwen-image")
                     continuation.yield(.completed(url: outURL, seed: request.seed ?? 0))
                     continuation.finish()
                 } catch {
@@ -111,12 +109,10 @@ public final class QwenImageEdit: ImageEditor, @unchecked Sendable {
                     ) { step, total, eta in
                         continuation.yield(.step(step: step, total: total, etaSeconds: eta))
                     }
-                    let outURL = try await MainActor.run {
-                        try ImageIO.writePNG(
-                            image,
-                            outputDir: request.outputDir,
-                            prefix: "qwen-image-edit")
-                    }
+                    let outURL = try ImageIO.writePNG(
+                        image,
+                        outputDir: request.outputDir,
+                        prefix: "qwen-image-edit")
                     continuation.yield(.completed(url: outURL, seed: request.seed ?? 0))
                     continuation.finish()
                 } catch {

--- a/Libraries/vMLXFluxModels/ZImage/ZImage.swift
+++ b/Libraries/vMLXFluxModels/ZImage/ZImage.swift
@@ -87,15 +87,11 @@ public final class ZImage: ImageGenerator, @unchecked Sendable {
             continuation.yield(.step(step: step, total: total, etaSeconds: eta))
         }
 
-        // Write the PNG. `ImageIO.writePNG` is @MainActor so the
-        // actor hop happens here.
-        let outURL = try await MainActor.run {
-            try ImageIO.writePNG(
-                image,
-                outputDir: request.outputDir,
-                prefix: "z-image"
-            )
-        }
+        let outURL = try ImageIO.writePNG(
+            image,
+            outputDir: request.outputDir,
+            prefix: "z-image"
+        )
         let seed = request.seed ?? 0
         continuation.yield(.completed(url: outURL, seed: seed))
     }


### PR DESCRIPTION
## Summary
- ImageIO.writePNG was marked @MainActor even though its body forces the MLX compute graph to evaluate via asArray(UInt8.self), which can block for seconds
- Removed the annotation and dropped the now-unnecessary MainActor.run wrappers at all 5 call sites (ZImage, QwenImage generate + edit, Ideogram4, Flux1)
- Resolves Sentry APPLE-MACOS-SE (App Hanging in ZImage.performGenerate)

## Test plan
- [ ] Generate an image with each affected model and confirm the UI stays responsive during PNG write
- [ ] Confirm output PNGs are still written correctly