### PR TITLE
Mistral3 VLM: honor bundle longest_edge instead of clamping images to 336px

### DIFF
--- a/Libraries/MLXVLM/Models/Mistral3.swift
+++ b/Libraries/MLXVLM/Models/Mistral3.swift
@@ -1123,8 +1123,16 @@ public struct Mistral3VLMProcessor: UserInputProcessor {
         var image = MediaProcessing.inSRGBToneCurveSpace(image)
         image = MediaProcessing.apply(image, processing: processing)
 
-        let maxVisionEdge = patchSize * 24  // Pixtral vision expects 24x24 patches (336px for patchSize=14)
-        let targetEdge = min(longestEdge ?? maxVisionEdge, maxVisionEdge)
+        // Pixtral / Mistral3 vision is VARIABLE-resolution: its 2D RoPE grid is
+        // precomputed for (image_size / patch_size) patches per side, so it
+        // handles any image up to the bundle's declared longest edge. Honor
+        // that `longest_edge` (e.g. 1540) instead of clamping to 336px. The old
+        // `patch_size * 24` (336px) cap crushed detailed images — handwriting,
+        // dense documents, small text — into an unreadable thumbnail, which made
+        // the model produce garbled or EMPTY responses on content it otherwise
+        // reads fine at native resolution. Fall back to a Pixtral-typical 1024px
+        // only when the bundle declares no size.
+        let targetEdge = longestEdge ?? (patchSize * 73)
 
         let originalSize = image.extent.size
         let scale = min(CGFloat(targetEdge) / max(originalSize.width, originalSize.height), 1.0)


### PR DESCRIPTION
## Problem

Mistral VLM chat with an image (plain vision-language, e.g. "read this note") returns garbled or **empty** responses on detailed images — handwriting, dense documents, small text, screenshots — while Gemma/Qwen read the same image fine. Field report: Mistral 128B VLM returns *"I wasn't able to generate a response"* on a messy-handwriting photo.

## Root cause

`Mistral3VLMProcessor.preprocessImage` hard-clamped the resized longest edge to `patch_size * 24 = 336px`, ignoring the bundle's declared `longest_edge` (1540 in `preprocessor_config.json`):

```swift
let maxVisionEdge = patchSize * 24            // 336
let targetEdge = min(longestEdge ?? maxVisionEdge, maxVisionEdge)  // min(1540, 336) = 336
```

Every image was downsampled to a 336px thumbnail before the vision tower saw it. At that resolution detailed content is illegible, so the model produces garbage or gives up entirely (empty turn → osaurus' empty-response fallback).

The Pixtral/Mistral3 vision tower is **variable-resolution**: its 2D RoPE grid is precomputed for `image_size / patch_size` (= 1540/14 = 110) patches per side, and `positionIdsInMeshgrid` indexes into that full grid with `maxWidth = image_size/patch_size`. So images up to the declared longest edge are fully supported. `Pixtral.swift` already honors `longest_edge`; only `Mistral3.swift` carried the stale clamp. All mistral3-family VL bundles (`mistral3`/`ministral3`/`mistral4` language variants + the JANGTQ pack) share this one processor, so the fix covers the whole family.

## Fix

Honor the bundle's `longest_edge`, falling back to a Pixtral-typical ~1024px only when none is declared.

## Verification

Live on `Mistral-Small-3.1-24B-Instruct-2503-4bit` (same vision arch as the 128B). A 2451×3267 handwritten note:

- **Before (336px):** `pixels [1,3,336,252]` → *"Daddy, darling … The weather was cloudy but I feel quite fine."* (garbled)
- **After (1540px):** `pixels [1,3,1540,1162]` → *"Dear diary, / Today I went to the market / and bought fresh apples, / bread, and a jar of honey. / The weather was cloudy but / I felt quite cheerful. / - signed, a messy hand"* (verbatim)

No crash/OOM; vision RoPE grid supports the full resolution by construction.