### PR TITLE
Follow-up to #102: eliminate the whole class of order-dependent (reload-flipping) load decisions

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -341,7 +341,16 @@ public enum LLMTypeRegistry {
         let routedBits: Int? = {
             switch probe?.mxtqBits {
             case .flat(let v): return v
-            case .roles(let dict): return dict["routed_expert"] ?? dict.values.first
+            // `dict` is a Dictionary — `.values.first` is randomized per process,
+            // so a bundle whose roles map lacks `routed_expert` would resolve the
+            // routed-expert bit width (→ gateUp/downBits → expert dequant) to an
+            // ARBITRARY value that flips on reload (garbage-on-some-loads). Prefer
+            // named routed aliases, then fall back to the MINIMUM declared width:
+            // routed experts are JANG's most aggressively quantized tier, and
+            // `.min()` is deterministic.
+            case .roles(let dict):
+                return dict["routed_expert"] ?? dict["routed"] ?? dict["expert"]
+                    ?? dict.values.min()
             case .projections(let gateUp, let down): return gateUp ?? down
             case nil: return nil
             }

--- a/Libraries/MLXLLM/Models/BailingHybrid.swift
+++ b/Libraries/MLXLLM/Models/BailingHybrid.swift
@@ -203,8 +203,11 @@ public struct BailingHybridConfiguration: Codable, Sendable {
             self.mxtqBits = flat
         } else if let dict = try? c.decodeIfPresent(
             [String: Int].self, forKey: .mxtqBits),
+            // `.values.first` is per-process-random on a multi-role dict → a
+            // reload-flipping routed bit width. Deterministic MINIMUM (routed
+            // experts are JANG's most aggressively quantized tier).
             let routed = dict["routed_expert"] ?? dict["routed"]
-                ?? dict.values.first
+                ?? dict.values.min()
         {
             self.mxtqBits = routed
         } else if let routedTop = try? c.decodeIfPresent(

--- a/Libraries/MLXLLM/Models/MiMoV2Flash.swift
+++ b/Libraries/MLXLLM/Models/MiMoV2Flash.swift
@@ -553,8 +553,17 @@ struct MiMoRoutedExpertBits: Codable, Sendable {
             let nested = try container.decode([String: [String: Int]].self)
             if let routed = nested["routed_expert"] ?? nested["routed_experts"] {
                 self.init(projections: routed)
-            } else if let first = nested.values.first {
-                self.init(projections: first)
+            } else if let routed = nested.min(by: { lhs, rhs in
+                // `.values.first` over a Dictionary is per-process-random → the
+                // adopted projections map (and its bit widths) would flip on
+                // reload. Deterministic: the role with the smallest bit width
+                // (routed experts are JANG's most aggressively quantized tier),
+                // tie-broken by key so the choice never depends on dict order.
+                let lmin = lhs.value.values.min() ?? .max
+                let rmin = rhs.value.values.min() ?? .max
+                return lmin != rmin ? lmin < rmin : lhs.key < rhs.key
+            })?.value {
+                self.init(projections: routed)
             } else {
                 self.init(projections: [:])
             }

--- a/Libraries/MLXLLM/Models/Qwen35JANGTQ.swift
+++ b/Libraries/MLXLLM/Models/Qwen35JANGTQ.swift
@@ -235,8 +235,11 @@ public struct Qwen35JANGTQTextConfiguration: Codable, Sendable {
             self.mxtqBits = flat
         } else if let dict = try? container.decodeIfPresent(
             [String: Int].self, forKey: .mxtqBits),
+            // `.values.first` is per-process-random on a multi-role dict → a
+            // reload-flipping routed bit width. Deterministic MINIMUM (routed
+            // experts are JANG's most aggressively quantized tier).
             let routed = dict["routed_expert"] ?? dict["routed"]
-                ?? dict.values.first
+                ?? dict.values.min()
         {
             self.mxtqBits = routed
         } else if let qBits = Self._peekQuantizationBits(decoder) {

--- a/Libraries/MLXLLM/Models/Zaya.swift
+++ b/Libraries/MLXLLM/Models/Zaya.swift
@@ -191,7 +191,11 @@ public struct ZayaTextConfiguration: Codable, Sendable {
             return RoutedExpertBitMetadata(routedBits: nil, gateUpBits: nil, downBits: nil)
         }
         if let dict = try? container.decode([String: Int].self, forKey: .mxtqBits) {
-            let routed = dict["routed_expert"] ?? dict.values.first
+            // `.values.first` is per-process-random on a multi-role dict → the
+            // routed bit width (hence every MoE layer's dequant) would flip on
+            // reload. Deterministic: named aliases, then the MINIMUM width
+            // (routed experts are the most aggressively quantized JANG tier).
+            let routed = dict["routed_expert"] ?? dict["routed"] ?? dict.values.min()
             return RoutedExpertBitMetadata(
                 routedBits: routed,
                 gateUpBits: routed,

--- a/Libraries/MLXLMCommon/JangLoader.swift
+++ b/Libraries/MLXLMCommon/JangLoader.swift
@@ -1776,7 +1776,16 @@ public struct JangLoader: Sendable {
                 let prev = counts[k] ?? (0, t.bits, t.groupSize)
                 counts[k] = (prev.count + 1, prev.bits, prev.gs)
             }
-            if let top = counts.values.max(by: { $0.count < $1.count }) {
+            // `max(by: count)` alone is order-dependent on a frequency TIE
+            // between two distinct (bits, gs) pairs — the survivor would then
+            // depend on Dictionary iteration order and flip the shared default
+            // across reloads. Total-order the comparison (count, then higher
+            // bits, then larger gs) so the winner is deterministic and, on a
+            // tie, biases toward the higher-precision default.
+            if let top = counts.values.max(by: { a, b in
+                a.count != b.count ? a.count < b.count
+                    : (a.bits != b.bits ? a.bits < b.bits : a.gs < b.gs)
+            }) {
                 chosenDefault = (top.bits, top.gs)
             } else {
                 chosenDefault = (4, 64)

--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -174,7 +174,12 @@ public func loadWeights(
         if totalsSeen.count > 1 {
             // Pick the LARGEST total whose count equals that total
             // (= the COMPLETE shard set). All others are partials.
-            let completeTotal = totalsSeen.first(where: { $0.key == $0.value })?.key
+            // NB: `totalsSeen` is a Dictionary — its iteration order is
+            // randomized per process, so `.first(where:)` would pick an
+            // ARBITRARY complete set when two coexist (garbage-on-some-loads,
+            // fixed-by-reload). `.max()` over the matches is deterministic AND
+            // matches the "largest" intent stated above.
+            let completeTotal = totalsSeen.filter { $0.key == $0.value }.keys.max()
                 ?? totalsSeen.keys.max()!
             let summary = totalsSeen
                 .map { "\($0.value)/\($0.key)" }


### PR DESCRIPTION
## Follow-up to #102: the same bug is a *class*, not one site

#102 (thanks @rcfa) correctly root-caused and fixed the qwen3.5 RMSNorm-shift degeneration. But that bug is one instance of a broader class:

> **A load-time decision made by taking the first element of a Swift `Dictionary`/`Set`.** Swift randomizes `Dictionary`/`Set` iteration order per process (hash seed at launch). So any load-time code that iterates such a collection and decides on the *first* match — when more than one element can match — produces a result that varies **per process launch**: the model loads fine on some launches and degenerates into garbage on others, "fixed" by reloading. That is exactly the "some models degenerate probabilistically on load" report.

A sweep of `Load.swift`, the factories, `JangLoader`, and every model `sanitize()`/config-decode path (two independent passes) found more instances. This PR makes them all deterministic.

### Fixed — routed-expert quant bit-width probes
A family of JANGTQ configs resolve the routed-expert bit width as `dict["routed_expert"] ?? dict.values.first` over a JSON-decoded `[String: Int]` role→bits map. When the named key is absent and the map is multi-valued (`{"attention": 8, "down_proj": 2, …}`), `.values.first` is per-process-random. That width drives MoE expert dequant, so a wrong pick corrupts the whole mixture on a fraction of loads:

- `LLMModelFactory.swift` (Zaya routed-bit probe)
- `Zaya.swift` (`RoutedExpertBitMetadata`)
- `BailingHybrid.swift` (`mxtqBits`)
- `Qwen35JANGTQ.swift` (`mxtqBits`)
- `MiMoV2Flash.swift` (nested projections map)

**Fix:** prefer named aliases, then a deterministic reduction — the **minimum** declared width (routed experts are JANG's most aggressively quantized tier); the nested-map case picks the smallest-bit role, tie-broken by key. No behavior change when `routed_expert` is present.

### Fixed — shard-set selection (`Load.swift`)
With two *complete* shard sets in one directory, `totalsSeen.first(where: { $0.key == $0.value })` over a `[Int: Int]` dict picked a random one — and the comment literally said "pick the LARGEST." Now `.filter { … }.keys.max()`: deterministic **and** matches the stated intent.

### Fixed — shared-default quant tie (`JangLoader`)
`counts.values.max(by: { $0.count < $1.count })` was order-dependent on a frequency **tie** between two distinct `(bits, gs)` pairs. Now total-ordered (count, then higher bits, then larger group size) — deterministic, biased toward higher precision on ties.

### Verified NOT affected (checked, left as-is)
- **JANG quant shape-walk** (`inferBitWidthAndGroupSize`, `inferFromUniqueValidInDim`): fixed `preferred` candidate arrays + `.sorted()` candidates + collect-then-require-`Set(...).count == 1`. Deterministic. *(This clears the bulk of the JANG fleet.)*
- **`mtpNormWeightsNeedShift`** (qwen3.5 LLM+VLM): looks like the old first-match probe, but its suffixes pin to **unique** keys and the outer loop is a fixed array → deterministic. It is a *single-sample* decision (could misjudge a bundle whose one probe norm is legitimately > 0.5); harmless w.r.t. this class, but ideally it should route through the same `NormConventionResolver` vote for robustness — noted as a follow-up.
- Architecture/format dispatch, per-layer quant config decode, expert-stacking/key-rename loops, conv1d checks: all transform-every-entry or unique-match. Deterministic.

### Separately noted (silent, not per-process-random) — NOT changed here
`Load.swift` applies weights with `model.update(parameters:, verify: [.noUnusedKeys])` but **not** `.allModelKeysSet`, so a model parameter that never appears in the supplied weights is silently left at random init rather than raising. That is a *silent* degeneration risk, not a reload-flip; flipping the flag naively breaks MXFP4/MXFP8 optional `.biases`. The principled fix (`[.noUnusedKeys, .allModelKeysSet]` + per-model missing-key allowances) is deferred to its own change so it can be validated per-model.

Builds clean. All changes are behavior-preserving when the named key / strict winner is present; they only make the ambiguous fallback deterministic.
