### PR TITLE
Stop strings: discard post-stop buffers at end-of-stream instead of leaking them

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -733,6 +733,14 @@ public actor BatchEngine {
             }
 
             func flush() {
+                // A matched stop string is the semantic end of the
+                // response: everything still held in the detokenizer /
+                // reasoning / tool buffers is chronologically AFTER the
+                // match (a few tokens decode before the halt lands) and
+                // must be discarded, not flushed — the matcher's buffer
+                // was cleared at match time, so re-feeding would leak
+                // post-stop text past the truncation point.
+                if stopMatched { return }
                 if let text = detokenizer.flush() {
                     pump(text)
                 }
@@ -759,11 +767,17 @@ public actor BatchEngine {
                     }
                     reasoningParser = parser
                 }
+                // Route the tool processor's end-of-stream remainder
+                // through the stop matcher (via emitRouted), not around
+                // it: a stop-string occurrence held in the tool buffer at
+                // EOS must still truncate, and feeding it keeps the
+                // matcher's tail ordered AFTER this text so the drain
+                // below cannot reorder characters.
                 for event in flushGenerationText(
                     channel: reasoningParser?.isInsideReasoning == true ? .reasoning : .content,
                     through: toolCallProcessor
                 ) {
-                    continuation.yield(event)
+                    emitRouted(event)
                 }
 
                 // Drain the stop-string matcher's held tail — no more

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -3790,7 +3790,9 @@ extension TokenLoopHandler {
     var emittedToolCall: Bool { false }
 }
 
-private struct TextToolTokenLoopHandler: TokenLoopHandler, @unchecked Sendable {
+// Internal (not private) so the stop-string truncation contract is unit-testable
+// (Tests/MLXLMTests/StopStringPostStopLeakTests.swift drives the handler directly).
+struct TextToolTokenLoopHandler: TokenLoopHandler, @unchecked Sendable {
     typealias Output = Generation
 
     var detokenizer: NaiveStreamingDetokenizer
@@ -3919,6 +3921,19 @@ private struct TextToolTokenLoopHandler: TokenLoopHandler, @unchecked Sendable {
     mutating func onGenerationEnd(
         emit: (sending Generation) -> AsyncStream<Generation>.Continuation.YieldResult
     ) {
+        // A matched stop string is the semantic end of the response.
+        // Everything still held downstream of it — the detokenizer's
+        // undecoded tail, reasoning/tool buffers, and any text queued
+        // behind them — is chronologically AFTER the match (the engine
+        // decodes a few more tokens before the halt lands) and must be
+        // discarded, not flushed. Flushing it re-feeds post-stop text
+        // through a matcher whose buffer was cleared at match time, so
+        // it leaks mangled text after the truncation point (e.g.
+        // stop=["three"] on "one, two, three, four, five" emitted
+        // "one, two, our, fi").
+        if stopSequenceHit {
+            return
+        }
         if let chunk = detokenizer.flush(), !dispatch(chunk, emit: emit) {
             return
         }
@@ -3958,11 +3973,16 @@ private struct TextToolTokenLoopHandler: TokenLoopHandler, @unchecked Sendable {
             reasoningParser = parser
         }
 
+        // Route the tool processor's end-of-stream remainder through the
+        // stop matcher (via emitRouted), not around it: a stop-string
+        // occurrence held in the tool buffer at EOS must still truncate,
+        // and feeding it keeps the matcher's tail ordered AFTER this
+        // text so the final drain below cannot reorder characters.
         for event in flushGenerationText(
             channel: reasoningParser?.isInsideReasoning == true ? .reasoning : .content,
             through: toolCallProcessor
         ) {
-            if case .terminated = emit(event) {
+            if !emitRouted(event, emit: emit) {
                 return
             }
         }

--- a/Tests/MLXLMTests/StopStringPostStopLeakTests.swift
+++ b/Tests/MLXLMTests/StopStringPostStopLeakTests.swift
@@ -1,0 +1,132 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+/// Regression tests for the post-stop-string leak: after a stop string
+/// matched mid-stream, `TextToolTokenLoopHandler.onGenerationEnd` used to
+/// flush the detokenizer's ~24-char held-back tail — text chronologically
+/// AFTER the match — back through a stop matcher whose buffer had been
+/// cleared at match time, appending mangled post-stop text to the response.
+///
+/// Live repro (osaurus solo path, Mistral-Small, temperature 0):
+///   stop=["five"]  → "one, two, three, four,  six, "   (post-stop " six, " leaked)
+///   stop=["three"] → "one,two,our,fi"                  (post-stop tail leaked mangled)
+struct StopStringPostStopLeakTests {
+
+    /// Deterministic tokenizer: each token id maps to a fixed text piece;
+    /// decode is a plain concatenation. This makes the
+    /// `NaiveStreamingDetokenizer` 24-char hold-back window (the leak's
+    /// raw material) fully predictable.
+    struct FixedPieceTokenizer: MLXLMCommon.Tokenizer {
+        let pieces: [String]
+
+        var vocabularySize: Int { pieces.count }
+
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
+
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+            tokenIds.map { pieces.indices.contains($0) ? pieces[$0] : "" }.joined()
+        }
+
+        func convertTokenToId(_ token: String) -> Int? { pieces.firstIndex(of: token) }
+        func convertIdToToken(_ id: Int) -> String? {
+            pieces.indices.contains(id) ? pieces[id] : nil
+        }
+
+        var bosToken: String? = nil
+        var eosToken: String? = nil
+        var eosTokenId: Int? { nil }
+        var unknownToken: String? = nil
+        var unknownTokenId: Int? { nil }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] { [] }
+    }
+
+    /// "one, " ... "ten." as token ids 0...9.
+    static let countingPieces = [
+        "one, ", "two, ", "three, ", "four, ", "five, ",
+        "six, ", "seven, ", "eight, ", "nine, ", "ten.",
+    ]
+
+    /// Drive the handler exactly like `generateLoopTask` does: feed tokens
+    /// through `onToken` until it returns false (stop hit / terminated),
+    /// then call `onGenerationEnd`. Returns the visible content collected
+    /// (a) after the token loop and (b) after the end-of-stream flush.
+    private func run(
+        stopStrings: [String],
+        tokens: [Int]
+    ) -> (afterLoop: String, afterFlush: String, stopHit: Bool) {
+        var handler = TextToolTokenLoopHandler(
+            tokenizer: FixedPieceTokenizer(pieces: Self.countingPieces),
+            format: .json,
+            tools: nil,
+            reasoningParser: nil,
+            stopStringMatcher: StopStringMatcher(stopStrings: stopStrings)
+        )
+        var collected = ""
+        let emit: (sending Generation) -> AsyncStream<Generation>.Continuation.YieldResult = {
+            event in
+            if case .chunk(let text) = event {
+                collected += text
+            }
+            return .enqueued(remaining: .max)
+        }
+        for token in tokens {
+            if !handler.onToken(token, emit: emit) {
+                break
+            }
+        }
+        let afterLoop = collected
+        handler.onGenerationEnd(emit: emit)
+        return (afterLoop, collected, handler.stopSequenceHit)
+    }
+
+    @Test("Stop match mid-stream truncates exactly; end-of-stream flush leaks nothing")
+    func postStopTailDoesNotLeak() {
+        let result = run(stopStrings: ["three"], tokens: Array(0 ..< 10))
+        #expect(result.stopHit)
+        // Everything before the match, nothing after it.
+        #expect(result.afterLoop == "one, two, ")
+        // onGenerationEnd must not append the detokenizer's held tail
+        // (post-stop text) after the truncation point.
+        #expect(result.afterFlush == "one, two, ")
+    }
+
+    @Test("Stop string 'five' — the live osaurus repro shape")
+    func liveReproShape() {
+        let result = run(stopStrings: ["five"], tokens: Array(0 ..< 10))
+        #expect(result.stopHit)
+        #expect(result.afterFlush == "one, two, three, four, ")
+    }
+
+    @Test("No stop configured: flush emits the full text (no over-suppression)")
+    func noStopEmitsEverything() {
+        let result = run(stopStrings: [], tokens: Array(0 ..< 10))
+        #expect(!result.stopHit)
+        #expect(result.afterFlush == Self.countingPieces.joined())
+    }
+
+    @Test("Unmatched stop: flush emits the full text and matcher tail in order")
+    func unmatchedStopEmitsEverythingInOrder() {
+        let result = run(stopStrings: ["XYZZY"], tokens: Array(0 ..< 10))
+        #expect(!result.stopHit)
+        #expect(result.afterFlush == Self.countingPieces.joined())
+    }
+
+    @Test("Stop string arriving only in the end-of-stream flush still truncates")
+    func stopInFlushTailStillTruncates() {
+        // "ten." sits inside the detokenizer's 24-char hold-back window at
+        // end of stream, so the matcher first sees it during
+        // onGenerationEnd's detokenizer flush — which must still truncate.
+        let result = run(stopStrings: ["ten."], tokens: Array(0 ..< 10))
+        #expect(result.afterFlush == Self.countingPieces.dropLast().joined())
+    }
+}


### PR DESCRIPTION
## Bug: text after a matched stop string leaks into the response

A matched stop string truncates the response, but the engine decodes a few more tokens before the halt lands, and `NaiveStreamingDetokenizer` holds back ~24 trailing characters. At end-of-stream the solo-path handler (`TextToolTokenLoopHandler.onGenerationEnd`) flushed that held tail — text chronologically **after** the stop match — back through a `StopStringMatcher` whose buffer was cleared at match time, so post-stop text leaked into the response past the truncation point.

**Live repro** (osaurus solo path — the default `maxBatchSize == 1` route — Mistral-Small 3.1 24B, `temperature: 0`, prompt "Count from one to ten as words"):

| request | expected | actual (before this fix) |
|---|---|---|
| `stop: ["five"]` | `one, two, three, four, ` | `one, two, three, four,  six, ` |
| `stop: ["three"]` | `one, two, ` | `one,two,our,fi` |

Identical behavior streaming and non-streaming (deltas showed the excised stop and the leaked tail: `['one,', ' ', 'two, three, four, ', ' six, ']`). Model-family timing dependent — qwen3-4b happened to truncate cleanly because its detokenizer tail was empty at match time; Mistral's was not.

## Fixes (mirrored across both pipelines)

- **`Evaluate.swift` `onGenerationEnd`**: early-return when `stopSequenceHit` — everything still held downstream of the match (detokenizer tail, reasoning/tool buffers) is post-stop text and must be discarded. BatchEngine's batched `pump()` already had this gate; the solo handler did not.
- **`BatchEngine.swift` batched `flush()`**: same gate (`flushGenerationText` and the reasoning-parser drain were previously emitted even after a stop).
- **Both paths**: route the tool processor's end-of-stream remainder through the stop matcher instead of around it, so a stop occurrence held in the tool buffer at EOS still truncates, and the matcher-tail drain can no longer reorder characters (older held text emitted after newer flush text).

`TextToolTokenLoopHandler` becomes `internal` (was `private`) so the truncation contract is unit-testable.

## Tests

New `StopStringPostStopLeakTests` drive the handler with a deterministic fixed-piece tokenizer:
- mid-stream match truncates exactly and end-of-stream flush leaks nothing (both the `three` and the live-repro `five` shapes)
- no-stop and unmatched-stop cases still emit the full text (no over-suppression)
- a stop string arriving only in the final detokenizer flush still truncates

`StopStringMatcherTests` and the tool-call/EOS suites pass unchanged. (`ToolCallEdgeCasesTests` "LFM2 processor accepts observed OpenAI tool_call JSON envelope" fails identically on clean main — pre-existing, unrelated: a leading `"\n"` before a bare-JSON envelope is emitted as visible text.)
