### PR TITLE
Mistral: recover tool calls emitted as a bare JSON array (VL-history turns)

### DIFF
--- a/Libraries/MLXLMCommon/Tool/Parsers/MistralToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/MistralToolCallParser.swift
@@ -27,6 +27,12 @@ public struct MistralToolCallParser: ToolCallParser, Sendable {
     public let startTag: String? = "[TOOL_CALLS]"
     public let endTag: String? = nil
 
+    /// V7/V11 checkpoints drop the `[TOOL_CALLS]` token on tool turns whose
+    /// history contains images, emitting the call array as plain text
+    /// (`[{"name": "get_weather", "arguments": {...}}]`). Let the processor
+    /// buffer that exact shape for registered tools.
+    public let supportsBareJSONArrayToolFallback = true
+
     public init() {}
 
     public func parse(content: String, tools: [[String: any Sendable]]?) -> ToolCall? {

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -67,6 +67,15 @@ public protocol ToolCallParser: Sendable {
     /// `call:name{...}` body as a possible tool call. Gemma4 can emit this
     /// body without its `<|tool_call>` wrapper on required-tool turns.
     var supportsBareCallToolFallback: Bool { get }
+
+    /// Whether a tagged parser should also buffer a bare
+    /// `[{"name": "...", "arguments": {...}}]` JSON array as a possible tool
+    /// call. Mistral V7/V11 drops the leading `[TOOL_CALLS]` token on tool
+    /// turns whose history contains images, emitting the call array as plain
+    /// text. The processor only engages while the bytes remain consistent
+    /// with that exact shape for a registered tool name, so ordinary prose
+    /// and JSON answers stay visible.
+    var supportsBareJSONArrayToolFallback: Bool { get }
 }
 
 extension ToolCallParser {
@@ -89,6 +98,8 @@ extension ToolCallParser {
     public var supportsInlineJSONToolFallback: Bool { false }
 
     public var supportsBareCallToolFallback: Bool { false }
+
+    public var supportsBareJSONArrayToolFallback: Bool { false }
 
     public func parseEOS(_ toolCallBuffer: String, tools: [[String: any Sendable]]?) -> [ToolCall] {
         if let startTag {

--- a/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
@@ -107,6 +107,7 @@ public class ToolCallProcessor {
         case embeddedAPIToolJSON
         case bareNameJSON
         case bareNameKeyValue
+        case bareJSONArray
     }
 
     private enum BareNameKeyValueTailState {
@@ -432,6 +433,34 @@ public class ToolCallProcessor {
         case .potentialToolCall, .collectingToolCall, .collectingInlineToolCall:
             toolCallBuffer += chunk
 
+            if state == .collectingInlineToolCall, inlineToolCallKind == .bareJSONArray {
+                switch bareJSONArrayToolCallMatch(toolCallBuffer) {
+                case .noMatch:
+                    // The bytes stopped looking like a tool-call array
+                    // (e.g. a JSON example whose "name" is not a registered
+                    // tool). Flush the held text verbatim.
+                    state = .normal
+                    let buffer = toolCallBuffer
+                    toolCallBuffer = ""
+                    inlineToolCallKind = .json
+                    return buffer
+                case .match where bareJSONArrayCallBalanced(toolCallBuffer):
+                    // Route through parseEOS: the array may carry multiple
+                    // calls, and parse(content:) only returns the first.
+                    let parsed = parser.parseEOS(toolCallBuffer, tools: tools)
+                    state = .normal
+                    let buffer = toolCallBuffer
+                    toolCallBuffer = ""
+                    inlineToolCallKind = .json
+                    guard !parsed.isEmpty else { return buffer }
+                    recordToolCalls(parsed)
+                    suppressingTextAfterInlineToolCall = true
+                    return nil
+                case .possible, .match:
+                    return nil
+                }
+            }
+
             if shouldAttemptInlineToolParse(toolCallBuffer),
                 let toolCall = parser.parse(content: toolCallBuffer, tools: tools)
             {
@@ -492,12 +521,15 @@ public class ToolCallProcessor {
             return bareNameJSONCallBalanced(text)
         case .bareNameKeyValue:
             return bareNameKeyValueCallComplete(text)
+        case .bareJSONArray:
+            return bareJSONArrayCallBalanced(text)
         }
     }
 
     private func shouldAttemptInlineToolParse(_ text: String) -> Bool {
         switch inlineToolCallKind {
-        case .actionJSON, .requestToolXML, .embeddedAPIToolJSON, .bareNameKeyValue:
+        case .actionJSON, .requestToolXML, .embeddedAPIToolJSON, .bareNameKeyValue,
+            .bareJSONArray:
             return inlineToolCallComplete(text)
         case .json, .functionCall, .bareCall, .bareNameJSON:
             return true
@@ -507,6 +539,98 @@ public class ToolCallProcessor {
     private func bareCallBracesBalanced(_ text: String) -> Bool {
         guard let open = text.firstIndex(of: "{") else { return false }
         return jsonBracesBalanced(String(text[open...]))
+    }
+
+    private enum BareJSONArrayMatch {
+        case noMatch
+        case possible
+        case match
+    }
+
+    /// Match `text` against the opening shape of a bare tool-call JSON array:
+    /// `[` `{` `"name"` `:` `"<registered tool>"`, whitespace-tolerant between
+    /// tokens. `.possible` means every byte so far is consistent with that
+    /// shape but the tool name has not closed yet; `.match` means a registered
+    /// tool name closed its quote (the rest of the array is governed by the
+    /// balance check). Requires request tool schemas — with no registered
+    /// names there is nothing safe to match against.
+    private func bareJSONArrayToolCallMatch(_ text: String) -> BareJSONArrayMatch {
+        let toolNames = registeredToolNames()
+        guard !toolNames.isEmpty else { return .noMatch }
+
+        var cursor = text.startIndex
+        func skipWhitespace() {
+            while cursor < text.endIndex, isInlineWhitespace(text[cursor]) {
+                cursor = text.index(after: cursor)
+            }
+        }
+        // Consume `literal`; `.possible` if text ended inside it, `.noMatch`
+        // on a mismatch, nil when fully consumed.
+        func expect(_ literal: String) -> BareJSONArrayMatch? {
+            for ch in literal {
+                guard cursor < text.endIndex else { return .possible }
+                guard text[cursor] == ch else { return .noMatch }
+                cursor = text.index(after: cursor)
+            }
+            return nil
+        }
+
+        if let early = expect("[") { return early }
+        skipWhitespace()
+        if let early = expect("{") { return early }
+        skipWhitespace()
+        if let early = expect("\"name\"") { return early }
+        skipWhitespace()
+        if let early = expect(":") { return early }
+        skipWhitespace()
+        if let early = expect("\"") { return early }
+
+        var name = ""
+        while cursor < text.endIndex {
+            let ch = text[cursor]
+            if ch == "\"" {
+                return toolNames.contains(name) ? .match : .noMatch
+            }
+            name.append(ch)
+            cursor = text.index(after: cursor)
+        }
+        return toolNames.contains(where: { $0.hasPrefix(name) }) ? .possible : .noMatch
+    }
+
+    /// Whether a bare tool-call JSON array has closed its top-level `[`.
+    /// String-aware so bracket characters inside argument values don't
+    /// terminate the scan early.
+    private func bareJSONArrayCallBalanced(_ text: String) -> Bool {
+        var depth = 0
+        var inString = false
+        var escaped = false
+        for ch in text {
+            if escaped {
+                escaped = false
+                continue
+            }
+            if ch == "\\" {
+                escaped = inString
+                continue
+            }
+            if inString {
+                if ch == "\"" { inString = false }
+                continue
+            }
+            switch ch {
+            case "\"":
+                inString = true
+            case "[", "{":
+                depth += 1
+            case "]", "}":
+                depth -= 1
+                if depth == 0 { return true }
+                if depth < 0 { return false }
+            default:
+                break
+            }
+        }
+        return false
     }
 
     private func bareNameJSONCallBalanced(_ text: String) -> Bool {
@@ -1417,6 +1541,12 @@ public class ToolCallProcessor {
             }
         }
 
+        if allowInlineFallback && parser.supportsBareJSONArrayToolFallback,
+            state == .collectingInlineToolCall, inlineToolCallKind == .bareJSONArray
+        {
+            return processInlineChunk(chunk)
+        }
+
         if allowInlineFallback && parser.supportsInlineJSONToolFallback && !hasTaggedStartCandidate {
             switch state {
             case .collectingInlineToolCall:
@@ -1524,6 +1654,25 @@ public class ToolCallProcessor {
                     return nil
                 }
             } else {
+                // A failed `[`-tag candidate may still be a bare tool-call
+                // JSON array: Mistral drops the leading [TOOL_CALLS] token on
+                // tool turns whose history contains images, emitting
+                // `[{"name": "...", "arguments": {...}}]` as plain text. Only
+                // engage while the bytes remain consistent with that shape
+                // for a registered tool; anything else flushes verbatim.
+                if allowInlineFallback, parser.supportsBareJSONArrayToolFallback,
+                    bareJSONArrayToolCallMatch(toolCallBuffer) != .noMatch
+                {
+                    state = .collectingInlineToolCall
+                    inlineToolCallKind = .bareJSONArray
+                    let visible = leadingTextBeforeToolCall
+                    leadingTextBeforeToolCall = ""
+                    // The array may already be complete within this chunk;
+                    // an empty append re-evaluates the buffer.
+                    let inline = processInlineChunk("") ?? ""
+                    let combined = visible + inline
+                    return combined.isEmpty ? nil : combined
+                }
                 // Otherwise, return the collected text and reset the state
                 state = .normal
                 let buffer = toolCallBuffer

--- a/Tests/MLXLMTests/MistralBareJSONArrayFallbackTests.swift
+++ b/Tests/MLXLMTests/MistralBareJSONArrayFallbackTests.swift
@@ -1,0 +1,196 @@
+// Copyright © 2025 Apple Inc.
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+/// Mistral V7/V11 drops the leading `[TOOL_CALLS]` token on tool turns whose
+/// history contains images, emitting the call array as plain text:
+/// `[{"name": "get_weather", "arguments": {"city": "Tokyo", "unit": "celsius"}}]`
+/// (live repro: mistral-small-3.1-24b, deterministic at temperature 0).
+/// These tests cover the bare-JSON-array fallback that routes that shape back
+/// into tool calls, and the guards that keep ordinary text byte-exact.
+struct MistralBareJSONArrayFallbackTests {
+
+    private let weatherTools: [[String: any Sendable]] = [
+        [
+            "type": "function",
+            "function": ["name": "get_weather"] as [String: any Sendable],
+        ]
+    ]
+
+    /// Drive the processor with chunks and return the visible text.
+    private func drive(
+        _ processor: ToolCallProcessor, chunks: [String]
+    ) -> String {
+        var visible = ""
+        for chunk in chunks {
+            if let text = processor.processChunk(chunk) {
+                visible += text
+            }
+        }
+        if let tail = processor.processEOS() {
+            visible += tail
+        }
+        return visible
+    }
+
+    @Test("bare tool-call array streamed in small chunks parses, no visible text")
+    func bareArraySmallChunks() throws {
+        let processor = ToolCallProcessor(format: .mistral, tools: weatherTools)
+        let visible = drive(
+            processor,
+            chunks: [
+                "[", "{\"", "name", "\": \"get_", "weather\", ",
+                "\"arguments\": {\"city\": \"Tokyo\", ", "\"unit\": \"celsius\"}}", "]",
+            ])
+
+        #expect(visible == "")
+        #expect(processor.toolCalls.count == 1)
+        let call = try #require(processor.toolCalls.first)
+        #expect(call.function.name == "get_weather")
+        #expect(call.function.arguments["city"] == .string("Tokyo"))
+        #expect(call.function.arguments["unit"] == .string("celsius"))
+    }
+
+    @Test("bare tool-call array in a single chunk parses")
+    func bareArraySingleChunk() throws {
+        let processor = ToolCallProcessor(format: .mistral, tools: weatherTools)
+        let visible = drive(
+            processor,
+            chunks: [
+                #"[{"name": "get_weather", "arguments": {"city": "Tokyo", "unit": "celsius"}}]"#
+            ])
+
+        #expect(visible == "")
+        #expect(processor.toolCalls.count == 1)
+        #expect(processor.toolCalls.first?.function.name == "get_weather")
+    }
+
+    @Test("leading prose before the bare array stays visible")
+    func leadingProseStaysVisible() throws {
+        let processor = ToolCallProcessor(format: .mistral, tools: weatherTools)
+        let visible = drive(
+            processor,
+            chunks: [
+                "I'll check that for you. ",
+                #"[{"name": "get_weather", "arguments": {"city": "Tokyo"}}]"#,
+            ])
+
+        #expect(visible == "I'll check that for you. ")
+        #expect(processor.toolCalls.count == 1)
+        #expect(processor.toolCalls.first?.function.name == "get_weather")
+    }
+
+    @Test("multi-call bare array records every call")
+    func multiCallArray() throws {
+        let processor = ToolCallProcessor(format: .mistral, tools: weatherTools)
+        let visible = drive(
+            processor,
+            chunks: [
+                #"[{"name": "get_weather", "arguments": {"city": "Tokyo"}}, "#,
+                #"{"name": "get_weather", "arguments": {"city": "Paris"}}]"#,
+            ])
+
+        #expect(visible == "")
+        #expect(processor.toolCalls.count == 2)
+        #expect(processor.toolCalls[0].function.arguments["city"] == .string("Tokyo"))
+        #expect(processor.toolCalls[1].function.arguments["city"] == .string("Paris"))
+    }
+
+    @Test("JSON example with a non-registered name passes through byte-exact")
+    func nonToolJSONPassesThrough() {
+        let processor = ToolCallProcessor(format: .mistral, tools: weatherTools)
+        let text = #"Here is an example: [{"name": "John", "age": 30}] as requested."#
+        let visible = drive(processor, chunks: [text])
+
+        #expect(visible == text)
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    @Test("registered-name prefix that keeps going passes through byte-exact")
+    func unknownNameWithRegisteredPrefixPassesThrough() {
+        let processor = ToolCallProcessor(format: .mistral, tools: weatherTools)
+        let text = #"[{"name": "get_weather_hourly", "arguments": {}}]"#
+        let visible = drive(processor, chunks: [text])
+
+        #expect(visible == text)
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    @Test("markdown links and bracketed prose stay byte-exact")
+    func markdownStaysVisible() {
+        let processor = ToolCallProcessor(format: .mistral, tools: weatherTools)
+        let text = "See [the docs](https://example.com) for details. [Note] Also [1] and [2]."
+        let visible = drive(processor, chunks: [text])
+
+        #expect(visible == text)
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    @Test("without registered tools the array passes through verbatim")
+    func noToolsPassesThrough() {
+        let processor = ToolCallProcessor(format: .mistral, tools: nil)
+        let text = #"[{"name": "get_weather", "arguments": {"city": "Tokyo"}}]"#
+        let visible = drive(processor, chunks: [text])
+
+        #expect(visible == text)
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    @Test("tagged [TOOL_CALLS] path still parses (regression)")
+    func taggedPathUnchanged() throws {
+        let processor = ToolCallProcessor(format: .mistral, tools: weatherTools)
+        let visible = drive(
+            processor,
+            chunks: [
+                "[TOOL", "_CALLS]",
+                #"[{"name": "get_weather", "arguments": {"city": "Berlin"}}]"#,
+            ])
+
+        #expect(visible == "")
+        #expect(processor.toolCalls.count == 1)
+        #expect(processor.toolCalls.first?.function.arguments["city"] == .string("Berlin"))
+    }
+
+    @Test("bracket characters inside argument strings do not end the array early")
+    func bracketsInsideStrings() throws {
+        let processor = ToolCallProcessor(format: .mistral, tools: weatherTools)
+        let visible = drive(
+            processor,
+            chunks: [
+                #"[{"name": "get_weather", "arguments": {"city": "Tokyo ]{[ \" oddity"}}]"#
+            ])
+
+        #expect(visible == "")
+        #expect(processor.toolCalls.count == 1)
+        #expect(
+            processor.toolCalls.first?.function.arguments["city"]
+                == .string(#"Tokyo ]{[ " oddity"#))
+    }
+
+    @Test("EOS while the array is incomplete flushes the held text verbatim")
+    func eosMidArrayFlushes() {
+        let processor = ToolCallProcessor(format: .mistral, tools: weatherTools)
+        let text = #"[{"name": "get_weather", "arguments": {"city":"#
+        let visible = drive(processor, chunks: [text])
+
+        #expect(visible == text)
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    @Test("whitespace between shape tokens is tolerated")
+    func whitespaceTolerated() throws {
+        let processor = ToolCallProcessor(format: .mistral, tools: weatherTools)
+        let visible = drive(
+            processor,
+            chunks: [
+                "[ \n  { \"name\" : \"get_weather\", \"arguments\": {\"city\": \"Oslo\"} } ]"
+            ])
+
+        #expect(visible == "")
+        #expect(processor.toolCalls.count == 1)
+        #expect(processor.toolCalls.first?.function.arguments["city"] == .string("Oslo"))
+    }
+}


### PR DESCRIPTION
## Problem

Mistral V7/V11 checkpoints drop the leading `[TOOL_CALLS]` token on tool turns whose conversation history contains images, emitting the call as plain assistant text. This is **deterministic at temperature 0** on `mistral-small-3.1-24b-instruct-2503-4bit` (3/3 live runs against osaurus):

```
finish_reason=stop
content: '[{"name": "get_weather", "arguments": {"city": "Tokyo", "unit": "celsius"}}]'
```

The no-VL control on the same build parses correctly (`finish_reason=tool_calls`), so the model's tool competence is intact — only the envelope changes with images in history.

## Root cause

The streamed bytes start with `[`, so the processor buffers them as a *potential* `[TOOL_CALLS]` tag. The prefix match fails at the second character (`{` vs `T`) and the whole buffer flushes to visible text. `MistralToolCallParser.parse()`/`parseEOS()` already handle the bare array body — the stream router just never hands it over.

## Fix

New per-parser capability `supportsBareJSONArrayToolFallback` (default **false**; enabled only by `MistralToolCallParser`). When a failed `[`-tag candidate is still byte-consistent with the exact shape

```
[ { "name" : "<registered tool>"
```

the processor buffers it as an inline tool-call array, completes on string-aware bracket balance, and routes the body through `parseEOS` (multi-call arrays keep every call). Any deviation flushes the held bytes verbatim:

- markdown links / bracketed prose (`[Note]`, `[1]`) — byte-exact pass-through
- JSON examples whose `name` is not a registered tool (`[{"name": "John", ...}]`)
- registered-name *prefixes* that keep going (`get_weather_hourly`)
- no tool schemas on the request → fallback never engages
- EOS mid-array → held text flushed verbatim

## Tests

12 new tests in `MistralBareJSONArrayFallbackTests` (streamed small-chunk repro, single-chunk, leading prose, multi-call, whitespace tolerance, brackets inside argument strings, every pass-through guard, tagged-path regression). Full `ToolTests` + Mistral focused contracts + `StopStringPostStopLeakTests` pass; the only failure in the tool suites is the pre-existing LFM2 envelope case already failing on main.