### PR TITLE
Prefill: honor task cancellation between chunks (orphan-producer GPU aborts)

### DIFF
--- a/Libraries/MLXLLM/LLMModel.swift
+++ b/Libraries/MLXLLM/LLMModel.swift
@@ -57,6 +57,16 @@ extension LLMModel {
         // Clear Metal cache between chunks to reduce memory pressure,
         // matching Python mlx-lm behavior. Critical for MoE models.
         while flatTokens.size > prefillStepSize {
+            // Prefill is the only long-running generation phase with no
+            // cancellation points: a client that disconnects mid-prefill
+            // cancels the producer task, but without this check the loop
+            // keeps encoding GPU work for the dead request until the whole
+            // prompt is consumed. A follow-up request racing that orphan
+            // producer on the shared command queue aborts the process
+            // ("A command encoder is already encoding to this command
+            // buffer"). Checking between chunks bounds the orphan window
+            // to a single chunk.
+            try Task.checkCancellation()
             // Build a [1, prefillStepSize] chunk for the model forward pass.
             let chunkTokens = flatTokens[..<prefillStepSize][.newAxis, 0...]
             let chunkMask = flatMask.map { $0[..<prefillStepSize] }

--- a/Libraries/MLXLMCommon/ChunkedPrefillVLM.swift
+++ b/Libraries/MLXLMCommon/ChunkedPrefillVLM.swift
@@ -52,7 +52,7 @@ public func chunkedPrefillEmbedding<Result>(
     cache: [KVCache],
     prefillStepSize: Int,
     step: (MLXArray) -> Result
-) -> Result {
+) throws -> Result {
     let T = inputEmbedding.dim(1)
     guard prefillStepSize > 0, T > prefillStepSize else {
         return step(inputEmbedding)
@@ -60,6 +60,11 @@ public func chunkedPrefillEmbedding<Result>(
 
     var offset = 0
     while offset + prefillStepSize < T {
+        // Bound the orphan-producer window on client disconnect: prefill has
+        // no other cancellation points, and an uncancellable producer racing
+        // a follow-up request's prefill on the shared GPU command queue
+        // aborts the process. See LLMModel.prepare for the full story.
+        try Task.checkCancellation()
         let end = offset + prefillStepSize
         let chunk = inputEmbedding[0..., offset ..< end, 0...]
         _ = step(chunk)

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -3307,6 +3307,21 @@ private func generateLoopTask<Handler: TokenLoopHandler>(
             var iterator: any TokenIteratorProtocol
             do {
                 iterator = try makeIterator.consume()()
+            } catch is CancellationError {
+                // Client disconnected while the prompt was still prefilling —
+                // the chunked prepare loops bail between chunks. Not an error;
+                // finish the stream with a `.cancelled` info like any other
+                // cancellation.
+                handler.onGenerationEnd(emit: continuation.yield)
+                _ = continuation.yield(handler.infoEvent(GenerateCompletionInfo(
+                    promptTokenCount: promptTokenCount,
+                    generationTokenCount: 0,
+                    promptTime: 0,
+                    generationTime: 0,
+                    stopReason: .cancelled
+                )))
+                continuation.finish()
+                return
             } catch {
                 Logger(subsystem: "vmlx", category: "generateLoopTask").error(
                     "Iterator construction failed: \(error.localizedDescription, privacy: .public)")

--- a/Libraries/MLXVLM/Models/Gemma3.swift
+++ b/Libraries/MLXVLM/Models/Gemma3.swift
@@ -1028,7 +1028,7 @@ public class Gemma3: Module, VLMModel, KVCacheDimensionProvider {
         // per-chunk inside the LM, so slicing the embedding along axis 1
         // is safe. Without chunking, multi-image / long-image prompts
         // exceed the Metal single-buffer cap on large MoE models.
-        let result = chunkedPrefillEmbedding(
+        let result = try chunkedPrefillEmbedding(
             inputEmbedding: inputEmbeddings,
             cache: convertedCache,
             prefillStepSize: windowSize ?? 512

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -1308,6 +1308,11 @@ public class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
         if prefillStepSize > 0, tokenCount > prefillStepSize {
             var offset = 0
             while offset + prefillStepSize < tokenCount {
+                // Bound the orphan-producer window on client disconnect —
+                // see LLMModel.prepare. Prefill has no other cancellation
+                // points and an orphan producer racing a follow-up request
+                // on the shared GPU command queue aborts the process.
+                try Task.checkCancellation()
                 let end = offset + prefillStepSize
                 let tokenChunk = llmTokens[0..., offset ..< end]
                 let embeddingChunk = emb[0..., offset ..< end, 0...]

--- a/Libraries/MLXVLM/Models/Mistral3.swift
+++ b/Libraries/MLXVLM/Models/Mistral3.swift
@@ -842,7 +842,7 @@ public class Mistral3VLM: Module, VLMModel, KVCacheDimensionProvider {
         // attention-scale length, which reflects the per-chunk embedding.
         // Without chunking, large-image prompts (100k+ token embeddings)
         // blow past the Metal single-buffer cap on the bigger MoE models.
-        let logits = chunkedPrefillEmbedding(
+        let logits = try chunkedPrefillEmbedding(
             inputEmbedding: embeddings,
             cache: cache,
             prefillStepSize: windowSize ?? 512

--- a/Libraries/MLXVLM/Models/Mistral3VLMJANGTQ.swift
+++ b/Libraries/MLXVLM/Models/Mistral3VLMJANGTQ.swift
@@ -542,7 +542,7 @@ public class Mistral3VLMJANGTQ: Module, VLMModel, KVCacheDimensionProvider {
             imageSizes: imageSizes
         )
 
-        let logits = chunkedPrefillEmbedding(
+        let logits = try chunkedPrefillEmbedding(
             inputEmbedding: embeddings,
             cache: cache,
             prefillStepSize: windowSize ?? 512

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -1953,6 +1953,11 @@ public class Qwen35: Module, VLMModel, HiddenStateCaptureModel, TokenEmbedderMod
         {
             var offset = 0
             while offset + prefillStepSize < promptTokenCount {
+                // Bound the orphan-producer window on client disconnect —
+                // see LLMModel.prepare. Prefill has no other cancellation
+                // points and an orphan producer racing a follow-up request
+                // on the shared GPU command queue aborts the process.
+                try Task.checkCancellation()
                 let end = offset + prefillStepSize
                 _ = languageModel(
                     inputIds[0..., offset ..< end],

--- a/Tests/MLXLMTests/ChunkedPrefillVLMTests.swift
+++ b/Tests/MLXLMTests/ChunkedPrefillVLMTests.swift
@@ -7,11 +7,11 @@ import XCTest
 
 final class ChunkedPrefillVLMTests: XCTestCase {
 
-    func testShortEmbeddingCallsStepOnceWithFullInput() {
+    func testShortEmbeddingCallsStepOnceWithFullInput() throws {
         let embedding = MLXArray.zeros([1, 4, 3])
         var chunkShapes: [[Int]] = []
 
-        let result = chunkedPrefillEmbedding(
+        let result = try chunkedPrefillEmbedding(
             inputEmbedding: embedding,
             cache: [],
             prefillStepSize: 8
@@ -24,11 +24,11 @@ final class ChunkedPrefillVLMTests: XCTestCase {
         XCTAssertEqual(chunkShapes, [[1, 4, 3]])
     }
 
-    func testDisabledChunkingCallsStepOnceWithFullInput() {
+    func testDisabledChunkingCallsStepOnceWithFullInput() throws {
         let embedding = MLXArray.zeros([1, 6, 3])
         var callCount = 0
 
-        let result = chunkedPrefillEmbedding(
+        let result = try chunkedPrefillEmbedding(
             inputEmbedding: embedding,
             cache: [],
             prefillStepSize: 0
@@ -41,11 +41,11 @@ final class ChunkedPrefillVLMTests: XCTestCase {
         XCTAssertEqual(result, [1, 6, 3])
     }
 
-    func testExactChunkBoundaryCallsStepOnceWithFullInput() {
+    func testExactChunkBoundaryCallsStepOnceWithFullInput() throws {
         let embedding = MLXArray.zeros([1, 5, 3])
         var chunkShapes: [[Int]] = []
 
-        let result = chunkedPrefillEmbedding(
+        let result = try chunkedPrefillEmbedding(
             inputEmbedding: embedding,
             cache: [],
             prefillStepSize: 5
@@ -58,11 +58,11 @@ final class ChunkedPrefillVLMTests: XCTestCase {
         XCTAssertEqual(chunkShapes, [[1, 5, 3]])
     }
 
-    func testLongEmbeddingChunksAlongSequenceAxisAndReturnsFinalChunkResult() {
+    func testLongEmbeddingChunksAlongSequenceAxisAndReturnsFinalChunkResult() throws {
         let embedding = MLXArray.zeros([1, 10, 3])
         var chunkShapes: [[Int]] = []
 
-        let result = chunkedPrefillEmbedding(
+        let result = try chunkedPrefillEmbedding(
             inputEmbedding: embedding,
             cache: [KVCacheSimple()],
             prefillStepSize: 4

--- a/Tests/MLXLMTests/LLMPreparePrefillTests.swift
+++ b/Tests/MLXLMTests/LLMPreparePrefillTests.swift
@@ -176,6 +176,96 @@ final class LLMPreparePrefillTests: XCTestCase {
         XCTAssertEqual(r.tokens.ndim, 1)
     }
 
+    // MARK: - Cancellation between chunks
+
+    /// A client that disconnects mid-prefill cancels the producer task; the
+    /// chunk loop must bail at the next chunk boundary instead of encoding
+    /// the rest of the prompt for a dead request (an orphan producer racing
+    /// a follow-up request's prefill on the shared GPU command queue aborts
+    /// the process — osaurus cold-load disconnect crash).
+    func testPrepareThrowsCancellationErrorWhenTaskCancelled() async {
+        let recorder = ProgressRecorder()
+        let totalLen = self.totalLen
+        let step = self.step
+
+        let task = Task { () throws -> Void in
+            // Build the (non-Sendable) model/input inside the task so the
+            // closure sends nothing across the boundary.
+            let model = makeTinyPrefillLlama()
+            let cache = model.newCache(parameters: nil)
+            let tokens = MLXArray((0..<totalLen).map { Int32($0 % 64) })[.newAxis, 0...]
+            let input = LMInput(text: .init(tokens: tokens))
+            // Deterministic: set the cancellation flag before prepare runs so
+            // the first chunk-boundary check observes it.
+            withUnsafeCurrentTask { $0?.cancel() }
+            _ = try PrefillProgressReporter.withHandler({ recorder.append($0) }) {
+                try model.prepare(input, cache: cache, windowSize: step)
+            }
+        }
+
+        do {
+            try await task.value
+            XCTFail("prepare must throw CancellationError when the task is cancelled")
+        } catch is CancellationError {
+            // Expected — and no chunk may have completed.
+            XCTAssertEqual(
+                recorder.snapshot(), [],
+                "cancelled prepare must not encode any prompt chunks")
+        } catch {
+            XCTFail("expected CancellationError, got \(error)")
+        }
+    }
+
+    /// Uncancelled tasks are unaffected: the loop still consumes the whole
+    /// prompt and returns the remainder (guards against an over-eager check).
+    func testPrepareInsideLiveTaskStillCompletes() async throws {
+        let totalLen = self.totalLen
+        let step = self.step
+
+        let task = Task { () throws -> Int in
+            let model = makeTinyPrefillLlama()
+            let cache = model.newCache(parameters: nil)
+            let tokens = MLXArray((0..<totalLen).map { Int32($0 % 64) })[.newAxis, 0...]
+            let input = LMInput(text: .init(tokens: tokens))
+            let result = try model.prepare(input, cache: cache, windowSize: step)
+            guard case .tokens(let r) = result else { return -1 }
+            return r.tokens.size
+        }
+        let remainderSize = try await task.value
+        XCTAssertEqual(remainderSize, totalLen - 2 * step)
+    }
+
+    /// The VLM chunked-embedding helper shares the same contract.
+    func testChunkedPrefillEmbeddingThrowsCancellationErrorWhenTaskCancelled() async {
+        let stepCalls = ProgressRecorder()
+        let totalLen = self.totalLen
+        let step = self.step
+
+        let task = Task { () throws -> Void in
+            let embedding = MLXArray.zeros([1, totalLen, 8])
+            withUnsafeCurrentTask { $0?.cancel() }
+            _ = try chunkedPrefillEmbedding(
+                inputEmbedding: embedding,
+                cache: [],
+                prefillStepSize: step
+            ) { chunk in
+                stepCalls.append(chunk.dim(1))
+                return chunk
+            }
+        }
+
+        do {
+            try await task.value
+            XCTFail("chunkedPrefillEmbedding must throw when the task is cancelled")
+        } catch is CancellationError {
+            XCTAssertEqual(
+                stepCalls.snapshot(), [],
+                "cancelled chunked prefill must not invoke the model step")
+        } catch {
+            XCTFail("expected CancellationError, got \(error)")
+        }
+    }
+
     // MARK: - Mask rank follows tokens rank
 
     func testMaskFlattenedAlongsideTokens() throws {
@@ -196,4 +286,17 @@ final class LLMPreparePrefillTests: XCTestCase {
             XCTAssertEqual(remainderMask.size, totalLen - 2 * step)
         }
     }
+}
+
+/// Free-function twin of `LLMPreparePrefillTests.makeModel` for use inside
+/// `Task` closures, where capturing the (non-Sendable) test instance would
+/// trip strict-concurrency sending checks.
+private func makeTinyPrefillLlama(vocab: Int = 64) -> LlamaModel {
+    let config = LlamaConfiguration(
+        hiddenSize: 32, hiddenLayers: 2, intermediateSize: 64,
+        attentionHeads: 4, rmsNormEps: 1e-5,
+        vocabularySize: vocab, kvHeads: 4)
+    let model = LlamaModel(config)
+    MLX.eval(model)
+    return model
 }


### PR DESCRIPTION
## Problem

Prefill is the only long-running generation phase with **no cancellation points**: `generateLoopTask` checks `Task.isCancelled` between decode tokens, but a cancelled producer inside `TokenIterator.prepare` keeps encoding GPU work until the entire prompt is consumed.

A client that disconnects mid-prefill cancels the producer task (vmlx wires `continuation.onTermination → generationTask.cancel()`), yet the orphan producer stays on the shared Metal command queue for seconds. If the serving layer reacts to the hangup by dropping its engine handle and the follow-up request starts a fresh prefill, the two producers collide:

```
AGX...CommandBuffer tryCoalescingPreviousComputeCommandEncoderWithConfig:
failed assertion 'A command encoder is already encoding to this command buffer'
```

100%-reproducible in osaurus: fresh server → streaming request that cold-loads the model → hard socket close mid-prefill → immediate second request → SIGABRT with two threads both in `startSoloFastPath → TokenIterator.prepare → asyncEval`. Matches the production crash cluster on the same assertion.

## Fix

`try Task.checkCancellation()` at every chunk boundary in the five chunked-prefill loops:

- `LLMModel.prepare` (default text path, all LLM families)
- `chunkedPrefillEmbedding` (now `throws`) + its three VLM callers (Mistral3, Mistral3VLMJANGTQ, Gemma3)
- Gemma4 and Qwen35 inline embedding loops

This bounds the orphan window to a single chunk (~512 tokens). Every `prepare` call site already handles throws — `BatchEngine.stepPrefill` finishes the slot as `.cancelled`, the solo/deferred path yields a `.cancelled` info and closes the stream. `generateLoopTask` additionally finishes a cancelled iterator construction quietly instead of logging it as an iterator-construction error.

Uncancelled behavior is bit-identical — the check is a no-op on live tasks.

## Tests

- `prepare` throws `CancellationError` with **zero chunks encoded** when the task is already cancelled (progress recorder stays empty)
- same contract for `chunkedPrefillEmbedding` (step closure never invoked)
- live-task control: full 600-token prompt still prefills to the expected 88-token remainder
- all existing `LLMPreparePrefillTests` + `ChunkedPrefillVLMTests` pass unchanged

The osaurus-side companion (keep the engine registered on hangup instead of evicting it) lands separately; either fix alone prevents the crash, together they also stop wasting GPU on dead requests.