### PR TITLE
BatchEngine.shutdown: await producer exit + drain GPU before returning

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -1189,10 +1189,22 @@ public actor BatchEngine {
     ///
     /// Pending requests receive a `.info` with `.cancelled` stop reason.
     /// Active slots are allowed to complete their current step before finishing.
-    public func shutdown() {
+    ///
+    /// Returns only after the engine's producer tasks have actually exited
+    /// and their queued GPU work has drained. This is the invariant serving
+    /// layers rely on for teardown ordering: "shutdown returned" must mean
+    /// "no producer owned by this engine will touch the shared Metal command
+    /// queue again". Cancelling alone is not enough — a producer mid-prefill
+    /// observes cancellation only at its next chunk/token boundary, and a
+    /// model unload that frees weights while that producer is still encoding
+    /// segfaults inside the Metal encoder (osaurus cold-load disconnect
+    /// crash: disconnect → unload raced the dropped request's prefill).
+    public func shutdown() async {
         guard !isShutdown else { return }
         isShutdown = true
 
+        let drainLoopTask = loopTask
+        let drainSoloTask = soloFastPathTask
         loopTask?.cancel()
         loopTask = nil
         soloFastPathTask?.cancel()
@@ -1217,6 +1229,19 @@ public actor BatchEngine {
             finishSlot(slot, reason: .cancelled)
         }
         activeSlots.removeAll()
+
+        // Await the cancelled producers before returning. Both tasks observe
+        // cancellation at their next boundary (chunked prefill, per-token
+        // decode) and end with their own GPU drains, so this is bounded.
+        // The producers never call back into this actor, so awaiting them
+        // here cannot deadlock; concurrent calls that interleave during the
+        // suspension see `isShutdown == true` and fail closed.
+        await drainSoloTask?.value
+        await drainLoopTask?.value
+
+        // Final fence: producers submit via `asyncEval`, so their last
+        // command buffers may still be in flight when the tasks return.
+        Stream().synchronize()
     }
 
     /// The number of requests currently waiting in the queue.


### PR DESCRIPTION
## Problem

`shutdown()` cancelled the solo/loop producer tasks and returned immediately. Cancellation is only observed at the producer's next chunk/token boundary (#111), so **"shutdown returned" did not mean "no producer will touch the GPU again"**. Serving-layer teardown that frees model weights right after `shutdownEngine` races the dying producer's encodes:

```
SIGSEGV in objc_msgSend / AGX...CommandBuffer encoder creation
orphan thread still in TokenIterator.prepare → asyncEval
```

Live case (osaurus, 100%-reproducible): a client disconnect during a cold model load triggers an unload of the just-loading model. The model lease that unload drains is held by the serving wrapper task — not by this engine's producer — so the lease hits zero and teardown frees weights while the producer is still encoding. Crash report shows the orphan producer segfaulting inside Metal encoder creation while the retry request waits cleanly on the same engine.

## Fix

`shutdown()` is now `async`: after cancelling the producers and finishing all streams, it awaits both producer tasks' completion, then issues a final `Stream().synchronize()` for their in-flight `asyncEval` work. This restores the invariant teardown ordering relies on: shutdown returns ⇒ this engine's producers are off the shared command queue.

- Bounded: producers observe cancellation at chunk/token boundaries (#111) and end with their own drains.
- No deadlock: the producers never call back into the engine actor; concurrent calls that interleave during the suspension see `isShutdown == true` and fail closed.
- Source-compatible: `shutdown` is an actor method — every call site already `await`ed it.

## Verification

Deterministic suites pass (`LLMPreparePrefillTests`, `ChunkedPrefillVLMTests`, `BatchEngineTests`, stop-string suites). Note: `BatchEngineIntegrationTests` aborts nondeterministically on a local GPU box **both with and without this change** (pre-existing leaked-producer flake across tests sharing one Metal queue — same bug class, tracked separately). The decisive proof is the live osaurus disconnect repro on the paired serving-side PR (osaurus #1796), posted there.