### PR TITLE
Serialize disk-cache restore evals under MLXCacheIOLock

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -1604,13 +1604,31 @@ public actor BatchEngine {
 
                     // Disk cache restore (blocks are empty, arrays are present)
                     if let diskArrays, !restored {
-                        let diskRestored = restoreFromDiskArrays(diskArrays, into: &slot.cache)
-                        if diskRestored > 0 {
-                            if let ssm = ssmStates,
-                               TQDiskSerializer.formatVersion(of: diskArrays) < 2
-                            {
-                                restoreSSMStates(ssm, into: slot.cache)
+                        // Under `MLXCacheIOLock`: the restore's Metal evals
+                        // must not interleave with other cache-adjacent GPU
+                        // submitters (serving layers tokenize the next
+                        // request's input under this lock). See the
+                        // TokenIterator disk-restore path for the abort this
+                        // prevents.
+                        let diskRestored = MLXCacheIOLock.withSerializedMLXCacheIO {
+                            () -> Int in
+                            let count = restoreFromDiskArrays(diskArrays, into: &slot.cache)
+                            if count > 0 {
+                                if let ssm = ssmStates,
+                                   TQDiskSerializer.formatVersion(of: diskArrays) < 2
+                                {
+                                    restoreSSMStates(ssm, into: slot.cache)
+                                }
+                                // The materializing eval below is what
+                                // actually submits the restore compute;
+                                // keep it inside the lock so the whole
+                                // restore is serialized, not just its
+                                // graph construction.
+                                MLX.eval(slot.cache)
                             }
+                            return count
+                        }
+                        if diskRestored > 0 {
                             // 2026-04-27 fix: materialize restored cache state
                             // in its own command buffer BEFORE prefill builds
                             // its forward graph. Disk restore produces lazy
@@ -1630,7 +1648,8 @@ public actor BatchEngine {
                             // Eager eval forces the cache state into GPU
                             // memory in a SEPARATE command buffer that
                             // commits before prefill encoding starts.
-                            MLX.eval(slot.cache)
+                            // (The eval itself runs above, inside the
+                            // MLXCacheIOLock region.)
                             restored = true
                             slot.continuation.yield(.prefillProgress(PrefillProgress(
                                 stage: .cacheRestore,

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1421,18 +1421,34 @@ public struct TokenIterator: TokenIteratorProtocol {
 
                 // Disk cache restore (blocks are empty, arrays are present)
                 if let diskArrays, !restored {
-                    let diskRestored = restoreFromDiskArrays(diskArrays, into: &self.cache)
-                    if diskRestored > 0 {
-                        if let ssm = ssmStates,
-                           TQDiskSerializer.formatVersion(of: diskArrays) < 2
-                        {
-                            restoreSSMStates(ssm, into: self.cache)
+                    // Serialize the restore's Metal evals (TQ component
+                    // deserialization `.item()` reads, asType conversions,
+                    // and the materializing eval below) against other
+                    // cache-adjacent GPU submitters. Serving layers tokenize
+                    // the NEXT request's input under `MLXCacheIOLock` while
+                    // this producer restores; unserialized, the two encode
+                    // concurrently on the shared command queue and abort
+                    // ("Completed handler provided after commit call" —
+                    // osaurus disconnect repro, iteration with a warm disk
+                    // entry).
+                    let diskRestored = MLXCacheIOLock.withSerializedMLXCacheIO {
+                        () -> Int in
+                        let count = restoreFromDiskArrays(diskArrays, into: &self.cache)
+                        if count > 0 {
+                            if let ssm = ssmStates,
+                               TQDiskSerializer.formatVersion(of: diskArrays) < 2
+                            {
+                                restoreSSMStates(ssm, into: self.cache)
+                            }
+                            // Mirror BatchEngine's disk-hit path: materialize
+                            // restored arrays before prefill builds the next
+                            // forward graph, instead of fusing restore + model
+                            // compute into one high-pressure command buffer.
+                            MLX.eval(self.cache)
                         }
-                        // Mirror BatchEngine's disk-hit path: materialize
-                        // restored arrays before prefill builds the next
-                        // forward graph, instead of fusing restore + model
-                        // compute into one high-pressure command buffer.
-                        MLX.eval(self.cache)
+                        return count
+                    }
+                    if diskRestored > 0 {
                         restored = true
                         Self.logger.info(
                             "Cache \(detail.rawValue) hit: restored \(diskRestored) tokens from disk, prefilling \(remainingTokens.count) remaining"


### PR DESCRIPTION
Third and final layer of the osaurus disconnect-crash fix train (#111 chunk-level prefill cancellation, #112 shutdown drains producers).

## Problem

The disk-tier restore — `TQDiskSerializer` `.item()` reads, `asType` conversions, and the materializing `MLX.eval` of the restored cache — ran **outside** `MLXCacheIOLock` in both restore paths (`TokenIterator.init` and `BatchEngine`'s slot prefill). Serving layers tokenize the *next* request's input under that lock while a producer restores; unserialized, the two encode concurrently on the shared Metal command queue and abort:

```
-[_MTLCommandBuffer addCompletedHandler:]: failed assertion
'Completed handler provided after commit call'
```

Deterministic repro (osaurus): disconnect a streaming request whose prompt has a **warm disk-cache entry**, send an immediate follow-up — the orphan producer restores while the follow-up tokenizes. The disconnect repro surfaced it deterministically, but the race is latent in ordinary serving too (any request's input prep can overlap another request's disk restore). Matches the production Sentry cluster on the same assertion (APPLE-MACOS-BV).

## Fix

Both restore paths now run their full restore-and-materialize region inside `MLXCacheIOLock.withSerializedMLXCacheIO`, consistent with the lock's documented purpose (cache tensor I/O vs concurrent MLX materialization). The lock's entry/exit synchronizes give the restore its own serialized command-buffer window; the previously separate materializing eval in the BatchEngine path moved inside the region since the eval is what actually submits the restore compute.

No behavior change outside serialization; deterministic suites pass. Live proof on the paired osaurus PR #1796 (full disconnect-repro cycles including warm-disk-entry iterations).