### PR TITLE
Strip orphan tool-call closer tags from the visible stream

### DIFF
--- a/Libraries/MLXLMCommon/Tool/Parsers/Gemma4ToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/Gemma4ToolCallParser.swift
@@ -47,6 +47,14 @@ public struct Gemma4ToolCallParser: ToolCallParser, Sendable {
         native.endTagAliases + zyphra.endTagAliases
     }
 
+    /// Both transports' closers strip when orphaned: Gemma-4 AppleScript
+    /// fine-tunes emit the Zyphra XML envelope (and its stray-closer leak
+    /// shape), and an orphan native `<tool_call|>` is the same protocol
+    /// residue class.
+    public var orphanStripTags: [String] {
+        native.endTagAliases + zyphra.orphanStripTags
+    }
+
     public func parse(content: String, tools: [[String: any Sendable]]?) -> ToolCall? {
         native.parse(content: content, tools: tools)
             ?? zyphra.parse(content: content, tools: tools)

--- a/Libraries/MLXLMCommon/Tool/Parsers/XMLFunctionParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/XMLFunctionParser.swift
@@ -22,6 +22,17 @@ public struct XMLFunctionParser: ToolCallParser, Sendable {
         self.unwrapJSONQuotedStringParameters = unwrapJSONQuotedStringParameters
     }
 
+    /// The XML-function transport's closers are protocol control markers even
+    /// when orphaned (no matching opener): live ZAYA rows emit stray
+    /// `</parameter></function></zyphra_tool_call>` runs mid-conversation
+    /// (MODEL_ISSUES_TRIAGE Issue 3 — the wrapper tags are dedicated special
+    /// tokens for that family). Register the wrapper closer plus the body
+    /// closers so the streaming processor strips an orphan run instead of
+    /// surfacing it as visible assistant text.
+    public var orphanStripTags: [String] {
+        endTagAliases + ["</function>", "</parameter>"]
+    }
+
     public func parse(content: String, tools: [[String: any Sendable]]?) -> ToolCall? {
         // Pattern: <function=(content)</function> — [\s\S] matches newlines
         guard

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -36,6 +36,19 @@ public protocol ToolCallParser: Sendable {
     /// Prefixes for dynamic end tags matching ``startTagPrefixes``.
     var endTagPrefixes: [String] { get }
 
+    /// Exact protocol CLOSER tags that must be stripped from the visible
+    /// stream even when they appear WITHOUT a matching opener ("orphan
+    /// closers"). Live rows of some families (ZAYA / Gemma-4 AppleScript
+    /// fine-tunes) emit stray `</parameter></function></zyphra_tool_call>`
+    /// runs after several agent-loop steps; the state machine only enters
+    /// collection on an OPEN tag, so without this registry the orphan closer
+    /// would stream to the user as literal protocol text. Scoped to the
+    /// format's OWN registered closers so ordinary tag-looking prose
+    /// (`</div>`) is never touched — the same robustness class as the
+    /// `ReasoningParser` stray-tag strip. Default: empty (no behavior
+    /// change for formats that have not opted in).
+    var orphanStripTags: [String] { get }
+
     /// Parse the content into a `ToolCall`.
     /// - Parameters:
     ///   - content: The text content to parse (may include tags)
@@ -90,6 +103,8 @@ extension ToolCallParser {
     public var startTagPrefixes: [String] { [] }
 
     public var endTagPrefixes: [String] { [] }
+
+    public var orphanStripTags: [String] { [] }
 
     public func isValidPartialContent(_ toolCallBuffer: String) -> Bool {
         true

--- a/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
@@ -722,6 +722,7 @@ public class ToolCallProcessor {
         let tags =
             parser.startTagAliases + parser.endTagAliases
             + parser.startTagPrefixes + parser.endTagPrefixes
+            + parser.orphanStripTags
 
         if tags.contains(where: { trimmed.hasPrefix($0) }) {
             return true
@@ -1673,6 +1674,67 @@ public class ToolCallProcessor {
                     let combined = visible + inline
                     return combined.isEmpty ? nil : combined
                 }
+
+                // The buffer is not a start tag. Before flushing it as
+                // visible text, screen it against the format's registered
+                // ORPHAN closers: live rows (ZAYA / Gemma-4 AppleScript) emit
+                // stray `</parameter></function></zyphra_tool_call>` runs
+                // with no matching opener, and those protocol markers must
+                // strip rather than stream to the user. Only the format's
+                // own registered tags are touched — unregistered tag-looking
+                // prose (`</div>`) still flushes verbatim.
+                let orphanTags = parser.orphanStripTags
+                if !orphanTags.isEmpty {
+                    var remainder = toolCallBuffer
+                    var strippedOrphan = false
+                    while let tag = orphanTags.first(where: { remainder.hasPrefix($0) }) {
+                        remainder.removeFirst(tag.count)
+                        strippedOrphan = true
+                    }
+                    if strippedOrphan {
+                        state = .normal
+                        toolCallBuffer = ""
+                        let leading = leadingTextBeforeToolCall
+                        leadingTextBeforeToolCall = ""
+                        // Whatever follows the orphan run goes back through
+                        // the machine — it may hold prose, another marker, or
+                        // a real envelope.
+                        let trailing =
+                            remainder.isEmpty
+                            ? nil
+                            : processTaggedChunk(
+                                remainder, allowInlineFallback: allowInlineFallback)
+                        let visible = leading + (trailing ?? "")
+                        return visible.isEmpty ? nil : visible
+                    }
+                    // A strict prefix of an orphan closer may still complete
+                    // on the next chunk — keep buffering instead of leaking
+                    // the partial marker.
+                    if orphanTags.contains(where: { $0.hasPrefix(toolCallBuffer) }) {
+                        return nil
+                    }
+                    // A closer can also sit EMBEDDED later in this same
+                    // non-matching buffer (one big chunk: `<zyx</function>`).
+                    // Emit the non-matching head and re-scan the tail so the
+                    // embedded marker still strips; each level drops at least
+                    // one character, so this terminates.
+                    if toolCallBuffer.count > 1,
+                        toolCallBuffer.dropFirst().contains(startChar)
+                    {
+                        state = .normal
+                        let head = String(toolCallBuffer.prefix(1))
+                        let tail = String(toolCallBuffer.dropFirst())
+                        toolCallBuffer = ""
+                        let leading = leadingTextBeforeToolCall
+                        leadingTextBeforeToolCall = ""
+                        let trailing =
+                            processTaggedChunk(tail, allowInlineFallback: allowInlineFallback)
+                            ?? ""
+                        let visible = leading + head + trailing
+                        return visible.isEmpty ? nil : visible
+                    }
+                }
+
                 // Otherwise, return the collected text and reset the state
                 state = .normal
                 let buffer = toolCallBuffer

--- a/Tests/MLXLMCommonToolParserFocusedTests/OrphanToolCloserStripTests.swift
+++ b/Tests/MLXLMCommonToolParserFocusedTests/OrphanToolCloserStripTests.swift
@@ -1,0 +1,194 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Testing
+@testable import MLXLMCommon
+
+/// Orphan tool-call CLOSER tags must never leak as visible text.
+///
+/// Live Zaya/AppleScript rows (MODEL_ISSUES_TRIAGE Issue 3) emit orphan
+/// closing tags — `</parameter></function></zyphra_tool_call>` with no
+/// matching opener — after several agent-loop steps. The streaming
+/// `ToolCallProcessor` state machine only entered tool-call collection after
+/// matching an OPEN tag, so an orphan closer fell through the
+/// `.potentialToolCall` flush and streamed to the user as literal protocol
+/// text. These are protocol control markers for the format (for ZAYA the
+/// wrapper tags are dedicated special tokens 101/102), the same robustness
+/// class as the Gemma `<channel|>` stray-tag strip in `ReasoningParser`.
+///
+/// The strip is scoped to the format's OWN registered closers
+/// (`orphanStripTags`) — arbitrary tag-looking prose (`</div>`) must still
+/// pass through untouched, and real envelopes must keep parsing.
+@Suite("Orphan tool-call closer strip")
+struct OrphanToolCloserStripFocusedTests {
+
+    // MARK: - The Issue 3 leak shape (zayaXml)
+
+    @Test("zayaXml: an orphan closer run streams invisible, char-by-char")
+    func zayaOrphanCloserRunStrippedCharByChar() {
+        let output = "Volume set to 30.\n</parameter>\n</function>\n</zyphra_tool_call>"
+        let processor = ToolCallProcessor(format: .zayaXml, tools: [lineCountToolSpec()])
+        var visible = ""
+        for ch in output {
+            visible += processor.processChunk(String(ch)) ?? ""
+        }
+        visible += processor.processEOS() ?? ""
+
+        #expect(visible.trimmingCharacters(in: .whitespacesAndNewlines) == "Volume set to 30.")
+        #expect(!visible.contains("</parameter>"))
+        #expect(!visible.contains("</function>"))
+        #expect(!visible.contains("</zyphra_tool_call>"))
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    @Test("zayaXml: back-to-back orphan closers in one chunk strip, prose around them survives")
+    func zayaOrphanClosersSingleChunk() {
+        let processor = ToolCallProcessor(format: .zayaXml, tools: [lineCountToolSpec()])
+        var visible = ""
+        visible += processor.processChunk("Done.</parameter></function></zyphra_tool_call> All set.") ?? ""
+        visible += processor.processEOS() ?? ""
+
+        #expect(visible == "Done. All set.")
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    @Test("zayaXml: an orphan closer split across chunk boundaries still strips")
+    func zayaOrphanCloserSplitAcrossChunks() {
+        let processor = ToolCallProcessor(format: .zayaXml, tools: [lineCountToolSpec()])
+        var visible = ""
+        for chunk in ["ok </zy", "phra_tool", "_call>", " done"] {
+            visible += processor.processChunk(chunk) ?? ""
+        }
+        visible += processor.processEOS() ?? ""
+
+        #expect(visible == "ok  done")
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    @Test("zayaXml: a partial orphan closer at EOS is suppressed, not leaked")
+    func zayaPartialOrphanCloserAtEOS() {
+        let processor = ToolCallProcessor(format: .zayaXml, tools: [lineCountToolSpec()])
+        var visible = ""
+        visible += processor.processChunk("answer 42 ") ?? ""
+        visible += processor.processChunk("</functi") ?? ""
+        visible += processor.processEOS() ?? ""
+
+        #expect(visible == "answer 42 ")
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    // MARK: - No over-stripping
+
+    @Test("zayaXml: tag-looking prose that is NOT a registered closer passes through")
+    func zayaUnregisteredTagsPassThrough() {
+        let processor = ToolCallProcessor(format: .zayaXml, tools: [lineCountToolSpec()])
+        var visible = ""
+        for ch in "HTML uses </div> and </p> to close elements." {
+            visible += processor.processChunk(String(ch)) ?? ""
+        }
+        visible += processor.processEOS() ?? ""
+
+        #expect(visible == "HTML uses </div> and </p> to close elements.")
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    @Test("zayaXml: a real complete envelope still parses to a tool call with no leak")
+    func zayaRealEnvelopeStillParses() {
+        let output = """
+        <zyphra_tool_call>
+        <function=line_count>
+        <parameter=text>
+        red
+        green
+        </parameter>
+        </function>
+        </zyphra_tool_call>
+        """
+        let processor = ToolCallProcessor(format: .zayaXml, tools: [lineCountToolSpec()])
+        var visible = ""
+        for ch in output {
+            visible += processor.processChunk(String(ch)) ?? ""
+        }
+        visible += processor.processEOS() ?? ""
+
+        #expect(visible.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        #expect(processor.toolCalls.count == 1)
+        #expect(processor.toolCalls.first?.function.name == "line_count")
+        #expect(processor.toolCalls.first?.function.arguments["text"] == .string("red\ngreen"))
+    }
+
+    @Test("zayaXml: orphan closers AFTER a real envelope strip while the call still parses")
+    func zayaOrphanClosersAfterRealEnvelope() {
+        let output = "<zyphra_tool_call>\n<function=line_count>\n<parameter=text>\nhi\n</parameter>\n</function>\n</zyphra_tool_call>\n</function>\n</zyphra_tool_call>"
+        let processor = ToolCallProcessor(format: .zayaXml, tools: [lineCountToolSpec()])
+        var visible = ""
+        for ch in output {
+            visible += processor.processChunk(String(ch)) ?? ""
+        }
+        visible += processor.processEOS() ?? ""
+
+        #expect(visible.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        #expect(processor.toolCalls.count == 1)
+        #expect(processor.toolCalls.first?.function.name == "line_count")
+    }
+
+    // MARK: - gemma4 (the shipped AppleScript 16B transport, zyphra-aliased)
+
+    @Test("gemma4: orphan zyphra closers strip on the Gemma4 parser path")
+    func gemma4OrphanZyphraClosersStrip() {
+        let processor = ToolCallProcessor(format: .gemma4, tools: [lineCountToolSpec()])
+        var visible = ""
+        for ch in "Saved the note.</parameter></function></zyphra_tool_call>" {
+            visible += processor.processChunk(String(ch)) ?? ""
+        }
+        visible += processor.processEOS() ?? ""
+
+        #expect(visible == "Saved the note.")
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    @Test("gemma4: an orphan native closer strips too")
+    func gemma4OrphanNativeCloserStrips() {
+        let processor = ToolCallProcessor(format: .gemma4, tools: [lineCountToolSpec()])
+        var visible = ""
+        for ch in "Done.<tool_call|> next" {
+            visible += processor.processChunk(String(ch)) ?? ""
+        }
+        visible += processor.processEOS() ?? ""
+
+        #expect(visible == "Done. next")
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    // MARK: - Strip-only mode (no tools offered)
+
+    @Test("zayaXml strip-only: orphan closers still strip and no calls are recorded")
+    func zayaStripOnlyOrphanClosers() {
+        let processor = ToolCallProcessor(format: .zayaXml, tools: nil, stripOnly: true)
+        var visible = ""
+        for ch in "hello </zyphra_tool_call> world" {
+            visible += processor.processChunk(String(ch)) ?? ""
+        }
+        visible += processor.processEOS() ?? ""
+
+        #expect(visible == "hello  world")
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    private func lineCountToolSpec() -> [String: any Sendable] {
+        [
+            "type": "function",
+            "function": [
+                "name": "line_count",
+                "parameters": [
+                    "type": "object",
+                    "properties": [
+                        "text": ["type": "string"] as [String: any Sendable],
+                    ] as [String: any Sendable],
+                    "required": ["text"],
+                    "additionalProperties": false,
+                ] as [String: any Sendable],
+            ] as [String: any Sendable],
+        ]
+    }
+}


### PR DESCRIPTION
## Summary

- Live ZAYA / Gemma-4 AppleScript rows emit stray `</parameter></function></zyphra_tool_call>` runs with no matching opener after several agent-loop steps (osaurus `MODEL_ISSUES_TRIAGE.md` Issue 3). The tool-call state machine only enters collection on an OPEN tag, so those protocol closers streamed to the user as literal visible text.
- Adds an opt-in `orphanStripTags` registry to `ToolCallParser` (default empty — no behavior change for formats that don't opt in) and teaches `ToolCallProcessor` to strip registered orphan closers: back-to-back runs, closers split across chunk boundaries, partial closers at EOS, and closers embedded mid-buffer.
- Scoped strictly to the format's OWN registered closers, so ordinary tag-looking prose (`</div>`) still flushes verbatim — same robustness class as the `ReasoningParser` stray-tag strip. `XMLFunctionParser` and `Gemma4ToolCallParser` register their closers.

This is the engine-gap half of Issue 3 only. The `<pad>`/gibberish degeneration of the AppleScript 8B fine-tune was separately root-caused model-side (sampling tail over a defective post-tool-turn distribution; cache and precision ruled out by A/B through the real loop) and is documented in the osaurus triage doc — no visible-text masking is applied for it.

## Test plan

- [x] `swift test --filter OrphanToolCloserStripTests` — 10 new focused tests: orphan runs strip invisibly (whole-chunk, char-by-char, chunk-split, partial-at-EOS, back-to-back with surrounding prose), real complete envelopes still parse into tool calls with no leak, closers after a real envelope strip, unregistered tags pass through, and the Gemma4 combined parser path strips both native and Zyphra closers.
- [x] Full `MLXLMCommonToolParserFocusedTests` suite passes.