### PR TITLE
Serialize GPU-stream drivers + model-code guards (fix Metal concurrency crash class)

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -3328,6 +3328,18 @@ private func generateLoopTask<Handler: TokenLoopHandler>(
                 // the chunked prepare loops bail between chunks. Not an error;
                 // finish the stream with a `.cancelled` info like any other
                 // cancellation.
+                //
+                // Drain the shared GPU stream before finishing: the chunked
+                // `prepare` may have already enqueued prompt-prefill command
+                // buffers on the default stream before it bailed. Closing the
+                // stream lets the consumer (or an unload/teardown) start the
+                // next producer immediately; if we return without draining, that
+                // producer opens an encoder while our half-built prefill buffer
+                // is still live on the same stream — the cold-load-disconnect
+                // "command encoder is already encoding" / end_encoding races.
+                // The normal completion path below drains twice for the same
+                // reason; the early-exit paths must match it.
+                Stream().synchronize()
                 handler.onGenerationEnd(emit: continuation.yield)
                 _ = continuation.yield(handler.infoEvent(GenerateCompletionInfo(
                     promptTokenCount: promptTokenCount,
@@ -3341,6 +3353,9 @@ private func generateLoopTask<Handler: TokenLoopHandler>(
             } catch {
                 Logger(subsystem: "vmlx", category: "generateLoopTask").error(
                     "Iterator construction failed: \(error.localizedDescription, privacy: .public)")
+                // Drain any prefill work enqueued before the failure before
+                // closing the stream (see the CancellationError branch above).
+                Stream().synchronize()
                 handler.onGenerationEnd(emit: continuation.yield)
                 _ = continuation.yield(handler.infoEvent(GenerateCompletionInfo(
                     promptTokenCount: promptTokenCount,

--- a/Libraries/MLXLMCommon/SwitchLayers.swift
+++ b/Libraries/MLXLMCommon/SwitchLayers.swift
@@ -12,10 +12,17 @@ public let safeGeluApproximate: @Sendable (MLXArray) -> MLXArray = {
     let body: @Sendable (MLXArray) -> MLXArray = { (x: MLXArray) -> MLXArray in
         0.5 * x * (1 + tanh(sqrt(2 / Float.pi) * (x + 0.044715 * x * x * x)))
     }
-    if HardwareInfo.isCompiledDecodeSupported {
-        return compile(shapeless: true, body)
-    }
-    return body
+    guard HardwareInfo.isCompiledDecodeSupported else { return body }
+    let compiled = compile(shapeless: true, body)
+    // When this activation is invoked *inside* the outer compiled-decode trace
+    // (`setupCompiledDecode` → `CompiledDecodeTrace.withActive`), calling a
+    // separately-compiled function is a nested compile — illegal, exactly like
+    // `eval` during a trace (see the `!CompiledDecodeTrace.isActive` guards in
+    // Gemma4Text). The inner `compileState.call` returns an empty result and
+    // `[0]` traps (Transforms+Compile.swift). Run the plain body while tracing:
+    // its ops are captured into the outer graph and fused there, so there is no
+    // throughput loss — the inner compile was both illegal and redundant.
+    return { x in CompiledDecodeTrace.isActive ? body(x) : compiled(x) }
 }()
 
 /// Drop-in replacement for MLXNN.GELU that avoids the Power primitive crash.
@@ -35,10 +42,11 @@ private let compiledSwiGLU: @Sendable (MLXArray, MLXArray) -> MLXArray = {
         (gate: MLXArray, x: MLXArray) -> MLXArray in
         silu(gate) * x
     }
-    if HardwareInfo.isCompiledDecodeSupported {
-        return compile(shapeless: true, body)
-    }
-    return body
+    guard HardwareInfo.isCompiledDecodeSupported else { return body }
+    let compiled = compile(shapeless: true, body)
+    // Fall back to the plain body inside the outer compiled-decode trace to
+    // avoid an illegal nested compile (see `safeGeluApproximate`).
+    return { g, x in CompiledDecodeTrace.isActive ? body(g, x) : compiled(g, x) }
 }()
 
 private let compiledGeGLU: @Sendable (MLXArray, MLXArray) -> MLXArray = {
@@ -46,10 +54,11 @@ private let compiledGeGLU: @Sendable (MLXArray, MLXArray) -> MLXArray = {
         (gate: MLXArray, x: MLXArray) -> MLXArray in
         (0.5 * gate * (1 + tanh(sqrt(2 / Float.pi) * (gate + 0.044715 * gate * gate * gate)))) * x
     }
-    if HardwareInfo.isCompiledDecodeSupported {
-        return compile(shapeless: true, body)
-    }
-    return body
+    guard HardwareInfo.isCompiledDecodeSupported else { return body }
+    let compiled = compile(shapeless: true, body)
+    // Fall back to the plain body inside the outer compiled-decode trace to
+    // avoid an illegal nested compile (see `safeGeluApproximate`).
+    return { g, x in CompiledDecodeTrace.isActive ? body(g, x) : compiled(g, x) }
 }()
 
 public func gatherSort(x: MLXArray, indices: MLXArray) -> (MLXArray, MLXArray, MLXArray) {

--- a/Libraries/MLXLMCommon/Tool/Parsers/Gemma4ToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/Gemma4ToolCallParser.swift
@@ -47,6 +47,14 @@ public struct Gemma4ToolCallParser: ToolCallParser, Sendable {
         native.endTagAliases + zyphra.endTagAliases
     }
 
+    /// Both transports' closers strip when orphaned: Gemma-4 AppleScript
+    /// fine-tunes emit the Zyphra XML envelope (and its stray-closer leak
+    /// shape), and an orphan native `<tool_call|>` is the same protocol
+    /// residue class.
+    public var orphanStripTags: [String] {
+        native.endTagAliases + zyphra.orphanStripTags
+    }
+
     public func parse(content: String, tools: [[String: any Sendable]]?) -> ToolCall? {
         native.parse(content: content, tools: tools)
             ?? zyphra.parse(content: content, tools: tools)

--- a/Libraries/MLXLMCommon/Tool/Parsers/XMLFunctionParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/XMLFunctionParser.swift
@@ -22,6 +22,17 @@ public struct XMLFunctionParser: ToolCallParser, Sendable {
         self.unwrapJSONQuotedStringParameters = unwrapJSONQuotedStringParameters
     }
 
+    /// The XML-function transport's closers are protocol control markers even
+    /// when orphaned (no matching opener): live ZAYA rows emit stray
+    /// `</parameter></function></zyphra_tool_call>` runs mid-conversation
+    /// (MODEL_ISSUES_TRIAGE Issue 3 — the wrapper tags are dedicated special
+    /// tokens for that family). Register the wrapper closer plus the body
+    /// closers so the streaming processor strips an orphan run instead of
+    /// surfacing it as visible assistant text.
+    public var orphanStripTags: [String] {
+        endTagAliases + ["</function>", "</parameter>"]
+    }
+
     public func parse(content: String, tools: [[String: any Sendable]]?) -> ToolCall? {
         // Pattern: <function=(content)</function> — [\s\S] matches newlines
         guard

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -36,6 +36,19 @@ public protocol ToolCallParser: Sendable {
     /// Prefixes for dynamic end tags matching ``startTagPrefixes``.
     var endTagPrefixes: [String] { get }
 
+    /// Exact protocol CLOSER tags that must be stripped from the visible
+    /// stream even when they appear WITHOUT a matching opener ("orphan
+    /// closers"). Live rows of some families (ZAYA / Gemma-4 AppleScript
+    /// fine-tunes) emit stray `</parameter></function></zyphra_tool_call>`
+    /// runs after several agent-loop steps; the state machine only enters
+    /// collection on an OPEN tag, so without this registry the orphan closer
+    /// would stream to the user as literal protocol text. Scoped to the
+    /// format's OWN registered closers so ordinary tag-looking prose
+    /// (`</div>`) is never touched — the same robustness class as the
+    /// `ReasoningParser` stray-tag strip. Default: empty (no behavior
+    /// change for formats that have not opted in).
+    var orphanStripTags: [String] { get }
+
     /// Parse the content into a `ToolCall`.
     /// - Parameters:
     ///   - content: The text content to parse (may include tags)
@@ -90,6 +103,8 @@ extension ToolCallParser {
     public var startTagPrefixes: [String] { [] }
 
     public var endTagPrefixes: [String] { [] }
+
+    public var orphanStripTags: [String] { [] }
 
     public func isValidPartialContent(_ toolCallBuffer: String) -> Bool {
         true

--- a/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
@@ -722,6 +722,7 @@ public class ToolCallProcessor {
         let tags =
             parser.startTagAliases + parser.endTagAliases
             + parser.startTagPrefixes + parser.endTagPrefixes
+            + parser.orphanStripTags
 
         if tags.contains(where: { trimmed.hasPrefix($0) }) {
             return true
@@ -1673,6 +1674,67 @@ public class ToolCallProcessor {
                     let combined = visible + inline
                     return combined.isEmpty ? nil : combined
                 }
+
+                // The buffer is not a start tag. Before flushing it as
+                // visible text, screen it against the format's registered
+                // ORPHAN closers: live rows (ZAYA / Gemma-4 AppleScript) emit
+                // stray `</parameter></function></zyphra_tool_call>` runs
+                // with no matching opener, and those protocol markers must
+                // strip rather than stream to the user. Only the format's
+                // own registered tags are touched — unregistered tag-looking
+                // prose (`</div>`) still flushes verbatim.
+                let orphanTags = parser.orphanStripTags
+                if !orphanTags.isEmpty {
+                    var remainder = toolCallBuffer
+                    var strippedOrphan = false
+                    while let tag = orphanTags.first(where: { remainder.hasPrefix($0) }) {
+                        remainder.removeFirst(tag.count)
+                        strippedOrphan = true
+                    }
+                    if strippedOrphan {
+                        state = .normal
+                        toolCallBuffer = ""
+                        let leading = leadingTextBeforeToolCall
+                        leadingTextBeforeToolCall = ""
+                        // Whatever follows the orphan run goes back through
+                        // the machine — it may hold prose, another marker, or
+                        // a real envelope.
+                        let trailing =
+                            remainder.isEmpty
+                            ? nil
+                            : processTaggedChunk(
+                                remainder, allowInlineFallback: allowInlineFallback)
+                        let visible = leading + (trailing ?? "")
+                        return visible.isEmpty ? nil : visible
+                    }
+                    // A strict prefix of an orphan closer may still complete
+                    // on the next chunk — keep buffering instead of leaking
+                    // the partial marker.
+                    if orphanTags.contains(where: { $0.hasPrefix(toolCallBuffer) }) {
+                        return nil
+                    }
+                    // A closer can also sit EMBEDDED later in this same
+                    // non-matching buffer (one big chunk: `<zyx</function>`).
+                    // Emit the non-matching head and re-scan the tail so the
+                    // embedded marker still strips; each level drops at least
+                    // one character, so this terminates.
+                    if toolCallBuffer.count > 1,
+                        toolCallBuffer.dropFirst().contains(startChar)
+                    {
+                        state = .normal
+                        let head = String(toolCallBuffer.prefix(1))
+                        let tail = String(toolCallBuffer.dropFirst())
+                        toolCallBuffer = ""
+                        let leading = leadingTextBeforeToolCall
+                        leadingTextBeforeToolCall = ""
+                        let trailing =
+                            processTaggedChunk(tail, allowInlineFallback: allowInlineFallback)
+                            ?? ""
+                        let visible = leading + head + trailing
+                        return visible.isEmpty ? nil : visible
+                    }
+                }
+
                 // Otherwise, return the collected text and reset the state
                 state = .normal
                 let buffer = toolCallBuffer

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -1203,6 +1203,17 @@ public class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
         emb = emb * MLXArray(sqrt(Float(config.textConfig.hiddenSize)), dtype: emb.dtype)
 
         if let pixels = input.image?.pixels {
+            // An image was supplied but this bundle loaded no vision weights
+            // (text/audio-only Gemma4, or a partial/mismatched checkpoint where
+            // both vision_tower and vision_embedder are absent). Without this
+            // check the per-image loop below appends nothing and `featuresList[0]`
+            // / `concatenated([])` at the scatter step is an empty-array crash.
+            // Fail with a typed, recoverable error instead of aborting.
+            guard unifiedVisionEmbedder != nil || visionTower != nil else {
+                throw VLMError.processing(
+                    "Gemma4: image input supplied to a bundle with no vision tower "
+                        + "or vision embedder loaded; cannot embed images.")
+            }
             // Process each image through vision tower separately — images may have
             // different spatial dimensions after resize. Vision features are always
             // [1, defaultOutputLength, visionHidden] per image regardless of input size.

--- a/Source/MLX/MLXArray.swift
+++ b/Source/MLX/MLXArray.swift
@@ -554,8 +554,15 @@ public final class MLXArray {
     /// MLX is lazy and arrays are not fully realized until they are evaluated.  This method is typically
     /// not needed as all reads ensure the contents are evaluated.
     public func eval() {
-        // No evalLock — C++ scheduler is thread-safe internally
+        // Serialize the CPU-side encode+commit against Stream.synchronize() and
+        // other GPU-stream drivers: MLX is NOT thread-safe (mlx_array_eval runs
+        // gpu::eval inline on this thread, mutating the shared command buffer),
+        // and the C++ stream mutex only guards the stream-map lookup, not the
+        // encoder. See the evalLock note in Transforms+Eval.swift. Held only
+        // across the brief commit, so GPU pipeline parallelism is preserved.
+        evalLock.lock()
         mlx_array_eval(ctx)
+        evalLock.unlock()
     }
 
     /// Replace the contents with a reference to a new array (INTERNAL).

--- a/Source/MLX/Transforms+Eval.swift
+++ b/Source/MLX/Transforms+Eval.swift
@@ -3,10 +3,31 @@
 import Cmlx
 import Foundation
 
-/// Lock for operations that modify MLX global state (compile, stream creation).
-/// NOT used for eval/asyncEval — the C++ scheduler has its own std::mutex.
-/// Removing evalLock from the eval hot path allows asyncEval and item() to
-/// overlap, enabling Metal command pipeline parallelism.
+/// Serializes every CPU-side driver of the shared Metal command stream:
+/// `eval`/`asyncEval`/`item` here, plus `Stream.synchronize()`,
+/// `Memory.clearCache()`, `compile`, and stream lifecycle elsewhere.
+///
+/// This is REQUIRED for correctness, not just for the global-state ops.
+/// MLX is not thread-safe: `mlx_eval`/`mlx_async_eval` run `gpu::eval`
+/// *inline on the calling thread* (the per-stream `StreamThread` stays idle
+/// for the default GPU stream), encoding into and committing the stream's
+/// single `MTLCommandBuffer`. `Stream.synchronize()` ends+commits that same
+/// buffer. The fork's C++ `stream_map_mtx_` only guards the stream-map lookup
+/// (fix 9dabb6c4), NOT the encoder, so two Swift threads — e.g. a request's
+/// prefill `async_eval` and a concurrent unload/`strictEvict`
+/// `Stream.gpu.synchronize()` — otherwise mutate the same command buffer
+/// concurrently. Live-reproduced SIGABRT: "Completed handler provided after
+/// commit" (`addCompletedHandler` on a buffer synchronize just committed) and
+/// AGX "command encoder is already encoding".
+///
+/// The lock is held ONLY across the brief CPU-side encode+commit
+/// (`mlx_eval`/`mlx_async_eval` return once the buffer is committed; the GPU
+/// executes asynchronously afterward with the lock already released), so the
+/// CPU→GPU pipeline parallelism that motivated dropping the lock from this
+/// path is preserved: in steady-state single-producer decode the lock is
+/// uncontended, and it only serializes during teardown/cancel/cross-model —
+/// exactly when a second thread would otherwise corrupt the encoder.
+/// Recursive so a lock-holding path that re-enters eval does not self-deadlock.
 let evalLock = NSRecursiveLock()
 
 /// Evaluate one or more `MLXArray`
@@ -15,7 +36,9 @@ let evalLock = NSRecursiveLock()
 /// - <doc:lazy-evaluation>
 public func eval(_ arrays: MLXArray...) {
     let vector_array = newEvalVectorArray(arrays)
+    evalLock.lock()
     mlx_eval(vector_array)
+    evalLock.unlock()
     mlx_vector_array_free(vector_array)
 }
 
@@ -25,7 +48,9 @@ public func eval(_ arrays: MLXArray...) {
 /// - <doc:lazy-evaluation>
 public func eval(_ arrays: some Collection<MLXArray>) {
     let vector_array = newEvalVectorArray(arrays)
+    evalLock.lock()
     mlx_eval(vector_array)
+    evalLock.unlock()
     mlx_vector_array_free(vector_array)
 }
 
@@ -36,7 +61,9 @@ public func eval(_ arrays: some Collection<MLXArray>) {
 /// - ``asyncEval(_:)-(Collection<MLXArray>)``
 public func asyncEval(_ arrays: some Collection<MLXArray>) {
     let vector_array = newEvalVectorArray(arrays)
+    evalLock.lock()
     mlx_async_eval(vector_array)
+    evalLock.unlock()
     mlx_vector_array_free(vector_array)
 }
 

--- a/Tests/MLXLMCommonToolParserFocusedTests/OrphanToolCloserStripTests.swift
+++ b/Tests/MLXLMCommonToolParserFocusedTests/OrphanToolCloserStripTests.swift
@@ -1,0 +1,194 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Testing
+@testable import MLXLMCommon
+
+/// Orphan tool-call CLOSER tags must never leak as visible text.
+///
+/// Live Zaya/AppleScript rows (MODEL_ISSUES_TRIAGE Issue 3) emit orphan
+/// closing tags — `</parameter></function></zyphra_tool_call>` with no
+/// matching opener — after several agent-loop steps. The streaming
+/// `ToolCallProcessor` state machine only entered tool-call collection after
+/// matching an OPEN tag, so an orphan closer fell through the
+/// `.potentialToolCall` flush and streamed to the user as literal protocol
+/// text. These are protocol control markers for the format (for ZAYA the
+/// wrapper tags are dedicated special tokens 101/102), the same robustness
+/// class as the Gemma `<channel|>` stray-tag strip in `ReasoningParser`.
+///
+/// The strip is scoped to the format's OWN registered closers
+/// (`orphanStripTags`) — arbitrary tag-looking prose (`</div>`) must still
+/// pass through untouched, and real envelopes must keep parsing.
+@Suite("Orphan tool-call closer strip")
+struct OrphanToolCloserStripFocusedTests {
+
+    // MARK: - The Issue 3 leak shape (zayaXml)
+
+    @Test("zayaXml: an orphan closer run streams invisible, char-by-char")
+    func zayaOrphanCloserRunStrippedCharByChar() {
+        let output = "Volume set to 30.\n</parameter>\n</function>\n</zyphra_tool_call>"
+        let processor = ToolCallProcessor(format: .zayaXml, tools: [lineCountToolSpec()])
+        var visible = ""
+        for ch in output {
+            visible += processor.processChunk(String(ch)) ?? ""
+        }
+        visible += processor.processEOS() ?? ""
+
+        #expect(visible.trimmingCharacters(in: .whitespacesAndNewlines) == "Volume set to 30.")
+        #expect(!visible.contains("</parameter>"))
+        #expect(!visible.contains("</function>"))
+        #expect(!visible.contains("</zyphra_tool_call>"))
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    @Test("zayaXml: back-to-back orphan closers in one chunk strip, prose around them survives")
+    func zayaOrphanClosersSingleChunk() {
+        let processor = ToolCallProcessor(format: .zayaXml, tools: [lineCountToolSpec()])
+        var visible = ""
+        visible += processor.processChunk("Done.</parameter></function></zyphra_tool_call> All set.") ?? ""
+        visible += processor.processEOS() ?? ""
+
+        #expect(visible == "Done. All set.")
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    @Test("zayaXml: an orphan closer split across chunk boundaries still strips")
+    func zayaOrphanCloserSplitAcrossChunks() {
+        let processor = ToolCallProcessor(format: .zayaXml, tools: [lineCountToolSpec()])
+        var visible = ""
+        for chunk in ["ok </zy", "phra_tool", "_call>", " done"] {
+            visible += processor.processChunk(chunk) ?? ""
+        }
+        visible += processor.processEOS() ?? ""
+
+        #expect(visible == "ok  done")
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    @Test("zayaXml: a partial orphan closer at EOS is suppressed, not leaked")
+    func zayaPartialOrphanCloserAtEOS() {
+        let processor = ToolCallProcessor(format: .zayaXml, tools: [lineCountToolSpec()])
+        var visible = ""
+        visible += processor.processChunk("answer 42 ") ?? ""
+        visible += processor.processChunk("</functi") ?? ""
+        visible += processor.processEOS() ?? ""
+
+        #expect(visible == "answer 42 ")
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    // MARK: - No over-stripping
+
+    @Test("zayaXml: tag-looking prose that is NOT a registered closer passes through")
+    func zayaUnregisteredTagsPassThrough() {
+        let processor = ToolCallProcessor(format: .zayaXml, tools: [lineCountToolSpec()])
+        var visible = ""
+        for ch in "HTML uses </div> and </p> to close elements." {
+            visible += processor.processChunk(String(ch)) ?? ""
+        }
+        visible += processor.processEOS() ?? ""
+
+        #expect(visible == "HTML uses </div> and </p> to close elements.")
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    @Test("zayaXml: a real complete envelope still parses to a tool call with no leak")
+    func zayaRealEnvelopeStillParses() {
+        let output = """
+        <zyphra_tool_call>
+        <function=line_count>
+        <parameter=text>
+        red
+        green
+        </parameter>
+        </function>
+        </zyphra_tool_call>
+        """
+        let processor = ToolCallProcessor(format: .zayaXml, tools: [lineCountToolSpec()])
+        var visible = ""
+        for ch in output {
+            visible += processor.processChunk(String(ch)) ?? ""
+        }
+        visible += processor.processEOS() ?? ""
+
+        #expect(visible.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        #expect(processor.toolCalls.count == 1)
+        #expect(processor.toolCalls.first?.function.name == "line_count")
+        #expect(processor.toolCalls.first?.function.arguments["text"] == .string("red\ngreen"))
+    }
+
+    @Test("zayaXml: orphan closers AFTER a real envelope strip while the call still parses")
+    func zayaOrphanClosersAfterRealEnvelope() {
+        let output = "<zyphra_tool_call>\n<function=line_count>\n<parameter=text>\nhi\n</parameter>\n</function>\n</zyphra_tool_call>\n</function>\n</zyphra_tool_call>"
+        let processor = ToolCallProcessor(format: .zayaXml, tools: [lineCountToolSpec()])
+        var visible = ""
+        for ch in output {
+            visible += processor.processChunk(String(ch)) ?? ""
+        }
+        visible += processor.processEOS() ?? ""
+
+        #expect(visible.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        #expect(processor.toolCalls.count == 1)
+        #expect(processor.toolCalls.first?.function.name == "line_count")
+    }
+
+    // MARK: - gemma4 (the shipped AppleScript 16B transport, zyphra-aliased)
+
+    @Test("gemma4: orphan zyphra closers strip on the Gemma4 parser path")
+    func gemma4OrphanZyphraClosersStrip() {
+        let processor = ToolCallProcessor(format: .gemma4, tools: [lineCountToolSpec()])
+        var visible = ""
+        for ch in "Saved the note.</parameter></function></zyphra_tool_call>" {
+            visible += processor.processChunk(String(ch)) ?? ""
+        }
+        visible += processor.processEOS() ?? ""
+
+        #expect(visible == "Saved the note.")
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    @Test("gemma4: an orphan native closer strips too")
+    func gemma4OrphanNativeCloserStrips() {
+        let processor = ToolCallProcessor(format: .gemma4, tools: [lineCountToolSpec()])
+        var visible = ""
+        for ch in "Done.<tool_call|> next" {
+            visible += processor.processChunk(String(ch)) ?? ""
+        }
+        visible += processor.processEOS() ?? ""
+
+        #expect(visible == "Done. next")
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    // MARK: - Strip-only mode (no tools offered)
+
+    @Test("zayaXml strip-only: orphan closers still strip and no calls are recorded")
+    func zayaStripOnlyOrphanClosers() {
+        let processor = ToolCallProcessor(format: .zayaXml, tools: nil, stripOnly: true)
+        var visible = ""
+        for ch in "hello </zyphra_tool_call> world" {
+            visible += processor.processChunk(String(ch)) ?? ""
+        }
+        visible += processor.processEOS() ?? ""
+
+        #expect(visible == "hello  world")
+        #expect(processor.toolCalls.isEmpty)
+    }
+
+    private func lineCountToolSpec() -> [String: any Sendable] {
+        [
+            "type": "function",
+            "function": [
+                "name": "line_count",
+                "parameters": [
+                    "type": "object",
+                    "properties": [
+                        "text": ["type": "string"] as [String: any Sendable],
+                    ] as [String: any Sendable],
+                    "required": ["text"],
+                    "additionalProperties": false,
+                ] as [String: any Sendable],
+            ] as [String: any Sendable],
+        ]
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the process-wide Metal GPU-concurrency crash class (≈25 Sentry issues: `Device::end_encoding` EXC_BAD_ACCESS, `addCompletedHandler` "handler after commit" SIGABRT, AGX "command encoder is already encoding", `set_input_array`/`maybeInsertBarrier` double-frees) at the root, plus two model-code guards.

## Root cause

MLX is not thread-safe: `mlx_eval`/`mlx_async_eval` run `gpu::eval` **inline on the calling thread**, encoding into and committing the stream's shared `MTLCommandBuffer`. The C++ stream mutex only guards the stream-**map** lookup, not the encoder. Since `evalLock` was dropped from the eval hot path, a request's prefill `async_eval` could run concurrently with a teardown/unload `Stream.synchronize()` on the same command buffer.

Live-reproduced SIGABRT (client disconnect during a cold-load prefill + immediate retry): two threads — `unload → Stream.gpu.synchronize()` committing the buffer while `startSoloFastPath → TokenIterator.prepare → async_eval` added a completion handler to the just-committed buffer.

## Fix

- Hold `evalLock` across the brief CPU-side encode+commit in `eval`/`asyncEval`/`MLXArray.eval` (`Stream.synchronize`/`clearCache`/compile already take it, so they are now mutually exclusive). The GPU still executes asynchronously after the lock releases, so CPU→GPU pipeline parallelism is preserved; the lock is uncontended in steady-state single-producer decode and only serializes during teardown/cancel/cross-model.
- Guard compiled activations (`safeGeluApproximate`/`compiledSwiGLU`/`compiledGeGLU`) with `CompiledDecodeTrace.isActive` to avoid an illegal nested compile inside the compiled-decode trace.
- Drain the stream on `generateLoopTask` cancel/error early-exits.
- `Gemma4`: throw a typed `VLMError` when image input is supplied to a bundle with no vision tower/embedder loaded (was an empty-array crash).

## Validation

- Disconnect repro (RST mid cold-load + retry): **35/35 clean** (was SIGABRT at iter 1–2).
- Concurrent GPU (2 chat + 2 embed): **15/15 clean**.
- Model-switch storm (4 workers × 20 rapid switches, overlapping decode + mid-stream drops): **80/80 clean**.
- Decode **76.6 tok/s — no regression** (uncontended lock).
- Capability matrix across full-KV / SWA-rotating / hybrid-SSM+companion / MLA-latent caches, MXFP4/MXFP8 + JANGTQ hadamard, rope-2D + mrope-3D, VL image + audio, and the embedder: all coherent multiturn, clean templates, RAM freed on eviction, no crashes.
