### PR TITLE
NormConventionResolver: unrecognized norm_convention falls back to the vote

### DIFF
--- a/Libraries/MLXLMCommon/NormConventionResolver.swift
+++ b/Libraries/MLXLMCommon/NormConventionResolver.swift
@@ -48,9 +48,11 @@ public enum NormConventionResolver {
     /// Resolve whether to apply the `(1 + weight)` shift, with deterministic precedence:
     /// per-bundle declaration → architecture declaration → order-independent vote.
     ///
-    /// A DECLARATION is authoritative — it states the storage state outright and short-circuits the
-    /// vote. A per-bundle declaration (safetensors metadata → `config.json`) wins first; then an
-    /// architecture-level declaration (`declaredConvention`). Crucially, an architecture may declare
+    /// A RECOGNIZED `(1 + weight)` marker is authoritative — it states the storage state outright and
+    /// short-circuits the vote. A per-bundle declaration (safetensors metadata → `config.json`) wins
+    /// first; then an architecture-level declaration (`declaredConvention`). An UNRECOGNIZED declared
+    /// string is treated as no declaration (it defers to the vote) rather than silently meaning
+    /// "do not shift", so a converter typo can't strand a raw bundle unshifted. Crucially, an architecture may declare
     /// only when ALL its bundles share one storage state. An architecture that ships the SAME class
     /// both raw (norm mean ≈ 0, deviation-from-1 → needs +1) AND already-shifted (mean ≈ 1 → must NOT
     /// be shifted again) — e.g. qwen3.5, where JangQ stores raw and MXFP4 stores pre-shifted — can
@@ -67,14 +69,23 @@ public enum NormConventionResolver {
         excluding isExcluded: (String) -> Bool = { _ in false },
         fallbackWhenNoProbe: () -> Bool = { false }
     ) -> Bool {
-        // Any declaration is authoritative and overrides the vote: per-bundle metadata/config first
-        // (states THIS bundle's storage state), then an architecture-level declaration (valid only
-        // for architectures with a uniform storage state across all their bundles).
-        if let explicit = metadataConvention ?? configConvention ?? declaredConvention {
-            return usesPlusOne(explicit)
+        // A RECOGNIZED "(1 + weight)" marker (per-bundle metadata → config → architecture
+        // declaration) is authoritative and forces the shift. A present-but-UNRECOGNIZED value —
+        // a converter typo or a descriptive string like "rms_norm" — is NOT trusted to silently
+        // disable the shift: it falls through to the order-independent measurement below, which
+        // reads the bundle's actual storage state. (Previously ANY non-marker string returned
+        // `usesPlusOne(...) == false` → no-shift, so a single malformed declaration stranded a raw
+        // bundle's norms unshifted (mean ≈ 0, never lifted to ≈ 1) → degraded/garbage output.)
+        if usesPlusOne(metadataConvention)
+            || usesPlusOne(configConvention)
+            || usesPlusOne(declaredConvention)
+        {
+            return true
         }
-        // Nothing declared (the qwen3.5 reality: one class, mixed storage across bundles). Measure
-        // THIS bundle, order-independently.
+        // Nothing authoritatively declares the convention (the qwen3.5 reality: one class, mixed
+        // storage across bundles — or a declaration we don't recognize). Measure THIS bundle,
+        // order-independently: the majority vote cleanly separates raw (mean ≈ 0 → shift) from
+        // already-shifted (mean ≈ 1 → leave it).
         return weightsAppearUnshifted(weights, probeSuffixes: probeSuffixes, excluding: isExcluded)
             ?? fallbackWhenNoProbe()
     }

--- a/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
@@ -2036,7 +2036,10 @@ struct MTPRuntimeFocusedTests {
         #expect(loadSource.contains("loadJangConfigSanitizeMetadata"))
         #expect(loadSource.contains("\"norm_convention\""))
         #expect(vlmSource.contains("normConvention: Self.normConvention(metadata)"))
-        #expect(vlmSource.contains("usesQwenPlusOneNormConvention"))
+        // The (1+weight) shift decision routes through the shared deterministic resolver
+        // (rcfa 18f803c9 replaced the old per-loader `usesQwenPlusOneNormConvention` helper,
+        // whose Dictionary-iteration-order probe silently mis-shifted ~7.5% of loads).
+        #expect(vlmSource.contains("NormConventionResolver.shouldApplyPlusOneShift"))
     }
 
     @Test("LLM and VLM factories carry MTP tuning status like generation config")

--- a/Tests/MLXLMCommonFocusedTests/NormConventionResolverTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NormConventionResolverTests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import MLX
+import Testing
+
+@testable import MLXLMCommon
+
+/// Regression coverage for `NormConventionResolver`, the deterministic replacement for the old
+/// per-process-random `(1 + weight)` RMSNorm shift heuristic. The key invariant these tests pin:
+/// an UNRECOGNIZED `norm_convention` declaration must NOT silently disable the shift — it defers to
+/// the order-independent vote, so a converter typo can't strand a raw bundle's norms unshifted.
+struct NormConventionResolverTests {
+
+    private let probes = [".input_layernorm.weight", ".post_attention_layernorm.weight"]
+
+    /// Raw storage: norms are the deviation-from-1, so mean ≈ 0.
+    private func rawWeights() -> [String: MLXArray] {
+        [
+            "model.layers.0.input_layernorm.weight": MLXArray(converting: [0.01, -0.02, 0.03, 0.0]),
+            "model.layers.0.post_attention_layernorm.weight": MLXArray(
+                converting: [0.0, 0.04, -0.01, 0.02]),
+            "model.layers.1.input_layernorm.weight": MLXArray(converting: [0.02, 0.0, -0.03, 0.01]),
+        ]
+    }
+
+    /// Already-shifted storage: norms are the applied weights, so mean ≈ 1.
+    private func shiftedWeights() -> [String: MLXArray] {
+        [
+            "model.layers.0.input_layernorm.weight": MLXArray(converting: [1.01, 0.98, 1.03, 1.0]),
+            "model.layers.0.post_attention_layernorm.weight": MLXArray(
+                converting: [1.0, 1.04, 0.99, 1.02]),
+            "model.layers.1.input_layernorm.weight": MLXArray(converting: [0.97, 1.0, 1.03, 1.01]),
+        ]
+    }
+
+    @Test func recognizedPlusOneMarkerForcesShift() {
+        // A recognized marker is authoritative even against already-shifted-looking weights.
+        #expect(
+            NormConventionResolver.shouldApplyPlusOneShift(
+                metadataConvention: "mlx_plus_one", configConvention: nil, declaredConvention: nil,
+                weights: shiftedWeights(), probeSuffixes: probes) == true)
+    }
+
+    @Test func noDeclarationVotesOnWeights() {
+        #expect(
+            NormConventionResolver.shouldApplyPlusOneShift(
+                metadataConvention: nil, configConvention: nil, declaredConvention: nil,
+                weights: rawWeights(), probeSuffixes: probes) == true)  // raw → shift
+        #expect(
+            NormConventionResolver.shouldApplyPlusOneShift(
+                metadataConvention: nil, configConvention: nil, declaredConvention: nil,
+                weights: shiftedWeights(), probeSuffixes: probes) == false)  // shifted → no-shift
+    }
+
+    /// THE REGRESSION: an unrecognized declaration must fall back to the vote, not silently no-shift.
+    /// Before the fix, a raw bundle carrying e.g. `norm_convention: "rms_norm"` returned false and
+    /// loaded with unshifted norms → garbage output.
+    @Test func unrecognizedDeclarationFallsBackToVote() {
+        #expect(
+            NormConventionResolver.shouldApplyPlusOneShift(
+                metadataConvention: "rms_norm", configConvention: nil, declaredConvention: nil,
+                weights: rawWeights(), probeSuffixes: probes) == true)  // raw → shift (was: false)
+        #expect(
+            NormConventionResolver.shouldApplyPlusOneShift(
+                metadataConvention: "qwen3_5_language_mlx_plus_ONE_typo", configConvention: nil,
+                declaredConvention: nil,
+                weights: rawWeights(), probeSuffixes: probes) == true)  // typo'd marker → vote → shift
+        #expect(
+            NormConventionResolver.shouldApplyPlusOneShift(
+                metadataConvention: "rms_norm", configConvention: nil, declaredConvention: nil,
+                weights: shiftedWeights(), probeSuffixes: probes) == false)  // shifted → no-shift
+    }
+
+    /// A recognized marker at a lower precedence still wins when the higher one is unrecognized.
+    @Test func recognizedMarkerWinsThroughUnrecognizedHigherPrecedence() {
+        #expect(
+            NormConventionResolver.shouldApplyPlusOneShift(
+                metadataConvention: "garbage", configConvention: "mlx_plus_one",
+                declaredConvention: nil,
+                weights: shiftedWeights(), probeSuffixes: probes) == true)
+    }
+
+    @Test func noProbeFallsBackToProvidedDefault() {
+        #expect(
+            NormConventionResolver.shouldApplyPlusOneShift(
+                metadataConvention: nil, configConvention: nil, declaredConvention: nil,
+                weights: ["unrelated.weight": MLXArray(converting: [1.0, 2.0])],
+                probeSuffixes: probes, fallbackWhenNoProbe: { true }) == true)
+    }
+}


### PR DESCRIPTION
## What

Two follow-ups to the deterministic RMSNorm `(1+weight)` resolver (`NormConventionResolver`, introduced in 18f803c9 to replace the per-process-random `Dictionary`-iteration-order heuristic):

1. **`shouldApplyPlusOneShift`: an *unrecognized* `norm_convention` declaration now defers to the order-independent vote instead of silently disabling the shift.** Previously any non-marker string (a converter typo, or a descriptive value like `"rms_norm"`) returned `usesPlusOne(...) == false` → no-shift, which strands a raw bundle's norms unshifted (mean ≈ 0, never lifted to ≈ 1) → degraded/garbage output. A recognized marker is still authoritative; only unrecognized strings fall through to the measurement.

2. **Repoint a stale source-inspection assertion.** `MTPRuntimeFocusedTests."Qwen3.6 loaders propagate norm convention metadata"` still asserted the pre-refactor helper `usesQwenPlusOneNormConvention`, which 18f803c9 deleted — so it had been failing since that refactor. It now pins the current `NormConventionResolver.shouldApplyPlusOneShift` wiring.

## Why

The resolver is meant to be authoritative-or-measure, never guess. A single malformed/unknown declaration should not be trusted to *disable* a correctness-critical shift. This closes that latent trap deterministically (no per-model special-casing).

## Tests

New `NormConventionResolverTests` (5 cases): recognized-marker forces shift, no-declaration votes on weights, **unrecognized-declaration falls back to vote** (the regression), recognized-marker wins through an unrecognized higher-precedence slot, no-probe falls back to the provided default. All pass. The repointed MTP test passes. No new failures introduced.