### PR TITLE
emit toolCallProgress deltas while a tool call envelope is being collected

### DIFF
--- a/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
+++ b/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
@@ -234,6 +234,8 @@ public enum ChatSessionTests {
                 break
             case .toolCall(let toolCall):
                 toolCalls.append(toolCall)
+            case .toolCallProgress:
+                break
             case .prefillProgress:
 
                 break
@@ -676,7 +678,7 @@ public enum BatchEngineIntegrationTests {
             case .prefillProgress:
 
                 break
-            case .info, .prefillProgress, .toolCall, .reasoning:
+            case .info, .prefillProgress, .toolCall, .toolCallProgress, .reasoning:
                 break
             }
         }
@@ -910,7 +912,7 @@ public enum ToolCallTests {
                     text += chunk
                 case .toolCall(let toolCall):
                     toolCalls.append(toolCall)
-                case .reasoning, .prefillProgress, .info:
+                case .reasoning, .prefillProgress, .toolCallProgress, .info:
                     break
                 }
             }

--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -690,6 +690,8 @@ public actor BatchEngine {
                     continuation.yield(event)
                 case .toolCall:
                     continuation.yield(event)
+                case .toolCallProgress:
+                    continuation.yield(event)
                 case .info:
                     continuation.yield(event)
                 }

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -3675,6 +3675,16 @@ public enum Generation: Sendable {
     /// A tool call from the language model.
     case toolCall(ToolCall)
 
+    /// An incremental delta of a tool-call envelope that is still being
+    /// generated. Emitted while the tool-call processor is collecting a call
+    /// — the payload is the raw envelope text (format-specific, e.g. the
+    /// growing JSON object), NOT parsed arguments. Consumers can use it to
+    /// preview long calls (e.g. a file write) as they stream; the complete,
+    /// parsed call still arrives as a single `.toolCall` when the envelope
+    /// closes. Callers that don't need previews can ignore this case —
+    /// `.toolCall` remains the only actionable tool event.
+    case toolCallProgress(String)
+
     /// Generated text or nil
     public var chunk: String? {
         switch self {
@@ -3683,6 +3693,7 @@ public enum Generation: Sendable {
         case .info: nil
         case .prefillProgress: nil
         case .toolCall: nil
+        case .toolCallProgress: nil
         }
     }
 
@@ -3694,6 +3705,7 @@ public enum Generation: Sendable {
         case .info: nil
         case .prefillProgress: nil
         case .toolCall: nil
+        case .toolCallProgress: nil
         }
     }
 
@@ -3705,6 +3717,7 @@ public enum Generation: Sendable {
         case .info(let info): info
         case .prefillProgress: nil
         case .toolCall: nil
+        case .toolCallProgress: nil
         }
     }
 
@@ -3716,6 +3729,7 @@ public enum Generation: Sendable {
         case .info: nil
         case .prefillProgress(let progress): progress
         case .toolCall: nil
+        case .toolCallProgress: nil
         }
     }
 
@@ -3727,6 +3741,7 @@ public enum Generation: Sendable {
         case .info: nil
         case .prefillProgress: nil
         case .toolCall(let toolCall): toolCall
+        case .toolCallProgress: nil
         }
     }
 
@@ -4056,7 +4071,7 @@ struct TextToolTokenLoopHandler: TokenLoopHandler, @unchecked Sendable {
                 return false
             }
             return !stopSequenceHit
-        case .reasoning, .prefillProgress, .toolCall, .info:
+        case .reasoning, .prefillProgress, .toolCall, .toolCallProgress, .info:
             if case .toolCall = event {
                 emittedToolCall = true
             }

--- a/Libraries/MLXLMCommon/GenerationStreamRouting.swift
+++ b/Libraries/MLXLMCommon/GenerationStreamRouting.swift
@@ -25,6 +25,7 @@ public func routeGenerationText(
 
     var events: [Generation] = []
     let toolCallCountBeforeChunk = toolCallProcessor.toolCalls.count
+    let collectingBeforeChunk = toolCallProcessor.collectingToolCallText
     let visibleChunk: String?
     if channel == .reasoning, toolCallProcessor.usesTaggedOnlyReasoningExtraction {
         visibleChunk = toolCallProcessor.processTaggedProtocolChunk(text)
@@ -40,6 +41,22 @@ public func routeGenerationText(
             if !parsedToolCallInChunk || toolCallProcessor.preservesReasoningTextAroundToolCalls {
                 events.append(.reasoning(visible))
             }
+        }
+    }
+    // Surface the growth of an in-flight tool-call envelope as a progress
+    // delta. Diffing the processor's collecting buffer around the chunk
+    // keeps the parser state machines untouched: a call that completed (or
+    // reverted to plain text) within this chunk simply reports no growth.
+    // The prefix check guards the boundary where one call completed and the
+    // next began inside the same chunk — the buffer then holds unrelated
+    // text, so the whole new buffer is the delta.
+    if let after = toolCallProcessor.collectingToolCallText, !after.isEmpty {
+        if let before = collectingBeforeChunk, after.hasPrefix(before) {
+            if after.count > before.count {
+                events.append(.toolCallProgress(String(after.dropFirst(before.count))))
+            }
+        } else {
+            events.append(.toolCallProgress(after))
         }
     }
     events.append(contentsOf: drainToolCallEvents(from: toolCallProcessor))

--- a/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
@@ -47,6 +47,27 @@ public class ToolCallProcessor {
     /// The tool calls extracted during processing.
     public var toolCalls: [ToolCall] = []
 
+    /// Raw text of the tool-call envelope currently being collected, or nil
+    /// when no call is in flight. The stream-routing layer diffs this around
+    /// each processed chunk to surface incremental `.toolCallProgress`
+    /// deltas while the model is still writing the call (e.g. a UI that
+    /// previews a large file write as it streams). `potentialToolCall` — an
+    /// ambiguous prefix that may still revert to plain text — intentionally
+    /// reports nil so consumers never see text that might later be
+    /// re-emitted as a visible chunk.
+    public var collectingToolCallText: String? {
+        // Strip-only processors discard the parsed calls entirely (no tools
+        // were offered), so surfacing their envelope as progress would leak
+        // text the consumer will never get a `.toolCall` for.
+        guard !stripOnly else { return nil }
+        switch state {
+        case .collectingToolCall, .collectingInlineToolCall:
+            return toolCallBuffer
+        case .normal, .potentialToolCall:
+            return nil
+        }
+    }
+
     /// Record extracted tool calls unless running strip-only (markers are
     /// stripped from visible text either way; in strip-only mode the call
     /// itself is discarded because no tools were offered).

--- a/Sources/MLXPressCLI/main.swift
+++ b/Sources/MLXPressCLI/main.swift
@@ -202,7 +202,7 @@ struct MLXPressCLI {
                         reasoningText += text
                     case .prefillProgress:
                         break
-                    case .toolCall:
+                    case .toolCall, .toolCallProgress:
                         break
                     case .info(let info):
                         completionInfo = info

--- a/Tests/MLXLMCommonFocusedTests/ToolCallProgressRoutingTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/ToolCallProgressRoutingTests.swift
@@ -1,0 +1,97 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+
+import Foundation
+import MLXLMCommon
+import Testing
+
+@Suite("Tool-call progress routing contracts")
+struct ToolCallProgressRoutingTests {
+
+    private let weatherTool: [[String: any Sendable]] = [
+        [
+            "type": "function",
+            "function": [
+                "name": "get_weather",
+                "parameters": [
+                    "type": "object",
+                    "properties": ["city": ["type": "string"]],
+                ],
+            ] as [String: any Sendable],
+        ]
+    ]
+
+    /// Streaming a tagged JSON envelope in small chunks must surface
+    /// `.toolCallProgress` deltas that concatenate to the collected envelope
+    /// text, followed by exactly one parsed `.toolCall`.
+    @Test("progress deltas stream while a call is collected")
+    func progressDeltasWhileCollecting() {
+        let processor = ToolCallProcessor(format: .json, tools: weatherTool)
+        let chunks = [
+            "<tool_call>", "{\"name\": \"get_w", "eather\", \"argu",
+            "ments\": {\"city\": \"Par", "is\"}}", "</tool_call>",
+        ]
+
+        var progress = ""
+        var progressEvents = 0
+        var calls: [ToolCall] = []
+        var visible = ""
+        for chunk in chunks {
+            for event in routeGenerationText(chunk, channel: .content, through: processor) {
+                switch event {
+                case .toolCallProgress(let delta):
+                    #expect(!delta.isEmpty)
+                    progress += delta
+                    progressEvents += 1
+                case .toolCall(let call):
+                    calls.append(call)
+                case .chunk(let text):
+                    visible += text
+                default:
+                    break
+                }
+            }
+        }
+        for event in flushGenerationText(channel: .content, through: processor) {
+            if case .toolCall(let call) = event { calls.append(call) }
+        }
+
+        #expect(progressEvents > 1, "multi-chunk envelope should yield multiple deltas")
+        #expect(progress.contains("\"city\": \"Par"))
+        #expect(calls.count == 1)
+        #expect(calls.first?.function.name == "get_weather")
+        #expect(visible.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+
+    /// Plain prose through the processor must never produce progress events.
+    @Test("no progress events for plain text")
+    func noProgressForPlainText() {
+        let processor = ToolCallProcessor(format: .json, tools: weatherTool)
+        var progressEvents = 0
+        var visible = ""
+        for chunk in ["Hello ", "world, no ", "tools here."] {
+            for event in routeGenerationText(chunk, channel: .content, through: processor) {
+                switch event {
+                case .toolCallProgress: progressEvents += 1
+                case .chunk(let text): visible += text
+                default: break
+                }
+            }
+        }
+        #expect(progressEvents == 0)
+        #expect(visible == "Hello world, no tools here.")
+    }
+
+    /// Strip-only processors (no tools offered) must not leak envelope text
+    /// as progress — the call itself is discarded, so no preview either.
+    @Test("strip-only processors emit no progress")
+    func stripOnlyEmitsNoProgress() {
+        let processor = ToolCallProcessor(format: .json, tools: nil, stripOnly: true)
+        var progressEvents = 0
+        for chunk in ["<tool_call>", "{\"name\": \"x\", \"arguments\": {}}", "</tool_call>"] {
+            for event in routeGenerationText(chunk, channel: .content, through: processor) {
+                if case .toolCallProgress = event { progressEvents += 1 }
+            }
+        }
+        #expect(progressEvents == 0)
+    }
+}

--- a/Tests/MLXLMTests/BatchEngineTests.swift
+++ b/Tests/MLXLMTests/BatchEngineTests.swift
@@ -875,7 +875,7 @@ class BatchEngineIntegrationTests: XCTestCase {
             case .prefillProgress(let p):
                 XCTAssertFalse(sawChunkOrInfo, "prefill progress must arrive before output/info")
                 progress.append(p)
-            case .chunk, .reasoning, .toolCall, .info:
+            case .chunk, .reasoning, .toolCall, .toolCallProgress, .info:
                 sawChunkOrInfo = true
             }
         }

--- a/Tests/MLXLMTests/ZayaSmokeJANGTQ2Tests.swift
+++ b/Tests/MLXLMTests/ZayaSmokeJANGTQ2Tests.swift
@@ -278,6 +278,8 @@ struct ZayaSmokeJANGTQ2Tests {
                 reasoning += chunk
             case .toolCall:
                 toolCalls += 1
+            case .toolCallProgress:
+                break
             case .prefillProgress:
 
                 break


### PR DESCRIPTION
## Proposed changes

Local models that write files through tools produce long silent gaps in consumer UIs. While a model generates a tool call, the tool call processor buffers the entire envelope internally and the stream emits nothing until the parsed call is complete. For a large file write this means tens of seconds with no events at all, so a chat UI cannot preview the code being written the way it can for ordinary streamed text. Downstream, Osaurus renders file writes as a live diff card, but on the local path that card can only appear after the whole call has finished.

This PR adds an incremental progress channel for in flight tool calls.

- Added a new `Generation.toolCallProgress(String)` event carrying raw envelope text deltas while a tool call is being collected. The payload is the format specific envelope text, not parsed arguments. The complete parsed call still arrives as a single `.toolCall` when the envelope closes, so `.toolCall` remains the only actionable tool event and existing consumers can ignore the new case.
- Exposed `ToolCallProcessor.collectingToolCallText`, the raw buffer of the call currently being collected. It reports nil in the `potentialToolCall` state, where an ambiguous prefix may still revert to plain text, so consumers never see text that could later be re-emitted as a visible chunk. It also reports nil for strip only processors, whose parsed calls are discarded because no tools were offered.
- Emitted the deltas from `routeGenerationText` by diffing the collecting buffer around each processed chunk. Because every streaming path (the token loop handler, `BatchEngine`, and SpecDec) already routes text through this shared function, all of them gain progress events with no changes to any per family parser state machine. A call that completes or reverts within a chunk simply reports no growth, and the prefix check handles the boundary where one call completes and the next begins inside the same chunk.
- Updated the exhaustive `Generation` switches in `BatchEngine`, the CLI, the integration test helpers, and existing tests to pass the new case through or ignore it.
- Added a focused test suite covering three contracts: multi chunk envelopes yield multiple deltas that concatenate to the collected text followed by exactly one parsed call, plain prose never yields progress events, and strip only processors never leak envelope text as progress.

Consumer impact: additive only. `Generation` gains one case; consumers with `@unknown default` or `default` branches are unaffected. Osaurus will map the new event to its streaming args channel so file writes preview live during generation.

## Checklist

Put an `x` in the boxes that apply.

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (if needed)