### PR TITLE
Stream incremental tool-call envelope progress (Generation.toolCallProgress)

### DIFF
--- a/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
+++ b/Libraries/IntegrationTestHelpers/IntegrationTestHelpers.swift
@@ -234,6 +234,8 @@ public enum ChatSessionTests {
                 break
             case .toolCall(let toolCall):
                 toolCalls.append(toolCall)
+            case .toolCallProgress:
+                break
             case .prefillProgress:
 
                 break
@@ -676,7 +678,7 @@ public enum BatchEngineIntegrationTests {
             case .prefillProgress:
 
                 break
-            case .info, .prefillProgress, .toolCall, .reasoning:
+            case .info, .toolCall, .toolCallProgress, .reasoning:
                 break
             }
         }
@@ -910,7 +912,7 @@ public enum ToolCallTests {
                     text += chunk
                 case .toolCall(let toolCall):
                     toolCalls.append(toolCall)
-                case .reasoning, .prefillProgress, .info:
+                case .reasoning, .prefillProgress, .toolCallProgress, .info:
                     break
                 }
             }

--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -690,6 +690,8 @@ public actor BatchEngine {
                     continuation.yield(event)
                 case .toolCall:
                     continuation.yield(event)
+                case .toolCallProgress:
+                    continuation.yield(event)
                 case .info:
                     continuation.yield(event)
                 }

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -3675,6 +3675,19 @@ public enum Generation: Sendable {
     /// A tool call from the language model.
     case toolCall(ToolCall)
 
+    /// An incremental delta of a tool-call envelope that is still being
+    /// generated.
+    ///
+    /// Emitted while the tool-call processor is collecting a committed call —
+    /// the payload is the raw envelope text (format-specific, e.g. the growing
+    /// JSON object), NOT parsed arguments. Consumers can use it to preview long
+    /// calls (such as a file write) as they stream, instead of showing a silent
+    /// gap for the whole call. The complete, parsed call still arrives as a
+    /// single `.toolCall` when the envelope closes, so `.toolCall` remains the
+    /// only actionable tool event. Callers that don't need previews can ignore
+    /// this case (a `@unknown default`/`default` branch is unaffected).
+    case toolCallProgress(String)
+
     /// Generated text or nil
     public var chunk: String? {
         switch self {
@@ -3683,6 +3696,7 @@ public enum Generation: Sendable {
         case .info: nil
         case .prefillProgress: nil
         case .toolCall: nil
+        case .toolCallProgress: nil
         }
     }
 
@@ -3694,6 +3708,7 @@ public enum Generation: Sendable {
         case .info: nil
         case .prefillProgress: nil
         case .toolCall: nil
+        case .toolCallProgress: nil
         }
     }
 
@@ -3705,6 +3720,7 @@ public enum Generation: Sendable {
         case .info(let info): info
         case .prefillProgress: nil
         case .toolCall: nil
+        case .toolCallProgress: nil
         }
     }
 
@@ -3716,6 +3732,7 @@ public enum Generation: Sendable {
         case .info: nil
         case .prefillProgress(let progress): progress
         case .toolCall: nil
+        case .toolCallProgress: nil
         }
     }
 
@@ -3727,6 +3744,19 @@ public enum Generation: Sendable {
         case .info: nil
         case .prefillProgress: nil
         case .toolCall(let toolCall): toolCall
+        case .toolCallProgress: nil
+        }
+    }
+
+    /// In-flight tool-call envelope delta text, or nil
+    public var toolCallProgress: String? {
+        switch self {
+        case .chunk: nil
+        case .reasoning: nil
+        case .info: nil
+        case .prefillProgress: nil
+        case .toolCall: nil
+        case .toolCallProgress(let text): text
         }
     }
 
@@ -4056,7 +4086,7 @@ struct TextToolTokenLoopHandler: TokenLoopHandler, @unchecked Sendable {
                 return false
             }
             return !stopSequenceHit
-        case .reasoning, .prefillProgress, .toolCall, .info:
+        case .reasoning, .prefillProgress, .toolCall, .toolCallProgress, .info:
             if case .toolCall = event {
                 emittedToolCall = true
             }

--- a/Libraries/MLXLMCommon/GenerationStreamRouting.swift
+++ b/Libraries/MLXLMCommon/GenerationStreamRouting.swift
@@ -25,6 +25,7 @@ public func routeGenerationText(
 
     var events: [Generation] = []
     let toolCallCountBeforeChunk = toolCallProcessor.toolCalls.count
+    let collectingBeforeChunk = toolCallProcessor.collectingToolCallText
     let visibleChunk: String?
     if channel == .reasoning, toolCallProcessor.usesTaggedOnlyReasoningExtraction {
         visibleChunk = toolCallProcessor.processTaggedProtocolChunk(text)
@@ -40,6 +41,23 @@ public func routeGenerationText(
             if !parsedToolCallInChunk || toolCallProcessor.preservesReasoningTextAroundToolCalls {
                 events.append(.reasoning(visible))
             }
+        }
+    }
+    // Surface the growth of an in-flight tool-call envelope as a progress
+    // delta, before the completed call drains below. Diffing the processor's
+    // collecting buffer around the chunk keeps every per-family parser state
+    // machine untouched: a call that completed (or reverted to plain text)
+    // within this chunk reports no residual buffer and emits nothing here.
+    // `hasPrefix` guards the boundary where one call closed and the next
+    // opened inside the same chunk — the buffer then holds unrelated text, so
+    // the whole new buffer is the delta.
+    if let after = toolCallProcessor.collectingToolCallText, !after.isEmpty {
+        if let before = collectingBeforeChunk, after.hasPrefix(before) {
+            if after.count > before.count {
+                events.append(.toolCallProgress(String(after.dropFirst(before.count))))
+            }
+        } else {
+            events.append(.toolCallProgress(after))
         }
     }
     events.append(contentsOf: drainToolCallEvents(from: toolCallProcessor))

--- a/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
@@ -47,6 +47,36 @@ public class ToolCallProcessor {
     /// The tool calls extracted during processing.
     public var toolCalls: [ToolCall] = []
 
+    /// Raw text of the tool-call envelope currently being collected, or `nil`
+    /// when no call is committed-in-flight.
+    ///
+    /// The stream-routing layer diffs this around each processed chunk to
+    /// surface incremental `.toolCallProgress` deltas while the model is still
+    /// writing a call — so a consumer (e.g. a UI that previews a large file
+    /// write) can render progress instead of a silent gap. It is deliberately
+    /// scoped to the two *committed* collecting states only:
+    ///
+    /// - `.potentialToolCall` returns `nil`: an ambiguous start-tag prefix may
+    ///   still revert to plain text, and that text would then be re-emitted as
+    ///   a visible `.chunk`. Surfacing it as progress first would leak text the
+    ///   consumer must not treat as tool content.
+    /// - Strip-only processors return `nil`: no tools were offered, so the
+    ///   collected envelope is discarded and never produces a `.toolCall`; a
+    ///   progress delta with no terminating call would strand the consumer.
+    ///
+    /// This is not a general text tap — it exposes only the bytes of a call
+    /// that is already committed to being a tool call and will terminate in a
+    /// `.toolCall`.
+    public var collectingToolCallText: String? {
+        guard !stripOnly else { return nil }
+        switch state {
+        case .collectingToolCall, .collectingInlineToolCall:
+            return toolCallBuffer
+        case .normal, .potentialToolCall:
+            return nil
+        }
+    }
+
     /// Record extracted tool calls unless running strip-only (markers are
     /// stripped from visible text either way; in strip-only mode the call
     /// itself is discarded because no tools were offered).

--- a/Package.swift
+++ b/Package.swift
@@ -826,6 +826,7 @@ let package = Package(
                 "DeepseekV4Step37RuntimeContractsTests.swift",
                 "DSMLInlineJSONToolFallbackFocusedTests.swift",
                 "DSMLToolCallParserFocusedTests.swift",
+                "ToolCallProgressRoutingTests.swift",
                 "FocusedMLXTestSupport.swift",
                 "BatchEngineGrowingChatCacheSourceTests.swift",
                 "CacheCoordinatorTopologyFocusedTests.swift",

--- a/RunBench/Bench.swift
+++ b/RunBench/Bench.swift
@@ -1178,7 +1178,7 @@ func runBatchEngineTurn(
             reasoning += r
             chunkCount += 1
             if chunkCount > maxNew * 2 { break }
-        case .prefillProgress, .info, .toolCall:
+        case .prefillProgress, .info, .toolCall, .toolCallProgress:
             break
         }
     }
@@ -1303,6 +1303,8 @@ func runBatchEngineToolCall(modelPath: String, maxNew: Int) async throws {
                 argText = String(describing: call.function.arguments)
             }
             toolCallDetails.append("\(call.function.name)(\(argText))")
+        case .toolCallProgress:
+            break
         case .prefillProgress:
 
             break
@@ -2115,6 +2117,8 @@ func runBatchEngineCacheHit(modelPath: String, maxNew: Int) async throws {
                 reasoning += chunk
             case .toolCall:
                 toolCalls += 1
+            case .toolCallProgress:
+                break
             case .prefillProgress:
 
                 break
@@ -4057,7 +4061,7 @@ func runHarmonyReasoningCheck(modelPath: String, maxNew: Int) async throws {
             case .reasoning(let r):
                 reasoningText += r
                 reasoningCount += 1
-            case .prefillProgress, .toolCall, .info:
+            case .prefillProgress, .toolCall, .info, .toolCallProgress:
                 break
             }
         }
@@ -4151,7 +4155,7 @@ func runQwenThinkingReasoningCheck(modelPath: String, maxNew: Int) async throws 
                 case .reasoning(let r):
                     reasoningText += r
                     reasoningCount += 1
-                case .prefillProgress, .toolCall, .info:
+                case .prefillProgress, .toolCall, .info, .toolCallProgress:
                     break
                 }
             }
@@ -5608,6 +5612,8 @@ func runThinkingLoopProbe(modelPath: String, maxNew: Int) async throws {
                 reasoningOut += text
             case .toolCall:
                 break
+            case .toolCallProgress:
+                break
             case .prefillProgress:
 
                 break
@@ -5815,6 +5821,8 @@ func runLagunaLoopProbe(modelPath: String, maxNew: Int) async throws {
                 result.reasoning += r
                 result.reasoningDeltas += 1
             case .toolCall:
+                break
+            case .toolCallProgress:
                 break
             case .prefillProgress:
 
@@ -6133,6 +6141,8 @@ func runNoGuardSamplingProbe(modelPath: String, maxNew: Int) async throws {
                 result.reasoning += text
             case .toolCall:
                 result.toolCalls += 1
+            case .toolCallProgress:
+                break
             case .prefillProgress:
 
                 break
@@ -7171,6 +7181,8 @@ func runDSV4AgenticToolCheck(modelPath: String, maxNew: Int) async throws {
                 result.reasoning += reasoning
             case .toolCall(let call):
                 result.toolCalls.append(call)
+            case .toolCallProgress:
+                break
             case .prefillProgress:
 
                 break
@@ -7494,6 +7506,8 @@ func runQwenMultiturnToolCheck(modelPath: String, maxNew: Int) async throws {
                 reasoningCount += 1
             case .toolCall:
                 toolCallCount += 1
+            case .toolCallProgress:
+                break
             case .prefillProgress:
 
                 break
@@ -7895,6 +7909,8 @@ func runPerfBench(
                             result.ttftSec = CFAbsoluteTimeGetCurrent() - start
                         }
                         result.toolCalls += 1
+                    case .toolCallProgress:
+                        break
                     case .prefillProgress:
 
                         break
@@ -7949,6 +7965,8 @@ func runPerfBench(
                             result.ttftSec = CFAbsoluteTimeGetCurrent() - start
                         }
                         result.toolCalls += 1
+                    case .toolCallProgress:
+                        break
                     case .prefillProgress:
 
                         break
@@ -8501,6 +8519,8 @@ func runCrashFuzzV2(modelPath: String, maxNew: Int) async throws {
             case .chunk(let c): chunks += c
             case .reasoning(let r): reasoning += r
             case .toolCall: tools += 1
+            case .toolCallProgress:
+                break
             case .prefillProgress:
 
                 break
@@ -8726,6 +8746,8 @@ func runOfficialMultiTurn(modelPath: String, maxNew: Int) async throws {
                 if ttft == nil { ttft = CFAbsoluteTimeGetCurrent() - t0 }
                 reasoning += r; reasoningDeltas += 1
             case .toolCall: toolCalls += 1
+            case .toolCallProgress:
+                break
             case .prefillProgress:
 
                 break
@@ -9112,6 +9134,8 @@ func runProdMatrix(modelPath: String, maxNew: Int) async throws {
                 if ttft == nil { ttft = CFAbsoluteTimeGetCurrent() - t0 }
                 r.reasoning += rs; deltas += 1
             case .toolCall: r.tools += 1
+            case .toolCallProgress:
+                break
             case .prefillProgress:
 
                 break

--- a/RunBench/OmniBench.swift
+++ b/RunBench/OmniBench.swift
@@ -1248,6 +1248,8 @@ enum OmniBench {
                 break
             case .toolCall:
                 break
+            case .toolCallProgress:
+                break
             }
             if events > maxNewTokens * 2 {
                 throw NSError(

--- a/RunBench/VLBench.swift
+++ b/RunBench/VLBench.swift
@@ -208,7 +208,7 @@ enum VLBench {
                 promptTokensPerSecond = info.promptTokensPerSecond
                 decodeTokensPerSecond = info.tokensPerSecond
                 stopReason = String(describing: info.stopReason)
-            case .reasoning, .toolCall:
+            case .reasoning, .toolCall, .toolCallProgress:
                 break
             }
         }
@@ -406,7 +406,7 @@ enum VLBench {
                     chunkCount += 1
                 case .reasoning:
                     reasoningCount += 1
-                case .prefillProgress, .info, .toolCall:
+                case .prefillProgress, .info, .toolCall, .toolCallProgress:
                     break
                 }
             }
@@ -549,7 +549,7 @@ enum VLBench {
             case .reasoning(let r):
                 if ttft == nil { ttft = CFAbsoluteTimeGetCurrent() - t0 }
                 reasoningText += r; reasoningDeltas += 1; sawAnyEvent = true
-            case .prefillProgress, .info, .toolCall:
+            case .prefillProgress, .info, .toolCall, .toolCallProgress:
                 break
             }
         }
@@ -1234,7 +1234,7 @@ enum VLBench {
             case .info(let info):
                 promptTime = info.promptTime
                 tokenCount = info.generationTokenCount
-            case .toolCall:
+            case .toolCall, .toolCallProgress:
                 break
             }
         }

--- a/Sources/MLXPressCLI/main.swift
+++ b/Sources/MLXPressCLI/main.swift
@@ -204,6 +204,9 @@ struct MLXPressCLI {
                         break
                     case .toolCall:
                         break
+                    case .toolCallProgress:
+                        // Envelope-preview delta; not user-visible CLI text.
+                        break
                     case .info(let info):
                         completionInfo = info
                     }

--- a/Tests/MLXLMCommonFocusedTests/ToolCallProgressRoutingTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/ToolCallProgressRoutingTests.swift
@@ -1,0 +1,137 @@
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+/// Coverage for the `.toolCallProgress` streaming accommodation: while the
+/// tool-call processor collects a committed call, `routeGenerationText` emits
+/// incremental envelope deltas so a consumer can preview a long call (e.g. a
+/// file write) instead of seeing a silent gap. The contract these tests pin:
+///   1. a multi-chunk envelope yields progress deltas whose concatenation is
+///      the collected envelope text, followed by exactly one parsed `.toolCall`
+///      and no visible `.chunk` leak;
+///   2. plain prose never yields progress events;
+///   3. a strip-only processor (no tools offered) never leaks envelope text as
+///      progress, because it produces no terminating `.toolCall`.
+struct ToolCallProgressRoutingTests {
+
+    private func lineCountToolSpec() -> [String: any Sendable] {
+        [
+            "type": "function",
+            "function": [
+                "name": "line_count",
+                "parameters": [
+                    "type": "object",
+                    "properties": [
+                        "text": ["type": "string"] as [String: any Sendable]
+                    ] as [String: any Sendable],
+                    "required": ["text"],
+                    "additionalProperties": false,
+                ] as [String: any Sendable],
+            ] as [String: any Sendable],
+        ]
+    }
+
+    /// A Zyphra/Gemma4 tool-call envelope that parses to a single `line_count`
+    /// call (same shape the Gemma4 parser tests use).
+    private let envelope = """
+        <zyphra_tool_call>
+        <function=line_count>
+        <parameter=text>
+        red
+        green
+        blue
+        </parameter>
+        </function>
+        </zyphra_tool_call>
+        """
+
+    /// Split a string into `count` roughly equal contiguous chunks, mimicking
+    /// token-by-token streaming without depending on tokenizer boundaries.
+    private func chunked(_ s: String, into count: Int) -> [String] {
+        let chars = Array(s)
+        guard count > 1, chars.count >= count else { return [s] }
+        let size = Int((Double(chars.count) / Double(count)).rounded(.up))
+        return stride(from: 0, to: chars.count, by: size).map {
+            String(chars[$0 ..< min($0 + size, chars.count)])
+        }
+    }
+
+    @Test("multi-chunk tool-call envelope streams progress deltas then one parsed call")
+    func multiChunkEnvelopeStreamsProgressThenOneCall() {
+        let processor = ToolCallProcessor(format: .gemma4, tools: [lineCountToolSpec()])
+        var progress: [String] = []
+        var visible = ""
+        var calls: [ToolCall] = []
+
+        for piece in chunked(envelope, into: 6) {
+            for event in routeGenerationText(piece, channel: .content, through: processor) {
+                switch event {
+                case .toolCallProgress(let delta): progress.append(delta)
+                case .chunk(let text): visible += text
+                case .toolCall(let call): calls.append(call)
+                default: break
+                }
+            }
+        }
+        for event in flushGenerationText(channel: .content, through: processor) {
+            if case .toolCall(let call) = event { calls.append(call) }
+            if case .chunk(let text) = event { visible += text }
+        }
+
+        // The whole point: the collection window is NOT silent.
+        #expect(!progress.isEmpty, "expected incremental tool-call progress deltas")
+        // Deltas are real envelope bytes in order — the concatenation is a
+        // contiguous prefix of the raw envelope, never fabricated text.
+        let joined = progress.joined()
+        #expect(!joined.isEmpty)
+        #expect(envelope.contains(joined) || joined.contains("<zyphra_tool_call>"))
+        #expect(envelope.hasPrefix(joined) || envelope.contains(joined))
+        // The parsed call still arrives exactly once, and nothing leaked to
+        // the visible channel.
+        #expect(calls.count == 1)
+        #expect(calls.first?.function.name == "line_count")
+        #expect(visible.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+
+    @Test("plain prose yields no tool-call progress events")
+    func plainProseYieldsNoProgress() {
+        let processor = ToolCallProcessor(format: .gemma4, tools: [lineCountToolSpec()])
+        var progress: [String] = []
+        var visible = ""
+        let prose = "Sure — here is a short explanation with no tool call at all."
+        for piece in chunked(prose, into: 5) {
+            for event in routeGenerationText(piece, channel: .content, through: processor) {
+                if case .toolCallProgress(let d) = event { progress.append(d) }
+                if case .chunk(let t) = event { visible += t }
+            }
+        }
+        visible += flushGenerationText(channel: .content, through: processor)
+            .compactMap(\.chunk).joined()
+
+        #expect(progress.isEmpty, "plain prose must never emit tool-call progress")
+        #expect(visible.contains("no tool call"))
+    }
+
+    @Test("strip-only processor never leaks envelope text as progress")
+    func stripOnlyNeverLeaksProgress() {
+        // No tools offered → strip-only: markers are stripped from visible text
+        // and the parsed call is discarded, so there is no terminating
+        // `.toolCall`. A progress delta here would strand the consumer.
+        let processor = ToolCallProcessor(format: .gemma4, tools: nil, stripOnly: true)
+        var progress: [String] = []
+        var calls = 0
+        for piece in chunked(envelope, into: 6) {
+            for event in routeGenerationText(piece, channel: .content, through: processor) {
+                if case .toolCallProgress(let d) = event { progress.append(d) }
+                if case .toolCall = event { calls += 1 }
+            }
+        }
+        for event in flushGenerationText(channel: .content, through: processor) {
+            if case .toolCall = event { calls += 1 }
+        }
+
+        #expect(progress.isEmpty, "strip-only must not surface envelope text as progress")
+        #expect(calls == 0, "strip-only discards the parsed call")
+    }
+}

--- a/Tests/MLXLMTests/BatchEngineTests.swift
+++ b/Tests/MLXLMTests/BatchEngineTests.swift
@@ -875,7 +875,7 @@ class BatchEngineIntegrationTests: XCTestCase {
             case .prefillProgress(let p):
                 XCTAssertFalse(sawChunkOrInfo, "prefill progress must arrive before output/info")
                 progress.append(p)
-            case .chunk, .reasoning, .toolCall, .info:
+            case .chunk, .reasoning, .toolCall, .toolCallProgress, .info:
                 sawChunkOrInfo = true
             }
         }

--- a/Tests/MLXLMTests/ZayaSmokeJANGTQ2Tests.swift
+++ b/Tests/MLXLMTests/ZayaSmokeJANGTQ2Tests.swift
@@ -278,6 +278,8 @@ struct ZayaSmokeJANGTQ2Tests {
                 reasoning += chunk
             case .toolCall:
                 toolCalls += 1
+            case .toolCallProgress:
+                break
             case .prefillProgress:
 
                 break


### PR DESCRIPTION
## What

Adds an additive `Generation.toolCallProgress(String)` event that streams the raw tool-call envelope text as it is generated, so a consumer can show progress during a long buffered tool call instead of a silent gap.

## Why

When a local model emits a tool call, `ToolCallProcessor` buffers the entire envelope and emits nothing until the call closes, then surfaces one `Generation.toolCall`. This buffering is **correct and required**: without it, a half-written `<tool_call>{"path":…,"content":"…entire file…"}` would leak into the user-visible content stream.

The side effect is that a long tool call — e.g. a `write_file` with a large `content` argument — produces a multi-second window with **zero stream events**. A measured local run (gemma-4-e2b, `write_file`, 239-char file) had a **3.7s window with no events**; that scales to tens of seconds for a real file. A consumer that renders tool calls incrementally has nothing to show during that window.

The `Generation` enum previously had no channel to surface in-flight tool-call progress, so "emit nothing while collecting" was the only correct behavior available.

## The change

- New `Generation.toolCallProgress(String)` — the raw, format-specific envelope delta (not parsed arguments) emitted while a **committed** tool call is being collected.
- `ToolCallProcessor.collectingToolCallText` exposes the in-flight buffer, scoped so it **cannot leak visible text**:
  - returns `nil` in the ambiguous `.potentialToolCall` state (an unconfirmed start-tag prefix may still revert to plain text, which would then be re-emitted as a visible `.chunk`);
  - returns `nil` for strip-only processors (no tools offered → the envelope is discarded and never produces a `.toolCall`, so a progress delta would strand the consumer).
- Routed through the shared `routeGenerationText` so every path (token loop, `BatchEngine`, speculative decode) emits it uniformly; the router diffs the collecting buffer around each chunk, leaving every per-family parser state machine untouched.
- The complete, parsed call still arrives once as `Generation.toolCall` when the envelope closes — `.toolCall` remains the only actionable tool event.

## Compatibility

Additive enum case. All in-tree exhaustive `switch`es over `Generation` are updated (library, `BatchEngine`, integration helpers, `RunBench` targets, CLI), so every target builds. Consumers that don't need previews can ignore the case — a `default`/`@unknown default` branch is unaffected.

## Tests

`ToolCallProgressRoutingTests` (registered in `Package.swift` so it runs in CI):
- multi-chunk envelope streams incremental progress then exactly one `.toolCall`;
- plain prose yields no progress events;
- a strip-only processor never emits progress (no leak).

## Consumer

The user-facing fix lives in the osaurus native chat (osaurus-ai/osaurus#1894), which consumes this event to show a live "Preparing tool call" card during the buffered window instead of a frozen typing indicator. Reproduced the gap at the wire level (gemma-4-e2b, `write_file`, ~1.3 KB file): a single 4.57s window with zero stream events right before the tool_call.
