### PR TITLE
Extract nested-XML tool args for ZAYA rows

### DIFF
--- a/Libraries/MLXLMCommon/Tool/Parsers/XMLFunctionParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/XMLFunctionParser.swift
@@ -34,6 +34,26 @@ public struct XMLFunctionParser: ToolCallParser, Sendable {
     }
 
     public func parse(content: String, tools: [[String: any Sendable]]?) -> ToolCall? {
+        // Some ZAYA rows emit a fully *nested* XML body instead of the
+        // attribute form this parser was written for:
+        //
+        //   <function>file_write
+        //   <parameter>
+        //   <name>path</name>
+        //   <value>out.txt</value>
+        //   </parameter>
+        //
+        // i.e. `<function>name` (no `=`) and `<parameter><name>k</name>
+        // <value>v</value></parameter>` instead of `<function=name>` /
+        // `<parameter=k>v</parameter>`. The attribute scan below finds no
+        // `<parameter=` and drops every argument (observed: file_write parses
+        // but `path` is reported missing). Handle the nested form first — gated
+        // on the distinctive `<name>`-inside-`<parameter>` marker so the
+        // attribute path is left completely untouched (no regression). See
+        // MODEL_ISSUES_TRIAGE / ZAYA tool-arg extraction.
+        if let nested = parseNestedParameterForm(content, tools: tools) {
+            return nested
+        }
         // Pattern: <function=(content)</function> — [\s\S] matches newlines
         guard
             let funcMatch = content.range(
@@ -150,6 +170,79 @@ public struct XMLFunctionParser: ToolCallParser, Sendable {
             return ToolCall(function: .init(name: funcName, arguments: invalidArguments))
         }
 
+        return ToolCall(function: .init(name: funcName, arguments: arguments))
+    }
+
+    /// Parse the *nested* ZAYA XML body:
+    /// `<function>name … <parameter><name>key</name><value>val</value></parameter> …`.
+    /// Returns nil — so the caller falls through to the attribute-style scan —
+    /// unless the distinctive nested `<name>…</name>` / `<value>…</value>`
+    /// parameter markers are present, so attribute-style calls are never
+    /// rerouted here. Reuses the same value post-processing / schema validation
+    /// as the attribute path so both wire forms behave identically downstream.
+    private func parseNestedParameterForm(
+        _ content: String,
+        tools: [[String: any Sendable]]?
+    ) -> ToolCall? {
+        // Gate on the nested markers so the attribute path stays untouched.
+        guard content.range(of: "<name>") != nil,
+            content.range(of: "<value>") != nil,
+            let funcOpen = content.range(of: "<function")
+        else { return nil }
+
+        // Function name: `<function>name` (nested) or `<function=name>`
+        // (attribute) — read from just after the opener to the first
+        // newline / `<` / `>`.
+        var cursor = funcOpen.upperBound
+        if cursor < content.endIndex, content[cursor] == "=" || content[cursor] == ">" {
+            cursor = content.index(after: cursor)
+        }
+        let nameStop =
+            content[cursor...].firstIndex { $0 == "\n" || $0 == "<" || $0 == ">" }
+            ?? content.endIndex
+        let funcName = String(content[cursor ..< nameStop])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !funcName.isEmpty else { return nil }
+
+        // Pair each `<name>key</name>` with the following `<value>val</value>`.
+        var arguments: [String: any Sendable] = [:]
+        var search = content.startIndex ..< content.endIndex
+        while let nameOpen = content.range(of: "<name>", range: search),
+            let nameClose = content.range(
+                of: "</name>", range: nameOpen.upperBound ..< content.endIndex)
+        {
+            let key = String(content[nameOpen.upperBound ..< nameClose.lowerBound])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            search = nameClose.upperBound ..< content.endIndex
+            guard !key.isEmpty,
+                let valueOpen = content.range(of: "<value>", range: search),
+                let valueClose = content.range(
+                    of: "</value>", range: valueOpen.upperBound ..< content.endIndex)
+            else { continue }
+
+            var value = String(content[valueOpen.upperBound ..< valueClose.lowerBound])
+            value = trimBoundaryNewlines(value)
+            if decodesHTMLLineBreaks,
+                isStringType(funcName: funcName, argName: key, tools: tools) {
+                value = decodeHTMLLineBreaks(value)
+            }
+            if unwrapJSONQuotedStringParameters,
+                isStringType(funcName: funcName, argName: key, tools: tools),
+                let unwrapped = decodeQuotedStringParameter(value) {
+                value = trimBoundaryNewlines(unwrapped)
+            }
+            arguments[key] = convertParameterValue(
+                value, paramName: key, funcName: funcName, tools: tools)
+            search = valueClose.upperBound ..< content.endIndex
+        }
+
+        // No nested params extracted → let the attribute-style scan try.
+        guard !arguments.isEmpty else { return nil }
+
+        if let invalidArguments = schemaValidationFailure(
+            toolName: funcName, arguments: arguments, tools: tools) {
+            return ToolCall(function: .init(name: funcName, arguments: invalidArguments))
+        }
         return ToolCall(function: .init(name: funcName, arguments: arguments))
     }
 

--- a/Tests/MLXLMCommonToolParserFocusedTests/ZayaNestedToolArgTests.swift
+++ b/Tests/MLXLMCommonToolParserFocusedTests/ZayaNestedToolArgTests.swift
@@ -82,6 +82,87 @@ struct ZayaNestedToolArgTests {
         #expect(call.function.arguments["content"] == .string("hi"))
     }
 
+    /// VERBATIM live JANGTQ4 capture: `<name>` / `<type>` / `<value>` interleaved.
+    /// The `<type>string</type>` tag sits between name and value — the pairing
+    /// must skip it and still bind name→value.
+    @Test("nested body with interleaved <type> tag extracts every argument")
+    func nestedWithTypeTagExtractsArgs() throws {
+        let content = """
+            <zyphra_tool_call>
+            <function=file_write>
+            <parameter>
+            <name>content</name>
+            <type>string</type>
+            <value>hi</value>
+            </parameter>
+            <parameter>
+            <name>path</name>
+            <type>string</type>
+            <value>note.txt</value>
+            </parameter>
+            </function>
+            </zyphra_tool_call>
+            """
+        let call = try #require(zayaParser().parse(content: content, tools: fileWrite))
+        #expect(call.function.name == "file_write")
+        #expect(call.function.arguments["path"] == .string("note.txt"))
+        #expect(call.function.arguments["content"] == .string("hi"))
+    }
+
+    /// VERBATIM live JANGTQ4 capture under `tool_choice:required`: the function
+    /// name is wrapped in a *closed* `<function>name</function>` tag (not
+    /// `<function=name>`), followed by nested `<name>`/`<value>` params.
+    @Test("closed <function>name</function> tag with nested values extracts args")
+    func closedFunctionTagNestedValuesExtractsArgs() throws {
+        let content = """
+            <zyphra_tool_call>
+            <function>file_write</function>
+            <parameter>
+            <name>path</name>
+            <value>note.txt</value>
+            </parameter>
+            <parameter>
+            <name>content</name>
+            <value>hi there</value>
+            </parameter>
+            </function>
+            </zyphra_tool_call>
+            """
+        let call = try #require(zayaParser().parse(content: content, tools: fileWrite))
+        #expect(call.function.name == "file_write")
+        #expect(call.function.arguments["path"] == .string("note.txt"))
+        #expect(call.function.arguments["content"] == .string("hi there"))
+    }
+
+    /// REGRESSION GUARD: a nested body that carries names/types but NO `<value>`
+    /// tags (live JANGTQ4 auto-mode: the model echoes the tool-definition
+    /// skeleton) must NOT fabricate arguments — it yields the schema-validation
+    /// envelope, never a partial call with mispaired values.
+    @Test("nested names without values does not fabricate arguments")
+    func nestedNamesWithoutValuesNoFabrication() {
+        let content = """
+            <zyphra_tool_call>
+            <function=file_write>
+            <parameter>
+            <name>content</name>
+            <type>string</type>
+            </parameter>
+            <parameter>
+            <name>path</name>
+            <type>string</type>
+            </parameter>
+            </function>
+            </zyphra_tool_call>
+            """
+        let call = zayaParser().parse(content: content, tools: fileWrite)
+        // No <value> anywhere → nested gate fails → attribute scan finds no
+        // `<parameter=` → schema validation envelope (not a real call).
+        if let call {
+            #expect(call.function.arguments["path"] == nil)
+            #expect(call.function.arguments["_error"] == .string("invalid_tool_arguments"))
+        }
+    }
+
     /// REGRESSION GUARD: the classic attribute form must be unchanged.
     @Test("attribute-style body is untouched")
     func attributeStyleUnchanged() throws {

--- a/Tests/MLXLMCommonToolParserFocusedTests/ZayaNestedToolArgTests.swift
+++ b/Tests/MLXLMCommonToolParserFocusedTests/ZayaNestedToolArgTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+import MLXLMCommon
+import Testing
+
+/// ZAYA rows emit a fully *nested* XML tool body —
+/// `<function>name … <parameter><name>key</name><value>val</value></parameter>` —
+/// instead of the attribute form `<function=name><parameter=key>val</parameter>`.
+/// The attribute-only scan found no `<parameter=` and dropped every argument
+/// (live: `file_write` parsed but `path` reported missing). These pin the nested
+/// extraction and guard the attribute path against regression.
+@Suite("ZAYA nested XML tool-arg extraction")
+struct ZayaNestedToolArgTests {
+
+    private let fileWrite: [[String: any Sendable]] = [
+        [
+            "type": "function",
+            "function": [
+                "name": "file_write",
+                "parameters": [
+                    "type": "object",
+                    "properties": [
+                        "path": ["type": "string"],
+                        "content": ["type": "string"],
+                    ] as [String: any Sendable],
+                    "required": ["path", "content"],
+                ] as [String: any Sendable],
+            ] as [String: any Sendable],
+        ]
+    ]
+
+    private func zayaParser() -> XMLFunctionParser {
+        XMLFunctionParser(
+            startTag: "<zyphra_tool_call>",
+            endTag: "</zyphra_tool_call>",
+            decodesHTMLLineBreaks: true,
+            unwrapJSONQuotedStringParameters: true)
+    }
+
+    /// Exact live shape (JANGTQ4): `<function>name` with no `=`, nested params.
+    @Test("nested body with <function>name extracts every argument")
+    func nestedFunctionOpenerExtractsArgs() throws {
+        let content = """
+            <zyphra_tool_call>
+            <function>file_write
+            <parameter>
+            <name>path</name>
+            <value>out.txt</value>
+            </parameter>
+            <parameter>
+            <name>content</name>
+            <value>hello</value>
+            </parameter>
+            </function>
+            </zyphra_tool_call>
+            """
+        let call = try #require(zayaParser().parse(content: content, tools: fileWrite))
+        #expect(call.function.name == "file_write")
+        #expect(call.function.arguments["path"] == .string("out.txt"))
+        #expect(call.function.arguments["content"] == .string("hello"))
+    }
+
+    /// JANGTQ_K shape: attribute `<function=name>` opener but nested params.
+    @Test("attribute function opener with nested params still extracts args")
+    func attributeOpenerNestedParamsExtractsArgs() throws {
+        let content = """
+            <zyphra_tool_call>
+            <function=file_write>
+            <parameter>
+            <name>path</name>
+            <value>note.txt</value>
+            </parameter>
+            <parameter>
+            <name>content</name>
+            <value>hi</value>
+            </parameter>
+            </function>
+            </zyphra_tool_call>
+            """
+        let call = try #require(zayaParser().parse(content: content, tools: fileWrite))
+        #expect(call.function.name == "file_write")
+        #expect(call.function.arguments["path"] == .string("note.txt"))
+        #expect(call.function.arguments["content"] == .string("hi"))
+    }
+
+    /// REGRESSION GUARD: the classic attribute form must be unchanged.
+    @Test("attribute-style body is untouched")
+    func attributeStyleUnchanged() throws {
+        let content =
+            "<zyphra_tool_call>\n<function=line_count>\n<parameter=text>\nhi there\n</parameter>\n</function>\n</zyphra_tool_call>"
+        let tools: [[String: any Sendable]] = [
+            [
+                "type": "function",
+                "function": [
+                    "name": "line_count",
+                    "parameters": [
+                        "type": "object",
+                        "properties": ["text": ["type": "string"]] as [String: any Sendable],
+                        "required": ["text"],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable],
+            ]
+        ]
+        let call = try #require(zayaParser().parse(content: content, tools: tools))
+        #expect(call.function.name == "line_count")
+        #expect(call.function.arguments["text"] == .string("hi there"))
+    }
+
+    /// REGRESSION GUARD: ordinary prose (no tool markers) never becomes a call.
+    @Test("plain prose yields no tool call")
+    func plainProseNoCall() {
+        #expect(zayaParser().parse(content: "Sure, I can help with that.", tools: fileWrite) == nil)
+    }
+}


### PR DESCRIPTION
ZAYA models emit a nested XML tool body — `<parameter><name>k</name>[<type>t</type>]<value>v</value></parameter>`, with the function opener as either `<function=name>` or a closed `<function>name</function>` — instead of the attribute form `<parameter=key>value</parameter>` that `XMLFunctionParser` was written for. The attribute-only scan found no `<parameter=` and dropped every argument, so a parsed `file_write` call surfaced with its required args missing (live: `Missing required property: path`).

## Fix
`parseNestedParameterForm` runs before the attribute scan, gated on the distinctive nested `<name>`/`<value>` markers so attribute-style calls are never rerouted. It pairs each `<name>key</name>` with the following `<value>…</value>` (skipping any interleaved `<type>`), and reuses the same value post-processing + schema validation as the attribute path so both wire forms behave identically downstream. Falls through (returns nil) when no nested params are present.

## Proof
- 7 focused unit tests: verbatim live captures (interleaved `<type>`, closed `<function>name</function>` opener), attribute-form regression guards, and a no-`<value>` non-fabrication guard (auto-mode skeleton must not invent args).
- Live-proven end to end: a JANGTQ4 nested-with-values call now parses to `{"path":…,"content":…}` where it previously failed.
- Zero regression: the attribute path is untouched; focused tool-parser suite green.