### PR TITLE
Correct compiled-decode 'minimal impact' comment with measured data

### DIFF
--- a/Libraries/MLXLMCommon/HardwareInfo.swift
+++ b/Libraries/MLXLMCommon/HardwareInfo.swift
@@ -30,11 +30,22 @@ public enum HardwareInfo {
     /// crash was confirmed on M4 Pro (Mac16,x) as well — the bug is a macOS Tahoe
     /// Metal shader compiler issue, not hardware-specific.
     ///
-    /// Performance impact of disabling: minimal. These are small activation function
-    /// fusions (GELU, SwiGLU, softcap). The individual Metal ops work correctly on
-    /// all hardware and the per-op overhead is negligible vs. the model forward pass.
+    /// Performance impact of disabling: SIGNIFICANT for real decode, not the
+    /// negligible micro-fusion cost this comment previously claimed.
+    /// `compile(shapeless:)` fuses the whole single-slot decode step (not just
+    /// GELU/SwiGLU/softcap), so gating it off leaves the per-token graph
+    /// unfused. Local decode-throughput benchmarks put the compile-ON gain in
+    /// the ~+45% to +70% range across gemma-4-e2b and qwen (the exact magnitude
+    /// varies with build config and measurement path — RunBench direct decode
+    /// vs. the full server path differ substantially in absolute tok/s, so
+    /// treat the *ratio*, not any single absolute, as the takeaway). It is
+    /// disabled only because it is not yet proven model-switch-safe (see #1173
+    /// below), NOT because it is cheap — enabling it (Settings -> Decode
+    /// Performance, or VMLX_ENABLE_UNSAFE_COMPILE=1) is the single biggest
+    /// local-decode speedup available.
     ///
-    /// Re-enable when Apple fixes the Metal JIT in a future macOS update.
+    /// Re-enable by default once the Metal JIT is fixed AND the #1173 model-switch
+    /// corruption is resolved (e.g. clearing the MLX compile cache on model swap).
     public static var isCompiledDecodeSupported: Bool {
         // 2026-05-20: keep MLX compile off by default for host apps. A live
         // Osaurus PR #1173 switch test reproduced process-local decode


### PR DESCRIPTION
`HardwareInfo.isCompiledDecodeSupported`'s doc claimed disabling compiled decode has *minimal impact* (only small GELU/SwiGLU/softcap fusions). Benchmarking says otherwise.

Measured decode throughput (M5 Max, Release build, engine-reported `usage.tokens_per_second`), compile OFF (current default) vs ON (`VMLX_ENABLE_UNSAFE_COMPILE=1`):

| model | OFF | ON | speedup |
|---|---|---|---|
| gemma-4-e2b-it-4bit | 47 t/s | 81 t/s | **+72%** |
| qwen3-0.6b-8bit | 131 t/s | 200 t/s | **+52%** |

`compile(shapeless:)` fuses the whole single-slot decode step, so gating it off leaves the per-token graph unfused — not a negligible micro-fusion cost. The gate correctly stays off pending model-switch safety (#1173), but the comment now reflects that a major decode speedup is being traded away. That reframes the priority of resolving #1173 (e.g. clearing the MLX compile cache on model swap) so compiled decode can return to default.

Comment-only; no behavior change. Correctness held across a gemma↔qwen model switch under compile-ON in local testing (the exact #1173 repro models weren't available to fully re-verify).