### PR TITLE
Fix production crash traps: Qwen3VL position ids, error-array subscripts, compiled-closure failures

### DIFF
--- a/Libraries/MLXLLM/Models/NemotronH.swift
+++ b/Libraries/MLXLLM/Models/NemotronH.swift
@@ -413,6 +413,12 @@ internal class NemotronHMamba2Mixer: Module, NemotronHMixer {
         let splitStart = profile ? CFAbsoluteTimeGetCurrent() : 0
         let splits = split(
             projected, indices: [intermediateSize, intermediateSize + convDim], axis: -1)
+        // A failed split (e.g. a checkpoint whose in_proj width disagrees with
+        // intermediateSize + convDim + numHeads) records an MLX error and
+        // returns an empty vector; subscripting it traps the process before
+        // the recorded error can surface. Bail with the input — the enclosing
+        // withError scope throws the real diagnostic at exit.
+        guard splits.count == 3 else { return hiddenStates }
         let gate = splits[0]
         let convInput = splits[1]
         let dt = splits[2]
@@ -435,6 +441,7 @@ internal class NemotronHMamba2Mixer: Module, NemotronHMixer {
             axis: -1
         )
 
+        guard convSplits.count == 3 else { return hiddenStates }
         var hidden = convSplits[0]
         var B = convSplits[1]
         var C = convSplits[2]

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -1101,11 +1101,15 @@ private func maskedScatter(input: MLXArray, mask: MLXArray, source: MLXArray) th
     // mis-stamped `imageSeqLength` would crash the whole process on
     // first image. Throw so the caller (osaurus, JANG Studio, etc.)
     // can surface the diagnostic without process abort.
-    guard sourceFlat.shape[0] == posArray.shape[0] else {
+    // `shape.first` (not `shape[0]`): a failed upstream MLX op inside a
+    // `withError` scope hands back a rank-0 error array, and a bare `shape[0]`
+    // on it traps in the Swift array bounds check before the recorded error is
+    // ever surfaced.
+    guard let sourceCount = sourceFlat.shape.first, sourceCount == posArray.shape.first else {
         throw VLMError.processing(
             """
             Gemma4 maskedScatter: size mismatch between vision features and image token positions. \
-            Vision features: \(sourceFlat.shape[0]), image positions: \(posArray.shape[0]). \
+            Vision features: \(sourceFlat.shape.first ?? 0), image positions: \(posArray.shape.first ?? 0). \
             Check that imageSeqLength in preprocessor_config matches vision tower output (defaultOutputLength).
             """)
     }

--- a/Libraries/MLXVLM/Models/Qwen3VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen3VL.swift
@@ -1099,6 +1099,13 @@ enum Qwen3VLLanguage {
 
         func callAsFunction(positionIds: MLXArray, dtype: MLX.DType) -> (MLXArray, MLXArray) {
             var positionIds = positionIds
+            // Normalize to the [3, batch, seq] mrope layout. The 4-op subscript
+            // below traps on anything lower-rank (Sentry: over-rank subscript
+            // during batch decode), so lift 1-D [seq] and 2-D [batch, seq]
+            // inputs instead of assuming callers always pre-shape.
+            if positionIds.ndim == 1 {
+                positionIds = positionIds[.newAxis, 0...]
+            }
             if positionIds.ndim == 2 {
                 positionIds = positionIds[.newAxis, 0..., 0...]
                 positionIds = tiled(positionIds, repetitions: [3, 1, 1])

--- a/Libraries/MLXVLM/Models/Qwen3VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen3VL.swift
@@ -1474,10 +1474,19 @@ enum Qwen3VLLanguage {
                         delta = repeated(delta, count: batch, axis: 0)
                     }
 
-                    base = base + delta
-
-                    positionIds = base[.newAxis, 0..., 0...]
-                    positionIds = broadcast(positionIds!, to: [3, batch, seqLength])
+                    if delta.dim(0) == batch {
+                        // Reshape to [batch, 1] so the add broadcasts per
+                        // sequence; a bare [batch] vector against
+                        // [batch, seqLength] aligns on the trailing axis and
+                        // yields [batch, batch] garbage on decode steps.
+                        base = base + delta.reshaped(batch, 1)
+                        positionIds = base[.newAxis, 0..., 0...]
+                        positionIds = broadcast(positionIds!, to: [3, batch, seqLength])
+                    }
+                    // Otherwise ropeDeltas is stale for this batch composition
+                    // (a sequence joined or left since prefill) — leave
+                    // positionIds nil so attention rebuilds them from the
+                    // per-sequence cache offsets instead of trapping.
                 }
             }
 

--- a/Source/MLX/Transforms+Compile.swift
+++ b/Source/MLX/Transforms+Compile.swift
@@ -131,7 +131,11 @@ final class CompiledFunction: @unchecked (Sendable) {
             s._updateInternal(newValues)
         }
 
-        let resultLength = resultsPlusStateOutput.count - stateOutput.count
+        // A failed `mlx_closure_apply` (error recorded via the withError
+        // handler) leaves `resultVector` empty. Clamp so `prefix` doesn't trap
+        // on a negative length — the caller sees an empty result and the
+        // recorded error surfaces when the enclosing error scope exits.
+        let resultLength = max(0, resultsPlusStateOutput.count - stateOutput.count)
         let results = Array(resultsPlusStateOutput.prefix(resultLength))
         return results
     }
@@ -182,7 +186,10 @@ public func compile(
     }
 
     return { a in
-        compileState.call([a])[0]
+        // `.first ?? .mlxNone`: a failed compiled evaluation returns an empty
+        // result (error already recorded); a bare `[0]` traps the process
+        // before that error can surface.
+        compileState.call([a]).first ?? .mlxNone
     }
 }
 
@@ -203,7 +210,7 @@ public func compile(
     }
 
     return { a, b in
-        compileState.call([a, b])[0]
+        compileState.call([a, b]).first ?? .mlxNone
     }
 }
 
@@ -224,7 +231,7 @@ public func compile(
     }
 
     return { a, b, c in
-        compileState.call([a, b, c])[0]
+        compileState.call([a, b, c]).first ?? .mlxNone
     }
 }
 


### PR DESCRIPTION
## Context

Triage of osaurus production Sentry crashes traced several distinct crash groups into this package. Two crash mechanisms account for all of them:

1. **A structural bug in the error-handling contract.** When an MLX C call fails inside a `withError` scope, the error handler records the error and the call returns an **empty vector** (or a rank-0 error array). Several Swift call sites then subscript that result (`splits[0]`, `shape[0]`, `call(...)[0]`) or take a negative `prefix`, which traps the process in the Swift bounds check **before the recorded error can surface**. The user sees a crash instead of a failed request.
2. **A shape bug in Qwen3VL's decode-path rope deltas** that produces malformed position ids during batched decode.

Sentry issues covered (all currently resolved-in-next-release pending this PR + an osaurus repin): APPLE-MACOS-WV (27 events, escalating), APPLE-MACOS-1A / 6S (43 events combined), APPLE-MACOS-EJ (19 events), APPLE-MACOS-YW (new on 0.21.7).

## Changes

- **Qwen3VL rotary embedding: normalized low-rank position ids** (`Libraries/MLXVLM/Models/Qwen3VL.swift`)
  - The frequency computation applies a 4-op subscript that requires a rank-3 `[3, batch, seq]` input; 2-D input was lifted but 1-D input trapped with an over-rank subscript precondition (APPLE-MACOS-WV, crashed during `stepBatchDecode`).
  - 1-D `[seq]` input is now lifted to 2-D and then through the existing 2-D → `[3, batch, seq]` path — the semantically correct mrope broadcast.

- **Qwen3VL decode-path rope deltas: fixed broadcast and stale-batch handling** (`Libraries/MLXVLM/Models/Qwen3VL.swift`)
  - `delta` is a 1-D `[batch]` vector but was added to a `[batch, seqLength]` base; broadcasting aligns trailing axes, so a decode step (`seqLength == 1`, `batch > 1`) produced a `[batch, batch]` result — garbage positions or a downstream trap. It is now reshaped to `[batch, 1]` so the add broadcasts per sequence.
  - `ropeDeltas` is captured at prefill; when the batch composition changes before the next decode step (a sequence finished or joined), the stale delta no longer applies at all — position ids are left nil so attention rebuilds them from per-sequence cache offsets instead of trapping.

- **Gemma4 `maskedScatter`: made the size guard total** (`Libraries/MLXVLM/Models/Gemma4.swift`)
  - The existing mismatch guard read `sourceFlat.shape[0]`; a rank-0 error array from a failed upstream vision-tower op has an empty shape, so the guard itself trapped (APPLE-MACOS-1A/6S — the highest-volume Swift crash).
  - Switched to `shape.first` so the failure throws the existing recoverable `VLMError` instead of aborting.

- **NemotronH `mambaForward`: guarded both `split` results** (`Libraries/MLXLLM/Models/NemotronH.swift`)
  - A failed `split` (e.g. a checkpoint whose `in_proj` width disagrees with `intermediateSize + convDim + numHeads`) returns an empty vector; `splits[0]` trapped (APPLE-MACOS-YW).
  - Both split sites now bail with the input on an unexpected count; the recorded MLX error surfaces when the enclosing error scope exits.

- **Compiled-closure failure path: degraded gracefully instead of trapping** (`Source/MLX/Transforms+Compile.swift`)
  - A failed `mlx_closure_apply` leaves the result vector empty. `innerCall` then computed a **negative** prefix length (`count - stateOutput.count`), and the single-output `compile()` overloads subscripted `[0]` on the empty result — both trapped (APPLE-MACOS-EJ, hit through Gemma4's compiled decode).
  - The prefix length is now clamped to zero and the overloads return `.first ?? .mlxNone`, matching the degradation mode the rest of the bindings already use for error-state arrays.

## Review notes

- The guiding principle throughout: **a recorded MLX error must reach the `withError` scope exit** — no Swift-side subscript should trap first. Placeholder/empty results flow only within an already-failed evaluation, so they are never consumed as real data.
- The rope-delta reshape changes numerics only for the previously-broken case (`batch > 1` decode with rope deltas, which produced `[batch, batch]` garbage before). Single-sequence decode (`batch == 1`) is arithmetically identical: `[1]` reshaped to `[1, 1]` broadcasts the same way.
- The stale-delta skip is a behavior change worth a close look: when `delta.dim(0)` matches neither `batch` nor 1, positions previously came from broken broadcasting; they now come from cache offsets (correct for text-only decode, and off by the vision delta only in the already-corrupt mixed case).
- Not build-verified here — please run the test suite; `ToolOutputCompressor`-style unit coverage does not exist for these paths, and a regression test for the 1-D position-ids lift and the negative-prefix clamp would be cheap to add.

## Verification suggestions

- Qwen3VL: batched decode with two concurrent sequences where one finishes mid-stream (the WV reporter hit this ~27 times in one day); image prefill followed by text-only decode.
- Gemma4: an image request with a mis-stamped `imageSeqLength` in `preprocessor_config` should now fail the request with the VLMError message, not abort.
- NemotronH: a checkpoint with a mismatched `in_proj` width should surface an MLX error instead of an index-out-of-range abort.