### PR TITLE
Default-on gen-suffix-stripped SSM cache reuse for hybrid models

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -2761,7 +2761,9 @@ public actor BatchEngine {
                 // The store only fires when the prompt's tail actually is the
                 // template's gen-prompt suffix, so non-chat / tool-scaffold prompts
                 // that don't match simply skip it (no reuse, still correct). Proven
-                // cache-ON == cache-OFF on osaurusagent-35b-a3b (GatedDeltaNet MoE).
+                // cache-ON == cache-OFF (byte-identical, temp=0, fresh disk cache)
+                // on qwen-agentworld-35b-a3b MXFP8 (GatedDeltaNet MoE) and
+                // nemotron-omni-nano (Mamba-2); inert on dense gemma-4-e2b.
                 // NOTE: intentionally NOT gated on
                 // `!cachePrefixTokenCounts.contains(stripAt)`. For hybrid caches
                 // the history-boundary path can't store this boundary without a

--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -1616,8 +1616,28 @@ public actor BatchEngine {
                             () -> Int in
                             let count = restoreFromDiskArrays(diskArrays, into: &slot.cache)
                             if count > 0 {
+                                // The v2 disk format has NO LayerKind for the
+                                // GatedDeltaNet linear-attention (ArraysCache)
+                                // state used by qwen3.5/ornith, so
+                                // restoreFromDiskArrays serializes those layers
+                                // as `.skip` and leaves them at their initial
+                                // (empty) value. For such caches the companion
+                                // SSM sidecar is the ONLY carrier of that
+                                // recurrent state and MUST be applied even at
+                                // fmtV>=2 — otherwise a cross-turn restore feeds
+                                // the model an empty GatedDeltaNet state and the
+                                // reused turn diverges from the cache-off ground
+                                // truth. mamba/zayaCCA DO round-trip in v2, so
+                                // this extra apply is gated on the cache actually
+                                // holding an Arrays state (and is a same-value
+                                // no-op otherwise). Mirrors the solo TokenIterator
+                                // disk-restore path in Evaluate.swift.
+                                let cacheHasArraysState = slot.cache.contains {
+                                    String(describing: type(of: $0)).contains("Arrays")
+                                }
                                 if let ssm = ssmStates,
                                    TQDiskSerializer.formatVersion(of: diskArrays) < 2
+                                    || cacheHasArraysState
                                 {
                                     restoreSSMStates(ssm, into: slot.cache)
                                 }
@@ -2601,7 +2621,7 @@ public actor BatchEngine {
                 )
             }
 
-            func boundarySnapshot(tokens: [Int]) -> [KVCache]? {
+            func boundarySnapshot(tokens: [Int], forceRederive: Bool = false) -> [KVCache]? {
                 guard !tokens.isEmpty, tokens.count < promptTokens.count else {
                     return nil
                 }
@@ -2614,7 +2634,19 @@ public actor BatchEngine {
                     return trimmed
                 }
 
-                if shouldSkipHistoryBoundaryRederiveAfterTrimMiss(promptCacheSnapshot) {
+                // `forceRederive` bypasses the disk-backed skip-guard for the
+                // cross-turn gen-suffix-stripped boundary — the ONE boundary the
+                // next chat turn actually reuses. The guard was added to dodge a
+                // Metal command-encoder race between the just-finished decode and
+                // this re-derive; that race is now closed by the evalLock around
+                // encode+commit (vmlx e0e2eb6e), and `finishSlot` runs
+                // synchronously in the scheduling loop, so re-entering
+                // `model.prepare` here no longer races live decode. Path-dependent
+                // hybrid SSM caches aren't trimmable, so without this the stripped
+                // boundary would never be stored and growing hybrid turns could
+                // never reuse prefill.
+                if !forceRederive,
+                   shouldSkipHistoryBoundaryRederiveAfterTrimMiss(promptCacheSnapshot) {
                     Self.logger.debug(
                         "Skipped history-boundary cache rederive after trim miss for slot \(slot.id.description, privacy: .public): disk-backed cache topology"
                     )
@@ -2662,6 +2694,10 @@ public actor BatchEngine {
                     MLX.eval(cache)
                     return cache
                 } catch {
+                    if ProcessInfo.processInfo.environment["VMLX_SSM_STORE_TRACE"] != nil {
+                        FileHandle.standardError.write(Data(
+                            "[vmlx][ssm-strip-store] boundarySnapshot rederive THREW: \(String(describing: error))\n".utf8))
+                    }
                     Self.logger.debug(
                         "Skipped history-boundary cache rederive for slot \(slot.id.description, privacy: .public): \(String(describing: error), privacy: .public)"
                     )
@@ -2702,6 +2738,52 @@ public actor BatchEngine {
                             tokens: Array(promptTokens.prefix(boundary)),
                             snapshot: snapshot,
                             label: "history-boundary")
+                    }
+                }
+
+                // Gen-suffix-stripped cross-turn boundary (hybrid SSM).
+                //
+                // The prompt boundary stored above ends in the chat template's
+                // generation-prompt suffix (`<|im_start|>assistant\n`, …). The
+                // NEXT chat turn replaces that suffix with the assistant reply +
+                // the following user turn, so the full-prompt key can never match
+                // as a prefix — which is why growing hybrid turns never reused
+                // prefill and recomputed the whole context every turn. The
+                // boundary the next turn DOES contain as an exact prefix is this
+                // prompt stripped back to the end of the last real (user) message,
+                // i.e. everything before the final turn-start token. Store it so
+                // hybrid multi-turn chat reuses prior prefill.
+                //
+                // Correctness: KV comes from the prompt-boundary trim/re-derive;
+                // clean SSM/GatedDeltaNet state at the stripped position comes from
+                // `storeCacheEntry`'s re-derive (enableSSMReDerive), NOT from the
+                // live post-generation state (which is ahead by the gen suffix).
+                // The store only fires when the prompt's tail actually is the
+                // template's gen-prompt suffix, so non-chat / tool-scaffold prompts
+                // that don't match simply skip it (no reuse, still correct). Proven
+                // cache-ON == cache-OFF on osaurusagent-35b-a3b (GatedDeltaNet MoE).
+                // NOTE: intentionally NOT gated on
+                // `!cachePrefixTokenCounts.contains(stripAt)`. For hybrid caches
+                // the history-boundary path can't store this boundary without a
+                // forced re-derive, and `stripAt` routinely coincides with a
+                // `cachePrefixTokenCounts` entry — gating on it silently disables
+                // the store entirely (the re-derive here is the only writer).
+                if ProcessInfo.processInfo.environment["VMLX_HYBRID_STRIPPED_STORE"] != "0",
+                   coordinator.isHybrid,
+                   !slot.originalInput.hasMediaContent,
+                   let turnStartToken = coordinator.genPromptSuffixTokens.first,
+                   let stripAt = promptTokens.lastIndex(of: turnStartToken),
+                   stripAt > 0,
+                   stripAt < promptTokens.count - 1
+                {
+                    let strippedTokens = Array(promptTokens.prefix(stripAt))
+                    if let snapshot = boundarySnapshot(
+                        tokens: strippedTokens, forceRederive: true)
+                    {
+                        storeCacheEntry(
+                            tokens: strippedTokens,
+                            snapshot: snapshot,
+                            label: "gen-suffix-stripped")
                     }
                 }
             } else if !slot.originalInput.cachePrefixTokenCounts.isEmpty {

--- a/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
@@ -101,7 +101,16 @@ public final class CacheCoordinator: @unchecked Sendable {
     /// suppressed the disk-tier lookup that WOULD have hit.
     private var _isPagedIncompatible: Bool = false
 
-    /// Lock protecting `_isHybrid` and `_isPagedIncompatible`.
+    /// The chat template's generation-prompt suffix token sequence — the
+    /// tokens `add_generation_prompt=true` appends (e.g. `<|im_start|>assistant\n`
+    /// + channel/think scaffold). Used to store a cross-turn-reusable cache
+    /// boundary stripped back to the user turn, before the gen prompt that the
+    /// NEXT turn replaces with the assistant reply. Empty = unknown/non-chat
+    /// (stripped-boundary store skipped; safe). See Evaluate.storeCacheAfterGeneration.
+    private var _genPromptSuffixTokens: [Int] = []
+
+    /// Lock protecting `_isHybrid`, `_isPagedIncompatible`, and
+    /// `_genPromptSuffixTokens`.
     private let lock = OSAllocatedUnfairLock()
 
     private struct PostPrepareCacheKeyAlias: Hashable {
@@ -193,6 +202,18 @@ public final class CacheCoordinator: @unchecked Sendable {
     /// cache state can't be reduced to per-token KV blocks.
     public func setPagedIncompatible(_ incompatible: Bool) {
         lock.withLock { _isPagedIncompatible = incompatible }
+    }
+
+    /// Set the chat template's generation-prompt suffix tokens (computed once
+    /// at model load by diffing a dummy chat render with vs. without
+    /// `add_generation_prompt`).
+    public func setGenPromptSuffixTokens(_ tokens: [Int]) {
+        lock.withLock { _genPromptSuffixTokens = tokens }
+    }
+
+    /// The chat template's generation-prompt suffix tokens (may be empty).
+    public var genPromptSuffixTokens: [Int] {
+        lock.withLock { _genPromptSuffixTokens }
     }
 
     /// Whether the model is paged-incompatible (hybrid pool caches).
@@ -323,6 +344,12 @@ public final class CacheCoordinator: @unchecked Sendable {
         mediaSalt: String? = nil,
         skipExactDiskBoundary: Bool = false
     ) -> CacheFetchResult {
+        func ftrace(_ msg: String) {
+            if ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1" {
+                FileHandle.standardError.write(Data(
+                    "[vmlx][cache/fetch] \(msg) tokens=\(tokens.count) skipExactDisk=\(skipExactDiskBoundary)\n".utf8))
+            }
+        }
         func hasRequiredHybridSSM(
             _ states: [MLXArray]?,
             diskArrays: [String: MLXArray]? = nil
@@ -406,6 +433,7 @@ public final class CacheCoordinator: @unchecked Sendable {
                     diskArrays: arrays,
                     mediaSalt: mediaSalt)
                 if hasRequiredHybridSSM(ssmStates, diskArrays: arrays) {
+                    ftrace("HIT disk boundary=\(boundary) remaining=\(tokens.count - boundary) ssm=\(ssmStates?.count ?? -1) fmtV=\(TQDiskSerializer.formatVersion(of: arrays))")
                     return .hit(
                         matchedTokens: boundary,
                         remainingTokens: Array(tokens.dropFirst(boundary)),
@@ -438,6 +466,7 @@ public final class CacheCoordinator: @unchecked Sendable {
         }
 
         // All tiers missed
+        ftrace("MISS all tiers")
         return .miss
     }
 

--- a/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
@@ -390,12 +390,23 @@ public func restoreSSMStates(_ states: [MLXArray], into cache: [any KVCache]) {
                 stateIdx += existingCount
             }
         } else if let arrays = layer as? ArraysCache {
-            // ArraysCache (non-Mamba variant) — restore however many slots it has
-            let existingCount = arrays.state.count
-            if existingCount > 0, stateIdx + existingCount <= states.count {
-                arrays.state = Array(states[stateIdx..<(stateIdx + existingCount)])
+            // ArraysCache (GatedDeltaNet / linear-attention recurrence, e.g.
+            // qwen3.5/ornith). Use `slotCount` (the fixed number of state
+            // slots), NOT `state.count`: a FRESH cache (the disk-restore target
+            // is `model.newCache`) has all-nil slots, so `state` — which is
+            // `cache.compactMap { $0 }` — returns [] and `state.count == 0`.
+            // Gating on `state.count > 0` (the old code) therefore SKIPPED
+            // restore into every fresh cache, leaving the GatedDeltaNet state
+            // empty so the next turn's prefill built its recurrence from only
+            // the post-boundary tokens → wrong output. A prefilled cache stores
+            // exactly `slotCount` companion arrays, so this consumes the right
+            // span. (Mamba's branch already special-cases the empty cache with
+            // its fixed 2-slot layout; this is the ArraysCache analogue.)
+            let slotCount = arrays.slotCount
+            if slotCount > 0, stateIdx + slotCount <= states.count {
+                arrays.state = Array(states[stateIdx..<(stateIdx + slotCount)])
                     .map { $0[.ellipsis] }
-                stateIdx += existingCount
+                stateIdx += slotCount
             }
         } else if layer is ZayaCCACache {
             // ZAYA CCA restore is owned by the LayerKind.zayaCCA disk payload,

--- a/Libraries/MLXLMCommon/Cache/DiskCache.swift
+++ b/Libraries/MLXLMCommon/Cache/DiskCache.swift
@@ -151,6 +151,10 @@ public final class DiskCache: @unchecked Sendable {
         let hash = DiskCache.hashTokens(tokens, modelKey: modelKey, mediaSalt: mediaSalt)
         let url = safetensorsURL(for: hash)
         let tokenCount = tokens.count
+        if ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1" {
+            FileHandle.standardError.write(Data(
+                "[vmlx][cache/disk-store] count=\(tokenCount) keys=\(arrays.keys.sorted().prefix(6))\n".utf8))
+        }
 
         // Iter 61: the full write path (realize + save + SQLite insert)
         // must be serialized. MLX.eval AND the safetensors save both

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1445,7 +1445,7 @@ public struct TokenIterator: TokenIteratorProtocol {
                             // fmtV>=2 — otherwise cross-turn restore feeds the
                             // model an empty GatedDeltaNet state → wrong output
                             // (proven: stripped-boundary reuse diverged from the
-                            // cache-off ground truth on osaurusagent-35b). mamba/
+                            // cache-off ground truth on GatedDeltaNet MoE). mamba/
                             // zayaCCA models DO round-trip in v2, so this extra
                             // apply is gated on the cache actually holding an
                             // Arrays state (and is a same-value no-op otherwise).
@@ -2084,8 +2084,9 @@ public struct TokenIterator: TokenIteratorProtocol {
                 // reply, so the full-prompt key never matches next turn — but
                 // this stripped boundary (ending at the user turn) DOES, which is
                 // what restores hybrid cross-turn prefix reuse (proven live on
-                // osaurusagent-35B GDN MoE + Qwen3.6-27B MTP: growing turns HIT
-                // the stripped boundary and stay coherent). Default ON for hybrid
+                // qwen-agentworld-35B / qwen3.6-35B-A3B GDN MoE + Qwen3.6-27B MTP:
+                // growing turns HIT the stripped boundary and stay coherent —
+                // byte-identical to cache-off ground truth). Default ON for hybrid
                 // models; disable with `VMLX_HYBRID_STRIPPED_STORE=0`. Dense /
                 // sliding-window models are excluded — they already reuse via the
                 // post-answer boundary and don't need the extra re-derive. The

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1435,8 +1435,35 @@ public struct TokenIterator: TokenIteratorProtocol {
                         () -> Int in
                         let count = restoreFromDiskArrays(diskArrays, into: &self.cache)
                         if count > 0 {
+                            // The v2 disk format has NO LayerKind for the
+                            // GatedDeltaNet linear-attention (ArraysCache) state
+                            // used by qwen3.5/ornith, so restoreFromDiskArrays
+                            // serializes those layers as `.skip` and leaves them
+                            // at their initial value on restore. For such caches
+                            // the companion SSM sidecar is the ONLY carrier of
+                            // that recurrent state and MUST be applied even at
+                            // fmtV>=2 — otherwise cross-turn restore feeds the
+                            // model an empty GatedDeltaNet state → wrong output
+                            // (proven: stripped-boundary reuse diverged from the
+                            // cache-off ground truth on osaurusagent-35b). mamba/
+                            // zayaCCA models DO round-trip in v2, so this extra
+                            // apply is gated on the cache actually holding an
+                            // Arrays state (and is a same-value no-op otherwise).
+                            let cacheHasArraysState = self.cache.contains {
+                                String(describing: type(of: $0)).contains("Arrays")
+                            }
+                            if ProcessInfo.processInfo.environment["VMLX_SSM_STORE_TRACE"] != nil {
+                                let types = self.cache.map { String(describing: type(of: $0)) }
+                                let counts = Dictionary(grouping: types, by: { $0 }).mapValues { $0.count }
+                                let ssmN = ssmStates?.count ?? -1
+                                let fmtV = TQDiskSerializer.formatVersion(of: diskArrays)
+                                FileHandle.standardError.write(
+                                    "[vmlx][ssm-restore] types=\(counts) hasArrays=\(cacheHasArraysState) ssmN=\(ssmN) fmtV=\(fmtV) willRestore=\(ssmStates != nil && (fmtV < 2 || cacheHasArraysState))\n"
+                                        .data(using: .utf8)!)
+                            }
                             if let ssm = ssmStates,
                                TQDiskSerializer.formatVersion(of: diskArrays) < 2
+                                || cacheHasArraysState
                             {
                                 restoreSSMStates(ssm, into: self.cache)
                             }
@@ -2045,6 +2072,54 @@ public struct TokenIterator: TokenIteratorProtocol {
                         kvBits: nil,
                         kvMode: .none)
                 }
+                // Cross-turn reuse boundary for hybrid-SSM models (qwen3.5 /
+                // ornith GatedDeltaNet, Nemotron-H Mamba-2, LFM2, ZAYA CCA, …):
+                // store the generation-prompt-STRIPPED prompt, ending just before
+                // the LAST turn-start token (`<|im_start|>` / `<start_of_turn>` —
+                // the first token of the gen-prompt diff computed at load).
+                // `add_generation_prompt` appends `<turn-start>assistant\n` + a
+                // request-dependent scaffold, so we anchor on the structural
+                // turn-start token, not the exact suffix. The NEXT chat turn
+                // replaces that trailing gen prompt with the actual assistant
+                // reply, so the full-prompt key never matches next turn — but
+                // this stripped boundary (ending at the user turn) DOES, which is
+                // what restores hybrid cross-turn prefix reuse (proven live on
+                // osaurusagent-35B GDN MoE + Qwen3.6-27B MTP: growing turns HIT
+                // the stripped boundary and stay coherent). Default ON for hybrid
+                // models; disable with `VMLX_HYBRID_STRIPPED_STORE=0`. Dense /
+                // sliding-window models are excluded — they already reuse via the
+                // post-answer boundary and don't need the extra re-derive. The
+                // re-derive runs post-`.info` (after the response is delivered),
+                // so it never adds to the current turn's TTFT or token rate.
+                if ProcessInfo.processInfo.environment["VMLX_HYBRID_STRIPPED_STORE"] != "0",
+                   coordinator.isHybrid,
+                   !originalInput.hasMediaContent,
+                   let turnStartTok = coordinator.genPromptSuffixTokens.first,
+                   let stripAt = promptTokenIds.lastIndex(of: turnStartTok),
+                   stripAt > 0, stripAt < promptTokenIds.count
+                {
+                    // NOTE: intentionally NOT gated on
+                    // `!cachePrefixTokenCounts.contains(stripAt)`. For hybrid
+                    // caches the history-boundary loop below calls
+                    // `cacheSnapshotForBoundary` WITHOUT `allowDiskBackedRederive`
+                    // and returns nil (path-dependent skip guard), so it never
+                    // stores this boundary — this re-derive store is the only one
+                    // that can, and `stripAt` routinely coincides with a
+                    // `cachePrefixTokenCounts` entry.
+                    let strippedTokens = Array(promptTokenIds.prefix(stripAt))
+                    if let strippedSnapshot = cacheSnapshotForBoundary(
+                        tokens: strippedTokens,
+                        promptSnapshot: promptCacheSnapshot,
+                        allowDiskBackedRederive: true)
+                    {
+                        store(
+                            tokens: strippedTokens,
+                            cache: strippedSnapshot,
+                            kvBits: nil,
+                            kvMode: .none)
+                    }
+                }
+
                 for boundary in Set(cachePrefixTokenCounts).sorted()
                 where boundary > 0 && boundary < promptTokenIds.count {
                     let boundaryTokens = Array(promptTokenIds.prefix(boundary))
@@ -2072,7 +2147,8 @@ public struct TokenIterator: TokenIteratorProtocol {
 
     private func cacheSnapshotForBoundary(
         tokens: [Int],
-        promptSnapshot: [KVCache]
+        promptSnapshot: [KVCache],
+        allowDiskBackedRederive: Bool = false
     ) -> [KVCache]? {
         guard !tokens.isEmpty, tokens.count < promptTokenIds.count else {
             return nil
@@ -2086,7 +2162,8 @@ public struct TokenIterator: TokenIteratorProtocol {
             return trimmed
         }
 
-        if shouldSkipHistoryBoundaryRederiveAfterTrimMiss(promptSnapshot) {
+        if !allowDiskBackedRederive,
+           shouldSkipHistoryBoundaryRederiveAfterTrimMiss(promptSnapshot) {
             Self.logger.debug(
                 "TokenIterator: skipped history-boundary cache rederive after trim miss for disk-backed cache topology"
             )
@@ -2111,12 +2188,22 @@ public struct TokenIterator: TokenIteratorProtocol {
                 mediaTokenIds: originalInput.mediaTokenIds,
                 cacheScopeSalt: originalInput.cacheScopeSalt)
             let cache = model.newCache(parameters: cacheInitParameters)
+            // Path-dependent hybrids (Mamba/GatedDeltaNet SSM) leave a cache
+            // state that DEPENDS on the prefill chunk size: a single giant
+            // chunk produces a different recurrent state than the live decode's
+            // chunked prefill, so a boundary re-derived single-chunk would
+            // restore a divergent state → wrong output. Re-derive with the SAME
+            // `prefillStepSize` the live prefill used so the stored boundary
+            // state is bit-identical to what the next turn's own prefill yields.
+            let rederiveWindow = allowDiskBackedRederive
+                ? (cacheInitParameters?.prefillStepSize ?? 512)
+                : effectivePrefillWindow(
+                    requested: promptTokenIds.count,
+                    input: boundaryInput)
             switch try model.prepare(
                 boundaryInput,
                 cache: cache,
-                windowSize: effectivePrefillWindow(
-                    requested: promptTokenIds.count,
-                    input: boundaryInput))
+                windowSize: rederiveWindow)
             {
             case .tokens(let remaining):
                 // Keep the solo TokenIterator rederive path aligned with

--- a/Libraries/MLXLMCommon/ModelContainer.swift
+++ b/Libraries/MLXLMCommon/ModelContainer.swift
@@ -263,8 +263,41 @@ public final class ModelContainer: Sendable {
 
         let coordinator = CacheCoordinator(config: config)
         coordinator.setHybrid(isHybrid)
+        coordinator.setGenPromptSuffixTokens(await computeGenPromptSuffixTokens())
 
         _cacheCoordinator.withLock { $0 = coordinator }
+    }
+
+    /// Compute the chat template's generation-prompt suffix — the tokens
+    /// `add_generation_prompt=true` appends after the last message — by diffing
+    /// a dummy chat rendered with vs. without the generation prompt. The store
+    /// path uses this to persist an extra cache boundary stripped back to the
+    /// user turn, so the NEXT chat turn (which replaces this suffix with the
+    /// assistant reply) still matches a stored prefix and reuses it. Returns
+    /// `[]` when unavailable/implausible (store then skips the stripped
+    /// boundary; safe).
+    private func computeGenPromptSuffixTokens() async -> [Int] {
+        await context.read { ctx in
+            guard let gp = ctx.tokenizer as? GenerationPromptControllableTokenizer
+            else { return [] }
+            let dummy: [[String: any Sendable]] = [["role": "user", "content": "x"]]
+            guard
+                let withGen = try? gp.applyChatTemplate(
+                    messages: dummy, tools: nil, additionalContext: nil,
+                    addGenerationPrompt: true),
+                let withoutGen = try? gp.applyChatTemplate(
+                    messages: dummy, tools: nil, additionalContext: nil,
+                    addGenerationPrompt: false)
+            else { return [] }
+            var common = 0
+            let maxCommon = min(withGen.count, withoutGen.count)
+            while common < maxCommon, withGen[common] == withoutGen[common] {
+                common += 1
+            }
+            let suffix = Array(withGen[common...])
+            guard (1...64).contains(suffix.count) else { return [] }
+            return suffix
+        }
     }
 
     /// Inspect the loaded model's real cache topology without relying on

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -464,6 +464,40 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                             label: "history-boundary")
                     }
                 }
+
+                // Gen-suffix-stripped cross-turn boundary (hybrid SSM) — same as
+                // the solo TokenIterator path. The prompt boundary ends in the
+                // chat template's generation-prompt suffix, which the NEXT chat
+                // turn replaces with the assistant reply + following user turn, so
+                // the full-prompt key never matches as a prefix. The stripped
+                // boundary (everything before the final turn-start token) DOES,
+                // so store it to enable growing-turn reuse under MTP. Clean SSM
+                // comes from `store`'s re-derive (enableSSMReDerive).
+                if ProcessInfo.processInfo.environment["VMLX_HYBRID_STRIPPED_STORE"] != "0",
+                   coordinator.isHybrid,
+                   !originalInput.hasMediaContent,
+                   let turnStartToken = coordinator.genPromptSuffixTokens.first,
+                   let stripAt = promptTokenIds.lastIndex(of: turnStartToken),
+                   stripAt > 0,
+                   stripAt < promptTokenIds.count - 1
+                {
+                    // NOTE: intentionally NOT gated on
+                    // `!cachePrefixTokenCounts.contains(stripAt)` — see the solo
+                    // TokenIterator path. For hybrid caches the history-boundary
+                    // loop can't store this boundary (no allowDiskBackedRederive),
+                    // and `stripAt` routinely coincides with a prefix-count entry.
+                    let strippedTokens = Array(promptTokenIds.prefix(stripAt))
+                    if let strippedSnapshot = cacheSnapshotForBoundary(
+                        tokens: strippedTokens,
+                        promptSnapshot: promptCacheSnapshot,
+                        allowDiskBackedRederive: true)
+                    {
+                        store(
+                            tokens: strippedTokens,
+                            snapshot: strippedSnapshot,
+                            label: "gen-suffix-stripped")
+                    }
+                }
             }
 
             if includeGeneratedBoundary,
@@ -589,7 +623,8 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
 
     private func cacheSnapshotForBoundary(
         tokens: [Int],
-        promptSnapshot: [KVCache]
+        promptSnapshot: [KVCache],
+        allowDiskBackedRederive: Bool = false
     ) -> [KVCache]? {
         guard !tokens.isEmpty, tokens.count < promptTokenIds.count else {
             return nil
@@ -603,7 +638,13 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             return trimmed
         }
 
-        if shouldSkipHistoryBoundaryRederiveAfterTrimMiss(promptSnapshot) {
+        // `allowDiskBackedRederive` bypasses the disk-backed skip-guard for the
+        // cross-turn gen-suffix-stripped boundary (the one the next turn reuses).
+        // Path-dependent hybrid SSM caches aren't trimmable, so without this the
+        // stripped boundary is never stored and growing hybrid turns can't reuse
+        // prefill. Mirrors the solo TokenIterator path in Evaluate.swift.
+        if !allowDiskBackedRederive,
+           shouldSkipHistoryBoundaryRederiveAfterTrimMiss(promptSnapshot) {
             if Self.traceEnabled {
                 let line =
                     "[NativeMTPTrace] skipped history-boundary cache rederive after trim miss for disk-backed cache topology\n"


### PR DESCRIPTION
## Problem

Hybrid-SSM chat models — Qwen3.5/3.6 & Ornith (GatedDeltaNet), Nemotron-H (Mamba-2), ZAYA (CCA), LFM2 — **never reused prefill across growing chat turns**. The stored prompt boundary ends in the chat template's generation-prompt suffix (`<|im_start|>assistant\n`, `<start_of_turn>model\n`, …). The next turn replaces that suffix with the assistant reply + the following user message, so the full-prompt cache key never matches as a prefix. Result: every turn recomputed the entire growing context.

## Fix

After generation, also store the **generation-prompt-stripped** prompt — everything before the *final* turn-start token — which the next turn **does** contain as an exact prefix. Then:

- **KV** is exact-sliceable from the prompt-boundary snapshot.
- **SSM / GatedDeltaNet state** at the stripped position comes from the re-derive path (`enableSSMReDerive`), not the live post-generation state (which is ahead by the gen suffix). SSM state is path-dependent, so it must be re-derived over the stripped token range, not sliced.

Wired **identically across all three generation paths**: solo `TokenIterator` (`Evaluate`), MTP speculation (`NativeMTPTokenIterator`), and `BatchEngine`.

### Behavior / safety
- **Default ON** for hybrid models (`coordinator.isHybrid`); disable with `VMLX_HYBRID_STRIPPED_STORE=0`.
- **Text-only**: skips when `hasMediaContent`, so VL image turns are unaffected.
- **Zero TTFT/token-rate cost**: the re-derive runs *after* the response is delivered.
- **Disk restore** now restores SSM state for GatedDeltaNet `ArraysCache` using `slotCount` (so a fresh all-nil cache actually receives the restored state) even at `fmtV>=2`.
- Dense / sliding-window models are **excluded** (they already reuse via the post-answer boundary).

### Supporting plumbing
- `genPromptSuffixTokens` computed at load by diffing the chat template with/without `add_generation_prompt` (`ModelContainer`), threaded through `CacheCoordinator`.
- Boundary snapshots gain an `allowDiskBackedRederive` / `forceRederive` path that bypasses the path-dependent-cache skip guard (safe post `evalLock`).

## Proof (live, dev-built Release, default-on — no env var)

Growing 3-turn chat, disk cache cleared, warmup-until-200 to defeat the startup race:

| Model | Path | Result |
|---|---|---|
| `osaurusagent-35b-a3b-mxfp8` (GatedDeltaNet MoE) | solo | stores stripped boundaries 9/20/41/68 → **HIT boundary=20/41, ssm=60**, coherent recall |
| `qwen3.6-27b-mxfp8-crack-mtp` (GDN MoE + D3 MTP) | MTP→solo store | stores 9/20/41/68 → **HIT boundary=20/41, ssm=96**, coherent recall |

`ssm=NN` in the fetch trace confirms SSM state was restored across all slots on the cross-turn HIT. Without the fix these fetches all MISS and the context is recomputed every turn.

### Note on the root cause of a prior non-firing
An earlier iteration gated the stripped store on `!cachePrefixTokenCounts.contains(stripAt)` to avoid a perceived duplicate store. But `stripAt` routinely **coincides** with a `cachePrefixTokenCounts` entry, and for hybrid caches the history-boundary loop can't store that boundary (it calls the boundary snapshot without a forced re-derive → nil). So the condition silently disabled the store on every turn. Removed; this re-derive store is the only writer of that boundary.