### PR TITLE
Guard split-subscript traps across all SSM/hybrid mixers

### DIFF
--- a/Libraries/MLXLLM/Models/BailingMoe.swift
+++ b/Libraries/MLXLLM/Models/BailingMoe.swift
@@ -130,6 +130,9 @@ class BailingMoeAttention: Module {
         let kSize = kvHeads * headDim
         let qkvOut = qkv(x)
         let splits = split(qkvOut, indices: [qSize, qSize + kSize], axis: -1)
+        // Bail on a failed split (empty vector from a recorded MLX error)
+        // rather than trapping on the q/k/v subscripts below.
+        guard splits.count == 3 else { return x }
         var queries = splits[0]
         var keys = splits[1]
         var values = splits[2]

--- a/Libraries/MLXLLM/Models/FalconH1.swift
+++ b/Libraries/MLXLLM/Models/FalconH1.swift
@@ -474,6 +474,8 @@ class FalconH1Mixer: Module {
             indices: [intermediateSize, intermediateSize + convDim],
             axis: -1
         )
+        // Bail on a failed split rather than trapping on the subscripts below.
+        guard splits.count == 3 else { return inputStates }
         let gate = splits[0]
         var convInput = splits[1]
         let dt = splits[2]
@@ -491,6 +493,7 @@ class FalconH1Mixer: Module {
             ],
             axis: -1
         )
+        guard convSplits.count == 3 else { return inputStates }
         let hiddenStatesSSM = convSplits[0]
         let B = convSplits[1]
         let C = convSplits[2]

--- a/Libraries/MLXLLM/Models/GraniteMoeHybrid.swift
+++ b/Libraries/MLXLLM/Models/GraniteMoeHybrid.swift
@@ -139,6 +139,8 @@ class GraniteMoeHybridMamba2Mixer: Module {
         let projected = inProj(hiddenStates)
         let splits = split(
             projected, indices: [intermediateSize, intermediateSize + convDim], axis: -1)
+        // Bail on a failed split rather than trapping on the subscripts below.
+        guard splits.count == 3 else { return hiddenStates }
         let gate = splits[0]
         var convInput = splits[1]
         let dt = splits[2]
@@ -155,6 +157,7 @@ class GraniteMoeHybridMamba2Mixer: Module {
             axis: -1
         )
 
+        guard convSplits.count == 3 else { return hiddenStates }
         var hidden = convSplits[0]
         var B = convSplits[1]
         var C = convSplits[2]

--- a/Libraries/MLXLLM/Models/Jamba.swift
+++ b/Libraries/MLXLLM/Models/Jamba.swift
@@ -264,6 +264,8 @@ class JambaMambaMixer: Module {
             indices: [timeStepRank, timeStepRank + ssmStateSize],
             axis: -1
         )
+        // Bail on a failed split rather than trapping on the subscripts below.
+        guard splits.count == 3 else { return (x, state ?? x) }
         var delta = splits[0]
         var B = splits[1]
         var C = splits[2]
@@ -294,6 +296,8 @@ class JambaMambaMixer: Module {
     ) {
         let xz = inProj(x)
         let splits = xz.split(parts: 2, axis: -1)
+        // Bail on a failed split rather than trapping on the subscripts below.
+        guard splits.count == 2 else { return (x, (x, x)) }
         var x = splits[0]
         let z = splits[1]
 

--- a/Libraries/MLXLLM/Models/LFM2.swift
+++ b/Libraries/MLXLLM/Models/LFM2.swift
@@ -206,6 +206,9 @@ class LFM2ShortConv: Module {
     public func callAsFunction(_ x: MLXArray, cache: MambaCache?) -> MLXArray {
         let BCx = inProj(x)
         let BCxSplit = BCx.split(parts: 3, axis: -1)
+        // Bail on a failed split (empty vector from a recorded MLX error)
+        // rather than trapping on the subscripts below.
+        guard BCxSplit.count == 3 else { return x }
         let B = BCxSplit[0]
         let C = BCxSplit[1]
         let x = BCxSplit[2]

--- a/Libraries/MLXLLM/Models/LFM2MoE.swift
+++ b/Libraries/MLXLLM/Models/LFM2MoE.swift
@@ -207,6 +207,8 @@ class LFM2MoEShortConv: Module {
     ) -> MLXArray {
         let BCx = inProj(x)
         let parts = BCx.split(parts: 3, axis: -1)
+        // Bail on a failed split rather than trapping on the subscripts below.
+        guard parts.count == 3 else { return x }
         let B = parts[0]
         let C = parts[1]
         let xComp = parts[2]

--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -290,6 +290,12 @@ final class Qwen35GatedDeltaNet: Module {
         let convOut = silu(conv1d(convInput))
 
         let convSplit = MLX.split(convOut, indices: [keyDim, 2 * keyDim], axis: -1)
+        // A failed split (e.g. a checkpoint whose conv width disagrees with
+        // keyDim*2 + valueDim) records an MLX error and returns an empty
+        // vector; subscripting it traps the process before the recorded error
+        // can surface. Bail with the input so the enclosing withError scope
+        // throws the real diagnostic at exit. (Same guard as NemotronH.)
+        guard convSplit.count == 3 else { return inputs }
         let q = convSplit[0].reshaped(B, S, numKHeads, headKDim)
         let k = convSplit[1].reshaped(B, S, numKHeads, headKDim)
         let v = convSplit[2].reshaped(B, S, numVHeads, headVDim)
@@ -465,6 +471,9 @@ final class Qwen35Attention: Module {
 
         let qProjOutput = qProj(x)
         let qSplit = qProjOutput.reshaped(B, L, attentionHeads, -1).split(parts: 2, axis: -1)
+        // Guard the query/gate split: an empty result from a recorded MLX error
+        // would trap on subscript before the diagnostic can surface.
+        guard qSplit.count == 2 else { return x }
         var queries = qSplit[0]
         let gate = qSplit[1].reshaped(B, L, -1)
 

--- a/Libraries/MLXLLM/Models/Qwen3Next.swift
+++ b/Libraries/MLXLLM/Models/Qwen3Next.swift
@@ -121,6 +121,8 @@ public final class Qwen3NextAttention: Module {
 
         let qProjOutput = qProj(x)
         let qSplit = qProjOutput.reshaped(B, L, args.attentionHeads, -1).split(parts: 2, axis: -1)
+        // Bail on a failed split rather than trapping on the subscripts below.
+        guard qSplit.count == 2 else { return x }
         var queries = qSplit[0]
         let gate = qSplit[1].reshaped(B, L, -1)
 
@@ -246,12 +248,16 @@ public final class Qwen3NextGatedDeltaNet: Module {
             indices: [dn, 2 * dn, 2 * dn + vHeadsPerK * dv],
             axis: -1
         )
+        // Bail on a failed split rather than trapping on the subscripts below;
+        // the recorded MLX error surfaces at the next eval.
+        guard qkvzSplit.count == 4 else { return (qkvz, qkvz, qkvz, qkvz, ba, ba) }
         let q = qkvzSplit[0]
         let k = qkvzSplit[1]
         let v = qkvzSplit[2].reshaped(B, S, -1, dv)
         let z = qkvzSplit[3].reshaped(B, S, -1, dv)
 
         let baSplit = MLX.split(ba, indices: [vHeadsPerK], axis: -1)
+        guard baSplit.count == 2 else { return (q, k, v, z, ba, ba) }
         let b = baSplit[0].reshaped(B, S, nv)
         let a = baSplit[1].reshaped(B, S, nv)
 
@@ -297,6 +303,8 @@ public final class Qwen3NextGatedDeltaNet: Module {
         let convOut = silu(conv1d(convInput))
         let convSplit = MLX.split(convOut, indices: [keyDim, 2 * keyDim], axis: -1)
 
+        // Bail on a failed split rather than trapping on the subscripts below.
+        guard convSplit.count == 3 else { return inputs }
         var qOut = convSplit[0].reshaped(B, S, numKHeads, headKDim)
         var kOut = convSplit[1].reshaped(B, S, numKHeads, headKDim)
         let vOut = convSplit[2].reshaped(B, S, numVHeads, headVDim)


### PR DESCRIPTION
Follow-up completing the crash-hardening that **#123** started but only applied to one file.

## The gap

#123 fixed the `split(...)[i]` process-abort trap in `NemotronH` — when a `split` records an MLX error and returns an empty vector, subscripting it trips a Swift bounds precondition (an **uncatchable process abort**) *before* the recorded error can surface. The **exact same pattern survives untouched in every sibling mixer**, including `Qwen35.swift`, which backs the most-downloaded family (qwen3.5 / 3.6 / Ornith / osaurusagent / Holo3).

## The fix

Same guard/bail idiom as #123 — 15 guards across 8 files, each returning the input so the enclosing `withError` scope throws the real diagnostic at exit:

| File | Site(s) | Backs |
|---|---|---|
| `Qwen35.swift` | GDN conv split (q/k/v) + query/gate split | qwen3.5/3.6, Ornith, osaurusagent, Holo3 |
| `LFM2.swift`, `LFM2MoE.swift` | B/C/x in_proj split | LFM2.5 (Top Pick) |
| `BailingMoe.swift` | q/k/v split | Ling-2.6 Flash |
| `FalconH1.swift` | in_proj + conv split | Falcon-H1 |
| `GraniteMoeHybrid.swift` | in_proj + conv split | Granite-MoE-Hybrid |
| `Qwen3Next.swift` | query/gate, conv, qkvz (4-way), ba splits | Qwen3-Next |
| `Jamba.swift` | ssmStep deltaBC + processSequence xz splits | Jamba |

## Safety

The guard only trips when `split` already recorded an error (a malformed / quant-mismatched checkpoint whose width disagrees with the config). On correctly converted bundles it never fires, so there is **no behavior change on good weights** — it only converts an uncatchable abort into a surfaced diagnostic. Builds clean (verified via the osaurus Release build).