### PR TITLE
Activate ZAYA tool-aware template from source_model.architecture

### DIFF
--- a/Libraries/MLXLMCommon/JangLoader.swift
+++ b/Libraries/MLXLMCommon/JangLoader.swift
@@ -1167,12 +1167,20 @@ public struct JangLoader: Sendable {
         }
 
         let family = config.capabilities?.family?.lowercased() ?? ""
+        // Fall back to `source_model.architecture` when `capabilities.family` is
+        // absent. Some ZAYA bundles (e.g. ZAYA1-VL JANGTQ) stamp only
+        // `source_model.architecture = zaya1_vl` and omit `capabilities.family`;
+        // without this fallback the tool-aware template never materializes, the
+        // bare role-only template is used, and the model leaks raw `<tool_call>`
+        // XML as visible text. The contract stays data-driven (parser +
+        // think_in_template + supports_tools), just not family-name-only.
+        let arch = config.sourceModel.architecture.lowercased()
         let parser = config.capabilities?.toolParser?.lowercased() ?? ""
         let supportsTools = config.capabilities?.supportsTools
-        let isZayaText = family == "zaya"
-            || family == "zaya1"
-            || family.hasPrefix("zaya1_")
-            || family.hasPrefix("zaya1-")
+        func isZayaIdent(_ s: String) -> Bool {
+            s == "zaya" || s == "zaya1" || s.hasPrefix("zaya1_") || s.hasPrefix("zaya1-")
+        }
+        let isZayaText = isZayaIdent(family) || isZayaIdent(arch)
         return isZayaText
             && ["zaya", "zaya_xml", "zyphra", "zyphra_xml"].contains(parser)
             && config.capabilities?.thinkInTemplate == false
@@ -1185,9 +1193,12 @@ public struct JangLoader: Sendable {
         }
 
         let family = config.capabilities?.family?.lowercased() ?? ""
+        // Same architecture fallback as the text gate: ZAYA1-VL JANGTQ bundles
+        // stamp `source_model.architecture = zaya1_vl` without a `capabilities.family`.
+        let arch = config.sourceModel.architecture.lowercased()
         let parser = config.capabilities?.toolParser?.lowercased() ?? ""
         let supportsTools = config.capabilities?.supportsTools
-        return family.contains("zaya1_vl")
+        return (family.contains("zaya1_vl") || arch.contains("zaya1_vl"))
             && ["zaya", "zaya_xml", "zyphra", "zyphra_xml"].contains(parser)
             && config.capabilities?.thinkInTemplate == false
             && supportsTools != false


### PR DESCRIPTION
## Bug

ZAYA1-VL JANGTQ bundles **leak raw `<tool_call><function>…` XML as visible assistant text** on tool calls.

Root cause: `shouldUseZayaToolAwareTemplate` / `shouldUseZayaVLToolAwareTemplate` gate the tool-aware template on `capabilities.family` being `zaya1*`. The ZAYA1-VL-8B-JANGTQ4 bundle's `jang_config` stamps `source_model.architecture = "zaya1_vl"` and `capabilities = {tool_parser: zaya_xml, think_in_template: false, supports_tools: true}` — but **no `capabilities.family`**. So the gate returns false, the tool-aware template never materializes, the bare 578-char role-only template is used, the model gets no tool-call format, hallucinates `<response><tool_call><function>…`, and the `zaya_xml` parser (which expects `<zyphra_tool_call>`) can't parse it → the tags leak into the visible stream.

## Fix

Recognize ZAYA from `capabilities.family` **or** `source_model.architecture` — honoring the gate's own comment that the check should be "data-driven, not family-name driven." Parser / `think_in_template` / `supports_tools` contract unchanged.

Additive & low-risk: bundles with `capabilities.family` set are unaffected (family checked first); non-ZAYA bundles never match the `zaya1*` idents.

## Verified live

ZAYA1-VL-8B-JANGTQ4, tool-calling matrix:
- **Before:** every tool turn leaked `<response><tool_call><function>…`; 2/7.
- **After:** tool-aware template activates — the model emits the correct `<zyphra_tool_response>` format and **`single_use` now passes** with a clean parsed call.

Residual: the JANGTQ4 quant is still too weak to follow the format on every multi-step turn (it intermittently reverts to the hallucinated format), so the model isn't fully reliable — but that's a **quantization** issue, separate from this template-gate bug. The gate fix is a strict improvement and lets any sufficiently-strong ZAYA bundle (or the MXFP4 build) work correctly.