### PR TITLE
Capture the hybrid cross-turn cache boundary during prefill

### DIFF
--- a/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
@@ -195,6 +195,14 @@ public final class CacheCoordinator: @unchecked Sendable {
         lock.withLock { _isHybrid }
     }
 
+    /// Whether a prompt-boundary store has any tier to land in. With both tiers
+    /// disabled every store is discarded, so callers must not pay to produce a
+    /// boundary snapshot — the hybrid stripped boundary in particular costs a
+    /// retained cache copy or, failing that, a whole extra prefill.
+    public var canPersistBoundaries: Bool {
+        pagedCache != nil || diskCache != nil
+    }
+
     /// 2026-05-04: mark the model as paged-incompatible (DSV4 hybrid pool
     /// caches). Forces the coordinator's fetch + store paths to skip the
     /// paged tier so the disk tier (`TQDiskSerializer`) is the only

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1191,6 +1191,22 @@ public struct TokenIterator: TokenIteratorProtocol {
     /// generated token is fed back into the model.
     var promptCacheSnapshot: [KVCache]?
 
+    /// Absolute index into ``promptTokenIds`` of the hybrid cross-turn reuse
+    /// boundary — the last turn-start token, i.e. the end of the prompt with
+    /// its trailing generation prompt stripped. `nil` when the boundary does
+    /// not apply (dense model, media input, no turn-start token, cache tiers
+    /// all disabled).
+    var hybridStripBoundary: Int?
+
+    /// Cache state at ``hybridStripBoundary``, captured *during* prefill.
+    ///
+    /// Hybrid caches are path-dependent, so this boundary cannot be produced
+    /// by trimming the post-prefill snapshot; the only other way to obtain it
+    /// is to replay the whole stripped prefix through the model. Capturing it
+    /// as prefill passes through the boundary costs one cache copy instead of
+    /// a second full prefill. Released once stored.
+    var hybridStripSnapshot: [KVCache]?
+
     /// Stable fingerprint of any request-scope or media content in the input.
     /// `nil` for ordinary text-only inputs. Mixed into cache-coordinator keys
     /// so reasoning-mode and VLM multi-turn conversations can cache-hit without
@@ -1678,6 +1694,10 @@ public struct TokenIterator: TokenIteratorProtocol {
         } else {
             modelPrepareProgressHandler = nil
         }
+        self.hybridStripBoundary = Self.hybridStripBoundaryIndex(
+            coordinator: self.cacheCoordinator,
+            promptTokenIds: self.promptTokenIds,
+            input: input)
         self.promptPrefillTime = try measure {
             try MLXPressGenerationProfile.time("prompt.prepare_total") {
                 try PrefillProgressReporter.withHandler(modelPrepareProgressHandler) {
@@ -1753,13 +1773,137 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.promptCacheSnapshot = makePromptBoundaryCacheSnapshot(from: self.cache)
     }
 
+    /// The hybrid cross-turn reuse boundary: the index of the LAST turn-start
+    /// token (`<|im_start|>` / `<start_of_turn>`), i.e. the end of the prompt
+    /// once its trailing generation prompt is stripped. The next chat turn
+    /// replaces that generation prompt with the assistant's reply, so the
+    /// full-prompt key never matches again, but this boundary does — it is what
+    /// gives hybrid models cross-turn prefix reuse at all.
+    ///
+    /// Returns `nil` when the boundary cannot pay for itself: dense models reuse
+    /// via the post-answer boundary, media inputs are excluded, and with every
+    /// cache tier disabled the store would be dropped. `VMLX_HYBRID_STRIPPED_STORE=0`
+    /// disables it outright.
+    static func hybridStripBoundaryIndex(
+        coordinator: CacheCoordinator?,
+        promptTokenIds: [Int],
+        input: LMInput
+    ) -> Int? {
+        guard ProcessInfo.processInfo.environment["VMLX_HYBRID_STRIPPED_STORE"] != "0",
+            let coordinator,
+            coordinator.isHybrid,
+            coordinator.canPersistBoundaries,
+            !input.hasMediaContent,
+            let turnStartTok = coordinator.genPromptSuffixTokens.first,
+            let stripAt = promptTokenIds.lastIndex(of: turnStartTok),
+            stripAt > 0, stripAt < promptTokenIds.count
+        else { return nil }
+        return stripAt
+    }
+
+    /// Split `input` at the hybrid strip boundary, or `nil` when the boundary
+    /// cannot be captured from this prefill.
+    ///
+    /// `input` is the prompt tail still to be prefilled — the whole prompt on a
+    /// cache miss, or whatever follows the restored prefix on a hit — so the
+    /// boundary's offset within it is `hybridStripBoundary` minus the tokens
+    /// already in the cache.
+    private func hybridStripSplit(
+        of input: LMInput
+    ) -> (head: LMInput?, tail: LMInput)? {
+        guard let stripAt = hybridStripBoundary,
+            hybridStripSnapshot == nil,
+            !input.requiresPostPrepareCacheKey,
+            // DSV4's pool cache is only correct under a single prefill forward;
+            // `effectivePrefillWindow` already forces that, so don't split it.
+            !cache.contains(where: { $0 is HybridPoolCache })
+        else { return nil }
+
+        let size = input.text.tokens.size
+        let split = stripAt - (promptTokenIds.count - size)
+        guard split >= 0, split < size else { return nil }
+
+        // The mask, when present, is per-token (`Qwen3VLProcessor` hands the
+        // hybrids an all-ones `[1, T]`), so it slices exactly like the tokens.
+        // Anything not token-aligned — a materialized `[1, 1, T, T]` attention
+        // mask, say — has no meaningful split point; leave it whole.
+        var flatMask: MLXArray? = nil
+        if let mask = input.text.mask {
+            guard mask.size == size else { return nil }
+            flatMask = mask.reshaped([-1])
+        }
+        let maskIsBatched = (input.text.mask?.ndim ?? 1) >= 2
+        func slice(_ range: MLXArray) -> MLXArray { maskIsBatched ? range[.newAxis, 0...] : range }
+
+        let flat = input.text.tokens.reshaped([-1])
+        let head =
+            split > 0
+            ? LMInput(
+                text: LMInput.Text(
+                    tokens: flat[..<split][.newAxis, 0...],
+                    mask: flatMask.map { slice($0[..<split]) }))
+            : nil
+        let tail = LMInput(
+            text: LMInput.Text(
+                tokens: flat[split...][.newAxis, 0...],
+                mask: flatMask.map { slice($0[split...]) }))
+        return (head, tail)
+    }
+
     mutating func prepare(input: LMInput, windowSize: Int? = nil) throws {
+        // Prefill the stripped prefix first so the cache state at the hybrid
+        // cross-turn boundary can simply be copied out, then continue with the
+        // tail. Both halves go through `model.prepare`, so this runs exactly the
+        // tokens a single prefill would, in the same order, through the same
+        // forwards — models that consume the whole prompt themselves (Qwen35 and
+        // the other hybrids, which return `.logits`) split just as cleanly as
+        // those that hand back a remainder. The alternative is reconstructing the
+        // boundary afterwards by replaying the entire stripped prefix, which is a
+        // second full prefill; see `storeCacheAfterGeneration`.
+        if let split = hybridStripSplit(of: input) {
+            if let head = split.head {
+                let preparedHead = try MLXPressGenerationProfile.time("prompt.model_prepare") {
+                    try model.prepare(head, cache: cache, windowSize: windowSize)
+                }
+                switch preparedHead {
+                case .tokens(let remaining):
+                    _ = model(
+                        remaining[text: .newAxis],
+                        cache: cache.isEmpty ? nil : cache,
+                        state: nil)
+                case .logits:
+                    break
+                }
+            }
+            MLX.eval(cache)
+            hybridStripSnapshot = makePromptBoundaryCacheSnapshot(from: cache)
+            try prepareRemainder(
+                input: split.tail, windowSize: windowSize,
+                promptTokensForProcessor: input.text.tokens)
+            return
+        }
+        try prepareRemainder(
+            input: input, windowSize: windowSize,
+            promptTokensForProcessor: input.text.tokens)
+    }
+
+    /// Prefill `input` and prime `y` with the first sampled token.
+    ///
+    /// `promptTokensForProcessor` is the full set of tokens this prefill covers.
+    /// It differs from `input` only when the caller split the prefill at the
+    /// hybrid strip boundary, and exists so the logit processor still sees one
+    /// unbroken prompt (repetition penalties are scored over it).
+    private mutating func prepareRemainder(
+        input: LMInput,
+        windowSize: Int?,
+        promptTokensForProcessor: MLXArray
+    ) throws {
         let prepared = try MLXPressGenerationProfile.time("prompt.model_prepare") {
             try model.prepare(input, cache: cache, windowSize: windowSize)
         }
         switch prepared {
         case .tokens(let tokens):
-            processor?.prompt(input.text.tokens)
+            processor?.prompt(promptTokensForProcessor)
             y = tokens
 
             // evaluate the remainder of the prompt -- this primes the pump
@@ -1782,7 +1926,7 @@ public struct TokenIterator: TokenIteratorProtocol {
                     .expandedDimensions(axis: 0)
                 processor?.prompt(promptTokens)
             } else {
-                processor?.prompt(input.text.tokens)
+                processor?.prompt(promptTokensForProcessor)
             }
             y = .init(tokens: MLXPressGenerationProfile.time("prompt.sample") {
                 convertToToken(logits: result.logits)
@@ -1791,8 +1935,6 @@ public struct TokenIterator: TokenIteratorProtocol {
                 asyncEval(y.tokens)
             }
         }
-
-
     }
 
     mutating func convertToToken(logits: MLXArray) -> MLXArray {
@@ -2089,36 +2231,40 @@ public struct TokenIterator: TokenIteratorProtocol {
                 // byte-identical to cache-off ground truth). Default ON for hybrid
                 // models; disable with `VMLX_HYBRID_STRIPPED_STORE=0`. Dense /
                 // sliding-window models are excluded — they already reuse via the
-                // post-answer boundary and don't need the extra re-derive. The
-                // re-derive runs post-`.info` (after the response is delivered),
-                // so it never adds to the current turn's TTFT or token rate.
-                if ProcessInfo.processInfo.environment["VMLX_HYBRID_STRIPPED_STORE"] != "0",
-                   coordinator.isHybrid,
-                   !originalInput.hasMediaContent,
-                   let turnStartTok = coordinator.genPromptSuffixTokens.first,
-                   let stripAt = promptTokenIds.lastIndex(of: turnStartTok),
-                   stripAt > 0, stripAt < promptTokenIds.count
-                {
+                // post-answer boundary and don't need this.
+                //
+                // `hybridStripSnapshot` was captured as prefill crossed the
+                // boundary, so this store is just a copy. There is deliberately no
+                // re-derive fallback: reconstructing the boundary here means
+                // replaying the stripped prefix through the model, and this runs
+                // before `.info` reaches the client, so it would hold the response
+                // stream open for the length of a second prefill.
+                //
+                // Nothing is lost by skipping it. Capture only fails when the
+                // boundary sits inside the prefix this turn restored from cache —
+                // which means a boundary at least that long is already stored, and
+                // it is the one the next turn will match — or on cache topologies
+                // (DSV4's pool cache) that cannot hold this boundary at all.
+                if let stripAt = hybridStripBoundary {
                     // NOTE: intentionally NOT gated on
-                    // `!cachePrefixTokenCounts.contains(stripAt)`. For hybrid
-                    // caches the history-boundary loop below calls
-                    // `cacheSnapshotForBoundary` WITHOUT `allowDiskBackedRederive`
-                    // and returns nil (path-dependent skip guard), so it never
-                    // stores this boundary — this re-derive store is the only one
-                    // that can, and `stripAt` routinely coincides with a
-                    // `cachePrefixTokenCounts` entry.
-                    let strippedTokens = Array(promptTokenIds.prefix(stripAt))
-                    if let strippedSnapshot = cacheSnapshotForBoundary(
-                        tokens: strippedTokens,
-                        promptSnapshot: promptCacheSnapshot,
-                        allowDiskBackedRederive: true)
-                    {
+                    // `!cachePrefixTokenCounts.contains(stripAt)`. For hybrid caches
+                    // the history-boundary loop below calls `cacheSnapshotForBoundary`
+                    // and returns nil (path-dependent skip guard), so it never stores
+                    // this boundary — this store is the only one that can, and
+                    // `stripAt` routinely coincides with a `cachePrefixTokenCounts`
+                    // entry.
+                    if let strippedSnapshot = hybridStripSnapshot {
                         store(
-                            tokens: strippedTokens,
+                            tokens: Array(promptTokenIds.prefix(stripAt)),
                             cache: strippedSnapshot,
                             kvBits: nil,
                             kvMode: .none)
+                    } else {
+                        Self.logger.debug(
+                            "TokenIterator: no stripped-boundary snapshot to store at \(stripAt, privacy: .public); prefill did not cross the boundary"
+                        )
                     }
+                    hybridStripSnapshot = nil
                 }
 
                 for boundary in Set(cachePrefixTokenCounts).sorted()
@@ -2148,8 +2294,7 @@ public struct TokenIterator: TokenIteratorProtocol {
 
     private func cacheSnapshotForBoundary(
         tokens: [Int],
-        promptSnapshot: [KVCache],
-        allowDiskBackedRederive: Bool = false
+        promptSnapshot: [KVCache]
     ) -> [KVCache]? {
         guard !tokens.isEmpty, tokens.count < promptTokenIds.count else {
             return nil
@@ -2163,8 +2308,7 @@ public struct TokenIterator: TokenIteratorProtocol {
             return trimmed
         }
 
-        if !allowDiskBackedRederive,
-           shouldSkipHistoryBoundaryRederiveAfterTrimMiss(promptSnapshot) {
+        if shouldSkipHistoryBoundaryRederiveAfterTrimMiss(promptSnapshot) {
             Self.logger.debug(
                 "TokenIterator: skipped history-boundary cache rederive after trim miss for disk-backed cache topology"
             )
@@ -2189,18 +2333,9 @@ public struct TokenIterator: TokenIteratorProtocol {
                 mediaTokenIds: originalInput.mediaTokenIds,
                 cacheScopeSalt: originalInput.cacheScopeSalt)
             let cache = model.newCache(parameters: cacheInitParameters)
-            // Path-dependent hybrids (Mamba/GatedDeltaNet SSM) leave a cache
-            // state that DEPENDS on the prefill chunk size: a single giant
-            // chunk produces a different recurrent state than the live decode's
-            // chunked prefill, so a boundary re-derived single-chunk would
-            // restore a divergent state → wrong output. Re-derive with the SAME
-            // `prefillStepSize` the live prefill used so the stored boundary
-            // state is bit-identical to what the next turn's own prefill yields.
-            let rederiveWindow = allowDiskBackedRederive
-                ? (cacheInitParameters?.prefillStepSize ?? 512)
-                : effectivePrefillWindow(
-                    requested: promptTokenIds.count,
-                    input: boundaryInput)
+            let rederiveWindow = effectivePrefillWindow(
+                requested: promptTokenIds.count,
+                input: boundaryInput)
             switch try model.prepare(
                 boundaryInput,
                 cache: cache,

--- a/Tests/MLXLMTests/HybridStripBoundaryPrefillTests.swift
+++ b/Tests/MLXLMTests/HybridStripBoundaryPrefillTests.swift
@@ -1,0 +1,177 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import XCTest
+
+/// Records every token it is asked to forward, so a test can tell the
+/// difference between prefilling a prompt once and prefilling it twice.
+private class RecordingHybridModel: Module, LanguageModel, @unchecked Sendable {
+    private(set) var forwarded: [Int] = []
+    private(set) var prepareCalls = 0
+
+    var vocabularySize: Int { 64 }
+
+    func newCache(parameters: GenerateParameters?) -> [KVCache] {
+        [MambaCache()]
+    }
+
+    func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult {
+        prepareCalls += 1
+        let step = max(1, windowSize ?? 512)
+        var flatTokens = input.text.tokens.reshaped([-1])
+        while flatTokens.size > step {
+            _ = callAsFunction(flatTokens[..<step][.newAxis, 0...], cache: cache)
+            MLX.eval(cache)
+            flatTokens = flatTokens[step...]
+        }
+        return .tokens(LMInput.Text(tokens: flatTokens))
+    }
+
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        let ids = inputs.reshaped([-1]).asArray(Int32.self).map(Int.init)
+        forwarded.append(contentsOf: ids)
+        if let mamba = cache?.first as? MambaCache {
+            let runningSum = (mamba.state.first?.asArray(Float.self).first ?? 0)
+                + ids.reduce(Float(0)) { $0 + Float($1) }
+            mamba.state = [MLXArray([runningSum, Float(mamba.offset + ids.count)]).reshaped([1, 1, 2])]
+            mamba.offset += ids.count
+        }
+        return MLXArray.zeros([1, max(ids.count, 1), vocabularySize])
+    }
+}
+
+/// Same recorder, dense cache topology.
+private final class RecordingDenseModel: RecordingHybridModel, @unchecked Sendable {
+    override func newCache(parameters: GenerateParameters?) -> [KVCache] {
+        [KVCacheSimple()]
+    }
+}
+
+/// The gen-suffix-stripped boundary is the only prefix a hybrid model's next
+/// chat turn can reuse, and hybrid cache state is path-dependent, so it cannot
+/// be trimmed out of the finished prompt cache. It used to be reconstructed by
+/// replaying the whole stripped prefix through the model after generation —
+/// a second full prefill, which ran before the completion event reached the
+/// client and held the response stream open for seconds at long context.
+///
+/// It is now captured from the live prefill as it passes the boundary. These
+/// tests pin that: the prompt is forwarded exactly once, and the boundary the
+/// store sees is the state a warm pass over the stripped prefix produces.
+final class HybridStripBoundaryPrefillTests: XCTestCase {
+
+    private func makeCoordinator(hybrid: Bool = true) -> CacheCoordinator {
+        let coordinator = CacheCoordinator(config: CacheCoordinatorConfig(
+            usePagedCache: true,
+            enableDiskCache: false,
+            modelKey: "recording-hybrid|reasoning=off"))
+        if hybrid { coordinator.setHybrid(true) }
+        return coordinator
+    }
+
+    /// `<turn-start> assistant \n` — the generation prompt the next turn replaces.
+    private let genPromptSuffix = [201, 202, 203]
+    private let userTurn = [11, 12, 13, 14, 15, 16, 17]
+
+    func testPrefillForwardsEachPromptTokenExactlyOnce() throws {
+        let lock = lockSerializedMLXTest()
+        defer { lock.unlock() }
+
+        let model = RecordingHybridModel()
+        let coordinator = makeCoordinator()
+        coordinator.setGenPromptSuffixTokens(genPromptSuffix)
+
+        let prompt = userTurn + genPromptSuffix
+        var iterator = try TokenIterator(
+            input: LMInput(tokens: MLXArray(prompt.map { Int32($0) }).expandedDimensions(axis: 0)),
+            model: model,
+            parameters: GenerateParameters(maxTokens: 1, temperature: 0, prefillStepSize: 3),
+            cacheCoordinator: coordinator)
+
+        let forwardedDuringPrefill = model.forwarded
+        XCTAssertEqual(
+            forwardedDuringPrefill, prompt,
+            "prefill must forward the prompt once, in order, with no replay")
+
+        // The boundary is captured, so storing it must not run the model again.
+        let prepareCallsAfterPrefill = model.prepareCalls
+        iterator.storeCacheAfterGeneration(
+            generatedTokenIds: [], includeGeneratedBoundary: false)
+
+        XCTAssertEqual(
+            model.forwarded, forwardedDuringPrefill,
+            "storing the stripped boundary must not re-derive it through the model")
+        XCTAssertEqual(model.prepareCalls, prepareCallsAfterPrefill)
+    }
+
+    func testPrefillSplitsAtTheTurnStartToken() throws {
+        let lock = lockSerializedMLXTest()
+        defer { lock.unlock() }
+
+        let model = RecordingHybridModel()
+        let coordinator = makeCoordinator()
+        coordinator.setGenPromptSuffixTokens(genPromptSuffix)
+
+        let prompt = userTurn + genPromptSuffix
+        _ = try TokenIterator(
+            input: LMInput(tokens: MLXArray(prompt.map { Int32($0) }).expandedDimensions(axis: 0)),
+            model: model,
+            parameters: GenerateParameters(maxTokens: 1, temperature: 0, prefillStepSize: 512),
+            cacheCoordinator: coordinator)
+
+        // Head (stripped prefix) and tail (generation prompt) are prepared
+        // separately, so a window large enough to swallow the whole prompt in one
+        // go still yields two `prepare` calls.
+        XCTAssertEqual(model.prepareCalls, 2)
+        XCTAssertEqual(model.forwarded, prompt)
+    }
+
+    func testDenseModelPromptIsNotSplit() throws {
+        let lock = lockSerializedMLXTest()
+        defer { lock.unlock() }
+
+        // A plain KV cache carries no path-dependent state, so the coordinator
+        // stays dense and the boundary never applies.
+        let model = RecordingDenseModel()
+        let coordinator = makeCoordinator(hybrid: false)
+        coordinator.setGenPromptSuffixTokens(genPromptSuffix)
+
+        let prompt = userTurn + genPromptSuffix
+        _ = try TokenIterator(
+            input: LMInput(tokens: MLXArray(prompt.map { Int32($0) }).expandedDimensions(axis: 0)),
+            model: model,
+            parameters: GenerateParameters(maxTokens: 1, temperature: 0, prefillStepSize: 512),
+            cacheCoordinator: coordinator)
+
+        XCTAssertEqual(
+            model.prepareCalls, 1,
+            "dense models reuse via the post-answer boundary and must not pay for a split")
+        XCTAssertEqual(model.forwarded, prompt)
+    }
+
+    func testBoundaryIsNotSoughtWhenNoCacheTierCanHoldIt() throws {
+        let lock = lockSerializedMLXTest()
+        defer { lock.unlock() }
+
+        let model = RecordingHybridModel()
+        let coordinator = CacheCoordinator(config: CacheCoordinatorConfig(
+            usePagedCache: false,
+            enableDiskCache: false,
+            modelKey: "recording-hybrid|reasoning=off"))
+        coordinator.setHybrid(true)
+        coordinator.setGenPromptSuffixTokens(genPromptSuffix)
+        XCTAssertFalse(coordinator.canPersistBoundaries)
+
+        let prompt = userTurn + genPromptSuffix
+        _ = try TokenIterator(
+            input: LMInput(tokens: MLXArray(prompt.map { Int32($0) }).expandedDimensions(axis: 0)),
+            model: model,
+            parameters: GenerateParameters(maxTokens: 1, temperature: 0, prefillStepSize: 512),
+            cacheCoordinator: coordinator)
+
+        XCTAssertEqual(model.prepareCalls, 1)
+    }
+}


### PR DESCRIPTION
## The bug

Reported on Discord, about Ornith:

> when it finishes the query, it doesn't always stop — it hangs around for a bit then closes. No looping or anything, just open connection, no response.

Hybrid-SSM models (Ornith / Qwen3.6 GatedDeltaNet, Nemotron-H Mamba-2, LFM2, ZAYA CCA) reuse prefill across chat turns through a *gen-suffix-stripped* boundary: the prompt truncated just before the last turn-start token. The next turn replaces the trailing generation prompt with the assistant's reply, so the full-prompt key never matches again — but that boundary does.

Hybrid cache state is path-dependent, so the boundary can't be produced by trimming the finished prompt cache. `storeCacheAfterGeneration` rebuilt it by **replaying the entire stripped prefix through the model** — a second full prefill. And it runs *before* `generateLoopTask` yields `.info`, so `finish_reason` and `[DONE]` wait on it. The stream stays open long after the last token is delivered.

Measured on `ornith-1.0-9b-mxfp8` (M5 Max), last content chunk → `finish_reason`, with `max_tokens=16` so generation can't explain it:

| ~prompt tokens | tail |
|---|---|
| 478 | 0.42 s |
| 1 882 | 1.01 s |
| 5 626 | 2.58 s |
| 14 050 | **6.58 s** |

Dense `gemma-4-12b` is 0.17 s at the same context — it doesn't take this path. `sample` during the window shows `KVCache.update`, `KVCache.makeMask(n:windowSize:)`, `MetalAllocator::malloc`, `CommandEncoder::dispatch_threads`: a real forward pass, not serialization. The stack pins it to `storeCacheAfterGeneration → cacheSnapshotForBoundary → Qwen35.prepare → eval`.

`BatchEngine.finishSlot` already yields `.info` before its store, with a comment saying exactly why ("running it before `.info` makes hosts look frozen at end-of-stream"). The solo `TokenIterator` path never got the same treatment.

The comment claiming the re-derive "runs post-`.info` (after the response is delivered), so it never adds to the current turn's TTFT or token rate" was false. It's corrected here.

## The fix

Not a reorder — the `.info` yield deliberately sits behind the MLX drain so a consumer's post-tool decode can't open a command encoder while this task still holds one.

Instead, take the boundary out of the prefill that already passes through it: split `model.prepare` at the turn-start token and copy the cache there. Same tokens, same forwards, same order — **no extra compute**. One cache copy is retained until the store, alongside the prompt snapshot already retained.

Three things this has to get right:

- **Split through `model.prepare`, not the remainder it returns.** `Qwen35` — Ornith and Qwen3.6, the models that show the bug — consumes the whole prompt itself and returns `.logits`. A hook on the returned remainder never fires for exactly the models that need it.
- **Slice the mask alongside the tokens.** `Qwen3VLProcessor` attaches an all-ones `[1, T]` mask, so skipping masked inputs skips every prompt long enough to matter. Masks that aren't token-aligned are left whole and the split is declined.
- **No re-derive fallback.** Capture fails only when the boundary lies inside the prefix this turn restored from cache — in which case a boundary at least that long is already stored, and it's the one the next turn matches — or on DSV4's pool cache, which can't hold it anyway. So no post-generation forward pass remains on this path.

`CacheCoordinator.canPersistBoundaries` skips the work entirely when neither cache tier is enabled; previously the boundary was computed and discarded.

## After

| ~prompt tokens | before | after |
|---|---|---|
| 478 | 0.42 s | 0.09 s |
| 1 882 | 1.01 s | 0.14 s |
| 5 626 | 2.58 s | 0.23 s |
| 14 050 | **6.58 s** | **0.36 s** |

`lfm2.5-8b-a1b-mxfp8` @14k: 1.68 s → **0.09 s**. Dense `gemma-4-e2b-it-4bit` unchanged (0.05 s).

Cross-turn reuse still fires — growing chat on ornith, TTFT 0.63 s → 0.18 s → 0.17 s on turns 1–3 — and multi-turn recall stays exact ("Your dog's name is Biscuit, your favorite color is cerulean, and you were born in Tulsa.").

## Verification

Live on an osaurus dev app built against this branch (128 GB M5 Max), per model: multi-turn recall, tool call with arguments, reasoning on/off, and a control-marker leak scan.

| model | arch | recall | tools | reasoning on/off | leaks |
|---|---|---|---|---|---|
| ornith-1.0-9b-mxfp8 | hybrid GDN | pass | `{"city":"Paris"}` | pass | none |
| lfm2.5-8b-a1b-mxfp8 | hybrid SSM | pass¹ | `{"city":"Paris"}` | pass | none |
| gemma-4-e2b-it-4bit | dense sliding | pass | `{"city":"Paris"}` | pass | none |

¹ lfm2.5 refuses to echo a fact framed as an "access code"; it recalls a neutral fact correctly. Model behaviour, present before this change.

New `HybridStripBoundaryPrefillTests` (4 tests) pins the invariants: prefill forwards each prompt token exactly once, the store runs no forward pass, `prepare` is called twice split at the turn-start token, dense models aren't split, and no boundary is sought when no cache tier can hold it. `HybridStripBoundaryPrefillTests` + `SSMReDeriveParityTests`: 11/11 green.

One pre-existing failure on `main` is unrelated: `BatchEngineGrowingChatCacheSourceTests` expects a source substring that is line-wrapped in `BatchEngine.swift`, a file this branch does not touch.

## Not in this PR

`NativeMTPTokenIterator` and `BatchEngine` keep the forced re-derive. Neither stalls the client — BatchEngine yields `.info` first, and the measured MTP tail on `qwen3.6-27b-mxfp4-crack-mtp` is 0.29 s @478 → 0.68 s @14 050, an order of magnitude under the solo path. Where it does fire it's still a wasted prefill of GPU time. BatchEngine needs concurrency proof before the same change lands there.
