### PR TITLE
Deliver the prose that precedes a tool call in full

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -4311,6 +4311,24 @@ struct TextToolTokenLoopHandler: TokenLoopHandler, @unchecked Sendable {
             return !stopSequenceHit
         case .reasoning, .prefillProgress, .toolCall, .toolCallProgress, .info:
             if case .toolCall = event {
+                // Drain the stop-string matcher BEFORE the call event goes
+                // out. Text still held there for disambiguation precedes the
+                // call in the model's output, but consumers stop forwarding
+                // text the moment a tool call lands (deliberate no-leak
+                // suppression of post-tool prose) — so a tail emitted after
+                // this event is silently dropped, cutting the visible answer
+                // mid-word ("…removing the temporary director", live ornith).
+                // A stop string can no longer straddle the call boundary, but
+                // stops match the assistant's answer text and a tool call
+                // legitimately ends that span.
+                if stopStringMatcher.isEnabled {
+                    let tail = stopStringMatcher.flush()
+                    if !tail.isEmpty {
+                        if case .terminated = emit(.chunk(tail)) {
+                            return false
+                        }
+                    }
+                }
                 emittedToolCall = true
             }
             if case .terminated = emit(event) {

--- a/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
@@ -253,7 +253,19 @@ public class ToolCallProcessor {
                 unparsedText = leadingTextBeforeToolCall + toolCallBuffer
             }
         } else {
-            unparsedText = nil
+            // A successful parse consumes only the ENVELOPE. The prose that
+            // preceded it — held in `leadingTextBeforeToolCall` since the
+            // chunk that carried the start tag — is the visible answer text
+            // and must still surface. Models that stop right after their
+            // envelope (Qwen3.5 `</tool_call>` then EOS) complete the call
+            // HERE rather than on the streaming end-tag path, so dropping
+            // the leading text cut the assistant's sentence mid-word on
+            // essentially every prose-then-tool-call turn ("…removing the
+            // temporary director" — live ornith-1.0-9b). Mirrors the
+            // streaming completion path, including its suppression of a
+            // bare tool-name echo.
+            let leading = visibleLeadingTextBeforeToolCall(parsedToolCalls: parsed)
+            unparsedText = leading.isEmpty ? nil : leading
         }
 
         toolCallBuffer = ""

--- a/Tests/MLXLMCommonToolParserFocusedTests/ProseBeforeToolCallEOSTests.swift
+++ b/Tests/MLXLMCommonToolParserFocusedTests/ProseBeforeToolCallEOSTests.swift
@@ -1,0 +1,123 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Testing
+
+@testable import MLXLMCommon
+
+/// Prose that precedes a tool-call envelope must survive when the envelope
+/// completes at end-of-sequence.
+///
+/// Qwen3.5-family models (Ornith, Qwen3.6) stop generating right after
+/// `</tool_call>`, and the streaming pipeline's trailing holdbacks mean the
+/// envelope's last characters routinely arrive only in the end-of-stream
+/// flush — so the call completes inside `processEOS`, not on the streaming
+/// end-tag path. `processEOS` used to discard `leadingTextBeforeToolCall`
+/// whenever the parse SUCCEEDED, cutting the assistant's visible sentence
+/// mid-word on essentially every prose-then-tool-call turn. Live signature
+/// (ornith-1.0-9b-mxfp8, temp 0): "…removing the temporary director" with
+/// "y." lost, "…finalize the Pipe function in the right plac" from the
+/// user report.
+struct ProseBeforeToolCallEOSTests {
+
+    private func runCommandTool() -> [String: any Sendable] {
+        [
+            "type": "function",
+            "function": [
+                "name": "run_command",
+                "description": "Run a shell command.",
+                "parameters": [
+                    "type": "object",
+                    "properties": ["command": ["type": "string"]],
+                    "required": ["command"],
+                ] as [String: any Sendable],
+            ] as [String: any Sendable],
+        ]
+    }
+
+    /// Byte-faithful chunk shapes from the live trace: the prose tail shares
+    /// a chunk with the envelope's `<`, and the end tag never fully arrives
+    /// before EOS (`</too` held by an upstream holdback).
+    @Test("prose survives when the envelope completes at EOS")
+    func proseSurvivesEOSCompletion() {
+        let processor = ToolCallProcessor(format: .xmlFunction, tools: [runCommandTool()])
+        let chunks = [
+            "Let me clean up the smoke test artifacts by removing the temporary direct",
+            "ory.<to",
+            "ol_call>\n<function=run_command>\n<parameter=command>\nrm -rf /tmp/smoke\n",
+            "</parameter>\n</function>\n</too",
+        ]
+        var visible = ""
+        for chunk in chunks {
+            if let text = processor.processChunk(chunk) {
+                visible += text
+            }
+        }
+        if let tail = processor.processEOS() {
+            visible += tail
+        }
+
+        #expect(processor.toolCalls.count == 1)
+        #expect(processor.toolCalls.first?.function.name == "run_command")
+        #expect(
+            visible
+                == "Let me clean up the smoke test artifacts by removing the temporary directory.",
+            "the prose before the envelope must be delivered in full")
+    }
+
+    @Test("prose survives when the end tag completes mid-stream")
+    func proseSurvivesStreamingCompletion() {
+        let processor = ToolCallProcessor(format: .xmlFunction, tools: [runCommandTool()])
+        let chunks = [
+            "Cleaning the directory now.<tool_call>\n<function=run_command>\n",
+            "<parameter=command>\nrm -rf /tmp/smoke\n</parameter>\n</function>\n</tool_call>",
+        ]
+        var visible = ""
+        for chunk in chunks {
+            if let text = processor.processChunk(chunk) {
+                visible += text
+            }
+        }
+        if let tail = processor.processEOS() {
+            visible += tail
+        }
+
+        #expect(processor.toolCalls.count == 1)
+        #expect(visible == "Cleaning the directory now.")
+    }
+
+    /// The whole envelope plus its leading prose can arrive in ONE chunk at
+    /// EOS (short calls, aggressive coalescing upstream).
+    @Test("prose survives a single-chunk envelope at EOS")
+    func proseSurvivesSingleChunkEOS() {
+        let processor = ToolCallProcessor(format: .xmlFunction, tools: [runCommandTool()])
+        var visible = ""
+        if let text = processor.processChunk(
+            "Done thinking.<tool_call>\n<function=run_command>\n"
+                + "<parameter=command>\nls\n</parameter>\n</function>\n</too")
+        {
+            visible += text
+        }
+        if let tail = processor.processEOS() {
+            visible += tail
+        }
+        #expect(processor.toolCalls.count == 1)
+        #expect(visible == "Done thinking.")
+    }
+
+    /// Failed parses keep today's behaviour: the buffered envelope text
+    /// flushes back as visible prose together with the leading text.
+    @Test("unparsed envelope still flushes with its leading text")
+    func unparsedEnvelopeStillFlushes() {
+        let processor = ToolCallProcessor(format: .xmlFunction, tools: [runCommandTool()])
+        var visible = ""
+        if let text = processor.processChunk("Prose head <tool_call>not really a call") {
+            visible += text
+        }
+        if let tail = processor.processEOS() {
+            visible += tail
+        }
+        #expect(processor.toolCalls.isEmpty)
+        #expect(visible.hasPrefix("Prose head "))
+    }
+}

--- a/Tests/MLXLMTests/ToolCallStopMatcherOrderingTests.swift
+++ b/Tests/MLXLMTests/ToolCallStopMatcherOrderingTests.swift
@@ -1,0 +1,137 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+/// The stop-string matcher holds back text that could be the start of a stop
+/// string. When a tool call completes, that held text — which PRECEDES the
+/// call in the model's output — must be emitted BEFORE the `.toolCall` event:
+/// consumers deliberately suppress all text once a tool call lands (no-leak
+/// guard for post-tool prose), so a tail emitted after the event is silently
+/// dropped. Live signature on ornith-1.0-9b-mxfp8: the assistant's sentence
+/// cut mid-word right before every tool call ("…removing the temporary
+/// director").
+struct ToolCallStopMatcherOrderingTests {
+
+    struct FixedPieceTokenizer: MLXLMCommon.Tokenizer {
+        let pieces: [String]
+        var vocabularySize: Int { pieces.count }
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+            tokenIds.map { pieces.indices.contains($0) ? pieces[$0] : "" }.joined()
+        }
+        func convertTokenToId(_ token: String) -> Int? { pieces.firstIndex(of: token) }
+        func convertIdToToken(_ id: Int) -> String? {
+            pieces.indices.contains(id) ? pieces[id] : nil
+        }
+        var bosToken: String? = nil
+        var eosToken: String? = nil
+        var eosTokenId: Int? { nil }
+        var unknownToken: String? = nil
+        var unknownTokenId: Int? { nil }
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] { [] }
+    }
+
+    private static let runCommandTool: [String: any Sendable] = [
+        "type": "function",
+        "function": [
+            "name": "run_command",
+            "description": "Run a shell command.",
+            "parameters": [
+                "type": "object",
+                "properties": ["command": ["type": "string"]],
+                "required": ["command"],
+            ] as [String: any Sendable],
+        ] as [String: any Sendable],
+    ]
+
+    private enum Event: Equatable {
+        case chunk(String)
+        case toolCall(String)
+    }
+
+    private func run(pieces: [String], stops: [String]) -> [Event] {
+        var handler = TextToolTokenLoopHandler(
+            tokenizer: FixedPieceTokenizer(pieces: pieces),
+            format: .xmlFunction,
+            tools: [Self.runCommandTool],
+            reasoningParser: nil,
+            stopStringMatcher: StopStringMatcher(stopStrings: stops)
+        )
+        var events: [Event] = []
+        let emit: (sending Generation) -> AsyncStream<Generation>.Continuation.YieldResult = {
+            event in
+            switch event {
+            case .chunk(let text): events.append(.chunk(text))
+            case .toolCall(let call): events.append(.toolCall(call.function.name))
+            default: break
+            }
+            return .enqueued(remaining: .max)
+        }
+        for token in pieces.indices {
+            if !handler.onToken(token, emit: emit) { break }
+        }
+        handler.onGenerationEnd(emit: emit)
+        return events
+    }
+
+    @Test("stop-matcher-held prose is emitted before the tool call event")
+    func heldTailPrecedesToolCall() {
+        // "EN" is a strict prefix of the stop string "END", so the matcher
+        // holds it back for disambiguation while the envelope streams in.
+        // Pad past the detokenizer's 24-char holdback so everything flushes.
+        let events = run(
+            pieces: [
+                "Removing the temporary directory now, hold on.",
+                "EN",
+                "<tool_call>\n<function=run_command>\n<parameter=command>\nls\n",
+                "</parameter>\n</function>\n</tool_call>",
+            ],
+            stops: ["END"])
+
+        guard let callIndex = events.firstIndex(of: .toolCall("run_command")) else {
+            Issue.record("tool call was not parsed: \(events)")
+            return
+        }
+        let textBeforeCall = events[..<callIndex].compactMap {
+            if case .chunk(let t) = $0 { return t } else { return nil }
+        }.joined()
+        let textAfterCall = events[(callIndex + 1)...].compactMap {
+            if case .chunk(let t) = $0 { return t } else { return nil }
+        }.joined()
+
+        #expect(
+            textBeforeCall == "Removing the temporary directory now, hold on.EN",
+            "held stop-prefix text must surface before the tool call")
+        #expect(
+            textAfterCall.isEmpty,
+            "no text may trail the tool call — consumers drop it as post-tool prose")
+    }
+
+    @Test("no stop strings: prose still fully precedes the tool call")
+    func noStopsBaseline() {
+        let events = run(
+            pieces: [
+                "Removing the temporary directory now, hold on.",
+                "<tool_call>\n<function=run_command>\n<parameter=command>\nls\n",
+                "</parameter>\n</function>\n</tool_call>",
+            ],
+            stops: [])
+
+        guard let callIndex = events.firstIndex(of: .toolCall("run_command")) else {
+            Issue.record("tool call was not parsed: \(events)")
+            return
+        }
+        let textBeforeCall = events[..<callIndex].compactMap {
+            if case .chunk(let t) = $0 { return t } else { return nil }
+        }.joined()
+        #expect(textBeforeCall == "Removing the temporary directory now, hold on.")
+    }
+}


### PR DESCRIPTION
## The bug

From agent runs on Ornith (screenshots): the assistant's visible sentence cuts off mid-word right before every tool call —

> Alright, let me clean up test artifacts, finalize the Pipe function in the right plac

Reproduced 4/8 turns at temperature 0 on `ornith-1.0-9b-mxfp8` with a prose-then-tool-call prompt: "…removing the temporary director" (missing "y."), "…to confirm they are in " (missing a whole clause). Engine-side: the SSE `content` deltas themselves end there. Not a cache issue and not a #129 regression — identical cuts with `VMLX_HYBRID_STRIPPED_STORE=0`.

## Root cause — two independent drops on the prose/envelope boundary

Layer-by-layer tracing (raw tokens → detokenizer → reasoning parser → tool processor → stop matcher → wire):

**1. `ToolCallProcessor.processEOS` discarded the held prose on a successful parse.** The prose that shares a chunk with the envelope's `<` is stashed in `leadingTextBeforeToolCall`. The mid-stream end-tag path returns it when the call completes — but Qwen3.5-family models stop generating right after `</tool_call>`, and the streaming pipeline's trailing holdbacks mean the envelope's last characters routinely arrive only in the end-of-stream flush. The call then completes inside `processEOS`, whose parsed-successfully branch set `unparsedText = nil` and wiped the stash. Fires on essentially every prose-then-tool-call turn for this family.

**2. The stop-string matcher's held tail was emitted after the `.toolCall` event.** The matcher holds back text that could open a stop string; its drain sat at the very end of `onGenerationEnd`, after `flushGenerationText` had already emitted the `.toolCall`. Consumers deliberately suppress all text once a tool call lands (the no-leak guard for post-tool prose) — so the tail, which *precedes* the call in the model's output, was silently dropped downstream. Live trace: the parser returned `…directory at /tmp/smoke.\n\n` in full; everything past the matcher's holdback point never reached the wire.

## The fix

- `processEOS` now surfaces the held prose through the same `visibleLeadingTextBeforeToolCall` helper the streaming completion path uses (including its suppression of bare tool-name echoes). Failed-parse behaviour is unchanged.
- `emitRouted` drains the stop matcher **before** any `.toolCall` event goes out. A stop string can no longer straddle the call boundary; stops match the assistant's answer span, which a tool call legitimately ends.

## Verification

Same repro, after: **0/7 truncations** (previously 4/8). Sentences complete on both sides of every tool call:

```
before: '…I will list the files in the current directory to confirm they are in '
after : '…I will list the files in the current directory to confirm they are in the right place.\n\n'

before: '…by removing the temporary director'
after : '…by removing the temporary directory at /tmp/smoke.\n\n'
```

Also clean on `lfm2.5-8b-a1b-mxfp8` (different tool format). Tool calls still parse with correct arguments; nothing leaks after them; reasoning stays separated.

New tests pin the invariants byte-faithfully to the live chunk shapes:
- `ProseBeforeToolCallEOSTests` (4): EOS-completed envelope returns the prose; mid-stream completion unchanged; failed parses still flush; single-chunk envelope.
- `ToolCallStopMatcherOrderingTests` (2): matcher-held text precedes the `.toolCall` event; nothing trails it.

Gate run: ProseBeforeToolCallEOSTests + ToolCallStopMatcherOrderingTests + StopStringPostStopLeakTests + StopStringMatcherTests + ToolCallProcessorFuzzTests + HybridStripBoundaryPrefillTests — one failure total, `ToolCallEdgeCasesTests` "LFM2 processor accepts observed OpenAI tool_call JSON envelope", which fails identically on `main` (pre-existing, untouched by this change).

There is an osaurus-side companion fix (HTTP stream loops dropped their delta-coalescer's pending text when the tool call throws) going up separately; both are needed for the full end-to-end result above.
