### PR TITLE
Expose native-MTP per-generation stats on GenerateCompletionInfo

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -945,6 +945,7 @@ public protocol TokenIteratorProtocol: Sequence, IteratorProtocol where Element 
     var promptPrefillTime: TimeInterval { get }
     var promptTokenIds: [Int] { get }
     var turboQuantCompressionCount: Int { get }
+    var nativeMTPStats: NativeMTPGenerationStats? { get }
     mutating func storeCacheAfterGeneration(
         generatedTokenIds: [Int],
         includeGeneratedBoundary: Bool)
@@ -953,6 +954,7 @@ public protocol TokenIteratorProtocol: Sequence, IteratorProtocol where Element 
 extension TokenIteratorProtocol {
     public var promptTokenIds: [Int] { [] }
     public var turboQuantCompressionCount: Int { 0 }
+    public var nativeMTPStats: NativeMTPGenerationStats? { nil }
 
     public mutating func storeCacheAfterGeneration(
         generatedTokenIds: [Int],
@@ -3523,15 +3525,6 @@ private func generateLoopTask<Handler: TokenLoopHandler>(
             MLXPressGenerationProfile.dumpAndReset(
                 reason: "generation-end tokens=\(tokenCount)")
 
-            let info = GenerateCompletionInfo(
-                promptTokenCount: promptTokenCount,
-                generationTokenCount: tokenCount,
-                promptTime: promptTime + iterator.promptPrefillTime,
-                generationTime: generateTime,
-                stopReason: stopReason ?? .cancelled,
-                turboQuantCompressions: iterator.turboQuantCompressionCount,
-                unclosedReasoning: unclosedReasoning
-            )
             // Multi-tier cache: drain the final async token eval before cache
             // snapshot/store, then keep completion info behind the cache-store
             // drain. Local chat/tool consumers may start a post-tool decode as
@@ -3543,6 +3536,27 @@ private func generateLoopTask<Handler: TokenLoopHandler>(
                 includeGeneratedBoundary: stopReason == .stop
                     && !handler.stopSequenceHit
                     && !handler.emittedToolCall)
+
+            // Build completion info only after `storeCacheAfterGeneration`
+            // returns: the native-MTP iterator snapshots `nativeMTPStats`
+            // there, from the same source values its `[NativeMTP]` stderr
+            // summary line prints for the corresponding keys (`outputTokens`
+            // depends on `generatedTokenIds`, which the iterator only sees
+            // in that call). `.info` is yielded
+            // further below, after the cache-store drain, exactly as before —
+            // only the construction moved — and no iterator mutates
+            // `turboQuantCompressionCount` or `promptPrefillTime` during the
+            // cache store, so every existing field is unchanged.
+            let info = GenerateCompletionInfo(
+                promptTokenCount: promptTokenCount,
+                generationTokenCount: tokenCount,
+                promptTime: promptTime + iterator.promptPrefillTime,
+                generationTime: generateTime,
+                stopReason: stopReason ?? .cancelled,
+                turboQuantCompressions: iterator.turboQuantCompressionCount,
+                unclosedReasoning: unclosedReasoning,
+                nativeMTPStats: iterator.nativeMTPStats
+            )
 
             Stream().synchronize()
 
@@ -3643,6 +3657,16 @@ public struct GenerateCompletionInfo: Sendable {
     /// (no behavior change on non-reasoning workloads).
     public let unclosedReasoning: Bool
 
+    /// Structured native-MTP speculative-decoding diagnostics for this
+    /// generation: the headline counters of the `[NativeMTP]` summary line
+    /// written to stderr, assigned from the same source values at the same
+    /// lifecycle point. Representation differs where
+    /// ``NativeMTPGenerationStats`` says so (rounding, `nil` vs `none`,
+    /// dense histogram), and the stderr line carries additional keys the
+    /// struct omits. `nil` for any generation that did not run the
+    /// native-MTP iterator.
+    public let nativeMTPStats: NativeMTPGenerationStats?
+
     /// The number of tokens processed per second during the prompt phase.
     public var promptTokensPerSecond: Double {
         Double(promptTokenCount) / promptTime
@@ -3660,7 +3684,8 @@ public struct GenerateCompletionInfo: Sendable {
         generationTime: TimeInterval,
         stopReason: GenerateStopReason = .stop,
         turboQuantCompressions: Int = 0,
-        unclosedReasoning: Bool = false
+        unclosedReasoning: Bool = false,
+        nativeMTPStats: NativeMTPGenerationStats? = nil
     ) {
         self.promptTokenCount = promptTokenCount
         self.generationTokenCount = generationTokenCount
@@ -3669,6 +3694,7 @@ public struct GenerateCompletionInfo: Sendable {
         self.stopReason = stopReason
         self.turboQuantCompressions = turboQuantCompressions
         self.unclosedReasoning = unclosedReasoning
+        self.nativeMTPStats = nativeMTPStats
     }
 
     public func summary() -> String {

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -45,6 +45,119 @@ private struct NativeMTPCacheCheckpoint {
     }
 }
 
+/// Structured per-generation diagnostics for native-MTP speculative decoding.
+///
+/// Carries the headline engagement/acceptance counters of the `[NativeMTP]`
+/// summary line the iterator writes to stderr at the end of every generation.
+/// Each field documents the `key=` entry it is assigned from; the assignment
+/// reads the same source values, at the same lifecycle point, as the
+/// `String(format:)` that renders the line, but representation can differ
+/// where a field's doc says so (rounding, `nil` vs `none`, dense histogram).
+/// The struct is a subset: the stderr line remains the complete diagnostic
+/// surface and additionally carries repair/commit counters
+/// (`residualCorrection=`, `prefixCommit=`, `rollbackRepair=`,
+/// `mtpCacheRefresh=`), forward-pass counters, per-phase timing fields,
+/// GDN-replay diagnostics, `phaseDiag=`, and `samplingMode=`, none of which
+/// appear here. Hosts that only need these headline counters can read them
+/// from ``GenerateCompletionInfo/nativeMTPStats`` instead of parsing stderr;
+/// that property is `nil` for any generation that did not run the native-MTP
+/// iterator.
+public struct NativeMTPGenerationStats: Sendable, Equatable {
+    /// Requested draft depth (`depth=`).
+    public let depth: Int
+
+    /// Draft depth in effect at end of generation, after any adaptive
+    /// downshifts (`activeDepth=`).
+    public let activeDepth: Int
+
+    /// Number of verify cycles executed (`verifyCalls=`).
+    public let verifyCalls: Int
+
+    /// The `generatedTokenIds.count` the generate loop passed to
+    /// `storeCacheAfterGeneration` — identical to the stderr `outputTokens=`
+    /// value. Because a generation-ending stop token is counted by the loop
+    /// but never appended to `generatedTokenIds`, this can be one less than
+    /// ``GenerateCompletionInfo/generationTokenCount`` on stop-token paths
+    /// (`outputTokens=`).
+    public let outputTokens: Int
+
+    /// Tokens produced by the autoregressive fallback path
+    /// (`arFallbackTokens=`).
+    public let arFallbackTokens: Int
+
+    /// Histogram of verify cycles by accepted draft count:
+    /// `acceptedByDepth[n]` is the number of cycles that accepted exactly `n`
+    /// draft tokens. Dense representation of the same counts the stderr line
+    /// prints sparsely as non-zero `n:count` pairs — and as the literal
+    /// `none` when the histogram is empty, which here is `[]`
+    /// (`acceptedByDepth=`).
+    public let acceptedByDepth: [Int]
+
+    /// Bonus tokens sampled from the target after full acceptance (`bonus=`).
+    public let bonusTokens: Int
+
+    /// Rejected draft tokens (`rejected=`).
+    public let rejectedTokens: Int
+
+    /// Average committed tokens per verify cycle over the speculative output.
+    /// Stores the same source double the stderr line prints, at full
+    /// precision — the line renders it rounded to two decimals via `%.2f`
+    /// (`avgCommittedPerVerify=`).
+    public let avgCommittedPerVerify: Double
+
+    /// Average draft acceptance probability; 0 under greedy sampling. Stores
+    /// the same source double the stderr line prints, at full precision — the
+    /// line renders it rounded to three decimals via `%.3f` (`avgAcceptP=`).
+    public let avgAcceptProbability: Double
+
+    /// Number of adaptive depth downshifts (`adaptiveDownshifts=`).
+    public let adaptiveDownshifts: Int
+
+    /// Why the adaptive controller fell back to autoregressive decode, or
+    /// `nil` when it did not. `nil` here corresponds exactly to the stderr
+    /// line printing `adaptiveFallback=none`; a non-`nil` reason is printed
+    /// verbatim (`adaptiveFallback=`).
+    public let adaptiveFallbackReason: String?
+
+    /// Verifier mode used for this generation (`verifierMode=`).
+    public let verifierMode: String
+
+    /// Cache handling mode (`cacheMode=`).
+    public let cacheMode: String
+
+    public init(
+        depth: Int,
+        activeDepth: Int,
+        verifyCalls: Int,
+        outputTokens: Int,
+        arFallbackTokens: Int,
+        acceptedByDepth: [Int],
+        bonusTokens: Int,
+        rejectedTokens: Int,
+        avgCommittedPerVerify: Double,
+        avgAcceptProbability: Double,
+        adaptiveDownshifts: Int,
+        adaptiveFallbackReason: String?,
+        verifierMode: String,
+        cacheMode: String
+    ) {
+        self.depth = depth
+        self.activeDepth = activeDepth
+        self.verifyCalls = verifyCalls
+        self.outputTokens = outputTokens
+        self.arFallbackTokens = arFallbackTokens
+        self.acceptedByDepth = acceptedByDepth
+        self.bonusTokens = bonusTokens
+        self.rejectedTokens = rejectedTokens
+        self.avgCommittedPerVerify = avgCommittedPerVerify
+        self.avgAcceptProbability = avgAcceptProbability
+        self.adaptiveDownshifts = adaptiveDownshifts
+        self.adaptiveFallbackReason = adaptiveFallbackReason
+        self.verifierMode = verifierMode
+        self.cacheMode = cacheMode
+    }
+}
+
 struct NativeMTPTokenIterator: TokenIteratorProtocol {
     let model: any NativeMTPModel
     var cache: [KVCache]
@@ -108,6 +221,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private var hybridSafetyWarmupComplete = false
     private var adaptiveWindow: [AdaptiveCycle] = []
     private var adaptiveFallbackReason: String?
+    private(set) var nativeMTPStats: NativeMTPGenerationStats?
     private let iteratorStartTime = Date.timeIntervalSinceReferenceDate
 
     private var usesHybridMambaCache: Bool {
@@ -560,6 +674,34 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         } else {
             verifierMode = "sequential_repair"
         }
+        // Structured snapshot of the headline counters of the stderr summary
+        // line below: each stats field is assigned here from the same source
+        // value the corresponding `key=` entry prints, at this same point.
+        // Representation differs where documented (the line rounds
+        // `avgCommittedPerVerify`/`avgAcceptP`, prints a nil fallback reason
+        // as `none`, and renders the histogram sparsely); the line's
+        // repair/forward/timing/diagnostic keys have no struct counterpart.
+        // `generateLoopTask` reads this after `storeCacheAfterGeneration`
+        // returns and carries it on `GenerateCompletionInfo.nativeMTPStats`.
+        let acceptedHistogram: [Int] = {
+            guard let maxAccepted = acceptedByDepth.keys.max() else { return [] }
+            return (0...maxAccepted).map { acceptedByDepth[$0] ?? 0 }
+        }()
+        nativeMTPStats = NativeMTPGenerationStats(
+            depth: depth,
+            activeDepth: currentDepth,
+            verifyCalls: verifyCalls,
+            outputTokens: generatedTokenIds.count,
+            arFallbackTokens: autoregressiveFallbackTokenCount,
+            acceptedByDepth: acceptedHistogram,
+            bonusTokens: bonusCount,
+            rejectedTokens: rejectedCount,
+            avgCommittedPerVerify: avgCommitted,
+            avgAcceptProbability: avgAcceptP,
+            adaptiveDownshifts: adaptiveDepthDownshiftCount,
+            adaptiveFallbackReason: adaptiveFallbackReason,
+            verifierMode: verifierMode,
+            cacheMode: "private-mtp+verifier-prefix-commit")
         let line = String(
             format:
                 "[NativeMTP] depth=%d activeDepth=%d verifyCalls=%d outputTokens=%d arFallbackTokens=%d acceptedByDepth=%@ bonus=%d rejected=%d residualCorrection=%d prefixCommit=%d rollbackRepair=%d mtpCacheRefresh=%d targetForwards=%d verifyInputTokens=%d repairForwards=%d seedMainForwards=%d verifyMainForwards=%d replayMainForwards=%d mtpForwards=%d avgCommittedPerVerify=%.2f avgAcceptP=%.3f adaptiveDownshifts=%d adaptiveFallback=%@ targetVerifySec=%.3f seedMainSec=%.3f verifyMainSec=%.3f replayMainSec=%.3f mtpDraftSec=%.3f samplingSec=%.3f cacheCommitSec=%.3f materializeSyncSec=%.3f cacheStateSec=%.3f iteratorWallSec=%.3f gdnReplayCalls=%d gdnReplayStates=%d gdnReplaySec=%.3f phaseDiag=%@ samplingMode=%@ verifierMode=%@ cacheMode=private-mtp+verifier-prefix-commit\n",

--- a/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
@@ -1307,6 +1307,102 @@ struct MTPRuntimeFocusedTests {
         }
     }
 
+    @Test("token iterators report nil native MTP stats by default")
+    func tokenIteratorsReportNilNativeMTPStatsByDefault() {
+        // `TokenIterator`, `SpeculativeTokenIterator`, and
+        // `BlockDiffusionTokenIterator` all inherit the same
+        // protocol-extension default this stub exercises; only
+        // `NativeMTPTokenIterator` overrides it.
+        var iterator = FocusedDefaultStatsIterator()
+
+        #expect(iterator.nativeMTPStats == nil)
+        #expect(iterator.next() == nil)
+    }
+
+    @Test("native MTP generation stats round-trip their fields")
+    func nativeMTPGenerationStatsRoundTripFields() {
+        func makeStats() -> NativeMTPGenerationStats {
+            NativeMTPGenerationStats(
+                depth: 3,
+                activeDepth: 2,
+                verifyCalls: 7,
+                outputTokens: 21,
+                arFallbackTokens: 4,
+                acceptedByDepth: [1, 3, 2, 1],
+                bonusTokens: 2,
+                rejectedTokens: 5,
+                avgCommittedPerVerify: 2.43,
+                avgAcceptProbability: 0.875,
+                adaptiveDownshifts: 1,
+                adaptiveFallbackReason: "acceptance-collapse",
+                verifierMode: "chunk_commit",
+                cacheMode: "private-mtp+verifier-prefix-commit")
+        }
+
+        let stats = makeStats()
+        #expect(stats.depth == 3)
+        #expect(stats.activeDepth == 2)
+        #expect(stats.verifyCalls == 7)
+        #expect(stats.outputTokens == 21)
+        #expect(stats.arFallbackTokens == 4)
+        #expect(stats.acceptedByDepth == [1, 3, 2, 1])
+        #expect(stats.bonusTokens == 2)
+        #expect(stats.rejectedTokens == 5)
+        #expect(stats.avgCommittedPerVerify == 2.43)
+        #expect(stats.avgAcceptProbability == 0.875)
+        #expect(stats.adaptiveDownshifts == 1)
+        #expect(stats.adaptiveFallbackReason == "acceptance-collapse")
+        #expect(stats.verifierMode == "chunk_commit")
+        #expect(stats.cacheMode == "private-mtp+verifier-prefix-commit")
+        #expect(stats == makeStats())
+    }
+
+    @Test("completion info defaults native MTP stats to nil")
+    func completionInfoDefaultsNativeMTPStatsToNil() {
+        let info = GenerateCompletionInfo(
+            promptTokenCount: 3,
+            generationTokenCount: 4,
+            promptTime: 0.1,
+            generationTime: 0.2)
+
+        #expect(info.nativeMTPStats == nil)
+    }
+
+    @Test("active native MTP generation carries structured stats on completion info")
+    func activeNativeMTPGenerationCarriesStructuredStats() async throws {
+        try await FocusedMLXTestSupport.withLock {
+            let model = FocusedNativeMTPProbeTarget()
+            let context = Self.nativeMTPDispatchContext(model: model)
+            let engine = BatchEngine(context: context, maxBatchSize: 2)
+            var params = GenerateParameters(maxTokens: 4, temperature: 0)
+            params.draftStrategy = .nativeMTP(depth: 3)
+
+            let stream = await engine.generate(
+                input: LMInput(tokens: MLXArray([3, 5, 7])),
+                parameters: params)
+            var completionInfo: GenerateCompletionInfo?
+            for await event in stream {
+                if case .info(let info) = event {
+                    completionInfo = info
+                }
+            }
+
+            let info = try #require(completionInfo)
+            let stats = try #require(info.nativeMTPStats)
+            #expect(stats.depth == 3)
+            #expect(stats.verifyCalls >= 1)
+            // No stop token fires with the zero-logit probe target, so the
+            // info's emitted-token count and the iterator's
+            // `generatedTokenIds.count` snapshot must agree.
+            #expect(stats.outputTokens == info.generationTokenCount)
+            // Every completed verify cycle records exactly one accepted-count
+            // histogram entry.
+            #expect(stats.acceptedByDepth.reduce(0, +) == stats.verifyCalls)
+            #expect(stats.cacheMode == "private-mtp+verifier-prefix-commit")
+            #expect(!stats.verifierMode.isEmpty)
+        }
+    }
+
     @Test("shape-walk quantization preserves MXFP4 mode")
     func shapeWalkQuantizationPreservesMXFP4Mode() {
         let weights: [String: MLXArray] = [
@@ -2216,4 +2312,14 @@ private final class FocusedNativeMTPProbeTarget: Module, LanguageModel, NativeMT
     private func hiddenStates(for inputs: MLXArray) -> MLXArray {
         MLXArray.zeros([1, sequenceLength(inputs), 4])
     }
+}
+
+/// Minimal conformer that relies on every `TokenIteratorProtocol`
+/// protocol-extension default, so tests can assert those defaults directly.
+private struct FocusedDefaultStatsIterator: TokenIteratorProtocol {
+    let maxTokens: Int? = nil
+    let tokenCount = 0
+    let promptPrefillTime: TimeInterval = 0
+
+    mutating func next() -> Int? { nil }
 }


### PR DESCRIPTION

## What

The `[NativeMTP]` per-generation summary is currently stderr-only; #120 (section 5) tells hosts to grep stderr for it. This PR carries the headline engagement/acceptance counters of that line structurally on `GenerateCompletionInfo` — following the existing `turboQuantCompressions` pattern — so a host (osaurus) can surface speculative-decoding health in its diagnostics endpoint without stderr parsing, which #120 (section 7) identified as the osaurus-side actionable. The struct is a subset of the ~40-key line (repair/commit counters, forward counts, timing fields, GDN-replay diagnostics, `phaseDiag`, and `samplingMode` remain stderr-only), so the full stderr line stays the authoritative diagnostic surface and is untouched; no existing behavior is gated or changed; every non-MTP path reports `nil`.

## How

- `NativeMTPGenerationStats` (public, `Sendable`, `Equatable`) is defined next to the iterator that produces it. It is snapshotted inside `storeCacheAfterGeneration`, from the same locals the stderr `String(format:)` consumes — `depth`, `currentDepth`, `verifyCalls`, `generatedTokenIds.count`, `autoregressiveFallbackTokenCount`, the accepted-by-depth histogram, `bonusCount`, `rejectedCount`, `avgCommitted`, `avgAcceptP`, `adaptiveDepthDownshiftCount`, `adaptiveFallbackReason`, `verifierMode`, and the `cacheMode` literal — same source values at the same call site. The rendering differs where the docs say so: stderr rounds `avgCommittedPerVerify`/`avgAcceptP` to `%.2f`/`%.3f` while the struct stores the full-precision source doubles; a `nil` `adaptiveFallbackReason` corresponds to the line printing `adaptiveFallback=none`; the struct's dense histogram is printed sparsely as non-zero `n:count` pairs (or `none` when empty). Doc comments name the exact `key=` entry each field is assigned from.
- `TokenIteratorProtocol` gains `var nativeMTPStats: NativeMTPGenerationStats? { get }` with a protocol-extension default of `nil` — exactly the `turboQuantCompressionCount` pattern; no other conformer changes.
- `GenerateCompletionInfo` gains `nativeMTPStats: NativeMTPGenerationStats?` with a default-`nil` init parameter, so all existing construction sites compile unchanged.

## Ordering finding (why the construction site moved)

`generateLoopTask` used to construct `GenerateCompletionInfo` *before* calling `storeCacheAfterGeneration`, but only *yields* it after the cache-store drain. Exactness forces construction after the call: the stderr line's `outputTokens` is `generatedTokenIds.count`, a parameter the iterator only sees inside `storeCacheAfterGeneration` — the iterator's internal token count differs from it when generation ends on a stop token (counted by `next()`, never appended to `generatedTokenIds`). A computed property reading iterator state at the old construction point could therefore disagree with the stderr line by one token on every EOS-terminated generation. Moving the construction is observable-behavior-neutral: `.info` is yielded at the same point as before, and nothing in the cache store mutates `turboQuantCompressionCount` or `promptPrefillTime` (the only iterator state the constructor reads besides the new field — the compression counter increments only in `maybeQuantizeCacheForStep` on the decode path).

## Construction sites audited (grep `GenerateCompletionInfo(`)

- `Evaluate.swift:generateLoopTask` — the only site fed by a live iterator; now passes `iterator.nativeMTPStats`. Both `generate(...) -> AsyncStream<Generation>` and `generateTokensTask` funnel here, so both native-MTP dispatch paths are covered by one change.
- `Evaluate.swift` early-exit sites (iterator construction cancelled/failed) and the deprecated synchronous `generate` — no generation ran; default `nil` is correct.
- `SpecDecStream.swift` (3 sites) — draft-model spec-dec, never the native-MTP iterator; default `nil`.
- `BatchEngine.swift` — the solo native-MTP fast path forwards `.info` events from `generateTask` **unmodified** (`continuation.yield(generation)`), so the stats flow through it with zero BatchEngine changes. The remaining sites (batched decode loop, cancel/shutdown/error paths) never run the native-MTP iterator; default `nil`. No BatchEngine diff in this PR.

## Tests

Added to `MTPRuntimeFocusedTests` (all using existing harness pieces):
- a minimal `TokenIteratorProtocol` conformer proves the protocol-extension default is `nil` — the default every non-MTP iterator (`TokenIterator`, `SpeculativeTokenIterator`, `BlockDiffusionTokenIterator`) inherits;
- `NativeMTPGenerationStats` round-trips every field and is `Equatable`;
- `GenerateCompletionInfo` defaults the field to `nil` (also proves init source-compat);
- end-to-end over the existing `FocusedNativeMTPProbeTarget` stub: after a native-MTP generation through `BatchEngine.generate`, the completion info carries non-nil stats with `depth == 3`, `verifyCalls >= 1`, `outputTokens == generationTokenCount` (no stop token fires with the zero-logit stub), accepted-by-depth histogram summing to `verifyCalls`, and the `cacheMode` literal. The `[NativeMTP]` stderr line emitted by that run (`verifyCalls=1 outputTokens=4 arFallbackTokens=0 acceptedByDepth=3:1 bonus=1 ...`) matches the structured values for the fields the struct carries (with the histogram rendered sparsely).

## Verification run

- `swift build` at repo root: clean.
- `swift test --filter MTPRuntimeFocusedTests`: 71 tests, all 4 new tests pass. One failure, "shape-walk quantization uses hidden size for JANG_2K routed expert inputs", fails identically on clean main @ 0d3444ca (verified via stash) — pre-existing, unrelated.
- `swift test --filter SpecDecStreamTests`: 2 failures, both fail identically on clean main (verified via stash) — pre-existing in this local `swift test` environment, unrelated.
- `swift test --filter "BatchEngineTurboQuantTests|BatchEngineCompileWiringTests"`: 13 tests passed.
- `swift test --filter BatchEngineTests`: 12 tests passed.
