### PR TITLE
Support official Hunyuan v3 (hy_v3) end to end

### DIFF
--- a/Libraries/MLXLLM/Hy3ReasoningTemplateContext.swift
+++ b/Libraries/MLXLLM/Hy3ReasoningTemplateContext.swift
@@ -1,0 +1,59 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+
+/// Template-context adapter for official Hunyuan v3 (`model_type = hy_v3`).
+///
+/// The official chat template keys thinking on a `reasoning_effort` variable
+/// with the closed set `no_think` / `low` / `high` — it IGNORES the
+/// `enable_thinking` boolean every other family understands, and it
+/// `raise_exception`s on any other effort value (so an OpenAI-style
+/// `reasoning_effort: "medium"` would fail the whole render). This adapter
+/// translates the request surface into the template's contract:
+///
+/// - explicit `reasoning_effort` wins: `no_think`/`low`/`high` pass through;
+///   `none`/`off` → `no_think`, `minimal`/`medium` → `low`, `max`/anything
+///   else non-empty → `high`.
+/// - otherwise `enable_thinking` maps `true` → `high`, `false` → `no_think`.
+/// - with neither present, nothing is injected and the template's own
+///   default (`no_think`) applies.
+public enum Hy3ReasoningTemplateContext {
+    public static func applies(to modelType: String?) -> Bool {
+        guard let t = modelType?.lowercased() else { return false }
+        return t == "hy_v3" || t.hasPrefix("hy_v3_") || t.hasPrefix("hy3")
+            || t.hasPrefix("hunyuan")
+    }
+
+    public static func apply(
+        additionalContext: [String: any Sendable]?,
+        modelType: String?
+    ) -> [String: any Sendable]? {
+        guard applies(to: modelType) else { return additionalContext }
+        var context = additionalContext ?? [:]
+
+        let effort: String?
+        if let requested = (context["reasoning_effort"] as? String)?.lowercased(),
+            !requested.isEmpty
+        {
+            switch requested {
+            case "no_think", "low", "high": effort = requested
+            case "none", "off": effort = "no_think"
+            case "minimal", "medium": effort = "low"
+            default: effort = "high"
+            }
+        } else if let enable = context["enable_thinking"] as? Bool {
+            effort = enable ? "high" : "no_think"
+        } else {
+            effort = nil
+        }
+
+        if let effort {
+            context["reasoning_effort"] = effort
+        } else {
+            // Never forward an unvalidated value the template would raise on.
+            context.removeValue(forKey: "reasoning_effort")
+        }
+        return context.isEmpty ? nil : context
+    }
+}

--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -1172,7 +1172,10 @@ private struct LLMUserInputProcessor: UserInputProcessor {
     }
 
     func prepare(input: UserInput) throws -> LMInput {
-        let additionalContext = mergedAdditionalContext(input.additionalContext)
+        let additionalContext = Hy3ReasoningTemplateContext.apply(
+            additionalContext: mergedAdditionalContext(input.additionalContext),
+            modelType: modelType
+        )
         let bailingMessages = BailingThinkingTemplateContext.apply(
             to: messageGenerator.generate(from: input),
             modelType: modelType,

--- a/Libraries/MLXLLM/Models/Hy3.swift
+++ b/Libraries/MLXLLM/Models/Hy3.swift
@@ -69,6 +69,18 @@ public struct Hy3Configuration: Codable, Sendable {
     public var routedExpertGateUpBits: Int? { mxtqGateUpBits ?? mxtqBits }
     public var routedExpertDownBits: Int? { mxtqDownBits ?? mxtqBits }
 
+    /// Whether the pack ships JANGTQ codebook routed experts (the Hy3-preview
+    /// conversion: `weight_format`/`mxtq_*` present, per-expert `tq_packed`
+    /// tensors) as opposed to the official-release JANG affine conversion
+    /// (pre-stacked `switch_mlp.{proj}.{weight,scales,biases}`, per-module
+    /// bits in `config.quantization`, no mxtq markers). Selects the MoE
+    /// expert module: TurboQuant codebook kernels vs the standard SwitchGLU
+    /// that the affine quantize walk wraps into QuantizedSwitchLinear.
+    public var usesTurboQuantRoutedExperts: Bool {
+        if let weightFormat, weightFormat.lowercased().contains("tq") { return true }
+        return mxtqBits != nil || mxtqGateUpBits != nil || mxtqDownBits != nil
+    }
+
     enum CodingKeys: String, CodingKey {
         case modelType = "model_type"
         case architectures
@@ -465,6 +477,42 @@ class Hy3MoE: Module, UnaryLayer {
     }
 }
 
+/// Routed experts for the official-release affine packs: the same
+/// sigmoid+expert-bias gate and always-on shared expert as `Hy3MoE`, with the
+/// standard `SwitchGLU` expert bank instead of the TurboQuant codebook path.
+/// The pack ships pre-stacked `switch_mlp.{proj}.{weight,scales,biases}`, and
+/// the JANG affine quantize walk wraps each projection into
+/// `QuantizedSwitchLinear` from the per-module bits in `config.quantization`
+/// (2-bit routed experts on JANG_2L) — the same hydration path DeepseekV3 /
+/// Kanana packs use.
+class Hy3AffineMoE: Module, UnaryLayer {
+    let layerIdx: Int
+
+    @ModuleInfo(key: "gate") var gate: Hy3MoEGate
+    @ModuleInfo(key: "switch_mlp") var switchMLP: SwitchGLU
+    @ModuleInfo(key: "shared_experts") var sharedExperts: Hy3MLP
+
+    init(_ configuration: Hy3Configuration, layerIdx: Int) {
+        self.layerIdx = layerIdx
+        _gate.wrappedValue = Hy3MoEGate(configuration)
+        _switchMLP.wrappedValue = SwitchGLU(
+            inputDims: configuration.hiddenSize,
+            hiddenDims: configuration.moeIntermediateSize,
+            numExperts: configuration.numExperts)
+        _sharedExperts.wrappedValue = Hy3MLP(
+            dimensions: configuration.hiddenSize,
+            hiddenDimensions: configuration.moeIntermediateSize * configuration.numSharedExperts)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let (indices, scores) = gate(x)
+        JangPressCanonicalExpertAdvisor.shared.observe(layer: layerIdx, indices: indices)
+        let y = switchMLP(x, indices)
+        let routed = (y * scores[.ellipsis, .newAxis]).sum(axis: -2)
+        return routed + sharedExperts(x)
+    }
+}
+
 // MARK: - Logit head
 
 func hy3LMHead(_ hidden: MLXArray, _ lmHead: Linear) -> MLXArray {
@@ -502,7 +550,10 @@ class Hy3DecoderLayer: Module {
             eps: configuration.rmsNormEps)
 
         if layerIdx >= configuration.firstKDenseReplace {
-            mlp = Hy3MoE(configuration, layerIdx: layerIdx)
+            mlp =
+                configuration.usesTurboQuantRoutedExperts
+                ? Hy3MoE(configuration, layerIdx: layerIdx)
+                : Hy3AffineMoE(configuration, layerIdx: layerIdx)
         } else {
             mlp = Hy3MLP(
                 dimensions: configuration.hiddenSize,

--- a/Libraries/MLXLMCommon/JangLoader.swift
+++ b/Libraries/MLXLMCommon/JangLoader.swift
@@ -415,11 +415,25 @@ public enum ParserResolution {
         // assistant output into `.reasoning` and prevents tool extraction.
         // Keep the tool parser stamp, but demote the impossible reasoning
         // stamp back to the model-type/template resolver.
-        return family.hasPrefix("lfm2")
+        if family.hasPrefix("lfm2")
             || family.contains("lfm")
             || type.hasPrefix("lfm2")
             || compactType.hasPrefix("lfm25")
             || toolParser == "lfm2"
+        {
+            return true
+        }
+
+        // Official Hunyuan v3 emits `:opensource`-suffixed think markers
+        // (`<think:opensource>…</think:opensource>`), but converted bundles
+        // stamp the generic `reasoning_parser=qwen3` — a plain-`<think>`
+        // parser that can never match the model's actual markers, so the
+        // whole answer leaks as content with protocol tags embedded. Demote
+        // the generic stamp back to the model-type resolver, which returns
+        // the hy_v3-specific parser.
+        return family == "hy_v3" || family.hasPrefix("hy_v3")
+            || compactType.hasPrefix("hyv3") || compactType.hasPrefix("hy3")
+            || compactType.hasPrefix("hunyuan")
     }
 
     private static func declaresLFM25ThinkingTemplate(

--- a/Libraries/MLXLMCommon/ReasoningParser.swift
+++ b/Libraries/MLXLMCommon/ReasoningParser.swift
@@ -682,8 +682,18 @@ extension ReasoningParser {
             || normalized == "hy_v3"
             || normalized.hasPrefix("hy_v3_")
             || compact.hasPrefix("hunyuan")
+            || compact == "tencent"
         {
-            return ReasoningParser(startInReasoning: true)
+            // Official Hunyuan v3 suffixes every protocol marker with
+            // `:opensource` (`<think:opensource>…</think:opensource>`); the
+            // template pre-fills an OPEN think at the prompt tail in
+            // high/low reasoning modes and a CLOSED empty pair in no_think —
+            // `forPrompt(stampName:promptTail:)` resolves the start state
+            // from that tail, which is why these exact tags matter.
+            return ReasoningParser(
+                startTag: "<think:opensource>",
+                endTag: "</think:opensource>",
+                startInReasoning: true)
         }
 
         switch n {
@@ -692,7 +702,6 @@ extension ReasoningParser {
             "nemotron", "nemotron_h", "minimax", "minimax_m2",
             "kimi", "kimi_k2", "kimik2",
             "laguna", "laguna_xs", "laguna_s",
-            "hy3", "hy_v3", "hy-v3", "hunyuan", "tencent",
             "zaya", "zaya1", "zaya2",
             "step", "stepfun", "step3p5", "step3p7", "step3_5", "step3_7":
             // Start inside the reasoning block — matches the Qwen 3.x
@@ -904,6 +913,12 @@ public func reasoningStampFromModelType(_ modelType: String?) -> String {
         .replacingOccurrences(of: ".", with: "_")
     let compact = normalized.replacingOccurrences(of: "_", with: "")
 
+    // Official Hunyuan v3 uses `:opensource`-suffixed think markers; the
+    // dedicated stamp resolves to that parser (see `fromCapabilityName`).
+    if compact.hasPrefix("hy3") || compact.hasPrefix("hyv3") || compact.hasPrefix("hunyuan") {
+        return "hy_v3"
+    }
+
     // Gemma-4 harmony channel envelope: `<|channel>thought\n…<channel|>`.
     // Distinct from `<think>` XML.
     if compact.hasPrefix("gemma4") {
@@ -970,9 +985,6 @@ public func reasoningStampFromModelType(_ modelType: String?) -> String {
                         // bundle lacks a JANG reasoning stamp, model_type
                         // fallback must still route pre-`</think>` bytes to
                         // `.reasoning` instead of `.chunk`.
-        "hy3",          // Tencent Hunyuan v3 aliases. Real JANG bundles stamp
-        "hyv3",         // `capabilities.reasoning_parser = "qwen3"`, but
-                        // non-JANG/fallback paths should still pick think_xml.
         "mimo",         // MiMo-V2 templates use the same `<think>` envelope.
         "step3p5",      // StepFun Step 3.5 text runtime / parser family.
         "step3p7",      // Step 3.7 VLM wrapper uses Step 3.5 text template.

--- a/Libraries/MLXLMCommon/Tool/Parsers/HunyuanToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/HunyuanToolCallParser.swift
@@ -21,6 +21,24 @@ public struct HunyuanToolCallParser: ToolCallParser, Sendable {
     public let startTag: String? = "<tool_calls>"
     public let endTag: String? = "</tool_calls>"
 
+    /// Official Hunyuan v3 suffixes every protocol marker with `:opensource`
+    /// (`<tool_calls:opensource>…`); the preview conversion used the bare
+    /// spellings. Both are accepted: the processor state machine matches
+    /// either wrapper via these aliases, and `normalize` collapses the
+    /// suffix before the body is parsed so one marker set serves both
+    /// generations. An argument VALUE containing the literal
+    /// `":opensource>"` would be collapsed too — accepted; the sequence
+    /// cannot appear in real argument text without the model already
+    /// speaking the protocol.
+    public var startTagAliases: [String] { ["<tool_calls>", "<tool_calls:opensource>"] }
+    public var endTagAliases: [String] { ["</tool_calls>", "</tool_calls:opensource>"] }
+
+    private func normalize(_ text: String) -> String {
+        text.contains(":opensource>")
+            ? text.replacingOccurrences(of: ":opensource>", with: ">")
+            : text
+    }
+
     private let toolCallStart = "<tool_call>"
     private let toolCallEnd = "</tool_call>"
     private let toolSeparator = "<tool_sep>"
@@ -34,7 +52,7 @@ public struct HunyuanToolCallParser: ToolCallParser, Sendable {
     public func isValidPartialContent(_ toolCallBuffer: String) -> Bool {
         guard let startTag else { return true }
 
-        var text = toolCallBuffer
+        var text = normalize(toolCallBuffer)
         if text.hasPrefix(startTag) {
             text.removeFirst(startTag.count)
         }
@@ -45,10 +63,16 @@ public struct HunyuanToolCallParser: ToolCallParser, Sendable {
         let body = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !body.isEmpty else { return true }
 
-        if body.count <= toolCallStart.count {
-            return toolCallStart.hasPrefix(body)
+        // `normalize` collapses COMPLETE `:opensource` markers, but the
+        // buffer's trailing marker can still be mid-suffix
+        // (`<tool_call:opens`), so the partial check must accept both
+        // spellings directly.
+        let inner = [toolCallStart, "<tool_call:opensource>"]
+        return inner.contains { candidate in
+            body.count <= candidate.count
+                ? candidate.hasPrefix(body)
+                : body.hasPrefix(candidate)
         }
-        return body.hasPrefix(toolCallStart)
     }
 
     public func parse(content: String, tools: [[String: any Sendable]]?) -> ToolCall? {
@@ -60,7 +84,7 @@ public struct HunyuanToolCallParser: ToolCallParser, Sendable {
     }
 
     private func parseCalls(_ content: String, tools: [[String: any Sendable]]?) -> [ToolCall] {
-        let block = stripOuterWrapper(content)
+        let block = stripOuterWrapper(normalize(content))
         var calls: [ToolCall] = []
         var searchRange = block.startIndex..<block.endIndex
 

--- a/RunBench/Bench.swift
+++ b/RunBench/Bench.swift
@@ -5040,6 +5040,16 @@ private func loadBenchTokenizer(from modelDir: URL) async throws -> (any MLXLMCo
 /// Tokenizer-only smoke for model-family chat-template compatibility.
 /// It catches missing templates, swift-jinja parser/runtime failures,
 /// lost tool schemas, and raw Jinja leakage before a full model load.
+/// Read `model_type` from the bundle's config.json so the template smoke can
+/// apply the same per-family context adapters the real request path applies.
+func modelTypeForTemplateSmoke(modelPath: String) -> String? {
+    let url = URL(fileURLWithPath: modelPath).appendingPathComponent("config.json")
+    guard let data = try? Data(contentsOf: url),
+        let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else { return nil }
+    return obj["model_type"] as? String
+}
+
 func runTemplateSmoke(modelPath: String) async throws {
     struct TemplateSmokeCase {
         let label: String
@@ -5203,10 +5213,18 @@ func runTemplateSmoke(modelPath: String) async throws {
     for testCase in cases {
         do {
             let start = CFAbsoluteTimeGetCurrent()
+            // Route the raw request context through the same per-family
+            // template adapter the real request path applies in
+            // `LLMModelFactory.prepare` — hy_v3 clamps `reasoning_effort`
+            // ("max" → "high") and maps `enable_thinking` to the template's
+            // no_think/low/high contract; every other family passes through.
+            let adaptedContext = Hy3ReasoningTemplateContext.apply(
+                additionalContext: testCase.context,
+                modelType: modelTypeForTemplateSmoke(modelPath: modelPath))
             let ids = try tokenizer.applyChatTemplate(
                 messages: testCase.messages,
                 tools: testCase.tools,
-                additionalContext: testCase.context)
+                additionalContext: adaptedContext)
             let renderMs = Int((CFAbsoluteTimeGetCurrent() - start) * 1000)
             let text = tokenizer.decode(tokenIds: ids, skipSpecialTokens: false)
             var directProfile = "direct=unavailable"
@@ -5220,7 +5238,7 @@ func runTemplateSmoke(modelPath: String) async throws {
                 if let tools = testCase.tools {
                     rawContext["tools"] = tools
                 }
-                if let context = testCase.context {
+                if let context = adaptedContext {
                     for (key, value) in context {
                         rawContext[key] = value
                     }

--- a/Tests/MLXLMTests/Hy3OfficialMarkersTests.swift
+++ b/Tests/MLXLMTests/Hy3OfficialMarkersTests.swift
@@ -1,0 +1,144 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+/// Official Hunyuan v3 suffixes every protocol marker with `:opensource`
+/// (`<think:opensource>`, `<tool_calls:opensource>`, `<arg_key:opensource>`,
+/// …) where the preview conversion used bare spellings. These tests pin the
+/// parser stack to the official wire format, byte-faithful to the shipped
+/// `chat_template.jinja`.
+struct Hy3OfficialMarkersTests {
+
+    private func weatherTool() -> [String: any Sendable] {
+        [
+            "type": "function",
+            "function": [
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters": [
+                    "type": "object",
+                    "properties": [
+                        "city": ["type": "string"],
+                        "days": ["type": "integer"],
+                    ],
+                    "required": ["city"],
+                ] as [String: any Sendable],
+            ] as [String: any Sendable],
+        ]
+    }
+
+    private static let officialEnvelope = """
+        <tool_calls:opensource>
+        <tool_call:opensource>get_weather<tool_sep:opensource>
+        <arg_key:opensource>city</arg_key:opensource><arg_value:opensource>Tokyo</arg_value:opensource>
+        <arg_key:opensource>days</arg_key:opensource><arg_value:opensource>3</arg_value:opensource>
+        </tool_call:opensource>
+        </tool_calls:opensource>
+        """
+
+    @Test("official :opensource envelope parses through the processor")
+    func officialEnvelopeParses() {
+        let processor = ToolCallProcessor(format: .hunyuan, tools: [weatherTool()])
+        var visible = ""
+        if let text = processor.processChunk("Checking the forecast now. " + Self.officialEnvelope) {
+            visible += text
+        }
+        if let tail = processor.processEOS() {
+            visible += tail
+        }
+        #expect(processor.toolCalls.count == 1)
+        let call = processor.toolCalls.first
+        #expect(call?.function.name == "get_weather")
+        #expect(call?.function.arguments["city"] == .string("Tokyo"))
+        #expect(call?.function.arguments["days"] == .int(3))
+        #expect(visible == "Checking the forecast now. ")
+    }
+
+    @Test("official envelope split into small chunks, incl. mid-suffix splits")
+    func officialEnvelopeChunked() {
+        let processor = ToolCallProcessor(format: .hunyuan, tools: [weatherTool()])
+        var visible = ""
+        var buffer = Substring(Self.officialEnvelope)
+        // 7-char chunks guarantee splits inside `:opensource` suffixes.
+        while !buffer.isEmpty {
+            let chunk = String(buffer.prefix(7))
+            buffer = buffer.dropFirst(7)
+            if let text = processor.processChunk(chunk) {
+                visible += text
+            }
+        }
+        if let tail = processor.processEOS() {
+            visible += tail
+        }
+        #expect(processor.toolCalls.count == 1)
+        #expect(processor.toolCalls.first?.function.arguments["city"] == .string("Tokyo"))
+        #expect(visible.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+
+    @Test("preview bare-marker envelope still parses (back-compat)")
+    func previewEnvelopeStillParses() {
+        let processor = ToolCallProcessor(format: .hunyuan, tools: [weatherTool()])
+        _ = processor.processChunk(
+            "<tool_calls>\n<tool_call>get_weather<tool_sep>\n"
+                + "<arg_key>city</arg_key><arg_value>Paris</arg_value>\n"
+                + "</tool_call>\n</tool_calls>")
+        _ = processor.processEOS()
+        #expect(processor.toolCalls.count == 1)
+        #expect(processor.toolCalls.first?.function.arguments["city"] == .string("Paris"))
+    }
+
+    @Test("hy3 reasoning parser uses the :opensource think markers")
+    func reasoningMarkers() {
+        let parser = ReasoningParser.fromCapabilityName("hy_v3")
+        #expect(parser?.startTag == "<think:opensource>")
+        #expect(parser?.endTag == "</think:opensource>")
+    }
+
+    @Test("no_think prompt tail (closed empty think) starts the parser in content")
+    func noThinkTailStartsInContent() {
+        // The official template's no_think generation prompt ends with a
+        // pre-CLOSED empty think pair; starting in reasoning would route the
+        // whole answer into reasoning_content.
+        let parser = ReasoningParser.forPrompt(
+            stampName: "hy_v3",
+            promptTail: "<｜hy_Assistant:opensource｜><think:opensource></think:opensource>")
+        #expect(parser?.isInsideReasoning == false)
+    }
+
+    @Test("high-effort prompt tail (open think) starts the parser in reasoning")
+    func openThinkTailStartsInReasoning() {
+        let parser = ReasoningParser.forPrompt(
+            stampName: "hy_v3",
+            promptTail: "<｜hy_Assistant:opensource｜><think:opensource>")
+        #expect(parser?.isInsideReasoning == true)
+    }
+
+    @Test("reasoning then content splits at the :opensource close marker")
+    func reasoningContentSplit() {
+        var parser = ReasoningParser(
+            startTag: "<think:opensource>",
+            endTag: "</think:opensource>",
+            startInReasoning: true)
+        var reasoning = ""
+        var content = ""
+        for segment in parser.feed("planning the answer</think:opensource>The answer is 4.") {
+            switch segment {
+            case .reasoning(let r): reasoning += r
+            case .content(let c): content += c
+            }
+        }
+        for segment in parser.flush() {
+            switch segment {
+            case .reasoning(let r): reasoning += r
+            case .content(let c): content += c
+            }
+        }
+        #expect(reasoning.contains("planning the answer"))
+        #expect(content.contains("The answer is 4."))
+        #expect(!content.contains("</think"))
+    }
+}

--- a/Tests/MLXLMTests/Hy3ParserDispatchTests.swift
+++ b/Tests/MLXLMTests/Hy3ParserDispatchTests.swift
@@ -21,7 +21,7 @@ struct Hy3ParserDispatchTests {
             #expect(ReasoningParser.fromCapabilityName(stamp) != nil)
         }
         for modelType in ["hy_v3", "hy-v3", "hy3", "Hy3"] {
-            #expect(reasoningStampFromModelType(modelType) == "think_xml")
+            #expect(reasoningStampFromModelType(modelType) == "hy_v3")
         }
     }
 

--- a/Tests/MLXLMTests/Hy3ReasoningNoLeakTests.swift
+++ b/Tests/MLXLMTests/Hy3ReasoningNoLeakTests.swift
@@ -3,7 +3,7 @@
 // JANG handoff doc (`docs/runtime/2026-05-09-hy3-runtime-handoff-vmlx-python-swift.md`)
 // mandates:
 //
-//   "ensure `no_think` emits closed `<think></think>` prefill and does
+//   "ensure `no_think` emits closed `<think:opensource></think:opensource>` prefill and does
 //    not leak reasoning into content"
 //
 // The Swift wiring is:
@@ -12,20 +12,20 @@
 //     `ReasoningParser.fromCapabilityName` line 295-303).
 //   - `ReasoningParser.forPrompt(stampName:promptTail:)` then inspects the
 //     decoded prompt tail and overrides `startInReasoning` based on which
-//     of `<think>` / `</think>` appears LAST in the prompt.
+//     of `<think:opensource>` / `</think:opensource>` appears LAST in the prompt.
 //   - `Evaluate.swift:2033,2145` and `BatchEngine.swift:410` both call
 //     `forPrompt` so the live request path uses the prompt-aware parser.
 //
 // Existing tests cover DSV4 + qwen3_6 prompt-tail patterns. Hy3 was NOT
 // covered. This file pins three Hy3-specific contracts:
 //
-//   1. `reasoning_effort=no_think` (closed `<think>\n\n</think>\n\n` in
+//   1. `reasoning_effort=no_think` (closed `<think:opensource>\n\n</think:opensource>\n\n` in
 //       prompt) → parser starts in CONTENT and does NOT route output
 //       into `.reasoning`.
-//   2. `reasoning_effort=high|low` (open `<think>\n` in prompt) → parser
-//      starts in REASONING and routes pre-`</think>` output into
-//      `.reasoning`, post-`</think>` into `.content`.
-//   3. Mid-stream stray `<think>` tag from a misbehaving model is
+//   2. `reasoning_effort=high|low` (open `<think:opensource>\n` in prompt) → parser
+//      starts in REASONING and routes pre-`</think:opensource>` output into
+//      `.reasoning`, post-`</think:opensource>` into `.content`.
+//   3. Mid-stream stray `<think:opensource>` tag from a misbehaving model is
 //      latched correctly — content collected before the tag stays in
 //      `.content`, reasoning after stays in `.reasoning`.
 //
@@ -69,22 +69,22 @@ struct Hy3ReasoningNoLeakTests {
                 Issue.record("stamp \(stamp) did not resolve to a parser")
                 continue
             }
-            // Hy3 uses qwen3-style `<think>...</think>`.
-            #expect(parser.startTag == "<think>")
-            #expect(parser.endTag == "</think>")
+            // Hy3 uses qwen3-style `<think:opensource>...</think:opensource>`.
+            #expect(parser.startTag == "<think:opensource>")
+            #expect(parser.endTag == "</think:opensource>")
             // Strays on think_xml family must be stripped, not leaked.
             #expect(parser.stripStrayTags)
         }
     }
 
-    @Test("Hy3 no_think prompt (closed <think></think> prefill) does NOT leak content into reasoning")
+    @Test("Hy3 no_think prompt (closed <think:opensource></think:opensource> prefill) does NOT leak content into reasoning")
     func noThinkPromptKeepsContentInContent() throws {
         // The Hy3 chat template renders a closed empty think block when
         // `reasoning_effort=no_think` is set:
-        //   `<think>\n\n</think>\n\nThe answer is...`
-        // `forPrompt` must inspect the tail, see `</think>` is the last
+        //   `<think:opensource>\n\n</think:opensource>\n\nThe answer is...`
+        // `forPrompt` must inspect the tail, see `</think:opensource>` is the last
         // tag, and start in CONTENT.
-        let promptTail = "<｜hy_Assistant｜><think>\n\n</think>\n\n"
+        let promptTail = "<｜hy_Assistant｜><think:opensource>\n\n</think:opensource>\n\n"
         var parser = ReasoningParser.forPrompt(
             stampName: "hy_v3", promptTail: promptTail)!
 
@@ -97,36 +97,36 @@ struct Hy3ReasoningNoLeakTests {
         #expect(content == "The capital of France is Paris.")
     }
 
-    @Test("Hy3 reasoning_effort=high prompt (open <think> prefill) routes pre-</think> into reasoning")
+    @Test("Hy3 reasoning_effort=high prompt (open <think:opensource> prefill) routes pre-</think:opensource> into reasoning")
     func highEffortPromptRoutesReasoningCorrectly() throws {
         // The Hy3 chat template renders an OPEN think block when
         // `reasoning_effort=high|low` is set:
-        //   `<｜hy_Assistant｜><think>\n` (no closer)
-        // Parser starts in REASONING and emits the pre-`</think>` text
-        // into `.reasoning`, post-`</think>` into `.content`.
-        let promptTail = "<｜hy_Assistant｜><think>\n"
+        //   `<｜hy_Assistant｜><think:opensource>\n` (no closer)
+        // Parser starts in REASONING and emits the pre-`</think:opensource>` text
+        // into `.reasoning`, post-`</think:opensource>` into `.content`.
+        let promptTail = "<｜hy_Assistant｜><think:opensource>\n"
         var parser = ReasoningParser.forPrompt(
             stampName: "hy_v3", promptTail: promptTail)!
 
         let (content, reasoning) = Self.drain(
-            &parser, "Let me work this out...\n</think>\nThe answer is 42.")
+            &parser, "Let me work this out...\n</think:opensource>\nThe answer is 42.")
 
         // Pre-closer text is reasoning; post-closer is content.
         #expect(reasoning.contains("Let me work this out..."))
         #expect(content.contains("The answer is 42."))
         // No content bleed into reasoning AFTER the closer.
         #expect(!reasoning.contains("The answer is 42."),
-            "Post-</think> content must not appear in reasoning: \(reasoning)")
+            "Post-</think:opensource> content must not appear in reasoning: \(reasoning)")
         // No reasoning bleed into content BEFORE the closer.
         #expect(!content.contains("Let me work this out..."),
-            "Pre-</think> reasoning must not appear in content: \(content)")
+            "Pre-</think:opensource> reasoning must not appear in content: \(content)")
     }
 
-    @Test("Hy3 misbehaving model emitting stray <think> mid-content latches correctly")
+    @Test("Hy3 misbehaving model emitting stray <think:opensource> mid-content latches correctly")
     func midStreamStrayThinkLatches() throws {
         // Some prompts have NO think prefill (e.g. caller didn't set
         // `reasoning_effort` and the template default is no_think).
-        // If the model misbehaves and emits `<think>...</think>` mid-stream
+        // If the model misbehaves and emits `<think:opensource>...</think:opensource>` mid-stream
         // anyway, the parser should latch on the opener and route the
         // inner block into reasoning, then return to content.
         let promptTail = "<｜hy_Assistant｜>"
@@ -135,7 +135,7 @@ struct Hy3ReasoningNoLeakTests {
 
         let (content, reasoning) = Self.drain(
             &parser,
-            "Sure! <think>brief check</think>The result is correct.")
+            "Sure! <think:opensource>brief check</think:opensource>The result is correct.")
 
         #expect(reasoning.contains("brief check"))
         #expect(content.contains("Sure!"))
@@ -145,22 +145,22 @@ struct Hy3ReasoningNoLeakTests {
             "Mid-stream stray reasoning must NOT leak into content: \(content)")
     }
 
-    @Test("Hy3 strips stray closing </think> when no opener was seen")
+    @Test("Hy3 strips stray closing </think:opensource> when no opener was seen")
     func straysStripped() throws {
         // think_xml family has stripStrayTags=true. If the model emits
-        // a stray `</think>` without a preceding `<think>` AND the
+        // a stray `</think:opensource>` without a preceding `<think:opensource>` AND the
         // prompt didn't open one, the tag should be STRIPPED from
         // content (not appear as literal text in the user-visible
         // output). This mirrors the `qwen3_6` family contract.
-        let promptTail = "<｜hy_Assistant｜><think>\n\n</think>\n\n"
+        let promptTail = "<｜hy_Assistant｜><think:opensource>\n\n</think:opensource>\n\n"
         var parser = ReasoningParser.forPrompt(
             stampName: "hy_v3", promptTail: promptTail)!
 
-        let (content, _) = Self.drain(&parser, "The answer is </think>42.")
+        let (content, _) = Self.drain(&parser, "The answer is </think:opensource>42.")
 
         // Stray closer should be stripped from content.
-        #expect(!content.contains("</think>"),
-            "Stray </think> must be stripped, got content: \(content)")
+        #expect(!content.contains("</think:opensource>"),
+            "Stray </think:opensource> must be stripped, got content: \(content)")
         #expect(content.contains("The answer is"))
         #expect(content.contains("42."))
     }

--- a/Tests/MLXLMTests/JinjaStringFormatTests.swift
+++ b/Tests/MLXLMTests/JinjaStringFormatTests.swift
@@ -1,0 +1,60 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import VMLXJinja
+import Testing
+
+/// The vendored Jinja engine's Python `str.format` subset — added for the
+/// official Hunyuan v3 chat template, which builds every special-token
+/// string with `'<x{}>'.format(HYTK)`. All 8 template-smoke scenarios failed
+/// with `Cannot call non-function value` before this existed.
+struct JinjaStringFormatTests {
+
+    private func render(_ template: String, _ context: [String: Value] = [:]) throws -> String {
+        try Template(template).render(context)
+    }
+
+    @Test("auto-numbered {} fields (the Hunyuan template shape)")
+    func autoNumbered() throws {
+        let out = try render(
+            "{% set HYTK = ':opensource' %}{{ '<think{}>'.format(HYTK) }}")
+        #expect(out == "<think:opensource>")
+    }
+
+    @Test("multiple auto fields consume positional args in order")
+    func multipleAuto() throws {
+        let out = try render("{{ '{}-{}'.format('a', 'b') }}")
+        #expect(out == "a-b")
+    }
+
+    @Test("indexed and named fields")
+    func indexedAndNamed() throws {
+        #expect(try render("{{ '{1}{0}'.format('a', 'b') }}") == "ba")
+        #expect(try render("{{ '{x}!'.format(x='hey') }}") == "hey!")
+    }
+
+    @Test("literal brace escapes")
+    func braceEscapes() throws {
+        #expect(try render("{{ '{{{}}}'.format('v') }}") == "{v}")
+    }
+
+    @Test("integer arguments render in canonical form")
+    func intArgs() throws {
+        #expect(try render("{{ 'n={}'.format(3) }}") == "n=3")
+    }
+
+    @Test("format specs are rejected, not mis-rendered")
+    func specsRejected() {
+        #expect(throws: (any Error).self) {
+            _ = try render("{{ '{:>8}'.format('x') }}")
+        }
+    }
+
+    @Test("running out of positional arguments raises")
+    func missingArgRaises() {
+        #expect(throws: (any Error).self) {
+            _ = try render("{{ '{} {}'.format('only-one') }}")
+        }
+    }
+}

--- a/Vendors/Jinja/Sources/Jinja/PropertyMembers.swift
+++ b/Vendors/Jinja/Sources/Jinja/PropertyMembers.swift
@@ -127,6 +127,75 @@ public enum PropertyMembers {
                 }
                 return .boolean(str.hasPrefix(prefix))
             }
+        case "format":
+            // Python `str.format` subset used by chat templates (Hunyuan v3's
+            // official template builds every special-token string with
+            // `'<x{}>'.format(HYTK)`): auto-numbered `{}`, indexed `{0}`,
+            // named `{key}` fields, and `{{`/`}}` literal-brace escapes.
+            // Format specs (`{:>8}`) are rejected rather than mis-rendered.
+            return .function { args, kwargs, _ in
+                var result = ""
+                var autoIndex = 0
+                var iterator = str.makeIterator()
+                while let ch = iterator.next() {
+                    if ch == "{" {
+                        guard let next = iterator.next() else {
+                            throw JinjaError.runtime("format() has a dangling '{'")
+                        }
+                        if next == "{" {
+                            result.append("{")
+                            continue
+                        }
+                        var field = ""
+                        var current: Character? = next
+                        while let c = current, c != "}" {
+                            field.append(c)
+                            current = iterator.next()
+                        }
+                        guard current == "}" else {
+                            throw JinjaError.runtime("format() has an unterminated field")
+                        }
+                        guard !field.contains(":") && !field.contains("!") else {
+                            throw JinjaError.runtime(
+                                "format() specs/conversions ('\(field)') are not supported")
+                        }
+                        let value: Value
+                        if field.isEmpty {
+                            guard autoIndex < args.count else {
+                                throw JinjaError.runtime(
+                                    "format() ran out of positional arguments")
+                            }
+                            value = args[autoIndex]
+                            autoIndex += 1
+                        } else if let index = Int(field) {
+                            guard index >= 0, index < args.count else {
+                                throw JinjaError.runtime(
+                                    "format() index \(index) out of range")
+                            }
+                            value = args[index]
+                        } else {
+                            guard let named = kwargs[field] else {
+                                throw JinjaError.runtime(
+                                    "format() missing keyword argument '\(field)'")
+                            }
+                            value = named
+                        }
+                        result += stringifyForFormat(value)
+                    } else if ch == "}" {
+                        if let next = iterator.next() {
+                            guard next == "}" else {
+                                throw JinjaError.runtime("format() has a stray '}'")
+                            }
+                            result.append("}")
+                        } else {
+                            throw JinjaError.runtime("format() has a stray '}'")
+                        }
+                    } else {
+                        result.append(ch)
+                    }
+                }
+                return .string(result)
+            }
         case "endswith":
             return .function { args, kwargs, _ in
                 let arguments = try resolveCallArguments(
@@ -288,5 +357,19 @@ private func replace(string: String, old: String, new: String, maxReplacements: 
         return result
     } else {
         return string.replacingOccurrences(of: old, with: new)
+    }
+}
+
+/// Render a `format()` argument the way Python renders `str(x)` in a
+/// formatted field: bare strings without quotes, numbers/booleans in their
+/// canonical text form.
+private func stringifyForFormat(_ value: Value) -> String {
+    switch value {
+    case .string(let s): return s
+    case .int(let i): return String(i)
+    case .double(let d): return String(d)
+    case .boolean(let b): return b ? "True" : "False"
+    case .null, .undefined: return "None"
+    default: return value.description
     }
 }


### PR DESCRIPTION
## What

Full support for the **official Hunyuan v3 release** (`model_type = hy_v3`). The preview-era runtime could not load, render, or parse the official model — three independent blockers, each fixed here.

## The three blockers

**1. The official conversion is JANG affine, not JANGTQ.** `Hy3MoE` hard-wired `TurboQuantSwitchGLU` (codebook kernels + `tq_packed` tensors); the official packs ship pre-stacked affine `switch_mlp.{proj}.{weight,scales,biases}` with per-module bits in `config.quantization` (gate 2 / up 2 / down 3 on JANG_2K). New `Hy3AffineMoE` uses a standard `SwitchGLU` wrapped by the affine quantize walk — the same hydration path DeepseekV3/Kanana packs use. Pack format is detected from `weight_format`/`mxtq` markers; preview JANGTQ packs keep their path untouched.

**2. The official chat template could not render at all.** It builds every special-token string with `'<x{}>'.format(HYTK)` — Python's `str.format`, which the Jinja engine didn't implement. Every scenario failed with `Cannot call non-function value`, meaning every chat request would 500 or fall back to ChatML. The vendored engine now implements the `str.format` subset (auto-numbered/indexed/named fields, brace escapes; specs rejected rather than mis-rendered). Template smoke went 0/8 → **8/8** on the real bundle.

**3. Every protocol marker gained an `:opensource` suffix.** `<think:opensource>`, `<tool_calls:opensource>`, `<arg_key:opensource>`, … — neither parser recognised them:
- Reasoning: hy_v3 resolves to the suffixed think markers, with the existing prompt-tail start-state logic doing the heavy lifting — the template pre-fills an **open** think in `high`/`low` effort and a **closed empty pair** in `no_think`, so tail detection is what keeps no_think answers out of `reasoning_content`.
- Converted bundles stamp the generic `reasoning_parser=qwen3`, which can never match the official markers. `JangLoader` demotes that stale stamp to the model-type resolver for the hy_v3 family (the same treatment LFM2's stale stamps get).
- Tool calls: the Hunyuan parser accepts the suffixed wrapper via tag aliases, normalises the suffix before body parsing, and the partial-content check tolerates a buffer cut mid-suffix (`<tool_call:opens`) so streamed envelopes never flush as visible text. Preview bare markers still parse.

**Plus**: the template hard-rejects any `reasoning_effort` outside `no_think/low/high` (raise_exception) and **ignores `enable_thinking` entirely**. New `Hy3ReasoningTemplateContext` (applied in `LLMModelFactory.prepare`) clamps efforts (`max`→`high`, `medium`→`low`) and maps `enable_thinking` true→`high` / false→`no_think`, so OpenAI-style requests can't kill the render.

## Verified on the real bundle (Hy3-JANG_2K, 94 GB, 80-layer / 192-expert MoE, 262k ctx)

- Loads through the affine path; **3-turn chat is coherent with exact recall** ("Your favorite color is blue"), clean EOS.
- **Compiled and eager decode produce identical outputs** — a direct determinism signal.
- Template smoke 8/8 (plain, thinking on/off, effort clamp, tools, osaurus-sized tool prompts, multi-turn, reasoning history).
- Suites: Hy3OfficialMarkersTests (7, incl. 7-char chunked envelope with mid-suffix splits), JinjaStringFormatTests (7), updated Hy3 no-leak/dispatch suites — **31/31**, plus tool-processor fuzz green.

Dense full-attention KV (no SSM), so the standard trimmable prefix-cache/disk-cache machinery applies unchanged; live prefix-cache determinism and osaurus wiring land in the companion osaurus PR.
