### PR TITLE
Hy3: fp32 activations into the quantized lm_head (reference parity)

### DIFF
--- a/Libraries/MLXLLM/Models/Hy3.swift
+++ b/Libraries/MLXLLM/Models/Hy3.swift
@@ -517,7 +517,11 @@ class Hy3AffineMoE: Module, UnaryLayer {
 
 func hy3LMHead(_ hidden: MLXArray, _ lmHead: Linear) -> MLXArray {
     if lmHead is QuantizedLinear {
-        return lmHead(hidden)
+        // `enable_lm_head_fp32`: the reference runtime casts activations to
+        // fp32 before the quantized head matmul (jang_tools/hy3/model.py).
+        // One [1, V] matmul per step — negligible cost, meaningful logit
+        // parity for greedy near-ties.
+        return lmHead(hidden.asType(.float32))
     }
 
     let hiddenFP32 = hidden.asType(.float32)


### PR DESCRIPTION
Follow-up to #134, from the cross-runtime parity review: the Python reference casts activations to fp32 before the quantized lm_head matmul (`enable_lm_head_fp32`); the Swift path ran it at the incoming dtype. One `[1, V]` matmul per decode step — negligible cost, meaningful for greedy near-tie parity with the reference runtime.