### PR TITLE
Materialize near-RAM-scale packs instead of mmap so weights stay resident

### DIFF
--- a/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
+++ b/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
@@ -483,6 +483,7 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
             base: baseLoadConfiguration.jangPress,
             facts: bundleFacts)
 
+
         var resolvedConcurrency = concurrency
         resolvedConcurrency.maxConcurrentSequences =
             memorySafety.customMaxConcurrentSequences
@@ -510,6 +511,42 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
             ?? profile.defaultMaxKVSize
 
         var warnings = profile.warnings
+        // Near-RAM-scale packs must materialize, not mmap. File-backed
+        // weights are "reclaimable under pressure" — for a bundle whose
+        // weights approach physical memory (Hy3-JANG_2K: 94 GB on 128 GB),
+        // macOS cannot keep the full mapping hot next to KV, apps, and the
+        // file cache itself, so decode refaults experts from SSD on every
+        // step: the model answers a 10-token probe in ~a minute, times out
+        // on real turns, and never shows up in RAM — reported live as "it
+        // attempted to load and then nothing happened". Anonymous
+        // (materialized) pages are not reclaimed that way, and a pack this
+        // size fits the working set (87.6 GiB weights vs a ~96 GB budget).
+        // The load fraction is raised to cover the weights plus headroom;
+        // the load entry clamps it to the GPU working set, so an impossible
+        // limit cannot be constructed here.
+        if profile.allowsNearRAMScaleMaterialization,
+            memorySafety.customPhysicalMemoryFraction == nil,
+            let facts = bundleFacts,
+            facts.totalSafetensorsBytes > 0,
+            physicalMemory > 0,
+            Double(facts.totalSafetensorsBytes) > 0.55 * Double(physicalMemory),
+            // Only when the weights actually fit. A pack larger than ~86%
+            // of RAM (e.g. 30 GiB on a 24 GiB host) cannot be made resident
+            // at all — mmap streaming is its only viable mode, and
+            // materializing it would push the host into swap/jetsam.
+            Double(facts.totalSafetensorsBytes) <= 0.86 * Double(physicalMemory)
+        {
+            loadConfiguration.useMmapSafetensors = false
+            let needFraction = min(
+                0.92,
+                Double(facts.totalSafetensorsBytes) / Double(physicalMemory) + 0.06)
+            if needFraction > requestedFraction {
+                loadConfiguration.memoryLimit = .fraction(needFraction)
+            }
+            warnings.append(
+                "Weights (\(facts.totalSafetensorsBytes / 1_073_741_824) GiB) approach physical memory; loading materialized instead of mmap so pages stay resident."
+            )
+        }
         var blockingIssues: [VMLXServerSettingsIssue] = []
 
         if case .diagnosticDangerous = memorySafety.mode {
@@ -1276,6 +1313,7 @@ public struct VMLXMemorySafetySettings: Codable, Sendable, Equatable {
         case .performance:
             return .init(
                 loadFraction: customPhysicalMemoryFraction ?? 0.90,
+                allowsNearRAMScaleMaterialization: true,
                 allocatorCap: customAllocatorCacheBytes.map(ResidentCap.absolute) ?? .unlimited,
                 maxConcurrentSequences: customMaxConcurrentSequences ?? 2,
                 prefixMemoryLimitMB: nil,
@@ -1287,6 +1325,7 @@ public struct VMLXMemorySafetySettings: Codable, Sendable, Equatable {
         case .balanced:
             return .init(
                 loadFraction: customPhysicalMemoryFraction ?? 0.75,
+                allowsNearRAMScaleMaterialization: true,
                 allocatorCap: customAllocatorCacheBytes.map(ResidentCap.absolute) ?? .absolute(1 << 30),
                 maxConcurrentSequences: customMaxConcurrentSequences ?? 2,
                 prefixMemoryLimitMB: 512,
@@ -1298,6 +1337,7 @@ public struct VMLXMemorySafetySettings: Codable, Sendable, Equatable {
         case .safeAuto:
             return .init(
                 loadFraction: customPhysicalMemoryFraction ?? 0.70,
+                allowsNearRAMScaleMaterialization: true,
                 allocatorCap: customAllocatorCacheBytes.map(ResidentCap.absolute) ?? .absolute(128 << 20),
                 maxConcurrentSequences: customMaxConcurrentSequences ?? 1,
                 prefixMemoryLimitMB: 128,
@@ -1334,6 +1374,11 @@ public struct VMLXMemorySafetySettings: Codable, Sendable, Equatable {
 
 fileprivate struct VMLXMemorySafetyProfile: Sendable, Equatable {
     var loadFraction: Double
+    /// Whether this profile may switch a near-RAM-scale bundle from mmap to
+    /// a materialized load (and raise the load fraction to cover it). The
+    /// strict profile keeps its explicit budget authoritative, and the
+    /// diagnostic mode uses caller-supplied limits verbatim.
+    var allowsNearRAMScaleMaterialization: Bool = false
     var allocatorCap: ResidentCap
     var maxConcurrentSequences: Int
     var prefixMemoryLimitMB: Int?

--- a/Tests/MLXLMCommonFocusedTests/VMLXMemorySafetySettingsTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/VMLXMemorySafetySettingsTests.swift
@@ -183,6 +183,54 @@ struct VMLXMemorySafetySettingsTests {
         #expect(routedPlan.loadConfiguration.jangPress == .auto(envFallback: true))
     }
 
+    @Test("near-RAM-scale packs materialize instead of mmap when they fit")
+    func nearRAMScalePacksMaterializeInsteadOfMmapWhenTheyFit() {
+        var settings = VMLXServerRuntimeSettings()
+        let hy3Scale = LoadBundleFacts(
+            totalSafetensorsBytes: 94 << 30,
+            isRouted: true,
+            physicalMemory: 128 << 30,
+            modelType: "hy_v3",
+            weightFormat: "jang-affine-mixed")
+
+        let plan = settings.resolvedMemorySafetyPlan(
+            baseLoadConfiguration: .osaurusProduction,
+            bundleFacts: hy3Scale)
+        #expect(!plan.loadConfiguration.useMmapSafetensors)
+        #expect(plan.loadConfiguration.memoryLimit == .fraction(94.0 / 128.0 + 0.06))
+        #expect(plan.warnings.contains { $0.contains("materialized instead of mmap") })
+
+        // A user-pinned load fraction wins: the rule must not override it.
+        settings.memorySafety.customPhysicalMemoryFraction = 0.75
+        let pinned = settings.resolvedMemorySafetyPlan(
+            baseLoadConfiguration: .osaurusProduction,
+            bundleFacts: hy3Scale)
+        #expect(pinned.loadConfiguration.useMmapSafetensors)
+        #expect(pinned.loadConfiguration.memoryLimit == .fraction(0.75))
+
+        // Strict mode never opts in.
+        settings.memorySafety.customPhysicalMemoryFraction = nil
+        settings.memorySafety.mode = .strict
+        let strict = settings.resolvedMemorySafetyPlan(
+            baseLoadConfiguration: .osaurusProduction,
+            bundleFacts: hy3Scale)
+        #expect(strict.loadConfiguration.useMmapSafetensors)
+
+        // A pack that cannot fit in RAM keeps mmap streaming.
+        settings.memorySafety.mode = .safeAuto
+        let cannotFit = LoadBundleFacts(
+            totalSafetensorsBytes: 30 << 30,
+            isRouted: false,
+            physicalMemory: 24 << 30,
+            modelType: "gemma4",
+            weightFormat: "mxfp4")
+        let oversized = settings.resolvedMemorySafetyPlan(
+            baseLoadConfiguration: .osaurusProduction,
+            bundleFacts: cannotFit)
+        #expect(oversized.loadConfiguration.useMmapSafetensors)
+        #expect(!oversized.warnings.contains { $0.contains("materialized instead of mmap") })
+    }
+
     @Test("memory safety preserves hybrid SSM and engine selected cache topology")
     func memorySafetyPreservesHybridSSMAndEngineSelectedCacheTopology() {
         var settings = VMLXServerRuntimeSettings()


### PR DESCRIPTION
## Problem

Production loads default to mmap-backed safetensors (`useMmapSafetensors=true` in `.osaurusProduction`). File-backed pages are reclaimable under memory pressure, so for a pack whose weights approach physical memory (Hy3-JANG_2K: 94 GB on a 128 GB host) macOS cannot keep the mapping hot next to KV, other apps, and the file cache itself. Decode then refaults experts from SSD on every step: a 10-token probe takes ~a minute, real turns time out, and the model never shows up as used RAM — observed live as "it attempted to load and then nothing happened".

## Fix

`resolvedMemorySafetyPlan` now disables mmap and raises the load fraction to weights + headroom (capped 0.92) when a bundle's weights exceed **55%** of physical memory **and still fit (≤ 86%)**. Materialized (anonymous) pages are not reclaimed the way file-backed pages are, so the working set stays resident.

Guard rails:
- Packs that **cannot** fit (e.g. 30 GiB on a 24 GiB host) keep mmap streaming — materializing them would push the host into swap/jetsam.
- Gated behind a new `allowsNearRAMScaleMaterialization` profile flag: performance / balanced / safeAuto opt in; **strict** and **diagnosticDangerous** never do.
- A user-pinned `customPhysicalMemoryFraction` is never overridden.
- The load entry still clamps the fraction to the GPU working set, so an impossible limit cannot be constructed here.

## Tests

New focused test `near-RAM-scale packs materialize instead of mmap when they fit` covers: fires at HY3 scale (94/128 GiB → mmap off, fraction raised, warning emitted), respects user-pinned fraction, strict mode never opts in, can't-fit packs stay mmap. Existing `memory safety does not make MLXPress the universal slider` dense fixture (30 GiB on 24 GiB) stays green via the fit bound.