### PR TITLE
fix(kv-cache): fill quantized attention masks with dtype finfo.min, not leastNormalMagnitude

### DIFF
--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -1713,11 +1713,11 @@ public func quantizedScaledDotProductAttention(
         let kIndices = MLXArray(0 ..< kL)
         let causalMask = greaterEqual(
             expandedDimensions(qIndices, axis: -1), expandedDimensions(kIndices, axis: -2))
-        scores = MLX.where(causalMask, scores, MLXArray(Float.leastNormalMagnitude))
+        scores = MLX.where(causalMask, scores, MLXArray(scores.dtype.finfo!.min, dtype: scores.dtype))
 
     case .array(let maskArray):
         if maskArray.dtype == .bool {
-            scores = MLX.where(maskArray, scores, MLXArray(Float.leastNormalMagnitude))
+            scores = MLX.where(maskArray, scores, MLXArray(scores.dtype.finfo!.min, dtype: scores.dtype))
         } else {
             scores = scores + maskArray
         }
@@ -1726,7 +1726,7 @@ public func quantizedScaledDotProductAttention(
         // Handle multiple mask arrays - just use the first one for simplicity
         if let maskArray = maskArrays.first {
             if maskArray.dtype == .bool {
-                scores = MLX.where(maskArray, scores, MLXArray(Float.leastNormalMagnitude))
+                scores = MLX.where(maskArray, scores, MLXArray(scores.dtype.finfo!.min, dtype: scores.dtype))
             } else {
                 scores = scores + maskArray
             }

--- a/Tests/MLXLMTests/KVCacheTests.swift
+++ b/Tests/MLXLMTests/KVCacheTests.swift
@@ -190,3 +190,149 @@ func testCacheListCopyIsIndependent() async throws {
         #expect(allClose(orig, saved).item(Bool.self))
     }
 }
+
+private func makeQuantizedAttentionInputs(dtype: DType = .float16) -> (
+    queries: MLXArray, keys: MLXArray, values: MLXArray,
+    quantizedKeys: (MLXArray, MLXArray, MLXArray?),
+    quantizedValues: (MLXArray, MLXArray, MLXArray?)
+) {
+    let headDimension = 32
+    let sequenceLength = 4
+    let queries = MLXArray.zeros([1, 1, sequenceLength, headDimension], dtype: dtype)
+    let keys = MLXArray(0 ..< sequenceLength * headDimension)
+        .reshaped([1, 1, sequenceLength, headDimension]).asType(dtype)
+    var valueData = [Float](repeating: 0, count: sequenceLength * headDimension)
+    for index in 0 ..< sequenceLength {
+        valueData[index * headDimension + index] = 1
+    }
+    let values = MLXArray(valueData, [1, 1, sequenceLength, headDimension]).asType(dtype)
+    let cache = QuantizedKVCache(groupSize: 32, bits: 8)
+    let (quantizedKeys, quantizedValues) = cache.updateQuantized(keys: keys, values: values)
+    return (
+        queries, keys, values,
+        quantizedKeys,
+        quantizedValues
+    )
+}
+
+private func additiveMask(_ mask: MLXArray, dtype: DType) -> MLXArray {
+    MLX.where(
+        mask, MLXArray(0, dtype: dtype),
+        MLXArray(dtype.finfo!.min, dtype: dtype))
+}
+
+@Test(.serialized)
+func testQuantizedAttentionCausalMaskMatchesReference() {
+    let mlxTestLock = lockSerializedMLXTest()
+    defer { mlxTestLock.unlock() }
+
+    let input = makeQuantizedAttentionInputs()
+    let scale = 1 / sqrt(Float(input.queries.dim(-1)))
+    let output = quantizedScaledDotProductAttention(
+        queries: input.queries,
+        quantizedKeys: input.quantizedKeys,
+        quantizedValues: input.quantizedValues,
+        scale: scale,
+        mask: .causal,
+        groupSize: 32,
+        bits: 8)
+    let reference = MLXFast.scaledDotProductAttention(
+        queries: input.queries,
+        keys: input.keys,
+        values: input.values,
+        scale: scale,
+        mask: .causal)
+    eval(output, reference)
+
+    #expect(output[0, 0, 0, 1 ..< 4].abs().max().item(Float.self) < 1e-3)
+    #expect(allClose(output, reference, rtol: 0.05, atol: 0.01).item(Bool.self))
+}
+
+@Test(.serialized, arguments: [DType.float16, DType.bfloat16])
+func testQuantizedAttentionBooleanArrayMaskMatchesReference(dtype: DType) {
+    let mlxTestLock = lockSerializedMLXTest()
+    defer { mlxTestLock.unlock() }
+
+    let input = makeQuantizedAttentionInputs(dtype: dtype)
+    let scale = 1 / sqrt(Float(input.queries.dim(-1)))
+    let mask = MLXArray([
+        true, false, false, false,
+        true, true, false, false,
+        true, true, true, false,
+        true, true, true, true,
+    ], [1, 1, 4, 4])
+    let output = quantizedScaledDotProductAttention(
+        queries: input.queries,
+        quantizedKeys: input.quantizedKeys,
+        quantizedValues: input.quantizedValues,
+        scale: scale,
+        mask: .array(mask),
+        groupSize: 32,
+        bits: 8)
+    let reference = MLXFast.scaledDotProductAttention(
+        queries: input.queries,
+        keys: input.keys,
+        values: input.values,
+        scale: scale,
+        mask: .array(additiveMask(mask, dtype: input.queries.dtype)))
+    eval(output, reference)
+
+    // Masked-position weight must sit at the 8-bit dequantization noise floor
+    // (one affine quantum ~= 1/255), not at the ~0.25 softmax mass the old
+    // positive fill produced; bf16 values carry a full quantum of noise.
+    let maskedTolerance: Float = dtype == .bfloat16 ? 5e-3 : 1e-3
+    #expect(output[0, 0, 0, 1 ..< 4].abs().max().item(Float.self) < maskedTolerance)
+    #expect(allClose(output, reference, rtol: 0.05, atol: 0.01).item(Bool.self))
+}
+
+@Test(.serialized)
+func testQuantizedAttentionFullyMaskedRowIsFinite() {
+    let mlxTestLock = lockSerializedMLXTest()
+    defer { mlxTestLock.unlock() }
+
+    let input = makeQuantizedAttentionInputs()
+    let output = quantizedScaledDotProductAttention(
+        queries: input.queries,
+        quantizedKeys: input.quantizedKeys,
+        quantizedValues: input.quantizedValues,
+        scale: 1 / sqrt(Float(input.queries.dim(-1))),
+        mask: .array(MLXArray.zeros([1, 1, 4, 4], dtype: .bool)),
+        groupSize: 32,
+        bits: 8)
+    eval(output)
+
+    #expect(isFinite(output).all().item(Bool.self))
+}
+
+@Test(.serialized)
+func testQuantizedAttentionAdditiveMaskMatchesReference() {
+    let mlxTestLock = lockSerializedMLXTest()
+    defer { mlxTestLock.unlock() }
+
+    let input = makeQuantizedAttentionInputs()
+    let scale = 1 / sqrt(Float(input.queries.dim(-1)))
+    let booleanMask = MLXArray([
+        true, false, false, false,
+        true, true, false, false,
+        true, true, true, false,
+        true, true, true, true,
+    ], [1, 1, 4, 4])
+    let mask = additiveMask(booleanMask, dtype: input.queries.dtype)
+    let output = quantizedScaledDotProductAttention(
+        queries: input.queries,
+        quantizedKeys: input.quantizedKeys,
+        quantizedValues: input.quantizedValues,
+        scale: scale,
+        mask: .array(mask),
+        groupSize: 32,
+        bits: 8)
+    let reference = MLXFast.scaledDotProductAttention(
+        queries: input.queries,
+        keys: input.keys,
+        values: input.values,
+        scale: scale,
+        mask: .array(mask))
+    eval(output, reference)
+
+    #expect(allClose(output, reference, rtol: 0.05, atol: 0.01).item(Bool.self))
+}


### PR DESCRIPTION
This is the offered fix for #133. The three boolean mask paths in `quantizedScaledDotProductAttention` filled excluded logits with `Float.leastNormalMagnitude`, the smallest positive normal Float, so masked logits were effectively zero and could retain softmax mass. They now use `scores.dtype.finfo!.min`, matching Python mlx-lm's `finfo(scores.dtype).min`; this is finite rather than `-inf` because an entirely masked row of infinities produces a NaN softmax row.

The affected code is not reached by vanilla one-token decode with no mask. It is reachable for multi-token quantized-cache steps, including speculative-decode verification.

Each fill scalar is constructed explicitly in `scores.dtype` before `MLX.where`, avoiding promotion of bf16 or fp16 scores by a float32 scalar. The additive floating-point mask branches are intentionally unchanged: caller-provided additive masks already encode their intended bias values, so no fill happens there.

Focused KV-cache tests now cover causal-mask parity with `MLXFast.scaledDotProductAttention`, boolean-array-mask parity (fp16 and bf16) and zero masked-position weight, a fully masked row remaining finite (that test documents the finite-fill semantics rather than the constant change), and unchanged additive-mask routing. The fixtures use tiny tensors and a real `QuantizedKVCache`; they require no model downloads.

One adjacent observation from reviewing for other occurrences, left out of this PR to keep it verifiable: `Gemma3nText.swift:599` builds its sliding-window exclusion with the same `Float.leastNormalMagnitude` constant (for fp16 masks it underflows to exactly +0, so positions beyond the window keep an additive bias of 0), and `:854` uses it as an epsilon that also underflows to 0 in fp16. Happy to file that separately or fold it in here if you prefer.

Happy for you to take this over or adjust the constant if leastNormalMagnitude was intentional for a Metal-side reason.
