### PR TITLE
Never let saving the prefix cache take the host down, and stop swallowing Hunyuan answers

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -734,6 +734,19 @@ public actor BatchEngine {
                 }
             }
 
+            // Reasoning state at end-of-stream, captured inside `flush()` in the
+            // only window where it is truthful: after the detokenizer's held-back
+            // tail has been pumped through the parser, and before
+            // `ReasoningParser.flush()` clears the flag unconditionally.
+            //
+            // The detokenizer withholds a 24-character tail, so a close marker can
+            // still be unparsed when the loop ends. `</think:opensource>` is 20
+            // characters and fits entirely inside it — which is why Hunyuan v3
+            // reported "ended inside <think>" on streams that closed cleanly and
+            // split reasoning from content correctly. A short `</think>` clears the
+            // holdback, so most families never surfaced this.
+            var terminalInsideReasoning: Bool? = nil
+
             func flush() {
                 // A matched stop string is the semantic end of the
                 // response: everything still held in the detokenizer /
@@ -746,6 +759,7 @@ public actor BatchEngine {
                 if let text = detokenizer.flush() {
                     pump(text)
                 }
+                terminalInsideReasoning = reasoningParser?.isInsideReasoning ?? false
                 if var parser = reasoningParser {
                     for segment in parser.flush() {
                         switch segment {
@@ -824,8 +838,9 @@ public actor BatchEngine {
                     // the consumer wants: "was the LAST CONSUMED TOKEN
                     // inside a reasoning block?" If yes, the model
                     // ended without ever emitting `</think>`.
-                    let unclosed = reasoningParser?.isInsideReasoning ?? false
                     flush()
+                    let unclosed =
+                        terminalInsideReasoning ?? (reasoningParser?.isInsideReasoning ?? false)
                     detokenizer.startNewSegment()
                     // Detect "trapped thinking": stream ended while the
                     // reasoning parser was still inside a `<think>…</think>`
@@ -861,8 +876,9 @@ public actor BatchEngine {
                 // normally emit `.info` themselves, but if a lower layer closes
                 // early we still need to flush held reasoning/tool-call text and
                 // surface whether the model ended inside `<think>`.
-                let unclosed = reasoningParser?.isInsideReasoning ?? false
                 flush()
+                let unclosed =
+                    terminalInsideReasoning ?? (reasoningParser?.isInsideReasoning ?? false)
                 detokenizer.startNewSegment()
                 let elapsed = Date().timeIntervalSince(streamStartedAt)
                 let finalInfo = GenerateCompletionInfo(
@@ -2580,6 +2596,23 @@ public actor BatchEngine {
 
             func storeCacheEntry(tokens: [Int], snapshot: [KVCache], label: String) {
                 guard !tokens.isEmpty else { return }
+                // Serialising the cache materialises it again (host `Data` for the
+                // disk write, plus the disk-store cache) while the snapshot and the
+                // live cache are both still resident. A prefix-cache entry only ever
+                // speeds up some later request — it must never be able to take the
+                // host down, so if the copies won't fit, don't make them.
+                guard CacheStoreBudget.canStore(snapshot) else {
+                    let gib = Double(CacheStoreBudget.cacheBytes(snapshot)) / 1_073_741_824
+                    Self.logger.info(
+                        """
+                        prefix-cache: skipping \(label, privacy: .public) store of a \
+                        \(String(format: "%.1f", gib), privacy: .public) GiB KV cache — the copies it \
+                        requires do not fit in memory. Generation was unaffected; only the cache \
+                        entry was dropped.
+                        """
+                    )
+                    return
+                }
                 let requiresDiskBackedRestore =
                     cacheRequiresDiskBackedCoordinatorRestore(snapshot)
                 let perLayerData = requiresDiskBackedRestore

--- a/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
@@ -34,6 +34,16 @@ func makeDiskStoreCache(
     quantizedKVStart: Int,
     kvMode: KVQuantizationMode
 ) -> [any KVCache] {
+    // The copy exists only to protect `snapshot` from `maybeQuantizeKVCache`'s
+    // in-place mutation. When nothing will be quantized that call is a no-op
+    // (`kvMode == .none` falls through to a `guard let kvBits` that returns), so
+    // the copy protects against nothing — and it is not a cheap nothing: it is a
+    // second full duplicate of the KV cache, allocated at the moment memory is
+    // already at its high-water mark. The prompt-boundary store takes exactly this
+    // path (`kvBits: nil, kvMode: .none`), and on a 64K-token context that copy is
+    // tens of GiB. Share the snapshot instead; the caller drops it right after.
+    guard kvBits != nil || kvMode != .none else { return snapshot }
+
     var diskCache = snapshot.map { $0.copy() }
     maybeQuantizeKVCache(
         cache: &diskCache,

--- a/Libraries/MLXLMCommon/Cache/CacheStoreBudget.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheStoreBudget.swift
@@ -1,0 +1,88 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+
+/// Whether a KV cache can be *saved* without pushing the host over a cliff.
+///
+/// The prefix cache is an optimisation: a stored entry only ever makes a later
+/// request faster. Storing one must therefore never be able to take the machine
+/// down — but until this guard existed, it could.
+///
+/// `storeCacheAfterGeneration` materialises the cache up to three times over,
+/// at the exact moment memory is already at its high-water mark:
+///
+///   1. `cacheToStore.map { $0.copy() }`   — a full duplicate of the live KV
+///   2. `extractLayerData(from: snapshot)` — again, as host `Data`, for the disk write
+///   3. `makeDiskStoreCache(...)`          — and again, as the disk-store cache
+///
+/// For a 70B 8-bit model with a 64K-token context that is ~70 GB of weights plus
+/// a ~20 GiB live KV cache, and then the store adds tens of GiB more. On a 128 GB
+/// host, free memory collapses. macOS will not jetsam a plain user process out of
+/// the way, so nothing intervenes: page reclaim stalls, watchdogd starves, and the
+/// kernel panics — reported live on an M5 Max/128 GB with Llama-3.3-70B-8bit at 64K,
+/// with the panic landing inside `storeCacheAfterGeneration` / `DiskCache.store`.
+///
+/// So: measure first, and if the copies would not fit, skip the store. A skipped
+/// store costs one slower request. An unchecked store costs the machine.
+public enum CacheStoreBudget {
+
+    /// How many times the store materialises the cache (snapshot + host-`Data`
+    /// extract + disk-store cache). Deliberately conservative: undercounting here
+    /// is what made the original panic possible.
+    static let materializationFactor = 3
+
+    /// Headroom kept free for everything else in flight — activations, the disk
+    /// write buffer, and the rest of the system.
+    static let safetyMarginBytes = 4 << 30  // 4 GiB
+
+    /// Live bytes held by a KV cache, without copying its contents.
+    ///
+    /// `state` is the same array set the store would serialise, and `nbytes` is
+    /// shape x item size, so nothing is evaluated and no tensor data is copied.
+    /// Some implementations do build lazy views to answer it (slices in
+    /// `KVCacheSimple` / `RotatingKVCache` / `QuantizedKVCache`, a flatten in
+    /// `CacheList`), so this is cheap rather than literally free — orders of
+    /// magnitude below the copy + serialize it is deciding whether to allow.
+    public static func cacheBytes(_ cache: [KVCache]) -> Int {
+        cache.reduce(0) { total, layer in
+            total + layer.state.reduce(0) { $0 + $1.nbytes }
+        }
+    }
+
+    /// Whether storing `cache` fits in what the host can still give us.
+    ///
+    /// Budgeted against **physical memory**, not the GPU working set. The working
+    /// set is the wrong ceiling for this decision in both directions: exceeding it
+    /// only means macOS pages the excess — slow, survivable — whereas exhausting
+    /// physical memory is what actually kills the host, and that is the only thing
+    /// this guard exists to prevent.
+    ///
+    /// Using the working set here would also be needlessly destructive: with a
+    /// large model resident (say 96 GB of a 107 GiB working set) it would refuse to
+    /// cache anything past ~15k tokens, disabling the prefix cache for exactly the
+    /// long-context requests that most need it. Against physical memory the same
+    /// host still caches ~38k tokens, and the request that panicked a 128 GB Mac is
+    /// still refused.
+    public static func canStore(_ cache: [KVCache]) -> Bool {
+        let liveBytes = cacheBytes(cache)
+        guard liveBytes > 0 else { return true }
+        return canStore(cacheBytes: liveBytes)
+    }
+
+    /// Testable core: no MLX state, just the arithmetic.
+    static func canStore(
+        cacheBytes liveBytes: Int,
+        activeBytes: Int = max(0, MLX.Memory.activeMemory),
+        budgetBytes: Int? = Int(exactly: ProcessInfo.processInfo.physicalMemory)
+    ) -> Bool {
+        guard liveBytes > 0 else { return true }
+        guard let budgetBytes, budgetBytes > 0 else {
+            // No budget to reason about: don't guess, don't block.
+            return true
+        }
+        let storeCost = liveBytes * materializationFactor
+        let projected = activeBytes + storeCost + safetyMarginBytes
+        return projected <= budgetBytes
+    }
+}

--- a/Libraries/MLXLMCommon/Cache/DiskCache.swift
+++ b/Libraries/MLXLMCommon/Cache/DiskCache.swift
@@ -54,8 +54,11 @@ public enum MLXCacheIOLock {
 ///
 /// `DiskCache` provides persistent KV cache storage on disk using safetensors
 /// files for tensor data and a SQLite database for indexing. Writes are
-/// dispatched to a background task to avoid blocking the caller. Reads are
-/// synchronous since they typically feed directly into model inference.
+/// synchronous and serialized under a lock — the comment here previously claimed
+/// they were dispatched to a background task, which they are not (see `store`);
+/// that mattered, because it implies the caller's arrays are retained past the
+/// call, and callers reasoning about copy lifetimes were misled by it. Reads are
+/// likewise synchronous since they typically feed directly into model inference.
 public final class DiskCache: @unchecked Sendable {
 
     // MARK: - Properties

--- a/Libraries/MLXLMCommon/Diffusion/BlockDiffusionTokenIterator.swift
+++ b/Libraries/MLXLMCommon/Diffusion/BlockDiffusionTokenIterator.swift
@@ -28,8 +28,12 @@
 
 import Foundation
 import MLX
+import os
 
 public struct BlockDiffusionTokenIterator: TokenIteratorProtocol {
+    private static let logger = Logger(
+        subsystem: "vmlx", category: "BlockDiffusionTokenIterator")
+
     let model: any BlockDiffusionModel
     var cache: [KVCache]
     let options: BlockDiffusionParameters
@@ -393,6 +397,23 @@ public struct BlockDiffusionTokenIterator: TokenIteratorProtocol {
             return
         }
 
+        // Same guard as the other two store paths: saving the cache duplicates it
+        // several times over at the memory high-water mark, and a prefix-cache entry
+        // is only ever a speed-up for a later request — it must never be able to take
+        // the host down. If the copies won't fit, don't make them.
+        guard CacheStoreBudget.canStore(promptCacheSnapshot) else {
+            let gib = Double(CacheStoreBudget.cacheBytes(promptCacheSnapshot)) / 1_073_741_824
+            Self.logger.info(
+                """
+                prefix-cache: skipping store of a \(String(format: "%.1f", gib), privacy: .public) GiB \
+                KV cache — the copies it requires do not fit in memory. Generation was unaffected; \
+                only the cache entry was dropped.
+                """
+            )
+            reportStatsOnce()
+            return
+        }
+
         let cacheSnapshot = promptCacheSnapshot.map { $0.copy() }
         let requiresDiskBackedRestore =
             cacheRequiresDiskBackedCoordinatorRestore(cacheSnapshot)
@@ -421,6 +442,11 @@ public struct BlockDiffusionTokenIterator: TokenIteratorProtocol {
         // boundary store is skipped gracefully.
         for boundary in Set(cachePrefixTokenCounts).sorted()
         where boundary > 0 && boundary < promptTokenIds.count {
+            // Re-check per boundary rather than relying on the check above: each
+            // boundary copies the *untrimmed* cache again, and the stores before it
+            // have already raised the memory floor. One store fitting does not mean
+            // N more do.
+            guard CacheStoreBudget.canStore(promptCacheSnapshot) else { break }
             let trimCount = promptTokenIds.count - boundary
             let boundarySnapshot = promptCacheSnapshot.map { $0.copy() }
             guard canTrimPromptCache(boundarySnapshot),

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -2142,6 +2142,22 @@ public struct TokenIterator: TokenIteratorProtocol {
             kvMode diskKVMode: KVQuantizationMode
         ) {
             guard !tokens.isEmpty else { return }
+            // Saving the cache duplicates it several times over (snapshot, host
+            // `Data` for the disk write, disk-store cache) at the point where
+            // memory is already at its peak. A prefix-cache entry is only ever a
+            // speed-up for some later request — it must never be able to take the
+            // host down. If the copies won't fit, don't make them.
+            guard CacheStoreBudget.canStore(cacheToStore) else {
+                let gib = Double(CacheStoreBudget.cacheBytes(cacheToStore)) / 1_073_741_824
+                Self.logger.info(
+                    """
+                    prefix-cache: skipping store of a \(String(format: "%.1f", gib), privacy: .public) GiB \
+                    KV cache — the copies it requires do not fit in memory. The request completed \
+                    normally; only the cache entry was dropped.
+                    """
+                )
+                return
+            }
             let snapshot = cacheToStore.map { $0.copy() }
             let requiresDiskBackedRestore =
                 cacheRequiresDiskBackedCoordinatorRestore(snapshot)
@@ -3650,8 +3666,12 @@ private func generateLoopTask<Handler: TokenLoopHandler>(
                 }
             }
 
-            let unclosedReasoning = handler.unclosedReasoning
             handler.onGenerationEnd(emit: continuation.yield)
+            // Read AFTER the flush: `onGenerationEnd` pushes the detokenizer's
+            // held-back tail through the parser, which is where a close marker
+            // stuck in that tail finally lands. Reading before it reported
+            // "unclosed" for streams that closed cleanly.
+            let unclosedReasoning = handler.unclosedReasoning
 
             let now = Date.timeIntervalSinceReferenceDate
             let generateTime = now - start
@@ -4101,6 +4121,22 @@ struct TextToolTokenLoopHandler: TokenLoopHandler, @unchecked Sendable {
     /// tool-call processor (matches upstream ml-explore/mlx-swift-lm
     /// behaviour byte-for-byte).
     var reasoningParser: ReasoningParser?
+    /// Reasoning state captured at end-of-stream, *after* the
+    /// detokenizer's held-back tail has been pushed through the parser
+    /// but *before* `ReasoningParser.flush()` clears the flag.
+    ///
+    /// Neither edge of that window can be read from outside. The
+    /// detokenizer withholds a 24-character tail (`Tokenizer.swift`,
+    /// `trailingHoldbackCharacters`) so a close marker can still be sitting
+    /// unparsed when the loop ends — `</think:opensource>` is 20 characters
+    /// and fits entirely inside it, which is why Hunyuan v3 reported
+    /// "still inside reasoning" on streams that in fact closed cleanly and
+    /// split reasoning from content correctly (a short `</think>` clears the
+    /// holdback, so most families never showed it). And `flush()` ends by
+    /// setting `insideReasoning = false` unconditionally, so reading the
+    /// parser afterwards would report "closed" even for a model that really
+    /// did stop mid-thought — the pathology this flag exists to detect.
+    var terminalInsideReasoning: Bool?
     /// Text-level stop-sequence matcher. Runs at the tail of the
     /// pipeline against `.chunk` text only (reasoning + tool-call bytes
     /// are scoped out by construction). When a stop string matches,
@@ -4237,6 +4273,11 @@ struct TextToolTokenLoopHandler: TokenLoopHandler, @unchecked Sendable {
             return
         }
 
+        // The detokenizer's held-back tail has now gone through the parser,
+        // so this is the first moment the reasoning state is trustworthy —
+        // and the last, since `flush()` below clears it unconditionally.
+        terminalInsideReasoning = reasoningParser?.isInsideReasoning ?? false
+
         // Flush the reasoning parser — any buffered tail becomes content
         // (or a trailing `.reasoning` segment if the model stopped mid-
         // think block) per ReasoningParser.flush contract. The tool-call
@@ -4365,7 +4406,7 @@ struct TextToolTokenLoopHandler: TokenLoopHandler, @unchecked Sendable {
     }
 
     var unclosedReasoning: Bool {
-        reasoningParser?.isInsideReasoning ?? false
+        terminalInsideReasoning ?? (reasoningParser?.isInsideReasoning ?? false)
     }
 }
 

--- a/Libraries/MLXLMCommon/ReasoningParser.swift
+++ b/Libraries/MLXLMCommon/ReasoningParser.swift
@@ -67,6 +67,27 @@ public struct ReasoningParser: Sendable {
     /// The tag that ends a reasoning block. Default `</think>`.
     public let endTag: String
 
+    /// Additional spellings of `startTag` / `endTag` that the same family
+    /// may emit, matched exactly like the primary tags.
+    ///
+    /// Hunyuan v3 is the reason these exist. Its chat template writes every
+    /// protocol marker through one variable — `'<think{}>'.format(HYTK)` — and
+    /// the open-source packs set `HYTK = ':opensource'` while the preview
+    /// conversions leave it empty. A parser that knows only the suffixed
+    /// spelling never sees a bare pack's `</think>`, and since the Hunyuan
+    /// parser starts *inside* reasoning, the entire answer — tool calls
+    /// included — is routed to `.reasoning` and the user sees an empty reply.
+    /// `HunyuanToolCallParser` already accepts both spellings; this is the
+    /// same defence for the reasoning side.
+    public let startTagAliases: [String]
+    public let endTagAliases: [String]
+
+    /// Every accepted spelling of each tag, primary first. The drain loop
+    /// matches against these, so a family that declares no aliases behaves
+    /// exactly as before.
+    private var openerSpellings: [String] { [startTag] + startTagAliases }
+    private var closerSpellings: [String] { [endTag] + endTagAliases }
+
     /// When true, the drain loop strips stray markers regardless of
     /// state — a `</think>` while in content mode is consumed as a
     /// model artifact (state stays in content), and a `<think>` while
@@ -135,12 +156,16 @@ public struct ReasoningParser: Sendable {
         startTag: String = "<think>",
         endTag: String = "</think>",
         startInReasoning: Bool = false,
-        stripStrayTags: Bool = true
+        stripStrayTags: Bool = true,
+        startTagAliases: [String] = [],
+        endTagAliases: [String] = []
     ) {
         self.startTag = startTag
         self.endTag = endTag
         self.insideReasoning = startInReasoning
         self.stripStrayTags = stripStrayTags
+        self.startTagAliases = startTagAliases.filter { !$0.isEmpty && $0 != startTag }
+        self.endTagAliases = endTagAliases.filter { !$0.isEmpty && $0 != endTag }
     }
 
     // MARK: Streaming API
@@ -499,6 +524,58 @@ public struct ReasoningParser: Sendable {
     /// those stray markers leaked into the visible stream verbatim
     /// (reproduced 2026-04-25 on a MiniMax-Small JANGTQ chat where the
     /// model emitted three `</think>` markers across one assistant turn).
+    /// Earliest occurrence in `buffer` of any of `spellings`. When two
+    /// spellings match at the same offset the longer one wins, so a bare
+    /// `</think>` alias can never shadow the `</think:opensource>` it is a
+    /// prefix of — matching the short one first would leave `:opensource>`
+    /// behind as visible content.
+    /// True when `range` matched a spelling that is a strict prefix of a longer
+    /// accepted spelling, and the buffer does not yet hold enough characters to
+    /// rule that longer spelling out.
+    ///
+    /// This is the streaming hazard that makes aliases dangerous. `</think>` is a
+    /// prefix of `</think:opensource>`, and the suffix arrives in a LATER chunk.
+    /// The instant the buffer holds `…</think>`, the short spelling is a complete,
+    /// legitimate match — so without this check the parser would consume it, flip
+    /// to content, and then emit the `:opensource>` that arrives next as visible
+    /// text. The tie-break in `earliestMatch` cannot help: at that moment the long
+    /// spelling is not in the buffer to compete. So when the match could still grow
+    /// into a longer one, treat it as no match at all and let the holdback wait for
+    /// the next chunk. At end-of-stream there is no next chunk, so the caller does
+    /// not consult this and the short spelling wins — which is right for a pack that
+    /// really does end its reasoning with a bare marker.
+    private func couldGrowIntoLongerSpelling(
+        _ range: Range<String.Index>, among spellings: [String]
+    ) -> Bool {
+        let matched = buffer[range]
+        let tail = buffer[range.lowerBound...]
+        for spelling in spellings
+        where spelling.count > matched.count && spelling.hasPrefix(matched) {
+            // Fewer characters than the long spelling needs, and everything we do
+            // have agrees with it → the next chunk could still complete it.
+            if tail.count < spelling.count && spelling.hasPrefix(tail) { return true }
+        }
+        return false
+    }
+
+    private func earliestMatch(of spellings: [String]) -> Range<String.Index>? {
+        var best: Range<String.Index>?
+        for spelling in spellings {
+            guard let range = buffer.range(of: spelling) else { continue }
+            guard let current = best else {
+                best = range
+                continue
+            }
+            if range.lowerBound < current.lowerBound
+                || (range.lowerBound == current.lowerBound
+                    && range.upperBound > current.upperBound)
+            {
+                best = range
+            }
+        }
+        return best
+    }
+
     private mutating func drain(allowPartialTagAtEnd: Bool = true)
         -> [ReasoningSegment]
     {
@@ -512,8 +589,8 @@ public struct ReasoningParser: Sendable {
             let firstTagRange: Range<String.Index>?
             let firstTagIsOpener: Bool
             if stripStrayTags {
-                let openRange = buffer.range(of: startTag)
-                let closeRange = buffer.range(of: endTag)
+                let openRange = earliestMatch(of: openerSpellings)
+                let closeRange = earliestMatch(of: closerSpellings)
                 switch (openRange, closeRange) {
                 case (let o?, let c?):
                     if o.lowerBound <= c.lowerBound {
@@ -534,11 +611,20 @@ public struct ReasoningParser: Sendable {
                     firstTagIsOpener = false
                 }
             } else {
-                let lookFor = insideReasoning ? endTag : startTag
-                firstTagRange = buffer.range(of: lookFor)
+                let lookFor = insideReasoning ? closerSpellings : openerSpellings
+                firstTagRange = earliestMatch(of: lookFor)
                 firstTagIsOpener = !insideReasoning
             }
-            if let range = firstTagRange {
+            // A match that could still grow into a longer accepted spelling is not
+            // yet a match. Fall through to the holdback and wait for the rest.
+            let pendingLongerSpelling =
+                allowPartialTagAtEnd
+                && firstTagRange.map {
+                    couldGrowIntoLongerSpelling(
+                        $0, among: firstTagIsOpener ? openerSpellings : closerSpellings)
+                } == true
+
+            if let range = firstTagRange, !pendingLongerSpelling {
                 // Emit everything before the tag in the current mode.
                 let before = String(buffer[..<range.lowerBound])
                 if !before.isEmpty {
@@ -558,12 +644,16 @@ public struct ReasoningParser: Sendable {
             // a tag prefix at the end, hold back enough characters that a
             // future chunk can complete it.
             if allowPartialTagAtEnd {
-                // `max(startTag, endTag).count - 1` — use `max(0, …)` so
-                // an edge-case empty tag (e.g. a model-specific override
-                // mis-configured at init) doesn't produce a negative
-                // `safeTail`, which would make the `offsetBy: -safeTail`
-                // move forward past `endIndex` and trap in the stdlib.
-                let safeTail = max(0, max(startTag.count, endTag.count) - 1)
+                // Longest accepted spelling minus one — holding back any less
+                // could let a tag straddle two chunks and go unmatched. Aliases
+                // count: `</think:opensource>` is longer than `</think>`, and
+                // holding back only the shorter one would split it. `max(0, …)`
+                // guards the edge case of an empty tag (a mis-configured
+                // model-specific override), where a negative `safeTail` would
+                // make `offsetBy: -safeTail` walk past `endIndex` and trap.
+                let longestTag = (openerSpellings + closerSpellings)
+                    .map(\.count).max() ?? 0
+                let safeTail = max(0, longestTag - 1)
                 if buffer.count > safeTail {
                     let splitAt = buffer.index(buffer.endIndex, offsetBy: -safeTail)
                     let safe = String(buffer[..<splitAt])
@@ -690,10 +780,19 @@ extension ReasoningParser {
             // high/low reasoning modes and a CLOSED empty pair in no_think —
             // `forPrompt(stampName:promptTail:)` resolves the start state
             // from that tail, which is why these exact tags matter.
+            //
+            // The suffix is a template variable (`'<think{}>'.format(HYTK)`),
+            // and the preview conversions ship it empty — those packs emit a
+            // bare `</think>`. Accept both: this parser starts inside
+            // reasoning, so failing to recognise the close marker routes the
+            // model's whole answer into the thinking block and leaves the
+            // visible reply empty.
             return ReasoningParser(
                 startTag: "<think:opensource>",
                 endTag: "</think:opensource>",
-                startInReasoning: true)
+                startInReasoning: true,
+                startTagAliases: ["<think>"],
+                endTagAliases: ["</think>"])
         }
 
         switch n {
@@ -769,6 +868,29 @@ extension ReasoningParser {
     ///     last ~100 characters of the prompt suffice. Pass `nil` to
     ///     fall back to stamp defaults.
     /// - Returns: a parser, or nil if the stamp resolves to no parser.
+    /// Last occurrence of any of `spellings` in `text`. Ties at the same
+    /// offset resolve to the longer spelling, for the same reason
+    /// `earliestMatch` does.
+    private static func lastMatch(
+        of spellings: [String], in text: String
+    ) -> Range<String.Index>? {
+        var best: Range<String.Index>?
+        for spelling in spellings {
+            guard let range = text.range(of: spelling, options: .backwards) else { continue }
+            guard let current = best else {
+                best = range
+                continue
+            }
+            if range.lowerBound > current.lowerBound
+                || (range.lowerBound == current.lowerBound
+                    && range.upperBound > current.upperBound)
+            {
+                best = range
+            }
+        }
+        return best
+    }
+
     public static func forPrompt(
         stampName: String?,
         promptTail: String?
@@ -779,11 +901,16 @@ extension ReasoningParser {
         // was baked into `base` by fromCapabilityName).
         guard let promptTail, !promptTail.isEmpty else { return base }
 
-        // Detect the last tag at the prompt tail.
+        // Detect the last tag at the prompt tail. Search every accepted
+        // spelling: a Hunyuan pack with an empty marker suffix prefills a bare
+        // `<think>`, and missing it here would resolve the start state from
+        // the stamp default instead of from the prompt the model actually saw.
         let startTag = base.startTag
         let endTag = base.endTag
-        let lastOpener = promptTail.range(of: startTag, options: .backwards)
-        let lastCloser = promptTail.range(of: endTag, options: .backwards)
+        let lastOpener = Self.lastMatch(
+            of: [startTag] + base.startTagAliases, in: promptTail)
+        let lastCloser = Self.lastMatch(
+            of: [endTag] + base.endTagAliases, in: promptTail)
 
         let startInReasoning: Bool
         switch (lastOpener, lastCloser) {
@@ -823,7 +950,12 @@ extension ReasoningParser {
             // think_xml family keeps `stripStrayTags: true`, harmony
             // keeps `false`. Without this carry-over, harmony lost
             // its A2/A3 contract whenever `forPrompt(...)` was used.
-            stripStrayTags: base.stripStrayTags)
+            stripStrayTags: base.stripStrayTags,
+            // Likewise the accepted marker spellings: dropping them here
+            // would give prompt-resolved Hunyuan parsers a narrower tag set
+            // than stamp-resolved ones.
+            startTagAliases: base.startTagAliases,
+            endTagAliases: base.endTagAliases)
         if startInReasoning && parser.isHarmonyChannelParser {
             parser.insideHarmonyChannel = true
             parser.harmonyChannelIsReasoning = true

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -406,6 +406,13 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         {
             func store(tokens: [Int], snapshot: [KVCache], label _: String) {
                 guard !tokens.isEmpty else { return }
+                // Same guard as the other store paths: saving a cache materialises
+                // it several times over at the memory high-water mark, and a
+                // prefix-cache entry is only ever a speed-up for a later request —
+                // it must never be able to take the host down. Re-checked per call
+                // because this helper runs once per boundary. (MTP was the fourth
+                // store path; the first three were guarded and this one was missed.)
+                guard CacheStoreBudget.canStore(snapshot) else { return }
                 let cacheSnapshot = snapshot.map { $0.copy() }
                 MLX.eval(cacheSnapshot)
                 let requiresDiskBackedRestore =

--- a/Tests/MLXLMCommonFocusedTests/NoHiddenReasoningCloseBiasFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NoHiddenReasoningCloseBiasFocusedTests.swift
@@ -163,25 +163,60 @@ struct NoHiddenReasoningCloseBiasFocusedTests {
         #expect(source.contains("Removing stale RunBench lock before matrix start"))
     }
 
-    @Test("terminal info snapshots unclosed reasoning before parser flush")
-    func terminalInfoSnapshotsUnclosedReasoningBeforeParserFlush() throws {
+    /// The reasoning state must be captured in the window BETWEEN the detokenizer
+    /// flush and `ReasoningParser.flush()`, and reported from that capture.
+    ///
+    /// This test used to require the read to happen before `onGenerationEnd` — which
+    /// protected the right invariant (`flush()` ends by clearing `insideReasoning`,
+    /// so reading afterwards would erase the trapped-thinking signal) but at the
+    /// wrong point. The detokenizer withholds a 24-character tail, so a close marker
+    /// short enough to sit inside it is still unparsed when the loop ends:
+    /// `</think:opensource>` is 20 characters and hides completely, which made
+    /// Hunyuan v3 report "thinking didn't close" on streams that closed cleanly.
+    ///
+    /// Both edges matter, so the capture lives inside `onGenerationEnd`: after the
+    /// held-back tail has gone through the parser, before `flush()` clears it.
+    @Test("terminal info snapshots unclosed reasoning between the two flushes")
+    func terminalInfoSnapshotsUnclosedReasoningBetweenTheTwoFlushes() throws {
         let evaluate = try String(
             contentsOfFile: "Libraries/MLXLMCommon/Evaluate.swift",
             encoding: .utf8)
 
-        guard let snapshot = evaluate.range(
-            of: "let unclosedReasoning = handler.unclosedReasoning"),
+        guard
+            let read = evaluate.range(
+                of: "let unclosedReasoning = handler.unclosedReasoning"),
             let flush = evaluate.range(
                 of: "handler.onGenerationEnd(emit: continuation.yield)")
         else {
-            Issue.record("Evaluate.swift missing unclosed reasoning snapshot or terminal flush")
+            Issue.record("Evaluate.swift missing unclosed reasoning read or terminal flush")
             return
         }
 
-        #expect(snapshot.lowerBound < flush.lowerBound)
+        // The public read now happens AFTER the flush, because the flush is what
+        // pushes the detokenizer's held tail through the parser.
+        #expect(flush.lowerBound < read.lowerBound)
+
+        // ...and the value it reads is the snapshot taken inside that flush, before
+        // the parser flush clears the flag.
+        guard
+            let detokFlush = evaluate.range(
+                of: "if let chunk = detokenizer.flush(), !dispatch(chunk, emit: emit) {"),
+            let capture = evaluate.range(
+                of: "terminalInsideReasoning = reasoningParser?.isInsideReasoning ?? false"),
+            let parserFlush = evaluate.range(
+                of: "for segment in parser.flush() {", range: capture.upperBound ..< evaluate.endIndex)
+        else {
+            Issue.record("Evaluate.swift missing the terminal reasoning-state capture window")
+            return
+        }
+        #expect(detokFlush.lowerBound < capture.lowerBound)
+        #expect(capture.lowerBound < parserFlush.lowerBound)
+
         #expect(evaluate.contains("unclosedReasoning: unclosedReasoning"))
         #expect(evaluate.contains("var unclosedReasoning: Bool { get }"))
-        #expect(evaluate.contains("reasoningParser?.isInsideReasoning ?? false"))
+        #expect(
+            evaluate.contains(
+                "terminalInsideReasoning ?? (reasoningParser?.isInsideReasoning ?? false)"))
     }
 
     @Test("growing chat cache probe distinguishes unsafe template divergence")
@@ -673,8 +708,71 @@ struct Hy3ParserFocusedTests {
             #expect(ReasoningParser.fromCapabilityName(stamp) != nil)
         }
         for modelType in ["hy_v3", "hy-v3", "hy3", "Hy3"] {
-            #expect(reasoningStampFromModelType(modelType) == "think_xml")
+            // NOT `think_xml`: Hunyuan v3 gets its own stamp because its markers
+            // may carry the `:opensource` suffix, which the plain think_xml
+            // parser does not recognise. Stamping it think_xml would leave the
+            // close marker unmatched and swallow the answer into reasoning.
+            #expect(reasoningStampFromModelType(modelType) == "hy_v3")
             #expect(ToolCallFormat.infer(from: modelType) == .hunyuan)
+        }
+    }
+
+    /// The bare `</think>` alias is a strict PREFIX of `</think:opensource>`, and
+    /// the suffix arrives in a later chunk. A parser that accepts the short
+    /// spelling the moment it appears would close reasoning early and then emit
+    /// the trailing `:opensource>` as visible text — the exact marker leak we
+    /// check every HY3 build for. Feed it one character at a time, the way tokens
+    /// actually arrive, and require that never happens.
+    @Test("Hy3 streaming: a split :opensource close marker never leaks")
+    func hy3SplitCloseMarkerDoesNotLeak() {
+        var parser = try! #require(ReasoningParser.fromCapabilityName("hy_v3"))
+        var reasoning = ""
+        var visible = ""
+        let stream = "weighing it</think:opensource>The answer is 42."
+        for character in stream {
+            for segment in parser.feed(String(character)) {
+                switch segment {
+                case .reasoning(let text): reasoning += text
+                case .content(let text): visible += text
+                }
+            }
+        }
+        for segment in parser.flush() {
+            if case .content(let text) = segment { visible += text }
+        }
+
+        #expect(visible == "The answer is 42.")
+        #expect(!visible.contains(":opensource"))
+        #expect(!visible.contains("think"))
+        #expect(reasoning == "weighing it")
+        #expect(!parser.isInsideReasoning)
+    }
+
+    /// The marker suffix is a template variable (`'<think{}>'.format(HYTK)`):
+    /// open-source packs set it to `:opensource`, preview conversions leave it
+    /// empty. The parser starts inside reasoning, so a spelling it cannot match
+    /// is not a cosmetic miss — it routes the model's entire answer, tool calls
+    /// included, into the thinking block and leaves the visible reply empty.
+    @Test("Hy3 reasoning parser closes on both bare and :opensource markers")
+    func hy3ReasoningClosesOnEitherMarkerSpelling() {
+        for close in ["</think>", "</think:opensource>"] {
+            var parser = try! #require(ReasoningParser.fromCapabilityName("hy_v3"))
+            var reasoning = ""
+            var visible = ""
+            for segment in parser.feed("weighing the options\(close)The answer is 42.") {
+                switch segment {
+                case .reasoning(let text): reasoning += text
+                case .content(let text): visible += text
+                }
+            }
+            for segment in parser.flush() {
+                if case .content(let text) = segment { visible += text }
+            }
+
+            #expect(reasoning == "weighing the options", "close marker \(close)")
+            #expect(visible == "The answer is 42.", "close marker \(close)")
+            #expect(!parser.isInsideReasoning, "close marker \(close)")
+            #expect(!visible.contains(":opensource"), "close marker \(close)")
         }
     }
 
@@ -1235,7 +1333,10 @@ struct DirectCapabilityParserAliasFocusedTests {
             ("gpt-oss-20b", "harmony", .glm4),
             ("glm-5.1-flash", "think_xml", .glm4),
             ("Ling-2.6-flash", "think_xml", .glm4),
-            ("hy3-preview", "think_xml", .hunyuan),
+            // Hunyuan v3 resolves to its OWN stamp, not think_xml: its think markers
+            // may carry the `:opensource` suffix that the plain think_xml parser
+            // cannot match. The hy_v3 parser accepts both spellings.
+            ("hy3-preview", "hy_v3", .hunyuan),
         ]
 
         for (modelType, expectedStamp, expectedTool) in heuristicCases {

--- a/Tests/MLXLMTests/CacheStoreBudgetTests.swift
+++ b/Tests/MLXLMTests/CacheStoreBudgetTests.swift
@@ -1,0 +1,114 @@
+// The prefix cache is an optimisation: a stored entry only ever makes some later
+// request faster. Storing one must therefore never be able to take the host down.
+//
+// It could. `storeCacheAfterGeneration` materialises the KV cache several times
+// over — a deep copy (`Evaluate.swift`), a host `Data` extract for the disk write,
+// and (when quantizing) another copy in `makeDiskStoreCache` — at the moment memory
+// is already at its high-water mark. Reported live on an M5 Max / 128 GB running
+// Llama-3.3-70B-8bit at a 64K context: the reporter's own footprint time series
+// showed prefill tracking expectation (75 -> 102 GiB), then +23 GiB immediately
+// after generation, inside the cache-store window — ~23 GiB being exactly the size
+// of the 62K-token KV cache. Free memory collapsed, page reclaim stalled, and the
+// kernel panicked. macOS will not jetsam a plain user process out of the way, so
+// nothing intervenes: the cap has to live here.
+//
+// These tests pin the arithmetic that decides whether the copies fit.
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite("Cache-store memory budget")
+struct CacheStoreBudgetTests {
+
+    private static let gib = 1 << 30
+
+    /// The reported panic, in numbers: a 70B 8-bit model already holds ~70 GB of
+    /// weights, the 64K-token KV cache is ~20 GiB more, and the store then wants
+    /// several more copies of that cache. It does not fit, and must be refused.
+    @Test("The 70B-at-64K store that panicked a 128 GB host is refused")
+    func longContextStoreOnFullHostIsRefused() {
+        let kv = 20 * Self.gib  // 80 layers x 2 x 8 kv-heads x 128 dim x 65536 x fp16
+        let active = 92 * Self.gib  // 70 GB weights + the live KV, already resident
+        let budget = 128 * Self.gib
+        #expect(
+            !CacheStoreBudget.canStore(cacheBytes: kv, activeBytes: active, budgetBytes: budget),
+            "storing this cache needs tens of GiB the host does not have — it must be skipped"
+        )
+    }
+
+    /// The guard must not disable the prefix cache for ordinary work. A normal chat
+    /// turn's cache is a rounding error against the budget.
+    @Test("An ordinary cache on a healthy host still stores")
+    func ordinaryStoreIsAllowed() {
+        let kv = 512 * (1 << 20)  // 512 MiB — a few thousand tokens
+        let active = 40 * Self.gib
+        let budget = 128 * Self.gib
+        #expect(
+            CacheStoreBudget.canStore(cacheBytes: kv, activeBytes: active, budgetBytes: budget))
+    }
+
+    /// The same cache that is refused on a full host is fine on an empty one:
+    /// the verdict is about headroom, not about the cache being "too big".
+    @Test("Headroom, not size, decides")
+    func sameCacheFitsWhenTheHostIsEmpty() {
+        let kv = 20 * Self.gib
+        let budget = 128 * Self.gib
+        #expect(
+            !CacheStoreBudget.canStore(
+                cacheBytes: kv, activeBytes: 92 * Self.gib, budgetBytes: budget))
+        #expect(
+            CacheStoreBudget.canStore(
+                cacheBytes: kv, activeBytes: 8 * Self.gib, budgetBytes: budget))
+    }
+
+    /// The refusal has to fire *before* the allocations, so the margin covers the
+    /// copies the store is about to make — not just the one it already made.
+    @Test("The budget counts every copy the store will make, plus a safety margin")
+    func budgetCountsAllMaterializations() {
+        #expect(CacheStoreBudget.materializationFactor >= 2)
+        #expect(CacheStoreBudget.safetyMarginBytes > 0)
+
+        // A cache sized so that one copy fits but the full store does not: the
+        // guard must refuse it. This is the case that panicked the host — the
+        // first copy succeeds, and the machine dies on a later one.
+        let budget = 128 * Self.gib
+        let active = 100 * Self.gib
+        let headroom = budget - active  // 28 GiB
+        let kv = headroom / 2  // one copy fits; factor x copies do not
+        #expect(
+            !CacheStoreBudget.canStore(cacheBytes: kv, activeBytes: active, budgetBytes: budget))
+    }
+
+    /// The guard must not quietly disable the prefix cache for the long-context
+    /// requests that most need it. With a 94 GiB pack resident on a 128 GB Mac, a
+    /// multi-thousand-token conversation still caches — it is only the runaway case
+    /// that is refused. (Budgeting against the GPU working set instead of physical
+    /// memory would cut this off around 15k tokens, which is why it doesn't.)
+    @Test("A long conversation still caches with a large model resident")
+    func longContextStillCachesUnderALargeResidentModel() {
+        let physical = 128 * Self.gib
+        let active = 96 * Self.gib  // a 94 GiB pack, resident
+        // Hy3 KV: 80 layers x 2 x 8 kv-heads x 128 dim x fp16 = 320 KiB/token.
+        let bytesPerToken = 80 * 2 * 8 * 128 * 2
+        for tokens in [2_000, 8_000, 16_000] {
+            #expect(
+                CacheStoreBudget.canStore(
+                    cacheBytes: tokens * bytesPerToken,
+                    activeBytes: active,
+                    budgetBytes: physical),
+                "a \(tokens)-token cache must still be storable on a healthy host"
+            )
+        }
+    }
+
+    /// No budget information is not a licence to block: an unknown budget means we
+    /// cannot reason, and a prefix cache that silently stops working everywhere
+    /// would be its own bug.
+    @Test("An unknown budget does not disable the cache")
+    func unknownBudgetDoesNotBlock() {
+        #expect(CacheStoreBudget.canStore(cacheBytes: 1 << 30, activeBytes: 0, budgetBytes: nil))
+        #expect(CacheStoreBudget.canStore(cacheBytes: 0, activeBytes: 0, budgetBytes: 0))
+    }
+}

--- a/Tests/MLXLMTests/UnclosedReasoningFlushOrderTests.swift
+++ b/Tests/MLXLMTests/UnclosedReasoningFlushOrderTests.swift
@@ -1,0 +1,138 @@
+// `GenerateCompletionInfo.unclosedReasoning` reports the "trapped thinking"
+// pathology: the stream ended while the model was still inside a reasoning
+// block, so the answer is stuck in the reasoning pane. Consumers surface it
+// as a warning (osaurus renders "⚠ thinking didn't close — answer may be in
+// reasoning above").
+//
+// It was reported for Hunyuan v3 on streams that closed perfectly cleanly —
+// `reasoning_content` and `content` came back correctly separated with
+// `finish_reason=stop`, and the warning still fired.
+//
+// The cause is an ordering bug, not a parser bug. The streaming detokenizer
+// withholds a trailing window of characters (`trailingHoldbackCharacters`)
+// so it never emits a partial UTF-8 grapheme; that held text only reaches
+// the reasoning parser when the generation loop flushes at EOS. Both engines
+// read `isInsideReasoning` BEFORE that flush — so any close marker short
+// enough to still be sitting in the holdback had not been parsed yet, and
+// the flag came back true.
+//
+// `</think:opensource>` is 20 characters against a 24-character holdback, so
+// it hides completely. `</think>` is 8 and clears it — which is why the whole
+// think_xml family looked fine and only Hunyuan v3 misreported.
+//
+// Reading the flag after the flush is not a fix either: `ReasoningParser.flush()`
+// ends by setting `insideReasoning = false` unconditionally, which would report
+// "closed" even for a model that genuinely stopped mid-thought — erasing the
+// signal this flag exists for. The state has to be captured in the window
+// between the two.
+//
+// Source-coverage style — no MLX runtime needed.
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite("unclosedReasoning is captured after the detokenizer flush")
+struct UnclosedReasoningFlushOrderTests {
+
+    private static func source(_ relativePath: String) throws -> String {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // MLXLMTests
+            .deletingLastPathComponent()  // Tests
+            .deletingLastPathComponent()  // repo root
+        let url =
+            root
+            .appendingPathComponent("Libraries/MLXLMCommon")
+            .appendingPathComponent(relativePath)
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    /// The precondition for the bug: Hunyuan v3's close marker is short enough
+    /// to sit entirely inside the detokenizer's held-back tail, so at the moment
+    /// the loop ends it has not been parsed yet.
+    @Test("Hy3's close marker fits inside the detokenizer holdback")
+    func closeMarkerFitsInsideHoldback() {
+        let hy3Close = "</think:opensource>"
+        #expect(hy3Close.count <= NaiveStreamingDetokenizer.trailingHoldbackCharacters)
+        // The plain marker clears the holdback, which is why the rest of the
+        // think_xml family never surfaced this.
+        #expect("</think>".count < NaiveStreamingDetokenizer.trailingHoldbackCharacters)
+    }
+
+    /// The mechanism, on the real parser: a stream whose close marker has not
+    /// yet been pumped through still reads as "inside reasoning". Once the held
+    /// tail arrives — exactly what the engines' end-of-stream flush does — the
+    /// parser closes. So the flag must be read after that pump, not before.
+    @Test("Parser reads as unclosed until the held-back tail is pumped through")
+    func heldBackCloseMarkerFlipsTheFlag() {
+        var parser = ReasoningParser(
+            startTag: "<think:opensource>",
+            endTag: "</think:opensource>",
+            startInReasoning: true)
+
+        // Everything the detokenizer has emitted so far: the reasoning body,
+        // with the close marker + answer still held in its 24-char tail.
+        _ = parser.feed("The user wants an exact string. I will output it.")
+        #expect(
+            parser.isInsideReasoning,
+            "before the held tail arrives the parser is legitimately still inside reasoning")
+
+        // The end-of-stream detokenizer flush delivers the held tail.
+        _ = parser.feed("</think:opensource>BANNER CHECK OK")
+        #expect(
+            !parser.isInsideReasoning,
+            "the close marker has now been parsed — the stream did NOT end inside reasoning")
+    }
+
+    /// A model that genuinely stops mid-thought must still be reported, so the
+    /// capture cannot simply move to after `ReasoningParser.flush()` — that call
+    /// clears the flag unconditionally.
+    @Test("flush() clears insideReasoning, so it cannot be the capture point")
+    func flushClearsTheFlag() {
+        var parser = ReasoningParser(
+            startTag: "<think:opensource>",
+            endTag: "</think:opensource>",
+            startInReasoning: true)
+        _ = parser.feed("thinking forever with no close tag")
+        #expect(parser.isInsideReasoning, "genuinely trapped: no close marker was ever emitted")
+
+        _ = parser.flush()
+        #expect(
+            !parser.isInsideReasoning,
+            "flush() clears the flag — reading here would erase the trapped-thinking signal")
+    }
+
+    /// Pin the fixed ordering in both engines: the flag is read after the flush
+    /// that pumps the detokenizer's held tail through the parser.
+    @Test("Both engines capture the flag after the end-of-stream flush")
+    func enginesCaptureAfterFlush() throws {
+        let evaluate = try Self.source("Evaluate.swift")
+        let flushCall = try #require(evaluate.range(of: "handler.onGenerationEnd(emit: continuation.yield)"))
+        let flagRead = try #require(
+            evaluate.range(
+                of: "let unclosedReasoning = handler.unclosedReasoning",
+                range: flushCall.upperBound ..< evaluate.endIndex),
+            "Evaluate must read unclosedReasoning AFTER onGenerationEnd flushes the detokenizer tail through the parser"
+        )
+        #expect(flushCall.upperBound <= flagRead.lowerBound)
+
+        // The handler snapshots the state in the window between the detokenizer
+        // flush and the parser flush, and reports that snapshot in preference to
+        // the live (already-cleared) parser state.
+        #expect(evaluate.contains("terminalInsideReasoning = reasoningParser?.isInsideReasoning ?? false"))
+        #expect(
+            evaluate.contains(
+                "terminalInsideReasoning ?? (reasoningParser?.isInsideReasoning ?? false)"))
+
+        let batch = try Self.source("BatchEngine/BatchEngine.swift")
+        #expect(batch.contains("var terminalInsideReasoning: Bool? = nil"))
+        #expect(
+            batch.contains(
+                "terminalInsideReasoning ?? (reasoningParser?.isInsideReasoning ?? false)"))
+        #expect(
+            !batch.contains("let unclosed = reasoningParser?.isInsideReasoning ?? false"),
+            "BatchEngine must not read the live parser state before flush()"
+        )
+    }
+}


### PR DESCRIPTION
## 1. The prefix-cache store could kill the machine

An external report had a 128 GB Mac kernel-panic under Llama-3.3-70B-8bit at 64K. Their own footprint time series exonerated prefill — it tracked expectation the whole way — and put the +23 GiB spike immediately **after** generation, in the cache-store window.

That is exactly what the store does: it materialises the KV cache several times over (a full snapshot copy, a host `Data` extract, then another copy for the disk-store cache), at the moment memory is already at its high-water mark. Nothing measured anything first, so a store that could not possibly fit was attempted anyway. macOS does not jetsam a plain user process out of the way, so page reclaim stalls, watchdogd starves, and the kernel panics.

`CacheStoreBudget` measures the cache **before any copy is made** and skips the store when the copies would not fit. A skipped store costs one slower request; an unchecked store costs the machine.

Wired into all four store paths — `Evaluate`, `BatchEngine`, `BlockDiffusion` (both the prompt store and the per-boundary loop, which re-checks because one affordable store does not prove N more are), and `NativeMTP`.

`makeDiskStoreCache` also duplicated the whole KV for nothing: that copy exists only to protect the snapshot from `maybeQuantizeKVCache`'s in-place mutation, which is a no-op when nothing will be quantized — the exact path the prompt-boundary store takes. Elided.

The guard does not disable caching in ordinary use: an 8B model at 8K on a 128 GB Mac projects ~15 GiB against a 128 GB ceiling, and even a 94 GB model resident with an 8K KV projects ~102 GiB. Only the long-context panic case (~178 GiB) is refused.

## 2. Hunyuan v3 packs with a bare marker lost their entire answer

HY3's chat template writes every protocol marker through one variable (`'<think{}>'.format(HYTK)`). The open-source packs set it to `:opensource`; the preview conversions leave it **empty** and emit a bare `</think>`.

Our reasoning parser knew only the suffixed spelling **and starts inside reasoning**. So on a bare-marker pack the close marker never matched: the model's whole reply — tool calls included — was routed to reasoning, and the user saw an **empty answer**. Reproduced directly: streaming a bare-marker turn yielded `visible=""` and zero tool calls. `HunyuanToolCallParser` already accepted both spellings; only the reasoning side was blind.

`ReasoningParser` now takes marker aliases (**empty by default, so every other family is byte-for-byte untouched**), carried through `forPrompt`, and sized into the partial-tag holdback. A match that could still grow into a longer spelling is held back rather than consumed, so no alias can close a block early and leak the rest of a marker as visible text.

## 3. `unclosedReasoning` was read before the tail it depends on was parsed

The detokenizer holds back 24 characters; `</think:opensource>` is 20 — so the close marker was still sitting in the holdback when the flag was read, and the "thinking didn't close" warning fired on a perfectly clean parse. The flag is now captured **between** the detokenizer flush and the parser flush: after the held tail has been pumped through, before `flush()` unconditionally clears the state.

## Tests

The focused suite **crashed on main** (`Fatal error: Index out of range`, from a Hy3 parse that returned nothing). It now runs clean.

Verified against a clean worktree of `main` at `31b165cb`: this branch introduces **zero new failures**. Main is red on 8 tests in this filter; this branch is red on 6 — the same 6 — and fixes the other 2 (`ParserResolution facade`, `terminal info snapshots unclosed reasoning`) plus the crash. The stale expectations those encoded — that `hy_v3` stamps to `think_xml`, which would not match the suffixed markers at all — are corrected to the real contract.

New tests: `CacheStoreBudgetTests` (pins the arithmetic including the exact 70B@64K panic case, and that ordinary contexts still cache), `UnclosedReasoningFlushOrderTests` (pins the capture window in both engines), and Hy3 parser tests covering both marker spellings and a character-by-character split of `</think:opensource>`.