### PR TITLE
Scale the cache-store safety margin to the host, and pin Hy3's stamp demotion

### DIFF
--- a/Libraries/MLXLMCommon/Cache/CacheStoreBudget.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheStoreBudget.swift
@@ -34,7 +34,17 @@ public enum CacheStoreBudget {
 
     /// Headroom kept free for everything else in flight — activations, the disk
     /// write buffer, and the rest of the system.
-    static let safetyMarginBytes = 4 << 30  // 4 GiB
+    ///
+    /// Scaled to the host, not fixed. A flat 4 GiB reserve is right on a 128 GB
+    /// Mac and nonsense on an 8 GB one: with a 4.5 GB model resident, `active +
+    /// 0 + 4 GiB` already exceeds 8 GB, so the guard would refuse EVERY store —
+    /// silently disabling the prefix cache on exactly the machines whose users
+    /// most notice a slow re-prefill. An eighth of RAM keeps the same absolute
+    /// headroom on large hosts (128 GB → 4 GiB, unchanged) while staying
+    /// proportionate on small ones (8 GB → 1 GiB).
+    static func safetyMarginBytes(budgetBytes: Int) -> Int {
+        min(4 << 30, budgetBytes / 8)
+    }
 
     /// Live bytes held by a KV cache, without copying its contents.
     ///
@@ -82,7 +92,7 @@ public enum CacheStoreBudget {
             return true
         }
         let storeCost = liveBytes * materializationFactor
-        let projected = activeBytes + storeCost + safetyMarginBytes
+        let projected = activeBytes + storeCost + safetyMarginBytes(budgetBytes: budgetBytes)
         return projected <= budgetBytes
     }
 }

--- a/Tests/MLXLMCommonFocusedTests/NoHiddenReasoningCloseBiasFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NoHiddenReasoningCloseBiasFocusedTests.swift
@@ -717,6 +717,56 @@ struct Hy3ParserFocusedTests {
         }
     }
 
+    /// The shipped Hunyuan v3 bundles stamp `reasoning_parser: "qwen3"` — a
+    /// plain-`<think>` parser that can NEVER match `</think:opensource>`. Honouring
+    /// that stamp would leave the close marker unmatched and the model's whole
+    /// answer, raw protocol markers and all, in the visible reply.
+    ///
+    /// `shouldIgnoreReasoningStamp` demotes the bogus stamp back to the model-type
+    /// resolver, which returns the hy_v3 parser. That demotion is the only thing
+    /// standing between the user and a marker leak, so pin the WHOLE chain — the
+    /// real bundle's capabilities in, a parser that actually closes on the model's
+    /// markers out — not just `fromCapabilityName` in isolation.
+    @Test("Hy3's bogus qwen3 reasoning stamp is demoted, not honoured")
+    func hy3BogusQwen3StampIsDemoted() {
+        // Verbatim from Hy3-JANG_2K's jang_config.json.
+        let shipped = JangCapabilities(
+            reasoningParser: "qwen3",
+            toolParser: "hunyuan",
+            thinkInTemplate: false,
+            supportsTools: true,
+            supportsThinking: true,
+            family: "hy_v3")
+
+        #expect(
+            ParserResolution.shouldIgnoreReasoningStamp(
+                capabilities: shipped, modelType: "hy_v3"),
+            "honouring the qwen3 stamp would leak every marker into the answer")
+
+        let resolved = ParserResolution.reasoning(
+            capabilities: shipped,
+            modelType: "hy_v3",
+            chatTemplate: "{%- set HYTK = ':opensource' %}<think:opensource>")
+        #expect(resolved.source == .modelTypeHeuristic)
+
+        var parser = try! #require(resolved.parser)
+        var reasoning = ""
+        var visible = ""
+        for segment in parser.feed("deciding</think:opensource>The answer is 42.") {
+            switch segment {
+            case .reasoning(let text): reasoning += text
+            case .content(let text): visible += text
+            }
+        }
+        for segment in parser.flush() {
+            if case .content(let text) = segment { visible += text }
+        }
+
+        #expect(reasoning == "deciding")
+        #expect(visible == "The answer is 42.")
+        #expect(!visible.contains(":opensource"))
+    }
+
     /// The bare `</think>` alias is a strict PREFIX of `</think:opensource>`, and
     /// the suffix arrives in a later chunk. A parser that accepts the short
     /// spelling the moment it appears would close reasoning early and then emit

--- a/Tests/MLXLMTests/CacheStoreBudgetTests.swift
+++ b/Tests/MLXLMTests/CacheStoreBudgetTests.swift
@@ -68,7 +68,7 @@ struct CacheStoreBudgetTests {
     @Test("The budget counts every copy the store will make, plus a safety margin")
     func budgetCountsAllMaterializations() {
         #expect(CacheStoreBudget.materializationFactor >= 2)
-        #expect(CacheStoreBudget.safetyMarginBytes > 0)
+        #expect(CacheStoreBudget.safetyMarginBytes(budgetBytes: 128 * Self.gib) > 0)
 
         // A cache sized so that one copy fits but the full store does not: the
         // guard must refuse it. This is the case that panicked the host — the
@@ -79,6 +79,32 @@ struct CacheStoreBudgetTests {
         let kv = headroom / 2  // one copy fits; factor x copies do not
         #expect(
             !CacheStoreBudget.canStore(cacheBytes: kv, activeBytes: active, budgetBytes: budget))
+    }
+
+    /// A flat 4 GiB reserve is right on a 128 GB Mac and nonsense on an 8 GB one:
+    /// with a 4.5 GiB model resident, `active + 0 + 4 GiB` already exceeds 8 GiB,
+    /// so the guard would refuse EVERY store — silently disabling the prefix cache
+    /// on the machines whose users most notice a slow re-prefill. The margin scales
+    /// with the host, so a small Mac running a small model still caches.
+    @Test("A small Mac running a small model still caches")
+    func smallHostStillCaches() {
+        // 8 GB Mac, ~4.5 GiB 8B 4-bit model resident, 4k-token KV (~0.5 GiB).
+        let budget = 8 * Self.gib
+        let active = 9 * Self.gib / 2
+        #expect(
+            CacheStoreBudget.canStore(
+                cacheBytes: Self.gib / 2, activeBytes: active, budgetBytes: budget),
+            "an 8 GB host must not have its prefix cache silently disabled")
+
+        // 16 GB Mac, same model, a much longer 32k context (~4 GiB of KV): three
+        // copies of that genuinely will not fit, so this one is still refused.
+        #expect(
+            !CacheStoreBudget.canStore(
+                cacheBytes: 4 * Self.gib, activeBytes: active, budgetBytes: 16 * Self.gib))
+
+        // The margin never exceeds the original 4 GiB on a large host.
+        #expect(CacheStoreBudget.safetyMarginBytes(budgetBytes: 128 * Self.gib) == 4 << 30)
+        #expect(CacheStoreBudget.safetyMarginBytes(budgetBytes: 8 * Self.gib) == Self.gib)
     }
 
     /// The guard must not quietly disable the prefix cache for the long-context


### PR DESCRIPTION
Two follow-ups to the cache-store guard in #139.

## 1. The flat 4 GiB margin silently disabled the prefix cache on small Macs

The guard checks `active + 3 × KV + margin ≤ physicalMemory`. A **flat 4 GiB** margin is right on a 128 GB host and nonsense on an 8 GB one: with a 4.5 GiB model resident, `active + 4 GiB` already exceeds 8 GiB — so the guard refused **every** store, even one whose copies would have fit comfortably. That silently disables the prefix cache on exactly the machines whose users most notice a slow re-prefill.

The margin now scales with the host (an eighth of RAM, capped at the original 4 GiB):

- 128 GB → 4 GiB. **Identical to today**, and the 64K panic case is still refused (~178 GiB projected).
- 8 GB → 1 GiB. A small model with a 4k context caches again.
- 16 GB with a 32k context → still refused, because three copies of that KV genuinely do not fit.

## 2. Pin the demotion that keeps Hunyuan v3's markers out of the visible answer

The shipped HY3 bundles stamp `reasoning_parser: "qwen3"` — a plain-`<think>` parser that can **never** match `</think:opensource>`. `shouldIgnoreReasoningStamp` demotes that bogus stamp back to the model-type resolver, and that demotion is the only thing standing between the user and a marker leak: honour the stamp and the model's whole answer, raw markers and all, lands in the visible reply.

#139 made the *parser* correct, but nothing pinned the *wiring* that reaches it — so a change to stamp precedence could have silently reintroduced the leak with every parser test still green. This pins the whole chain: the real bundle's capabilities in, a parser that actually closes on the model's markers out.

Found by an adversarial review that reconstructed the parser from the raw stamp and reproduced exactly that leak — the demotion is what the production path does differently.