### PR TITLE
Make the memory-safety level reach the prefix-cache store, and stop overcounting it

### DIFF
--- a/Libraries/MLXLMCommon/Cache/CacheStoreBudget.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheStoreBudget.swift
@@ -3,48 +3,85 @@
 import Foundation
 import MLX
 
+/// How much of the host's remaining memory a single prefix-cache store may take.
+///
+/// This is the engine-side projection of the user's memory-safety level. The
+/// resolver in `ServerRuntimeSettings` turns that level into load-time caps
+/// (`LoadConfiguration.memoryLimit` / `maxResidentBytes`); this carries the same
+/// level down to the one runtime decision those caps cannot reach, because
+/// `CacheStoreBudget` runs deep inside the decode loop with no settings handle.
+/// The host sets `CacheStoreBudget.policy` before each load, exactly as it
+/// already sets `TiedHeadQuantizationPolicy.current`.
+///
+/// A fraction of *free headroom*, deliberately — not a ceiling on total memory.
+/// The load caps are a graph-scheduling guideline, not a hard resident limit, so
+/// a large pack legitimately runs with `activeMemory` above them (Hy3 sits at
+/// ~96 GB on a 128 GB Mac under the default 0.70 load cap). Treating a load cap
+/// as a store ceiling would put `activeBytes` over budget before a single KV byte
+/// and refuse *every* store — silently killing the prefix cache for precisely the
+/// large models whose re-prefill hurts most. Scaling the *increment* instead lets
+/// the safety level bite without that collapse.
+public struct CacheStorePolicy: Sendable, Equatable {
+
+    /// Share of current free headroom (`physical - active`) that one store may use.
+    public var headroomFraction: Double
+
+    public init(headroomFraction: Double) {
+        self.headroomFraction = min(max(headroomFraction, 0), 1)
+    }
+
+    public static let performance = CacheStorePolicy(headroomFraction: 0.45)
+    public static let balanced = CacheStorePolicy(headroomFraction: 0.35)
+    public static let safeAuto = CacheStorePolicy(headroomFraction: 0.25)
+    public static let strict = CacheStorePolicy(headroomFraction: 0.15)
+    public static let diagnosticDangerous = CacheStorePolicy(headroomFraction: 0.55)
+}
+
 /// Whether a KV cache can be *saved* without pushing the host over a cliff.
 ///
 /// The prefix cache is an optimisation: a stored entry only ever makes a later
 /// request faster. Storing one must therefore never be able to take the machine
 /// down — but until this guard existed, it could.
 ///
-/// `storeCacheAfterGeneration` materialises the cache up to three times over,
-/// at the exact moment memory is already at its high-water mark:
+/// Reported live on an M5 Max / 128 GB running Llama-3.3-70B-8bit at a 64K
+/// context: prefill tracked expectation (75 → 102 GiB), then +23 GiB landed
+/// immediately after generation, inside the cache-store window — ~23 GiB being
+/// exactly the size of the 62K-token KV cache. Free memory collapsed, page
+/// reclaim stalled, and the kernel panicked. macOS will not jetsam a plain user
+/// process out of the way, so nothing intervenes: the cap has to live here.
 ///
-///   1. `cacheToStore.map { $0.copy() }`   — a full duplicate of the live KV
-///   2. `extractLayerData(from: snapshot)` — again, as host `Data`, for the disk write
-///   3. `makeDiskStoreCache(...)`          — and again, as the disk-store cache
-///
-/// For a 70B 8-bit model with a 64K-token context that is ~70 GB of weights plus
-/// a ~20 GiB live KV cache, and then the store adds tens of GiB more. On a 128 GB
-/// host, free memory collapses. macOS will not jetsam a plain user process out of
-/// the way, so nothing intervenes: page reclaim stalls, watchdogd starves, and the
-/// kernel panics — reported live on an M5 Max/128 GB with Llama-3.3-70B-8bit at 64K,
-/// with the panic landing inside `storeCacheAfterGeneration` / `DiskCache.store`.
-///
-/// So: measure first, and if the copies would not fit, skip the store. A skipped
-/// store costs one slower request. An unchecked store costs the machine.
+/// So: measure first, and if the store would not fit, skip it. A skipped store
+/// costs one slower request. An unchecked store costs the machine.
 public enum CacheStoreBudget {
 
-    /// How many times the store materialises the cache (snapshot + host-`Data`
-    /// extract + disk-store cache). Deliberately conservative: undercounting here
-    /// is what made the original panic possible.
-    static let materializationFactor = 3
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var _policy: CacheStorePolicy = .safeAuto
 
-    /// Headroom kept free for everything else in flight — activations, the disk
-    /// write buffer, and the rest of the system.
-    ///
-    /// Scaled to the host, not fixed. A flat 4 GiB reserve is right on a 128 GB
-    /// Mac and nonsense on an 8 GB one: with a 4.5 GB model resident, `active +
-    /// 0 + 4 GiB` already exceeds 8 GB, so the guard would refuse EVERY store —
-    /// silently disabling the prefix cache on exactly the machines whose users
-    /// most notice a slow re-prefill. An eighth of RAM keeps the same absolute
-    /// headroom on large hosts (128 GB → 4 GiB, unchanged) while staying
-    /// proportionate on small ones (8 GB → 1 GiB).
-    static func safetyMarginBytes(budgetBytes: Int) -> Int {
-        min(4 << 30, budgetBytes / 8)
+    /// The user's memory-safety level, projected onto this decision. Set by the
+    /// host before each model load; defaults to the same Safe Auto the settings
+    /// resolver defaults to, so an embedder that never sets it is unaffected.
+    public static var policy: CacheStorePolicy {
+        get { lock.withLock { _policy } }
+        set { lock.withLock { _policy = newValue } }
     }
+
+    /// Peak *additional* full-KV materialisation the store performs, in units of
+    /// the live cache.
+    ///
+    /// One, not three. An earlier revision of this guard claimed three copies —
+    /// a deep copy, a host `Data` extract, and the disk-store cache — and none of
+    /// the three survive contact with the code: `KVCacheSimple.copy()` takes
+    /// full-range slices that share the source buffer, `extractLayerData` returns
+    /// references, `makeDiskStoreCache` returns the snapshot unchanged on the raw
+    /// path, and `mlx_save_safetensors` streams to the file descriptor rather than
+    /// building a host `Data`. What is left is the `contiguous` pass the writer
+    /// makes before writing, which can allocate at most one compact copy of the
+    /// logical KV. The reporter's own footprint series agrees: the excursion was
+    /// +23 GiB against a 23 GiB cache — one copy, not three.
+    ///
+    /// Overcounting is not free: at 3x this refused stores that fit, quietly
+    /// costing the cache hits it was never meant to cost.
+    static let materializationFactor = 1
 
     /// Live bytes held by a KV cache, without copying its contents.
     ///
@@ -67,13 +104,6 @@ public enum CacheStoreBudget {
     /// only means macOS pages the excess — slow, survivable — whereas exhausting
     /// physical memory is what actually kills the host, and that is the only thing
     /// this guard exists to prevent.
-    ///
-    /// Using the working set here would also be needlessly destructive: with a
-    /// large model resident (say 96 GB of a 107 GiB working set) it would refuse to
-    /// cache anything past ~15k tokens, disabling the prefix cache for exactly the
-    /// long-context requests that most need it. Against physical memory the same
-    /// host still caches ~38k tokens, and the request that panicked a 128 GB Mac is
-    /// still refused.
     public static func canStore(_ cache: [KVCache]) -> Bool {
         let liveBytes = cacheBytes(cache)
         guard liveBytes > 0 else { return true }
@@ -81,18 +111,30 @@ public enum CacheStoreBudget {
     }
 
     /// Testable core: no MLX state, just the arithmetic.
+    ///
+    /// `active + storeCost + margin <= budget`, where the margin is whatever share
+    /// of the headroom the user's safety level says to leave alone. Equivalently,
+    /// and more directly: the store may consume `headroomFraction` of the memory
+    /// the host still has free.
     static func canStore(
         cacheBytes liveBytes: Int,
         activeBytes: Int = max(0, MLX.Memory.activeMemory),
-        budgetBytes: Int? = Int(exactly: ProcessInfo.processInfo.physicalMemory)
+        budgetBytes: Int? = Int(exactly: ProcessInfo.processInfo.physicalMemory),
+        policy: CacheStorePolicy = CacheStoreBudget.policy
     ) -> Bool {
         guard liveBytes > 0 else { return true }
         guard let budgetBytes, budgetBytes > 0 else {
             // No budget to reason about: don't guess, don't block.
             return true
         }
-        let storeCost = liveBytes * materializationFactor
-        let projected = activeBytes + storeCost + safetyMarginBytes(budgetBytes: budgetBytes)
-        return projected <= budgetBytes
+        // Already over the wall: nothing to hand out.
+        guard activeBytes < budgetBytes else { return false }
+
+        let headroom = budgetBytes - activeBytes
+        let allowance = Int(Double(headroom) * policy.headroomFraction)
+        // Overflow-safe: liveBytes and the factor are both bounded well below
+        // Int.max/2 in practice, but compare in the division direction anyway.
+        guard materializationFactor > 0 else { return true }
+        return liveBytes <= allowance / materializationFactor
     }
 }

--- a/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
+++ b/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
@@ -1245,11 +1245,53 @@ public enum VMLXMemorySafetyMode: String, Codable, Sendable, Equatable, CaseIter
     case safeAuto = "safe_auto"
     case strict
     case diagnosticDangerous = "diagnostic_dangerous"
+
+    /// The 0...4 "Safety Level" the host renders as a slider. The two are the same
+    /// choice in two spellings, in `allCases` order.
+    public var sliderIndex: Int {
+        Self.allCases.firstIndex(of: self) ?? 2
+    }
+
+    public init(sliderIndex: Int) {
+        let clamped = min(max(sliderIndex, 0), Self.allCases.count - 1)
+        self = Self.allCases[clamped]
+    }
+
+    /// This level, projected onto the one memory decision the load-time caps cannot
+    /// reach: how much of the host's free headroom a single prefix-cache store may
+    /// take. `CacheStoreBudget` runs inside the decode loop with no settings handle,
+    /// so the host pushes this to `CacheStoreBudget.policy` before each load.
+    public var cacheStorePolicy: CacheStorePolicy {
+        switch self {
+        case .performance: return .performance
+        case .balanced: return .balanced
+        case .safeAuto: return .safeAuto
+        case .strict: return .strict
+        case .diagnosticDangerous: return .diagnosticDangerous
+        }
+    }
 }
 
 public struct VMLXMemorySafetySettings: Codable, Sendable, Equatable {
     public var mode: VMLXMemorySafetyMode
-    public var slider: Int
+
+    /// The 0...4 safety level, as a view onto `mode` rather than a field beside it.
+    ///
+    /// It used to be stored, and nothing ever read it: every resolver switches on
+    /// `mode`, so a host that wired its "Safety Level" slider to `slider` (osaurus
+    /// does) moved a control that changed nothing, while the resolved-plan readout
+    /// printed the new level next to the old, still-in-force caps. Making it a
+    /// projection of `mode` means the slider and the mode picker cannot disagree,
+    /// and the slider starts doing what it always claimed to.
+    ///
+    /// `mode` stays the single source of truth — decoding ignores any persisted
+    /// `slider`, so an existing user's safety level does not shift under them on
+    /// upgrade; only the number shown for it gets honest.
+    public var slider: Int {
+        get { mode.sliderIndex }
+        set { mode = VMLXMemorySafetyMode(sliderIndex: newValue) }
+    }
+
     public var allowExperimentalMLXPress: Bool
     public var failClosedWhenEstimateUnknown: Bool
     public var customPhysicalMemoryFraction: Double?
@@ -1257,9 +1299,52 @@ public struct VMLXMemorySafetySettings: Codable, Sendable, Equatable {
     public var customDefaultMaxKVSize: Int?
     public var customMaxConcurrentSequences: Int?
 
+    private enum CodingKeys: String, CodingKey {
+        case mode
+        case slider
+        case allowExperimentalMLXPress
+        case failClosedWhenEstimateUnknown
+        case customPhysicalMemoryFraction
+        case customAllocatorCacheBytes
+        case customDefaultMaxKVSize
+        case customMaxConcurrentSequences
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        // `mode` wins over any persisted `slider`. A user whose stored settings
+        // disagree (they dragged the slider back when it did nothing) keeps the
+        // safety level the engine has actually been enforcing for them.
+        self.mode = try c.decodeIfPresent(VMLXMemorySafetyMode.self, forKey: .mode) ?? .safeAuto
+        self.allowExperimentalMLXPress =
+            try c.decodeIfPresent(Bool.self, forKey: .allowExperimentalMLXPress) ?? false
+        self.failClosedWhenEstimateUnknown =
+            try c.decodeIfPresent(Bool.self, forKey: .failClosedWhenEstimateUnknown) ?? false
+        self.customPhysicalMemoryFraction =
+            try c.decodeIfPresent(Double.self, forKey: .customPhysicalMemoryFraction)
+        self.customAllocatorCacheBytes =
+            try c.decodeIfPresent(UInt64.self, forKey: .customAllocatorCacheBytes)
+        self.customDefaultMaxKVSize =
+            try c.decodeIfPresent(Int.self, forKey: .customDefaultMaxKVSize)
+        self.customMaxConcurrentSequences =
+            try c.decodeIfPresent(Int.self, forKey: .customMaxConcurrentSequences)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(mode, forKey: .mode)
+        // Still emitted so the persisted/API shape is unchanged for readers.
+        try c.encode(slider, forKey: .slider)
+        try c.encode(allowExperimentalMLXPress, forKey: .allowExperimentalMLXPress)
+        try c.encode(failClosedWhenEstimateUnknown, forKey: .failClosedWhenEstimateUnknown)
+        try c.encodeIfPresent(customPhysicalMemoryFraction, forKey: .customPhysicalMemoryFraction)
+        try c.encodeIfPresent(customAllocatorCacheBytes, forKey: .customAllocatorCacheBytes)
+        try c.encodeIfPresent(customDefaultMaxKVSize, forKey: .customDefaultMaxKVSize)
+        try c.encodeIfPresent(customMaxConcurrentSequences, forKey: .customMaxConcurrentSequences)
+    }
+
     public init(
         mode: VMLXMemorySafetyMode = .safeAuto,
-        slider: Int = 2,
         allowExperimentalMLXPress: Bool = false,
         failClosedWhenEstimateUnknown: Bool = false,
         customPhysicalMemoryFraction: Double? = nil,
@@ -1268,7 +1353,6 @@ public struct VMLXMemorySafetySettings: Codable, Sendable, Equatable {
         customMaxConcurrentSequences: Int? = nil
     ) {
         self.mode = mode
-        self.slider = slider
         self.allowExperimentalMLXPress = allowExperimentalMLXPress
         self.failClosedWhenEstimateUnknown = failClosedWhenEstimateUnknown
         self.customPhysicalMemoryFraction = customPhysicalMemoryFraction
@@ -1279,11 +1363,8 @@ public struct VMLXMemorySafetySettings: Codable, Sendable, Equatable {
 
     public func validationIssues() -> [VMLXServerSettingsIssue] {
         var issues: [VMLXServerSettingsIssue] = []
-        if !(0...4).contains(slider) {
-            issues.append(.error(
-                field: "memorySafety.slider",
-                message: "Memory safety slider must be between 0 and 4."))
-        }
+        // `slider` no longer needs a range check: it is a projection of `mode`,
+        // and its setter clamps into `allCases`, so it cannot leave 0...4.
         if let fraction = customPhysicalMemoryFraction,
            fraction <= 0 || fraction > 1 {
             issues.append(.error(

--- a/Tests/MLXLMCommonFocusedTests/VMLXMemorySafetySettingsTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/VMLXMemorySafetySettingsTests.swift
@@ -57,6 +57,11 @@ struct VMLXMemorySafetySettingsTests {
         #expect(generate.repetitionPenalty == nil)
     }
 
+    /// The slider no longer needs validating: it is a projection of `mode` and its
+    /// setter clamps into range, so an out-of-range level is not expressible. It
+    /// used to be a stored field that nothing read, which is why it could be both
+    /// "9" and an error at the same time. Clamping is asserted in
+    /// `MemorySafetyLevelTests`; here we only pin that it no longer reports.
     @Test("validation rejects invalid custom values")
     func validationRejectsInvalidCustomValues() {
         var settings = VMLXServerRuntimeSettings()
@@ -68,7 +73,8 @@ struct VMLXMemorySafetySettingsTests {
 
         let fields = Set(settings.validationIssues().map(\.field))
 
-        #expect(fields.contains("memorySafety.slider"))
+        #expect(settings.memorySafety.mode == .diagnosticDangerous, "9 clamps to the top level")
+        #expect(!fields.contains("memorySafety.slider"))
         #expect(fields.contains("memorySafety.customPhysicalMemoryFraction"))
         #expect(fields.contains("memorySafety.customAllocatorCacheBytes"))
         #expect(fields.contains("memorySafety.customDefaultMaxKVSize"))

--- a/Tests/MLXLMTests/CacheStoreBudgetTests.swift
+++ b/Tests/MLXLMTests/CacheStoreBudgetTests.swift
@@ -1,18 +1,16 @@
 // The prefix cache is an optimisation: a stored entry only ever makes some later
 // request faster. Storing one must therefore never be able to take the host down.
 //
-// It could. `storeCacheAfterGeneration` materialises the KV cache several times
-// over — a deep copy (`Evaluate.swift`), a host `Data` extract for the disk write,
-// and (when quantizing) another copy in `makeDiskStoreCache` — at the moment memory
-// is already at its high-water mark. Reported live on an M5 Max / 128 GB running
-// Llama-3.3-70B-8bit at a 64K context: the reporter's own footprint time series
-// showed prefill tracking expectation (75 -> 102 GiB), then +23 GiB immediately
-// after generation, inside the cache-store window — ~23 GiB being exactly the size
-// of the 62K-token KV cache. Free memory collapsed, page reclaim stalled, and the
-// kernel panicked. macOS will not jetsam a plain user process out of the way, so
-// nothing intervenes: the cap has to live here.
+// It could. Reported live on an M5 Max / 128 GB running Llama-3.3-70B-8bit at a
+// 64K context: the reporter's own footprint time series showed prefill tracking
+// expectation (75 -> 102 GiB), then +23 GiB immediately after generation, inside
+// the cache-store window — ~23 GiB being exactly the size of the 62K-token KV
+// cache. Free memory collapsed, page reclaim stalled, and the kernel panicked.
+// macOS will not jetsam a plain user process out of the way, so nothing
+// intervenes: the cap has to live here.
 //
-// These tests pin the arithmetic that decides whether the copies fit.
+// These tests pin the arithmetic that decides whether the store fits, and pin it
+// to the user's memory-safety level rather than to a number we picked.
 
 import Foundation
 import Testing
@@ -24,16 +22,21 @@ struct CacheStoreBudgetTests {
 
     private static let gib = 1 << 30
 
+    /// Every case below runs at the shipped default unless it says otherwise, so
+    /// the default is what the assertions are really about.
+    private static let safeAuto = CacheStorePolicy.safeAuto
+
     /// The reported panic, in numbers: a 70B 8-bit model already holds ~70 GB of
     /// weights, the 64K-token KV cache is ~20 GiB more, and the store then wants
-    /// several more copies of that cache. It does not fit, and must be refused.
+    /// another copy of that cache. It does not fit, and must be refused.
     @Test("The 70B-at-64K store that panicked a 128 GB host is refused")
     func longContextStoreOnFullHostIsRefused() {
         let kv = 20 * Self.gib  // 80 layers x 2 x 8 kv-heads x 128 dim x 65536 x fp16
         let active = 92 * Self.gib  // 70 GB weights + the live KV, already resident
-        let budget = 128 * Self.gib
         #expect(
-            !CacheStoreBudget.canStore(cacheBytes: kv, activeBytes: active, budgetBytes: budget),
+            !CacheStoreBudget.canStore(
+                cacheBytes: kv, activeBytes: active, budgetBytes: 128 * Self.gib,
+                policy: Self.safeAuto),
             "storing this cache needs tens of GiB the host does not have — it must be skipped"
         )
     }
@@ -42,11 +45,12 @@ struct CacheStoreBudgetTests {
     /// turn's cache is a rounding error against the budget.
     @Test("An ordinary cache on a healthy host still stores")
     func ordinaryStoreIsAllowed() {
-        let kv = 512 * (1 << 20)  // 512 MiB — a few thousand tokens
-        let active = 40 * Self.gib
-        let budget = 128 * Self.gib
         #expect(
-            CacheStoreBudget.canStore(cacheBytes: kv, activeBytes: active, budgetBytes: budget))
+            CacheStoreBudget.canStore(
+                cacheBytes: 512 * (1 << 20),  // 512 MiB — a few thousand tokens
+                activeBytes: 40 * Self.gib,
+                budgetBytes: 128 * Self.gib,
+                policy: Self.safeAuto))
     }
 
     /// The same cache that is refused on a full host is fine on an empty one:
@@ -57,61 +61,67 @@ struct CacheStoreBudgetTests {
         let budget = 128 * Self.gib
         #expect(
             !CacheStoreBudget.canStore(
-                cacheBytes: kv, activeBytes: 92 * Self.gib, budgetBytes: budget))
+                cacheBytes: kv, activeBytes: 92 * Self.gib, budgetBytes: budget,
+                policy: Self.safeAuto))
         #expect(
             CacheStoreBudget.canStore(
-                cacheBytes: kv, activeBytes: 8 * Self.gib, budgetBytes: budget))
+                cacheBytes: kv, activeBytes: 8 * Self.gib, budgetBytes: budget,
+                policy: Self.safeAuto))
     }
 
-    /// The refusal has to fire *before* the allocations, so the margin covers the
-    /// copies the store is about to make — not just the one it already made.
-    @Test("The budget counts every copy the store will make, plus a safety margin")
-    func budgetCountsAllMaterializations() {
-        #expect(CacheStoreBudget.materializationFactor >= 2)
-        #expect(CacheStoreBudget.safetyMarginBytes(budgetBytes: 128 * Self.gib) > 0)
-
-        // A cache sized so that one copy fits but the full store does not: the
-        // guard must refuse it. This is the case that panicked the host — the
-        // first copy succeeds, and the machine dies on a later one.
-        let budget = 128 * Self.gib
-        let active = 100 * Self.gib
-        let headroom = budget - active  // 28 GiB
-        let kv = headroom / 2  // one copy fits; factor x copies do not
+    /// A host already past its own physical memory has nothing to hand out. This is
+    /// the degenerate end of the headroom calculation and must not underflow into
+    /// an accidental "yes".
+    @Test("A host already over budget stores nothing")
+    func overBudgetHostRefuses() {
         #expect(
-            !CacheStoreBudget.canStore(cacheBytes: kv, activeBytes: active, budgetBytes: budget))
+            !CacheStoreBudget.canStore(
+                cacheBytes: 1 << 20, activeBytes: 130 * Self.gib, budgetBytes: 128 * Self.gib,
+                policy: Self.safeAuto))
+    }
+
+    /// The store copies the cache once — not three times.
+    ///
+    /// An earlier revision of this guard budgeted for three materialisations (a deep
+    /// copy, a host `Data` extract, and the disk-store cache) and none of the three
+    /// exist: `copy()` takes buffer-sharing slices, `extractLayerData` returns
+    /// references, `makeDiskStoreCache` is a no-op on the raw path, and the
+    /// safetensors writer streams to the fd. The reporter's own numbers say the same
+    /// thing — a 23 GiB excursion against a 23 GiB cache. Overcounting is not free:
+    /// at 3x this refused stores that fit.
+    @Test("The store is budgeted at one copy of the cache, matching the reported excursion")
+    func materializationFactorMatchesTheEvidence() {
+        #expect(CacheStoreBudget.materializationFactor == 1)
     }
 
     /// A flat 4 GiB reserve is right on a 128 GB Mac and nonsense on an 8 GB one:
     /// with a 4.5 GiB model resident, `active + 0 + 4 GiB` already exceeds 8 GiB,
-    /// so the guard would refuse EVERY store — silently disabling the prefix cache
-    /// on the machines whose users most notice a slow re-prefill. The margin scales
-    /// with the host, so a small Mac running a small model still caches.
+    /// so a fixed margin would refuse EVERY store — silently disabling the prefix
+    /// cache on the machines whose users most notice a slow re-prefill. A share of
+    /// headroom scales on its own.
     @Test("A small Mac running a small model still caches")
     func smallHostStillCaches() {
         // 8 GB Mac, ~4.5 GiB 8B 4-bit model resident, 4k-token KV (~0.5 GiB).
-        let budget = 8 * Self.gib
+        // Headroom 3.5 GiB, of which Safe Auto lends 25% = 0.875 GiB.
         let active = 9 * Self.gib / 2
         #expect(
             CacheStoreBudget.canStore(
-                cacheBytes: Self.gib / 2, activeBytes: active, budgetBytes: budget),
+                cacheBytes: Self.gib / 2, activeBytes: active, budgetBytes: 8 * Self.gib,
+                policy: Self.safeAuto),
             "an 8 GB host must not have its prefix cache silently disabled")
 
-        // 16 GB Mac, same model, a much longer 32k context (~4 GiB of KV): three
-        // copies of that genuinely will not fit, so this one is still refused.
+        // 16 GB Mac, same model, a much longer 32k context (~4 GiB of KV): headroom
+        // is 11.5 GiB and Safe Auto lends 2.875 GiB, so this one is still refused.
         #expect(
             !CacheStoreBudget.canStore(
-                cacheBytes: 4 * Self.gib, activeBytes: active, budgetBytes: 16 * Self.gib))
-
-        // The margin never exceeds the original 4 GiB on a large host.
-        #expect(CacheStoreBudget.safetyMarginBytes(budgetBytes: 128 * Self.gib) == 4 << 30)
-        #expect(CacheStoreBudget.safetyMarginBytes(budgetBytes: 8 * Self.gib) == Self.gib)
+                cacheBytes: 4 * Self.gib, activeBytes: active, budgetBytes: 16 * Self.gib,
+                policy: Self.safeAuto))
     }
 
     /// The guard must not quietly disable the prefix cache for the long-context
     /// requests that most need it. With a 94 GiB pack resident on a 128 GB Mac, a
     /// multi-thousand-token conversation still caches — it is only the runaway case
-    /// that is refused. (Budgeting against the GPU working set instead of physical
-    /// memory would cut this off around 15k tokens, which is why it doesn't.)
+    /// that is refused.
     @Test("A long conversation still caches with a large model resident")
     func longContextStillCachesUnderALargeResidentModel() {
         let physical = 128 * Self.gib
@@ -123,9 +133,51 @@ struct CacheStoreBudgetTests {
                 CacheStoreBudget.canStore(
                     cacheBytes: tokens * bytesPerToken,
                     activeBytes: active,
-                    budgetBytes: physical),
+                    budgetBytes: physical,
+                    policy: Self.safeAuto),
                 "a \(tokens)-token cache must still be storable on a healthy host"
             )
+        }
+    }
+
+    /// The whole point of the change: the user's memory-safety level has to reach
+    /// this decision. It used to not — the budget was raw physical RAM and a
+    /// hard-coded margin, identical whether the user asked for Performance or
+    /// Strict. Same host, same model, same cache; only the safety level moves.
+    @Test("The user's safety level actually changes the verdict")
+    func safetyLevelIsHonoured() {
+        let physical = 128 * Self.gib
+        let active = 96 * Self.gib  // headroom = 32 GiB
+        let kv = 10 * Self.gib  // 31% of headroom
+
+        // Strict (15%) and Safe Auto (25%) both refuse a cache this size...
+        #expect(
+            !CacheStoreBudget.canStore(
+                cacheBytes: kv, activeBytes: active, budgetBytes: physical, policy: .strict))
+        #expect(
+            !CacheStoreBudget.canStore(
+                cacheBytes: kv, activeBytes: active, budgetBytes: physical, policy: .safeAuto))
+        // ...while Performance (45%) and the diagnostic mode (55%) allow it.
+        #expect(
+            CacheStoreBudget.canStore(
+                cacheBytes: kv, activeBytes: active, budgetBytes: physical, policy: .performance))
+        #expect(
+            CacheStoreBudget.canStore(
+                cacheBytes: kv, activeBytes: active, budgetBytes: physical,
+                policy: .diagnosticDangerous))
+    }
+
+    /// The levels have to be ordered the way their names promise, or the slider is
+    /// decorative in a new way. Strictly monotonic: no two levels are the same gate.
+    @Test("Stricter levels are strictly stricter")
+    func levelsAreMonotonic() {
+        let ordered: [CacheStorePolicy] = [
+            .strict, .safeAuto, .balanced, .performance, .diagnosticDangerous,
+        ]
+        for (looser, tighter) in zip(ordered.dropFirst(), ordered) {
+            #expect(
+                tighter.headroomFraction < looser.headroomFraction,
+                "each level must lend strictly more headroom than the one below it")
         }
     }
 
@@ -136,5 +188,73 @@ struct CacheStoreBudgetTests {
     func unknownBudgetDoesNotBlock() {
         #expect(CacheStoreBudget.canStore(cacheBytes: 1 << 30, activeBytes: 0, budgetBytes: nil))
         #expect(CacheStoreBudget.canStore(cacheBytes: 0, activeBytes: 0, budgetBytes: 0))
+    }
+}
+
+/// The "Safety Level" slider osaurus renders was wired to a field nothing read.
+@Suite("Memory-safety level")
+struct MemorySafetyLevelTests {
+
+    /// The bug, pinned: setting the slider used to leave `mode` — the thing every
+    /// resolver actually switches on — untouched, so the control changed nothing.
+    @Test("Moving the safety slider moves the safety mode")
+    func sliderDrivesMode() {
+        var settings = VMLXMemorySafetySettings()  // Safe Auto
+        #expect(settings.slider == 2)
+
+        settings.slider = 3
+        #expect(settings.mode == .strict, "the slider must move the mode, not a field beside it")
+
+        settings.slider = 0
+        #expect(settings.mode == .performance)
+
+        // And the reverse: the mode picker and the slider can never disagree.
+        settings.mode = .diagnosticDangerous
+        #expect(settings.slider == 4)
+    }
+
+    /// Out-of-range input clamps rather than trapping — it used to be validated as
+    /// an error, which is no longer expressible.
+    @Test("An out-of-range level clamps")
+    func sliderClamps() {
+        var settings = VMLXMemorySafetySettings()
+        settings.slider = 99
+        #expect(settings.mode == .diagnosticDangerous)
+        settings.slider = -1
+        #expect(settings.mode == .performance)
+    }
+
+    /// Existing users must not have their safety level shift under them on upgrade.
+    /// Persisted settings that disagree (they dragged the slider back when it did
+    /// nothing) keep the mode the engine has actually been enforcing.
+    @Test("A persisted slider never overrides the persisted mode")
+    func decodingPrefersModeOverStaleSlider() throws {
+        // Written by a build where the slider was stored and inert: the user dragged
+        // it to Performance (0) but the engine kept running Strict.
+        let json = #"{"mode":"strict","slider":0,"allowExperimentalMLXPress":false,"failClosedWhenEstimateUnknown":false}"#
+        let decoded = try JSONDecoder().decode(
+            VMLXMemorySafetySettings.self, from: Data(json.utf8))
+        #expect(decoded.mode == .strict, "the level actually in force must survive the upgrade")
+        #expect(decoded.slider == 3, "and the number shown for it must now tell the truth")
+    }
+
+    /// The persisted/API shape does not change: `slider` is still emitted.
+    @Test("The encoded shape still carries the slider")
+    func encodingStillEmitsSlider() throws {
+        let data = try JSONEncoder().encode(VMLXMemorySafetySettings(mode: .balanced))
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(object["slider"] as? Int == 1)
+        #expect(object["mode"] as? String == "balanced")
+    }
+
+    /// Each level has to reach the cache-store gate, which is the decision the
+    /// load-time caps cannot make.
+    @Test("Each safety level carries a distinct cache-store policy")
+    func modesMapToStorePolicies() {
+        #expect(VMLXMemorySafetyMode.performance.cacheStorePolicy == .performance)
+        #expect(VMLXMemorySafetyMode.safeAuto.cacheStorePolicy == .safeAuto)
+        #expect(VMLXMemorySafetyMode.strict.cacheStorePolicy == .strict)
+        #expect(VMLXMemorySafetyMode.diagnosticDangerous.cacheStorePolicy == .diagnosticDangerous)
     }
 }


### PR DESCRIPTION
Two defects in the cache-store guard added by #139/#140.

## The "Safety Level" slider did nothing

`VMLXMemorySafetySettings.slider` was a stored field that **no resolver ever read** — every one of them switches on `mode`. A host that wires its slider to it (osaurus does, `MemorySafetySection.swift`) shipped a control that changed nothing, while the Resolved Plan readout printed the new level right next to the old, still-in-force caps:

```
mode=safe_auto slider=3 load_cap=0.7 ...   <- slider says Strict, engine runs Safe Auto
```

`slider` is now a projection of `mode` — the same five choices in `allCases` order — so the mode picker and the slider cannot disagree, and the slider does what it always claimed to. **No host change is needed**: the existing binding writes `slider` and now lands on `mode`.

Decoding keeps `mode` authoritative, so an existing user's safety level does **not** shift under them on upgrade (someone who dragged the slider back when it was inert keeps the level the engine has actually been enforcing); only the number displayed for it becomes honest. The 0…4 validation error is gone because an out-of-range level is no longer expressible — the setter clamps.

## The store budget ignored the level entirely

It gated a KV copy against raw `ProcessInfo.physicalMemory` and a hard-coded margin — identical whether the user asked for Performance or Strict.

It now spends a share of **free headroom**, set by the level. A share of the *increment*, deliberately, not a ceiling on total memory: the load caps are an MLX **graph-scheduling guideline**, not a hard resident limit (`mlx/memory.h`), so a large pack legitimately runs above them — Hy3 sits at ~96 GB under the default 0.70 cap on a 128 GB Mac. Budgeting the store against `0.70 × physical` would put `activeBytes` over the line *before a single KV byte* and refuse **every** store, silently killing the prefix cache for precisely the models whose re-prefill hurts most.

`CacheStoreBudget.policy` carries the level down to the decode loop, which has no settings handle — the same channel `TiedHeadQuantizationPolicy.current` already uses.

| Level | Share of free headroom one store may take |
|---|---|
| Strict | 15% |
| Safe Auto (default) | 25% |
| Balanced | 35% |
| Performance | 45% |
| Diagnostic | 55% |

## The materialization factor was wrong

It budgeted **three** copies — a deep copy, a host `Data` extract, and the disk-store cache. None of the three survive contact with the code:

- `KVCacheSimple.copy()` takes full-range slices that **share** the source buffer
- `extractLayerData` returns **references**
- `makeDiskStoreCache` returns the snapshot **unchanged** on the raw path
- `mlx_save_safetensors` **streams to the fd**; there is no host `Data`

What remains is the `contiguous` pass before the write — at most **one** compact copy. The original bug report's own footprint series said so all along: a **+23 GiB excursion against a 23 GiB cache**. At 3× the guard refused stores that fit, quietly costing cache hits it was never meant to cost.

## Proof

All six previously-pinned cases still hold, plus new ones:

- the 70B-at-64K store that panicked a 128 GB host: still **refused**
- an 8 GB Mac with a 4.5 GiB model: still **caches**
- a 16k-token conversation under a 94 GiB resident pack: still **caches**
- a host already over budget: **refused** (no headroom underflow)
- Strict vs Performance now reach **different verdicts** on the same host/model/cache
- levels are **strictly monotonic**
- a persisted `slider` never overrides a persisted `mode`

15 tests, all green.

**Pre-existing failures, unchanged by this PR:** two `VMLXMemorySafetySettingsTests` cases (`defaultMaxKVSize` 65536≠8192 and 16384≠4096) fail identically on clean `main` — verified by stashing this diff and re-running.