### PR TITLE
RunBench: stop silently ignoring BENCH_COMPILE_DECODE on the batch path

### DIFF
--- a/RunBench/Bench.swift
+++ b/RunBench/Bench.swift
@@ -7866,6 +7866,21 @@ func runPerfBench(
             if let perfSeed {
                 params.randomSeed = perfSeed
             }
+            // BENCH_COMPILE_DECODE=1 routes decode through the compiled trace so
+            // eager-vs-compiled tok/s can be compared on the same deterministic
+            // harness.
+            //
+            // The perf bench used to SILENTLY IGNORE this variable. The only thing
+            // that set compile here was `enableCompiledDecode = useTokenIterator`,
+            // so a `BENCH_COMPILE_DECODE=1` run on the default `path=batch` measured
+            // the EAGER path and reported it as compiled — every "compiled decode is
+            // worth N%" figure taken from this bench on the batch path was actually
+            // eager-vs-eager. A flag that a harness accepts and drops is worse than
+            // one it rejects: it manufactures a comparison nobody ran.
+            params.enableCompiledBatchDecode = (env["BENCH_COMPILE_DECODE"] ?? "0") == "1"
+            if let compileMaxLen = env["BENCH_COMPILE_MAXLEN"].flatMap(Int.init) {
+                params.compiledMaxCacheLength = compileMaxLen
+            }
             if let override = env["BENCH_PERF_TEMP"].flatMap(Float.init) {
                 params.temperature = override
             }


### PR DESCRIPTION
## The bench accepted a flag and dropped it

`runPerfBench` never read `BENCH_COMPILE_DECODE`. The only thing that set compile there was:

```swift
params.enableCompiledDecode = useTokenIterator
```

So `BENCH_COMPILE_DECODE=1` on the default `path=batch` measured the **eager** path and printed it as compiled. **Every "compiled decode is worth N%" figure taken from this bench on the batch path was eager-vs-eager.**

A flag a harness accepts and drops is worse than one it rejects: it manufactures a comparison nobody ran, and you cannot catch it by reading the output — the output looks exactly like the run you asked for.

## What the flag reveals once it works

Compiled decode is strongly model-dependent, and in one case a **large regression**:

| model | eager | compiled | effect |
|---|---|---|---|
| gemma-4-E2B-it-qat-MXFP4 | 125.9 | 167.1 | **+33%** |
| Llama-3.2-1B-Instruct-4bit | 521.2 | **383.0** | **−26%** |
| Hy3-JANG_2K | 10.8 | 10.8 | ~0% |

Median of 3, 256 tokens, temp 0, quiet M5 Max (Hy3 at 128 tok, materialized).

## Why this matters beyond the bench

osaurus exposes compiled decode as a **single global "Decode Perf" toggle**. Its *sign changes by model* — flipping it on makes Gemma ~33% faster and Llama ~26% slower. A global switch is the wrong shape for that knob. Nobody could see this while the measurement harness was blind to the flag.

Follow-up (not in this PR): decide whether compiled decode should be per-model/auto-detected rather than global, and root-cause the Llama-1B regression.

**No runtime behaviour changes — bench-only.**