### PR TITLE
Guard the tok/s divisions: a cancelled stream reports NaN, a cache-hit prefill reports +inf

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -2702,13 +2702,22 @@ public struct GenerateResult {
     public let generateTime: TimeInterval
 
     /// The number of tokens processed per second during the prompt phase.
+    ///
+    /// Zero when the phase did not measurably run. Dividing by an unguarded
+    /// `promptTime` returns `+inf` for a cache-hit prefill and `NaN` for a
+    /// cancelled stream (which reports `0` tokens in `0` seconds) -- and both
+    /// then travel intact through the wire format and into the UI.
     public var promptTokensPerSecond: Double {
-        Double(inputText.tokens.size) / promptTime
+        guard promptTime > 0 else { return 0 }
+        return Double(inputText.tokens.size) / promptTime
     }
 
     /// The number of tokens generated per second during the generation phase.
+    ///
+    /// Zero when nothing was generated or the phase did not measurably run.
     public var tokensPerSecond: Double {
-        Double(tokenIds.count) / generateTime
+        guard generateTime > 0 else { return 0 }
+        return Double(tokenIds.count) / generateTime
     }
 
     public func summary() -> String {
@@ -3799,13 +3808,24 @@ public struct GenerateCompletionInfo: Sendable {
     public let unclosedReasoning: Bool
 
     /// The number of tokens processed per second during the prompt phase.
+    ///
+    /// Zero when the phase did not measurably run. `promptTime` is legitimately
+    /// `0` on the cancelled-stream path and can round to `0` on a full
+    /// prefix-cache hit, so an unguarded divide hands the caller `+inf` (or
+    /// `NaN`, when the token count is also zero) rather than a speed.
     public var promptTokensPerSecond: Double {
-        Double(promptTokenCount) / promptTime
+        guard promptTime > 0 else { return 0 }
+        return Double(promptTokenCount) / promptTime
     }
 
     /// The number of tokens generated per second during the generation phase.
+    ///
+    /// Zero when nothing was generated or the phase did not measurably run --
+    /// e.g. the cancelled-stream constructors below, which report `0` tokens in
+    /// `0` seconds and would otherwise compute `0/0`.
     public var tokensPerSecond: Double {
-        Double(generationTokenCount) / generateTime
+        guard generateTime > 0 else { return 0 }
+        return Double(generationTokenCount) / generateTime
     }
 
     public init(

--- a/Tests/MLXLMTests/GenerateCompletionInfoRateTests.swift
+++ b/Tests/MLXLMTests/GenerateCompletionInfoRateTests.swift
@@ -1,0 +1,69 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+/// A speed is a measurement, not a formality. When a phase did not measurably
+/// run there is no speed to report, and the honest answer is zero — not `+inf`,
+/// and not `NaN`.
+///
+/// Both of these are reachable in normal operation, not just in theory:
+///   - a cancelled stream is constructed with `generationTokenCount: 0` and
+///     `generationTime: 0` → `0/0` → `NaN`
+///   - a full prefix-cache hit can round `promptTime` to zero → `n/0` → `+inf`
+///
+/// Neither value is filtered on its way out: it is formatted straight into the
+/// stats wire hint and rendered in the chat UI.
+@Suite("Generation rate reporting")
+struct GenerateCompletionInfoRateTests {
+
+    @Test("A cancelled stream reports zero, not NaN")
+    func cancelledStreamIsNotNaN() {
+        // Exactly what `cancelledBatchStream` / `cancelledGenerationStream` build.
+        let info = GenerateCompletionInfo(
+            promptTokenCount: 128,
+            generationTokenCount: 0,
+            promptTime: 0,
+            generationTime: 0,
+            stopReason: .cancelled
+        )
+
+        #expect(!info.tokensPerSecond.isNaN, "0 tokens in 0 seconds must not be 0/0")
+        #expect(info.tokensPerSecond.isFinite)
+        #expect(info.tokensPerSecond == 0)
+
+        #expect(!info.promptTokensPerSecond.isNaN)
+        #expect(info.promptTokensPerSecond.isFinite, "128 tokens in 0 seconds must not be +inf")
+        #expect(info.promptTokensPerSecond == 0)
+    }
+
+    @Test("A zero-duration prefill reports zero, not infinity")
+    func instantPrefillIsNotInfinite() {
+        // A full cache hit: the prompt was never re-processed, so its "speed" is
+        // not a very large number — it is undefined.
+        let info = GenerateCompletionInfo(
+            promptTokenCount: 4096,
+            generationTokenCount: 32,
+            promptTime: 0,
+            generationTime: 0.5
+        )
+        #expect(info.promptTokensPerSecond.isFinite)
+        #expect(info.promptTokensPerSecond == 0)
+        // The generation phase DID run, so its rate is a real measurement.
+        #expect(info.tokensPerSecond == 64)
+    }
+
+    @Test("A real generation still reports its real rate")
+    func realGenerationIsUnchanged() {
+        let info = GenerateCompletionInfo(
+            promptTokenCount: 100,
+            generationTokenCount: 50,
+            promptTime: 0.25,
+            generationTime: 2.0
+        )
+        #expect(info.tokensPerSecond == 25)
+        #expect(info.promptTokensPerSecond == 400)
+    }
+}


### PR DESCRIPTION
`tokensPerSecond` and `promptTokensPerSecond` divide by a duration with no guard. Both denominators hit zero in normal operation, and neither result is filtered on the way out — it is formatted into the stats wire hint and rendered in the chat UI.

- The **cancelled-stream** constructors build the info with `generationTokenCount: 0, generationTime: 0`. That is literally `0/0` → **NaN**.
- A **full prefix-cache hit** can round `promptTime` to zero → `n/0` → **+inf**.

Proven rather than argued — the new tests go red on the unpatched code with exactly:

```
Expectation failed: !((info.tokensPerSecond → nan).isNaN → true → true)
Expectation failed: (info.promptTokensPerSecond → inf).isFinite → false
```

When a phase did not measurably run there is no speed to report, so the accessors return zero and the caller decides what to display. This is the engine half of the `2397.3 tok/s • 7 tokens` nonsense in the Osaurus chat card; the osaurus half (a UI "average" computed over the delivery burst) is fixed separately.