### PR TITLE
Report a token the vocabulary cannot encode, instead of trapping on it

### DIFF
--- a/Tests/MLXLMTests/TokenizerUnencodableTokenTests.swift
+++ b/Tests/MLXLMTests/TokenizerUnencodableTokenTests.swift
@@ -1,0 +1,70 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+/// A chat template writes control markers into the prompt as literal text
+/// (`<｜Assistant｜>`, `<think>`, …). If the bundle's vocabulary never shipped one of them
+/// there is no id to return, and DeepSeek-class byte-level BPE declares no unknown token
+/// to stand in either — so `convertTokenToId` yields nil.
+///
+/// `encode` force-unwrapped that nil. It killed the app in production (Sentry
+/// APPLE-MACOS-10S, 9 events on 0.22.0) from inside a prefix-cache probe that was merely
+/// measuring the generation-prompt suffix against a dummy message. The user had typed
+/// nothing unusual, and the caller already had a `try?` fallback it could never reach —
+/// a Swift trap is not an error you can catch.
+///
+/// Exercising this against a real tokenizer needs a model bundle whose vocab is missing a
+/// marker, which a unit test has no business shipping. So these pin the two properties
+/// that make the crash impossible, at the source level — the same convention this repo
+/// uses for the compiled-decode guards. They prove the shape of the fix, not the runtime
+/// behaviour; the runtime behaviour is proven live, in the app.
+@Suite("Tokenizer: unencodable tokens are reported, not fatal")
+struct TokenizerUnencodableTokenTests {
+
+    private static func source(_ path: String) throws -> String {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()  // MLXLMTests/
+            .deletingLastPathComponent()  // Tests/
+            .deletingLastPathComponent()  // repo root
+        return try String(contentsOf: root.appendingPathComponent(path), encoding: .utf8)
+    }
+
+    private static let tokenizerPath =
+        "Vendors/swift-transformers/Sources/Tokenizers/Tokenizer.swift"
+
+    @Test("A failure to encode is expressible as an error at all")
+    func unencodableTokenIsAnError() throws {
+        let src = try Self.source(Self.tokenizerPath)
+
+        // Without a case for it, the only way to signal "this cannot be encoded" is to
+        // trap — which is exactly how the app died.
+        #expect(src.contains("case unencodableToken(String)"))
+
+        // And a throwing entry point that reports it rather than force-unwrapping.
+        #expect(src.contains("public func encodeThrowing(text: String"))
+        #expect(src.contains("throw TokenizerError.unencodableToken(token)"))
+    }
+
+    @Test("The throwing path does not quietly drop the token instead")
+    func unencodableTokenIsNotSilentlyDropped() throws {
+        let src = try Self.source(Self.tokenizerPath)
+
+        guard let start = src.range(of: "public func encodeThrowing(text: String") else {
+            Issue.record("encodeThrowing not found")
+            return
+        }
+        let body = String(src[start.lowerBound...].prefix(600))
+
+        // `compactMap` here would silently shorten the prompt and shift every position
+        // after the missing token — a model that reads as working while attending to the
+        // wrong context. Failing loudly is the only honest option.
+        #expect(
+            !body.contains("compactMap"),
+            "dropping an unencodable token corrupts the prompt silently — throw instead"
+        )
+        #expect(body.contains("guard let id = model.convertTokenToId(token)"))
+    }
+}

--- a/Vendors/swift-transformers/Sources/Tokenizers/Tokenizer.swift
+++ b/Vendors/swift-transformers/Sources/Tokenizers/Tokenizer.swift
@@ -25,6 +25,10 @@ public enum TokenizerError: LocalizedError {
     case chatTemplate(String)
     case missingChatTemplate
     case tooLong(String)
+    /// A piece the vocabulary cannot represent, in a tokenizer that declares no unknown
+    /// token to stand in for it. Usually a chat-template control marker the bundle never
+    /// shipped.
+    case unencodableToken(String)
     case mismatchedConfig(String)
 
     public var errorDescription: String? {
@@ -43,6 +47,11 @@ public enum TokenizerError: LocalizedError {
             String(localized: "Chat template error: \(message)", comment: "Error with chat template")
         case .missingChatTemplate:
             String(localized: "This tokenizer does not have a chat template, and no template was passed.")
+        case let .unencodableToken(token):
+            String(
+                localized:
+                    "The tokenizer cannot encode '\(token)': it is not in the vocabulary and this model declares no unknown token.",
+                comment: "Error when a token has no id and there is no unknown token to fall back on")
         case let .tooLong(message):
             String(localized: "Input is too long: \(message)", comment: "Error when input exceeds maximum length")
         case let .mismatchedConfig(message):
@@ -654,6 +663,29 @@ public class PreTrainedTokenizer: @unchecked Sendable, Tokenizer {
     /// - Returns: An array of token IDs
     public func encode(text: String, addSpecialTokens: Bool = true) -> [Int] {
         postProcess(tokenize(text: text), addSpecialTokens: addSpecialTokens).map { model.convertTokenToId($0)! }
+    }
+
+    /// `encode`, but a token the vocabulary cannot represent is an error rather than a
+    /// process kill.
+    ///
+    /// `convertTokenToId` already falls back to the unknown token, so it returns nil only
+    /// when the piece is absent from the vocab AND the tokenizer declares no unknown token
+    /// — normal for DeepSeek's byte-level BPE. Force-unwrapping that in `encode` turned a
+    /// bad chat-template marker into a fatal trap, which is how the app died inside the
+    /// DeepSeek-V4 template while merely *measuring* the generation-prompt suffix (Sentry
+    /// APPLE-MACOS-10S, 9 events in 0.22.0).
+    ///
+    /// There is nothing honest to substitute for such a token — dropping it would shorten
+    /// the prompt and shift every position after it, which reads like a working model — so
+    /// this reports failure and lets the caller decide. Callers that treat the encode as
+    /// an optimization (a cache-boundary probe, say) can then simply do without it.
+    public func encodeThrowing(text: String, addSpecialTokens: Bool = true) throws -> [Int] {
+        try postProcess(tokenize(text: text), addSpecialTokens: addSpecialTokens).map { token in
+            guard let id = model.convertTokenToId(token) else {
+                throw TokenizerError.unencodableToken(token)
+            }
+            return id
+        }
     }
 
     /// Encodes input text into token IDs with special tokens included by default.


### PR DESCRIPTION
### The crash

Sentry `APPLE-MACOS-10S` — **9 crashes on 0.22.0**, a real user, still firing.

```
EXC_BREAKPOINT  (Swift trap)
  ModelContainer.computeGenPromptSuffixTokens   (ModelContainer.swift:285)
  → TokenizerBridge.applyChatTemplate
  → TokenizerBridge.applyDeepseekV4NativeTemplate
  → PreTrainedTokenizer.encode                  (Tokenizer.swift:656)
  → Collection.map → TRAP
```

### Why

```swift
public func encode(text: String, addSpecialTokens: Bool = true) -> [Int] {
    postProcess(tokenize(text: text), addSpecialTokens: addSpecialTokens)
        .map { model.convertTokenToId($0)! }   // ← here
}
```

`convertTokenToId` is already `tokensToIds[token] ?? unknownTokenId` (BPETokenizer.swift:139,
UnigramTokenizer.swift:118). So it returns `nil` only when a piece is **absent from the vocab
AND the tokenizer declares no unknown token** — the normal shape of DeepSeek-class byte-level
BPE. The DeepSeek-V4 template writes control markers (`<｜Assistant｜>`, `<think>`, …) into the
prompt as literal text; against a bundle whose vocab is missing one, the lookup is nil and the
`!` kills the process.

The insult: this fired inside `computeGenPromptSuffixTokens`, a **prefix-cache probe** running
against a *dummy* message. The user had typed nothing unusual. And the probe already documents
a safe `[]` fallback and wraps the call in `try?` — it just cannot catch a trap.

### The fix

`encodeThrowing`, which reports the offending token as `TokenizerError.unencodableToken`.

Deliberately **not** `compactMap`: dropping the token would shorten the prompt and shift every
position after it — a model that reads as working while attending to the wrong context. That is
strictly worse than a crash, because nobody can see it. So this fails loudly and lets the caller
decide; the cache probe's existing `try?` → `[]` path now actually works, and a mismatched
bundle costs a cache optimization instead of the user's session.

`encode` keeps its signature and behaviour for every existing caller.

### Not fixed here

**Which** marker is missing from **which** bundle is still unverified — it needs a DSV4 bundle
to confirm. The crash is closed either way; the underlying vocab/marker mismatch is not, and it
should be chased separately.

### Follow-up

osaurus pins vmlx by SHA, so this does nothing for the app until it merges and osaurus repins.
The osaurus-side change (pointing the DSV4 path at `encodeThrowing`) is staged and blocked on
that repin.