### PR TITLE
Stop a tool turn from stranding generation outside any turn

### DIFF
--- a/Tests/MLXLMTests/ChatTemplateRepairTests.swift
+++ b/Tests/MLXLMTests/ChatTemplateRepairTests.swift
@@ -80,6 +80,24 @@ struct ChatTemplateRepairTests {
         #expect(ChatTemplateRepair.repaired(healthy) == healthy)
     }
 
+    @Test("A template is inspected once, then answered from cache")
+    func templateIsInspectedOnce() {
+        // `applyChatTemplate` runs on every request and almost every template is healthy, so
+        // re-scanning it each turn is pure waste. Same input must give the same answer, and
+        // repeat lookups must not re-derive it.
+        let broken = "a \(Self.brokenMXFP) b"
+        let first = ChatTemplateRepair.repaired(broken)
+        let second = ChatTemplateRepair.repaired(broken)
+        #expect(first == second)
+        #expect(!ChatTemplateRepair.needsRepair(second))
+
+        // A healthy template must also be cached — it is the common case, and it must come
+        // back byte-identical, not merely equal-looking.
+        let healthy = "{{ bos_token }}{% for m in messages %}{{ m['content'] }}{% endfor %}"
+        #expect(ChatTemplateRepair.repaired(healthy) == healthy)
+        #expect(ChatTemplateRepair.repaired(healthy) == healthy)
+    }
+
     @Test("Repair is idempotent")
     func repairIsIdempotent() {
         // The loader may repair the same template more than once across reloads; doing so must

--- a/Tests/MLXLMTests/ChatTemplateRepairTests.swift
+++ b/Tests/MLXLMTests/ChatTemplateRepairTests.swift
@@ -1,0 +1,93 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import Testing
+import VMLXTokenizers
+
+/// The gemma-4 templates close the assistant turn when a history message carries BOTH content
+/// AND tool calls, and `add_generation_prompt` then skips `<|turn>model` because the last thing
+/// emitted was a tool response. Generation starts after a CLOSED turn with no role header — the
+/// model has nothing telling it who is speaking, improvises the scaffolding it has seen around
+/// assistant turns, and locks into repeating it:
+///
+///     thought
+///     <channel|>£thought
+///     <channel|>o'thought
+///     <channel|>o'thought          ← forever
+///
+/// It only fires after real tool use. A turn with tool calls but no content leaves the turn
+/// open, which is why plain chat repros look clean and this survived for months.
+///
+/// Patching the bundle on disk does not hold — the loader re-fetches `tokenizer_config.json`
+/// from the Hub and silently restores the broken template — so the repair happens in memory at
+/// the point every path selects the template.
+@Suite("Chat template repair: a tool turn must not strand generation")
+struct ChatTemplateRepairTests {
+
+    /// Both dialects that ship in the wild spell the same mistake.
+    private static let brokenMXFP = "{%- elif not (ns_tr_out.flag and not has_content) -%}"
+    private static let broken8Bit = "{%- if not (message['tool_responses'] and not message['content']) -%}"
+
+    @Test("The MXFP/JANG dialect's stranded-turn close is repaired")
+    func repairsMXFPDialect() {
+        let template = """
+            {%- for message in messages -%}
+                {%- if ns.prev_message_type == 'tool_call' and not ns_tr_out.flag -%}
+                    {{- '<|tool_response>' -}}
+                \(Self.brokenMXFP)
+                    {{- '<turn|>\\n' -}}
+                {%- endif -%}
+            {%- endfor -%}
+            """
+
+        #expect(ChatTemplateRepair.needsRepair(template))
+
+        let fixed = ChatTemplateRepair.repaired(template)
+        #expect(fixed.contains("{%- elif not ns_tr_out.flag -%}"))
+        #expect(
+            !fixed.contains(Self.brokenMXFP),
+            "a turn that emitted a tool response must stay OPEN whether or not it had content"
+        )
+    }
+
+    @Test("The 8-bit retention dialect's stranded-turn close is repaired")
+    func repairs8BitDialect() {
+        let template = """
+            {%- for message in messages -%}
+                \(Self.broken8Bit)
+                    {{- '<turn|>\\n' -}}
+                {%- endif -%}
+            {%- endfor -%}
+            """
+
+        #expect(ChatTemplateRepair.needsRepair(template))
+
+        let fixed = ChatTemplateRepair.repaired(template)
+        #expect(fixed.contains("{%- if not message['tool_responses'] -%}"))
+        #expect(!fixed.contains(Self.broken8Bit))
+    }
+
+    @Test("A template without the bug is returned untouched")
+    func healthyTemplateIsUnchanged() {
+        // Nothing else may be rewritten — this runs on EVERY model's template, not just gemma.
+        let healthy = """
+            {%- for message in messages -%}
+                {{- '<|im_start|>' + message['role'] + '\\n' + message['content'] + '<|im_end|>\\n' -}}
+            {%- endfor -%}
+            {%- if add_generation_prompt -%}{{- '<|im_start|>assistant\\n' -}}{%- endif -%}
+            """
+        #expect(!ChatTemplateRepair.needsRepair(healthy))
+        #expect(ChatTemplateRepair.repaired(healthy) == healthy)
+    }
+
+    @Test("Repair is idempotent")
+    func repairIsIdempotent() {
+        // The loader may repair the same template more than once across reloads; doing so must
+        // not corrupt it.
+        let broken = "x \(Self.brokenMXFP) y \(Self.broken8Bit) z"
+        let once = ChatTemplateRepair.repaired(broken)
+        let twice = ChatTemplateRepair.repaired(once)
+        #expect(once == twice)
+        #expect(!ChatTemplateRepair.needsRepair(once))
+    }
+}

--- a/Vendors/swift-transformers/Sources/Tokenizers/ChatTemplateRepair.swift
+++ b/Vendors/swift-transformers/Sources/Tokenizers/ChatTemplateRepair.swift
@@ -51,6 +51,38 @@ public enum ChatTemplateRepair {
         ),
     ]
 
+    /// Templates already inspected, mapped to their repaired form.
+    ///
+    /// `applyChatTemplate` runs on every single request, and the overwhelmingly common case is
+    /// a template with nothing wrong with it — scanning it again on each turn is pure waste.
+    /// A template is immutable for the life of a tokenizer, so decide once and remember: a
+    /// healthy template maps to itself and is never scanned again.
+    private static let cache = Cache()
+
+    private final class Cache: @unchecked Sendable {
+        private let lock = NSLock()
+        private var repairedByOriginal: [String: String] = [:]
+
+        func repaired(_ template: String, computing: (String) -> String) -> String {
+            lock.lock()
+            if let hit = repairedByOriginal[template] {
+                lock.unlock()
+                return hit
+            }
+            lock.unlock()
+
+            // Compute outside the lock: it is a pure function of the input, so a concurrent
+            // duplicate is harmless, and holding a lock across it would serialize every
+            // first-time template load behind one another.
+            let result = computing(template)
+
+            lock.lock()
+            repairedByOriginal[template] = result
+            lock.unlock()
+            return result
+        }
+    }
+
     /// Does this template contain the stranded-turn bug?
     public static func needsRepair(_ template: String) -> Bool {
         closeRepairs.contains { template.contains($0.broken) }
@@ -65,10 +97,12 @@ public enum ChatTemplateRepair {
     /// the close alone is what stops the runaway; the ordering is corrected at the source in
     /// the bundles.
     public static func repaired(_ template: String) -> String {
-        var out = template
-        for repair in closeRepairs where out.contains(repair.broken) {
-            out = out.replacingOccurrences(of: repair.broken, with: repair.fixed)
+        cache.repaired(template) { template in
+            var out = template
+            for repair in closeRepairs where out.contains(repair.broken) {
+                out = out.replacingOccurrences(of: repair.broken, with: repair.fixed)
+            }
+            return out
         }
-        return out
     }
 }

--- a/Vendors/swift-transformers/Sources/Tokenizers/ChatTemplateRepair.swift
+++ b/Vendors/swift-transformers/Sources/Tokenizers/ChatTemplateRepair.swift
@@ -1,0 +1,74 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+
+/// Repairs a chat template that would strand generation outside of any turn.
+///
+/// ## The failure
+///
+/// The gemma-4 templates close the assistant turn when a history message carries BOTH
+/// content AND tool calls, and then — because the last thing emitted was a tool response —
+/// `add_generation_prompt` skips the `<|turn>model` role header. Generation therefore
+/// begins *after a closed turn, with no role*. The model has nothing telling it who is
+/// speaking, so it improvises the scaffolding it has seen around assistant turns: it emits
+/// `thought` / `<channel|>` openers. In a long agent context it locks onto that and repeats
+/// the header line forever:
+///
+///     thought
+///     <channel|>£thought
+///     <channel|>o'thought
+///     <channel|>o'thought          ← until the token budget runs out
+///
+/// It only fires after real tool use — a turn with tool calls but no content leaves the turn
+/// open, so plain chat repros stay clean, which is exactly why this survived so long.
+///
+/// ## Why repair it here
+///
+/// Patching the bundle on disk does not hold: the loader re-fetches `tokenizer_config.json`
+/// and `chat_template.jinja` from the Hub, silently restoring the broken template. Repairing
+/// the template string in memory, at the one point where every path selects it, fixes every
+/// already-downloaded bundle without a re-download and cannot be undone by a refetch.
+///
+/// This is not a behavioural workaround. It biases no logits, injects no thinking tags, and
+/// coerces no output — it hands the model a well-formed turn instead of a malformed one. The
+/// bundles should still be corrected at the source; this keeps users working until they are.
+public enum ChatTemplateRepair {
+
+    /// A turn that emitted a tool response must stay OPEN, whether or not it also had
+    /// content — otherwise generation starts after `<turn|>` with no role header.
+    ///
+    /// Two dialects ship in the wild; both spell the same mistake.
+    private static let closeRepairs: [(broken: String, fixed: String)] = [
+        // MXFP4 / JANG / MXFP8 dialect
+        (
+            "{%- elif not (ns_tr_out.flag and not has_content) -%}",
+            "{%- elif not ns_tr_out.flag -%}"
+        ),
+        // 8-bit retention dialect
+        (
+            "{%- if not (message['tool_responses'] and not message['content']) -%}",
+            "{%- if not message['tool_responses'] -%}"
+        ),
+    ]
+
+    /// Does this template contain the stranded-turn bug?
+    public static func needsRepair(_ template: String) -> Bool {
+        closeRepairs.contains { template.contains($0.broken) }
+    }
+
+    /// Return a repaired template, or the original when there is nothing to fix.
+    ///
+    /// Only the turn-close condition is rewritten. The other half of the original bug — the
+    /// assistant's content rendering *after* the tool response, inverting the chronology the
+    /// model was trained on — is a block reordering that cannot be done safely with string
+    /// surgery on an arbitrary template, and it is the *close* that strands generation. Fixing
+    /// the close alone is what stops the runaway; the ordering is corrected at the source in
+    /// the bundles.
+    public static func repaired(_ template: String) -> String {
+        var out = template
+        for repair in closeRepairs where out.contains(repair.broken) {
+            out = out.replacingOccurrences(of: repair.broken, with: repair.fixed)
+        }
+        return out
+    }
+}

--- a/Vendors/swift-transformers/Sources/Tokenizers/Tokenizer.swift
+++ b/Vendors/swift-transformers/Sources/Tokenizers/Tokenizer.swift
@@ -854,7 +854,12 @@ public class PreTrainedTokenizer: @unchecked Sendable, Tokenizer {
             throw TokenizerError.missingChatTemplate
         }
 
-        let template = try compiledTemplate(for: selectedChatTemplate)
+        // A template that closes the assistant turn after a tool response and then skips the
+        // role header hands the model no turn to speak in; it improvises `<channel|>thought`
+        // scaffolding and, in an agent loop, repeats that header until the budget runs out.
+        // Repair it here, where every path converges — patching the bundle on disk does not
+        // survive the loader re-fetching it from the Hub.
+        let template = try compiledTemplate(for: ChatTemplateRepair.repaired(selectedChatTemplate))
         var context: [String: VMLXJinja.Value] = try [
             "messages": .array(messages.map { try Value(any: $0) }),
             "add_generation_prompt": .boolean(addGenerationPrompt),


### PR DESCRIPTION
### The symptom

Gemma-4 walls of this, after tool use, until the token budget runs out:

```
thought
<channel|>£thought
<channel|>o'thought
<channel|>o'thought
<channel|>o'thought
...
```

### Root cause — not quant, not cache

A **chat-template structural bug**. When an assistant history message carries BOTH content AND
tool_calls and is followed by a tool response, the template:

1. closes the assistant turn with `<turn|>` (because it has content), and
2. `add_generation_prompt` then **skips** `<|turn>model`, because the last thing emitted was a
   tool response.

Generation therefore begins **after a closed turn, with no role header**. Nothing tells the model
who is speaking, so it improvises the scaffolding it has seen around assistant turns — `thought` /
`<channel|>` openers — and in an agent loop it locks onto that and repeats it forever.

A turn with tool calls but **no content** leaves the turn open. That is why plain chat repros stay
clean and this only bites after real tool use — and why it went unnoticed for so long.

### It is upstream, and it is everywhere

Checked the live templates on the Hub:

| repo | template |
|---|---|
| `google/gemma-4-12B-it` | **BUGGY** |
| `google/gemma-4-E2B-it` | **BUGGY** |
| `OsaurusAI/gemma-4-12B-it-MXFP8` | **BUGGY** |
| `OsaurusAI/gemma-4-E2B-it-8bit` | **BUGGY** |
| `OsaurusAI/gemma-4-E4B-it-8bit` | **BUGGY** |
| `OsaurusAI/gemma-4-{E2B,12B,31B}-it-qat-MXFP4` | **BUGGY** |

We inherited it from Google. Re-uploading our quants would not save anyone pulling from upstream.

### Why the fix is in the runtime and not the bundle

Patching the bundle on disk **does not hold**. I patched all 13 local gemma bundles, verified the
checksums, launched the app — and the files reverted, with an mtime matching app launch. The loader
re-fetches `tokenizer_config.json` / `chat_template.jinja` from the Hub and silently restores the
broken template. That is exactly how an earlier round of bundle patches quietly evaporated, and why
"we already fixed this" had stopped being true.

So the repair happens **in memory**, at the single point where every path selects a template. It
fixes every already-downloaded bundle without a re-download, and a refetch cannot undo it.

### What it does

A turn that emitted a tool response stays **OPEN**, whether or not it also had content. Two dialects
ship in the wild (`ns_tr_out.flag and not has_content`, and `tool_responses and not content`); both
are repaired. A template without the bug is returned **untouched** — this runs on every model, not
just gemma.

Decided **once per template**, not once per turn: a template is immutable for the life of a
tokenizer, so a healthy one is inspected a single time and never scanned again.

No logit biasing, no injected thinking tags, no prompt coercion. The model is handed a well-formed
turn instead of a malformed one.

### Still to do (separately)

The bundles should be corrected at the source too — including the content/tool_response ordering,
which inverts the chronology the model was trained on and which is a block reordering that cannot be
done safely with string surgery on an arbitrary template. This PR stops the runaway; it does not
absolve the bundles.