### PR TITLE
Stop tool-call delimiters leaking into arguments, and prose being cut in batch

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -689,6 +689,19 @@ public actor BatchEngine {
                 case .prefillProgress:
                     continuation.yield(event)
                 case .toolCall:
+                    // Drain the stop-string matcher BEFORE the call event goes
+                    // out, exactly as the solo path does (`Evaluate.swift`).
+                    // Text still held there for disambiguation precedes the call
+                    // in the model's output, but consumers stop forwarding text
+                    // the moment a tool call lands (deliberate no-leak
+                    // suppression of post-tool prose) — so a tail emitted after
+                    // this event is silently dropped, cutting the visible answer
+                    // mid-word. Without this, batch serving reproduced the same
+                    // truncation the solo path already fixed.
+                    if stopMatcher.isEnabled && !stopMatched {
+                        let tail = stopMatcher.flush()
+                        if !tail.isEmpty { continuation.yield(.chunk(tail)) }
+                    }
                     continuation.yield(event)
                 case .toolCallProgress:
                     continuation.yield(event)

--- a/Libraries/MLXLMCommon/Tool/Parsers/GemmaFunctionParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/GemmaFunctionParser.swift
@@ -114,7 +114,15 @@ public struct GemmaFunctionParser: ToolCallParser, Sendable {
         text = text.trimmingCharacters(in: .whitespacesAndNewlines)
         if text.hasPrefix(escapeMarker) {
             text = String(text.dropFirst(escapeMarker.count))
-            guard let endEscape = text.range(of: escapeMarker) else { return nil }
+            guard let endEscape = text.range(of: escapeMarker) else {
+                // Unterminated string. Returning nil here breaks the caller's
+                // key/value loop, which silently drops this argument *and* every
+                // argument after it — a tool call arrives with no arguments at
+                // all. Taking the remainder loses nothing and keeps the call.
+                let value = text
+                text = ""
+                return decodeEscapedStringValue(value)
+            }
             let value = String(text[..<endEscape.lowerBound])
             text = String(text[endEscape.upperBound...])
             return decodeEscapedStringValue(value)
@@ -129,6 +137,14 @@ public struct GemmaFunctionParser: ToolCallParser, Sendable {
         }
 
         let value = takeRawValue(from: &text, terminators: [","])
+        // A model that omits the *opening* delimiter still emits the closing one,
+        // leaving it stranded after an unquoted scalar. It is structure, not data
+        // — consume it so it neither leaks into this value nor corrupts the next
+        // key. Live: an image-edit `source_path` reached the runtime as
+        // `/tmp/a.png<|"|>` and was rejected as a non-existent file.
+        while text.hasPrefix(escapeMarker) {
+            text = String(text.dropFirst(escapeMarker.count))
+        }
         return decodeRawValue(value)
     }
 
@@ -214,6 +230,12 @@ public struct GemmaFunctionParser: ToolCallParser, Sendable {
     private func takeRawValue(from text: inout String, terminators: Set<Character>) -> String {
         var index = text.startIndex
         while index < text.endIndex {
+            // The escape marker delimits string values in the wire format, so it
+            // can never occur inside an unquoted scalar. Stop before a stray one
+            // rather than swallowing it into the value.
+            if text[index...].hasPrefix(escapeMarker) {
+                break
+            }
             let character = text[index]
             // `]` and `}` always terminate a raw scalar so an element inside a
             // nested array/object (e.g. the `1` in `{mark:1}`) stops at the

--- a/Tests/MLXLMTests/BatchStopTailBeforeToolCallSourceTests.swift
+++ b/Tests/MLXLMTests/BatchStopTailBeforeToolCallSourceTests.swift
@@ -1,0 +1,79 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import Testing
+
+/// The stop-string matcher withholds up to `maxStopLen - 1` characters while it
+/// disambiguates a possible stop. That held text PRECEDES a tool call in the
+/// model's output — but consumers stop forwarding text the moment a `.toolCall`
+/// event lands (deliberate no-leak suppression of post-tool prose). So the
+/// matcher must be drained BEFORE the event, or the visible answer is silently
+/// cut mid-word.
+///
+/// `Evaluate.swift`'s solo handler does this, and `ToolCallStopMatcherOrderingTests`
+/// pins it behaviorally. `BatchEngine` — the path Osaurus actually serves with —
+/// shipped without it and reproduced the same truncation for any API client that
+/// sets `stop` (LangChain, aider, Cline all do) while the model calls a tool.
+///
+/// BatchEngine builds its emit closures inline rather than through a reusable
+/// handler, so there is no seam to drive without standing up a real engine and
+/// model. Pin the invariant in the source instead, the same way
+/// `Hy3CompiledDecodeGuardSourceTests` does: the `.toolCall` case must drain the
+/// matcher before it yields.
+@Suite("BatchEngine drains the stop matcher before .toolCall")
+struct BatchStopTailBeforeToolCallSourceTests {
+
+    private static func batchEngineSource() throws -> String {
+        // Tests run from the package root.
+        let path = "Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift"
+        let url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent(path)
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    /// Isolate `emitRouted`'s `.toolCall` case and require that it flushes the
+    /// stop matcher before yielding the event.
+    @Test("the .toolCall branch of emitRouted flushes the stop matcher first")
+    func toolCallBranchDrainsStopMatcher() throws {
+        let source = try Self.batchEngineSource()
+
+        // Anchor inside `emitRouted` — a doc comment earlier in the file also
+        // contains the literal `case .toolCall: break`, and matching that
+        // instead makes this guard fail for the wrong reason.
+        guard let fn = source.range(of: "func emitRouted(") else {
+            Issue.record("`emitRouted` is gone — rewrite this guard")
+            return
+        }
+        let body = source[fn.upperBound...]
+        guard let start = body.range(of: "case .toolCall:") else {
+            Issue.record("emitRouted's `case .toolCall:` branch is gone — rewrite this guard")
+            return
+        }
+        // The branch runs until the next `case .` at the same level.
+        let rest = body[start.upperBound...]
+        let end = rest.range(of: "\n                case .")?.lowerBound ?? rest.endIndex
+        let branch = String(rest[..<end])
+
+        #expect(
+            branch.contains("stopMatcher.flush()"),
+            """
+            BatchEngine's `.toolCall` branch must drain the stop-string matcher \
+            BEFORE yielding the event. Without it, prose the matcher is holding \
+            for disambiguation is emitted after the tool call and silently \
+            dropped by consumers, cutting the answer mid-word. Branch body was:
+            \(branch)
+            """)
+
+        // The flush must come before the yield, not after it.
+        if let flushAt = branch.range(of: "stopMatcher.flush()"),
+            let yieldAt = branch.range(of: "continuation.yield(event)")
+        {
+            #expect(
+                flushAt.lowerBound < yieldAt.lowerBound,
+                "the matcher must be drained BEFORE the .toolCall event is yielded")
+        } else {
+            Issue.record("could not locate both the flush and the yield in the branch")
+        }
+    }
+}

--- a/Tests/MLXLMTests/GemmaEscapeMarkerLeakTests.swift
+++ b/Tests/MLXLMTests/GemmaEscapeMarkerLeakTests.swift
@@ -1,0 +1,103 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+/// Gemma-4's `<|"|>` escape marker is a *structural delimiter* of the bare-call
+/// wire format (`call:name{key:<|"|>value<|"|>}`). It is never legitimate
+/// argument data.
+///
+/// Live capture (Qwen-Image-Edit delegation, Gemma-4-12B-it-MXFP8 orchestrating):
+/// the model emitted an unbalanced marker and the parser handed the tool a
+/// `source_path` ending in `<|"|>`, which the image runtime rejected as a
+/// non-existent file. The marker leaked because `takeRawValue` terminates only
+/// on `,` `]` `}` — never on the escape marker — so a stray delimiter is
+/// swallowed verbatim into an unquoted scalar.
+@Suite("Gemma escape marker never leaks into argument values")
+struct GemmaEscapeMarkerLeakTests {
+    private let parser = Gemma4ToolCallParser()
+
+    private func string(_ call: ToolCall, _ key: String) -> String? {
+        guard case .string(let value) = call.function.arguments[key] else { return nil }
+        return value
+    }
+
+    /// LIVE-OBSERVED: opening marker absent, closing marker present.
+    /// The raw scalar swallows the trailing delimiter.
+    @Test("stray trailing marker does not leak into a raw scalar")
+    func strayTrailingMarkerStripped() throws {
+        let wire =
+            #"<|tool_call>call:image_edit{source_path:/tmp/a.png<|"|>,prompt:<|"|>make it blue<|"|>}<tool_call|>"#
+        let call = try #require(parser.parse(content: wire, tools: nil))
+
+        #expect(call.function.name == "image_edit")
+        #expect(string(call, "source_path") == "/tmp/a.png")
+        #expect(string(call, "prompt") == "make it blue")
+    }
+
+    /// KNOWN AMBIGUITY, deliberately not "fixed": when a string opens with the
+    /// marker but never closes it, the delimiter count is odd and *which* marker
+    /// is missing is unknowable — the marker is a paired toggle, like a quote.
+    /// Any recovery here would be a guess at model intent, so the parser does not
+    /// attempt one. What IS enforced universally is the invariant below: whatever
+    /// value comes out, it never contains a raw delimiter.
+    @Test("no parsed string value ever contains a raw delimiter")
+    func noValueEverContainsARawDelimiter() throws {
+        let wires = [
+            #"<|tool_call>call:f{a:/tmp/a.png<|"|>,b:<|"|>x<|"|>}<tool_call|>"#,
+            #"<|tool_call>call:f{a:<|"|>/tmp/a.png<|"|>}<tool_call|>"#,
+            #"<|tool_call>call:f{a:<|"|>unterminated}<tool_call|>"#,
+            #"<|tool_call>call:f{a:[<|"|>x<|"|>,plain<|"|>]}<tool_call|>"#,
+        ]
+        for wire in wires {
+            guard let call = parser.parse(content: wire, tools: nil) else { continue }
+            for (key, value) in call.function.arguments {
+                if case .string(let s) = value {
+                    #expect(
+                        s.contains(#"<|"|>"#) == false,
+                        "delimiter leaked into \(key) for wire: \(wire)")
+                }
+            }
+        }
+    }
+
+    /// Unterminated string at the end of the body: `parseValue` returns nil,
+    /// which `break`s the key/value loop — dropping this argument *and* every
+    /// argument after it. A truncated-but-present value is strictly better than
+    /// a silently missing one.
+    @Test("unterminated trailing string still yields the argument")
+    func unterminatedTrailingStringStillParses() throws {
+        let wire = #"<|tool_call>call:image_edit{prompt:<|"|>make it blue}<tool_call|>"#
+        let call = try #require(parser.parse(content: wire, tools: nil))
+
+        #expect(call.function.name == "image_edit")
+        let prompt = try #require(string(call, "prompt"))
+        #expect(prompt.contains("make it blue"))
+        #expect(prompt.contains(#"<|"|>"#) == false)
+    }
+
+    /// Regression guard: the well-formed shape must be untouched by the above.
+    @Test("well-formed escaped values are unchanged")
+    func wellFormedUnchanged() throws {
+        let wire =
+            #"<|tool_call>call:image_edit{source_path:<|"|>/tmp/a.png<|"|>,prompt:<|"|>make it blue<|"|>}<tool_call|>"#
+        let call = try #require(parser.parse(content: wire, tools: nil))
+
+        #expect(string(call, "source_path") == "/tmp/a.png")
+        #expect(string(call, "prompt") == "make it blue")
+    }
+
+    /// Regression guard: a raw scalar that merely *contains* an angle bracket or
+    /// pipe (but not the full marker) is still ordinary data.
+    @Test("escaped values keep lone angle brackets and pipes")
+    func loneBracketsSurvive() throws {
+        let wire =
+            #"<|tool_call>call:shell_run{command:<|"|>echo a | grep b > out.txt<|"|>}<tool_call|>"#
+        let call = try #require(parser.parse(content: wire, tools: nil))
+
+        #expect(string(call, "command") == "echo a | grep b > out.txt")
+    }
+}


### PR DESCRIPTION
Two defects on the tool-call path. Both were found from live capture, not from reading.

## 1. Gemma's `<|"|>` delimiter leaks into argument values

`<|"|>` is the string-quote delimiter of gemma's bare-call wire format
(`call:name{key:<|"|>value<|"|>}`) — structure, never data. `takeRawValue` terminated only on
`,` `]` `}`, so a stray delimiter was swallowed verbatim into an unquoted scalar.

Live, verbatim, from an image-edit delegation (Gemma-4-12B-MXFP8 → Qwen-Image-Edit):

```
{"ok":false,"kind":"invalid_args","field":"source_paths",
 "message":"unsupported source image extension: \"output/elephant_image.png<|\"|>\"","tool":"image"}
```

The runtime rejected a real generated image as a non-existent file.

Raw scalars now terminate at the marker, and a stranded closing marker is consumed so it can
neither leak into the value nor corrupt the next key.

A second bug in the same function: an unterminated string made `parseValue` return nil, which
`break`s the caller's key/value loop — dropping that argument **and every argument after it**.
Reproduced with `arguments: [:]` (empty). It now takes the remainder instead.

**Deliberately not "fixed":** a string that opens with the marker and never closes it. The marker
is a paired toggle, so an odd count means one is missing and *which one* is unknowable. Recovering
there would be guessing at model intent. The tests pin the invariant that holds regardless — no
parsed value ever contains a raw delimiter.

## 2. BatchEngine cuts prose before a tool call

`StopStringMatcher` withholds up to `maxStopLen - 1` characters while it disambiguates a possible
stop. That held text *precedes* the tool call in the model's output — but consumers stop forwarding
text the moment a `.toolCall` lands (deliberate no-leak suppression of post-tool prose), so a tail
emitted afterwards is silently dropped, cutting the visible answer mid-word.

`Evaluate.swift` already drains the matcher before the event. **BatchEngine never got that fix** —
and BatchEngine is the path Osaurus serves with. Any API client that sets `stop` while the model
calls a tool hits this.

BatchEngine builds its emit closures inline, so there is no seam to drive without standing up a
real engine and model. The invariant is pinned in source instead (the same approach
`Hy3CompiledDecodeGuardSourceTests` uses), and sabotage-verified: green with the fix, red without.

## Tests
- `GemmaEscapeMarkerLeakTests` — 5 tests, red → green. Includes the exact live wire shape.
- `BatchStopTailBeforeToolCallSourceTests` — sabotage-verified red.
- `ToolCallStopMatcherOrderingTests` (existing, solo path) still green.