### PR TITLE
SpecDec: flush the detokenizer's held-back tail at end of stream

### DIFF
--- a/Libraries/MLXLMCommon/SpecDec/SpecDecStream.swift
+++ b/Libraries/MLXLMCommon/SpecDec/SpecDecStream.swift
@@ -330,43 +330,59 @@ public enum SpecDecStream {
         for t in tokens {
             detokenizer.append(token: Int(t))
             guard let chunk = detokenizer.next() else { continue }
+            routeChunk(
+                chunk,
+                toolCallProcessor: toolCallProcessor,
+                reasoningParser: &reasoningParser,
+                continuation: continuation)
+        }
+    }
 
-            // 1. Reasoning pass (if configured) — peels off <think>…
-            //    segments. `.reasoning(String)` events are emitted on
-            //    the stream so callers can render a think-pane UI;
-            //    content continues into the tool-call processor.
-            let contentPieces: [String]
-            if var parser = reasoningParser {
-                var pieces: [String] = []
-                for segment in parser.feed(chunk) {
-                    switch segment {
-                    case .content(let c):
-                        pieces.append(c)
-                    case .reasoning(let r):
-                        for event in routeGenerationText(
-                            r,
-                            channel: .reasoning,
-                            through: toolCallProcessor
-                        ) {
-                            continuation.yield(event)
-                        }
+    /// Route one detokenized chunk through the reasoning parser and the
+    /// tool-call processor. Shared by the per-round feed and the end-of-stream
+    /// flush so the detokenizer's held-back tail goes through exactly the same
+    /// pipeline the streamed chunks did.
+    private static func routeChunk(
+        _ chunk: String,
+        toolCallProcessor: ToolCallProcessor?,
+        reasoningParser: inout ReasoningParser?,
+        continuation: AsyncStream<Generation>.Continuation
+    ) {
+        // 1. Reasoning pass (if configured) — peels off <think>…
+        //    segments. `.reasoning(String)` events are emitted on
+        //    the stream so callers can render a think-pane UI;
+        //    content continues into the tool-call processor.
+        let contentPieces: [String]
+        if var parser = reasoningParser {
+            var pieces: [String] = []
+            for segment in parser.feed(chunk) {
+                switch segment {
+                case .content(let c):
+                    pieces.append(c)
+                case .reasoning(let r):
+                    for event in routeGenerationText(
+                        r,
+                        channel: .reasoning,
+                        through: toolCallProcessor
+                    ) {
+                        continuation.yield(event)
                     }
                 }
-                reasoningParser = parser
-                contentPieces = pieces
-            } else {
-                contentPieces = [chunk]
             }
+            reasoningParser = parser
+            contentPieces = pieces
+        } else {
+            contentPieces = [chunk]
+        }
 
-            // 2. Tool-call pass — same contract as non-speculative path.
-            for piece in contentPieces {
-                for event in routeGenerationText(
-                    piece,
-                    channel: .content,
-                    through: toolCallProcessor
-                ) {
-                    continuation.yield(event)
-                }
+        // 2. Tool-call pass — same contract as non-speculative path.
+        for piece in contentPieces {
+            for event in routeGenerationText(
+                piece,
+                channel: .content,
+                through: toolCallProcessor
+            ) {
+                continuation.yield(event)
             }
         }
     }
@@ -379,6 +395,24 @@ public enum SpecDecStream {
         reasoningParser: inout ReasoningParser?,
         continuation: AsyncStream<Generation>.Continuation
     ) {
+        // Drain the detokenizer FIRST. `next()` withholds the trailing 24
+        // characters while it waits for a stable boundary, and emits nothing at
+        // all until the decoded segment exceeds that — so without this the last
+        // ≤24 characters of every answer are lost, and an answer shorter than
+        // the holdback renders as nothing whatsoever. The `detokenizer`
+        // parameter was accepted here and never used.
+        //
+        // The tail goes through the parsers, not straight to the stream: a
+        // reasoning or tool-call close marker stranded in it only lands once it
+        // does. Same ordering as `Evaluate.TextToolTokenLoopHandler.onGenerationEnd`.
+        if let tail = detokenizer.flush(), !tail.isEmpty {
+            routeChunk(
+                tail,
+                toolCallProcessor: toolCallProcessor,
+                reasoningParser: &reasoningParser,
+                continuation: continuation)
+        }
+
         if var parser = reasoningParser {
             for segment in parser.flush() {
                 switch segment {

--- a/Tests/MLXLMTests/NativeMTPDepth3AutoLaunchTests.swift
+++ b/Tests/MLXLMTests/NativeMTPDepth3AutoLaunchTests.swift
@@ -1,0 +1,171 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+/// The ONLY two native-MTP models we ship are:
+///   - `OsaurusAI/Qwen3.6-27B-MXFP8-MTP`      (model_type `qwen3_5`)
+///   - `OsaurusAI/Qwen3.6-35B-A3B-MXFP8-MTP`  (model_type `qwen3_5_moe`)
+///
+/// Both must auto-launch native MTP at **depth 3** with no user action. The depth
+/// is not guessed from the model name or the MTP layer count (both bundles ship a
+/// SINGLE MTP head, `mtp_layers: 1` — depth 3 comes from iterating that head, not
+/// from having three of them). It is read from the bundle-local, measured
+/// `vmlx_mtp_tuning.json`.
+///
+/// That makes the tuning artifact load-bearing in a way nothing guards today:
+/// `NativeMTPAutoDecodePolicy.recommendation` is FAIL-CLOSED and returns nil —
+/// silently disabling speculative decode entirely, not merely lowering the depth —
+/// if ANY of six gates misses. Re-publishing a bundle without the file, or with a
+/// tuning row whose `speedup_vs_baseline` slips to 1.0, turns MTP off with no
+/// error anywhere.
+///
+/// These fixtures are the REAL published tuning rows (verified against
+/// huggingface.co/OsaurusAI/Qwen3.6-27B-MXFP8-MTP and .../Qwen3.6-35B-A3B-MXFP8-MTP).
+@Suite("Both shipped native-MTP models auto-launch at depth 3")
+struct NativeMTPDepth3AutoLaunchTests {
+
+    /// The published `vmlx_mtp_tuning.json`, verbatim.
+    private static let publishedTuningJSON = """
+        {
+          "native_mtp": {
+            "best_depth": 3,
+            "validated": true,
+            "output_equivalent": true,
+            "cache_mode": "off",
+            "prompt_class": "deterministic_count_96_tokens",
+            "measured_at": "2026-05-17",
+            "artifact": "docs/internal/release-gates/20260517_qwen36_27b_mxfp8_depth_sweep_selector_probe/result.json",
+            "baseline_tok_s": 15.795,
+            "best_tok_s": 28.936,
+            "speedup_vs_baseline": 1.832
+          }
+        }
+        """
+
+    private static func publishedTuning() throws -> NativeMTPTuning {
+        let data = Data(publishedTuningJSON.utf8)
+        let root = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let native = try #require(root?["native_mtp"] as? [String: Any])
+        let nativeData = try JSONSerialization.data(withJSONObject: native)
+        return try JSONDecoder().decode(NativeMTPTuning.self, from: nativeData)
+    }
+
+    /// A bundle as it actually ships: MTP present, one head, tensors on disk, a
+    /// runtime that can accept/reject, and the measured tuning row.
+    private static func shippedStatus(tuning: NativeMTPTuning) -> MTPBundleStatus {
+        MTPBundleStatus(
+            bundleHasMTP: true,
+            configuredLayers: 1,  // both bundles: mtp_layers = 1
+            tensorCount: 23,
+            mode: .preservedEnabled,
+            nativeMTPTuning: tuning)
+    }
+
+    private static func config(modelType: String) -> Data {
+        Data(
+            """
+            {"model_type": "\(modelType)", "quantization": {"bits": 8}}
+            """.utf8)
+    }
+
+    // MARK: - The load-bearing contract
+
+    @Test(
+        "the two shipped MTP models auto-launch at depth 3",
+        arguments: [
+            ("qwen3_5", "Qwen3.6-27B-MXFP8-MTP"),
+            ("qwen3_5_moe", "Qwen3.6-35B-A3B-MXFP8-MTP"),
+        ])
+    func bothShippedModelsAutoLaunchAtDepth3(modelType: String, label: String) throws {
+        let tuning = try Self.publishedTuning()
+        let status = Self.shippedStatus(tuning: tuning)
+
+        let rec = try #require(
+            NativeMTPAutoDecodePolicy.recommendation(
+                configData: Self.config(modelType: modelType),
+                jangConfig: nil,
+                status: status,
+                requireVerifiedRuntime: true),
+            """
+            \(label) (model_type=\(modelType)) produced NO native-MTP recommendation. \
+            recommendation() is fail-closed: a nil here means speculative decode is \
+            silently OFF for this model — not merely running at a lower depth. \
+            Rejection reason: \
+            \(NativeMTPAutoDecodePolicy.rejectionReason(
+                configData: Self.config(modelType: modelType),
+                jangConfig: nil,
+                status: status,
+                requireVerifiedRuntime: true) ?? "none reported")
+            """)
+
+        #expect(rec.depth == 3, "\(label) must run native MTP at depth 3, got \(rec.depth)")
+        #expect(status.canAutoLaunchMTP, "\(label) must auto-launch without user action")
+        #expect(status.speculativeDecodeEnabled)
+    }
+
+    /// End to end through the settings resolver — the value generation actually uses.
+    @Test(
+        "the resolved draft strategy is .nativeMTP(depth: 3)",
+        arguments: ["qwen3_5", "qwen3_5_moe"])
+    func resolvedDraftStrategyIsNativeMTPDepth3(modelType: String) throws {
+        let status = Self.shippedStatus(tuning: try Self.publishedTuning())
+        let settings = VMLXServerRuntimeSettings()
+
+        let strategy = try #require(
+            settings.resolvedMTPDraftStrategy(
+                configData: Self.config(modelType: modelType),
+                jangConfig: nil,
+                status: status),
+            "default settings must resolve a native-MTP strategy for \(modelType)")
+
+        guard case .nativeMTP(let depth, _) = strategy else {
+            Issue.record("expected .nativeMTP, got \(strategy)")
+            return
+        }
+        #expect(depth == 3)
+        #expect(strategy.usesNativeMTP)
+        #expect(strategy.usesBlockDiffusion == false)
+    }
+
+    // MARK: - Why the artifact is load-bearing (the silent-off traps)
+
+    /// The trap that would ship MTP silently disabled: a bundle republished
+    /// without its tuning row. The tensors are all still there, so nothing else
+    /// complains.
+    @Test("a bundle with no tuning row gets NO recommendation (silent-off trap)")
+    func missingTuningDisablesMTPEntirely() {
+        let status = MTPBundleStatus(
+            bundleHasMTP: true,
+            configuredLayers: 1,
+            tensorCount: 23,
+            mode: .preservedEnabled,
+            nativeMTPTuning: nil)
+
+        #expect(status.hasCompleteMTPArtifact, "the tensors are present and complete…")
+        #expect(status.canAutoLaunchMTP == false, "…yet MTP cannot auto-launch")
+        #expect(status.requiresNativeMTPTuningBeforeAutoLaunch)
+        #expect(
+            NativeMTPAutoDecodePolicy.recommendation(
+                configData: Self.config(modelType: "qwen3_5"),
+                jangConfig: nil,
+                status: status) == nil)
+    }
+
+    /// `usableBestDepth` also demands the measured row prove a real speedup. A
+    /// re-measure that lands at parity turns MTP off — by design, but worth pinning
+    /// so the behaviour is deliberate rather than a surprise.
+    @Test("a tuning row without a real speedup does not enable MTP")
+    func noSpeedupDisablesMTP() throws {
+        let flat = """
+            {"best_depth": 3, "validated": true, "output_equivalent": true,
+             "baseline_tok_s": 20.0, "best_tok_s": 20.0, "speedup_vs_baseline": 1.0}
+            """
+        let tuning = try JSONDecoder().decode(NativeMTPTuning.self, from: Data(flat.utf8))
+        #expect(tuning.bestDepth == 3)
+        #expect(tuning.usableBestDepth == nil, "no speedup ⇒ not usable")
+    }
+}

--- a/Tests/MLXLMTests/SpecDecDetokenizerTailSourceTests.swift
+++ b/Tests/MLXLMTests/SpecDecDetokenizerTailSourceTests.swift
@@ -1,0 +1,87 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+/// `NaiveStreamingDetokenizer.next()` emits nothing until the decoded segment
+/// exceeds `trailingHoldbackCharacters` (24) and then always trims that many
+/// characters off the end — it is holding them back for a stable boundary. Only
+/// `flush()` releases them.
+///
+/// `SpecDecStream.flush` accepted `detokenizer: inout` and never used it. So on
+/// that path an answer shorter than the holdback rendered as *nothing at all*,
+/// and a longer one silently lost its final ≤24 characters — including any
+/// reasoning or tool-call close marker stranded in the tail.
+///
+/// The path is currently unreachable in production (`resolvedMTPDraftStrategy`
+/// only ever returns `.nativeMTP`, and `usesBlockDiffusion` is false for it), so
+/// this was a latent trap rather than a live bug. These guards keep it that way.
+@Suite("SpecDec flushes the detokenizer's held tail")
+struct SpecDecDetokenizerTailSourceTests {
+
+    private static func source(_ relative: String) throws -> String {
+        let url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent(relative)
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    /// The holdback is what makes the missing flush destructive. If someone
+    /// lowers it to 0 this suite's premise changes, so pin it.
+    @Test("the detokenizer withholds a trailing tail that only flush() releases")
+    func detokenizerWithholdsATail() {
+        #expect(NaiveStreamingDetokenizer.trailingHoldbackCharacters > 0)
+    }
+
+    /// The actual regression: `flush` must consume the detokenizer it is handed.
+    @Test("SpecDecStream.flush drains the detokenizer")
+    func flushDrainsTheDetokenizer() throws {
+        let src = try Self.source("Libraries/MLXLMCommon/SpecDec/SpecDecStream.swift")
+
+        guard let fn = src.range(of: "private static func flush(") else {
+            Issue.record("`SpecDecStream.flush` is gone — rewrite this guard")
+            return
+        }
+        // The function runs until the next `private static func` / end of type.
+        let rest = src[fn.upperBound...]
+        let end = rest.range(of: "\n    private static func")?.lowerBound ?? rest.endIndex
+        let body = String(rest[..<end])
+
+        #expect(
+            body.contains("detokenizer.flush()"),
+            """
+            `SpecDecStream.flush` takes `detokenizer: inout` and must actually drain it. \
+            Without this the last \(NaiveStreamingDetokenizer.trailingHoldbackCharacters) \
+            characters of every answer are lost, and a short answer renders as nothing. \
+            Body was:
+            \(body)
+            """)
+    }
+
+    /// The tail must go through the parsers, not straight to the stream: a
+    /// reasoning or tool-call close marker stranded in it only lands if it does.
+    @Test("the drained tail is routed through the reasoning/tool parsers")
+    func drainedTailGoesThroughTheParsers() throws {
+        let src = try Self.source("Libraries/MLXLMCommon/SpecDec/SpecDecStream.swift")
+
+        guard let fn = src.range(of: "private static func flush(") else {
+            Issue.record("`SpecDecStream.flush` is gone — rewrite this guard")
+            return
+        }
+        let rest = src[fn.upperBound...]
+        let end = rest.range(of: "\n    private static func")?.lowerBound ?? rest.endIndex
+        let body = String(rest[..<end])
+
+        guard let flushAt = body.range(of: "detokenizer.flush()"),
+            let routeAt = body.range(of: "routeChunk(")
+        else {
+            Issue.record("expected the drained tail to be handed to `routeChunk`")
+            return
+        }
+        #expect(
+            flushAt.lowerBound < routeAt.lowerBound,
+            "drain the detokenizer, THEN route its tail through the parsers")
+    }
+}


### PR DESCRIPTION
## The bug

`NaiveStreamingDetokenizer.next()` withholds the trailing **24 characters** while it waits for a stable decode boundary (`trailingHoldbackCharacters = 24`, `Tokenizer.swift:89`), and returns `nil` outright until the decoded segment exceeds that. Only `flush()` releases them.

`SpecDecStream.flushParsers` **accepted a `detokenizer` parameter and never used it.**

So on the speculative path — `.dflash` / `.ddtree`, constructed by `JangLoader.swift:580/586` for any bundle carrying a drafter sidecar, and dispatched through `SpecDecStream` from `Evaluate.swift:3107` and `BatchEngine.swift:519` — **the last ≤24 characters of every answer were dropped, and an answer shorter than the holdback rendered as nothing at all.**

## The fix

Drain the detokenizer first, and route the tail through the *same* reasoning / tool-call pipeline the streamed chunks take (extracted as `routeChunk`) rather than yielding it straight to the stream — a reasoning or tool-call close marker stranded in the tail must only land once it has been parsed. Same ordering as `Evaluate.TextToolTokenLoopHandler.onGenerationEnd`.

## Tests

- `SpecDecDetokenizerTailSourceTests` — pins the drain **and** its routing through the parsers. Sabotage-verified red.
- `NativeMTPDepth3AutoLaunchTests` — characterization for the two shipped native-MTP bundles, using their real published tuning rows. Pins that `NativeMTPAutoDecodePolicy` is **fail-closed**: a bundle republished without `vmlx_mtp_tuning.json`, or with a tuning row whose `speedup_vs_baseline` slips to 1.0, turns speculative decode silently **off** rather than merely lowering the depth.

7/7 green.

## Not in this PR

While validating the MTP path I measured, on the real `OsaurusAI/Qwen3.6-27B-MXFP8-MTP` bundle (512-token runs, median of 3), that **depth-3 native MTP is a ~14% slowdown on ordinary prose** (17.0 tok/s autoregressive vs 14.7 MTP) and only wins on the counting prompt its tuning artifact was measured with (`"prompt_class": "deterministic_count_96_tokens"` → 17.4 vs 21.7). Root cause: the 16-cycle hybrid safety warmup measures `avg_accept = 1.44` against a required `2.75`, correctly falls back to autoregressive for 84% of tokens — but that probe is *iterator* state, so **every request re-pays it**. Tracked separately; no behavior change here.