### PR TITLE
feat: run schema-2 affine 1-bit JANG models natively

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -303,6 +303,7 @@ public actor BatchEngine {
     /// `submit(...)` and maxBatchSize > 1 on the continuous-batching scheduler.
     private var soloFastPathTask: Task<Void, Never>?
     private var soloFastPathID: UUID?
+    private var soloFastPathHadMedia = false
 
     /// Terminal lifecycle flag. Once shutdown begins, stale engine handles
     /// reject future submissions instead of restarting GPU work.
@@ -994,6 +995,7 @@ public actor BatchEngine {
         promptTail: String?
     ) -> AsyncStream<Generation> {
         let promptTokenCount = input.text.tokens.size
+        let hasMediaContent = input.hasMediaContent
         let toolSchemas = input.toolSchemas
         let disableDiskBackedRequiredToolRestore = shouldDisableDiskBackedRequiredToolRestore(
             toolSchemas: toolSchemas,
@@ -1157,6 +1159,7 @@ public actor BatchEngine {
 
         soloFastPathID = fastPathID
         soloFastPathTask = generationTask
+        soloFastPathHadMedia = hasMediaContent
 
         continuation.onTermination = { @Sendable _ in
             generationTask.cancel()
@@ -1178,8 +1181,14 @@ public actor BatchEngine {
     private func finishSoloFastPath(id: UUID) {
         guard soloFastPathID == id else { return }
         Stream().synchronize()
+        let shouldPurgeMediaWorkingSet = soloFastPathHadMedia
         soloFastPathID = nil
         soloFastPathTask = nil
+        soloFastPathHadMedia = false
+        if shouldPurgeMediaWorkingSet {
+            Memory.clearCache()
+            stepsSinceMemoryPurge = 0
+        }
         if !isShutdown && !waitQueue.isEmpty {
             ensureLoopRunning()
         }
@@ -1236,11 +1245,13 @@ public actor BatchEngine {
 
         let drainLoopTask = loopTask
         let drainSoloTask = soloFastPathTask
+        let shouldPurgeSoloMediaWorkingSet = soloFastPathHadMedia
         loopTask?.cancel()
         loopTask = nil
         soloFastPathTask?.cancel()
         soloFastPathTask = nil
         soloFastPathID = nil
+        soloFastPathHadMedia = false
 
         // Finish all pending requests
         for request in waitQueue {
@@ -1273,6 +1284,10 @@ public actor BatchEngine {
         // Final fence: producers submit via `asyncEval`, so their last
         // command buffers may still be in flight when the tasks return.
         Stream().synchronize()
+        if shouldPurgeSoloMediaWorkingSet {
+            Memory.clearCache()
+            stepsSinceMemoryPurge = 0
+        }
     }
 
     /// The number of requests currently waiting in the queue.
@@ -1335,8 +1350,20 @@ public actor BatchEngine {
             // 2. Run one scheduling step
             step()
 
-            // 3. Remove finished slots
+            // 3. Remove finished slots. Media requests retain their prepared
+            //    image/video arrays in `originalInput` for the lifetime of the
+            //    slot. Purge only after removing those final strong references;
+            //    clearing inside `finishSlot` is too early and lets successive
+            //    short media turns accumulate the allocator's released working
+            //    set until the generic 256-step purge.
+            let finishedMediaSlot = activeSlots.contains {
+                $0.isFinished && $0.originalInput.hasMediaContent
+            }
             activeSlots.removeAll { $0.isFinished }
+            if finishedMediaSlot {
+                Memory.clearCache()
+                stepsSinceMemoryPurge = 0
+            }
 
             // 4. Periodic memory cleanup
             stepsSinceMemoryPurge += 1

--- a/Libraries/MLXLMCommon/JangLoader.swift
+++ b/Libraries/MLXLMCommon/JangLoader.swift
@@ -143,6 +143,34 @@ public struct JangRuntime: Sendable, Equatable {
     }
 }
 
+/// Validated bundle contract for affine weights packed at one bit.
+///
+/// These tensors remain in their compact storage representation and are
+/// consumed directly by MLX's native affine-1 Metal kernels. The bundle's
+/// historical `runtime_bits=2` field documents the lossless widening fallback
+/// used by runtimes without native support; vMLX must not perform that
+/// expansion because it defeats the bundle's low-memory contract.
+public struct JangAffine1RuntimeContract: Sendable, Equatable {
+    public let storageBits: Int
+    public let runtimeBits: Int
+    public let modulePaths: Set<String>
+
+    public init(storageBits: Int, runtimeBits: Int, modulePaths: Set<String>) {
+        self.storageBits = storageBits
+        self.runtimeBits = runtimeBits
+        self.modulePaths = modulePaths
+    }
+}
+
+/// Per-tensor affine metadata from a schema-2 JANG manifest.
+public struct JangTensorQuantizationManifest: Sendable, Equatable {
+    public let entries: [String: BaseConfiguration.Quantization]
+
+    public init(entries: [String: BaseConfiguration.Quantization]) {
+        self.entries = entries
+    }
+}
+
 /// Capability hints stamped into `jang_config.json` by the JANG converter.
 ///
 /// Allows downstream consumers (osaurus, llm-tool, etc.) to pick the right
@@ -820,6 +848,170 @@ public struct JangConfig: Sendable {
 
 /// JANG model loader — detects, parses config, and infers per-layer quantization.
 public struct JangLoader: Sendable {
+
+    /// Load the exact per-tensor affine metadata stamped by the converter.
+    /// Shape inference remains the fallback for older bundles without a
+    /// schema-2 manifest.
+    public static func loadTensorQuantizationManifest(
+        at modelPath: URL
+    ) throws -> JangTensorQuantizationManifest? {
+        guard let configURL = findConfigPath(at: modelPath) else { return nil }
+        let data = try Data(contentsOf: configURL)
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            throw JangLoaderError.invalidConfig("Failed to parse tensor manifest JSON")
+        }
+        guard let quantization = json["quantization"] as? [String: Any],
+            let schema = quantization["tensor_quantization_manifest_schema"] as? Int
+        else {
+            return nil
+        }
+        guard schema == 2,
+            let rawManifest = quantization["tensor_quantization_manifest"] as? [String: Any]
+        else {
+            throw JangLoaderError.invalidConfig(
+                "unsupported tensor quantization manifest schema \(schema)")
+        }
+        if let declaredCount = quantization["tensor_quantization_manifest_count"] as? Int,
+            declaredCount != rawManifest.count
+        {
+            throw JangLoaderError.invalidConfig(
+                "tensor quantization manifest count mismatch: declared \(declaredCount), found \(rawManifest.count)")
+        }
+
+        let supportedAffineBits = Set([1, 2, 3, 4, 5, 6, 8])
+        var entries: [String: BaseConfiguration.Quantization] = [:]
+        entries.reserveCapacity(rawManifest.count)
+        for (path, rawEntry) in rawManifest {
+            guard let entry = rawEntry as? [String: Any],
+                let bits = entry["bits"] as? Int,
+                let groupSize = entry["group_size"] as? Int,
+                let mode = (entry["mode"] as? String)?.lowercased(),
+                mode == "affine",
+                supportedAffineBits.contains(bits),
+                groupSize > 0
+            else {
+                throw JangLoaderError.invalidConfig(
+                    "invalid affine tensor quantization manifest entry: \(path)")
+            }
+            if let storageBits = entry["storage_bits"] as? Int, storageBits != bits {
+                throw JangLoaderError.invalidConfig(
+                    "manifest bits/storage_bits mismatch for \(path): \(bits)/\(storageBits)")
+            }
+            entries[path] = BaseConfiguration.Quantization(
+                groupSize: groupSize, bits: bits, mode: .affine)
+        }
+        guard !entries.isEmpty else {
+            throw JangLoaderError.invalidConfig("tensor quantization manifest is empty")
+        }
+        return JangTensorQuantizationManifest(entries: entries)
+    }
+
+    /// Validate every manifest entry present in the selected model's weight
+    /// set. Text-only factories may intentionally omit vision tensors, so
+    /// absent entries are ignored; half-present or shape-inconsistent entries
+    /// fail closed.
+    public static func validateTensorQuantizationManifest(
+        _ manifest: JangTensorQuantizationManifest,
+        against weights: [String: MLXArray]
+    ) throws {
+        var validated = 0
+        for (path, quantization) in manifest.entries {
+            let weightKey = "\(path).weight"
+            let scalesKey = "\(path).scales"
+            let weight = weights[weightKey]
+            let scales = weights[scalesKey]
+            guard weight != nil || scales != nil else { continue }
+            guard let weight, let scales,
+                weight.dtype == .uint32,
+                let packedDim = weight.shape.last, packedDim > 0,
+                let numGroups = scales.shape.last, numGroups > 0,
+                (packedDim * 32) % quantization.bits == 0
+            else {
+                throw JangLoaderError.loadFailed(
+                    "manifest tensor is missing or malformed: \(path)")
+            }
+            let inputDim = (packedDim * 32) / quantization.bits
+            guard inputDim == numGroups * quantization.groupSize else {
+                throw JangLoaderError.loadFailed(
+                    "manifest tensor shape mismatch for \(path): packed=\(packedDim), groups=\(numGroups), bits=\(quantization.bits), group_size=\(quantization.groupSize)")
+            }
+            validated += 1
+        }
+        guard validated > 0 else {
+            throw JangLoaderError.loadFailed(
+                "tensor quantization manifest matched no loaded weights")
+        }
+    }
+
+    /// Read and validate a bundle's opt-in affine-1 runtime contract.
+    /// Bundles that do not request affine-1 support return `nil` and retain the
+    /// existing load path unchanged.
+    public static func loadAffine1RuntimeContract(
+        at modelPath: URL
+    ) throws -> JangAffine1RuntimeContract? {
+        guard let configURL = findConfigPath(at: modelPath) else { return nil }
+        let data = try Data(contentsOf: configURL)
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            throw JangLoaderError.invalidConfig("Failed to parse affine-1 contract JSON")
+        }
+        guard let runtime = json["runtime"] as? [String: Any],
+            runtime["requires_jang_affine1_expansion"] as? Bool == true
+        else {
+            return nil
+        }
+        guard let quantization = json["quantization"] as? [String: Any],
+            let expansion = quantization["affine1_runtime_expansion"] as? [String: Any]
+        else {
+            throw JangLoaderError.invalidConfig(
+                "runtime requires affine-1 expansion but quantization.affine1_runtime_expansion is missing")
+        }
+
+        guard let storageBits = expansion["storage_bits"] as? Int,
+            let runtimeBits = expansion["runtime_bits"] as? Int,
+            storageBits == 1, runtimeBits == 2,
+            expansion["lossless"] as? Bool == true,
+            expansion["scales_biases_unchanged"] as? Bool == true
+        else {
+            throw JangLoaderError.invalidConfig(
+                "unsupported affine-1 expansion contract; expected lossless storage_bits=1, runtime_bits=2, scales_biases_unchanged=true")
+        }
+        guard quantization["tensor_quantization_manifest_schema"] as? Int == 2,
+            let manifest = quantization["tensor_quantization_manifest"] as? [String: Any]
+        else {
+            throw JangLoaderError.invalidConfig(
+                "affine-1 expansion requires tensor_quantization_manifest schema 2")
+        }
+        if let declaredCount = quantization["tensor_quantization_manifest_count"] as? Int,
+            declaredCount != manifest.count
+        {
+            throw JangLoaderError.invalidConfig(
+                "tensor quantization manifest count mismatch: declared \(declaredCount), found \(manifest.count)")
+        }
+
+        var modulePaths = Set<String>()
+        for (path, rawEntry) in manifest {
+            guard let entry = rawEntry as? [String: Any] else {
+                throw JangLoaderError.invalidConfig(
+                    "tensor quantization manifest entry is not an object: \(path)")
+            }
+            guard entry["storage_bits"] as? Int == 1 else { continue }
+            guard entry["bits"] as? Int == 1,
+                (entry["mode"] as? String)?.lowercased() == "affine"
+            else {
+                throw JangLoaderError.invalidConfig(
+                    "storage_bits=1 entry must declare bits=1 and mode=affine: \(path)")
+            }
+            modulePaths.insert(path)
+        }
+        guard !modulePaths.isEmpty else {
+            throw JangLoaderError.invalidConfig(
+                "affine-1 expansion contract has no storage_bits=1 manifest entries")
+        }
+        return JangAffine1RuntimeContract(
+            storageBits: storageBits, runtimeBits: runtimeBits, modulePaths: modulePaths)
+    }
 
     /// Check if a model directory contains a JANG model.
     public static func isJangModel(at path: URL) -> Bool {
@@ -1845,7 +2037,8 @@ public struct JangLoader: Sendable {
         validInDims: Set<Int> = [],
         attentionOutputDimHints: Set<Int> = [],
         declaredDefaultQuantization: BaseConfiguration.Quantization? = nil,
-        declaredPerLayerQuantization: BaseConfiguration.PerLayerQuantization? = nil
+        declaredPerLayerQuantization: BaseConfiguration.PerLayerQuantization? = nil,
+        declaredManifestQuantization: [String: BaseConfiguration.Quantization] = [:]
     ) -> BaseConfiguration.PerLayerQuantization {
         // JANGTQ bundles use two independent bit namespaces:
         //   - `mxtq_bits` / `routed_expert_bits` for tq_packed routed experts.
@@ -2003,6 +2196,20 @@ public struct JangLoader: Sendable {
                 ?? declaredDefaultQuantization
         }
 
+        func manifestQuantization(for basePath: String) -> BaseConfiguration.Quantization? {
+            for key in [
+                basePath,
+                basePath.hasPrefix("language_model.")
+                    ? String(basePath.dropFirst("language_model.".count)) : nil,
+                basePath.hasPrefix("model.") ? "language_model.\(basePath)" : nil,
+            ].compactMap({ $0 }) {
+                if let quantization = declaredManifestQuantization[key] {
+                    return quantization
+                }
+            }
+            return nil
+        }
+
         func layerIndexFromQuantizedBasePath(_ basePath: String) -> Int? {
             guard let range = basePath.range(
                 of: #"(?:^|\.)(?:model\.)?layers\.(\d+)\."#,
@@ -2121,7 +2328,9 @@ public struct JangLoader: Sendable {
             // inputDim ∈ validInDims is the author's verified intent. A genuinely stale
             // config (claims 8-bit for 4-bit-packed) unpacks to a NON-model inputDim,
             // fails this check, and still falls through to the shape walk.
-            if let dq = declaredQuantization(for: basePath),
+            if let manifest = manifestQuantization(for: basePath) {
+                (bits, inferredGroupSize) = (manifest.bits, manifest.groupSize)
+            } else if let dq = declaredQuantization(for: basePath),
                dq.bits > 0, numGroups > 0, (packedDim * 32) % dq.bits == 0,
                case let declaredInputDim = (packedDim * 32) / dq.bits,
                declaredInputDim % numGroups == 0,

--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -276,6 +276,30 @@ public func loadWeights(
         }
     }
 
+    let jangTensorManifest = try JangLoader.loadTensorQuantizationManifest(
+        at: modelDirectory)
+    if let jangTensorManifest {
+        try JangLoader.validateTensorQuantizationManifest(
+            jangTensorManifest, against: weights)
+    }
+
+    // Affine-1 JANG bundles opt in through a schema-2 manifest. Validate that
+    // contract before model sanitization changes any weight paths, then leave
+    // the packed tensors untouched for MLX's native affine-1 Metal kernels.
+    if let contract = try JangLoader.loadAffine1RuntimeContract(at: modelDirectory) {
+        for modulePath in contract.modulePaths {
+            let key = "\(modulePath).weight"
+            guard let packed = weights[key], packed.dtype == .uint32,
+                packed.shape.last.map({ $0 > 0 }) == true
+            else {
+                throw JangLoaderError.loadFailed(
+                    "affine-1 manifest weight must be a non-empty uint32 tensor: \(key)")
+            }
+        }
+        FileHandle.standardError.write(Data(
+            "[Load] JANG affine-1 validated \(contract.modulePaths.count) native 1-bit weight(s)\n".utf8))
+    }
+
     // per-model cleanup (models can inspect metadata to customize behavior)
     //
     // Cap MetalAllocator's buffer_cache_ during sanitize() to keep the
@@ -377,7 +401,8 @@ public func loadWeights(
             validInDims: validInDims,
             attentionOutputDimHints: attentionOutputDimHints,
             declaredDefaultQuantization: declaredAffineQuantization ?? quantization,
-            declaredPerLayerQuantization: perLayerQuantization)
+            declaredPerLayerQuantization: perLayerQuantization,
+            declaredManifestQuantization: jangTensorManifest?.entries ?? [:])
 
         if !inferred.perLayerQuantization.isEmpty {
             let b = inferred.quantization?.bits ?? -1

--- a/Libraries/MLXVLM/Models/Qwen3VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen3VL.swift
@@ -175,7 +175,8 @@ public struct Qwen3VLProcessor: UserInputProcessor {
             return LMInput(
                 text: .init(tokens: promptArray, mask: mask, tokenIds: promptTokens),
                 cacheScopeSalt: cacheScopeSalt(from: input.additionalContext),
-                cachePrefixTokenCounts: cachePrefixTokenCounts)
+                cachePrefixTokenCounts: cachePrefixTokenCounts,
+                toolSchemas: input.tools)
         }
 
         var processedImage: LMInput.ProcessedImage?
@@ -257,7 +258,8 @@ public struct Qwen3VLProcessor: UserInputProcessor {
             text: .init(tokens: promptArray, mask: mask, tokenIds: promptTokens),
             image: processedImage,
             video: processedVideo,
-            cacheScopeSalt: cacheScopeSalt(from: input.additionalContext))
+            cacheScopeSalt: cacheScopeSalt(from: input.additionalContext),
+            toolSchemas: input.tools)
     }
 }
 

--- a/Package.swift
+++ b/Package.swift
@@ -838,6 +838,7 @@ let package = Package(
                 "MiniMaxJANGTQResidentExpertTests.swift",
                 "JangPressMachCacheTests.swift",
                 "JangPressPrestackerCleanupTests.swift",
+                "JangAffine1RuntimeContractTests.swift",
                 "DeepseekV4IndexerCausalTopKTests.swift",
                 "DeepseekV4ReasoningPolicyTests.swift",
                 "Gemma4ZyphraToolParserFocusedTests.swift",

--- a/RunBench/Bench.swift
+++ b/RunBench/Bench.swift
@@ -4110,11 +4110,11 @@ func runQwenThinkingReasoningCheck(modelPath: String, maxNew: Int) async throws 
     var reasoningText = ""
     var chunkCount = 0
     var reasoningCount = 0
+    var completionInfo: GenerateCompletionInfo?
 
     do {
         let loadStart = CFAbsoluteTimeGetCurrent()
-        let context = try await MLXLMCommon.loadModel(
-            from: modelDir, using: #huggingFaceTokenizerLoader())
+        let context = try await loadBenchModelContext(from: modelDir)
         print(String(format: "Load: %.2fs", CFAbsoluteTimeGetCurrent() - loadStart))
         print("Model: \(type(of: context.model))")
         print("Reasoning stamp: \(context.configuration.reasoningParserName ?? "nil")")
@@ -4155,7 +4155,9 @@ func runQwenThinkingReasoningCheck(modelPath: String, maxNew: Int) async throws 
                 case .reasoning(let r):
                     reasoningText += r
                     reasoningCount += 1
-                case .prefillProgress, .toolCall, .info, .toolCallProgress:
+                case .info(let info):
+                    completionInfo = info
+                case .prefillProgress, .toolCall, .toolCallProgress:
                     break
                 }
             }
@@ -4169,17 +4171,41 @@ func runQwenThinkingReasoningCheck(modelPath: String, maxNew: Int) async throws 
     try? await Task.sleep(nanoseconds: 50_000_000)
 
     print("chunks=\(chunkCount) reasoningDeltas=\(reasoningCount)")
+    if let completionInfo {
+        print(String(format:
+            "telemetry tokens=%d promptTok/s=%.1f decodeTok/s=%.1f stop=%@ unclosedReasoning=%@",
+            completionInfo.generationTokenCount,
+            completionInfo.promptTokensPerSecond,
+            completionInfo.tokensPerSecond,
+            String(describing: completionInfo.stopReason),
+            completionInfo.unclosedReasoning ? "yes" : "no"))
+    }
     print(".chunk preview: \"\(chunkText.prefix(300))\"")
     print(".reasoning preview: \"\(reasoningText.prefix(300))\"")
 
-    if chunkText.contains("<think>") || chunkText.contains("</think>") {
-        fputs("FAIL: .chunk leaked <think> markers — startInReasoning broken.\n", stderr)
+    let rawMarkers = ["<think>", "</think>", "<|channel>", "<|tool_call>", "<tool_call>"]
+        .filter { chunkText.contains($0) }
+    if !rawMarkers.isEmpty {
+        fputs("FAIL: .chunk leaked raw parser markers: \(rawMarkers).\n", stderr)
         exit(1)
     }
     if reasoningCount == 0 {
-        fputs("WARN: zero .reasoning deltas — prompt may not elicit CoT.\n", stderr)
+        fputs("FAIL: zero .reasoning deltas for an explicit thinking prompt.\n", stderr)
+        exit(1)
     }
-    print("PASS no <think> leakage in .chunk.")
+    if chunkText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        fputs("FAIL: thinking turn emitted no visible final answer.\n", stderr)
+        exit(1)
+    }
+    guard let completionInfo,
+          completionInfo.generationTokenCount > 0,
+          completionInfo.tokensPerSecond > 0,
+          !completionInfo.unclosedReasoning
+    else {
+        fputs("FAIL: missing generation telemetry or reasoning did not close.\n", stderr)
+        exit(1)
+    }
+    print("PASS reasoning/content split, closed reasoning, telemetry, and no raw-marker leakage.")
     print("=== BENCH_QWEN_THINKING_CHECK: passed ===")
 }
 

--- a/RunBench/VLBench.swift
+++ b/RunBench/VLBench.swift
@@ -22,13 +22,24 @@ import MLXVLM
 /// 7. Reports decode tok/s + first decoded text per turn
 enum VLBench {
 
+    /// Load through the same mmap-backed policy Osaurus uses in production.
+    /// The plain `loadModel(from:using:)` overload bypasses that policy and
+    /// copies safetensors into anonymous storage, which makes VL memory gates
+    /// measure a harness-only residency spike instead of the host runtime.
+    private static func loadProductionContext(from modelDir: URL) async throws -> ModelContext {
+        let loaded = try await MLXLMCommon.loadModel(
+            from: modelDir,
+            using: #huggingFaceTokenizerLoader(),
+            loadConfiguration: .osaurusProduction)
+        return loaded.0
+    }
+
     static func run(modelPath: String, maxNewTokens: Int) async throws {
         let modelDir = URL(fileURLWithPath: modelPath)
         print("=== VLBench — \(modelDir.lastPathComponent) ===")
 
         let loadStart = CFAbsoluteTimeGetCurrent()
-        let context = try await MLXLMCommon.loadModel(
-            from: modelDir, using: #huggingFaceTokenizerLoader())
+        let context = try await loadProductionContext(from: modelDir)
         print(String(format: "Load: %.2fs", CFAbsoluteTimeGetCurrent() - loadStart))
         print("Model: \(type(of: context.model))")
         print("Processor: \(type(of: context.processor))")
@@ -80,8 +91,7 @@ enum VLBench {
             preLoadRSS, preLoadFootprint, modelMiB))
 
         let loadStart = CFAbsoluteTimeGetCurrent()
-        let context = try await MLXLMCommon.loadModel(
-            from: modelDir, using: #huggingFaceTokenizerLoader())
+        let context = try await loadProductionContext(from: modelDir)
         print(String(format: "Load: %.2fs", CFAbsoluteTimeGetCurrent() - loadStart))
         print("Model: \(type(of: context.model))")
         print("Processor: \(type(of: context.processor))")
@@ -176,8 +186,12 @@ enum VLBench {
             print("    debug prompt tokens=\(ids.count) imageId=\(imageId) imageCount=\(imageCount) boiCount=\(boiCount) eoiCount=\(eoiCount)")
             print("    debug image pixels=\(lmInput.image?.pixels.shape.description ?? "nil") frames=\(lmInput.image?.frames?.map { "\($0.h)x\($0.w)" }.joined(separator: ",") ?? "nil")")
             if let pixels = lmInput.image?.pixels {
-                let means = pixels.mean(axes: [0, 2, 3]).asArray(Float.self)
-                print("    debug image channel means=\(means)")
+                if pixels.ndim >= 4 {
+                    let means = pixels.mean(axes: [0, 2, 3]).asArray(Float.self)
+                    print("    debug image channel means=\(means)")
+                } else {
+                    print("    debug image channel means=not-applicable for rank-\(pixels.ndim) processed features")
+                }
             }
             print("    debug prompt window: \(window.debugDescription)")
         }
@@ -349,16 +363,27 @@ enum VLBench {
         print("=== VLBench VIDEO BATCH — \(modelDir.lastPathComponent) ===")
         print("video: \(videoURL.lastPathComponent)")
 
+        let modelMiB = directorySizeMiB(modelDir)
+        let preLoadFootprint = currentPhysFootprintMiB()
+        var peakFootprint = preLoadFootprint
+        print(String(format:
+            "  video memory pre-load: footprintMiB=%.0f modelMiB=%.0f",
+            preLoadFootprint, modelMiB))
+
         let loadStart = CFAbsoluteTimeGetCurrent()
-        let context = try await MLXLMCommon.loadModel(
-            from: modelDir, using: #huggingFaceTokenizerLoader())
+        let context = try await loadProductionContext(from: modelDir)
         print(String(format: "Load: %.2fs", CFAbsoluteTimeGetCurrent() - loadStart))
         print("Model: \(type(of: context.model))")
         print("Processor: \(type(of: context.processor))")
+        let postLoadFootprint = currentPhysFootprintMiB()
+        peakFootprint = max(peakFootprint, postLoadFootprint)
+        print(String(format:
+            "  video memory post-load: footprintMiB=%.0f footprintDeltaMiB=%+.0f",
+            postLoadFootprint, postLoadFootprint - preLoadFootprint))
 
         nonisolated(unsafe) let ctx = context
 
-        var params = GenerateParameters(
+        let params = GenerateParameters(
             maxTokens: maxNewTokens, temperature: 0,
             prefillStepSize: 512)
 
@@ -398,6 +423,10 @@ enum VLBench {
             var chunkCount = 0
             var reasoningCount = 0
             var ttft: Double?
+            var generationTokens = 0
+            var promptTokensPerSecond = 0.0
+            var decodeTokensPerSecond = 0.0
+            var stopReason = "unknown"
             for await ev in stream {
                 switch ev {
                 case .chunk(let c):
@@ -406,17 +435,67 @@ enum VLBench {
                     chunkCount += 1
                 case .reasoning:
                     reasoningCount += 1
-                case .prefillProgress, .info, .toolCall, .toolCallProgress:
+                case .info(let info):
+                    generationTokens = info.generationTokenCount
+                    promptTokensPerSecond = info.promptTokensPerSecond
+                    decodeTokensPerSecond = info.tokensPerSecond
+                    stopReason = String(describing: info.stopReason)
+                case .prefillProgress, .toolCall, .toolCallProgress:
                     break
                 }
             }
             let total = CFAbsoluteTimeGetCurrent() - t0
+            let footprint = currentPhysFootprintMiB()
+            peakFootprint = max(peakFootprint, footprint)
             let preview = text.count > 220
                 ? String(text.prefix(220)) + "..." : text
             print(String(format:
                 "    TTFT %dms total %.2fs chunks=%d reasoningDeltas=%d",
                 Int((ttft ?? 0) * 1000), total, chunkCount, reasoningCount))
+            print(String(format:
+                "    telemetry tokens=%d promptTok/s=%.1f decodeTok/s=%.1f stop=%@ footprintMiB=%.0f",
+                generationTokens, promptTokensPerSecond, decodeTokensPerSecond,
+                stopReason, footprint))
             print("    \"\(preview)\"")
+
+            let visible = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard chunkCount > 0, !visible.isEmpty else {
+                throw NSError(
+                    domain: "VLBenchVideo",
+                    code: 1,
+                    userInfo: [NSLocalizedDescriptionKey: "\(turnLabel) emitted no visible video output"])
+            }
+            let rawMarkers = ["<think>", "</think>", "<|channel>", "<|tool_call>", "<tool_call>"]
+            if let marker = rawMarkers.first(where: { visible.contains($0) }) {
+                throw NSError(
+                    domain: "VLBenchVideo",
+                    code: 2,
+                    userInfo: [NSLocalizedDescriptionKey:
+                        "\(turnLabel) leaked raw parser marker \(marker): \(preview)"])
+            }
+            guard generationTokens > 0, decodeTokensPerSecond > 0 else {
+                throw NSError(
+                    domain: "VLBenchVideo",
+                    code: 3,
+                    userInfo: [NSLocalizedDescriptionKey:
+                        "\(turnLabel) did not emit usable generation telemetry"])
+            }
+        }
+
+        let peakDelta = peakFootprint - preLoadFootprint
+        let peakPercent = modelMiB > 0 ? (peakDelta / modelMiB) * 100 : -1
+        print(String(format:
+            "  video memory peak: footprintMiB=%.0f footprintDeltaMiB=%+.0f modelMiB=%.0f ratio=%.1f%% verdict=%@",
+            peakFootprint, peakDelta, modelMiB, peakPercent,
+            (modelMiB <= 0 || peakDelta <= modelMiB) ? "passed" : "failed"))
+        if modelMiB > 0, peakDelta > modelMiB {
+            throw NSError(
+                domain: "VLBenchVideo",
+                code: 4,
+                userInfo: [NSLocalizedDescriptionKey:
+                    String(format:
+                        "video memory gate failed (footprintDeltaMiB=%.0f modelMiB=%.0f ratio=%.1f%%)",
+                        peakDelta, modelMiB, peakPercent)])
         }
 
         print("=== VLBench VIDEO BATCH done ===")
@@ -453,8 +532,7 @@ enum VLBench {
         print("=== VLBench MIXED MULTI-TURN — \(modelDir.lastPathComponent) ===")
 
         let loadStart = CFAbsoluteTimeGetCurrent()
-        let context = try await MLXLMCommon.loadModel(
-            from: modelDir, using: #huggingFaceTokenizerLoader())
+        let context = try await loadProductionContext(from: modelDir)
         print(String(format: "Load: %.2fs", CFAbsoluteTimeGetCurrent() - loadStart))
         print("Model: \(type(of: context.model))")
         print("Processor: \(type(of: context.processor))")
@@ -606,8 +684,7 @@ enum VLBench {
             preLoadRSS, preLoadFootprint, modelMiB))
 
         let loadStart = CFAbsoluteTimeGetCurrent()
-        let context = try await MLXLMCommon.loadModel(
-            from: modelDir, using: #huggingFaceTokenizerLoader())
+        let context = try await loadProductionContext(from: modelDir)
         print(String(format: "Load: %.2fs", CFAbsoluteTimeGetCurrent() - loadStart))
         print("Model: \(type(of: context.model))")
         print("Processor: \(type(of: context.processor))")
@@ -764,8 +841,7 @@ enum VLBench {
         print("=== VLBench cross-engine byte-identity (iter 47) ===")
 
         let loadStart = CFAbsoluteTimeGetCurrent()
-        let context = try await MLXLMCommon.loadModel(
-            from: modelDir, using: #huggingFaceTokenizerLoader())
+        let context = try await loadProductionContext(from: modelDir)
         print(String(format: "Load: %.2fs", CFAbsoluteTimeGetCurrent() - loadStart))
         print("Model: \(type(of: context.model))")
         print("Processor: \(type(of: context.processor))")
@@ -865,8 +941,7 @@ enum VLBench {
         print("=== VLBench multi-turn cache reuse (iter 48) ===")
 
         let loadStart = CFAbsoluteTimeGetCurrent()
-        let context = try await MLXLMCommon.loadModel(
-            from: modelDir, using: #huggingFaceTokenizerLoader())
+        let context = try await loadProductionContext(from: modelDir)
         print(String(format: "Load: %.2fs", CFAbsoluteTimeGetCurrent() - loadStart))
         print("Model: \(type(of: context.model))")
         print("Processor: \(type(of: context.processor))")
@@ -1019,8 +1094,7 @@ enum VLBench {
                     nativeMTP: true))
             context = loaded.0
         } else {
-            context = try await MLXLMCommon.loadModel(
-                from: modelDir, using: #huggingFaceTokenizerLoader())
+            context = try await loadProductionContext(from: modelDir)
         }
         print(String(format: "Load: %.2fs", CFAbsoluteTimeGetCurrent() - loadStart))
         print("Model: \(type(of: context.model))")
@@ -1263,8 +1337,7 @@ enum VLBench {
         print("  video: \(videoPath)")
 
         let loadStart = CFAbsoluteTimeGetCurrent()
-        let context = try await MLXLMCommon.loadModel(
-            from: modelDir, using: #huggingFaceTokenizerLoader())
+        let context = try await loadProductionContext(from: modelDir)
         print(String(format: "Load: %.2fs", CFAbsoluteTimeGetCurrent() - loadStart))
         print("Model: \(type(of: context.model))")
         print("Processor: \(type(of: context.processor))")

--- a/Source/Cmlx/mlx-generated/metal/quantized.h
+++ b/Source/Cmlx/mlx-generated/metal/quantized.h
@@ -28,13 +28,22 @@ inline constexpr short get_bytes_per_pack() {
 template <typename T, typename U, int values_per_thread, int bits>
 inline U load_vector(const device T* x, thread U* x_thread) {
   static_assert(
-      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
-          bits == 8,
-      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+      bits == 1 || bits == 2 || bits == 3 || bits == 4 || bits == 5 ||
+          bits == 6 || bits == 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 8}");
 
   U sum = 0;
 
-  if (bits == 2) {
+  if (bits == 1) {
+    for (int i = 0; i < values_per_thread; i += 8) {
+      for (int j = 0; j < 8; j++) {
+        sum += x[i + j];
+        x_thread[i + j] = x[i + j] / static_cast<U>(1 << j);
+      }
+    }
+  }
+
+  else if (bits == 2) {
     for (int i = 0; i < values_per_thread; i += 4) {
       sum += x[i] + x[i + 1] + x[i + 2] + x[i + 3];
       x_thread[i] = x[i];
@@ -107,13 +116,22 @@ inline U load_vector(const device T* x, thread U* x_thread) {
 template <typename T, typename U, int values_per_thread, int bits>
 inline U load_vector_safe(const device T* x, thread U* x_thread, int N) {
   static_assert(
-      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
-          bits == 8,
-      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+      bits == 1 || bits == 2 || bits == 3 || bits == 4 || bits == 5 ||
+          bits == 6 || bits == 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 8}");
 
   U sum = 0;
 
-  if (bits == 2) {
+  if (bits == 1) {
+    for (int i = 0; i < N; i += 8) {
+      for (int j = 0; j < min(8, N - i); j++) {
+        sum += x[i + j];
+        x_thread[i + j] = x[i + j] / static_cast<U>(1 << j);
+      }
+    }
+  }
+
+  else if (bits == 2) {
     for (int i = 0; i < N; i += 4) {
       sum += x[i] + x[i + 1] + x[i + 2] + x[i + 3];
       x_thread[i] = x[i];
@@ -196,13 +214,21 @@ inline U qdot(
     U bias,
     U sum) {
   static_assert(
-      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
-          bits == 8,
-      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+      bits == 1 || bits == 2 || bits == 3 || bits == 4 || bits == 5 ||
+          bits == 6 || bits == 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 8}");
 
   U accum = 0;
 
-  if (bits == 2) {
+  if (bits == 1) {
+    for (int i = 0; i < (values_per_thread / 8); i++) {
+      for (int j = 0; j < 8; j++) {
+        accum += x_thread[8 * i + j] * (w[i] & (1 << j));
+      }
+    }
+  }
+
+  else if (bits == 2) {
     for (int i = 0; i < (values_per_thread / 4); i++) {
       accum +=
           (x_thread[4 * i] * (w[i] & 0x03) +
@@ -298,13 +324,21 @@ inline U qdot_safe(
     U sum,
     int N) {
   static_assert(
-      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
-          bits == 8,
-      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+      bits == 1 || bits == 2 || bits == 3 || bits == 4 || bits == 5 ||
+          bits == 6 || bits == 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 8}");
 
   U accum = 0;
 
-  if (bits == 2) {
+  if (bits == 1) {
+    for (int i = 0; i < N; i += 8) {
+      for (int j = 0; j < min(8, N - i); j++) {
+        accum += x_thread[i + j] * (w[i / 8] & (1 << j));
+      }
+    }
+  }
+
+  else if (bits == 2) {
     for (int i = 0; i < (N / 4); i++) {
       accum +=
           (x_thread[4 * i] * (w[i] & 0x03) +
@@ -395,11 +429,19 @@ template <typename U, int values_per_thread, int bits>
 inline void
 qouter(const thread uint8_t* w, U x, U scale, U bias, thread U* result) {
   static_assert(
-      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
-          bits == 8,
-      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+      bits == 1 || bits == 2 || bits == 3 || bits == 4 || bits == 5 ||
+          bits == 6 || bits == 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 8}");
 
-  if (bits == 2) {
+  if (bits == 1) {
+    for (int i = 0; i < (values_per_thread / 8); i++) {
+      for (int j = 0; j < 8; j++) {
+        result[8 * i + j] += x * (((w[i] >> j) & 1) * scale + bias);
+      }
+    }
+  }
+
+  else if (bits == 2) {
     U s[4] = {scale, scale / 4.0f, scale / 16.0f, scale / 64.0f};
     for (int i = 0; i < (values_per_thread / 4); i++) {
       result[4 * i] += x * (s[0] * (w[i] & 0x03) + bias);
@@ -484,11 +526,19 @@ template <typename U, int N, int bits>
 inline void
 dequantize(const device uint8_t* w, U scale, U bias, threadgroup U* w_local) {
   static_assert(
-      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
-          bits == 8,
-      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+      bits == 1 || bits == 2 || bits == 3 || bits == 4 || bits == 5 ||
+          bits == 6 || bits == 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 8}");
 
-  if (bits == 2) {
+  if (bits == 1) {
+    for (int i = 0; i < (N / 8); i++) {
+      for (int j = 0; j < 8; j++) {
+        w_local[8 * i + j] = ((w[i] >> j) & 1) * scale + bias;
+      }
+    }
+  }
+
+  else if (bits == 2) {
     U s[4] = {
         scale,
         scale / static_cast<U>(4.0f),
@@ -577,9 +627,9 @@ struct QuantizedBlockLoader {
       group_size % BCOLS == 0,
       "The group size should be divisible by the columns");
   static_assert(
-      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
-          bits == 8,
-      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+      bits == 1 || bits == 2 || bits == 3 || bits == 4 || bits == 5 ||
+          bits == 6 || bits == 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 8}");
 
   MLX_MTL_CONST short pack_factor = get_pack_factor<bits, 8>();
   MLX_MTL_CONST short bytes_per_pack = get_bytes_per_pack<bits>();
@@ -758,7 +808,7 @@ METAL_FUNC void qmv_fast_impl(
     uint3 tid [[threadgroup_position_in_grid]],
     uint simd_gid [[simdgroup_index_in_threadgroup]],
     uint simd_lid [[thread_index_in_simdgroup]]) {
-  constexpr int packs_per_thread = bits == 2 ? 1 : 2;
+  constexpr int packs_per_thread = (bits == 1 || bits == 2) ? 1 : 2;
   constexpr int num_simdgroups = 2;
   constexpr int results_per_simdgroup = 4;
   constexpr int pack_factor = get_pack_factor<bits, 32>();
@@ -2495,7 +2545,9 @@ template <typename T, const int group_size, const int bits>
 #pragma clang loop unroll(full)
     for (int i = 0; i < pack_factor; i++) {
       uint8_t d;
-      if (bits == 2) {
+      if (bits == 1) {
+        d = (val >> i) & 0x01;
+      } else if (bits == 2) {
         d = (val >> (bits * i)) & 0x03;
       } else if (bits == 4) {
         d = (val >> (bits * i)) & 0x0f;

--- a/Source/Cmlx/mlx-generated/metal/quantized_nax.h
+++ b/Source/Cmlx/mlx-generated/metal/quantized_nax.h
@@ -31,13 +31,22 @@ inline constexpr short get_bytes_per_pack() {
 template <typename T, typename U, int values_per_thread, int bits>
 inline U load_vector(const device T* x, thread U* x_thread) {
   static_assert(
-      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
-          bits == 8,
-      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+      bits == 1 || bits == 2 || bits == 3 || bits == 4 || bits == 5 ||
+          bits == 6 || bits == 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 8}");
 
   U sum = 0;
 
-  if (bits == 2) {
+  if (bits == 1) {
+    for (int i = 0; i < values_per_thread; i += 8) {
+      for (int j = 0; j < 8; j++) {
+        sum += x[i + j];
+        x_thread[i + j] = x[i + j] / static_cast<U>(1 << j);
+      }
+    }
+  }
+
+  else if (bits == 2) {
     for (int i = 0; i < values_per_thread; i += 4) {
       sum += x[i] + x[i + 1] + x[i + 2] + x[i + 3];
       x_thread[i] = x[i];
@@ -110,13 +119,22 @@ inline U load_vector(const device T* x, thread U* x_thread) {
 template <typename T, typename U, int values_per_thread, int bits>
 inline U load_vector_safe(const device T* x, thread U* x_thread, int N) {
   static_assert(
-      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
-          bits == 8,
-      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+      bits == 1 || bits == 2 || bits == 3 || bits == 4 || bits == 5 ||
+          bits == 6 || bits == 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 8}");
 
   U sum = 0;
 
-  if (bits == 2) {
+  if (bits == 1) {
+    for (int i = 0; i < N; i += 8) {
+      for (int j = 0; j < min(8, N - i); j++) {
+        sum += x[i + j];
+        x_thread[i + j] = x[i + j] / static_cast<U>(1 << j);
+      }
+    }
+  }
+
+  else if (bits == 2) {
     for (int i = 0; i < N; i += 4) {
       sum += x[i] + x[i + 1] + x[i + 2] + x[i + 3];
       x_thread[i] = x[i];
@@ -199,13 +217,21 @@ inline U qdot(
     U bias,
     U sum) {
   static_assert(
-      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
-          bits == 8,
-      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+      bits == 1 || bits == 2 || bits == 3 || bits == 4 || bits == 5 ||
+          bits == 6 || bits == 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 8}");
 
   U accum = 0;
 
-  if (bits == 2) {
+  if (bits == 1) {
+    for (int i = 0; i < (values_per_thread / 8); i++) {
+      for (int j = 0; j < 8; j++) {
+        accum += x_thread[8 * i + j] * (w[i] & (1 << j));
+      }
+    }
+  }
+
+  else if (bits == 2) {
     for (int i = 0; i < (values_per_thread / 4); i++) {
       accum +=
           (x_thread[4 * i] * (w[i] & 0x03) +
@@ -301,13 +327,21 @@ inline U qdot_safe(
     U sum,
     int N) {
   static_assert(
-      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
-          bits == 8,
-      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+      bits == 1 || bits == 2 || bits == 3 || bits == 4 || bits == 5 ||
+          bits == 6 || bits == 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 8}");
 
   U accum = 0;
 
-  if (bits == 2) {
+  if (bits == 1) {
+    for (int i = 0; i < N; i += 8) {
+      for (int j = 0; j < min(8, N - i); j++) {
+        accum += x_thread[i + j] * (w[i / 8] & (1 << j));
+      }
+    }
+  }
+
+  else if (bits == 2) {
     for (int i = 0; i < (N / 4); i++) {
       accum +=
           (x_thread[4 * i] * (w[i] & 0x03) +
@@ -398,11 +432,19 @@ template <typename U, int values_per_thread, int bits>
 inline void
 qouter(const thread uint8_t* w, U x, U scale, U bias, thread U* result) {
   static_assert(
-      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
-          bits == 8,
-      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+      bits == 1 || bits == 2 || bits == 3 || bits == 4 || bits == 5 ||
+          bits == 6 || bits == 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 8}");
 
-  if (bits == 2) {
+  if (bits == 1) {
+    for (int i = 0; i < (values_per_thread / 8); i++) {
+      for (int j = 0; j < 8; j++) {
+        result[8 * i + j] += x * (((w[i] >> j) & 1) * scale + bias);
+      }
+    }
+  }
+
+  else if (bits == 2) {
     U s[4] = {scale, scale / 4.0f, scale / 16.0f, scale / 64.0f};
     for (int i = 0; i < (values_per_thread / 4); i++) {
       result[4 * i] += x * (s[0] * (w[i] & 0x03) + bias);
@@ -487,11 +529,19 @@ template <typename U, int N, int bits>
 inline void
 dequantize(const device uint8_t* w, U scale, U bias, threadgroup U* w_local) {
   static_assert(
-      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
-          bits == 8,
-      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+      bits == 1 || bits == 2 || bits == 3 || bits == 4 || bits == 5 ||
+          bits == 6 || bits == 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 8}");
 
-  if (bits == 2) {
+  if (bits == 1) {
+    for (int i = 0; i < (N / 8); i++) {
+      for (int j = 0; j < 8; j++) {
+        w_local[8 * i + j] = ((w[i] >> j) & 1) * scale + bias;
+      }
+    }
+  }
+
+  else if (bits == 2) {
     U s[4] = {
         scale,
         scale / static_cast<U>(4.0f),
@@ -580,9 +630,9 @@ struct QuantizedBlockLoader {
       group_size % BCOLS == 0,
       "The group size should be divisible by the columns");
   static_assert(
-      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
-          bits == 8,
-      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+      bits == 1 || bits == 2 || bits == 3 || bits == 4 || bits == 5 ||
+          bits == 6 || bits == 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 8}");
 
   MLX_MTL_CONST short pack_factor = get_pack_factor<bits, 8>();
   MLX_MTL_CONST short bytes_per_pack = get_bytes_per_pack<bits>();
@@ -715,9 +765,9 @@ struct QuantizedBlockLoader<
       BCOLS % group_size == 0,
       "The group size should be divisible by the columns");
   static_assert(
-      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
-          bits == 8,
-      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+      bits == 1 || bits == 2 || bits == 3 || bits == 4 || bits == 5 ||
+          bits == 6 || bits == 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 8}");
 
   MLX_MTL_CONST short pack_factor = get_pack_factor<bits, 8>();
   MLX_MTL_CONST short bytes_per_pack = get_bytes_per_pack<bits>();

--- a/Source/Cmlx/mlx-generated/quantized.cpp
+++ b/Source/Cmlx/mlx-generated/quantized.cpp
@@ -41,13 +41,22 @@ inline constexpr short get_bytes_per_pack() {
 template <typename T, typename U, int values_per_thread, int bits>
 inline U load_vector(const device T* x, thread U* x_thread) {
   static_assert(
-      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
-          bits == 8,
-      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+      bits == 1 || bits == 2 || bits == 3 || bits == 4 || bits == 5 ||
+          bits == 6 || bits == 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 8}");
 
   U sum = 0;
 
-  if (bits == 2) {
+  if (bits == 1) {
+    for (int i = 0; i < values_per_thread; i += 8) {
+      for (int j = 0; j < 8; j++) {
+        sum += x[i + j];
+        x_thread[i + j] = x[i + j] / static_cast<U>(1 << j);
+      }
+    }
+  }
+
+  else if (bits == 2) {
     for (int i = 0; i < values_per_thread; i += 4) {
       sum += x[i] + x[i + 1] + x[i + 2] + x[i + 3];
       x_thread[i] = x[i];
@@ -120,13 +129,22 @@ inline U load_vector(const device T* x, thread U* x_thread) {
 template <typename T, typename U, int values_per_thread, int bits>
 inline U load_vector_safe(const device T* x, thread U* x_thread, int N) {
   static_assert(
-      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
-          bits == 8,
-      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+      bits == 1 || bits == 2 || bits == 3 || bits == 4 || bits == 5 ||
+          bits == 6 || bits == 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 8}");
 
   U sum = 0;
 
-  if (bits == 2) {
+  if (bits == 1) {
+    for (int i = 0; i < N; i += 8) {
+      for (int j = 0; j < min(8, N - i); j++) {
+        sum += x[i + j];
+        x_thread[i + j] = x[i + j] / static_cast<U>(1 << j);
+      }
+    }
+  }
+
+  else if (bits == 2) {
     for (int i = 0; i < N; i += 4) {
       sum += x[i] + x[i + 1] + x[i + 2] + x[i + 3];
       x_thread[i] = x[i];
@@ -209,13 +227,21 @@ inline U qdot(
     U bias,
     U sum) {
   static_assert(
-      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
-          bits == 8,
-      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+      bits == 1 || bits == 2 || bits == 3 || bits == 4 || bits == 5 ||
+          bits == 6 || bits == 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 8}");
 
   U accum = 0;
 
-  if (bits == 2) {
+  if (bits == 1) {
+    for (int i = 0; i < (values_per_thread / 8); i++) {
+      for (int j = 0; j < 8; j++) {
+        accum += x_thread[8 * i + j] * (w[i] & (1 << j));
+      }
+    }
+  }
+
+  else if (bits == 2) {
     for (int i = 0; i < (values_per_thread / 4); i++) {
       accum +=
           (x_thread[4 * i] * (w[i] & 0x03) +
@@ -311,13 +337,21 @@ inline U qdot_safe(
     U sum,
     int N) {
   static_assert(
-      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
-          bits == 8,
-      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+      bits == 1 || bits == 2 || bits == 3 || bits == 4 || bits == 5 ||
+          bits == 6 || bits == 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 8}");
 
   U accum = 0;
 
-  if (bits == 2) {
+  if (bits == 1) {
+    for (int i = 0; i < N; i += 8) {
+      for (int j = 0; j < min(8, N - i); j++) {
+        accum += x_thread[i + j] * (w[i / 8] & (1 << j));
+      }
+    }
+  }
+
+  else if (bits == 2) {
     for (int i = 0; i < (N / 4); i++) {
       accum +=
           (x_thread[4 * i] * (w[i] & 0x03) +
@@ -408,11 +442,19 @@ template <typename U, int values_per_thread, int bits>
 inline void
 qouter(const thread uint8_t* w, U x, U scale, U bias, thread U* result) {
   static_assert(
-      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
-          bits == 8,
-      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+      bits == 1 || bits == 2 || bits == 3 || bits == 4 || bits == 5 ||
+          bits == 6 || bits == 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 8}");
 
-  if (bits == 2) {
+  if (bits == 1) {
+    for (int i = 0; i < (values_per_thread / 8); i++) {
+      for (int j = 0; j < 8; j++) {
+        result[8 * i + j] += x * (((w[i] >> j) & 1) * scale + bias);
+      }
+    }
+  }
+
+  else if (bits == 2) {
     U s[4] = {scale, scale / 4.0f, scale / 16.0f, scale / 64.0f};
     for (int i = 0; i < (values_per_thread / 4); i++) {
       result[4 * i] += x * (s[0] * (w[i] & 0x03) + bias);
@@ -497,11 +539,19 @@ template <typename U, int N, int bits>
 inline void
 dequantize(const device uint8_t* w, U scale, U bias, threadgroup U* w_local) {
   static_assert(
-      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
-          bits == 8,
-      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+      bits == 1 || bits == 2 || bits == 3 || bits == 4 || bits == 5 ||
+          bits == 6 || bits == 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 8}");
 
-  if (bits == 2) {
+  if (bits == 1) {
+    for (int i = 0; i < (N / 8); i++) {
+      for (int j = 0; j < 8; j++) {
+        w_local[8 * i + j] = ((w[i] >> j) & 1) * scale + bias;
+      }
+    }
+  }
+
+  else if (bits == 2) {
     U s[4] = {
         scale,
         scale / static_cast<U>(4.0f),
@@ -590,9 +640,9 @@ struct QuantizedBlockLoader {
       group_size % BCOLS == 0,
       "The group size should be divisible by the columns");
   static_assert(
-      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
-          bits == 8,
-      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+      bits == 1 || bits == 2 || bits == 3 || bits == 4 || bits == 5 ||
+          bits == 6 || bits == 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 8}");
 
   MLX_MTL_CONST short pack_factor = get_pack_factor<bits, 8>();
   MLX_MTL_CONST short bytes_per_pack = get_bytes_per_pack<bits>();
@@ -771,7 +821,7 @@ METAL_FUNC void qmv_fast_impl(
     uint3 tid [[threadgroup_position_in_grid]],
     uint simd_gid [[simdgroup_index_in_threadgroup]],
     uint simd_lid [[thread_index_in_simdgroup]]) {
-  constexpr int packs_per_thread = bits == 2 ? 1 : 2;
+  constexpr int packs_per_thread = (bits == 1 || bits == 2) ? 1 : 2;
   constexpr int num_simdgroups = 2;
   constexpr int results_per_simdgroup = 4;
   constexpr int pack_factor = get_pack_factor<bits, 32>();
@@ -2508,7 +2558,9 @@ template <typename T, const int group_size, const int bits>
 #pragma clang loop unroll(full)
     for (int i = 0; i < pack_factor; i++) {
       uint8_t d;
-      if (bits == 2) {
+      if (bits == 1) {
+        d = (val >> i) & 0x01;
+      } else if (bits == 2) {
         d = (val >> (bits * i)) & 0x03;
       } else if (bits == 4) {
         d = (val >> (bits * i)) & 0x0f;

--- a/Source/Cmlx/mlx-generated/quantized_nax.cpp
+++ b/Source/Cmlx/mlx-generated/quantized_nax.cpp
@@ -44,13 +44,22 @@ inline constexpr short get_bytes_per_pack() {
 template <typename T, typename U, int values_per_thread, int bits>
 inline U load_vector(const device T* x, thread U* x_thread) {
   static_assert(
-      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
-          bits == 8,
-      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+      bits == 1 || bits == 2 || bits == 3 || bits == 4 || bits == 5 ||
+          bits == 6 || bits == 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 8}");
 
   U sum = 0;
 
-  if (bits == 2) {
+  if (bits == 1) {
+    for (int i = 0; i < values_per_thread; i += 8) {
+      for (int j = 0; j < 8; j++) {
+        sum += x[i + j];
+        x_thread[i + j] = x[i + j] / static_cast<U>(1 << j);
+      }
+    }
+  }
+
+  else if (bits == 2) {
     for (int i = 0; i < values_per_thread; i += 4) {
       sum += x[i] + x[i + 1] + x[i + 2] + x[i + 3];
       x_thread[i] = x[i];
@@ -123,13 +132,22 @@ inline U load_vector(const device T* x, thread U* x_thread) {
 template <typename T, typename U, int values_per_thread, int bits>
 inline U load_vector_safe(const device T* x, thread U* x_thread, int N) {
   static_assert(
-      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
-          bits == 8,
-      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+      bits == 1 || bits == 2 || bits == 3 || bits == 4 || bits == 5 ||
+          bits == 6 || bits == 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 8}");
 
   U sum = 0;
 
-  if (bits == 2) {
+  if (bits == 1) {
+    for (int i = 0; i < N; i += 8) {
+      for (int j = 0; j < min(8, N - i); j++) {
+        sum += x[i + j];
+        x_thread[i + j] = x[i + j] / static_cast<U>(1 << j);
+      }
+    }
+  }
+
+  else if (bits == 2) {
     for (int i = 0; i < N; i += 4) {
       sum += x[i] + x[i + 1] + x[i + 2] + x[i + 3];
       x_thread[i] = x[i];
@@ -212,13 +230,21 @@ inline U qdot(
     U bias,
     U sum) {
   static_assert(
-      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
-          bits == 8,
-      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+      bits == 1 || bits == 2 || bits == 3 || bits == 4 || bits == 5 ||
+          bits == 6 || bits == 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 8}");
 
   U accum = 0;
 
-  if (bits == 2) {
+  if (bits == 1) {
+    for (int i = 0; i < (values_per_thread / 8); i++) {
+      for (int j = 0; j < 8; j++) {
+        accum += x_thread[8 * i + j] * (w[i] & (1 << j));
+      }
+    }
+  }
+
+  else if (bits == 2) {
     for (int i = 0; i < (values_per_thread / 4); i++) {
       accum +=
           (x_thread[4 * i] * (w[i] & 0x03) +
@@ -314,13 +340,21 @@ inline U qdot_safe(
     U sum,
     int N) {
   static_assert(
-      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
-          bits == 8,
-      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+      bits == 1 || bits == 2 || bits == 3 || bits == 4 || bits == 5 ||
+          bits == 6 || bits == 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 8}");
 
   U accum = 0;
 
-  if (bits == 2) {
+  if (bits == 1) {
+    for (int i = 0; i < N; i += 8) {
+      for (int j = 0; j < min(8, N - i); j++) {
+        accum += x_thread[i + j] * (w[i / 8] & (1 << j));
+      }
+    }
+  }
+
+  else if (bits == 2) {
     for (int i = 0; i < (N / 4); i++) {
       accum +=
           (x_thread[4 * i] * (w[i] & 0x03) +
@@ -411,11 +445,19 @@ template <typename U, int values_per_thread, int bits>
 inline void
 qouter(const thread uint8_t* w, U x, U scale, U bias, thread U* result) {
   static_assert(
-      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
-          bits == 8,
-      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+      bits == 1 || bits == 2 || bits == 3 || bits == 4 || bits == 5 ||
+          bits == 6 || bits == 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 8}");
 
-  if (bits == 2) {
+  if (bits == 1) {
+    for (int i = 0; i < (values_per_thread / 8); i++) {
+      for (int j = 0; j < 8; j++) {
+        result[8 * i + j] += x * (((w[i] >> j) & 1) * scale + bias);
+      }
+    }
+  }
+
+  else if (bits == 2) {
     U s[4] = {scale, scale / 4.0f, scale / 16.0f, scale / 64.0f};
     for (int i = 0; i < (values_per_thread / 4); i++) {
       result[4 * i] += x * (s[0] * (w[i] & 0x03) + bias);
@@ -500,11 +542,19 @@ template <typename U, int N, int bits>
 inline void
 dequantize(const device uint8_t* w, U scale, U bias, threadgroup U* w_local) {
   static_assert(
-      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
-          bits == 8,
-      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+      bits == 1 || bits == 2 || bits == 3 || bits == 4 || bits == 5 ||
+          bits == 6 || bits == 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 8}");
 
-  if (bits == 2) {
+  if (bits == 1) {
+    for (int i = 0; i < (N / 8); i++) {
+      for (int j = 0; j < 8; j++) {
+        w_local[8 * i + j] = ((w[i] >> j) & 1) * scale + bias;
+      }
+    }
+  }
+
+  else if (bits == 2) {
     U s[4] = {
         scale,
         scale / static_cast<U>(4.0f),
@@ -593,9 +643,9 @@ struct QuantizedBlockLoader {
       group_size % BCOLS == 0,
       "The group size should be divisible by the columns");
   static_assert(
-      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
-          bits == 8,
-      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+      bits == 1 || bits == 2 || bits == 3 || bits == 4 || bits == 5 ||
+          bits == 6 || bits == 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 8}");
 
   MLX_MTL_CONST short pack_factor = get_pack_factor<bits, 8>();
   MLX_MTL_CONST short bytes_per_pack = get_bytes_per_pack<bits>();
@@ -728,9 +778,9 @@ struct QuantizedBlockLoader<
       BCOLS % group_size == 0,
       "The group size should be divisible by the columns");
   static_assert(
-      bits == 2 || bits == 3 || bits == 4 || bits == 5 || bits == 6 ||
-          bits == 8,
-      "Template undefined for bits not in {2, 3, 4, 5, 6, 8}");
+      bits == 1 || bits == 2 || bits == 3 || bits == 4 || bits == 5 ||
+          bits == 6 || bits == 8,
+      "Template undefined for bits not in {1, 2, 3, 4, 5, 6, 8}");
 
   MLX_MTL_CONST short pack_factor = get_pack_factor<bits, 8>();
   MLX_MTL_CONST short bytes_per_pack = get_bytes_per_pack<bits>();

--- a/Tests/MLXLMCommonFocusedTests/JangAffine1RuntimeContractTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/JangAffine1RuntimeContractTests.swift
@@ -1,0 +1,168 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import MLX
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite("JANG affine-1 runtime contract", .serialized)
+struct JangAffine1RuntimeContractTests {
+    @Test("schema-2 contract selects only affine one-bit modules")
+    func contractSelectsOnlyAffineOneBitModules() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("jang-affine1-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let config: [String: Any] = [
+            "format": "jang",
+            "format_version": "2.0",
+            "runtime": ["requires_jang_affine1_expansion": true],
+            "quantization": [
+                "affine1_runtime_expansion": [
+                    "lossless": true,
+                    "runtime_bits": 2,
+                    "scales_biases_unchanged": true,
+                    "storage_bits": 1,
+                ],
+                "tensor_quantization_manifest_schema": 2,
+                "tensor_quantization_manifest_count": 2,
+                "tensor_quantization_manifest": [
+                    "model.binary": [
+                        "bits": 1, "storage_bits": 1, "group_size": 128,
+                        "mode": "affine",
+                    ],
+                    "model.four_bit": [
+                        "bits": 4, "storage_bits": 4, "group_size": 64,
+                        "mode": "affine",
+                    ],
+                ],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: config, options: [.sortedKeys])
+            .write(to: root.appendingPathComponent("jang_config.json"))
+
+        let loadedContract = try JangLoader.loadAffine1RuntimeContract(at: root)
+        let contract = try #require(loadedContract)
+        #expect(contract.storageBits == 1)
+        #expect(contract.runtimeBits == 2)
+        #expect(contract.modulePaths == ["model.binary"])
+
+        let loadedManifest = try JangLoader.loadTensorQuantizationManifest(at: root)
+        let manifest = try #require(loadedManifest)
+        #expect(manifest.entries["model.binary"]?.bits == 1)
+        #expect(manifest.entries["model.binary"]?.groupSize == 128)
+        #expect(manifest.entries["model.four_bit"]?.bits == 4)
+        #expect(manifest.entries["model.four_bit"]?.groupSize == 64)
+    }
+
+    @Test("required malformed contract fails closed")
+    func malformedContractFailsClosed() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("jang-affine1-invalid-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try JSONSerialization.data(withJSONObject: [
+            "runtime": ["requires_jang_affine1_expansion": true],
+            "quantization": [:],
+        ]).write(to: root.appendingPathComponent("jang_config.json"))
+
+        #expect(throws: JangLoaderError.self) {
+            try JangLoader.loadAffine1RuntimeContract(at: root)
+        }
+    }
+
+    @Test("native one-bit qmv matches lossless two-bit representation")
+    func nativeOneBitQMVMatchesLosslessTwoBit() {
+        compareNativeOneBitToLosslessTwoBit(inputRows: 1, columns: 512)
+    }
+
+    @Test("native one-bit fast qmv matches lossless two-bit representation")
+    func nativeOneBitFastQMVMatchesLosslessTwoBit() {
+        compareNativeOneBitToLosslessTwoBit(inputRows: 1, columns: 1024)
+    }
+
+    @Test("native one-bit qmm matches lossless two-bit representation")
+    func nativeOneBitQMMMatchesLosslessTwoBit() {
+        compareNativeOneBitToLosslessTwoBit(inputRows: 16, columns: 512)
+    }
+
+    @Test("schema-2 manifest resolves ambiguous vision packing")
+    func manifestResolvesAmbiguousVisionPacking() {
+        let base = "vision_tower.blocks.0.attn.qkv"
+        let weights: [String: MLXArray] = [
+            "\(base).weight": MLXArray.zeros([3456, 144], dtype: .uint32),
+            "\(base).scales": MLXArray.zeros([3456, 18], dtype: .float32),
+            "\(base).biases": MLXArray.zeros([3456, 18], dtype: .float32),
+        ]
+        let exact = BaseConfiguration.Quantization(
+            groupSize: 64, bits: 4, mode: .affine)
+        let inferred = JangLoader.inferPerLayerQuantization(
+            weights: weights,
+            jangConfig: JangConfig(
+                quantization: JangQuantization(
+                    blockSize: 128, bitWidthsUsed: [1, 4])),
+            declaredManifestQuantization: [base: exact])
+
+        guard case .quantize(let actual)? = inferred.perLayerQuantization[base] else {
+            Issue.record("Expected an exact vision quantization override")
+            return
+        }
+        #expect(actual == exact)
+    }
+
+    private func compareNativeOneBitToLosslessTwoBit(inputRows: Int, columns: Int) {
+        Device.withDefaultDevice(.gpu) {
+            let rows = 8
+            let packedOneBit = (0 ..< (rows * columns / 32)).map {
+                UInt32(truncatingIfNeeded: 0x9E37_79B9 &* UInt32($0 + 1))
+            }
+            let packedTwoBit = packedOneBit.flatMap { value in
+                [spread16(value & 0xFFFF), spread16(value >> 16)]
+            }
+            let input = MLXArray(
+                (0 ..< (inputRows * columns)).map { Float(($0 % 17) - 8) * 0.0625 },
+                [inputRows, columns])
+            let groupsPerRow = columns / 128
+            let scales = MLXArray(
+                (0 ..< (rows * groupsPerRow)).map { Float($0 + 1) * 0.03125 },
+                [rows, groupsPerRow])
+            let biases = MLXArray(
+                (0 ..< (rows * groupsPerRow)).map { Float($0 - 4) * 0.015625 },
+                [rows, groupsPerRow])
+
+            let oneBit = quantizedMM(
+                input,
+                MLXArray(packedOneBit, [rows, columns / 32]),
+                scales: scales,
+                biases: biases,
+                groupSize: 128,
+                bits: 1)
+            let twoBit = quantizedMM(
+                input,
+                MLXArray(packedTwoBit, [rows, columns / 16]),
+                scales: scales,
+                biases: biases,
+                groupSize: 128,
+                bits: 2)
+            eval(oneBit, twoBit)
+
+            let oneBitValues = oneBit.asArray(Float.self)
+            let twoBitValues = twoBit.asArray(Float.self)
+            #expect(oneBitValues.count == twoBitValues.count)
+            for (actual, expected) in zip(oneBitValues, twoBitValues) {
+                #expect(abs(actual - expected) < 1e-5)
+            }
+        }
+    }
+
+    private func spread16(_ input: UInt32) -> UInt32 {
+        var result: UInt32 = 0
+        for bit in 0 ..< 16 {
+            result |= ((input >> UInt32(bit)) & 1) << UInt32(bit * 2)
+        }
+        return result
+    }
+}

--- a/Tests/MLXLMTests/VLMProcessorCacheScopeSaltTests.swift
+++ b/Tests/MLXLMTests/VLMProcessorCacheScopeSaltTests.swift
@@ -78,6 +78,47 @@ struct VLMProcessorCacheScopeSaltTests {
         }
     }
 
+    @Test("Qwen3VL processor preserves tool schemas for streaming parser")
+    func qwen3VLPreservesToolSchemas() async throws {
+        try await MLXMetalTestLock.withLock {
+            let config: Qwen3VLProcessorConfiguration = try Self.decode("""
+            {
+              "image_mean": [0.5, 0.5, 0.5],
+              "image_std": [0.5, 0.5, 0.5],
+              "merge_size": 2,
+              "patch_size": 14,
+              "temporal_patch_size": 1,
+              "image_processor_type": "Qwen3VLImageProcessor",
+              "size": {"min_pixels": 3136, "max_pixels": 12845056},
+              "video_min_pixels": 3136,
+              "video_max_pixels": 12845056,
+              "video_fps": 2.0,
+              "video_min_frames": 1,
+              "video_max_frames": 768
+            }
+            """)
+            let processor = Qwen3VLProcessor(config, tokenizer: GenerationPromptTokenizer())
+            let tool: [String: any Sendable] = [
+                "type": "function",
+                "function": [
+                    "name": "get_weather",
+                    "description": "Get current weather.",
+                    "parameters": ["type": "object"],
+                ] as [String: any Sendable],
+            ]
+
+            let input = try await processor.prepare(input: UserInput(
+                prompt: "Call the weather tool.",
+                tools: [tool],
+                additionalContext: ["enable_thinking": false]))
+
+            let schemas = try #require(input.toolSchemas)
+            #expect(schemas.count == 1)
+            let function = try #require(schemas[0]["function"] as? [String: any Sendable])
+            #expect(function["name"] as? String == "get_weather")
+        }
+    }
+
     @Test("GlmOcr processor threads reasoning cache scope on text-only inputs")
     func glmOcrThreadsCacheScopeSalt() async throws {
         try await MLXMetalTestLock.withLock {

--- a/docs/BONSAI_27B_AFFINE1_READINESS_2026-07-14.md
+++ b/docs/BONSAI_27B_AFFINE1_READINESS_2026-07-14.md
@@ -1,0 +1,124 @@
+# Bonsai 27B affine-1 readiness — 2026-07-14
+
+## Scope
+
+This checkpoint adds native Metal consumption of the schema-2 affine one-bit
+weights in `/Users/eric/models/Bonsai-27b-1bit-JANG`. It also preserves the
+bundle's exact per-tensor quantization manifest, including its four-bit vision
+tensors, and hardens the real image/video/tool/reasoning proof harnesses.
+
+The bundle declares Qwen 3.5 VLM image and video support. It declares
+`audio_verified=false`; audio is therefore not a supported modality row for
+this bundle and was not treated as a pass requirement.
+
+## Source checkpoint
+
+- vmlx-swift base: `a9b10f60e330337a9de2d8ebe3ca74a7370525e4`
+- MLX dependency PR: `osaurus-ai/mlx#2`
+- merged MLX integration pin: `9e01acd573a18540468160ccaffeb6fb566e891e`
+- 1-bit bundle size: 4,472 MiB measured by the release harness
+- schema-2 manifest: 581 entries
+  - 498 language affine1/group-128 entries
+  - 83 vision affine4/group-64 entries
+
+The runtime keeps affine1 tensors packed. A lossless Swift-side expansion to
+two bits was evaluated and rejected because it raised peak physical footprint
+to about 8.8 GiB (202.5% of bundle size).
+
+## Current source tests
+
+All commands used a release build and the full Xcode toolchain.
+
+| Gate | Result |
+| --- | --- |
+| Fresh local MLX Python build, `TestQuantized.test_affine_one_bit_metal` | PASS, 1 test |
+| MLX pre-commit hooks on the six-file kernel change | PASS |
+| `swift test -c release --filter JangAffine1RuntimeContractTests` | PASS, 6 tests |
+| `swift test -c release --filter VLMProcessorCacheScopeSaltTests` | PASS, 7 tests |
+
+The affine1 suite covers schema validation, malformed-contract rejection,
+unaligned QMV, optimized 1024-wide QMV, QMM, and exact manifest resolution for
+the ambiguous four-bit vision packing.
+
+The complete repository suite is **not green** and is not claimed as evidence
+for this PR. A default parallel run deadlocked in the existing opposite lock
+order between `/vmlx_mlx_lock` and `MLXMetalTestLock`. An explicit
+`--no-parallel` run avoided that deadlock but recorded failures in untouched
+Gemma4 source-contract tests, emoji detokenizer tests, memory-safety-settings
+expectations, DSV4 prompt tests, and other unrelated suites before the test
+runner exited with signal 5. No failure was recorded in the changed affine1 or
+Qwen3VL processor suites. The two focused suites above were rerun separately
+from the current PR source and passed.
+
+## 1-bit live release matrix
+
+All rows below used the real bundle and production mmap-backed load policy.
+No prompt coercion, forced reasoning closer, sampler clamp, hidden repetition
+penalty, or synthetic generation default was added.
+
+| Row | Live result | Verdict |
+| --- | --- | --- |
+| Text multi-turn | `SAVED` at 44.52 tok/s; callback `ORCHID` at 44.35 tok/s; clean stops | PASS |
+| Text physical footprint | peak delta about 1.55 GiB, 35.7% of bundle size | PASS |
+| Image, compile off | coherent synthetic red/blue gradient description at 39.8 tok/s; follow-up `blue` at 34.9 tok/s | PASS |
+| Image, compile on | same grounded description at 39.2 tok/s; follow-up `blue` at 38.4 tok/s | PASS |
+| Image physical footprint | peak delta 3,151 MiB, 70.4% of bundle size | PASS |
+| Structured image cache | cold A; same-media disk restore HIT 99/99; coherent A replay; different-media MISS; grounded follow-up | PASS |
+| Video multi-turn | real triangle fixture; grounded circle/triangle answer at 41.8 tok/s; foreground follow-up at 42.6 tok/s | PASS |
+| Video physical footprint | peak delta 3,671 MiB, 82.1% of bundle size; post-turn footprint dropped to 1,765 MiB | PASS |
+| Tool parser | structured `get_weather({"location":"Tokyo"})`; one tool event; no raw XML marker leakage | PASS |
+| Reasoning parser | natural stop after 372 tokens at 39.2 tok/s; 332 reasoning deltas; visible `Answer: 4.`; closed reasoning; no markers | PASS |
+
+The tool-only envelope measured 17.14 tok/s. That row validates structured
+parser behavior, not the text throughput target; the release text rows are the
+approximately 45 tok/s performance gate.
+
+## Ternary regression matrix
+
+`/Users/eric/models/Bonsai-27b-Ternary-JANG` remained coherent after the
+affine1 work.
+
+| Row | Live result | Verdict |
+| --- | --- | --- |
+| Text multi-turn | `SAVED` at 38.63 tok/s; `ORCHID` at 33.73 tok/s | PASS |
+| Text physical footprint | peak delta about 1.37 GiB, 18.3% of bundle size | PASS |
+| Image | grounded gradient and color follow-up, compile off/on; peak 34.6% of bundle size | PASS |
+| Video | grounded circle/triangle outputs; 34.2 and 16.0 tok/s; peak 27.4% of bundle size | PASS |
+
+The ternary row is a regression check, not a 45 tok/s claim.
+
+## Rejected or superseded diagnostics
+
+- Original vmlx main crashed the 1-bit bundle at the Metal bits assertion.
+- The lossless Swift 1-to-2-bit expansion was coherent at 35.59 tok/s but
+  failed low-RAM requirements at 202.5% of bundle size and was removed.
+- The old plain-loader VL harness reached 145.6% of bundle size. It bypassed
+  the production mmap policy; all VL harness entry points now use the
+  production loader.
+- Video initially peaked at 113.7% because completed media arrays remained in
+  allocator working-set caches. Post-slot GPU fencing and media-only cache
+  cleanup reduced the current row to 82.1%.
+- A 128-token reasoning diagnostic stopped inside reasoning and failed by
+  design. The 512-token row closed naturally and passed; no forced closer or
+  length-cap pass was used.
+- Qwen emitted valid tool XML before the processor fix, but `LMInput` had
+  dropped the active schemas and the stream parser stripped the call. The
+  processor now preserves schemas on both text and media inputs, and both the
+  focused test and real structured tool row pass.
+
+## Still pending after this runtime PR
+
+These items must not be described as complete until their own evidence lands:
+
+1. vmlx-swift PR CI and merge.
+2. Focused Osaurus pin PR to the merged vmlx-swift revision.
+3. Isolated signed Osaurus development build that does not replace or disturb
+   the user's installed/running app.
+4. Computer Use visual proof in that isolated build: model discovery/load,
+   coherent text multi-turn, image/video where exposed by the app, tool and
+   reasoning presentation, physical-footprint observation, and clean unload.
+5. Finder AppleScript re-confirmation after the prior AppleEvents TCC reset.
+6. Sustained repeated-spawn/delegation physical-footprint proof.
+7. Separate automatic model routing and clearer hardware guidance work in the
+   preserved Osaurus routing lane. That work is intentionally paused until the
+   runtime and pin chain is merged.


### PR DESCRIPTION
Adds production runtime support for /Users/eric/models/Bonsai-27b-1bit-JANG without widening its packed one-bit language weights in RAM.

Dependency:
- osaurus-ai/mlx#2 merged into the pinned integration branch at 9e01acd573a18540468160ccaffeb6fb566e891e

Runtime changes:
- validate and consume schema-2 per-tensor JANG quantization manifests
- retain native affine1/group-128 language weights and exact affine4/group-64 vision overrides
- embed the merged standard and NAX affine1 Metal kernels
- preserve Qwen3VL tool schemas for the streaming parser on text and media inputs
- release completed media working sets after a GPU fence in BatchEngine
- make all VL proof entry points use the production mmap-backed load policy
- add fail-closed telemetry, marker, memory, reasoning, tool, image, and video proof gates

Current source tests:
- fresh local MLX Python build: affine1 Metal dequantize/QMV-fast/QMV/QMM test passed
- six JANG affine1 release tests passed
- seven VLM processor release tests passed

Live release evidence on the real 4.4 GB 1-bit bundle:
- coherent text multi-turn: 44.52 and 44.35 tok/s; peak physical-footprint delta 35.7% of bundle size
- real image multi-turn: 34.9-39.8 tok/s; peak 70.4%; compile off/on coherent
- structured image cache: same-media disk restore HIT 99/99; different-media MISS
- real video multi-turn: 41.8 and 42.6 tok/s; peak 82.1%
- structured get_weather Tokyo tool event; no raw XML leakage
- Qwen reasoning closed naturally with visible Answer: 4., 39.2 tok/s, and no raw markers
- ternary Bonsai text/image/video regression rows remained coherent and below their memory gate

The rejected Swift 1-to-2-bit expansion and the old non-production VL loader are not included. Full evidence, rejected rows, and the still-pending Osaurus pin/UI proof are recorded in docs/BONSAI_27B_AFFINE1_READINESS_2026-07-14.md.