### PR TITLE
Gate MLXLMCommon language mode: strict Swift 6 on 6.2+, .v5 fallback on 6.0/6.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,17 @@
 import CompilerPluginSupport
 import PackageDescription
 
+// Strict Swift 6 on 6.2+ (which no longer emit the region-isolation over-report
+// noted on the MLXLMCommon target below); .v5 fallback on 6.0/6.1 so the package
+// stays buildable across the full tools-version-6.1 toolchain range.
+let mlxLMCommonSwiftSettings: [SwiftSetting] = {
+    #if compiler(>=6.2)
+    return [.swiftLanguageMode(.v6)]
+    #else
+    return [.swiftLanguageMode(.v5)]
+    #endif
+}()
+
 #if os(Linux)
     let platformExcludes: [String] = [
         // Linux specific excludes
@@ -490,7 +501,7 @@ let package = Package(
             // tools-version-6.1 toolchain range, while every other target
             // (incl. Jinja) stays in Swift 6 mode. No real data race exists:
             // MLXLMCommon compiles cleanly in Swift 6 mode on current compilers.
-            swiftSettings: [.swiftLanguageMode(.v5)]
+            swiftSettings: mlxLMCommonSwiftSettings
         ),
         .target(
             name: "MLXLLM",


### PR DESCRIPTION
## Summary

`MLXLMCommon` is pinned to `.swiftLanguageMode(.v5)` to keep a known region-isolation over-report (on the `stepPrefill` struct read/mutate/write-back locals) as *warnings* on some Swift 6.0/6.1 compilers. The target's own comment already notes that **current toolchains (6.2+) no longer emit it** and that "MLXLMCommon compiles cleanly in Swift 6 mode on current compilers."

This gates the language mode on the compiler version, so nothing is lost:

```swift
let mlxLMCommonSwiftSettings: [SwiftSetting] = {
    #if compiler(>=6.2)
    return [.swiftLanguageMode(.v6)]
    #else
    return [.swiftLanguageMode(.v5)]
    #endif
}()
```

- **6.2+** → strict `.v6`, matching the "no longer emit" threshold in the target comment
- **6.0/6.1** → `.v5` exactly as today — the full tools-version-6.1 toolchain range still builds

No behavior change for existing toolchains; it only adds strict concurrency where it's already clean. Verified on Swift 6.4: `swift build --target MLXLMCommon` → 0 errors (the only concurrency diagnostics are `withValue(…isolation:)` deprecations in MLX itself, unrelated to this).

### Why

A downstream package that compiles everything in Swift 6 language mode otherwise inherits `.v5` semantics for this one target transitively — so a fully-Swift-6 consumer can't stay strict end-to-end. Gating keeps your compiler-range compatibility intact while letting modern-toolchain builds be uniformly strict.

(Threshold is set to the 6.2+ your comment cites; I verified 6.4 directly — adjust the `compiler(>=…)` floor if you'd prefer.)
