### PR TITLE
Mark Hub.Repo Sendable for Swift 6.2 region isolation

### DIFF
--- a/Vendors/swift-transformers/Sources/Hub/Hub.swift
+++ b/Vendors/swift-transformers/Sources/Hub/Hub.swift
@@ -77,7 +77,7 @@ public extension Hub {
     }
 
     /// The type of repository on the Hugging Face Hub.
-    enum RepoType: String, Codable {
+    enum RepoType: String, Codable, Sendable {
         /// Model repositories containing machine learning models.
         case models
         /// Dataset repositories containing training and evaluation data.
@@ -90,7 +90,7 @@ public extension Hub {
     ///
     /// A repository is identified by its unique ID and type, allowing access to
     /// different kinds of resources hosted on the Hub platform.
-    struct Repo: Codable {
+    struct Repo: Codable, Sendable {
         /// The unique identifier for the repository (e.g., "microsoft/DialoGPT-medium").
         public let id: String
         /// The type of repository (models, datasets, or spaces).


### PR DESCRIPTION
## Summary
- Mark `Hub.RepoType` and `Hub.Repo` as `Sendable` in the vendored swift-transformers Hub module.
- Fixes Xcode 27 / Swift 6.2 build failure when `VMLXHub` is compiled with `StrictConcurrency`:

```
HubApi.swift:849:51: error: sending 'self.repo' risks causing data races
```

`HubFileDownloader.download()` passes `repo` into an async `withTaskCancellationHandler` closure; the repo identity types are immutable `String`-backed values and are safe to send.

This is the same change as #71, rebased onto current `main` (`1ca4029` / #149).

## Test plan
- [x] Patch is the two-line Sendable conformance only
- [ ] `swift build --target VMLXHub` on Xcode 27
- [ ] Osaurus app build on Xcode 27