### PR TITLE
Fall back instead of failing on pre-schema-2 JANG manifests (restores loading for existing bundles)

### DIFF
--- a/Libraries/MLXLMCommon/JangLoader.swift
+++ b/Libraries/MLXLMCommon/JangLoader.swift
@@ -866,11 +866,21 @@ public struct JangLoader: Sendable {
         else {
             return nil
         }
-        guard schema == 2,
-            let rawManifest = quantization["tensor_quantization_manifest"] as? [String: Any]
+        guard schema == 2 else {
+            // "Shape inference remains the fallback for older bundles without a schema-2
+            // manifest" (see the doc comment above). A bundle declaring a pre-2 manifest
+            // schema is exactly such a bundle: before this path existed the field was never
+            // read at all, and the legacy per-module / shape-inference route loaded those
+            // bundles correctly. Throwing here turns a previously-ignored field into a hard
+            // load failure for every pre-schema-2 bundle — including every schema-1 bundle
+            // the current converter emits. Fall back instead; only schema 2 is consumed here.
+            return nil
+        }
+        guard let rawManifest = quantization["tensor_quantization_manifest"] as? [String: Any]
         else {
+            // A declared schema-2 manifest that is missing its payload IS malformed: fail closed.
             throw JangLoaderError.invalidConfig(
-                "unsupported tensor quantization manifest schema \(schema)")
+                "schema-2 tensor quantization manifest declared but tensor_quantization_manifest is missing")
         }
         if let declaredCount = quantization["tensor_quantization_manifest_count"] as? Int,
             declaredCount != rawManifest.count

--- a/Tests/MLXLMCommonFocusedTests/JangAffine1RuntimeContractTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/JangAffine1RuntimeContractTests.swift
@@ -165,4 +165,57 @@ struct JangAffine1RuntimeContractTests {
         }
         return result
     }
+
+    /// Regression: a bundle declaring a PRE-schema-2 manifest must fall back to shape
+    /// inference (this function's documented contract), not fail the load. Before the
+    /// schema-2 manifest path existed, `tensor_quantization_manifest_schema` was never read,
+    /// so every schema-1 bundle the converter emits loaded fine via the legacy route.
+    @Test("pre-schema-2 manifest falls back instead of failing the load")
+    func olderManifestSchemaFallsBack() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("jang-schema1-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let config: [String: Any] = [
+            "format": "jang",
+            "format_version": "2.0",
+            "quantization": [
+                "tensor_quantization_manifest_schema": 1,
+                "tensor_quantization_manifest_count": 1,
+                "tensor_quantization_manifest": [
+                    "model.six_bit": ["bits": 6, "group_size": 64, "mode": "affine"]
+                ],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: config, options: [.sortedKeys])
+            .write(to: root.appendingPathComponent("jang_config.json"))
+
+        // Must not throw: nil hands the bundle to the legacy shape-inference path.
+        let manifest = try JangLoader.loadTensorQuantizationManifest(at: root)
+        #expect(manifest == nil)
+    }
+
+    /// The other side of the fence: a bundle that DOES declare schema 2 but omits the
+    /// manifest payload is malformed and must still fail closed.
+    @Test("schema-2 declared without a manifest still fails closed")
+    func schema2WithoutManifestFailsClosed() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("jang-schema2-bad-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let config: [String: Any] = [
+            "format": "jang",
+            "format_version": "2.0",
+            "quantization": ["tensor_quantization_manifest_schema": 2],
+        ]
+        try JSONSerialization.data(withJSONObject: config, options: [.sortedKeys])
+            .write(to: root.appendingPathComponent("jang_config.json"))
+
+        #expect(throws: JangLoaderError.self) {
+            _ = try JangLoader.loadTensorQuantizationManifest(at: root)
+        }
+    }
+
 }


### PR DESCRIPTION
## Summary

**#149 made a previously-ignored field fatal.** Every JANG bundle whose `jang_config.json` declares `tensor_quantization_manifest_schema: 1` now fails to load on `main`:

```
invalidConfig("unsupported tensor quantization manifest schema 1")
```

That is every bundle the current converter emits — schema 1 is what it stamps today.

## Why this looks unintended rather than a deprecation

Four things in the existing code say "fall back", not "reject":

1. **The function's own doc comment:** *"Shape inference remains the fallback for older bundles without a schema-2 manifest."* A schema-1 bundle **is** an older bundle without a schema-2 manifest — so by this contract it should fall back.
2. **The absent-key branch already returns `nil`** — pre-manifest bundles were explicitly considered. Only "manifest present, older schema" was missed.
3. **`948f03a` introduced this whole path** (`+211/−2` to JangLoader.swift). Before it, `tensor_quantization_manifest_schema` was never read, and schema-1 bundles loaded correctly via the legacy per-module / shape-inference route. Nothing was removed — a previously-ignored field simply became a hard error.
4. **#149 is additive throughout** ("run schema-2 affine 1-bit JANG models natively") and never mentions deprecating schema 1.

## The change

Split the guard so the two cases are distinguished:

- **unknown schema → `return nil`** → the documented shape-inference fallback (restores pre-#149 behaviour for every existing bundle)
- **schema 2 declared but payload missing → still throws**, now with a message that says which case it is instead of reporting it as an unsupported schema

Schema-2 consumption is untouched — Bonsai and any other schema-2 bundle behave exactly as before.

## Reproduction

`empero-ai/Qwythos-9B-Claude-Mythos-5-1M-Jang_6M` (`jang_config.json`: schema=1, count=250), same patches/toolchain, only the engine differs:

| engine | result |
|---|---|
| `main` (1ca4029) | ✗ `invalidConfig("unsupported tensor quantization manifest schema 1")` |
| `cee0f8e` (pre-#149) | ✅ loads, `gsm8k 1/1`, 11s |

The build is green either way — this is purely a load-path gate.

## Tests

Added to `JangAffine1RuntimeContractTests` (pure, no GPU/model needed — 7-line JSON fixture):

- **`pre-schema-2 manifest falls back instead of failing the load`** — a schema-1 manifest returns `nil` rather than throwing
- **`schema-2 declared without a manifest still fails closed`** — the fail-closed path is preserved

Verified red→green: without the fix the first test fails with exactly the production error above; with it, both pass. Your existing **`required malformed contract fails closed`** test also still passes — strictness is unchanged, only the degradation path is restored.
