### PR TITLE
Restore schema-1 JANG manifest loading

### DIFF
--- a/Libraries/MLXLMCommon/JangLoader.swift
+++ b/Libraries/MLXLMCommon/JangLoader.swift
@@ -850,8 +850,10 @@ public struct JangConfig: Sendable {
 public struct JangLoader: Sendable {
 
     /// Load the exact per-tensor affine metadata stamped by the converter.
-    /// Shape inference remains the fallback for older bundles without a
-    /// schema-2 manifest.
+    /// Schema 1 encoded affine mode at the quantization-block level; schema 2
+    /// carries it on every tensor so that affine-1 storage can be described.
+    /// Shape inference remains the fallback for older bundles without either
+    /// manifest.
     public static func loadTensorQuantizationManifest(
         at modelPath: URL
     ) throws -> JangTensorQuantizationManifest? {
@@ -866,11 +868,22 @@ public struct JangLoader: Sendable {
         else {
             return nil
         }
-        guard schema == 2,
-            let rawManifest = quantization["tensor_quantization_manifest"] as? [String: Any]
-        else {
+        guard schema == 1 || schema == 2 else {
             throw JangLoaderError.invalidConfig(
                 "unsupported tensor quantization manifest schema \(schema)")
+        }
+        guard let rawManifest = quantization["tensor_quantization_manifest"] as? [String: Any]
+        else {
+            throw JangLoaderError.invalidConfig(
+                "tensor quantization manifest schema \(schema) is missing its manifest")
+        }
+        if schema == 1 {
+            let scheme = (quantization["quantization_scheme"] as? String)?.lowercased()
+            let backend = (quantization["quantization_backend"] as? String)?.lowercased()
+            guard scheme == "asymmetric", backend == "mx.quantize" else {
+                throw JangLoaderError.invalidConfig(
+                    "schema-1 tensor manifest requires asymmetric mx.quantize affine metadata")
+            }
         }
         if let declaredCount = quantization["tensor_quantization_manifest_count"] as? Int,
             declaredCount != rawManifest.count
@@ -886,13 +899,26 @@ public struct JangLoader: Sendable {
             guard let entry = rawEntry as? [String: Any],
                 let bits = entry["bits"] as? Int,
                 let groupSize = entry["group_size"] as? Int,
-                let mode = (entry["mode"] as? String)?.lowercased(),
-                mode == "affine",
                 supportedAffineBits.contains(bits),
                 groupSize > 0
             else {
                 throw JangLoaderError.invalidConfig(
                     "invalid affine tensor quantization manifest entry: \(path)")
+            }
+            if schema == 1 {
+                guard bits != 1,
+                    entry["weight_key"] as? String == "\(path).weight",
+                    entry["scales_key"] as? String == "\(path).scales",
+                    entry["biases_key"] as? String == "\(path).biases"
+                else {
+                    throw JangLoaderError.invalidConfig(
+                        "invalid schema-1 tensor quantization manifest entry: \(path)")
+                }
+            } else {
+                guard (entry["mode"] as? String)?.lowercased() == "affine" else {
+                    throw JangLoaderError.invalidConfig(
+                        "invalid affine tensor quantization manifest entry: \(path)")
+                }
             }
             if let storageBits = entry["storage_bits"] as? Int, storageBits != bits {
                 throw JangLoaderError.invalidConfig(

--- a/Tests/MLXLMCommonFocusedTests/JangAffine1RuntimeContractTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/JangAffine1RuntimeContractTests.swift
@@ -9,6 +9,75 @@ import Testing
 
 @Suite("JANG affine-1 runtime contract", .serialized)
 struct JangAffine1RuntimeContractTests {
+    @Test("schema-1 converter manifest retains its implicit affine contract")
+    func schemaOneManifestRetainsImplicitAffineContract() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("jang-schema1-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let path = "model.layers.0.mlp.down_proj"
+        let config: [String: Any] = [
+            "format": "jang",
+            "format_version": "2.0",
+            "quantization": [
+                "quantization_backend": "mx.quantize",
+                "quantization_scheme": "asymmetric",
+                "tensor_quantization_manifest_schema": 1,
+                "tensor_quantization_manifest_count": 1,
+                "tensor_quantization_manifest": [
+                    path: [
+                        "bits": 4,
+                        "group_size": 64,
+                        "weight_key": "\(path).weight",
+                        "scales_key": "\(path).scales",
+                        "biases_key": "\(path).biases"
+                    ],
+                ],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: config, options: [.sortedKeys])
+            .write(to: root.appendingPathComponent("jang_config.json"))
+
+        let loadedManifest = try JangLoader.loadTensorQuantizationManifest(at: root)
+        let manifest = try #require(loadedManifest)
+        #expect(manifest.entries[path]?.bits == 4)
+        #expect(manifest.entries[path]?.groupSize == 64)
+        #expect(manifest.entries[path]?.mode == .affine)
+    }
+
+    @Test("schema-1 manifest fails closed when its tensor keys disagree")
+    func schemaOneManifestRejectsMismatchedTensorKeys() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("jang-schema1-invalid-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let config: [String: Any] = [
+            "quantization": [
+                "quantization_backend": "mx.quantize",
+                "quantization_scheme": "asymmetric",
+                "tensor_quantization_manifest_schema": 1,
+                "tensor_quantization_manifest_count": 1,
+                "tensor_quantization_manifest": [
+                    "model.proj": [
+                        "bits": 4,
+                        "group_size": 64,
+                        "weight_key": "model.other.weight",
+                        "scales_key": "model.proj.scales",
+                        "biases_key": "model.proj.biases"
+                    ],
+                ]
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: config, options: [.sortedKeys])
+            .write(to: root.appendingPathComponent("jang_config.json"))
+
+        #expect(throws: JangLoaderError.self) {
+            try JangLoader.loadTensorQuantizationManifest(at: root)
+        }
+    }
+
     @Test("schema-2 contract selects only affine one-bit modules")
     func contractSelectsOnlyAffineOneBitModules() throws {
         let root = FileManager.default.temporaryDirectory


### PR DESCRIPTION
## Scope

- Accept JANG tensor manifest schema 1 only when it matches the historical asymmetric `mx.quantize` affine contract.
- Validate declared count, supported bit width, positive group size, and exact weight/scales/biases keys.
- Preserve schema-2 per-entry affine validation and reject unknown schemas.
- Add focused positive and fail-closed schema-1 tests.

## Root cause

PR #149 introduced the schema-2 affine-1 loader. Its source comment retained older-bundle fallback intent, but the implementation threw on every declared schema-1 manifest before model construction. The installed Ornith JANG_4M bundle at `~/models/JANGQ-AI/Ornith-1.0-9B-JANG_4M` therefore failed with `unsupported tensor quantization manifest schema 1`.

## Verification

Source/test evidence:

- All five installed non-MXFP4 schema-1 manifests under `~/models` satisfy the bounded historical converter contract.
- `swift test --filter schemaOneManifest`: 2 tests passed.
- The broader affine-1 suite reaches and passes both new tests and the existing schema-2 parser test, then the SwiftPM lane fails in an existing GPU test because its default metallib is not packaged.

Live Osaurus evidence:

- Osaurus Release app was pinned to exact commit `a26c7ecec950f18e3d07c8402fbd8c80f40ac764`, ad-hoc signed under an isolated proof bundle id, and operated through the real UI.
- Storage was pointed at exact local bundle `/Users/eric/models/JANGQ-AI/Ornith-1.0-9B-JANG_4M`; the Custom model folder row was selected and reached `Model warm — ready for a fast first response`.
- Runtime logged `JANG shape walk produced 250 per-layer quant override(s) over default (bits=4, gs=64)`; the former schema-1 rejection did not recur.
- The exact model generated valid streamed `file_read` and `file_edit` tool calls and a normal final response in Thinking-off and Thinking-on UI rows.

## Scope boundary

This proves schema-1 loading and generation through the packaged Osaurus path. The model still produced a semantically incomplete multi-step handbook edit despite structurally valid tool calls; that separate app/model behavior is documented and is not claimed fixed by this loader PR. No MXFP4 model was downloaded, loaded, or used for inference.
