### PR TITLE
Correct Gemma QAT cache defaults and TQ telemetry

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -292,6 +292,11 @@ public actor BatchEngine {
     /// proof that the live codec activated.
     private var turboQuantCompressionCount: Int = 0
 
+    /// Most recent real before/after layer topology for a successful
+    /// TurboQuant transition. This remains available after its request slot
+    /// completes so host diagnostics can prove which layers converted.
+    private var lastTurboQuantCacheTransition: TurboQuantCacheTransitionSnapshot?
+
     /// Background scheduling loop task handle.
     private var loopTask: Task<Void, Never>?
 
@@ -876,9 +881,13 @@ public actor BatchEngine {
                         generationTime: info.generateTime,
                         stopReason: finalStop,
                         turboQuantCompressions: info.turboQuantCompressions,
+                        turboQuantCacheTransition: info.turboQuantCacheTransition,
                         unclosedReasoning: unclosed)
                     if info.turboQuantCompressions > 0 {
                         turboQuantCompressionCount += info.turboQuantCompressions
+                    }
+                    if let transition = info.turboQuantCacheTransition {
+                        lastTurboQuantCacheTransition = transition
                     }
                     terminationState.markCompleted()
                     continuation.yield(.info(finalInfo))
@@ -1169,6 +1178,11 @@ public actor BatchEngine {
                 if case .info(let info) = generation, info.turboQuantCompressions > 0 {
                     turboQuantCompressionCount += info.turboQuantCompressions
                 }
+                if case .info(let info) = generation,
+                   let transition = info.turboQuantCacheTransition
+                {
+                    lastTurboQuantCacheTransition = transition
+                }
                 continuation.yield(generation)
             }
             self.finishSoloFastPath(id: fastPathID)
@@ -1307,6 +1321,12 @@ public actor BatchEngine {
     /// Number of successful KVCacheSimple -> TurboQuantKVCache transitions.
     public var turboQuantCompressionCountForDiagnostics: Int {
         turboQuantCompressionCount
+    }
+
+    /// Exact before/after cache classes from the most recent successful live
+    /// TurboQuant transition, or `nil` when no transition has occurred.
+    public var lastTurboQuantCacheTransitionForDiagnostics: TurboQuantCacheTransitionSnapshot? {
+        lastTurboQuantCacheTransition
     }
 
     /// Whether the engine is currently running (has active or pending work).
@@ -2574,13 +2594,18 @@ public actor BatchEngine {
 
     private func maybeCompressSlotCache(_ slot: inout BatchSlot) {
         let hadTQ = slot.cache.contains { $0 is TurboQuantKVCache }
+        let before = hadTQ ? nil : ModelCacheTopologySnapshot(cache: slot.cache)
         BatchQuantize.maybeCompress(
             cache: &slot.cache,
             parameters: slot.parameters
         )
         let hasTQ = slot.cache.contains { $0 is TurboQuantKVCache }
-        if !hadTQ && hasTQ {
+        if !hadTQ, hasTQ, let before {
             turboQuantCompressionCount += 1
+            lastTurboQuantCacheTransition = TurboQuantCacheTransitionSnapshot(
+                before: before,
+                after: ModelCacheTopologySnapshot(cache: slot.cache)
+            )
         }
     }
 

--- a/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
@@ -200,7 +200,7 @@ public final class CacheCoordinator: @unchecked Sendable {
     /// boundary snapshot — the hybrid stripped boundary in particular costs a
     /// retained cache copy or, failing that, a whole extra prefill.
     public var canPersistBoundaries: Bool {
-        pagedCache != nil || diskCache != nil
+        (pagedCache != nil && !isPagedIncompatible) || diskCache != nil
     }
 
     /// 2026-05-04: mark the model as paged-incompatible (DSV4 hybrid pool
@@ -231,9 +231,10 @@ public final class CacheCoordinator: @unchecked Sendable {
 
     /// Thread-safe snapshot for diagnostics, UI status, and admin routes.
     public func snapshotStats() -> CacheCoordinatorStatsSnapshot {
-        CacheCoordinatorStatsSnapshot(
-            pagedEnabled: pagedCache != nil,
-            pagedStats: pagedCache?.snapshotStats(),
+        let pagedIsEffective = pagedCache != nil && !isPagedIncompatible
+        return CacheCoordinatorStatsSnapshot(
+            pagedEnabled: pagedIsEffective,
+            pagedStats: pagedIsEffective ? pagedCache?.snapshotStats() : nil,
             diskEnabled: diskCache != nil,
             diskStats: diskCache?.snapshotStats(),
             ssmStats: ssmStateCache.snapshotStats(),

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -945,6 +945,7 @@ public protocol TokenIteratorProtocol: Sequence, IteratorProtocol where Element 
     var promptPrefillTime: TimeInterval { get }
     var promptTokenIds: [Int] { get }
     var turboQuantCompressionCount: Int { get }
+    var lastTurboQuantCacheTransition: TurboQuantCacheTransitionSnapshot? { get }
     mutating func storeCacheAfterGeneration(
         generatedTokenIds: [Int],
         includeGeneratedBoundary: Bool)
@@ -953,6 +954,7 @@ public protocol TokenIteratorProtocol: Sequence, IteratorProtocol where Element 
 extension TokenIteratorProtocol {
     public var promptTokenIds: [Int] { [] }
     public var turboQuantCompressionCount: Int { 0 }
+    public var lastTurboQuantCacheTransition: TurboQuantCacheTransitionSnapshot? { nil }
 
     public mutating func storeCacheAfterGeneration(
         generatedTokenIds: [Int],
@@ -1148,6 +1150,7 @@ public struct TokenIterator: TokenIteratorProtocol {
     public var tokenCount = 0
     public let maxTokens: Int?
     public private(set) var turboQuantCompressionCount = 0
+    public private(set) var lastTurboQuantCacheTransition: TurboQuantCacheTransitionSnapshot?
 
     // Cache quantization parameters
     let kvBits: Int?
@@ -1971,6 +1974,7 @@ public struct TokenIterator: TokenIteratorProtocol {
 
     mutating func maybeQuantizeCacheForStep() {
         let hadTQ = cache.contains { $0 is TurboQuantKVCache }
+        let before = hadTQ ? nil : ModelCacheTopologySnapshot(cache: cache)
         maybeQuantizeKVCache(
             cache: &cache,
             kvBits: kvBits,
@@ -1978,8 +1982,12 @@ public struct TokenIterator: TokenIteratorProtocol {
             quantizedKVStart: quantizedKVStart,
             kvMode: kvMode)
         let hasTQ = cache.contains { $0 is TurboQuantKVCache }
-        if !hadTQ && hasTQ {
+        if !hadTQ, hasTQ, let before {
             turboQuantCompressionCount += 1
+            lastTurboQuantCacheTransition = TurboQuantCacheTransitionSnapshot(
+                before: before,
+                after: ModelCacheTopologySnapshot(cache: cache)
+            )
         }
     }
 
@@ -3694,6 +3702,7 @@ private func generateLoopTask<Handler: TokenLoopHandler>(
                 generationTime: generateTime,
                 stopReason: stopReason ?? .cancelled,
                 turboQuantCompressions: iterator.turboQuantCompressionCount,
+                turboQuantCacheTransition: iterator.lastTurboQuantCacheTransition,
                 unclosedReasoning: unclosedReasoning
             )
             // Multi-tier cache: drain the final async token eval before cache
@@ -3786,6 +3795,12 @@ public struct GenerateCompletionInfo: Sendable {
     /// live KVCacheSimple -> TurboQuantKVCache transition.
     public let turboQuantCompressions: Int
 
+    /// Real cache-class topology immediately before and after the most recent
+    /// live TurboQuant transition in this generation. `nil` means no layer
+    /// transition was observed; callers must not infer activation from the
+    /// requested KV mode alone.
+    public let turboQuantCacheTransition: TurboQuantCacheTransitionSnapshot?
+
     /// True when the stream ended with the reasoning parser still in
     /// REASONING state — i.e. the model never emitted `</think>` (or
     /// the family-specific close tag) before EOS or `max_tokens`.
@@ -3835,6 +3850,7 @@ public struct GenerateCompletionInfo: Sendable {
         generationTime: TimeInterval,
         stopReason: GenerateStopReason = .stop,
         turboQuantCompressions: Int = 0,
+        turboQuantCacheTransition: TurboQuantCacheTransitionSnapshot? = nil,
         unclosedReasoning: Bool = false
     ) {
         self.promptTokenCount = promptTokenCount
@@ -3843,6 +3859,7 @@ public struct GenerateCompletionInfo: Sendable {
         self.generateTime = generationTime
         self.stopReason = stopReason
         self.turboQuantCompressions = turboQuantCompressions
+        self.turboQuantCacheTransition = turboQuantCacheTransition
         self.unclosedReasoning = unclosedReasoning
     }
 

--- a/Libraries/MLXLMCommon/ModelContainer.swift
+++ b/Libraries/MLXLMCommon/ModelContainer.swift
@@ -169,6 +169,40 @@ public struct ModelCacheTopologySnapshot: Codable, Sendable, Equatable {
     }
 }
 
+/// Exact cache-layer transition observed when a live request crosses from
+/// ordinary float KV into TurboQuant KV.
+///
+/// A requested ``KVQuantizationMode/turboQuant(keyBits:valueBits:)`` value or
+/// a non-zero transition-event counter proves only that the hook ran. This
+/// snapshot records the real cache classes immediately before and after the
+/// hook so hosts can prove how many eligible full-attention layers converted
+/// and which architecture-specific layers (for example Gemma rotating SWA)
+/// remained native.
+public struct TurboQuantCacheTransitionSnapshot: Codable, Sendable, Equatable {
+    public let before: ModelCacheTopologySnapshot
+    public let after: ModelCacheTopologySnapshot
+    public let convertedTurboQuantKVLayerCount: Int
+
+    public init(
+        before: ModelCacheTopologySnapshot,
+        after: ModelCacheTopologySnapshot
+    ) {
+        self.before = before
+        self.after = after
+        self.convertedTurboQuantKVLayerCount = max(
+            0,
+            after.turboQuantKVLayerCount - before.turboQuantKVLayerCount
+        )
+    }
+
+    public init(before: [any KVCache], after: [any KVCache]) {
+        self.init(
+            before: ModelCacheTopologySnapshot(cache: before),
+            after: ModelCacheTopologySnapshot(cache: after)
+        )
+    }
+}
+
 /// Container for models that guarantees single threaded access.
 ///
 /// Wrap models used by e.g. the UI in a ModelContainer. Callers can access

--- a/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
+++ b/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
@@ -492,7 +492,10 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
 
         var resolvedCache = cache
         if resolvedCache.prefix.enabled {
-            resolvedCache.blockDisk.enabled = true
+            // Block-disk L2 is enabled by default, but an explicit user Off
+            // must survive memory-safety resolution. Prefix reuse can still
+            // operate without a persistent tier; only the deprecated legacy
+            // disk implementation is suppressed here.
             resolvedCache.legacyDisk.enabled = false
             if resolvedCache.prefix.memoryLimitMB == nil {
                 resolvedCache.prefix.memoryLimitMB = profile.prefixMemoryLimitMB
@@ -941,7 +944,10 @@ public struct VMLXServerCacheSettings: Codable, Sendable, Equatable {
     public var defaultKVMode: KVQuantizationMode {
         switch liveKVCodec {
         case .engineSelected:
-            return .turboQuant()
+            // Engine-selected is the safe native default. TurboQuant KV is an
+            // explicit opt-in because its encode/decode cost and topology
+            // compatibility must be proven per runtime/model family.
+            return .none
         case .native, .none:
             return .none
         case .turboQuant:

--- a/Tests/MLXLMCommonFocusedTests/VMLXMemorySafetySettingsTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/VMLXMemorySafetySettingsTests.swift
@@ -111,6 +111,35 @@ struct VMLXMemorySafetySettingsTests {
         #expect(!coordinator.enableDiskCache)
     }
 
+    @Test("memory safety preserves explicit block disk disable with prefix reuse enabled")
+    func memorySafetyPreservesExplicitBlockDiskDisableWithPrefixReuseEnabled() {
+        var settings = VMLXServerRuntimeSettings()
+        settings.cache.prefix.enabled = true
+        settings.cache.pagedKV.enabled = false
+        settings.cache.blockDisk.enabled = false
+
+        let plan = settings.resolvedMemorySafetyPlan(
+            baseLoadConfiguration: .osaurusProduction,
+            bundleFacts: LoadBundleFacts(
+                totalSafetensorsBytes: 12 << 30,
+                isRouted: false,
+                physicalMemory: 64 << 30,
+                modelType: "gemma4",
+                weightFormat: "mxfp8"))
+        let coordinator = VMLXServerRuntimeSettings(
+            cache: plan.cache,
+            memorySafety: settings.memorySafety
+        )
+        .cacheCoordinatorConfig(modelKey: "gemma4|disk=explicit-off")
+
+        #expect(plan.cache.prefix.enabled)
+        #expect(!plan.cache.pagedKV.enabled)
+        #expect(!plan.cache.blockDisk.enabled)
+        #expect(!plan.cache.legacyDisk.enabled)
+        #expect(!coordinator.usePagedCache)
+        #expect(!coordinator.enableDiskCache)
+    }
+
     @Test("strict mode returns typed refusal for unknown and over budget estimates")
     func strictModeReturnsTypedRefusalForUnknownAndOverBudgetEstimates() {
         var settings = VMLXServerRuntimeSettings()
@@ -266,11 +295,6 @@ struct VMLXMemorySafetySettingsTests {
         #expect(coordinator.enableDiskCache)
         #expect(coordinator.enableSSMReDerive)
         #expect(coordinator.ssmMaxEntries == 96)
-        if case .turboQuant(let keyBits, let valueBits) = coordinator.defaultKVMode {
-            #expect(keyBits == 3)
-            #expect(valueBits == 3)
-        } else {
-            Issue.record("Memory safety should preserve engine-selected TurboQuant KV policy.")
-        }
+        #expect(coordinator.defaultKVMode == .none)
     }
 }

--- a/Tests/MLXLMCommonFocusedTests/VMLXServerRuntimeSettingsTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/VMLXServerRuntimeSettingsTests.swift
@@ -22,7 +22,7 @@ struct VMLXServerRuntimeSettingsTests {
         #expect(settings.cache.enableSSMReDerive)
         #expect(settings.cache.defaultMaxKVSize == nil)
         #expect(settings.cache.longPromptMultiplier == 2.0)
-        #expect(settings.cache.defaultKVMode == .turboQuant(keyBits: 3, valueBits: 3))
+        #expect(settings.cache.defaultKVMode == .none)
         #expect(settings.generation.temperature == nil)
         #expect(settings.generation.topP == nil)
         #expect(settings.generation.topK == nil)
@@ -750,17 +750,12 @@ struct VMLXServerRuntimeSettingsTests {
         }
     }
 
-    @Test("engine-selected cache codec enables automatic TurboQuant KV")
-    func engineSelectedCacheCodecEnablesAutomaticTurboQuantKV() {
+    @Test("engine-selected cache codec keeps TurboQuant KV off by default")
+    func engineSelectedCacheCodecKeepsTurboQuantKVOffByDefault() {
         var settings = VMLXServerRuntimeSettings()
         settings.cache.liveKVCodec = .engineSelected
 
-        if case .turboQuant(let keyBits, let valueBits) = settings.cacheCoordinatorConfig().defaultKVMode {
-            #expect(keyBits == 3)
-            #expect(valueBits == 3)
-        } else {
-            Issue.record("Engine-selected cache codec should resolve the production TurboQuant KV default")
-        }
+        #expect(settings.cacheCoordinatorConfig().defaultKVMode == .none)
 
         settings.cache.liveKVCodec = .native
         #expect(settings.cacheCoordinatorConfig().defaultKVMode == .none)
@@ -793,12 +788,7 @@ struct VMLXServerRuntimeSettingsTests {
         #expect(config.enableSSMReDerive)
         #expect(config.modelKey == "matrix|reasoning=auto|tools=auto")
         #expect(resolvedPolicy.maxKVSize == nil)
-        if case .turboQuant(let keyBits, let valueBits) = resolvedPolicy.kvMode {
-            #expect(keyBits == 3)
-            #expect(valueBits == 3)
-        } else {
-            Issue.record("Engine-selected automatic cache policy did not resolve TurboQuant KV")
-        }
+        #expect(resolvedPolicy.kvMode == .none)
 
         for row in rows {
             #expect(ToolCallFormat.infer(from: row.modelType) == row.tool)

--- a/Tests/MLXLMTests/CacheCoordinatorTests.swift
+++ b/Tests/MLXLMTests/CacheCoordinatorTests.swift
@@ -44,6 +44,13 @@ import Testing
     // Flip the flag: subsequent fetch + store must skip the paged tier.
     coordinator.setPagedIncompatible(true)
     #expect(coordinator.isPagedIncompatible == true)
+    #expect(coordinator.canPersistBoundaries == false,
+        "an incompatible paged tier without disk L2 cannot persist a usable boundary")
+    let incompatibleSnapshot = coordinator.snapshotStats()
+    #expect(incompatibleSnapshot.pagedEnabled == false,
+        "telemetry must report effective paged state, not the inert requested allocation")
+    #expect(incompatibleSnapshot.pagedStats == nil,
+        "inert paged counters must not be exposed as an active cache tier")
     let result = coordinator.fetch(tokens: tokens)
     if case .miss = result {
         // expected — paged tier skipped, no disk tier present

--- a/Tests/MLXLMTests/TurboQuantCacheTransitionTelemetryTests.swift
+++ b/Tests/MLXLMTests/TurboQuantCacheTransitionTelemetryTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite("TurboQuant live cache transition telemetry")
+struct TurboQuantCacheTransitionTelemetryTests {
+    @Test("mixed Gemma topology reports eight converted KV and forty preserved rotating layers")
+    func mixedGemmaTopology() {
+        let before: [any KVCache] =
+            (0..<8).map { _ in KVCacheSimple() as any KVCache }
+            + (0..<40).map { _ in RotatingKVCache(maxSize: 1_024) as any KVCache }
+        let after: [any KVCache] =
+            (0..<8).map { _ in TurboQuantKVCache(keyBits: 4, valueBits: 4) as any KVCache }
+            + (0..<40).map { _ in RotatingKVCache(maxSize: 1_024) as any KVCache }
+
+        let snapshot = TurboQuantCacheTransitionSnapshot(before: before, after: after)
+
+        #expect(snapshot.before.layerCount == 48)
+        #expect(snapshot.before.kvLayerCount == 8)
+        #expect(snapshot.before.turboQuantKVLayerCount == 0)
+        #expect(snapshot.before.rotatingKVLayerCount == 40)
+        #expect(snapshot.after.layerCount == 48)
+        #expect(snapshot.after.kvLayerCount == 0)
+        #expect(snapshot.after.turboQuantKVLayerCount == 8)
+        #expect(snapshot.after.rotatingKVLayerCount == 40)
+        #expect(snapshot.convertedTurboQuantKVLayerCount == 8)
+    }
+
+    @Test("completion info retains the exact transition snapshot")
+    func completionInfoRetainsTransition() {
+        let before = ModelCacheTopologySnapshot(
+            layerCount: 48,
+            kvLayerCount: 8,
+            rotatingKVLayerCount: 40
+        )
+        let after = ModelCacheTopologySnapshot(
+            layerCount: 48,
+            turboQuantKVLayerCount: 8,
+            rotatingKVLayerCount: 40
+        )
+        let transition = TurboQuantCacheTransitionSnapshot(before: before, after: after)
+
+        let info = GenerateCompletionInfo(
+            promptTokenCount: 512,
+            generationTokenCount: 32,
+            promptTime: 1,
+            generationTime: 1,
+            turboQuantCompressions: 1,
+            turboQuantCacheTransition: transition
+        )
+
+        #expect(info.turboQuantCompressions == 1)
+        #expect(info.turboQuantCacheTransition == transition)
+    }
+
+    @Test("transition snapshot round-trips through Codable")
+    func codableRoundTrip() throws {
+        let transition = TurboQuantCacheTransitionSnapshot(
+            before: ModelCacheTopologySnapshot(
+                layerCount: 48,
+                kvLayerCount: 8,
+                rotatingKVLayerCount: 40
+            ),
+            after: ModelCacheTopologySnapshot(
+                layerCount: 48,
+                turboQuantKVLayerCount: 8,
+                rotatingKVLayerCount: 40
+            )
+        )
+
+        let data = try JSONEncoder().encode(transition)
+        let decoded = try JSONDecoder().decode(
+            TurboQuantCacheTransitionSnapshot.self,
+            from: data
+        )
+
+        #expect(decoded == transition)
+    }
+}

--- a/docs/GEMMA4_QAT_CACHE_CORRECTNESS_CHECKPOINT_2026-07-19.md
+++ b/docs/GEMMA4_QAT_CACHE_CORRECTNESS_CHECKPOINT_2026-07-19.md
@@ -1,0 +1,84 @@
+# Gemma 4 QAT cache correctness checkpoint — 2026-07-19
+
+Status: **PARTIAL — live mixed-cache TurboQuant transition, paged-L1 eviction,
+and fresh-process L2 restore still require the telemetry build below.**
+
+This checkpoint is intentionally limited to locally installed Gemma 4 MXFP8
+and JANG_4M bundles through the real Osaurus/vMLX Swift runtime. MXFP4 is not a
+substitute test artifact and is not part of this checkpoint.
+
+## Source contract
+
+- Ordinary Osaurus single-batch loads keep paged RAM KV off by default.
+- The tested Gemma 4 12B bundles declare 48 attention layers: 8 full-attention
+  `KVCacheSimple` layers and 40 `RotatingKVCache` sliding-attention layers.
+- TurboQuant converts only eligible `KVCacheSimple` layers. It must preserve
+  all rotating SWA layers as rotating caches.
+- `TurboQuantCacheTransitionSnapshot` records the real before/after cache
+  classes at the conversion point. A configured TurboQuant mode or a non-zero
+  compression-event counter is not accepted as layer-level proof.
+- Prompt-boundary L2 entries may intentionally remain typed raw KV plus typed
+  rotating state even when live decode uses TurboQuant. Telemetry must report
+  the live codec and stored codec separately; neither implies the other.
+- Gemma mixed SWA/full attention has no recurrent SSM/GLA companion state.
+  Hybrid SSM/GDN/CCA async-rederive gates therefore remain separate family
+  rows and must not be inferred from Gemma evidence.
+
+## Current evidence
+
+| Row | Current evidence | Status |
+|---|---|---|
+| Stale `<end_of_turn>` stop | vMLX `604d24e4`; focused Gemma 3/4 regression 3/3; live MXFP8 and JANG_4M both emitted a literal marker and continued through `FINAL-OMEGA` | VERIFIED-LIVE |
+| Default paged policy | Real isolated Release app Settings showed GPU paged KV off; `/admin/cache-stats` reported `paged.enabled=false` | VERIFIED-LIVE |
+| MXFP8, TurboQuant off | Two visible UI turns, 31.0/29.3 tok/s; native codec; 8 KV + 40 rotating topology | VERIFIED-LIVE |
+| MXFP8, TurboQuant 4/4 | Two visible UI turns, 15.4/28.6 tok/s; compression events and L2 counters increased | PARTIAL: exact per-layer transition requires telemetry rebuild |
+| JANG_4M, TurboQuant off | Two visible UI turns, both 40.8 tok/s; native codec; 8 KV + 40 rotating topology | VERIFIED-LIVE |
+| JANG_4M, TurboQuant 4/4 | Two visible UI turns, 35.3/35.8 tok/s; compression events and L2 counters increased | PARTIAL: exact per-layer transition requires telemetry rebuild |
+| TurboQuant transition telemetry | `TurboQuantCacheTransitionTelemetryTests` 3/3: synthetic mixed Gemma topology reports 8 converted KV and 40 preserved rotating layers and round-trips through Codable | VERIFIED-SOURCE; live endpoint pending |
+| RAM safety refusal/override | Real Settings UI: Strict 10% refused MXFP8 at 12.8 GB budget; No Automatic Limits then loaded and generated `LOADED`; restored Safe Auto afterwards | VERIFIED-LIVE |
+| Activity Monitor footprint | Real Activity Monitor showed Osaurus at 5.13 GB with green memory pressure after the override row | VERIFIED-LIVE for that row only |
+
+## Required live closure matrix
+
+Every row must use a fresh Release development build with an isolated bundle
+identifier and preferences root. Visible UI behavior and matching runtime
+telemetry are both required.
+
+| Gate | Required evidence | Status |
+|---|---|---|
+| Exact MXFP8 TQ transition | `/admin/cache-stats` before: 48 total / 8 KV / 40 rotating; after: 48 total / 8 TQ / 40 rotating; coherent visible continuation | OPEN |
+| Exact JANG_4M TQ transition | Same exact before/after layer proof and coherent visible continuation | OPEN |
+| Paged L1 explicit opt-in | User turns paged cache on in Settings; reload shows effective on; second matching prompt increases paged hits and returns coherent tail sentinel | OPEN |
+| Paged L1 capacity/eviction | Constrain the visible paged-cache capacity, create more blocks than fit, observe allocated/free/eviction counters and bounded Activity Monitor footprint | OPEN |
+| L1-before-L2 ordering | With a matching block still resident, paged-hit counter increases without a disk-hit increase for the same fetch | OPEN |
+| L2 fallback after eviction | Evict the matching paged block while retaining its disk entry; next matching prompt increases disk hit and restores typed 8-full/40-rotating state | OPEN |
+| Fresh-process L2 restore | Quit only the isolated proof app, relaunch it, load the same model, and show a disk hit plus a coherent continuation dependent on cached context | OPEN |
+| Raw-prefill fallback | Use a cache-salted or genuinely new prefix absent from both tiers; paged/disk miss counters increase, real prefill progress is visible, output remains coherent | OPEN |
+| TurboQuant after L2 restore | With TQ enabled, restore the typed raw prompt boundary from L2, then prove the resumed live decode transitions 8 KV layers to TQ while preserving 40 rotating layers | OPEN |
+| TurboQuant off control | Repeat the same restore with Native selected; live transition remains null and TQ layer count remains zero | OPEN |
+| Long rotating-window sentinel | Cross the 1,024-token SWA window, reuse prefix/L2, and reproduce exact early/middle/tail facts without a loop or truncated tail | OPEN |
+| Ten-turn coherence | Ten visible turns with cache reuse, measured TTFT/tok/s on every generated turn, no marker leakage, no hidden-only answer, no looping | OPEN |
+| Tool/parser continuation | Required tool, auto tool, no tool, tool-result continuation, tool error recovery, and post-tool text turn with TQ off/on | OPEN |
+| Reasoning/template state | UI Thinking off/on/auto maps to the emitted reasoning/content channels and model-owned generation config; no prompt or sampler masking | OPEN |
+| API parity | Chat Completions stream/non-stream, Responses stream/non-stream, Anthropic, and Ollama reconstruct the same visible content and finish reason | OPEN |
+| Stop/cancel cleanup | Cancel during prefill and decode; next warm turn neither restores a poisoned partial boundary nor leaks stale output | OPEN |
+| Memory settings next-load semantics | Safe Auto, Strict, Custom, and No Automatic Limits are visibly changed, saved, and proven on the next real model load; refusal occurs before eviction/load | PARTIAL: Strict/No-Limits proven; remaining modes open |
+| Delegation/admission | Local text subagent, Computer Use/AppleScript, image generation/edit, and concurrent delegation receive the same memory admission decision before model eviction | OPEN; Osaurus-level row |
+
+## Non-Gemma rows retained for the wider campaign
+
+- Hybrid SSM/GDN/GLA families (Qwen 3.5/3.5 VL, Ornith, Bonsai, Nemotron and
+  applicable MiniMax variants) require typed companion-state hit/miss/rederive
+  counters, partial-hit rollback/rederive proof, media-salt proof for VL, and
+  coherent post-hit continuation with TurboQuant off/on.
+- DSV4/ZAYA and MiniMax-M3 native composite caches remain explicit exceptions
+  to generic TurboQuant KV until their typed native codecs are separately
+  live-proven. Their evidence must not be generalized from Gemma.
+- JANGTQ/MXTQ weight-format correctness is a separate issue from TurboQuant KV
+  cache encoding and must remain a separate matrix.
+- AppleScript 8B JANG_6M import/discovery, Computer Use app switching, success
+  finalization, unexpected tool fallback, and spawned-agent plugin inheritance
+  remain Osaurus UI/runtime rows. They are not closed by this cache checkpoint.
+
+No row becomes release-ready from source inspection, a configured setting, or
+an aggregate counter alone.

--- a/docs/GEMMA4_QAT_CACHE_CORRECTNESS_CHECKPOINT_2026-07-19.md
+++ b/docs/GEMMA4_QAT_CACHE_CORRECTNESS_CHECKPOINT_2026-07-19.md
@@ -1,7 +1,8 @@
 # Gemma 4 QAT cache correctness checkpoint — 2026-07-19
 
-Status: **PARTIAL — live mixed-cache TurboQuant transition, paged-L1 eviction,
-and fresh-process L2 restore still require the telemetry build below.**
+Status: **PARTIAL — exact mixed-cache TurboQuant and fresh-process L2 restore
+are live-proven on vMLX `718522bc`, but the current cache-default/explicit-Off
+patch still requires a rebuilt isolated Release app and repeat UI proof.**
 
 This checkpoint is intentionally limited to locally installed Gemma 4 MXFP8
 and JANG_4M bundles through the real Osaurus/vMLX Swift runtime. MXFP4 is not a
@@ -10,6 +11,10 @@ substitute test artifact and is not part of this checkpoint.
 ## Source contract
 
 - Ordinary Osaurus single-batch loads keep paged RAM KV off by default.
+- Engine-selected/native cache mode keeps TurboQuant KV off. TurboQuant is an
+  explicit user opt-in with explicit key/value bit widths.
+- Block-disk L2 is on by default and is independent of paged RAM cache. An
+  explicit block-disk Off must survive memory-safety policy resolution.
 - The tested Gemma 4 12B bundles declare 48 attention layers: 8 full-attention
   `KVCacheSimple` layers and 40 `RotatingKVCache` sliding-attention layers.
 - TurboQuant converts only eligible `KVCacheSimple` layers. It must preserve
@@ -29,14 +34,16 @@ substitute test artifact and is not part of this checkpoint.
 | Row | Current evidence | Status |
 |---|---|---|
 | Stale `<end_of_turn>` stop | vMLX `604d24e4`; focused Gemma 3/4 regression 3/3; live MXFP8 and JANG_4M both emitted a literal marker and continued through `FINAL-OMEGA` | VERIFIED-LIVE |
-| Default paged policy | Real isolated Release app Settings showed GPU paged KV off; `/admin/cache-stats` reported `paged.enabled=false` | VERIFIED-LIVE |
-| MXFP8, TurboQuant off | Two visible UI turns, 31.0/29.3 tok/s; native codec; 8 KV + 40 rotating topology | VERIFIED-LIVE |
-| MXFP8, TurboQuant 4/4 | Two visible UI turns, 15.4/28.6 tok/s; compression events and L2 counters increased | PARTIAL: exact per-layer transition requires telemetry rebuild |
-| JANG_4M, TurboQuant off | Two visible UI turns, both 40.8 tok/s; native codec; 8 KV + 40 rotating topology | VERIFIED-LIVE |
-| JANG_4M, TurboQuant 4/4 | Two visible UI turns, 35.3/35.8 tok/s; compression events and L2 counters increased | PARTIAL: exact per-layer transition requires telemetry rebuild |
-| TurboQuant transition telemetry | `TurboQuantCacheTransitionTelemetryTests` 3/3: synthetic mixed Gemma topology reports 8 converted KV and 40 preserved rotating layers and round-trips through Codable | VERIFIED-SOURCE; live endpoint pending |
+| Default paged policy | Isolated Release app at exact vMLX `718522bc`: Settings showed paged KV off and `/admin/cache-stats` reported `paged.enabled=false` | VERIFIED-LIVE on prior pin; current patch rebuild pending |
+| MXFP8, TurboQuant off | Fresh single-root first turn `COBALT-LIGHTHOUSE-7314`: 32.0 tok/s; cold-restart exact continuation: 31.7 tok/s; disk hit restored boundary 1,769; native 8 KV + 40 rotating topology; transition null | VERIFIED-LIVE on prior pin |
+| MXFP8, TurboQuant 4/4 | Fresh single-root first turn `COPPER-HARBOR-6158`: 28.1 tok/s; cold-restart exact continuation: 26.1 tok/s; disk hit restored boundary 1,771; transition 8 KV to 8 TQ with all 40 rotating layers preserved | VERIFIED-LIVE on prior pin |
+| JANG_4M, TurboQuant off | Fresh single-root first turn `RIVER-CLOCK-7319`: 39.1 tok/s; follow-up 41.4 tok/s; native 8 KV + 40 rotating topology; paged off | VERIFIED-LIVE on prior pin |
+| JANG_4M, TurboQuant 4/4 | Fresh single-root first turn `SAPPHIRE-FORGE-9062`: 34.3 tok/s; cold-restart exact continuation: 32.5 tok/s; partial/full disk hits; transition 8 KV to 8 TQ with all 40 rotating layers preserved | VERIFIED-LIVE on prior pin |
+| TurboQuant transition telemetry | `TurboQuantCacheTransitionTelemetryTests` 3/3 on the current source: completion retention, Codable round-trip, and exact mixed Gemma 8-KV-to-8-TQ/40-rotating transition | VERIFIED-SOURCE; current-patch live repeat pending |
+| Explicit block-disk Off | Current source preserves `blockDisk.enabled=false` through memory-safety resolution; focused regression 1/1 | VERIFIED-SOURCE; live Settings/save/restart/counter proof pending |
+| Engine-selected TurboQuant default | Current source resolves engine-selected to native `.none`; focused default/codec regressions 2/2 | VERIFIED-SOURCE; live Settings and endpoint proof pending |
 | RAM safety refusal/override | Real Settings UI: Strict 10% refused MXFP8 at 12.8 GB budget; No Automatic Limits then loaded and generated `LOADED`; restored Safe Auto afterwards | VERIFIED-LIVE |
-| Activity Monitor footprint | Real Activity Monitor showed Osaurus at 5.13 GB with green memory pressure after the override row | VERIFIED-LIVE for that row only |
+| Activity Monitor footprint | Exact prior-pin proof process/path inspected in Activity Monitor: main Memory 1.99 GB; inspector Real Memory 1.37 GB, Private 1.03 GB | VERIFIED-LIVE on prior pin; current-patch repeat pending |
 
 ## Required live closure matrix
 
@@ -46,16 +53,15 @@ telemetry are both required.
 
 | Gate | Required evidence | Status |
 |---|---|---|
-| Exact MXFP8 TQ transition | `/admin/cache-stats` before: 48 total / 8 KV / 40 rotating; after: 48 total / 8 TQ / 40 rotating; coherent visible continuation | OPEN |
-| Exact JANG_4M TQ transition | Same exact before/after layer proof and coherent visible continuation | OPEN |
-| Paged L1 explicit opt-in | User turns paged cache on in Settings; reload shows effective on; second matching prompt increases paged hits and returns coherent tail sentinel | OPEN |
-| Paged L1 capacity/eviction | Constrain the visible paged-cache capacity, create more blocks than fit, observe allocated/free/eviction counters and bounded Activity Monitor footprint | OPEN |
-| L1-before-L2 ordering | With a matching block still resident, paged-hit counter increases without a disk-hit increase for the same fetch | OPEN |
-| L2 fallback after eviction | Evict the matching paged block while retaining its disk entry; next matching prompt increases disk hit and restores typed 8-full/40-rotating state | OPEN |
-| Fresh-process L2 restore | Quit only the isolated proof app, relaunch it, load the same model, and show a disk hit plus a coherent continuation dependent on cached context | OPEN |
+| Current-build MXFP8 TQ transition | Rebuild after the default/Off patch; repeat 48 total / 8 KV / 40 rotating before and 48 / 8 TQ / 40 rotating after, plus coherent visible continuation | OPEN |
+| Current-build JANG_4M TQ transition | Same current-build exact transition and coherent visible continuation | OPEN |
+| Paged default/effective policy | Defaults visibly off. Gemma's rotating topology is paged-incompatible, so an explicit request must truthfully report effective paged off rather than claim nonexistent paged hits | OPEN on current build |
+| SSD L2 with paged off | With paged off and SSD L2 on, cold restart restores the longest valid full or partial prefix from disk and produces a coherent continuation | VERIFIED-LIVE on prior pin; current-build repeat open |
+| Explicit SSD L2 off | Turn SSD Cache (L2) off in Settings, save/restart/load, and show block-disk and legacy disk both false, zero disk hits/stores, and no new cache artifacts in the isolated root | OPEN |
+| Fresh-process L2 restore | Turn SSD L2 back on, quit only the isolated proof app, relaunch it, and show a disk hit plus a coherent continuation dependent on cached context | VERIFIED-LIVE on prior pin; current-build repeat open |
 | Raw-prefill fallback | Use a cache-salted or genuinely new prefix absent from both tiers; paged/disk miss counters increase, real prefill progress is visible, output remains coherent | OPEN |
-| TurboQuant after L2 restore | With TQ enabled, restore the typed raw prompt boundary from L2, then prove the resumed live decode transitions 8 KV layers to TQ while preserving 40 rotating layers | OPEN |
-| TurboQuant off control | Repeat the same restore with Native selected; live transition remains null and TQ layer count remains zero | OPEN |
+| TurboQuant after L2 restore | With TQ enabled, restore the typed raw prompt boundary from L2, then prove the resumed live decode transitions 8 KV layers to TQ while preserving 40 rotating layers | VERIFIED-LIVE on prior pin; current-build repeat open |
+| TurboQuant off control | Repeat the same restore with Native selected; live transition remains null and TQ layer count remains zero | VERIFIED-LIVE on prior pin; current-build repeat open |
 | Long rotating-window sentinel | Cross the 1,024-token SWA window, reuse prefix/L2, and reproduce exact early/middle/tail facts without a loop or truncated tail | OPEN |
 | Ten-turn coherence | Ten visible turns with cache reuse, measured TTFT/tok/s on every generated turn, no marker leakage, no hidden-only answer, no looping | OPEN |
 | Tool/parser continuation | Required tool, auto tool, no tool, tool-result continuation, tool error recovery, and post-tool text turn with TQ off/on | OPEN |
@@ -71,6 +77,10 @@ telemetry are both required.
   applicable MiniMax variants) require typed companion-state hit/miss/rederive
   counters, partial-hit rollback/rederive proof, media-salt proof for VL, and
   coherent post-hit continuation with TurboQuant off/on.
+- LFM and MiniMax M2.7 also remain wider-campaign rows for explicit
+  TurboQuant off/on, partial SSD-only restore, paged eviction where their
+  topology supports it, multi-turn coherence, TTFT/tok/s, and physical
+  footprint. Gemma evidence does not close those rows.
 - DSV4/ZAYA and MiniMax-M3 native composite caches remain explicit exceptions
   to generic TurboQuant KV until their typed native codecs are separately
   live-proven. Their evidence must not be generalized from Gemma.
@@ -82,3 +92,12 @@ telemetry are both required.
 
 No row becomes release-ready from source inspection, a configured setting, or
 an aggregate counter alone.
+
+## Current-source test note
+
+The current patch's four directly changed cache-policy assertions pass when
+run individually, and the transition/stale-EOS suites pass 3/3 each. The older
+`automaticRuntimeCachePolicyCoversDownloadedArchitectureFamilies` matrix still
+contains a separate stale Hunyuan reasoning expectation (`think_xml` while the
+current source returns `hy_v3`). That unrelated row is not changed or counted
+as Gemma cache proof in this checkpoint.

--- a/docs/GEMMA4_QAT_CACHE_CORRECTNESS_CHECKPOINT_2026-07-19.md
+++ b/docs/GEMMA4_QAT_CACHE_CORRECTNESS_CHECKPOINT_2026-07-19.md
@@ -1,8 +1,11 @@
 # Gemma 4 QAT cache correctness checkpoint — 2026-07-19
 
-Status: **PARTIAL — exact mixed-cache TurboQuant and fresh-process L2 restore
-are live-proven on vMLX `718522bc`, but the current cache-default/explicit-Off
-patch still requires a rebuilt isolated Release app and repeat UI proof.**
+Status: **PARTIAL — the exact current vMLX `bbc0b20d` pin is live-proven in an
+isolated Release Osaurus build for the Gemma 4 12B JANG_4M and MXFP8 native,
+TurboQuant, SSD-only restart/partial-restore, explicit SSD-Off, and settings
+default rows. The 31B RAM-override control works, but its Activity Monitor
+Memory column exceeded the bundle's on-disk size, so the low-footprint row is
+failed rather than release-cleared.**
 
 This checkpoint is intentionally limited to locally installed Gemma 4 MXFP8
 and JANG_4M bundles through the real Osaurus/vMLX Swift runtime. MXFP4 is not a
@@ -19,6 +22,12 @@ substitute test artifact and is not part of this checkpoint.
   `KVCacheSimple` layers and 40 `RotatingKVCache` sliding-attention layers.
 - TurboQuant converts only eligible `KVCacheSimple` layers. It must preserve
   all rotating SWA layers as rotating caches.
+- The shared conversion hook is type-selective, not architecture-name driven:
+  it converts `KVCacheSimple` only and leaves rotating, DeepseekV4, Mamba,
+  Arrays/CCA, and composite cache entries native. For hybrid families, an
+  explicit TQ request therefore applies only to actual full-attention KV
+  layers; companion state must be restored in its matching native type or the
+  prefix hit must be rejected and synchronously rederived.
 - `TurboQuantCacheTransitionSnapshot` records the real before/after cache
   classes at the conversion point. A configured TurboQuant mode or a non-zero
   compression-event counter is not accepted as layer-level proof.
@@ -34,16 +43,17 @@ substitute test artifact and is not part of this checkpoint.
 | Row | Current evidence | Status |
 |---|---|---|
 | Stale `<end_of_turn>` stop | vMLX `604d24e4`; focused Gemma 3/4 regression 3/3; live MXFP8 and JANG_4M both emitted a literal marker and continued through `FINAL-OMEGA` | VERIFIED-LIVE |
-| Default paged policy | Isolated Release app at exact vMLX `718522bc`: Settings showed paged KV off and `/admin/cache-stats` reported `paged.enabled=false` | VERIFIED-LIVE on prior pin; current patch rebuild pending |
-| MXFP8, TurboQuant off | Fresh single-root first turn `COBALT-LIGHTHOUSE-7314`: 32.0 tok/s; cold-restart exact continuation: 31.7 tok/s; disk hit restored boundary 1,769; native 8 KV + 40 rotating topology; transition null | VERIFIED-LIVE on prior pin |
-| MXFP8, TurboQuant 4/4 | Fresh single-root first turn `COPPER-HARBOR-6158`: 28.1 tok/s; cold-restart exact continuation: 26.1 tok/s; disk hit restored boundary 1,771; transition 8 KV to 8 TQ with all 40 rotating layers preserved | VERIFIED-LIVE on prior pin |
-| JANG_4M, TurboQuant off | Fresh single-root first turn `RIVER-CLOCK-7319`: 39.1 tok/s; follow-up 41.4 tok/s; native 8 KV + 40 rotating topology; paged off | VERIFIED-LIVE on prior pin |
-| JANG_4M, TurboQuant 4/4 | Fresh single-root first turn `SAPPHIRE-FORGE-9062`: 34.3 tok/s; cold-restart exact continuation: 32.5 tok/s; partial/full disk hits; transition 8 KV to 8 TQ with all 40 rotating layers preserved | VERIFIED-LIVE on prior pin |
-| TurboQuant transition telemetry | `TurboQuantCacheTransitionTelemetryTests` 3/3 on the current source: completion retention, Codable round-trip, and exact mixed Gemma 8-KV-to-8-TQ/40-rotating transition | VERIFIED-SOURCE; current-patch live repeat pending |
-| Explicit block-disk Off | Current source preserves `blockDisk.enabled=false` through memory-safety resolution; focused regression 1/1 | VERIFIED-SOURCE; live Settings/save/restart/counter proof pending |
-| Engine-selected TurboQuant default | Current source resolves engine-selected to native `.none`; focused default/codec regressions 2/2 | VERIFIED-SOURCE; live Settings and endpoint proof pending |
-| RAM safety refusal/override | Real Settings UI: Strict 10% refused MXFP8 at 12.8 GB budget; No Automatic Limits then loaded and generated `LOADED`; restored Safe Auto afterwards | VERIFIED-LIVE |
-| Activity Monitor footprint | Exact prior-pin proof process/path inspected in Activity Monitor: main Memory 1.99 GB; inspector Real Memory 1.37 GB, Private 1.03 GB | VERIFIED-LIVE on prior pin; current-patch repeat pending |
+| Default paged policy | Exact Release binary at `bbc0b20d`: Settings visibly showed paged off and `/admin/cache-stats` reported requested/effective paged false. Explicit paged On on Gemma truthfully remained effective false with `is_paged_incompatible=true` | VERIFIED-LIVE |
+| MXFP8, TurboQuant off | Current build visibly emitted `MXFP8-NATIVE-COLD-7412` at 31.9 tok/s and, after restoring defaults, `MXFP8-DEFAULT-RESTORED-9021` at 32.0 tok/s. Endpoint: native fp16, 8 KV + 40 rotating, transition null, paged off, SSD on | VERIFIED-LIVE |
+| MXFP8, TurboQuant 4/4 | Current build visibly emitted eight exact `MXFP8-TQ-*` lines at 38.0 tok/s. Transition: 8 KV to 8 TQ; all 40 rotating layers preserved | VERIFIED-LIVE |
+| MXFP8, TQ restart/partial SSD restore | After quitting/relaunching only the isolated app, changed `MXFP8-RESTORE-*` lines completed at 36.7 tok/s. Endpoint: disk hits 2, misses 13, stores 3; paged hits/misses 0; transition re-established 8-to-8/40 | VERIFIED-LIVE |
+| JANG_4M, TurboQuant off | Current build visibly emitted `NATIVE-COLD-6724` at 36.8 tok/s and partial-reuse `NATIVE-PARTIAL-9381` at 41.7 tok/s; endpoint native 8 KV + 40 rotating, transition null, paged off, SSD active | VERIFIED-LIVE |
+| JANG_4M, TurboQuant 4/4 | Current build visibly emitted eight exact CACHE lines at 55.2 tok/s; process-restart RESTORE lines at 52.8 tok/s; exact 8 KV to 8 TQ conversion with all 40 rotating layers preserved | VERIFIED-LIVE |
+| TurboQuant transition telemetry | `TurboQuantCacheTransitionTelemetryTests` 3/3 on current source plus current-build endpoint transitions for both 12B formats | VERIFIED-SOURCE + VERIFIED-LIVE |
+| Explicit block-disk Off | Settings visibly saved SSD Off; `DISK-OFF-CURRENT-2846` completed at 41.4 tok/s; endpoint reported block disk false and all disk/paged counters zero | VERIFIED-SOURCE + VERIFIED-LIVE |
+| Engine-selected TurboQuant default | Settings visibly restored Engine Selected; current MXFP8 endpoint reported `effective_kv_mode=fp16`, transition null, paged off, SSD on | VERIFIED-SOURCE + VERIFIED-LIVE |
+| RAM safety refusal/override | Strict custom 10% visibly refused the 31B JANG_4M at a 12.8 GiB budget before load. No Automatic Limits then loaded the same model and visibly emitted `RAM-OVERRIDE-3179` at 12.2 tok/s. Endpoint reported `automatic_memory_limits_disabled=true` and allowed the estimated 30.9 GiB request. Safe Auto was restored and saved | VERIFIED-LIVE for control behavior |
+| Activity Monitor footprint | Exact proof executable inspected. 31B JANG_4M: main Memory 28.37 GB; inspector Real Memory 19.30 GB, Private 996 MB. Bundle is 25G on disk (25,926,564 KiB). Main Memory exceeded full bundle size, so this does not satisfy the low-footprint gate | FAILED-LIVE |
 
 ## Required live closure matrix
 
@@ -53,37 +63,42 @@ telemetry are both required.
 
 | Gate | Required evidence | Status |
 |---|---|---|
-| Current-build MXFP8 TQ transition | Rebuild after the default/Off patch; repeat 48 total / 8 KV / 40 rotating before and 48 / 8 TQ / 40 rotating after, plus coherent visible continuation | OPEN |
-| Current-build JANG_4M TQ transition | Same current-build exact transition and coherent visible continuation | OPEN |
-| Paged default/effective policy | Defaults visibly off. Gemma's rotating topology is paged-incompatible, so an explicit request must truthfully report effective paged off rather than claim nonexistent paged hits | OPEN on current build |
-| SSD L2 with paged off | With paged off and SSD L2 on, cold restart restores the longest valid full or partial prefix from disk and produces a coherent continuation | VERIFIED-LIVE on prior pin; current-build repeat open |
-| Explicit SSD L2 off | Turn SSD Cache (L2) off in Settings, save/restart/load, and show block-disk and legacy disk both false, zero disk hits/stores, and no new cache artifacts in the isolated root | OPEN |
-| Fresh-process L2 restore | Turn SSD L2 back on, quit only the isolated proof app, relaunch it, and show a disk hit plus a coherent continuation dependent on cached context | VERIFIED-LIVE on prior pin; current-build repeat open |
+| Current-build MXFP8 TQ transition | 48 total / 8 KV / 40 rotating before and 48 / 8 TQ / 40 rotating after, plus coherent visible native/TQ/restart output | VERIFIED-LIVE |
+| Current-build JANG_4M TQ transition | Same current-build exact transition and coherent visible native/TQ/restart output | VERIFIED-LIVE |
+| Paged default/effective policy | Default visibly off; explicit request on paged-incompatible Gemma truthfully remained effective off with zero paged hits/misses | VERIFIED-LIVE |
+| SSD L2 with paged off | Both 12B formats restored partial prefixes from disk after process restart while paged counters remained zero | VERIFIED-LIVE |
+| Explicit SSD L2 off | Visible SSD-Off save plus endpoint false/zero-counter proof | VERIFIED-LIVE |
+| Fresh-process L2 restore | Both 12B formats showed post-restart disk hits and coherent changed-prefix continuations | VERIFIED-LIVE |
 | Raw-prefill fallback | Use a cache-salted or genuinely new prefix absent from both tiers; paged/disk miss counters increase, real prefill progress is visible, output remains coherent | OPEN |
-| TurboQuant after L2 restore | With TQ enabled, restore the typed raw prompt boundary from L2, then prove the resumed live decode transitions 8 KV layers to TQ while preserving 40 rotating layers | VERIFIED-LIVE on prior pin; current-build repeat open |
-| TurboQuant off control | Repeat the same restore with Native selected; live transition remains null and TQ layer count remains zero | VERIFIED-LIVE on prior pin; current-build repeat open |
+| TurboQuant after L2 restore | Post-restart MXFP8 and JANG_4M rows re-established 8 TQ layers while preserving 40 rotating layers | VERIFIED-LIVE |
+| TurboQuant off control | Current restored-default MXFP8 endpoint reported fp16, transition null, and zero TQ topology | VERIFIED-LIVE |
 | Long rotating-window sentinel | Cross the 1,024-token SWA window, reuse prefix/L2, and reproduce exact early/middle/tail facts without a loop or truncated tail | OPEN |
 | Ten-turn coherence | Ten visible turns with cache reuse, measured TTFT/tok/s on every generated turn, no marker leakage, no hidden-only answer, no looping | OPEN |
 | Tool/parser continuation | Required tool, auto tool, no tool, tool-result continuation, tool error recovery, and post-tool text turn with TQ off/on | OPEN |
 | Reasoning/template state | UI Thinking off/on/auto maps to the emitted reasoning/content channels and model-owned generation config; no prompt or sampler masking | OPEN |
 | API parity | Chat Completions stream/non-stream, Responses stream/non-stream, Anthropic, and Ollama reconstruct the same visible content and finish reason | OPEN |
 | Stop/cancel cleanup | Cancel during prefill and decode; next warm turn neither restores a poisoned partial boundary nor leaks stale output | OPEN |
-| Memory settings next-load semantics | Safe Auto, Strict, Custom, and No Automatic Limits are visibly changed, saved, and proven on the next real model load; refusal occurs before eviction/load | PARTIAL: Strict/No-Limits proven; remaining modes open |
+| Memory settings next-load semantics | Strict custom 10% refusal and No Automatic Limits success are live-proven on the same 31B bundle; Safe Auto restored. Performance/Balanced modes remain open | PARTIAL |
+| Low-RAM physical footprint | Activity Monitor main Memory must remain below full bundle size during load/generation | FAILED-LIVE on 31B: 28.37 GB versus 25G bundle |
 | Delegation/admission | Local text subagent, Computer Use/AppleScript, image generation/edit, and concurrent delegation receive the same memory admission decision before model eviction | OPEN; Osaurus-level row |
 
 ## Non-Gemma rows retained for the wider campaign
 
 - Hybrid SSM/GDN/GLA families (Qwen 3.5/3.5 VL, Ornith, Bonsai, Nemotron and
   applicable MiniMax variants) require typed companion-state hit/miss/rederive
-  counters, partial-hit rollback/rederive proof, media-salt proof for VL, and
-  coherent post-hit continuation with TurboQuant off/on.
+  counters, selective TQ conversion of full-attention KV only, native
+  SSM/GDN/CCA companion-state preservation, partial-hit rollback/rederive
+  proof, media-salt proof for VL, and coherent post-hit continuation with
+  TurboQuant off/on. Detached async rederive is not accepted as a production
+  substitute for prompt-boundary synchronization.
 - LFM and MiniMax M2.7 also remain wider-campaign rows for explicit
   TurboQuant off/on, partial SSD-only restore, paged eviction where their
   topology supports it, multi-turn coherence, TTFT/tok/s, and physical
   footprint. Gemma evidence does not close those rows.
-- DSV4/ZAYA and MiniMax-M3 native composite caches remain explicit exceptions
-  to generic TurboQuant KV until their typed native codecs are separately
-  live-proven. Their evidence must not be generalized from Gemma.
+- DSV4 Flash and OpenPangu must remain hard-excluded from TurboQuant KV even
+  under explicit user opt-in. DSV4/ZAYA and MiniMax-M3 native composite caches
+  remain explicit exceptions until their typed native codecs are separately
+  source- and live-proven. Their evidence must not be generalized from Gemma.
 - JANGTQ/MXTQ weight-format correctness is a separate issue from TurboQuant KV
   cache encoding and must remain a separate matrix.
 - AppleScript 8B JANG_6M import/discovery, Computer Use app switching, success
@@ -95,9 +110,12 @@ an aggregate counter alone.
 
 ## Current-source test note
 
-The current patch's four directly changed cache-policy assertions pass when
-run individually, and the transition/stale-EOS suites pass 3/3 each. The older
-`automaticRuntimeCachePolicyCoversDownloadedArchitectureFamilies` matrix still
-contains a separate stale Hunyuan reasoning expectation (`think_xml` while the
-current source returns `hy_v3`). That unrelated row is not changed or counted
-as Gemma cache proof in this checkpoint.
+With the Xcode 26 toolchain selected, the current patch's focused run passed
+8/8 assertions: 3 transition telemetry rows, the MiMo selective-conversion
+source contract, both paged-incompatible coordinator rows, Engine Selected
+keeping TQ off, and explicit SSD-Off preservation through memory-safety
+resolution. The
+older `automaticRuntimeCachePolicyCoversDownloadedArchitectureFamilies`
+matrix still contains a separate stale Hunyuan reasoning expectation
+(`think_xml` while the current source returns `hy_v3`). That unrelated row is
+not changed or counted as Gemma cache proof in this checkpoint.


### PR DESCRIPTION
## Scope

- keep ordinary single-batch paged RAM KV off by default
- keep Engine Selected/native KV as the default; TurboQuant requires explicit key/value bit selection
- preserve an explicit SSD block-cache Off through memory-safety policy resolution
- keep disk-L2 boundary persistence available when a model is paged-incompatible
- report requested versus effective paged-cache state truthfully
- record the exact live cache classes immediately before and after TurboQuant conversion
- propagate the exact transition through solo and batched decode diagnostics

The shared conversion remains type-selective: only `KVCacheSimple` full-attention layers are eligible. Rotating SWA, DeepseekV4, Mamba, Arrays/CCA, and composite cache entries stay native. No prompt, sampler, parser, tool schema, content-delta, AppleScript, Sentry, MLXPress, or model-routing implementation changes are included.

## Current source verification

- Xcode 26 toolchain focused run: 8/8 passed
  - TurboQuant transition telemetry: 3/3
  - MiMo selective full-attention-only conversion contract: 1/1
  - paged-incompatible coordinator disk-tier behavior: 2/2
  - Engine Selected keeps TQ off: 1/1
  - explicit SSD-Off survives memory-safety resolution: 1/1
- `git diff --check`: passed
- branch is 0 commits behind current `main`

## Current live verification

Exact artifact: `/private/tmp/osaurus-gemma4-bbc0-release-derived/Build/Products/Release/osaurus.app`, bundle ID `com.dinoki.osaurus.gemma4proofbbc0`, executable SHA-256 `7b26f98a6d3ae9ddec53357972abebed93829b81ce62b51cb04d4c8392651943`, vMLX `bbc0b20d7dd46445c9ff3d76be7caf329310a338`.

- Gemma 4 12B JANG_4M and MXFP8 both produced coherent visible native, TQ4/4, and process-restart/partial-SSD continuations
- both live TQ rows reported 48 layers: 8 ordinary KV to 8 TQ while all 40 rotating SWA layers remained rotating
- SSD L2 restored partial prefixes after process restart while paged counters stayed zero
- explicit SSD Off produced zero disk/paged counters
- explicit paged On on Gemma truthfully reported requested true, effective false, paged-incompatible true
- final restored UI state: Safe Auto, paged off, SSD L2 on, Engine Selected/native, SSM rederive on, MLXPress off

## Honest remaining gate

PARTIAL, not release-ready: the 31B JANG_4M RAM-control row proved Strict 10% refusal and No Automatic Limits success, but Activity Monitor showed 28.37 GB in the main Memory column versus a 25G on-disk bundle. The low-footprint gate is therefore FAILED-LIVE and is not hidden by this PR. Long-window, ten-turn, tool/API, and cancellation rows also remain open in the committed checkpoint.
