### PR TITLE
NemotronHOmni: accept the mlx-community bundle layout (nested llm_config + language_model.* weights)

### DIFF
--- a/Libraries/MLXVLM/Models/NemotronHOmni/NemotronHOmni.swift
+++ b/Libraries/MLXVLM/Models/NemotronHOmni/NemotronHOmni.swift
@@ -61,10 +61,20 @@ public struct NemotronHOmniConfiguration: Codable, Sendable {
         case mxtqSeed = "mxtq_seed"
     }
 
+    enum WrapperKeys: String, CodingKey { case llmConfig = "llm_config" }
+
     public init(from decoder: Decoder) throws {
-        // The bundle's config.json is the LLM config directly. Decode it as
-        // NemotronHConfiguration; multimodal dims are fixed defaults.
-        self.llmConfig = try NemotronHConfiguration(from: decoder)
+        // Two bundle layouts carry the nemotron_h LLM config:
+        //  - OsaurusAI/JANGTQ bundles: config.json IS the LLM config at top level (multimodal dims in
+        //    a sibling config_omni.json), so decode the whole decoder as NemotronHConfiguration.
+        //  - mlx-community conversion: the full omni config.json NESTS the LLM under `llm_config`
+        //    (alongside vision_config/sound_config), so `vocab_size` isn't at top level — decode from
+        //    the `llm_config` sub-container instead. Support both.
+        if let wrapper = try? decoder.container(keyedBy: WrapperKeys.self), wrapper.contains(.llmConfig) {
+            self.llmConfig = try wrapper.decode(NemotronHConfiguration.self, forKey: .llmConfig)
+        } else {
+            self.llmConfig = try NemotronHConfiguration(from: decoder)
+        }
 
         // Hardcoded V3 multimodal dims (match config_omni.json from
         // OsaurusAI/Nemotron-3-Nano-Omni-30B-A3B-{MXFP4,JANGTQ4,JANGTQ2}).
@@ -594,9 +604,14 @@ public class NemotronHOmni: Module, VLMModel, KVCacheDimensionProvider, LoRAMode
                 // Skip — preprocess applies CLIP norm.
                 continue
             } else {
-                // Treat as LLM weight — strip any leading "language_model." (rare)
-                // and forward to NemotronHModel.sanitize via a fresh dict.
-                llmKeys[k] = v
+                // Treat as LLM weight — strip any leading "language_model." so NemotronHModel.sanitize
+                // sees ROOT-level keys; the single "language_model." segment is re-added below. The
+                // OsaurusAI bundles ship the LLM weights unprefixed (so this is a no-op there), but the
+                // mlx-community conversion prefixes them "language_model.*" — without stripping here that
+                // re-add produced a DOUBLE "language_model.language_model." prefix → unhandledKeys.
+                let stripped = k.hasPrefix("language_model.")
+                    ? String(k.dropFirst("language_model.".count)) : k
+                llmKeys[stripped] = v
             }
         }
 


### PR DESCRIPTION
## Summary

`NemotronHOmni` only loaded the OsaurusAI JANGTQ bundle layout. The mlx-community conversion
(`mlx-community/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-*`) ships a different, equally valid layout and
failed on **both** its config and its weight keys. This makes the loader accept both, with the existing
OsaurusAI path left byte-identical.

## Two independent failures, one layout difference

**1. `vocab_size not found` — the LLM config is nested.**
OsaurusAI bundles put the `nemotron_h` LLM config at the top level of `config.json` (multimodal dims in
a sibling `config_omni.json`). mlx-community's `config.json` is the *full* omni config, with the LLM
config nested under `llm_config`, next to `vision_config`/`sound_config`. So decoding the whole decoder
as `NemotronHConfiguration` found no top-level `vocab_size`. Fixed by decoding from the `llm_config`
sub-container when it's present, falling back to the top level otherwise.

**2. `unhandledKeys ["language_model"]` — a double prefix.**
`sanitize()` forwards LLM keys to `NemotronHModel.sanitize` through a fresh dict and re-adds a
`language_model.` segment. The OsaurusAI bundles ship the LLM weights unprefixed, so that's correct
there. mlx-community already prefixes them `language_model.*`, so the re-add produced
`language_model.language_model.*` and the keys fell through as unhandled. Fixed by stripping a leading
`language_model.` before forwarding — a no-op on the unprefixed bundles.

## Scope / safety

Both changes are guarded so the OsaurusAI path is unchanged: the config branch only fires when
`llm_config` is actually present in the JSON, and the strip only touches keys that carry the prefix.

Validated on-device: the `nvfp4` mlx-community bundle now loads and runs **text (gsm8k)** and **vision
(mmmu)**; the `JANGTQ4` / `MXFP4` / `JANGTQ2` bundles are byte-identical before and after.

## Note on the `language_model.` strip

This is the same converter artifact addressed more generally by `Weights.stripLanguageModelPrefix` in
#95/#96. The case here is narrower — a single known prefix, re-added immediately, with no collision
surface — so it's inlined. If the shared helper lands, this call site can collapse onto it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
