### PR TITLE
Fix ZAYA cache state and Nemotron Omni multimodal correctness

### DIFF
--- a/Libraries/MLXLLM/Models/Zaya.swift
+++ b/Libraries/MLXLLM/Models/Zaya.swift
@@ -985,9 +985,10 @@ public final class ZayaModel: Module, LLMModel, KVCacheDimensionProvider {
                     convChannels: convChannels,
                     hiddenSize: cfg.hiddenSize)
             } else {
-                // No-op stub for MoE layers — the layer's forward never
-                // touches its slot, but the engine indexes per-decoder-layer.
-                return KVCacheSimple()
+                // Explicit no-op for MoE-only layers. Using KVCacheSimple here
+                // made generic TQ conversion compress unused placeholders
+                // while leaving the real KV inside ZayaCCACache untouched.
+                return ZayaMoEPlaceholderCache()
             }
         }
     }

--- a/Libraries/MLXLMCommon/BatchEngine/BatchCompile.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchCompile.swift
@@ -128,16 +128,17 @@ public enum CacheFamily: Hashable, Sendable, CustomStringConvertible {
         precondition(!cache.isEmpty, "CacheFamily.classify requires non-empty cache array")
 
         // ZAYA1 special case: the model returns 80 entries, even=ZayaCCACache
-        // (CCA-attention layers), odd=KVCacheSimple (MoE no-op stubs that the
+        // (CCA-attention layers), odd=ZayaMoEPlaceholderCache (MoE no-op
+        // stubs that the
         // forward never writes to). Treat the whole array as the `.zayaCCA`
         // family so diagnostics + future CompilableZayaCCACache wiring see a
         // coherent label instead of `.heterogeneous`.
         let hasZayaCCA = cache.contains { $0 is ZayaCCACache }
         if hasZayaCCA {
-            let onlyZayaOrSimple = cache.allSatisfy {
-                $0 is ZayaCCACache || $0 is KVCacheSimple
+            let onlyZayaOrPlaceholder = cache.allSatisfy {
+                $0 is ZayaCCACache || $0 is ZayaMoEPlaceholderCache
             }
-            if onlyZayaOrSimple {
+            if onlyZayaOrPlaceholder {
                 return .zayaCCA
             }
         }

--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -2883,11 +2883,13 @@ public actor BatchEngine {
                 // the store entirely (the re-derive here is the only writer).
                 if ProcessInfo.processInfo.environment["VMLX_HYBRID_STRIPPED_STORE"] != "0",
                    coordinator.isHybrid,
-                   !slot.originalInput.hasMediaContent,
                    let turnStartToken = coordinator.genPromptSuffixTokens.first,
                    let stripAt = promptTokens.lastIndex(of: turnStartToken),
                    stripAt > 0,
-                   stripAt < promptTokens.count - 1
+                   stripAt < promptTokens.count - 1,
+                   slot.originalInput.canCaptureHybridStripBoundary(
+                       promptTokenIds: promptTokens,
+                       boundary: stripAt)
                 {
                     let strippedTokens = Array(promptTokens.prefix(stripAt))
                     if let snapshot = boundarySnapshot(

--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -2586,6 +2586,11 @@ public actor BatchEngine {
             if let tq = layer as? TurboQuantKVCache {
                 return "TurboQuantKVCache:\(tq.keyBits):\(tq.valueBits):\(tq.phase)"
             }
+            if let zaya = layer as? ZayaCCACache,
+               let tq = zaya.turboQuantKVCache
+            {
+                return "ZayaCCACache:TQ:\(tq.keyBits):\(tq.valueBits):\(tq.phase)"
+            }
             return String(reflecting: type(of: layer))
         }.joined(separator: "|")
 
@@ -2593,13 +2598,13 @@ public actor BatchEngine {
     }
 
     private func maybeCompressSlotCache(_ slot: inout BatchSlot) {
-        let hadTQ = slot.cache.contains { $0 is TurboQuantKVCache }
+        let hadTQ = ModelCacheTopologySnapshot(cache: slot.cache).turboQuantKVLayerCount > 0
         let before = hadTQ ? nil : ModelCacheTopologySnapshot(cache: slot.cache)
         BatchQuantize.maybeCompress(
             cache: &slot.cache,
             parameters: slot.parameters
         )
-        let hasTQ = slot.cache.contains { $0 is TurboQuantKVCache }
+        let hasTQ = ModelCacheTopologySnapshot(cache: slot.cache).turboQuantKVLayerCount > 0
         if !hadTQ, hasTQ, let before {
             turboQuantCompressionCount += 1
             lastTurboQuantCacheTransition = TurboQuantCacheTransitionSnapshot(
@@ -2704,9 +2709,17 @@ public actor BatchEngine {
                     }
                     return extractSSMStates(from: snapshot)
                 }()
+                let diskKVMode = snapshot.contains(where: { $0 is ZayaCCACache })
+                    ? selectivePromptBoundaryDiskKVMode(
+                        cache: snapshot,
+                        requested: slot.parameters.kvMode)
+                    : slot.parameters.kvMode
                 let diskStoreCache = makeDiskStoreCache(
                     fromPromptBoundary: snapshot,
-                    parameters: slot.parameters)
+                    kvBits: slot.parameters.kvBits,
+                    kvGroupSize: slot.parameters.kvGroupSize,
+                    quantizedKVStart: slot.parameters.quantizedKVStart,
+                    kvMode: diskKVMode)
                 coordinator.storeAfterGeneration(
                     promptTokens: tokens,
                     perLayerData: perLayerData,
@@ -2901,6 +2914,7 @@ public actor BatchEngine {
             let generatedBoundaryTokens = promptTokens + slot.generatedTokenIds
             if reason == .stop,
                !slot.disablesGeneratedCacheBoundary,
+               !containsUnprovenZayaTurboQuantDiskState(slot.cache),
                !slot.generatedTokenIds.isEmpty,
                cacheCovers(generatedBoundaryTokens.count, cache: slot.cache)
             {

--- a/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
@@ -54,6 +54,45 @@ func makeDiskStoreCache(
     return diskCache
 }
 
+/// Resolve the lossy codec used for a solo-generation prompt-boundary disk
+/// store.
+///
+/// The generic solo path keeps prompt boundaries raw so an exact warm hit
+/// samples its first token from the same KV values as a cold request. ZAYA is
+/// a narrower case: CCA makes the topology path-dependent, so coordinator
+/// lookup deliberately skips the exact prompt boundary and only uses a stored
+/// boundary as a prefix for additional prefill. Its typed serializer can keep
+/// CCA companion state native beside encoded attention KV, but exact JANG_6M
+/// A/B proof found that 3-bit disk KV drifted while 4-bit and raw disk did not.
+/// Keep sub-4-bit ZAYA prompt records lossless; the live attention KV can still
+/// transition to the user-selected TurboQuant mode after first-token sampling.
+///
+/// Do not generalize this to other hybrid families. Each needs its own typed
+/// companion-state proof before a lossy prompt-boundary record is eligible.
+func selectivePromptBoundaryDiskKVMode(
+    cache: [any KVCache],
+    requested: KVQuantizationMode
+) -> KVQuantizationMode {
+    guard case .turboQuant(let keyBits, let valueBits) = requested,
+          keyBits >= 4,
+          valueBits >= 4,
+          cache.contains(where: { $0 is ZayaCCACache })
+    else { return .none }
+    return requested
+}
+
+/// A sub-4-bit encoded ZAYA cache is valid for the live decode path, but is not
+/// a proven cross-turn disk boundary. Such a boundary must not be persisted as
+/// TQ-native; the raw prefill/stripped boundary remains available for reuse.
+func containsUnprovenZayaTurboQuantDiskState(_ cache: [any KVCache]) -> Bool {
+    cache.contains { layer in
+        guard let tq = (layer as? ZayaCCACache)?.turboQuantKVCache else {
+            return false
+        }
+        return tq.keyBits < 4 || tq.valueBits < 4
+    }
+}
+
 func makeDiskStoreCache(
     fromPromptBoundary snapshot: [any KVCache],
     parameters: GenerateParameters
@@ -492,6 +531,45 @@ private func restoreFromV2Arrays(
     let indexed = TQDiskSerializer.deserializeIndexed(arrays)
     guard !indexed.isEmpty else { return 0 }
 
+    // ZAYA disk records are an all-or-nothing prompt-boundary snapshot. Restore
+    // every typed layer into a private copy first, including encoded TQ state,
+    // so a corrupt later CCA layer cannot leave the caller's cache half-seated.
+    var validatedZayaIndices = Set<Int>()
+    var zayaBoundary: Int?
+    for entry in indexed {
+        guard entry.index < cache.count else {
+            if case .zayaCCA = entry.data { return 0 }
+            if case .zayaCCATQ = entry.data { return 0 }
+            continue
+        }
+        switch entry.data {
+        case .zayaCCA(let comp):
+            let staged = cache[entry.index].copy()
+            guard canRestoreZayaCCALayer(comp, into: staged),
+                  zayaBoundary == nil || zayaBoundary == comp.offset,
+                  restoreZayaCCALayer(comp, into: staged)
+            else {
+                return 0
+            }
+            zayaBoundary = comp.offset
+            validatedZayaIndices.insert(entry.index)
+        case .zayaCCATQ(let comp):
+            let staged = cache[entry.index].copy()
+            guard canRestoreZayaCCATQLayer(comp, into: staged),
+                  zayaBoundary == nil || zayaBoundary == comp.tq.offset,
+                  restoreZayaCCATQLayer(comp, into: staged)
+            else {
+                return 0
+            }
+            zayaBoundary = comp.tq.offset
+            validatedZayaIndices.insert(entry.index)
+        case .requiredMiss:
+            return 0
+        default:
+            break
+        }
+    }
+
     var totalTokens = 0
 
     for entry in indexed {
@@ -584,10 +662,25 @@ private func restoreFromV2Arrays(
             // Restore the four-array state (keys, values, conv_state,
             // prev_hs) as one unit. KV-only restore would be a false hit
             // because conv_state and prev_hs are path-dependent.
-            restoreZayaCCALayer(comp, into: cache[i])
+            guard validatedZayaIndices.contains(i),
+                  restoreZayaCCALayer(comp, into: cache[i])
+            else { return 0 }
             if totalTokens == 0 {
                 totalTokens = comp.offset
             }
+
+        case .zayaCCATQ(let comp):
+            // Atomic restore: encoded attention KV and native fp32 CCA state
+            // must both seat successfully at the same prompt boundary.
+            guard validatedZayaIndices.contains(i),
+                  restoreZayaCCATQLayer(comp, into: cache[i])
+            else { return 0 }
+            if totalTokens == 0 {
+                totalTokens = comp.tq.offset
+            }
+
+        case .requiredMiss:
+            return 0
 
         case .cacheList(let subLayers):
             // CacheList composite (BaichuanM1, FalconH1, MiMoV2Flash
@@ -627,7 +720,8 @@ private func restoreFromV2Arrays(
                         totalTokens = comp.offset
                     }
 
-                case .tq, .qkv, .deepseekV4, .zayaCCA, .cacheList, .skip:
+                case .tq, .qkv, .deepseekV4, .zayaCCA, .zayaCCATQ, .cacheList,
+                     .requiredMiss, .skip:
                     // .skip is a per-sub no-op (sub-cache had no
                     // persistable state). The other cases are not
                     // currently emitted as sub-cache kinds — see
@@ -1001,12 +1095,63 @@ private func restoreDeepseekV4Layer(
 /// cache); the cache's setter handles that case without instantiating an
 /// empty KVCacheSimple buffer. Silently no-ops on type mismatch so the
 /// caller falls back to fresh prefill.
+private func canRestoreZayaCCALayer(
+    _ comp: TQDiskSerializer.ZayaCCALayerComponents,
+    into layer: any KVCache
+) -> Bool {
+    guard let zaya = layer as? ZayaCCACache,
+          zaya.convChannels == comp.convChannels,
+          zaya.hiddenSize == comp.hiddenSize,
+          zaya.batchSize == comp.batchSize,
+          comp.keys.ndim >= 3,
+          comp.values.ndim >= 3,
+          comp.keys.dim(2) == comp.values.dim(2),
+          comp.keys.dim(2) == comp.offset,
+          comp.convState.shape == [comp.batchSize, comp.convChannels, 2],
+          comp.prevHS.shape == [comp.batchSize, comp.hiddenSize]
+    else { return false }
+    return true
+}
+
 private func restoreZayaCCALayer(
     _ comp: TQDiskSerializer.ZayaCCALayerComponents,
     into layer: any KVCache
-) {
-    guard let zaya = layer as? ZayaCCACache else { return }
+) -> Bool {
+    guard let zaya = layer as? ZayaCCACache,
+          canRestoreZayaCCALayer(comp, into: layer)
+    else { return false }
     zaya.state = [comp.keys, comp.values, comp.convState, comp.prevHS]
+    return zaya.offset == comp.offset
+}
+
+private func canRestoreZayaCCATQLayer(
+    _ comp: TQDiskSerializer.ZayaCCATQLayerComponents,
+    into layer: any KVCache
+) -> Bool {
+    guard let zaya = layer as? ZayaCCACache,
+          zaya.convChannels == comp.convChannels,
+          zaya.hiddenSize == comp.hiddenSize,
+          zaya.batchSize == comp.batchSize,
+          comp.tq.offset > 0,
+          comp.convState.shape == [comp.batchSize, comp.convChannels, 2],
+          comp.prevHS.shape == [comp.batchSize, comp.hiddenSize]
+    else { return false }
+    return true
+}
+
+private func restoreZayaCCATQLayer(
+    _ comp: TQDiskSerializer.ZayaCCATQLayerComponents,
+    into layer: any KVCache
+) -> Bool {
+    guard let zaya = layer as? ZayaCCACache,
+          canRestoreZayaCCATQLayer(comp, into: layer),
+          zaya.restoreTurboQuantAttentionKV(
+              encodedKeys: comp.tq.encodedKeys,
+              encodedValues: comp.tq.encodedValues,
+              sourceOffset: comp.tq.offset)
+    else { return false }
+    zaya.writeCCA(conv: comp.convState, prev: comp.prevHS)
+    return zaya.offset == comp.tq.offset && zaya.usesTurboQuantKV
 }
 
 /// Helper: restore Mamba SSM state into a `MambaCache` layer (or a

--- a/Libraries/MLXLMCommon/Cache/MediaSalt.swift
+++ b/Libraries/MLXLMCommon/Cache/MediaSalt.swift
@@ -217,8 +217,8 @@ private func cachePolicySalt(for parameters: GenerateParameters) -> String {
     let kvBits = parameters.kvBits.map(String.init) ?? "none"
     let maxKV = parameters.maxKVSize.map(String.init) ?? "none"
     return [
-        "cache-policy-v3",
-        "promptBoundaryDisk=raw-kv",
+        "cache-policy-v4",
+        "promptBoundaryDisk=raw-kv|zaya-typed-tq-min44-v1",
         "kvMode=\(cachePolicyDescription(parameters.kvMode))",
         "kvBits=\(kvBits)",
         "kvGroup=\(parameters.kvGroupSize)",

--- a/Libraries/MLXLMCommon/Cache/TQDiskSerializer.swift
+++ b/Libraries/MLXLMCommon/Cache/TQDiskSerializer.swift
@@ -122,6 +122,11 @@ public enum TQDiskSerializer {
         /// CCA state is a false hit per the Zyphra runtime contract, so
         /// the four arrays round-trip together. Added 2026-05-06.
         case zayaCCA = 9
+        /// `ZayaCCACache` with TurboQuant-native attention KV plus the same
+        /// native fp32 CCA companion arrays. The TQ payload and companion
+        /// state are one atomic prompt-boundary record; restoring either half
+        /// alone would be a false cache hit.
+        case zayaCCATQ = 10
         /// Cache type we don't know how to persist. On restore, treated as
         /// a forced miss for the affected layer only.
         case skip = 4
@@ -592,6 +597,21 @@ public enum TQDiskSerializer {
         index i: Int,
         into result: inout [String: MLXArray]
     ) {
+        if let tq = zaya.turboQuantKVCache {
+            serializeTQLayer(tq, index: i, into: &result)
+            let cca = zaya.readCCA()
+            result["zaya_\(i)_conv_state"] = cca.conv
+            result["zaya_\(i)_prev_hs"] = cca.prev
+            result["__zaya_\(i)_meta__"] = MLXArray([
+                Int32(zaya.offset),
+                Int32(zaya.convChannels),
+                Int32(zaya.hiddenSize),
+                Int32(zaya.batchSize),
+            ])
+            result[kindKey(for: i)] = kindArray(.zayaCCATQ)
+            return
+        }
+
         let s = zaya.state
         guard s.count == 4 else {
             result[kindKey(for: i)] = kindArray(.skip)
@@ -728,6 +748,17 @@ public enum TQDiskSerializer {
         public let batchSize: Int
     }
 
+    /// TurboQuant-native KV plus native path-dependent CCA state for one
+    /// ZAYA attention layer.
+    public struct ZayaCCATQLayerComponents {
+        public let tq: TQLayerComponents
+        public let convState: MLXArray
+        public let prevHS: MLXArray
+        public let convChannels: Int
+        public let hiddenSize: Int
+        public let batchSize: Int
+    }
+
     /// Result of deserializing one cache layer from a dict.
     public indirect enum LayerData {
         case tq(TQLayerComponents)
@@ -737,6 +768,11 @@ public enum TQDiskSerializer {
         case rotating(RotatingLayerComponents)
         case deepseekV4(DeepseekV4LayerComponents)
         case zayaCCA(ZayaCCALayerComponents)
+        case zayaCCATQ(ZayaCCATQLayerComponents)
+        /// A typed path-dependent layer advertised a payload that could not be
+        /// decoded completely. Callers must reject the whole restore rather
+        /// than treating it like an optional/unknown skipped layer.
+        case requiredMiss
         /// `CacheList` composite: ordered per-sub-cache LayerData. Each
         /// sub-element carries its own kind (`.standard`, `.mamba`,
         /// `.rotating`, etc.). Restore walks the array and dispatches
@@ -887,7 +923,13 @@ public enum TQDiskSerializer {
                 if let comp = deserializeZayaCCALayer(index: i, from: arrays) {
                     out.append(IndexedLayerData(index: i, data: .zayaCCA(comp)))
                 } else {
-                    out.append(IndexedLayerData(index: i, data: .skip))
+                    out.append(IndexedLayerData(index: i, data: .requiredMiss))
+                }
+            case .zayaCCATQ:
+                if let comp = deserializeZayaCCATQLayer(index: i, from: arrays) {
+                    out.append(IndexedLayerData(index: i, data: .zayaCCATQ(comp)))
+                } else {
+                    out.append(IndexedLayerData(index: i, data: .requiredMiss))
                 }
             case .cacheList:
                 let subs = deserializeCacheListLayer(index: i, from: arrays)
@@ -1162,7 +1204,7 @@ public enum TQDiskSerializer {
                 }
             case .skip, .unknown:
                 subs.append(.skip)
-            case .tq, .qkv, .deepseekV4, .cacheList, .zayaCCA:
+            case .tq, .qkv, .deepseekV4, .cacheList, .zayaCCA, .zayaCCATQ:
                 // Not currently emitted as sub-cache types — see
                 // serializeCacheListLayer. If a future bundle ships
                 // these we'll need to extend serialize too. Skip for
@@ -1242,6 +1284,28 @@ public enum TQDiskSerializer {
             convChannels: Int(m[1]),
             hiddenSize: Int(m[2]),
             batchSize: Int(m[3]))
+    }
+
+    private static func deserializeZayaCCATQLayer(
+        index i: Int,
+        from arrays: [String: MLXArray]
+    ) -> ZayaCCATQLayerComponents? {
+        guard let tq = deserializeTQLayer(index: i, from: arrays),
+              let convState = arrays["zaya_\(i)_conv_state"],
+              let prevHS = arrays["zaya_\(i)_prev_hs"],
+              let metaArr = arrays["__zaya_\(i)_meta__"],
+              !metaArr.shape.isEmpty,
+              metaArr.shape[0] == 4
+        else { return nil }
+        let meta = metaArr.asArray(Int32.self)
+        guard meta.count == 4, Int(meta[0]) == tq.offset else { return nil }
+        return ZayaCCATQLayerComponents(
+            tq: tq,
+            convState: convState,
+            prevHS: prevHS,
+            convChannels: Int(meta[1]),
+            hiddenSize: Int(meta[2]),
+            batchSize: Int(meta[3]))
     }
 
     // MARK: - Helpers

--- a/Libraries/MLXLMCommon/Cache/ZayaCCACache.swift
+++ b/Libraries/MLXLMCommon/Cache/ZayaCCACache.swift
@@ -20,7 +20,7 @@ import MLXNN
 public final class ZayaCCACache: KVCache {
     /// Inner standard rolling KV. We delegate `update`, `makeMask`, and
     /// `offset` to it. The CCA-specific state lives outside it.
-    private let kv: KVCacheSimple
+    private var kv: any KVCache
 
     /// Path-dependent CCA state. Float32 per the runtime contract; do not
     /// downcast or compress these (the conv_qk module reads/writes them
@@ -47,7 +47,7 @@ public final class ZayaCCACache: KVCache {
     // MARK: - KVCache protocol
 
     public var offset: Int { kv.offset }
-    public var maxSize: Int? { nil }
+    public var maxSize: Int? { kv.maxSize }
     public var isTrimmable: Bool { false }   // v1: prefix-cache off, no trim path needed
 
     public func innerState() -> [MLXArray] {
@@ -57,6 +57,83 @@ public final class ZayaCCACache: KVCache {
 
     public func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray) {
         kv.update(keys: keys, values: values)
+    }
+
+    /// True only when the *real CCA attention KV* is in TurboQuant's
+    /// compressed phase. ZAYA's odd decoder entries are MoE-only placeholders
+    /// and must never be counted as compressed attention layers.
+    public var usesTurboQuantKV: Bool {
+        (kv as? TurboQuantKVCache)?.phase == .compressed
+    }
+
+    /// The encoded attention KV owned by this CCA layer, when present.
+    /// CCA companion state is deliberately not part of this object and stays
+    /// native fp32 in ``convState`` and ``prevHS``.
+    public var turboQuantKVCache: TurboQuantKVCache? {
+        guard let tq = kv as? TurboQuantKVCache, tq.phase == .compressed else {
+            return nil
+        }
+        return tq
+    }
+
+    /// Promote only this CCA layer's ordinary attention KV to TurboQuant.
+    /// Returns true only after an actual encoded transition; a short/empty
+    /// cache remains native and can be retried after more prompt tokens exist.
+    @discardableResult
+    public func promoteAttentionKVToTurboQuant(
+        keyBits: Int,
+        valueBits: Int,
+        sinkTokens: Int = 4,
+        residualTokens: Int = TurboQuantKVCache.defaultResidualTokens
+    ) -> Bool {
+        guard let simple = kv as? KVCacheSimple,
+              TurboQuantKVCache.hasCompressibleMiddle(
+                  tokenCount: simple.offset,
+                  sinkTokens: sinkTokens,
+                  residualTokens: residualTokens)
+        else { return false }
+
+        let promoted = TurboQuantKVCache.fromSimpleCache(
+            simple,
+            keyBits: keyBits,
+            valueBits: valueBits,
+            sinkTokens: sinkTokens,
+            residualTokens: residualTokens)
+        guard promoted.phase == .compressed else { return false }
+        kv = promoted
+        return true
+    }
+
+    /// Restore TQ-native attention KV while leaving the native CCA companion
+    /// arrays untouched. The caller restores `conv_state` / `prev_hs` from
+    /// the same typed disk payload immediately before or after this call.
+    @discardableResult
+    public func restoreTurboQuantAttentionKV(
+        encodedKeys: EncodedKeys,
+        encodedValues: EncodedValues,
+        sourceOffset: Int
+    ) -> Bool {
+        let keyBits = encodedKeys.indexBits + 1
+        let valueBits = encodedValues.indexBits
+        let sinkTokens = max(encodedKeys.sinkCount, encodedValues.sinkCount, 4)
+        let residualTokens = max(
+            encodedKeys.tailCount,
+            encodedValues.tailCount,
+            TurboQuantKVCache.defaultResidualTokens)
+        let restored = TurboQuantKVCache(
+            keyBits: keyBits,
+            valueBits: valueBits,
+            sinkTokens: sinkTokens,
+            residualTokens: residualTokens)
+        restored.restoreCompressed(
+            encodedKeys: encodedKeys,
+            encodedValues: encodedValues,
+            sourceOffset: sourceOffset)
+        guard restored.phase == .compressed, restored.offset == sourceOffset else {
+            return false
+        }
+        kv = restored
+        return true
     }
 
     public func makeMask(
@@ -132,8 +209,9 @@ public final class ZayaCCACache: KVCache {
             batchSize: batchSize,
             convChannels: convChannels,
             hiddenSize: hiddenSize)
-        dup.state = self.state.map { $0[.ellipsis] }
-        dup.metaState = self.metaState
+        dup.kv = kv.copy()
+        dup.convState = convState[.ellipsis]
+        dup.prevHS = prevHS[.ellipsis]
         return dup
     }
 
@@ -152,5 +230,21 @@ public final class ZayaCCACache: KVCache {
             "ZayaCCACache: prev_hs must be [B=\(batchSize), \(hiddenSize)], got \(prev.shape)")
         convState = conv
         prevHS = prev
+    }
+}
+
+/// Explicit cache placeholder for ZAYA's odd MoE-only decoder entries.
+///
+/// Those layers have no attention operation and never read or write KV. A
+/// `KVCacheSimple` placeholder was structurally convenient but made generic
+/// cache policy and telemetry misidentify 40 non-attention slots as eligible
+/// KV layers. This type is intentionally state-free and non-quantizable.
+public final class ZayaMoEPlaceholderCache: BaseKVCache {
+    public override init() {
+        super.init()
+    }
+
+    public override func copy() -> any KVCache {
+        ZayaMoEPlaceholderCache()
     }
 }

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1796,10 +1796,12 @@ public struct TokenIterator: TokenIteratorProtocol {
             let coordinator,
             coordinator.isHybrid,
             coordinator.canPersistBoundaries,
-            !input.hasMediaContent,
             let turnStartTok = coordinator.genPromptSuffixTokens.first,
             let stripAt = promptTokenIds.lastIndex(of: turnStartTok),
-            stripAt > 0, stripAt < promptTokenIds.count
+            stripAt > 0, stripAt < promptTokenIds.count,
+            input.canCaptureHybridStripBoundary(
+                promptTokenIds: promptTokenIds,
+                boundary: stripAt)
         else { return nil }
         return stripAt
     }
@@ -1839,17 +1841,29 @@ public struct TokenIterator: TokenIteratorProtocol {
         func slice(_ range: MLXArray) -> MLXArray { maskIsBatched ? range[.newAxis, 0...] : range }
 
         let flat = input.text.tokens.reshaped([-1])
+        let headTokenIds = input.text.tokenIds.map { Array($0[..<split]) }
+        let tailTokenIds = input.text.tokenIds.map { Array($0[split...]) }
         let head =
             split > 0
             ? LMInput(
                 text: LMInput.Text(
                     tokens: flat[..<split][.newAxis, 0...],
-                    mask: flatMask.map { slice($0[..<split]) }))
+                    mask: flatMask.map { slice($0[..<split]) },
+                    tokenIds: headTokenIds),
+                image: input.image,
+                video: input.video,
+                audio: input.audio,
+                mediaTokenIds: input.mediaTokenIds,
+                cacheScopeSalt: input.cacheScopeSalt,
+                toolSchemas: input.toolSchemas)
             : nil
         let tail = LMInput(
             text: LMInput.Text(
                 tokens: flat[split...][.newAxis, 0...],
-                mask: flatMask.map { slice($0[split...]) }))
+                mask: flatMask.map { slice($0[split...]) },
+                tokenIds: tailTokenIds),
+            cacheScopeSalt: input.cacheScopeSalt,
+            toolSchemas: input.toolSchemas)
         return (head, tail)
     }
 

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1973,7 +1973,7 @@ public struct TokenIterator: TokenIteratorProtocol {
     }
 
     mutating func maybeQuantizeCacheForStep() {
-        let hadTQ = cache.contains { $0 is TurboQuantKVCache }
+        let hadTQ = ModelCacheTopologySnapshot(cache: cache).turboQuantKVLayerCount > 0
         let before = hadTQ ? nil : ModelCacheTopologySnapshot(cache: cache)
         maybeQuantizeKVCache(
             cache: &cache,
@@ -1981,7 +1981,7 @@ public struct TokenIterator: TokenIteratorProtocol {
             kvGroupSize: kvGroupSize,
             quantizedKVStart: quantizedKVStart,
             kvMode: kvMode)
-        let hasTQ = cache.contains { $0 is TurboQuantKVCache }
+        let hasTQ = ModelCacheTopologySnapshot(cache: cache).turboQuantKVLayerCount > 0
         if !hadTQ, hasTQ, let before {
             turboQuantCompressionCount += 1
             lastTurboQuantCacheTransition = TurboQuantCacheTransitionSnapshot(
@@ -2216,11 +2216,18 @@ public struct TokenIterator: TokenIteratorProtocol {
             // lossy KV compression until after the first surfaced token; a
             // warm full-prefix hit must therefore seed first-token sampling
             // from the same exact prompt KV, not from a compressed prompt.
+            // ZAYA is the typed exception only at four bits or higher: its CCA
+            // topology already rejects exact disk boundaries, and the typed
+            // record keeps path-dependent CCA arrays native beside encoded
+            // attention KV. Sub-four-bit ZAYA prompt boundaries stay raw.
+            let promptDiskKVMode = selectivePromptBoundaryDiskKVMode(
+                cache: promptCacheSnapshot,
+                requested: kvMode)
             store(
                 tokens: promptTokenIds,
                 cache: promptCacheSnapshot,
                 kvBits: nil,
-                kvMode: .none)
+                kvMode: promptDiskKVMode)
 
             if !originalInput.requiresPostPrepareCacheKey {
                 let requiresDiskBackedRestore =
@@ -2236,7 +2243,9 @@ public struct TokenIterator: TokenIteratorProtocol {
                         tokens: Array(promptTokenIds.dropLast()),
                         cache: boundarySnapshot,
                         kvBits: nil,
-                        kvMode: .none)
+                        kvMode: selectivePromptBoundaryDiskKVMode(
+                            cache: boundarySnapshot,
+                            requested: kvMode))
                 }
                 // Cross-turn reuse boundary for hybrid-SSM models (qwen3.5 /
                 // ornith GatedDeltaNet, Nemotron-H Mamba-2, LFM2, ZAYA CCA, …):
@@ -2282,7 +2291,9 @@ public struct TokenIterator: TokenIteratorProtocol {
                             tokens: Array(promptTokenIds.prefix(stripAt)),
                             cache: strippedSnapshot,
                             kvBits: nil,
-                            kvMode: .none)
+                            kvMode: selectivePromptBoundaryDiskKVMode(
+                                cache: strippedSnapshot,
+                                requested: kvMode))
                     } else {
                         Self.logger.debug(
                             "TokenIterator: no stripped-boundary snapshot to store at \(stripAt, privacy: .public); prefill did not cross the boundary"
@@ -2302,7 +2313,9 @@ public struct TokenIterator: TokenIteratorProtocol {
                             tokens: boundaryTokens,
                             cache: boundarySnapshot,
                             kvBits: nil,
-                            kvMode: .none)
+                            kvMode: selectivePromptBoundaryDiskKVMode(
+                                cache: boundarySnapshot,
+                                requested: kvMode))
                     }
                 }
             }
@@ -2310,6 +2323,7 @@ public struct TokenIterator: TokenIteratorProtocol {
 
         guard includeGeneratedBoundary, !generatedTokenIds.isEmpty else { return }
         guard !needsCacheQuantization else { return }
+        guard !containsUnprovenZayaTurboQuantDiskState(cache) else { return }
         let generatedBoundaryTokens = promptTokenIds + generatedTokenIds
         guard (cache.map(\.offset).max() ?? 0) >= generatedBoundaryTokens.count
         else { return }

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -1781,15 +1781,9 @@ public func maybeQuantizeKVCache(
 ) {
     guard !cache.isEmpty else { return }
 
-    // Find the first quantizable (KVCacheSimple) layer to check offset threshold.
-    // Hybrid models may have MambaCache/RotatingKVCache at layer 0, so we can't
-    // just check cache[0].
-    let firstSimple = cache.first { $0 is KVCacheSimple }
-
     // TurboQuant mode takes precedence
     switch kvMode {
     case .turboQuant(let keyBits, let valueBits):
-        // Already compressed? Skip. Check if any layer is already TQ.
         // TQ keeps exact sink tokens plus an exact recent tail; compression only
         // begins once there is a real middle span to encode. This preserves the
         // active prompt/instruction boundary instead of trying to repair model
@@ -1798,24 +1792,45 @@ public func maybeQuantizeKVCache(
             quantizedKVStart,
             4 + TurboQuantKVCache.defaultResidualTokens
                 + TurboQuantKVCache.minimumCompressedTokens)
-        guard !cache.contains(where: { $0 is TurboQuantKVCache }),
-              let ref = firstSimple,
-              ref.offset > tqMinStart,
-              TurboQuantKVCache.hasCompressibleMiddle(tokenCount: ref.offset)
-        else { return }
+        let hasEligibleLayer = cache.contains { layer in
+            if let simple = layer as? KVCacheSimple {
+                return simple.offset > tqMinStart
+                    && TurboQuantKVCache.hasCompressibleMiddle(tokenCount: simple.offset)
+            }
+            if let zaya = layer as? ZayaCCACache {
+                return !zaya.usesTurboQuantKV
+                    && zaya.offset > tqMinStart
+                    && TurboQuantKVCache.hasCompressibleMiddle(tokenCount: zaya.offset)
+            }
+            return false
+        }
+        guard hasEligibleLayer else { return }
 
         for i in 0..<cache.count {
             if let simpleCache = cache[i] as? KVCacheSimple {
-                cache[i] = TurboQuantKVCache.fromSimpleCache(
+                guard simpleCache.offset > tqMinStart,
+                      TurboQuantKVCache.hasCompressibleMiddle(tokenCount: simpleCache.offset)
+                else { continue }
+                let promoted = TurboQuantKVCache.fromSimpleCache(
                     simpleCache, keyBits: keyBits, valueBits: valueBits)
+                if promoted.phase == .compressed {
+                    cache[i] = promoted
+                }
+            } else if let zaya = cache[i] as? ZayaCCACache {
+                zaya.promoteAttentionKVToTurboQuant(
+                    keyBits: keyBits,
+                    valueBits: valueBits)
             }
-            // RotatingKVCache, DeepseekV4Cache, MambaCache, CacheList: skip
+            // RotatingKVCache, DeepseekV4Cache, MambaCache, CacheList,
+            // ZayaMoEPlaceholderCache: skip.
             // (no ordinary full-history KV to compress, or already manages its
             // own memory/pool layout)
         }
         return
 
     case .affine(let bits, let groupSize):
+        // Affine cache quantization remains limited to top-level simple KV.
+        let firstSimple = cache.first { $0 is KVCacheSimple }
         guard !cache.contains(where: { $0 is QuantizedKVCache }),
               let ref = firstSimple, ref.offset > quantizedKVStart
         else { return }
@@ -1832,6 +1847,7 @@ public func maybeQuantizeKVCache(
     }
 
     // Legacy path: use kvBits if set
+    let firstSimple = cache.first { $0 is KVCacheSimple }
     guard let kvBits = kvBits,
         !cache.contains(where: { $0 is QuantizedKVCache }),
         let ref = firstSimple, ref.offset > quantizedKVStart

--- a/Libraries/MLXLMCommon/LanguageModel.swift
+++ b/Libraries/MLXLMCommon/LanguageModel.swift
@@ -232,6 +232,34 @@ public extension LMInput {
         image != nil || video != nil || audio != nil
     }
 
+    /// Whether a hybrid-cache snapshot taken at `boundary` can safely carry
+    /// this request's media-derived state into a later growing-chat request.
+    ///
+    /// Image/audio placeholders are expanded by the processor before model
+    /// prefill, so a boundary after the complete placeholder run has a stable
+    /// token identity and can be captured with the media tensors attached to
+    /// the head of the split. A boundary inside/before that run is unsafe.
+    /// Video EVS is also excluded here because it prunes placeholder tokens in
+    /// `model.prepare`; its cache key is only known after that transformation.
+    func canCaptureHybridStripBoundary(
+        promptTokenIds: [Int],
+        boundary: Int
+    ) -> Bool {
+        guard hasMediaContent else { return true }
+        guard !requiresPostPrepareCacheKey,
+              boundary > 0,
+              boundary <= promptTokenIds.count,
+              let mediaTokenIds,
+              !mediaTokenIds.isEmpty
+        else { return false }
+
+        let mediaTokens = Set(mediaTokenIds)
+        let prefix = promptTokenIds[..<boundary]
+        let suffix = promptTokenIds[boundary...]
+        return prefix.contains(where: mediaTokens.contains)
+            && !suffix.contains(where: mediaTokens.contains)
+    }
+
     /// True when a cache hit boundary would leave model-side media
     /// placeholder tokens in the suffix still being prefetched.
     ///

--- a/Libraries/MLXLMCommon/ModelContainer.swift
+++ b/Libraries/MLXLMCommon/ModelContainer.swift
@@ -144,8 +144,16 @@ public struct ModelCacheTopologySnapshot: Codable, Sendable, Equatable {
             rotatingWrapperLayerCount += 1
         case is RotatingKVCacheWrapper:
             rotatingWrapperLayerCount += 1
-        case is ZayaCCACache:
+        case let zaya as ZayaCCACache:
             zayaCCALayerCount += 1
+            if zaya.usesTurboQuantKV {
+                turboQuantKVLayerCount += 1
+            } else {
+                kvLayerCount += 1
+            }
+        case is ZayaMoEPlaceholderCache:
+            // Decoder-layer index placeholder only; not an attention KV layer.
+            break
         case is CompilableMambaCache:
             compilableMambaLayerCount += 1
             mambaLayerCount += 1

--- a/Libraries/MLXVLM/Models/NemotronHOmni/NemotronHOmni.swift
+++ b/Libraries/MLXVLM/Models/NemotronHOmni/NemotronHOmni.swift
@@ -889,27 +889,17 @@ public struct NemotronHOmniProcessor: UserInputProcessor {
         // messages and add the expanded run again, desynchronizing
         // placeholder count from the encoded media embeddings.
         var messages = Self.textOnlyMessages(from: input)
-        var templateContext = input.additionalContext
         if !media.isEmpty {
             if let index = Self.mediaTargetMessageIndex(in: input) {
                 Self.prependMedia(media, toMessageAt: index, in: &messages)
             } else {
                 Self.prependMedia(media, toLastUserIn: &messages)
             }
-            // Nemotron Omni's text-only reasoning path is valid, but live
-            // media probes show that its open-thinking media template
-            // hallucinates over placeholder text instead of grounding in the
-            // spliced RADIO/Parakeet embeddings. Media turns therefore use
-            // the model's documented closed-thinking template contract.
-            Self.addNoThinkingMediaInstruction(to: &messages)
-            var mediaContext = templateContext ?? [:]
-            mediaContext["enable_thinking"] = false
-            templateContext = mediaContext
         }
 
         let promptTokens = try tokenizer.applyChatTemplate(
             messages: messages, tools: input.tools,
-            additionalContext: templateContext)
+            additionalContext: input.additionalContext)
         let promptArray = MLXArray(promptTokens).expandedDimensions(axis: 0)
         let mask = ones(like: promptArray).asType(.int8)
 
@@ -952,23 +942,6 @@ public struct NemotronHOmniProcessor: UserInputProcessor {
         _ = messages
     }
 
-    private static func addSystemInstruction(
-        _ instruction: String,
-        to messages: inout [Message]
-    ) {
-        if let systemIndex = messages.firstIndex(where: {
-            ($0["role"] as? String) == "system"
-        }) {
-            let existing = contentText(from: messages[systemIndex]["content"])
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            messages[systemIndex]["content"] = existing.isEmpty
-                ? instruction
-                : instruction + "\n" + existing
-            return
-        }
-        messages.insert(["role": "system", "content": instruction], at: 0)
-    }
-
     private static func prependMedia(_ media: String, toLastUserIn messages: inout [Message]) {
         guard !messages.isEmpty else {
             messages = [["role": "user", "content": media]]
@@ -1006,13 +979,6 @@ public struct NemotronHOmniProcessor: UserInputProcessor {
                 || !message.videos.isEmpty
                 || !message.audios.isEmpty
         }
-    }
-
-    private static func addNoThinkingMediaInstruction(to messages: inout [Message]) {
-        let instruction =
-            "Answer directly with only the final visible response. " +
-            "Do not include analysis, reasoning, scratchpad steps, or drafts."
-        addSystemInstruction(instruction, to: &messages)
     }
 
     private static func videoTokensPerGroup(pixelValues: MLXArray) -> Int {

--- a/Libraries/MLXVLM/Models/NemotronHOmni/NemotronHOmni.swift
+++ b/Libraries/MLXVLM/Models/NemotronHOmni/NemotronHOmni.swift
@@ -306,8 +306,31 @@ public class NemotronHOmni: Module, VLMModel, KVCacheDimensionProvider, LoRAMode
             effectivePromptTokens = pruned.tokenIds
         }
 
+        // The text-only path above chunks Nemotron-H prefill because every
+        // Mamba layer builds sequence-quadratic intermediate state. The
+        // multimodal path previously bypassed that protection and forwarded
+        // the entire 4K+ image/video/audio embedding sequence in one call.
+        // On the real JANGTQ4 Omni bundle a 512px image then reached a 76 GiB
+        // physical-footprint high-water mark despite an ~19 GiB bundle.
+        // Materialize the media tower once, then feed the language stack in
+        // the same bounded chunks used for text prompts.
+        MLX.eval(spliced)
+        Memory.clearCache()
+        let prefillStepSize = max(1, windowSize ?? 512)
+        let sequenceLength = spliced.dim(1)
+        var offset = 0
+        while sequenceLength - offset > prefillStepSize {
+            let end = offset + prefillStepSize
+            let chunk = spliced[0..., offset..<end, 0...]
+            _ = languageModel.callAsFunction(
+                inputsEmbeds: chunk, cache: convertedCache)
+            MLX.eval(convertedCache)
+            offset = end
+            Memory.clearCache()
+        }
         let logits = languageModel.callAsFunction(
-            inputsEmbeds: spliced, cache: convertedCache)
+            inputsEmbeds: spliced[0..., offset..<sequenceLength, 0...],
+            cache: convertedCache)
         return .logits(LMOutput(
             logits: logits,
             effectivePromptTokens: effectivePromptTokens))

--- a/Libraries/MLXVLM/Models/NemotronHOmni/Projectors.swift
+++ b/Libraries/MLXVLM/Models/NemotronHOmni/Projectors.swift
@@ -1,10 +1,12 @@
 // Projectors.swift
 // mlp1 (vision) and sound_projection (audio) projectors for Nemotron-Omni.
 //
-// Mirrors jang_tools/nemotron_omni/projectors.py.
+// Mirrors the model bundle's authoritative `modeling.py`.  The older
+// jang_tools projector copy used LayerNorm/GELU, but Nemotron Omni V3 was
+// trained with RMSNorm/SquaredReLU.
 //
 // Tensor naming on disk:
-//   mlp1.0.weight                       LayerNorm   (5120,)
+//   mlp1.0.weight                       RMSNorm     (5120,)
 //   mlp1.1.weight                       Linear      (20480, 5120)
 //   mlp1.3.weight                       Linear      (2688, 20480)
 //   sound_projection.norm.weight        RMSNorm     (1024,)
@@ -16,14 +18,14 @@ import MLX
 import MLXNN
 
 /// Vision MLP projector (post-pixel-shuffle ViT features → LLM hidden).
-/// Forward: LayerNorm → Linear → GELU → Linear
+/// Forward: RMSNorm → Linear → SquaredReLU → Linear
 public class NemotronHVisionMLPProjector: Module, UnaryLayer {
-    @ModuleInfo(key: "layer_norm") var layerNorm: LayerNorm
+    @ModuleInfo(key: "layer_norm") var layerNorm: RMSNorm
     @ModuleInfo(key: "fc1") var fc1: Linear
     @ModuleInfo(key: "fc2") var fc2: Linear
 
     public init(inDim: Int, projectorDim: Int, llmDim: Int) {
-        self._layerNorm.wrappedValue = LayerNorm(dimensions: inDim)
+        self._layerNorm.wrappedValue = RMSNorm(dimensions: inDim, eps: 1e-5)
         self._fc1.wrappedValue = Linear(inDim, projectorDim, bias: false)
         self._fc2.wrappedValue = Linear(projectorDim, llmDim, bias: false)
     }
@@ -31,7 +33,8 @@ public class NemotronHVisionMLPProjector: Module, UnaryLayer {
     public func callAsFunction(_ x: MLXArray) -> MLXArray {
         var h = layerNorm(x)
         h = fc1(h)
-        h = gelu(h)
+        let r = MLX.maximum(h, MLXArray(0, dtype: h.dtype))
+        h = r * r
         h = fc2(h)
         return h
     }
@@ -70,7 +73,6 @@ public class NemotronHSoundProjector: Module, UnaryLayer {
 public func remapMlp1Weights(_ weights: [String: MLXArray]) -> [String: MLXArray] {
     let rename: [String: String] = [
         "mlp1.0.weight": "layer_norm.weight",
-        "mlp1.0.bias": "layer_norm.bias",
         "mlp1.1.weight": "fc1.weight",
         "mlp1.1.bias": "fc1.bias",
         "mlp1.3.weight": "fc2.weight",

--- a/Libraries/MLXVLM/Models/NemotronHOmni/RADIOVision.swift
+++ b/Libraries/MLXVLM/Models/NemotronHOmni/RADIOVision.swift
@@ -154,9 +154,12 @@ public class NemotronHViTBlock: Module, UnaryLayer {
     @ModuleInfo(key: "mlp") var mlp: NemotronHViTMLP
 
     public init(dim: Int, numHeads: Int, mlpRatio: Float) {
-        self._norm1.wrappedValue = LayerNorm(dimensions: dim)
+        // timm's ViT blocks use LayerNorm(eps=1e-6). MLXNN defaults to
+        // 1e-5, which compounds across RADIO's 32 blocks and materially
+        // changes the vision embeddings.
+        self._norm1.wrappedValue = LayerNorm(dimensions: dim, eps: 1e-6)
         self._attn.wrappedValue = NemotronHViTAttention(dim: dim, numHeads: numHeads)
-        self._norm2.wrappedValue = LayerNorm(dimensions: dim)
+        self._norm2.wrappedValue = LayerNorm(dimensions: dim, eps: 1e-6)
         self._mlp.wrappedValue = NemotronHViTMLP(dim: dim, hiddenDim: Int(Float(dim) * mlpRatio))
     }
 

--- a/RunBench/OmniBench.swift
+++ b/RunBench/OmniBench.swift
@@ -93,6 +93,82 @@ enum OmniBench {
             exit(1)
         }
 
+        if ProcessInfo.processInfo.environment["BENCH_OMNI_DIAG"] == "1",
+           let processor = context.processor as? NemotronHOmniProcessor
+        {
+            let image: CIImage
+            if let path = ProcessInfo.processInfo.environment["BENCH_OMNI_DIAG_IMAGE"],
+               let loaded = CIImage(contentsOf: URL(fileURLWithPath: path))
+            {
+                image = loaded
+            } else {
+                image = try synthesiseGradient(side: 224)
+            }
+            let (pixels, tokenCounts) = try processor.preprocess(images: [image])
+            MLX.eval(pixels)
+            let values = pixels.asArray(Float.self)
+            let height = pixels.dim(2)
+            let width = pixels.dim(3)
+            let channelSize = pixels.dim(2) * pixels.dim(3)
+            let channelMeans = (0 ..< pixels.dim(1)).map { channel -> Float in
+                let start = channel * channelSize
+                let end = start + channelSize
+                return values[start ..< end].reduce(0, +) / Float(channelSize)
+            }
+            let firstHalfMeans = (0 ..< pixels.dim(1)).map { channel -> Float in
+                let start = channel * channelSize
+                let end = start + (height / 2) * width
+                return values[start ..< end].reduce(0, +) / Float(end - start)
+            }
+            let secondHalfMeans = (0 ..< pixels.dim(1)).map { channel -> Float in
+                let start = channel * channelSize + (height / 2) * width
+                let end = (channel + 1) * channelSize
+                return values[start ..< end].reduce(0, +) / Float(end - start)
+            }
+            print(
+                "[OMNI_DIAG] image_pixels shape=\(pixels.shape) "
+                    + "tokens=\(tokenCounts) means=\(channelMeans) "
+                    + "firstHalf=\(firstHalfMeans) secondHalf=\(secondHalfMeans)")
+            let imageEmbeds = omni.extractImageEmbeds(pixelValues: pixels)
+            MLX.eval(imageEmbeds)
+            let embedValues = imageEmbeds.asArray(Float.self)
+            let embedMean = embedValues.reduce(0, +) / Float(embedValues.count)
+            let embedVariance = embedValues.reduce(Float(0)) { partial, value in
+                let delta = value - embedMean
+                return partial + delta * delta
+            } / Float(embedValues.count)
+            print(
+                "[OMNI_DIAG] image_embeds shape=\(imageEmbeds.shape) "
+                    + "mean=\(embedMean) std=\(sqrt(embedVariance)) "
+                    + "min=\(embedValues.min() ?? .nan) max=\(embedValues.max() ?? .nan) "
+                    + "first16=\(Array(embedValues.prefix(16)))")
+            if ProcessInfo.processInfo.environment["BENCH_OMNI_DIAG_ONLY"] == "1" {
+                return
+            }
+        }
+
+        if ProcessInfo.processInfo.environment["BENCH_OMNI_VIDEO_ONLY"] == "1" {
+            let videoURL = URL(
+                fileURLWithPath: ProcessInfo.processInfo.environment[
+                    "BENCH_OMNI_VIDEO_PATH"]
+                    ?? "Tests/MLXLMTests/Resources/1080p_30.mov")
+            let thinking = ProcessInfo.processInfo.environment[
+                "BENCH_OMNI_VIDEO_THINKING"] != "0"
+            let cache = context.model.newCache(parameters: .init())
+            let result = try await runVideoTurn(
+                prompt: "Describe this video briefly.",
+                videoURL: videoURL,
+                context: context,
+                cache: cache,
+                maxNewTokens: maxNewTokens,
+                enableThinking: thinking)
+            print(
+                "OMNI_VIDEO_ONLY thinking=\(thinking) tokens=\(result.tokens) "
+                    + "seconds=\(String(format: "%.2f", result.secs)) "
+                    + "text=\(result.shortText)")
+            return
+        }
+
 
         var results: [RowResult] = []
 
@@ -805,6 +881,7 @@ enum OmniBench {
             lmInput: lmInput,
             raw: raw,
             visibleText: text)
+        try requireNormalStop(raw, row: "text turn")
         if !enableThinking && text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             throw NSError(
                 domain: "OmniBench", code: 104,
@@ -897,6 +974,7 @@ enum OmniBench {
             lmInput: lmInput,
             raw: raw,
             visibleText: text)
+        try requireNormalStop(raw, row: "image turn")
         try validateVisibleOmniText(text, row: "image turn")
         try validateSyntheticGradientImageText(text, row: "image turn")
         return TurnResult(
@@ -962,6 +1040,7 @@ enum OmniBench {
             totalTokens += tokens.count
             totalSecs += secs
             do {
+                try requireNormalStop(raw, row: "image tail \(variant.name)")
                 try validateVisibleOmniText(text, row: "image tail \(variant.name)")
                 try validateSyntheticGradientImageText(
                     text,
@@ -1060,6 +1139,7 @@ enum OmniBench {
             lmInput: lmInput,
             raw: raw,
             visibleText: text)
+        try requireNormalStop(raw, row: "video turn")
         try validateVisibleOmniText(text, row: "video turn")
         return TurnResult(
             shortText: text.replacingOccurrences(of: "\n", with: " "),
@@ -1356,6 +1436,7 @@ enum OmniBench {
             lmInput: lmInput,
             raw: raw,
             visibleText: text)
+        try requireNormalStop(raw, row: "audio turn")
         try validateVisibleOmniText(text, row: "audio turn")
         return TurnResult(
             shortText: text.replacingOccurrences(of: "\n", with: " "),
@@ -1397,6 +1478,18 @@ enum OmniBench {
             tokenIds: tokens,
             stopTokenID: nil,
             hitMaxTokens: false)
+    }
+
+    private static func requireNormalStop(
+        _ result: RawGenerationResult,
+        row: String
+    ) throws {
+        guard !result.hitMaxTokens else {
+            throw NSError(
+                domain: "OmniBench", code: 129,
+                userInfo: [NSLocalizedDescriptionKey:
+                    "\(row) hit max_tokens before a normal stop"])
+        }
     }
 
     private static func debugOmniRawDecode(

--- a/Tests/MLXLMCommonFocusedTests/NemotronHOmniPreEncodedAudioTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NemotronHOmniPreEncodedAudioTests.swift
@@ -368,8 +368,8 @@ struct NemotronHOmniPreEncodedAudioTests {
         ]
     }
 
-    @Test("media no-thinking prompt carries explicit direct-answer instruction")
-    func mediaNoThinkingPromptCarriesDirectAnswerInstruction() async throws {
+    @Test("media no-thinking request preserves the caller template contract")
+    func mediaNoThinkingRequestPreservesCallerTemplateContract() async throws {
         try await FocusedMLXTestSupport.withLock {
             let tokenizer = FocusedOmniTemplateTokenizer()
             let processor = NemotronHOmniProcessor(
@@ -390,16 +390,16 @@ struct NemotronHOmniPreEncodedAudioTests {
                 tokenIds: lmInput.text.tokens.reshaped(-1).asArray(Int.self),
                 skipSpecialTokens: false)
 
-            #expect(rendered.contains(
+            #expect(!rendered.contains(
                 "Answer directly with only the final visible response."))
-            #expect(rendered.contains(
+            #expect(!rendered.contains(
                 "Do not include analysis, reasoning, scratchpad steps, or drafts."))
             #expect(rendered.hasSuffix("<|im_start|>assistant\n<think></think>"))
         }
     }
 
-    @Test("media thinking request uses direct-answer media contract")
-    func mediaThinkingRequestUsesDirectAnswerMediaContract() async throws {
+    @Test("media thinking request preserves the caller template contract")
+    func mediaThinkingRequestPreservesCallerTemplateContract() async throws {
         try await FocusedMLXTestSupport.withLock {
             let tokenizer = FocusedOmniTemplateTokenizer()
             let processor = NemotronHOmniProcessor(
@@ -420,15 +420,15 @@ struct NemotronHOmniPreEncodedAudioTests {
                 tokenIds: lmInput.text.tokens.reshaped(-1).asArray(Int.self),
                 skipSpecialTokens: false)
 
-            #expect(rendered.hasSuffix("<|im_start|>assistant\n<think></think>"))
-            #expect(!rendered.hasSuffix("<|im_start|>assistant\n<think>\n"))
-            #expect(rendered.contains(
+            #expect(!rendered.hasSuffix("<|im_start|>assistant\n<think></think>"))
+            #expect(rendered.hasSuffix("<|im_start|>assistant\n<think>\n"))
+            #expect(!rendered.contains(
                 "Answer directly with only the final visible response."))
         }
     }
 
-    @Test("media default prompt uses direct-answer media contract")
-    func mediaDefaultPromptUsesDirectAnswerMediaContract() async throws {
+    @Test("media default prompt preserves the bundle template default")
+    func mediaDefaultPromptPreservesBundleTemplateDefault() async throws {
         try await FocusedMLXTestSupport.withLock {
             let tokenizer = FocusedOmniTemplateTokenizer()
             let processor = NemotronHOmniProcessor(
@@ -448,9 +448,9 @@ struct NemotronHOmniPreEncodedAudioTests {
                 tokenIds: lmInput.text.tokens.reshaped(-1).asArray(Int.self),
                 skipSpecialTokens: false)
 
-            #expect(rendered.hasSuffix("<|im_start|>assistant\n<think></think>"))
-            #expect(!rendered.hasSuffix("<|im_start|>assistant\n<think>\n"))
-            #expect(rendered.contains(
+            #expect(!rendered.hasSuffix("<|im_start|>assistant\n<think></think>"))
+            #expect(rendered.hasSuffix("<|im_start|>assistant\n<think>\n"))
+            #expect(!rendered.contains(
                 "Answer directly with only the final visible response."))
         }
     }
@@ -537,14 +537,13 @@ struct NemotronHOmniPreEncodedAudioTests {
         FocusedMLXTestSupport.withLock {
             let mlpRaw: [String: MLXArray] = [
                 "mlp1.0.weight": MLXArray.zeros([5120]),
-                "mlp1.0.bias": MLXArray.zeros([5120]),
                 "mlp1.1.weight": MLXArray.zeros([20_480, 5120]),
                 "mlp1.3.weight": MLXArray.zeros([2688, 20_480]),
                 "irrelevant.weight": MLXArray.zeros([1]),
             ]
             let mlp = remapMlp1Weights(mlpRaw)
             #expect(mlp["layer_norm.weight"]?.shape == [5120])
-            #expect(mlp["layer_norm.bias"]?.shape == [5120])
+            #expect(mlp["layer_norm.bias"] == nil)
             #expect(mlp["fc1.weight"]?.shape == [20_480, 5120])
             #expect(mlp["fc2.weight"]?.shape == [2688, 20_480])
             #expect(mlp["irrelevant.weight"] == nil)

--- a/Tests/MLXLMTests/GenerationConfigDefaultsTests.swift
+++ b/Tests/MLXLMTests/GenerationConfigDefaultsTests.swift
@@ -289,7 +289,9 @@ final class GenerationConfigDefaultsTests: XCTestCase {
         let topology = await container.cacheTopologySnapshot()
 
         XCTAssertEqual(topology.layerCount, 13)
-        XCTAssertEqual(topology.kvLayerCount, 3)
+        // ZayaCCACache owns one ordinary attention-KV cache in addition to
+        // its separately counted native CCA companion state.
+        XCTAssertEqual(topology.kvLayerCount, 4)
         XCTAssertEqual(topology.chunkedKVLayerCount, 1)
         XCTAssertEqual(topology.quantizedKVLayerCount, 1)
         XCTAssertEqual(topology.turboQuantKVLayerCount, 2)

--- a/Tests/MLXLMTests/HybridStripBoundaryPrefillTests.swift
+++ b/Tests/MLXLMTests/HybridStripBoundaryPrefillTests.swift
@@ -12,6 +12,7 @@ import XCTest
 private class RecordingHybridModel: Module, LanguageModel, @unchecked Sendable {
     private(set) var forwarded: [Int] = []
     private(set) var prepareCalls = 0
+    private(set) var prepareMediaFlags: [Bool] = []
 
     var vocabularySize: Int { 64 }
 
@@ -21,6 +22,7 @@ private class RecordingHybridModel: Module, LanguageModel, @unchecked Sendable {
 
     func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult {
         prepareCalls += 1
+        prepareMediaFlags.append(input.hasMediaContent)
         let step = max(1, windowSize ?? 512)
         var flatTokens = input.text.tokens.reshaped([-1])
         while flatTokens.size > step {
@@ -63,10 +65,24 @@ private final class RecordingDenseModel: RecordingHybridModel, @unchecked Sendab
 /// store sees is the state a warm pass over the stripped prefix produces.
 final class HybridStripBoundaryPrefillTests: XCTestCase {
 
+    private var tempDirs: [URL] = []
+
+    override func tearDown() {
+        for dir in tempDirs {
+            try? FileManager.default.removeItem(at: dir)
+        }
+        tempDirs.removeAll()
+        super.tearDown()
+    }
+
     private func makeCoordinator(hybrid: Bool = true) -> CacheCoordinator {
+        let diskDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("hybrid-strip-\(UUID().uuidString)")
+        tempDirs.append(diskDir)
         let coordinator = CacheCoordinator(config: CacheCoordinatorConfig(
             usePagedCache: true,
-            enableDiskCache: false,
+            enableDiskCache: true,
+            diskCacheDir: diskDir,
             modelKey: "recording-hybrid|reasoning=off"))
         if hybrid { coordinator.setHybrid(true) }
         return coordinator
@@ -149,6 +165,63 @@ final class HybridStripBoundaryPrefillTests: XCTestCase {
         XCTAssertEqual(
             model.prepareCalls, 1,
             "dense models reuse via the post-answer boundary and must not pay for a split")
+        XCTAssertEqual(model.forwarded, prompt)
+    }
+
+    func testMediaBeforeBoundaryStaysOnHeadAndStillSplits() throws {
+        let lock = lockSerializedMLXTest()
+        defer { lock.unlock() }
+
+        let model = RecordingHybridModel()
+        let coordinator = makeCoordinator()
+        coordinator.setGenPromptSuffixTokens(genPromptSuffix)
+
+        let imageToken = 99
+        let prompt = [imageToken] + userTurn + genPromptSuffix
+        let input = LMInput(
+            text: .init(
+                tokens: MLXArray(prompt.map { Int32($0) }).expandedDimensions(axis: 0),
+                tokenIds: prompt),
+            image: .init(pixels: MLXArray.zeros([1, 3, 2, 2])),
+            mediaTokenIds: [imageToken])
+
+        _ = try TokenIterator(
+            input: input,
+            model: model,
+            parameters: GenerateParameters(maxTokens: 1, temperature: 0, prefillStepSize: 512),
+            cacheCoordinator: coordinator)
+
+        XCTAssertEqual(model.prepareCalls, 2)
+        XCTAssertEqual(model.prepareMediaFlags, [true, false])
+        XCTAssertEqual(model.forwarded, prompt)
+    }
+
+    func testMediaPlaceholderAfterBoundaryDoesNotSplit() throws {
+        let lock = lockSerializedMLXTest()
+        defer { lock.unlock() }
+
+        let model = RecordingHybridModel()
+        let coordinator = makeCoordinator()
+        coordinator.setGenPromptSuffixTokens(genPromptSuffix)
+
+        let imageToken = 99
+        let prompt = userTurn + [genPromptSuffix[0], imageToken]
+            + Array(genPromptSuffix.dropFirst())
+        let input = LMInput(
+            text: .init(
+                tokens: MLXArray(prompt.map { Int32($0) }).expandedDimensions(axis: 0),
+                tokenIds: prompt),
+            image: .init(pixels: MLXArray.zeros([1, 3, 2, 2])),
+            mediaTokenIds: [imageToken])
+
+        _ = try TokenIterator(
+            input: input,
+            model: model,
+            parameters: GenerateParameters(maxTokens: 1, temperature: 0, prefillStepSize: 512),
+            cacheCoordinator: coordinator)
+
+        XCTAssertEqual(model.prepareCalls, 1)
+        XCTAssertEqual(model.prepareMediaFlags, [true])
         XCTAssertEqual(model.forwarded, prompt)
     }
 

--- a/Tests/MLXLMTests/NemotronHOmniSmokeTests.swift
+++ b/Tests/MLXLMTests/NemotronHOmniSmokeTests.swift
@@ -29,6 +29,29 @@ final class NemotronHOmniSmokeTests: XCTestCase {
         XCTAssertEqual(outA.shape, [1, 64, 2688])
     }
 
+    func testVisionProjectorUsesBundleRMSNormAndSquaredReLUContract() throws {
+        let projector = NemotronHVisionMLPProjector(
+            inDim: 2, projectorDim: 2, llmDim: 1)
+        var parameters = ModuleParameters()
+        parameters["layer_norm"] = .dictionary([
+            "weight": .value(MLXArray.ones([2])),
+        ])
+        parameters["fc1"] = .dictionary([
+            "weight": .value(MLXArray([Float(1), 0, 0, 1], [2, 2])),
+        ])
+        parameters["fc2"] = .dictionary([
+            "weight": .value(MLXArray([Float(1), 1], [1, 2])),
+        ])
+        try projector.update(parameters: parameters, verify: .all)
+
+        let output = projector(MLXArray([Float(3), 4], [1, 2]))
+        MLX.eval(output)
+        // RMSNorm([3,4]) is approximately [0.8485,1.1314]; squaring the
+        // positive components and summing produces 2.0. LayerNorm+GELU,
+        // the broken implementation, produces approximately 0.68 instead.
+        XCTAssertEqual(output.item(Float.self), 2.0, accuracy: 1e-4)
+    }
+
     func testRADIOForwardShape() throws {
         // Tiny ViT to keep test fast: 2 blocks, 64 hidden, 8 heads, 16 patch.
         // (The default V3 model is 1280-hidden 32-block; we only validate
@@ -130,7 +153,6 @@ final class NemotronHOmniSmokeTests: XCTestCase {
     func testRemapMlp1Weights() throws {
         let raw: [String: MLXArray] = [
             "mlp1.0.weight": MLXArray.zeros([5120]),
-            "mlp1.0.bias": MLXArray.zeros([5120]),
             "mlp1.1.weight": MLXArray.zeros([20_480, 5120]),
             "mlp1.3.weight": MLXArray.zeros([2688, 20_480]),
             "irrelevant.weight": MLXArray.zeros([1]),
@@ -138,7 +160,7 @@ final class NemotronHOmniSmokeTests: XCTestCase {
         let out = remapMlp1Weights(raw)
         // remap returns unprefixed keys — wrapper sanitize prefixes with mlp1.
         XCTAssertEqual(out["layer_norm.weight"]?.shape, [5120])
-        XCTAssertEqual(out["layer_norm.bias"]?.shape, [5120])
+        XCTAssertNil(out["layer_norm.bias"])
         XCTAssertEqual(out["fc1.weight"]?.shape, [20_480, 5120])
         XCTAssertEqual(out["fc2.weight"]?.shape, [2688, 20_480])
         XCTAssertNil(out["irrelevant.weight"])

--- a/Tests/MLXLMTests/ZayaCCACacheDiskRoundTripTests.swift
+++ b/Tests/MLXLMTests/ZayaCCACacheDiskRoundTripTests.swift
@@ -150,4 +150,100 @@ struct ZayaCCACacheDiskRoundTripTests {
         let zayaDelta = (r1.readCCA().conv - l1.readCCA().conv).abs().sum().item(Float.self)
         #expect(zayaDelta < 1e-3)
     }
+
+    @Test("TQ-native ZAYA disk payload restores encoded KV and native CCA atomically")
+    func turboQuantNativeRoundTrip() {
+        let mlxTestLock = lockSerializedMLXTest()
+        defer { mlxTestLock.unlock() }
+
+        let src = ZayaCCACache(batchSize: 1, convChannels: 4, hiddenSize: 8)
+        _ = src.update(
+            keys: MLXArray.ones([1, 1, 96, 32], dtype: .bfloat16),
+            values: MLXArray.ones([1, 1, 96, 32], dtype: .bfloat16) * 2)
+        src.writeCCA(
+            conv: MLXArray.ones([1, 4, 2], dtype: .float32) * 3,
+            prev: MLXArray.ones([1, 8], dtype: .float32) * 4)
+        #expect(src.promoteAttentionKVToTurboQuant(keyBits: 3, valueBits: 3))
+
+        let encoded = TQDiskSerializer.serialize(cache: [src])
+        #expect(
+            encoded["__layer_kind_0__"]?.item(Int32.self)
+                == TQDiskSerializer.LayerKind.zayaCCATQ.rawValue)
+        #expect(encoded["tq_0_ck_indices"] != nil)
+        #expect(encoded["tq_0_cv_indices"] != nil)
+        #expect(encoded["zaya_0_keys"] == nil)
+        #expect(encoded["zaya_0_values"] == nil)
+        #expect(encoded["zaya_0_conv_state"]?.dtype == .float32)
+        #expect(encoded["zaya_0_prev_hs"]?.dtype == .float32)
+
+        let dst = ZayaCCACache(batchSize: 1, convChannels: 4, hiddenSize: 8)
+        var target: [any KVCache] = [dst]
+        let restored = restoreFromDiskArrays(encoded, into: &target)
+
+        #expect(restored == 96)
+        #expect(dst.offset == 96)
+        #expect(dst.usesTurboQuantKV)
+        #expect(dst.turboQuantKVCache?.compressedKeys != nil)
+        #expect(dst.turboQuantKVCache?.compressedValues != nil)
+        #expect(dst.readCCA().conv.dtype == .float32)
+        #expect(dst.readCCA().prev.dtype == .float32)
+        #expect((dst.readCCA().conv - src.readCCA().conv).abs().sum().item(Float.self) < 1e-3)
+        #expect((dst.readCCA().prev - src.readCCA().prev).abs().sum().item(Float.self) < 1e-3)
+    }
+
+    @Test("TQ-native ZAYA restore rejects a missing CCA companion")
+    func turboQuantNativeRejectsMissingCompanion() {
+        let mlxTestLock = lockSerializedMLXTest()
+        defer { mlxTestLock.unlock() }
+
+        let src = ZayaCCACache(batchSize: 1, convChannels: 4, hiddenSize: 8)
+        _ = src.update(
+            keys: MLXArray.ones([1, 1, 96, 32], dtype: .bfloat16),
+            values: MLXArray.ones([1, 1, 96, 32], dtype: .bfloat16))
+        #expect(src.promoteAttentionKVToTurboQuant(keyBits: 3, valueBits: 3))
+        var encoded = TQDiskSerializer.serialize(cache: [src])
+        encoded["zaya_0_prev_hs"] = nil
+
+        let dst = ZayaCCACache(batchSize: 1, convChannels: 4, hiddenSize: 8)
+        var target: [any KVCache] = [dst]
+        let restored = restoreFromDiskArrays(encoded, into: &target)
+
+        #expect(restored == 0)
+        #expect(dst.offset == 0)
+        #expect(!dst.usesTurboQuantKV)
+    }
+
+    @Test("A corrupt later ZAYA layer cannot partially mutate earlier layers")
+    func turboQuantNativeWholeRecordIsAtomic() {
+        let mlxTestLock = lockSerializedMLXTest()
+        defer { mlxTestLock.unlock() }
+
+        func makeSource(multiplier: Float, tokens: Int = 96) -> ZayaCCACache {
+            let source = ZayaCCACache(batchSize: 1, convChannels: 4, hiddenSize: 8)
+            _ = source.update(
+                keys: MLXArray.ones([1, 1, tokens, 32], dtype: .bfloat16) * multiplier,
+                values: MLXArray.ones([1, 1, tokens, 32], dtype: .bfloat16) * multiplier)
+            source.writeCCA(
+                conv: MLXArray.ones([1, 4, 2], dtype: .float32) * multiplier,
+                prev: MLXArray.ones([1, 8], dtype: .float32) * multiplier)
+            #expect(source.promoteAttentionKVToTurboQuant(keyBits: 3, valueBits: 3))
+            return source
+        }
+
+        let encoded = TQDiskSerializer.serialize(cache: [
+            makeSource(multiplier: 1),
+            makeSource(multiplier: 2, tokens: 97),
+        ])
+
+        let dst0 = ZayaCCACache(batchSize: 1, convChannels: 4, hiddenSize: 8)
+        let dst1 = ZayaCCACache(batchSize: 1, convChannels: 4, hiddenSize: 8)
+        var target: [any KVCache] = [dst0, dst1]
+        let restored = restoreFromDiskArrays(encoded, into: &target)
+
+        #expect(restored == 0)
+        #expect(dst0.offset == 0)
+        #expect(dst1.offset == 0)
+        #expect(!dst0.usesTurboQuantKV)
+        #expect(!dst1.usesTurboQuantKV)
+    }
 }

--- a/Tests/MLXLMTests/ZayaCCACacheStateRoundTripTests.swift
+++ b/Tests/MLXLMTests/ZayaCCACacheStateRoundTripTests.swift
@@ -121,4 +121,104 @@ struct ZayaCCACacheStateRoundTripTests {
         #expect((lastSum - Float(3 * 1 * 3 * 8)).magnitude < 1e-3)
         _ = v1
     }
+
+    @Test("TurboQuant promotion encodes only attention KV and preserves native CCA state")
+    func turboQuantPromotionPreservesCCAState() {
+        let mlxTestLock = lockSerializedMLXTest()
+        defer { mlxTestLock.unlock() }
+
+        let cache = ZayaCCACache(batchSize: 1, convChannels: 4, hiddenSize: 8)
+        _ = cache.update(
+            keys: MLXArray.ones([1, 1, 96, 32], dtype: .bfloat16),
+            values: MLXArray.ones([1, 1, 96, 32], dtype: .bfloat16) * 2)
+        let conv = MLXArray.ones([1, 4, 2], dtype: .float32) * 3
+        let prev = MLXArray.ones([1, 8], dtype: .float32) * 4
+        cache.writeCCA(conv: conv, prev: prev)
+
+        #expect(cache.promoteAttentionKVToTurboQuant(keyBits: 3, valueBits: 3))
+        #expect(cache.usesTurboQuantKV)
+        #expect(cache.turboQuantKVCache?.offset == 96)
+        #expect(cache.turboQuantKVCache?.compressedKeys != nil)
+        #expect(cache.turboQuantKVCache?.compressedValues != nil)
+        #expect(containsUnprovenZayaTurboQuantDiskState([cache]))
+        #expect(cache.readCCA().conv.dtype == .float32)
+        #expect(cache.readCCA().prev.dtype == .float32)
+        #expect((cache.readCCA().conv - conv).abs().sum().item(Float.self) < 1e-3)
+        #expect((cache.readCCA().prev - prev).abs().sum().item(Float.self) < 1e-3)
+
+        let (keys, _) = cache.update(
+            keys: MLXArray.ones([1, 1, 1, 32], dtype: .bfloat16) * 5,
+            values: MLXArray.ones([1, 1, 1, 32], dtype: .bfloat16) * 6)
+        #expect(cache.offset == 97)
+        #expect(keys.dim(2) == 97)
+        #expect(cache.usesTurboQuantKV)
+
+        let fourBit = ZayaCCACache(batchSize: 1, convChannels: 4, hiddenSize: 8)
+        _ = fourBit.update(
+            keys: MLXArray.ones([1, 1, 96, 32], dtype: .bfloat16),
+            values: MLXArray.ones([1, 1, 96, 32], dtype: .bfloat16))
+        #expect(fourBit.promoteAttentionKVToTurboQuant(keyBits: 4, valueBits: 4))
+        #expect(!containsUnprovenZayaTurboQuantDiskState([fourBit]))
+    }
+
+    @Test("generic TQ conversion ignores ZAYA MoE placeholders")
+    func genericTurboQuantConversionTargetsZayaAttentionOnly() {
+        let mlxTestLock = lockSerializedMLXTest()
+        defer { mlxTestLock.unlock() }
+
+        let zaya = ZayaCCACache(batchSize: 1, convChannels: 4, hiddenSize: 8)
+        _ = zaya.update(
+            keys: MLXArray.ones([1, 1, 96, 32], dtype: .bfloat16),
+            values: MLXArray.ones([1, 1, 96, 32], dtype: .bfloat16))
+        var cache: [any KVCache] = [zaya, ZayaMoEPlaceholderCache()]
+
+        let before = ModelCacheTopologySnapshot(cache: cache)
+        maybeQuantizeKVCache(
+            cache: &cache,
+            kvBits: nil,
+            kvMode: .turboQuant(keyBits: 3, valueBits: 3))
+        let after = ModelCacheTopologySnapshot(cache: cache)
+
+        #expect(before.layerCount == 2)
+        #expect(before.kvLayerCount == 1)
+        #expect(before.zayaCCALayerCount == 1)
+        #expect(before.turboQuantKVLayerCount == 0)
+        #expect(after.kvLayerCount == 0)
+        #expect(after.zayaCCALayerCount == 1)
+        #expect(after.turboQuantKVLayerCount == 1)
+        #expect(cache[1] is ZayaMoEPlaceholderCache)
+        #expect(!(cache[1] is TurboQuantKVCache))
+    }
+
+    @Test("disk prompt policy requires typed ZAYA and at least four TQ bits")
+    func selectivePromptDiskPolicyIsZayaOnly() {
+        let mlxTestLock = lockSerializedMLXTest()
+        defer { mlxTestLock.unlock() }
+
+        let requested = KVQuantizationMode.turboQuant(keyBits: 4, valueBits: 4)
+        let subFourBit = KVQuantizationMode.turboQuant(keyBits: 3, valueBits: 3)
+        let zaya: [any KVCache] = [
+            ZayaCCACache(batchSize: 1, convChannels: 4, hiddenSize: 8),
+            ZayaMoEPlaceholderCache(),
+        ]
+        let dense: [any KVCache] = [KVCacheSimple()]
+
+        #expect(
+            selectivePromptBoundaryDiskKVMode(cache: zaya, requested: requested)
+                == requested)
+        #expect(
+            selectivePromptBoundaryDiskKVMode(cache: dense, requested: requested)
+                == .none)
+        #expect(
+            selectivePromptBoundaryDiskKVMode(cache: zaya, requested: subFourBit)
+                == .none)
+        #expect(
+            selectivePromptBoundaryDiskKVMode(cache: zaya, requested: .none)
+                == .none)
+        #expect(
+            selectivePromptBoundaryDiskKVMode(
+                cache: zaya,
+                requested: .affine(bits: 4, groupSize: 64))
+                == .none)
+    }
 }

--- a/Tests/MLXLMTests/ZayaSmokeJANGTQ2Tests.swift
+++ b/Tests/MLXLMTests/ZayaSmokeJANGTQ2Tests.swift
@@ -13,6 +13,17 @@ import Testing
 
 @Suite("ZAYA1-8B JANGTQ2 smoke", .serialized)
 struct ZayaSmokeJANGTQ2Tests {
+    private struct TracingTokenizerLoader: TokenizerLoader {
+        let base: any TokenizerLoader
+
+        func load(from directory: URL) async throws -> any MLXLMCommon.Tokenizer {
+            let tokenizerURL = directory.appendingPathComponent("tokenizer.json")
+            print(
+                "ZAYA_TOKENIZER_LOAD directory=\(directory.path) tokenizerExists=\(FileManager.default.fileExists(atPath: tokenizerURL.path))"
+            )
+            return try await base.load(from: directory)
+        }
+    }
     static let bundleRoot: String = {
         if let override = ProcessInfo.processInfo.environment["VMLX_ZAYA_BUNDLE_ROOT"],
            !override.isEmpty {
@@ -28,7 +39,13 @@ struct ZayaSmokeJANGTQ2Tests {
                 atPath: $0.appendingPathComponent("ZAYA1-8B-JANGTQ2/config.json").path)
         }?.path ?? candidates[0].path
     }()
-    static let bundlePath = bundleRoot + "/ZAYA1-8B-JANGTQ2"
+    static let bundlePath: String = {
+        if let exact = ProcessInfo.processInfo.environment["VMLX_ZAYA_EXACT_BUNDLE"],
+           !exact.isEmpty {
+            return exact
+        }
+        return bundleRoot + "/ZAYA1-8B-JANGTQ2"
+    }()
     static let jangTQ4BundlePath = bundleRoot + "/ZAYA1-8B-JANGTQ4"
     static let mxfp4BundlePath = bundleRoot + "/ZAYA1-8B-MXFP4"
     static let bf16BundlePath = bundleRoot + "/ZAYA1-8B"
@@ -44,6 +61,10 @@ struct ZayaSmokeJANGTQ2Tests {
     }
     static var bf16BundlePresent: Bool {
         FileManager.default.fileExists(atPath: bf16BundlePath + "/config.json")
+    }
+    static var selectiveTQCacheGateEnabled: Bool {
+        bundlePresent &&
+            ProcessInfo.processInfo.environment["VMLX_ZAYA_SELECTIVE_TQ_LIVE"] == "1"
     }
 
     @Test("Bundle loads through factory and forward returns [1,T,vocab]",
@@ -242,23 +263,306 @@ struct ZayaSmokeJANGTQ2Tests {
         #expect(logitsShape[2] == 262_272)
     }
 
-    @Test("newCache returns 80 entries: even ZayaCCACache, odd KVCacheSimple",
+    @Test("newCache returns 80 entries: even ZayaCCACache, odd explicit MoE placeholder",
           .enabled(if: ZayaSmokeJANGTQ2Tests.bundlePresent))
     func newCacheShape() async throws {
         let url = URL(fileURLWithPath: Self.bundlePath)
         let factory = LLMModelFactory.shared
         let container = try await factory.loadContainer(from: url, using: NoOpTokenizerLoader())
-        let layout: (count: Int, evenIsZaya: Bool, oddIsSimple: Bool) =
+        let layout: (count: Int, evenIsZaya: Bool, oddIsPlaceholder: Bool) =
             await container.perform { context in
                 let cache = context.model.newCache(parameters: nil)
                 let count = cache.count
                 let evenIsZaya = (cache[0] is ZayaCCACache)
-                let oddIsSimple = (cache[1] is KVCacheSimple)
-                return (count, evenIsZaya, oddIsSimple)
+                let oddIsPlaceholder = (cache[1] is ZayaMoEPlaceholderCache)
+                return (count, evenIsZaya, oddIsPlaceholder)
             }
         #expect(layout.count == 80)
         #expect(layout.evenIsZaya)
-        #expect(layout.oddIsSimple)
+        #expect(layout.oddIsPlaceholder)
+    }
+
+    @Test(
+        "Exact ZAYA bundle uses selective TQ attention KV across partial SSD restore",
+        .enabled(if: ZayaSmokeJANGTQ2Tests.selectiveTQCacheGateEnabled))
+    func selectiveTQAttentionKVPartialDiskRestore() async throws {
+        struct Result {
+            var text = ""
+            var reasoning = ""
+            var toolCalls = 0
+            var info: GenerateCompletionInfo?
+        }
+
+        let modelURL = URL(fileURLWithPath: Self.bundlePath)
+        let diskURL = URL(fileURLWithPath:
+            ProcessInfo.processInfo.environment["VMLX_ZAYA_SELECTIVE_TQ_CACHE_DIR"]
+                ?? "/tmp/vmlx-zaya-selective-tq-live")
+        try? FileManager.default.removeItem(at: diskURL)
+        try FileManager.default.createDirectory(
+            at: diskURL, withIntermediateDirectories: true)
+        let keepCache =
+            ProcessInfo.processInfo.environment["VMLX_ZAYA_SELECTIVE_TQ_KEEP_CACHE"] == "1"
+        defer {
+            if !keepCache {
+                try? FileManager.default.removeItem(at: diskURL)
+            }
+        }
+
+        let context = try await MLXLMCommon.loadModel(
+            from: modelURL,
+            using: TracingTokenizerLoader(base: #huggingFaceTokenizerLoader()))
+        nonisolated(unsafe) let ctx = context
+
+        var params = GenerateParameters(
+            generationConfig: context.configuration.generationDefaults,
+            fallback: GenerateParameters(maxTokens: 64, prefillStepSize: 512))
+        params.maxTokens = 64
+        params.prefillStepSize = 512
+        params.randomSeed = 47
+        let testKVBits = Int(
+            ProcessInfo.processInfo.environment["VMLX_ZAYA_SELECTIVE_TQ_BITS"] ?? "3") ?? 3
+        let expectEncodedDisk = testKVBits >= 4
+        params.kvMode = testKVBits > 0
+            ? .turboQuant(keyBits: testKVBits, valueBits: testKVBits)
+            : .none
+        params.enableCompiledBatchDecode = false
+        params.extraStopStrings = ["<END>"]
+
+        let generationPromptSuffix: [Int] = {
+            guard let tokenizer = context.tokenizer as? GenerationPromptControllableTokenizer
+            else { return [] }
+            let dummy: [[String: any Sendable]] = [["role": "user", "content": "x"]]
+            guard
+                let withGenerationPrompt = try? tokenizer.applyChatTemplate(
+                    messages: dummy,
+                    tools: nil,
+                    additionalContext: nil,
+                    addGenerationPrompt: true),
+                let withoutGenerationPrompt = try? tokenizer.applyChatTemplate(
+                    messages: dummy,
+                    tools: nil,
+                    additionalContext: nil,
+                    addGenerationPrompt: false)
+            else { return [] }
+            var common = 0
+            let limit = min(withGenerationPrompt.count, withoutGenerationPrompt.count)
+            while common < limit,
+                  withGenerationPrompt[common] == withoutGenerationPrompt[common] {
+                common += 1
+            }
+            return Array(withGenerationPrompt[common...])
+        }()
+        #expect((1...64).contains(generationPromptSuffix.count))
+
+        func makeCoordinator() -> CacheCoordinator {
+            var config = CacheCoordinatorConfig()
+            config.usePagedCache = false
+            config.enableDiskCache = true
+            config.diskCacheDir = diskURL
+            config.diskCacheMaxGB = 2
+            config.modelKey = "zaya-jang6m-selective-tq-v1"
+            let coordinator = CacheCoordinator(config: config)
+            coordinator.setHybrid(true)
+            coordinator.setPagedIncompatible(true)
+            coordinator.setGenPromptSuffixTokens(generationPromptSuffix)
+            return coordinator
+        }
+
+        func clone(_ input: LMInput) -> LMInput {
+            LMInput(
+                text: LMInput.Text(
+                    tokens: input.text.tokens,
+                    mask: input.text.mask,
+                    tokenIds: input.text.tokenIds),
+                image: input.image,
+                video: input.video,
+                audio: input.audio,
+                mediaTokenIds: input.mediaTokenIds,
+                cacheScopeSalt: input.cacheScopeSalt,
+                cachePrefixTokenCounts: input.cachePrefixTokenCounts,
+                toolSchemas: input.toolSchemas)
+        }
+
+        func run(_ engine: BatchEngine, _ input: sending LMInput) async -> Result {
+            var result = Result()
+            let stream = await engine.generate(input: input, parameters: params)
+            for await event in stream {
+                switch event {
+                case .chunk(let chunk):
+                    result.text += chunk
+                case .reasoning(let chunk):
+                    result.reasoning += chunk
+                case .toolCall:
+                    result.toolCalls += 1
+                case .info(let info):
+                    result.info = info
+                case .toolCallProgress, .prefillProgress:
+                    break
+                }
+            }
+            return result
+        }
+
+        func assertClean(_ result: Result, label: String) {
+            #expect(!result.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                    "\(label) emitted no visible answer")
+            #expect(result.reasoning.isEmpty, "\(label) routed reasoning while thinking was off")
+            #expect(result.toolCalls == 0, "\(label) emitted an unrequested tool call")
+            #expect(result.info != nil, "\(label) emitted no completion info")
+            #expect(result.info?.unclosedReasoning == false,
+                    "\(label) ended inside reasoning")
+            #expect(result.info?.stopReason != .length,
+                    "\(label) only stopped at the test token limit")
+            for marker in ["<think>", "</think>", "<zyphra_tool_call>", "<|im_end|>"] {
+                #expect(!result.text.contains(marker), "\(label) leaked \(marker)")
+            }
+        }
+
+        let system = String(repeating: """
+            This is stable cache-proof context. Keep exact identifiers unchanged,
+            follow the latest user instruction, and answer concisely. The repeated
+            prose exists only to make the prompt large enough for a real encoded
+            KV middle region; do not summarize or discuss it.
+            """, count: 5)
+        var chat: [Chat.Message] = [
+            .system(system),
+            .user("Remember the exact access key CERULEAN-47. Reply only with saved, then <END>."),
+        ]
+        let prepared1 = try await context.processor.prepare(input: UserInput(
+            chat: chat,
+            additionalContext: ["enable_thinking": false]))
+        let prompt1Tokens = prepared1.text.tokens.reshaped(-1).asArray(Int.self)
+        #expect(prompt1Tokens.count > 96)
+
+        let coordinatorA = makeCoordinator()
+        let engineA = BatchEngine(
+            context: ctx, maxBatchSize: 1, cacheCoordinator: coordinatorA)
+        nonisolated(unsafe) let prepared1Send = clone(prepared1)
+        let coldBoundary = await run(engineA, prepared1Send)
+        await engineA.shutdown()
+        assertClean(coldBoundary, label: "cold boundary")
+
+        if testKVBits > 0 {
+            let transition = try #require(coldBoundary.info?.turboQuantCacheTransition)
+            #expect(coldBoundary.info?.turboQuantCompressions == 1)
+            #expect(transition.before.layerCount == 80)
+            #expect(transition.before.kvLayerCount == 40)
+            #expect(transition.before.zayaCCALayerCount == 40)
+            #expect(transition.before.turboQuantKVLayerCount == 0)
+            #expect(transition.after.layerCount == 80)
+            #expect(transition.after.kvLayerCount == 0)
+            #expect(transition.after.zayaCCALayerCount == 40)
+            #expect(transition.after.turboQuantKVLayerCount == 40)
+            #expect(transition.convertedTurboQuantKVLayerCount == 40)
+        } else {
+            #expect(coldBoundary.info?.turboQuantCompressions == 0)
+            #expect(coldBoundary.info?.turboQuantCacheTransition == nil)
+        }
+
+        chat.append(.assistant(coldBoundary.text))
+        chat.append(.user(
+            "What exact access key did I ask you to remember? Reply only with the key, then <END>."))
+        let prepared2 = try await context.processor.prepare(input: UserInput(
+            chat: chat,
+            additionalContext: ["enable_thinking": false]))
+        let prompt2Tokens = prepared2.text.tokens.reshaped(-1).asArray(Int.self)
+        let salt2 = computeCacheSalt(for: prepared2, parameters: params)
+
+        let coordinatorB = makeCoordinator()
+        let probe = coordinatorB.fetch(
+            tokens: prompt2Tokens,
+            mediaSalt: salt2,
+            skipExactDiskBoundary: true)
+        let arrays: [String: MLXArray]
+        let matched: Int
+        let remaining: Int
+        switch probe {
+        case .hit(let matchedTokens, let remainingTokens, let detail, let blocks, _, let disk):
+            coordinatorB.release(blocks: blocks)
+            #expect(detail == .disk)
+            arrays = try #require(disk)
+            matched = matchedTokens
+            remaining = remainingTokens.count
+        case .miss:
+            Issue.record("fresh coordinator missed the prior turn's SSD prefix")
+            return
+        }
+        #expect(matched > 0)
+        #expect(matched < prompt2Tokens.count)
+        #expect(remaining == prompt2Tokens.count - matched)
+
+        let indexed = TQDiskSerializer.deserializeIndexed(arrays)
+        var zayaTQ = 0
+        var zayaRaw = 0
+        var skipped = 0
+        var requiredMiss = 0
+        for entry in indexed {
+            switch entry.data {
+            case .zayaCCATQ: zayaTQ += 1
+            case .zayaCCA: zayaRaw += 1
+            case .skip: skipped += 1
+            case .requiredMiss: requiredMiss += 1
+            default: break
+            }
+        }
+        #expect(TQDiskSerializer.formatVersion(of: arrays) == 2)
+        #expect(indexed.count == 80)
+        #expect(zayaTQ == (expectEncodedDisk ? 40 : 0))
+        #expect(zayaRaw == (expectEncodedDisk ? 0 : 40))
+        #expect(skipped == 40)
+        #expect(requiredMiss == 0)
+        #expect(arrays.keys.filter { $0.hasPrefix("zaya_") && $0.hasSuffix("_conv_state") }.count == 40)
+        #expect(arrays.keys.filter { $0.hasPrefix("zaya_") && $0.hasSuffix("_prev_hs") }.count == 40)
+        let rawKeyCount = arrays.keys.filter {
+            $0.hasPrefix("zaya_") && $0.hasSuffix("_keys")
+        }.count
+        let rawValueCount = arrays.keys.filter {
+            $0.hasPrefix("zaya_") && $0.hasSuffix("_values")
+        }.count
+        #expect(rawKeyCount == (expectEncodedDisk ? 0 : 40))
+        #expect(rawValueCount == (expectEncodedDisk ? 0 : 40))
+
+        let safetensors = (try? FileManager.default.contentsOfDirectory(
+            at: diskURL,
+            includingPropertiesForKeys: [.fileSizeKey]))?.filter {
+                $0.pathExtension == "safetensors"
+            } ?? []
+        let diskBytes = safetensors.reduce(Int64(0)) { total, url in
+            total + Int64((try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0)
+        }
+        #expect(!safetensors.isEmpty)
+        #expect(diskBytes > 0)
+        print(String(format:
+            "ZAYA_SELECTIVE_TQ_DISK bits=%d matched=%d/%d remaining=%d files=%d bytes=%lld gib=%.6f kinds{zayaTQ=%d,zayaRaw=%d,skip=%d}",
+            testKVBits, matched, prompt2Tokens.count, remaining, safetensors.count, diskBytes,
+            Double(diskBytes) / 1_073_741_824.0, zayaTQ, zayaRaw, skipped))
+
+        let engineB = BatchEngine(
+            context: ctx, maxBatchSize: 1, cacheCoordinator: coordinatorB)
+        nonisolated(unsafe) let prepared2WarmSend = clone(prepared2)
+        let warm = await run(engineB, prepared2WarmSend)
+        await engineB.shutdown()
+        assertClean(warm, label: "warm partial SSD")
+
+        let engineCold = BatchEngine(context: ctx, maxBatchSize: 1)
+        nonisolated(unsafe) let prepared2ColdSend = clone(prepared2)
+        let cold = await run(engineCold, prepared2ColdSend)
+        await engineCold.shutdown()
+        assertClean(cold, label: "cold comparison")
+
+        #expect(warm.text.uppercased().contains("CERULEAN-47"))
+        #expect(cold.text.uppercased().contains("CERULEAN-47"))
+        let stats = coordinatorB.snapshotStats()
+        #expect(stats.diskStats?.hits ?? 0 >= 2)
+        print(String(format:
+            "ZAYA_SELECTIVE_TQ_RESULT warm{ttft=%.3f,tokps=%.2f,text=%@} cold{ttft=%.3f,tokps=%.2f,text=%@} diskHits=%d",
+            warm.info?.promptTime ?? -1,
+            warm.info?.tokensPerSecond ?? 0,
+            warm.text.replacingOccurrences(of: "\n", with: "\\n"),
+            cold.info?.promptTime ?? -1,
+            cold.info?.tokensPerSecond ?? 0,
+            cold.text.replacingOccurrences(of: "\n", with: "\\n"),
+            stats.diskStats?.hits ?? 0))
     }
 
     private static func collectGeneration(_ stream: AsyncStream<Generation>)

--- a/docs/NEMOTRON_OMNI_MULTIMODAL_CHECKPOINT_2026-07-19.md
+++ b/docs/NEMOTRON_OMNI_MULTIMODAL_CHECKPOINT_2026-07-19.md
@@ -1,0 +1,61 @@
+# Nemotron Omni Multimodal Correctness Checkpoint — 2026-07-19
+
+Status: **PARTIAL — patched engine is not yet accepted in the rebuilt Osaurus UI.**
+
+Scope is the locally available non-MXFP4 bundle:
+
+`/Users/eric/models/dealign.ai/Nemotron-Omni-Nano-JANGTQ4-CRACK`
+
+## Current-source root causes
+
+1. The vision projector did not match the bundle's authoritative
+   `modeling.py`. The bundle uses `RMSNorm(eps=1e-5) -> Linear ->
+   SquaredReLU -> Linear`; Swift used `LayerNorm -> Linear -> GELU -> Linear`.
+   The indexed bundle weights contain `mlp1.0.weight` and no norm bias.
+2. RADIO ViT blocks used MLXNN's `LayerNorm` default epsilon rather than the
+   RADIO/timm `1e-6` contract.
+3. The processor contained a media-only synthetic system instruction and
+   silently forced `enable_thinking=false`. Those guards masked the projection
+   defect and contradicted the caller's visible Thinking setting. They are
+   removed; explicit on/off and an omitted control now reach the bundle chat
+   template unchanged.
+
+## Current direct evidence
+
+| Row | Status | Evidence |
+|---|---|---|
+| Vision tensor parity | PASS | `/tmp/nemotron_projector_fix_tensor_parity_20260719.log`: exact-bundle Swift projector mean `0.000916`, std `0.189765`, min `-2.8788`, max `9.472`, closely matching the independent PyTorch projector mean `0.000696`, std `0.186325`, min `-2.78125`, max `9.5`. |
+| Smoke regression | PASS | `/tmp/nemotron_projector_fix_smoke_tests_xcode2_20260719.log`: 14/14 `NemotronHOmniSmokeTests`, including the deterministic RMSNorm + SquaredReLU contract test. |
+| Prompt-contract regression | PASS | `/tmp/nemotron_preencoded_audio_tests_xcode2_20260719.log`: 19/19 focused tests; explicit Thinking on/off and bundle-default behavior remain distinct and no hidden direct-answer instruction is injected. |
+| Exact JANGTQ4 full matrix | PARTIAL | `/tmp/nemotron_jangtq4_projector_fix_full_matrix_20260719.log`: 19/20 rows passed across text, image, video, audio, mixed media, multi-turn, media salt, cache, and BatchEngine. Video with Thinking on hit the 512-token test ceiling. |
+| Exact JANGTQ4 1024-token matrix | PARTIAL | `/tmp/nemotron_jangtq4_projector_fix_native_1024_20260719.log`: 14/15; video with Thinking on remained the sole length-stop row. Three isolated Swift seeds reproduced the long-reasoning row in `/tmp/nemotron_swift_video_thinking_seed_{1,2,3}_20260719.log`. |
+| Independent reference | PASS with topology caveat | `/tmp/nemotron_python_vmlx_jangtq4_reference_20260719/SUMMARY.json` passed 13/13 image/video/audio/multi-turn rows. `/tmp/nemotron_python_reference_thinking_on_smpte_video_20260719.log` stopped normally, but that dispatcher sampled four images rather than exercising Swift's native 32-frame temporal-video tower, so it does not prove a Swift decode defect. |
+
+The 32-frame Swift default is retained. The bundle-side Nemotron video helper
+and the retained Python JANG tool both define `target_frames=32`; reducing the
+frame count merely to shorten reasoning would be an unproven behavior change.
+
+## Osaurus boundary already traced
+
+Osaurus constructs real image, video, and audio content parts in
+`ChatView.buildUserChatMessage`, lowers video data URLs and audio PCM/container
+payloads in `ModelRuntime`, and builds `MLXLMCommon.UserInput(chat:)` in
+`MLXBatchAdapter`. The companion Osaurus change recognizes
+`config_omni.json` as a VLM sidecar so this exact bundle is selectable through
+the multimodal UI instead of being filtered as text-only.
+
+## Remaining release proof
+
+- Commit and push this engine change, then pin the exact revision in the
+  isolated Osaurus checkout.
+- Run Osaurus multimodal-content and VLM-detection focused tests.
+- Build and ad-hoc sign an isolated Release Osaurus app under the proof bundle
+  identifier and proof root.
+- Use Computer Use to confirm settings and visible real-user flows for image,
+  video, audio, mixed media, multi-turn recall, media-salt isolation, and
+  Thinking on/off with this exact JANGTQ4 bundle.
+- Capture TTFT/token rate, Activity Monitor physical footprint, effective
+  prefix/paged/L2/TurboQuant telemetry, and a real L2 restore before changing
+  this checkpoint from PARTIAL.
+- Do not call video Thinking-on passed while it still length-stops, and do not
+  force Thinking off to manufacture a pass.

--- a/docs/NEMOTRON_OMNI_MULTIMODAL_CHECKPOINT_2026-07-19.md
+++ b/docs/NEMOTRON_OMNI_MULTIMODAL_CHECKPOINT_2026-07-19.md
@@ -1,6 +1,8 @@
 # Nemotron Omni Multimodal Correctness Checkpoint — 2026-07-19
 
-Status: **PARTIAL — patched engine is not yet accepted in the rebuilt Osaurus UI.**
+Status: **PARTIAL — the patched engine passes the rebuilt isolated Release
+Osaurus default-cache multimodal matrix; video Thinking-on and 4/4
+TurboQuant-KV video accuracy remain open.**
 
 Scope is the locally available non-MXFP4 bundle:
 
@@ -77,18 +79,64 @@ payloads in `ModelRuntime`, and builds `MLXLMCommon.UserInput(chat:)` in
 `config_omni.json` as a VLM sidecar so this exact bundle is selectable through
 the multimodal UI instead of being filtered as text-only.
 
-## Remaining release proof
+## Rebuilt Osaurus live proof
 
-- Commit and push the bounded media-prefill and safe hybrid-media-boundary
-  change, then pin the exact revision in the isolated Osaurus checkout.
-- Run Osaurus multimodal-content and VLM-detection focused tests.
-- Build and ad-hoc sign an isolated Release Osaurus app under the proof bundle
-  identifier and proof root.
-- Use Computer Use to confirm settings and visible real-user flows for image,
-  video, audio, mixed media, multi-turn recall, media-salt isolation, and
-  Thinking on/off with this exact JANGTQ4 bundle.
-- Capture TTFT/token rate, Activity Monitor physical footprint, effective
-  prefix/paged/L2/TurboQuant telemetry, and a real L2 restore before changing
-  this checkpoint from PARTIAL.
-- Do not call video Thinking-on passed while it still length-stops, and do not
-  force Thinking off to manufacture a pass.
+Osaurus pinned this engine at
+`4634af5151ffd71262d180e32962939dd8b2263f`, built an ad-hoc-signed Release app
+at `/tmp/osaurus-nemotron-proof-dd-4634/Build/Products/Release/osaurus.app`, and
+ran it under the isolated bundle `com.dinoki.osaurus.nemotron4634proof` and
+root `/tmp/osaurus-nemotron-ui-proof-20260719-4634`. The exact JANGTQ4 bundle
+was selected from `/Users/eric/models` through the real UI; no MXFP4 bundle was
+loaded.
+
+With Thinking off, prefix on, paged RAM off, SSD L2 on, SSM re-derive on, and
+live KV codec `Engine Selected`, the UI produced:
+
+- correct image at 6.46s TTFT / 103.4 tok/s and correct no-attachment recall at
+  0.95s / 103.2 tok/s;
+- correct post-restart image recall at 1.17s / 102.6 tok/s, with fresh-process
+  telemetry showing four disk-L2 hits and four SSM-companion hits;
+- correct audio transcript at 1.05s / 101.3 tok/s;
+- correct mixed image/audio result at 5.53s / 101.4 tok/s;
+- SMPTE/timecode video recognition at 12.20s / 109.3 tok/s, with a remaining
+  fine-detail miss on the final frame number;
+- a correct fresh Thinking-on mixed-media answer at 5.56s / 101.8 tok/s and a
+  correct no-attachment follow-up at 0.95s / 101.9 tok/s.
+
+`vmmap -summary` measured a 17.6-17.9 GiB physical footprint and 20.3 GiB peak
+during the current live matrix, down from the pre-patch 76 GiB high-water mark.
+The isolated chat evidence is retained in
+`/tmp/osaurus-nemotron-ui-proof-20260719-4634/chat-history/history.sqlite`.
+
+The default fresh-load telemetry was six FP16 KV layers plus 23 Mamba layers,
+disk-backed restore and SSM companion state required, zero TurboQuant-KV
+layers, and paged cache off. JANGTQ4 describes the weights and was not reported
+as TurboQuant KV.
+
+## Explicit TurboQuant-KV live row
+
+The real Server -> Settings -> Cache UI was changed to TurboQuant with explicit
+4-bit key and value widths, saved, and the app restarted. Telemetry showed a
+selective transition from six KV + 23 Mamba layers to six TurboQuant-KV + 23
+Mamba layers, three compressions, four disk hits, four SSM companion hits, and
+zero paged hits. Mixed image/audio stayed correct at 6.71s / 21.3 tok/s and its
+cached follow-up stayed correct at 0.97s / 68.3 tok/s.
+
+The video row is not accepted for quality. On the same prompt and fixture, the
+4/4 cache run coherently recognized SMPTE bars but misread a roughly five-second
+clip as five minutes / 24 frames. After restoring `Engine Selected`, saving,
+and restarting, the FP16-cache run tracked the counter to about 140 at 11.91s
+TTFT / 110.6 tok/s. Fresh telemetry then confirmed effective `fp16`, zero
+TurboQuant-KV layers, and paged cache off.
+
+## Remaining release limits
+
+- Video with Thinking enabled still length-stops in the deterministic direct
+  matrix. Do not force Thinking off or change sampling to manufacture a pass.
+- One off-to-on Thinking transition follow-up repeated a correct sentence
+  three times; a fresh Thinking-on chat did not reproduce it.
+- One transcript-only audio request selected a valid but unsolicited
+  `share_artifact` tool. That is a model/tool-choice caveat, not a media
+  transport or schema-parser failure.
+- 4/4 TurboQuant-KV is structurally selective and cache-compatible for this
+  hybrid topology, but the live video-detail A/B is a quality failure.

--- a/docs/NEMOTRON_OMNI_MULTIMODAL_CHECKPOINT_2026-07-19.md
+++ b/docs/NEMOTRON_OMNI_MULTIMODAL_CHECKPOINT_2026-07-19.md
@@ -19,6 +19,20 @@ Scope is the locally available non-MXFP4 bundle:
    defect and contradicted the caller's visible Thinking setting. They are
    removed; explicit on/off and an omitted control now reach the bundle chat
    template unchanged.
+4. `NemotronHOmni.prepare` chunked text prefill but forwarded the entire
+   multimodal embedding sequence to the Mamba/attention stack in one call. A
+   real 512 px image expands this bundle's prompt beyond 4K positions, so the
+   Mamba sequence-quadratic intermediates produced a 76 GiB live-app physical
+   footprint high-water mark. Multimodal embeddings are now materialized once
+   and sent through the same bounded 512-position prefill used by text.
+5. Hybrid cross-turn prefix capture rejected every media-bearing `LMInput`.
+   The first image turn therefore stored only full prompt/post-answer keys,
+   neither of which is a prefix of the next rendered chat turn. Image/audio
+   inputs may now capture the generation-suffix-stripped boundary only when
+   every media placeholder is wholly before that boundary. Media tensors stay
+   on the split head so the re-derived Mamba state includes the media. Video
+   EVS remains excluded because its stable key is only available after
+   post-prepare pruning.
 
 ## Current direct evidence
 
@@ -30,6 +44,25 @@ Scope is the locally available non-MXFP4 bundle:
 | Exact JANGTQ4 full matrix | PARTIAL | `/tmp/nemotron_jangtq4_projector_fix_full_matrix_20260719.log`: 19/20 rows passed across text, image, video, audio, mixed media, multi-turn, media salt, cache, and BatchEngine. Video with Thinking on hit the 512-token test ceiling. |
 | Exact JANGTQ4 1024-token matrix | PARTIAL | `/tmp/nemotron_jangtq4_projector_fix_native_1024_20260719.log`: 14/15; video with Thinking on remained the sole length-stop row. Three isolated Swift seeds reproduced the long-reasoning row in `/tmp/nemotron_swift_video_thinking_seed_{1,2,3}_20260719.log`. |
 | Independent reference | PASS with topology caveat | `/tmp/nemotron_python_vmlx_jangtq4_reference_20260719/SUMMARY.json` passed 13/13 image/video/audio/multi-turn rows. `/tmp/nemotron_python_reference_thinking_on_smpte_video_20260719.log` stopped normally, but that dispatcher sampled four images rather than exercising Swift's native 32-frame temporal-video tower, so it does not prove a Swift decode defect. |
+| Media-boundary source regression | PASS | `/tmp/nemotron_media_hybrid_strip_tests_swift_20260719.log`: 6/6 focused tests. The media tensor is present only on the prefix head, the suffix is media-free, placeholders after the boundary fail closed, and text/dense/no-cache controls retain their prior behavior. |
+| Patched Release exact-bundle matrix | PARTIAL | `/tmp/nemotron_jangtq4_patched_omni_192_20260719.log`: 19/20 with bundle sampling defaults and fixed seed. Text, three-turn text, image, image follow-up, audio, mixed media, media-salt isolation, hybrid SSM, BatchEngine image/audio, video Thinking off, and repeated-video disk alias passed. Video Thinking on remained the sole 192-token length stop. |
+| Patched direct physical footprint | PASS for direct diagnostic only | `/tmp/nemotron_jangtq4_patched_footprint_192_20260719.log`: `phys_footprint_peak` remained 29 GiB through the 20-row exact-bundle matrix, down from the 76 GiB high-water mark observed in the pre-patch live app. This is not the app acceptance gate. |
+
+## Pre-patch live-app reproduction
+
+The isolated Release Osaurus build at vMLX `6fb10658` was operated through the
+actual UI under bundle identifier `com.dinoki.osaurus.nemotron20260719proof`.
+The exact JANGTQ4 model was selected from the user-configured
+`/Users/eric/models` storage path with Thinking visibly off. A two-region image
+was correctly described as yellow over blue at 115.1 tok/s, and the text-only
+follow-up correctly recalled those colors at 55.4 tok/s. However, the first
+turn reached 76 GiB physical footprint and the follow-up visibly re-prefilled
+`0/4729`. Its isolated L2 database contained only the full 4433/4577 and
+4729/4758 boundaries, confirming that media-prefix reuse had not occurred.
+
+That run is reproduction evidence for the two additional root causes above;
+it is not verification of the current patch. A newly pinned and rebuilt app
+must show both lower physical footprint and a real partial-prefix/L2 restore.
 
 The 32-frame Swift default is retained. The bundle-side Nemotron video helper
 and the retained Python JANG tool both define `target_frames=32`; reducing the
@@ -46,8 +79,8 @@ the multimodal UI instead of being filtered as text-only.
 
 ## Remaining release proof
 
-- Commit and push this engine change, then pin the exact revision in the
-  isolated Osaurus checkout.
+- Commit and push the bounded media-prefill and safe hybrid-media-boundary
+  change, then pin the exact revision in the isolated Osaurus checkout.
 - Run Osaurus multimodal-content and VLM-detection focused tests.
 - Build and ad-hoc sign an isolated Release Osaurus app under the proof bundle
   identifier and proof root.

--- a/docs/ZAYA_SELECTIVE_TQ_CACHE_CHECKPOINT_2026-07-19.md
+++ b/docs/ZAYA_SELECTIVE_TQ_CACHE_CHECKPOINT_2026-07-19.md
@@ -1,0 +1,92 @@
+# ZAYA selective TurboQuant cache checkpoint — 2026-07-19
+
+Status: **PARTIAL — exact-model Swift runtime proof passes; no live Osaurus UI proof yet.**
+
+## Scope
+
+- Bundle: `/Users/eric/models/OsaurusAI/Osaurus-AppleScript-8B-JANG_6M`
+- Architecture: ZAYA, 80 decoder entries: 40 CCA-attention layers and 40
+  MoE-only entries.
+- Cache policy under test: paged RAM default off, SSD L2 on, TurboQuant KV
+  default off and user-opt-in only.
+
+## Current-source root cause
+
+Before this branch, `ZayaModel.newCache` used `ZayaCCACache` for the 40 real
+attention layers and `KVCacheSimple` as unused placeholders for the 40 MoE
+layers. Generic TQ conversion only promoted top-level `KVCacheSimple`, so an
+enabled TQ policy compressed/counted the unused placeholders while the real KV
+inside every `ZayaCCACache` stayed native. Telemetry could therefore claim a
+TQ transition without compressing a single ZAYA attention layer.
+
+## Required invariant
+
+- TQ encodes only the internal attention KV in each `ZayaCCACache`.
+- `conv_state` and `prev_hs` remain native fp32.
+- SSD L2 always stores both native CCA arrays atomically with attention KV.
+  ZAYA `turbo(4,4)` and higher may store typed encoded attention KV; sub-4-bit
+  live TQ uses a raw prompt-boundary disk record because exact-model `3/3`
+  encoded-disk A/B drifted while raw-disk `3/3` did not.
+- MoE-only decoder entries use an explicit state-free placeholder and never
+  count as KV or TQ layers.
+- ZAYA remains paged-incompatible until token-addressable paged blocks can
+  restore an exact matching CCA prompt boundary. Explicit paged opt-in must be
+  reported as ineffective, not silently treated as a paged hit.
+
+## Proof matrix
+
+| Gate | State | Evidence / remaining work |
+|---|---|---|
+| Selective CCA KV promotion | PASS-RUNTIME | Exact JANG_6M runs reported 40 native CCA layers plus 40 real attention-TQ layers; the 40 MoE placeholders were not counted. |
+| Native fp32 CCA preservation | PASS-FOCUSED | Current source passed 22 selected ZAYA cache checks, including native CCA state, TQ promotion, disk atomicity, cross-layer boundary rejection, and the four-bit disk floor. Log: `/tmp/vmlx_zaya_selective_tq_unit_final2_20260719.log`. |
+| TQ-native SSD round trip | PASS-RUNTIME-4BIT | Current source at `4/4` stored 40 `zayaCCATQ` plus 40 native CCA pairs, no raw ZAYA KV, hit `297/340`, and produced the same `CERULEAN-47` answer warm/cold (13.28 vs 10.43 tok/s). Log: `/tmp/vmlx_zaya_jang6m_tq44_current_live_20260719.log`. |
+| Sub-4-bit disk safety | PASS-RUNTIME-3BIT | Current source at `3/3` still transitioned the live 40 attention layers to TQ, but stored 40 raw ZAYA KV plus native CCA pairs; `297/340` hit and warm/cold both returned `CERULEAN-47` (10.32 tok/s each). Log: `/tmp/vmlx_zaya_jang6m_tq33_current_live_20260719.log`. |
+| Accurate topology telemetry | PASS-FOCUSED | Explicit MoE placeholder and nested ZAYA TQ counting passed the focused source/runtime checks. |
+| Paged-off SSD full hit | NOT-APPLICABLE-EXACT | ZAYA disk restore intentionally rejects exact path-dependent prompt boundaries; a growing partial boundary is required. UI must report paged ineffective rather than a false hit. |
+| SSD partial-prefix hit | PASS-RUNTIME | Both current-source real-bundle rows hit `297/340`, then prefilled 43 tokens. Four retained records occupied 53 MB for `3/3` raw-disk policy and 23 MB for `4/4` typed-TQ disk policy. |
+| Restart SSD restore | OPEN | Requires isolated Release Osaurus restart. |
+| Thinking off coherence | PASS-RUNTIME / UI OPEN | Both live rows used `enable_thinking=false`, emitted visible answers with no reasoning/tool markers, and stopped normally. Visible app confirmation remains open. |
+| Thinking on coherence | OPEN | Requires real UI turns and visible channel inspection. |
+| AppleScript direct tools | OPEN | TextEdit, Calculator, Safari, success finalization, and non-request feedback. |
+| Spawn/delegation tools | OPEN | Configure AppleScript delegate in Settings and exercise inherited tool scope. |
+| RAM admission override | OPEN | Prove strict refusal, user toggle override, load, unload, and Safe Auto restore. |
+| Activity Monitor + tok/s | OPEN | Record physical footprint, TTFT, prefill, cold/warm decode rate. |
+
+No merge-readiness claim is permitted until the source tests pass and the
+isolated Release Osaurus app is operated through its visible UI for the live
+rows above.
+
+## Failure that determined the disk policy
+
+The first exact `turbo(3,3)` encoded-disk row restored the expected structural
+payload (`40 zayaCCATQ`, `40 skip`, all 40 native CCA pairs) and recorded two
+disk hits, but its warm answer became incoherent and lost `CERULEAN-47`; the
+cache-off comparison answered correctly. Log:
+`/tmp/vmlx_zaya_jang6m_selective_tq_live_20260719.log`.
+
+Two controlled follow-ups separated codec loss from companion-state restore:
+
+- raw KV plus the same typed native CCA restore was coherent;
+- live `turbo(3,3)` plus a raw SSD boundary was coherent;
+- encoded SSD `turbo(4,4)` was coherent for the same partial restore.
+
+The implementation therefore does not silently change a user's selected live
+bit width. It keeps sub-4-bit ZAYA disk boundaries lossless and does not persist
+a sub-4-bit TQ-native post-answer boundary. A raw stripped boundary remains
+available for correct partial reuse.
+
+## Required follow-on family matrix
+
+ZAYA proof does not prove any other hybrid topology. Each row needs current
+source inspection plus an isolated Release Osaurus UI run with cold/warm,
+partial-prefix, restart, cache-size, TTFT/tok/s, and coherence evidence.
+
+| Family/topology | Required TQ ownership | Current state |
+|---|---|---|
+| Qwen 3.5/3.6 and Ornith GatedDeltaNet | TQ only full-attention KV; GDN/Arrays recurrent state native with exact-boundary companion restore or async rederive | NOT CURRENT-LIVE-VERIFIED |
+| Nemotron hybrid/Mamba | TQ only attention KV; Mamba convolution/SSM state native and boundary-aligned | NOT CURRENT-LIVE-VERIFIED |
+| LFM/Jamba/Falcon-H1 and other SSM hybrids | TQ only attention KV; typed recurrent companion state native | NOT CURRENT-LIVE-VERIFIED |
+| Gemma 4 rotating SWA | TQ only eligible full-attention KV; rotating/SWA ring state and geometry remain native | NOT CURRENT-LIVE-VERIFIED |
+| MiniMax and ordinary full-attention models | TQ may own all real KV layers; no fake placeholder layers may be counted | NOT CURRENT-LIVE-VERIFIED |
+| DSV4 hybrid pool and OpenPangu special cache | Generic TQ must remain ineligible; native typed cache/restore only | NEGATIVE UI PROOF OPEN |
+| VL/video variants of the rows above | Same topology rules plus real-media cache salt, companion state, restart, and post-media text/tool turns | NOT CURRENT-LIVE-VERIFIED |


### PR DESCRIPTION
## Proposed changes

This PR contains two scoped runtime fixes:

- ZAYA selective TurboQuant cache serialization preserves native CCA companion state and quantizes only eligible attention KV layers.
- Nemotron Omni matches the exact bundle contract: RADIO normalization epsilon, RMSNorm + SquaredReLU projector, no hidden media-only prompt, no forced Thinking override, bounded multimodal Mamba prefill, and safe image/audio hybrid-prefix capture.
- Nemotron benchmark rows reject max-token length stops.
- Checkpoint docs record exact direct and isolated-app evidence.

Exact Nemotron bundle: /Users/eric/models/dealign.ai/Nemotron-Omni-Nano-JANGTQ4-CRACK. No MXFP4 bundle was loaded or evaluated.

## Evidence

Source/direct:

- Nemotron projector tensor parity matches the independent PyTorch reference.
- 14/14 Nemotron smoke tests and 6/6 hybrid media-boundary tests passed.
- Exact JANGTQ4 matrix passed 19/20; only video with Thinking on length-stopped at the honest cap.
- Patched direct peak physical footprint was 29 GiB versus the pre-patch app's 76 GiB.

Isolated Release Osaurus app:

- App pin: 4634af5151ffd71262d180e32962939dd8b2263f.
- Bundle ID: com.dinoki.osaurus.nemotron4634proof.
- Root: /tmp/osaurus-nemotron-ui-proof-20260719-4634.
- UI settings: Prefix on, Paged RAM off, SSD L2 on, SSM re-derive on, Engine Selected KV codec by default.
- Correct image: 6.46s TTFT / 103.4 tok/s; no-attachment follow-up: 0.95s / 103.2 tok/s.
- Correct post-restart image recall: 1.17s / 102.6 tok/s with disk-L2 and SSM-companion hits.
- Correct audio transcript: 1.05s / 101.3 tok/s.
- Correct image + audio: 5.53s / 101.4 tok/s.
- SMPTE video recognition: 12.20s / 109.3 tok/s.
- Fresh Thinking-on mixed media and follow-up were correct at 101.8 and 101.9 tok/s.
- Current live physical footprint was 17.6-17.9 GiB, 20.3 GiB peak.

TurboQuant-KV was separately toggled through the real Settings UI at 4/4 and did not get conflated with JANGTQ4 weights. Telemetry showed exactly 6 KV layers converted, 23 Mamba layers preserved, 3 compressions, disk/SSM hits, and zero paged hits. Mixed media and its follow-up stayed coherent. Same-prompt video detail degraded under 4/4 TQ, so that optional row remains PARTIAL and the setting was restored to Engine Selected; a fresh restart confirmed fp16 and zero TQ-KV layers.

Known limits are documented rather than hidden: video Thinking-on length stop, one non-reproduced off-to-on repetition, one unsolicited but valid share_artifact choice on audio, and 4/4 TQ video-detail accuracy.

## Checklist

- [ ] I have read the CONTRIBUTING document
- [ ] I have run pre-commit run --all-files
- [x] I have added tests that prove the scoped fixes
- [x] I have updated the necessary documentation
- [x] I have run the exact bundle through an isolated Release Osaurus UI