### PR TITLE
Preserve chronological video frame order

### DIFF
--- a/Libraries/MLXVLM/MediaProcessing.swift
+++ b/Libraries/MLXVLM/MediaProcessing.swift
@@ -20,6 +20,39 @@ public struct ProcessedVideoFrames {
 
 private let context = CIContext()
 
+private struct DecodedVideoFrame {
+    let requestedTime: CMTime
+    let actualTime: CMTime
+    let image: CGImage
+}
+
+func chronologicalVideoFrameOrder(
+    requestedTimes: [CMTime],
+    actualTimes: [CMTime]
+) -> [Int] {
+    precondition(requestedTimes.count == actualTimes.count)
+    return requestedTimes.indices.sorted { lhs, rhs in
+        let requestedOrder = CMTimeCompare(requestedTimes[lhs], requestedTimes[rhs])
+        if requestedOrder != 0 {
+            return requestedOrder < 0
+        }
+
+        let actualOrder = CMTimeCompare(actualTimes[lhs], actualTimes[rhs])
+        if actualOrder != 0 {
+            return actualOrder < 0
+        }
+
+        return lhs < rhs
+    }
+}
+
+private func chronologicallySorted(_ frames: [DecodedVideoFrame]) -> [DecodedVideoFrame] {
+    chronologicalVideoFrameOrder(
+        requestedTimes: frames.map(\.requestedTime),
+        actualTimes: frames.map(\.actualTime)
+    ).map { frames[$0] }
+}
+
 /// Collection of methods for processing media (images, video, etc.).
 ///
 /// A typical image preparation pipeline might look like this:
@@ -314,19 +347,25 @@ public enum MediaProcessing {
         let sampledTimes = sampledTimeValues.map { CMTime(value: $0, timescale: timescale) }
 
         // Collect the frames
-        var ciImages: [CIImage] = []
+        var decodedFrames: [DecodedVideoFrame] = []
         for await result in generator.images(for: sampledTimes) {
             switch result {
-            case .success(requestedTime: _, let image, actualTime: _):
-                let ciImage = CIImage(
-                    cgImage: image, options: [.colorSpace: CGColorSpace(name: CGColorSpace.sRGB)!])
-                ciImages.append(ciImage)
+            case .success(let requestedTime, let image, let actualTime):
+                decodedFrames.append(
+                    DecodedVideoFrame(
+                        requestedTime: requestedTime,
+                        actualTime: actualTime,
+                        image: image))
             case .failure(requestedTime: _, _):
                 break
             }
         }
 
-        return ciImages
+        return chronologicallySorted(decodedFrames).map { frame in
+            CIImage(
+                cgImage: frame.image,
+                options: [.colorSpace: CGColorSpace(name: CGColorSpace.sRGB)!])
+        }
     }
 
     private static func validateAsset(_ asset: AVAsset) async throws {
@@ -516,18 +555,30 @@ public enum MediaProcessing {
         let sampledTimes = sampledTimeValues.map { CMTime(value: $0, timescale: timescale) }
 
         // Collect the frames
-        var frames: [VideoFrame] = []
+        var decodedFrames: [DecodedVideoFrame] = []
 
         for await result in generator.images(for: sampledTimes) {
             switch result {
-            case .success(requestedTime: _, let image, actualTime: let actual):
-                let ciImage = CIImage(
-                    cgImage: image, options: [.colorSpace: CGColorSpace(name: CGColorSpace.sRGB)!])
-                let frame = try frameProcessing(.init(frame: ciImage, timeStamp: actual))
-                frames.append(frame)
+            case .success(let requestedTime, let image, let actualTime):
+                decodedFrames.append(
+                    DecodedVideoFrame(
+                        requestedTime: requestedTime,
+                        actualTime: actualTime,
+                        image: image))
             case .failure(requestedTime: _, _):
                 break
             }
+        }
+
+        var frames: [VideoFrame] = []
+        frames.reserveCapacity(decodedFrames.count)
+        for decoded in chronologicallySorted(decodedFrames) {
+            let ciImage = CIImage(
+                cgImage: decoded.image,
+                options: [.colorSpace: CGColorSpace(name: CGColorSpace.sRGB)!])
+            let frame = try frameProcessing(
+                .init(frame: ciImage, timeStamp: decoded.actualTime))
+            frames.append(frame)
         }
 
         return ProcessedVideoFrames(frames: frames, totalDuration: duration)

--- a/Tests/MLXLMTests/MediaProcessingTests.swift
+++ b/Tests/MLXLMTests/MediaProcessingTests.swift
@@ -5,10 +5,30 @@ import CoreMedia
 import Foundation
 import MLX
 import MLXLMCommon
-import MLXVLM
 import XCTest
 
+@testable import MLXVLM
+
 public class MediaProcesingTests: XCTestCase {
+
+    func testDecodedVideoFramesAreSortedByRequestedThenActualTime() {
+        let requested = [
+            CMTime(seconds: 2, preferredTimescale: 10),
+            CMTime(seconds: 0, preferredTimescale: 10),
+            CMTime(seconds: 1, preferredTimescale: 10),
+            CMTime(seconds: 1, preferredTimescale: 10),
+        ]
+        let actual = [
+            CMTime(seconds: 2.1, preferredTimescale: 10),
+            CMTime(seconds: 0.1, preferredTimescale: 10),
+            CMTime(seconds: 1.2, preferredTimescale: 10),
+            CMTime(seconds: 1.1, preferredTimescale: 10),
+        ]
+
+        XCTAssertEqual(
+            chronologicalVideoFrameOrder(requestedTimes: requested, actualTimes: actual),
+            [1, 3, 2, 0])
+    }
 
     func testResize() {
         // resampleBicubic should produce an image with the desired dimensions
@@ -35,6 +55,10 @@ public class MediaProcesingTests: XCTestCase {
         let frames = try await MediaProcessing.asProcessedSequence(video, samplesPerSecond: 1)
 
         XCTAssert(frames.frames.count == 5)
+        XCTAssertEqual(frames.timestamps.count, frames.frames.count)
+        for (earlier, later) in zip(frames.timestamps, frames.timestamps.dropFirst()) {
+            XCTAssertLessThanOrEqual(CMTimeCompare(earlier, later), 0)
+        }
     }
 
     func testVideoFileValidationThisShouldFail() async throws {


### PR DESCRIPTION
## Status

PARTIAL. Source tests pass and the pre-fix failure is reproduced in the real Osaurus UI. The isolated Release app pinned to this commit is still building; the repeated post-fix live UI matrix remains required before this can leave draft or merge.

## Root cause

AVAssetImageGenerator.images(for:) is asynchronous. Both shared AVAsset decode paths appended successful frames in callback-arrival order and discarded requestedTime. Nemotron Omni calls MediaProcessing.asCIImageSequence, then groups consecutive frames for its temporal RADIO encoder, so callback reordering changed video chronology before model inference.

Pre-fix visible reproduction using the exact local non-MXFP4 bundle /Users/eric/models/dealign.ai/Nemotron-Omni-Nano-JANGTQ4-CRACK and a verified three-second red-to-green-to-blue fixture returned Green, Blue, Red in current Osaurus main.

## Change

- retain requested and actual timestamps for decoded frames
- sort by requested time, then actual time, then original arrival index
- apply the ordering in both shared AVAsset decode paths
- add deterministic scrambled-callback ordering coverage
- assert integration-test timestamps are nondecreasing

## Current source evidence

- commit 86e7ea5e6317a1e4a59becea705028c7d1330180
- MediaProcesingTests: 6/6 passed, including deterministic chronology
- NemotronHOmniSmokeTests: 14/14 passed
- diff is two files only: Libraries/MLXVLM/MediaProcessing.swift and Tests/MLXLMTests/MediaProcessingTests.swift

## Missing live gate

The rebuilt isolated Release Osaurus app must visually pass three fresh video attachments in chronological order, a no-attachment follow-up, image and AIFF regressions, settings verification, cache telemetry, and physical-footprint evidence. No MXFP4 model is used or claimed.