### PR TITLE
Fix JANG semantic-width quantization precedence

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -1892,10 +1892,10 @@ public final class LLMModelFactory: ModelFactory {
             for: templateResolvedDir)
         async let tokenizerTask = tokenizerLoader.load(from: tokenizerDirectory)
 
-        // When JANG, skip config.json's perLayerQuantization — JANG infers correct
-        // per-layer bits from tensor shapes. This avoids creating QuantizedLinear at
-        // the wrong bit width (which can't be re-quantized later).
-        // BUT: still pass `quantization` (the global config.json group_size /
+        // For JANG, pass config.json's per-layer metadata as declared evidence;
+        // loadWeights validates it against exact manifests, semantic widths, and
+        // tensor geometry before constructing QuantizedLinear modules.
+        // Also pass `quantization` (the global config.json group_size /
         // bits) so JangLoader.inferPerLayerQuantization gets the correct
         // `knownGroupSize` even when jang_config.json doesn't carry quant
         // metadata (e.g. DSV4-Flash bundles ship `weight_format: "bf16"`).
@@ -1903,10 +1903,9 @@ public final class LLMModelFactory: ModelFactory {
             modelDirectory: modelDirectory, model: model,
             quantization: jangConfig != nil ? baseConfig.quantizationContainer?.quantization : nil,
             // 2026-04-28: pass perLayerQuantization through even when JANG;
-            // loadWeights merges config.json's explicit per-layer dict on
-            // top of the shape walk to fix mis-inference of (bits, gs) pairs
-            // that share a packed shape (e.g., (4,64) ≡ (8,32)). Closes
-            // Cascade-2 JANG_4M / Nemotron-Omni MXFP4 first-prefill rmsNorm.
+            // loadWeights treats config.json's explicit per-layer dict as
+            // declared evidence, then validates it against exact manifests,
+            // semantic widths, and packed tensor geometry.
             perLayerQuantization: baseConfig.perLayerQuantization,
             jangConfig: jangConfig,
             loadPreservedMTP: loadNativeMTP)

--- a/Libraries/MLXLMCommon/JangLoader.swift
+++ b/Libraries/MLXLMCommon/JangLoader.swift
@@ -2181,29 +2181,40 @@ public struct JangLoader: Sendable {
             return nil
         }
 
-        func declaredQuantization(for basePath: String) -> BaseConfiguration.Quantization? {
-            func variants(_ key: String) -> [String] {
-                var out = [key]
-                if key.contains(".attn.") || key.hasSuffix(".attn") {
-                    out.append(key.replacingOccurrences(of: ".attn.", with: ".self_attn."))
-                    if key.hasSuffix(".attn") {
-                        out.append(String(key.dropLast(".attn".count)) + ".self_attn")
-                    }
+        func declaredPathVariants(_ key: String) -> [String] {
+            var out = [key]
+            if key.contains(".attn.") || key.hasSuffix(".attn") {
+                out.append(key.replacingOccurrences(of: ".attn.", with: ".self_attn."))
+                if key.hasSuffix(".attn") {
+                    out.append(String(key.dropLast(".attn".count)) + ".self_attn")
                 }
-                if key.hasPrefix("language_model.model.") {
-                    out.append(String(key.dropFirst("language_model.".count)))
-                } else if key.hasPrefix("language_model.") {
-                    out.append(String(key.dropFirst("language_model.".count)))
-                } else {
-                    out.append("model.\(key)")
-                    out.append("language_model.\(key)")
-                    out.append("language_model.model.\(key)")
-                }
-                return Array(Set(out))
             }
+            if key.hasPrefix("language_model.model.") {
+                out.append(String(key.dropFirst("language_model.".count)))
+            } else if key.hasPrefix("language_model.") {
+                out.append(String(key.dropFirst("language_model.".count)))
+            } else {
+                out.append("model.\(key)")
+                out.append("language_model.\(key)")
+                out.append("language_model.model.\(key)")
+            }
+            return Array(Set(out))
+        }
 
+        func declaredSpecificQuantization(
+            for basePath: String
+        ) -> BaseConfiguration.Quantization? {
             if let declaredPerLayerQuantization {
-                for key in variants(basePath) {
+                let variants = declaredPathVariants(basePath)
+                if variants.contains(where: {
+                    if case .skip? = declaredPerLayerQuantization.perLayerQuantization[$0] {
+                        return true
+                    }
+                    return false
+                }) {
+                    return nil
+                }
+                for key in variants {
                     if let declared = declaredPerLayerQuantization.perLayerQuantization[key] {
                         switch declared {
                         case .quantize(let quantization):
@@ -2217,6 +2228,24 @@ public struct JangLoader: Sendable {
             if let roleBits = declaredMXTQRoleBits(for: basePath) {
                 return BaseConfiguration.Quantization(
                     groupSize: groupSize, bits: roleBits, mode: defaultMode)
+            }
+            return nil
+        }
+
+        func hasDeclaredSkip(for basePath: String) -> Bool {
+            guard let declaredPerLayerQuantization else { return false }
+            for key in declaredPathVariants(basePath) {
+                if case .skip? = declaredPerLayerQuantization.perLayerQuantization[key] {
+                    return true
+                }
+            }
+            return false
+        }
+
+        func declaredQuantization(for basePath: String) -> BaseConfiguration.Quantization? {
+            guard !hasDeclaredSkip(for: basePath) else { return nil }
+            if let declared = declaredSpecificQuantization(for: basePath) {
+                return declared
             }
             return declaredPerLayerQuantization?.quantization
                 ?? declaredDefaultQuantization
@@ -2271,10 +2300,11 @@ public struct JangLoader: Sendable {
             let numGroups = scalesArray.shape.last ?? 1
             let (bits, inferredGroupSize): (Int, Int)
 
-            let isHiddenAnchor =
-                basePath.hasSuffix("embed_tokens")
-                || basePath.hasSuffix("embed")
-                || basePath.hasSuffix("lm_head")
+            let isLanguageHiddenAnchor =
+                basePath == "embed_tokens"
+                || basePath.hasSuffix(".embed_tokens")
+                || basePath == "lm_head"
+                || basePath.hasSuffix(".lm_head")
             let isHiddenInputProjection =
                 basePath.hasSuffix(".linear_attn.in_proj_qkv")
                 || basePath.hasSuffix(".linear_attn.in_proj_z")
@@ -2294,6 +2324,8 @@ public struct JangLoader: Sendable {
                 || basePath.hasSuffix(".switch_glu.up_proj")
                 || basePath.hasSuffix(".shared_expert.gate_proj")
                 || basePath.hasSuffix(".shared_expert.up_proj")
+                || basePath.hasSuffix(".shared_experts.gate_proj")
+                || basePath.hasSuffix(".shared_experts.up_proj")
             let isMTPFusionFC =
                 basePath.hasSuffix(".mtp.fc")
                 || basePath.hasSuffix("mtp.fc")
@@ -2345,17 +2377,67 @@ public struct JangLoader: Sendable {
                 return (first.bits, first.groupSize)
             }
 
-            // Trust the bundle's EXPLICIT declared per-module quant when it unpacks the
-            // real `.weight`/`.scales` to an inputDim that is a known model dimension.
+            func inferExactQuantization(
+                expectedInDim: Int
+            ) -> (bits: Int, groupSize: Int)? {
+                guard packedDim > 0, numGroups > 0, expectedInDim > 0 else {
+                    return nil
+                }
+                let packedBits = packedDim * 32
+                guard packedBits % expectedInDim == 0,
+                    expectedInDim % numGroups == 0
+                else {
+                    return nil
+                }
+                let bits = packedBits / expectedInDim
+                let inferredGroupSize = expectedInDim / numGroups
+                guard [2, 3, 4, 5, 6, 8].contains(bits),
+                    [32, 64, 128].contains(inferredGroupSize)
+                else {
+                    return nil
+                }
+                return (bits, inferredGroupSize)
+            }
+
+            // Exact manifests are authoritative. Language anchors and projections
+            // with a known semantic input width precede per-path declarations: their
+            // packed geometry must realize hidden_size exactly. A stale declaration
+            // can otherwise look self-consistent against another valid model width
+            // (for example a routed gate/up input of 3072 misread as the 1536 expert
+            // width). Keep roles without an exact semantic width after per-path
+            // metadata but before a generic top-level default.
+            // This avoids treating vision paths such as `visual.pos_embed` as language
+            // anchors and avoids falling back to an unrelated generic pair when an
+            // expected hidden width cannot be represented by the tensor shapes.
+            //
+            // Otherwise trust the bundle's EXPLICIT declared per-module quant when it
+            // unpacks the real `.weight`/`.scales` to a known model dimension.
             // On ambiguous packed widths (512 → bits ∈ {2,4,8}) the shape walk can pick
             // a different, WRONG bit width: Laguna-M.1 ships 4-bit dense MLP, the walk
             // re-stamped 8-bit, and the 4-bit weights dequantized to a degenerate (empty)
             // output that collapsed the forward. A self-consistent declaration whose
-            // inputDim ∈ validInDims is the author's verified intent. A genuinely stale
-            // config (claims 8-bit for 4-bit-packed) unpacks to a NON-model inputDim,
-            // fails this check, and still falls through to the shape walk.
+            // inputDim ∈ validInDims is the strongest available evidence for roles
+            // without a more specific tensor manifest or semantic width constraint.
             if let manifest = manifestQuantization(for: basePath) {
                 (bits, inferredGroupSize) = (manifest.bits, manifest.groupSize)
+            } else if isLanguageHiddenAnchor,
+                      let hiddenSize = hiddenSizeHint,
+                      let exact = inferExactQuantization(expectedInDim: hiddenSize)
+            {
+                (bits, inferredGroupSize) = exact
+            } else if isHiddenInputProjection,
+                      let hiddenSize = hiddenSizeHint,
+                      let exact = inferExactQuantization(expectedInDim: hiddenSize)
+            {
+                (bits, inferredGroupSize) = exact
+            } else if let dq = declaredSpecificQuantization(for: basePath),
+               dq.bits > 0, numGroups > 0, (packedDim * 32) % dq.bits == 0,
+               case let declaredInputDim = (packedDim * 32) / dq.bits,
+               declaredInputDim % numGroups == 0,
+               declaredInputDim / numGroups == dq.groupSize,
+               validInDims.contains(declaredInputDim)
+            {
+                (bits, inferredGroupSize) = (dq.bits, dq.groupSize)
             } else if let dq = declaredQuantization(for: basePath),
                dq.bits > 0, numGroups > 0, (packedDim * 32) % dq.bits == 0,
                case let declaredInputDim = (packedDim * 32) / dq.bits,
@@ -2364,15 +2446,6 @@ public struct JangLoader: Sendable {
                validInDims.contains(declaredInputDim)
             {
                 (bits, inferredGroupSize) = (dq.bits, dq.groupSize)
-            } else if (isHiddenAnchor || isHiddenInputProjection),
-               let hiddenSize = hiddenSizeHint, hiddenSize > 0
-            {
-                (bits, inferredGroupSize) = inferBitWidthAndGroupSize(
-                    packedDim: packedDim,
-                    numGroups: numGroups,
-                    knownGroupSize: groupSize,
-                    bitWidthsUsed: bitWidthsUsed,
-                    expectedInDim: hiddenSize)
             } else if isMTPFusionFC,
                       let hiddenSize = hiddenSizeHint, hiddenSize > 0
             {

--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -381,10 +381,10 @@ public func loadWeights(
         // the authoritative prior — see `JangLoader.swift` for the
         // root-cause writeup of the (8, 32) ≡ (4, 64) shape ambiguity
         // that crashed Cascade-2 JANG_4M / Nemotron-Omni MXFP4 with
-        // mid-prefill rmsNorm. We do NOT merge config.json's per-layer
-        // dict here because that dict can be HF-tooling-stale (claims
-        // `(gs=32, bits=8)` for layers actually packed at `(gs=64,
-        // bits=4)`) and would re-introduce the wrong values.
+        // mid-prefill rmsNorm. Config.json's per-layer dictionary is passed
+        // through as evidence, but the shape walk accepts an entry only when
+        // it is geometrically self-consistent and no exact manifest or
+        // narrowly defined semantic-width constraint has higher precedence.
         let hiddenHint = readHiddenSizeHint(at: modelDirectory)
         let hiddenSizePerLayerInputHint = readHiddenSizePerLayerInputHint(at: modelDirectory)
         let linearAttnValueDimHint = readLinearAttnValueDimHint(at: modelDirectory)

--- a/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
@@ -1427,6 +1427,332 @@ struct MTPRuntimeFocusedTests {
         #expect(inferred?.perLayerQuantization["language_model.model.embed_tokens"] == nil)
     }
 
+    @Test("JANG hidden anchor overrides stale quantization metadata")
+    func jangHiddenAnchorOverridesStaleQuantizationMetadata() {
+        FocusedMLXTestSupport.withLock {
+            let base = "model.embed_tokens"
+            let weights: [String: MLXArray] = [
+                "\(base).weight": MLXArray.zeros([200_064, 384], dtype: .uint32),
+                "\(base).scales": MLXArray.zeros([200_064, 24], dtype: .float16),
+                "\(base).biases": MLXArray.zeros([200_064, 24], dtype: .float16),
+            ]
+            let stale = BaseConfiguration.PerLayerQuantization(
+                quantization: BaseConfiguration.Quantization(
+                    groupSize: 128, bits: 8, mode: .affine),
+                perLayerQuantization: [
+                    base: .quantize(BaseConfiguration.Quantization(
+                        groupSize: 64, bits: 8, mode: .affine))
+                ])
+
+            let inferred = JangLoader.inferPerLayerQuantization(
+                weights: weights,
+                jangConfig: JangConfig(
+                    quantization: JangQuantization(
+                        blockSize: 128,
+                        bitWidthsUsed: [3, 4, 8])),
+                hiddenSizeHint: 3_072,
+                validInDims: [1_536, 3_072],
+                declaredDefaultQuantization: stale.quantization,
+                declaredPerLayerQuantization: stale)
+
+            guard case .quantize(let actual)? = inferred.perLayerQuantization[base] else {
+                Issue.record("Expected shape-derived hidden-anchor quantization override")
+                return
+            }
+            #expect(actual.bits == 4)
+            #expect(actual.groupSize == 128)
+        }
+    }
+
+    @Test("JANG hidden-input projections override width-colliding metadata")
+    func jangHiddenInputProjectionsOverrideWidthCollidingMetadata() {
+        FocusedMLXTestSupport.withLock {
+            let gate = "model.layers.0.block_sparse_moe.switch_mlp.gate_proj"
+            let up = "model.layers.0.block_sparse_moe.switch_mlp.up_proj"
+            let sharedGate = "model.layers.0.mlp.shared_experts.gate_proj"
+            let sharedUp = "model.layers.0.mlp.shared_experts.up_proj"
+            var weights = [String: MLXArray]()
+            for base in [gate, up, sharedGate, sharedUp] {
+                weights["\(base).weight"] = MLXArray.zeros(
+                    [256, 1_536, 288], dtype: .uint32)
+                weights["\(base).scales"] = MLXArray.zeros(
+                    [256, 1_536, 24], dtype: .float16)
+                weights["\(base).biases"] = MLXArray.zeros(
+                    [256, 1_536, 24], dtype: .float16)
+            }
+            let staleProjection = BaseConfiguration.Quantization(
+                groupSize: 64, bits: 6, mode: .affine)
+            let declared = BaseConfiguration.PerLayerQuantization(
+                quantization: BaseConfiguration.Quantization(
+                    groupSize: 128, bits: 8, mode: .affine),
+                perLayerQuantization: [
+                    gate: .quantize(staleProjection),
+                    up: .quantize(staleProjection),
+                    sharedGate: .quantize(staleProjection),
+                    sharedUp: .quantize(staleProjection),
+                ])
+
+            let inferred = JangLoader.inferPerLayerQuantization(
+                weights: weights,
+                jangConfig: JangConfig(
+                    quantization: JangQuantization(
+                        blockSize: 128,
+                        bitWidthsUsed: [3, 4, 8])),
+                hiddenSizeHint: 3_072,
+                expertIntermediateSizeHint: 1_536,
+                validInDims: [1_536, 3_072],
+                declaredDefaultQuantization: declared.quantization,
+                declaredPerLayerQuantization: declared)
+
+            for base in [gate, up, sharedGate, sharedUp] {
+                guard case .quantize(let actual)? = inferred.perLayerQuantization[base] else {
+                    Issue.record("Expected hidden-width override for \(base)")
+                    continue
+                }
+                #expect(actual.bits == 3)
+                #expect(actual.groupSize == 128)
+            }
+        }
+    }
+
+    @Test("JANG vision position embedding does not inherit language hidden width")
+    func jangVisionPositionEmbeddingDoesNotInheritLanguageHiddenWidth() {
+        FocusedMLXTestSupport.withLock {
+            let base = "visual.pos_embed"
+            let weights: [String: MLXArray] = [
+                "\(base).weight": MLXArray.zeros([16, 384], dtype: .uint32),
+                "\(base).scales": MLXArray.zeros([16, 24], dtype: .float16),
+                "\(base).biases": MLXArray.zeros([16, 24], dtype: .float16),
+            ]
+            let declared = BaseConfiguration.Quantization(
+                groupSize: 64, bits: 8, mode: .affine)
+
+            let inferred = JangLoader.inferPerLayerQuantization(
+                weights: weights,
+                jangConfig: JangConfig(
+                    quantization: JangQuantization(
+                        blockSize: 64,
+                        bitWidthsUsed: [4, 8])),
+                hiddenSizeHint: 3_072,
+                validInDims: [1_536, 3_072],
+                declaredDefaultQuantization: declared)
+
+            guard case .quantize(let actual)? = inferred.perLayerQuantization[base] else {
+                Issue.record("Expected generic vision position-embedding quantization")
+                return
+            }
+            #expect(actual.bits == 8)
+            #expect(actual.groupSize == 64)
+        }
+    }
+
+    @Test("JANG declared skip blocks generic metadata before specialized geometry")
+    func jangDeclaredSkipBlocksGenericMetadataBeforeSpecializedGeometry() {
+        FocusedMLXTestSupport.withLock {
+            let base = "model.layers.0.linear_attn.out_proj"
+            let weights: [String: MLXArray] = [
+                "\(base).weight": MLXArray.zeros([16, 384], dtype: .uint32),
+                "\(base).scales": MLXArray.zeros([16, 24], dtype: .float16),
+            ]
+            let declared = BaseConfiguration.PerLayerQuantization(
+                quantization: BaseConfiguration.Quantization(
+                    groupSize: 64, bits: 8, mode: .affine),
+                perLayerQuantization: [base: .skip])
+
+            let inferred = JangLoader.inferPerLayerQuantization(
+                weights: weights,
+                jangConfig: JangConfig(
+                    quantization: JangQuantization(
+                        blockSize: 64,
+                        bitWidthsUsed: [4, 8])),
+                linearAttnValueDimHint: 3_072,
+                validInDims: [1_536, 3_072],
+                declaredDefaultQuantization: declared.quantization,
+                declaredPerLayerQuantization: declared)
+
+            guard case .quantize(let actual)? = inferred.perLayerQuantization[base] else {
+                Issue.record("Expected specialized geometry after the declared skip")
+                return
+            }
+            #expect(actual.bits == 4)
+            #expect(actual.groupSize == 128)
+        }
+    }
+
+    @Test("JANG declared skip wins across contradictory path aliases")
+    func jangDeclaredSkipWinsAcrossContradictoryPathAliases() {
+        FocusedMLXTestSupport.withLock {
+            let base = "language_model.model.layers.0.linear_attn.out_proj"
+            let alias = "model.layers.0.linear_attn.out_proj"
+            let weights: [String: MLXArray] = [
+                "\(base).weight": MLXArray.zeros([16, 384], dtype: .uint32),
+                "\(base).scales": MLXArray.zeros([16, 24], dtype: .float16),
+            ]
+            let declared = BaseConfiguration.PerLayerQuantization(
+                quantization: BaseConfiguration.Quantization(
+                    groupSize: 64, bits: 8, mode: .affine),
+                perLayerQuantization: [
+                    base: .quantize(BaseConfiguration.Quantization(
+                        groupSize: 64, bits: 8, mode: .affine)),
+                    alias: .skip,
+                ])
+
+            let inferred = JangLoader.inferPerLayerQuantization(
+                weights: weights,
+                jangConfig: JangConfig(
+                    quantization: JangQuantization(
+                        blockSize: 64,
+                        bitWidthsUsed: [4, 8])),
+                linearAttnValueDimHint: 3_072,
+                validInDims: [1_536, 3_072],
+                declaredDefaultQuantization: declared.quantization,
+                declaredPerLayerQuantization: declared)
+
+            guard case .quantize(let actual)? = inferred.perLayerQuantization[base] else {
+                Issue.record("Expected specialized geometry after the aliased skip")
+                return
+            }
+            #expect(actual.bits == 4)
+            #expect(actual.groupSize == 128)
+        }
+    }
+
+    @Test("JANG hidden anchor preserves declaration when hidden width is unrealizable")
+    func jangHiddenAnchorPreservesDeclarationWhenHiddenWidthIsUnrealizable() {
+        FocusedMLXTestSupport.withLock {
+            let base = "model.embed_tokens"
+            let weights: [String: MLXArray] = [
+                "\(base).weight": MLXArray.zeros([16, 256], dtype: .uint32),
+                "\(base).scales": MLXArray.zeros([16, 16], dtype: .float16),
+            ]
+            let declared = BaseConfiguration.PerLayerQuantization(
+                quantization: BaseConfiguration.Quantization(
+                    groupSize: 64, bits: 8, mode: .affine),
+                perLayerQuantization: [
+                    base: .quantize(BaseConfiguration.Quantization(
+                        groupSize: 128, bits: 4, mode: .affine))
+                ])
+
+            let inferred = JangLoader.inferPerLayerQuantization(
+                weights: weights,
+                jangConfig: JangConfig(
+                    quantization: JangQuantization(
+                        blockSize: 64,
+                        bitWidthsUsed: [4, 8])),
+                hiddenSizeHint: 3_072,
+                validInDims: [2_048, 3_072],
+                declaredDefaultQuantization: declared.quantization,
+                declaredPerLayerQuantization: declared)
+
+            guard case .quantize(let actual)? = inferred.perLayerQuantization[base] else {
+                Issue.record("Expected the realizable declaration to be preserved")
+                return
+            }
+            #expect(actual.bits == 4)
+            #expect(actual.groupSize == 128)
+        }
+    }
+
+    @Test("JANG exact manifest precedes hidden-anchor semantics")
+    func jangExactManifestPrecedesHiddenAnchorSemantics() {
+        FocusedMLXTestSupport.withLock {
+            let base = "model.embed_tokens"
+            let weights: [String: MLXArray] = [
+                "\(base).weight": MLXArray.zeros([16, 384], dtype: .uint32),
+                "\(base).scales": MLXArray.zeros([16, 24], dtype: .float16),
+            ]
+            let exact = BaseConfiguration.Quantization(
+                groupSize: 64, bits: 8, mode: .affine)
+
+            let inferred = JangLoader.inferPerLayerQuantization(
+                weights: weights,
+                jangConfig: JangConfig(
+                    quantization: JangQuantization(
+                        blockSize: 128,
+                        bitWidthsUsed: [4, 8])),
+                hiddenSizeHint: 3_072,
+                validInDims: [1_536, 3_072],
+                declaredManifestQuantization: [base: exact])
+
+            guard case .quantize(let actual)? = inferred.perLayerQuantization[base] else {
+                Issue.record("Expected exact manifest quantization")
+                return
+            }
+            #expect(actual == exact)
+        }
+    }
+
+    @Test("JANG missing hidden-size hint disables semantic override")
+    func jangMissingHiddenSizeHintDisablesSemanticOverride() {
+        FocusedMLXTestSupport.withLock {
+            let base = "model.embed_tokens"
+            let weights: [String: MLXArray] = [
+                "\(base).weight": MLXArray.zeros([16, 384], dtype: .uint32),
+                "\(base).scales": MLXArray.zeros([16, 24], dtype: .float16),
+            ]
+            let declared = BaseConfiguration.PerLayerQuantization(
+                quantization: BaseConfiguration.Quantization(
+                    groupSize: 128, bits: 4, mode: .affine),
+                perLayerQuantization: [
+                    base: .quantize(BaseConfiguration.Quantization(
+                        groupSize: 64, bits: 8, mode: .affine))
+                ])
+
+            let inferred = JangLoader.inferPerLayerQuantization(
+                weights: weights,
+                jangConfig: JangConfig(
+                    quantization: JangQuantization(
+                        blockSize: 128,
+                        bitWidthsUsed: [4, 8])),
+                validInDims: [1_536, 3_072],
+                declaredDefaultQuantization: declared.quantization,
+                declaredPerLayerQuantization: declared)
+
+            guard case .quantize(let actual)? = inferred.perLayerQuantization[base] else {
+                Issue.record("Expected declared quantization without a hidden-size hint")
+                return
+            }
+            #expect(actual.bits == 8)
+            #expect(actual.groupSize == 64)
+        }
+    }
+
+    @Test("JANG lm_head uses uniquely realizable hidden width")
+    func jangLMHeadUsesUniquelyRealizableHiddenWidth() {
+        FocusedMLXTestSupport.withLock {
+            let base = "lm_head"
+            let weights: [String: MLXArray] = [
+                "\(base).weight": MLXArray.zeros([200_064, 384], dtype: .uint32),
+                "\(base).scales": MLXArray.zeros([200_064, 24], dtype: .float16),
+            ]
+            let stale = BaseConfiguration.PerLayerQuantization(
+                quantization: BaseConfiguration.Quantization(
+                    groupSize: 128, bits: 8, mode: .affine),
+                perLayerQuantization: [
+                    base: .quantize(BaseConfiguration.Quantization(
+                        groupSize: 64, bits: 8, mode: .affine))
+                ])
+
+            let inferred = JangLoader.inferPerLayerQuantization(
+                weights: weights,
+                jangConfig: JangConfig(
+                    quantization: JangQuantization(
+                        blockSize: 128,
+                        bitWidthsUsed: [4, 8])),
+                hiddenSizeHint: 3_072,
+                validInDims: [1_536, 3_072],
+                declaredDefaultQuantization: stale.quantization,
+                declaredPerLayerQuantization: stale)
+
+            guard case .quantize(let actual)? = inferred.perLayerQuantization[base] else {
+                Issue.record("Expected hidden-width lm_head quantization")
+                return
+            }
+            #expect(actual.bits == 4)
+            #expect(actual.groupSize == 128)
+        }
+    }
+
     @Test("shape-walk quantization uses Gemma4 PLE input width")
     func shapeWalkQuantizationUsesGemma4PLEInputWidth() {
         let projection = "language_model.model.layers.0.per_layer_projection"


### PR DESCRIPTION
## Summary

- prefer exact language `hidden_size` geometry for `embed_tokens`, `lm_head`, and known hidden-input projections before stale but width-colliding per-path metadata
- keep exact tensor manifests first and keep valid declarations when the semantic width is absent or cannot be represented by the packed tensors
- stop treating unrelated `*embed` paths such as `visual.pos_embed` as language anchors
- make aliased `.skip` entries deterministic and cover both `shared_expert` and `shared_experts` gate/up spellings
- add focused regressions for anchor, manifest, alias, vision, routed-expert, and shared-expert precedence

## What went wrong

The affected model contains stale per-path quantization settings that still look valid because they match a different model dimension. The loader accepted those settings before the projection's known 3,072-wide input, expanded some weights to 1,536 columns, and crashed on the first forward pass. This change makes the known semantic input width win when the packed tensor can represent it, while keeping exact tensor manifests first.

## Affected model and reproduction

The failure was reproduced with [`dealignai/MiniMax-M2.7-JANG_3L-CRACK`](https://huggingface.co/dealignai/MiniMax-M2.7-JANG_3L-CRACK/tree/1f37a1f2c244c152b1e20bba7a7414d025ebfc01), pinned at revision `1f37a1f2c244c152b1e20bba7a7414d025ebfc01`. The pinned download is 95,169,214,157 bytes across 126 weight shards, so allow at least 100 GB of free disk space. Validation used macOS on a 128 GB Apple-silicon Mac; lower-memory systems were not tested.

The following commands reproduce the failure on the PR's public base commit and then verify the fix. They require Xcode, `gh`, and `uvx`:

```bash
MODEL_DIR="$(
  env HF_XET_HIGH_PERFORMANCE=1 HF_HUB_DOWNLOAD_TIMEOUT=120 \
    uvx --from huggingface_hub hf download \
    dealignai/MiniMax-M2.7-JANG_3L-CRACK \
    --revision 1f37a1f2c244c152b1e20bba7a7414d025ebfc01
)"

run_repro() {
  local cache_dir
  cache_dir="$(mktemp -d /tmp/vmlx-pr159-repro-cache.XXXXXX)"
  caffeinate -dims .build/debug/mlxpress "$MODEL_DIR" \
    'Reply with exactly OK.' \
    --max-tokens 4 --temp 0 --thinking off \
    --expect OK --min-visible-chars 1 --min-generation-tokens 1 \
    --disk-cache-dir "$cache_dir" \
    --activity-gate 40 --print-memory
}

# Reproduce the failure on the PR base.
git switch --detach 2bfa9caffb951b14a76c869353abe1ff230668bd
git submodule update --init --recursive
swift build --product mlxpress
./Scripts/prepare-mlx-metal.sh
run_repro

# Verify the fix on this PR.
gh pr checkout 159
git submodule update --init --recursive
swift build --product mlxpress
./Scripts/prepare-mlx-metal.sh
run_repro
```

Observed base result at `2bfa9caffb951b14a76c869353abe1ff230668bd`:

```text
Fatal error: [gather_qmm] Last dimension of first input with shape (..., 3072)
does not match the expanded quantized matrix (1536, 1536) computed from shape
(256,1536,288) with group_size=64, bits=6 and transpose=true
```

The base run exited 133 before producing a token. The fixed run at `6268889066384c373ef3841d3a9acda7f8fd40b3` corrected 186 projections from 6-bit/group-64 to 3-bit/group-128 and generated `OK` without the first-forward failure.

## Proven failure mechanism

MiniMax-M2.7 JANG_3L exposed two instances of the same loader error.

For `embed_tokens`, a packed width of 384 with 24 scale groups can describe either 4-bit/group-128 at the required 3,072 hidden width or stale 8-bit/group-64 metadata at the unrelated 1,536 intermediate width.

For routed `gate_proj` and `up_proj`, packed tensors shaped `[256, 1536, 288]` with 24 scale groups require 3-bit/group-128 for their 3,072-wide hidden input. Stale 6-bit/group-64 metadata also looks self-consistent because it expands to the unrelated 1,536 expert width.

Four evidence classes support the precedence error as the mechanism:

1. **Source:** the old order accepted a path declaration when its unpacked width appeared anywhere in the model-wide `validInDims` set, before applying the projection's known input width.
2. **Arithmetic:** `288 * 32 / 6 = 1536` with `1536 / 24 = 64`, while `288 * 32 / 3 = 3072` with `3072 / 24 = 128`.
3. **Runtime:** the real model failed on first forward when `gather_qmm` received a 3,072-wide activation and a matrix expanded as 1,536 from 6-bit/group-64.
4. **Intervention:** the width-collision regression returned 6/64 before the reorder and 3/128 after it. The exact committed tree then completed real generation without the `gather_qmm` failure.

Rivals considered include corrupt tensors, a wrong hidden-size hint, an exact manifest, MLXPress/mmap behavior, and a downstream/common-cause failure. The weight/scale geometry is internally consistent; the model source fixes the projection input at 3,072; no manifest overrides these paths; and changing only the precedence clears both the focused failure and first-forward crash. Residual: the live smoke is one short turn, so it proves this quantization geometry and first-forward path, not multi-turn production readiness.

## Precedence

1. exact tensor manifest
2. exact language hidden-width geometry for `embed_tokens` and `lm_head`
3. exact language hidden-width geometry for known hidden-input projections
4. valid path-specific metadata
5. valid generic or top-level declaration
6. existing specialized and shape-walk fallbacks

## Validation

- `swift test --filter MTPRuntimeFocusedTests`: **76/76 passed**
- counterfactual hidden-anchor test against the old implementation: **failed as expected** at 8/64 instead of 4/128
- width-collision test before the projection reorder: **failed as expected** at 6/64 instead of 3/128
- final width-collision coverage: routed gate/up plus plural shared-expert gate/up, all at 3/128
- SHA-labeled real MiniMax-M2.7 JANG_3L smoke on `6268889066384c373ef3841d3a9acda7f8fd40b3`: expected `OK`, 186 corrected 6/64 -> 3/128 projections, no first-forward failure, 8.0% peak physical-footprint ratio
- `git diff --check`: clean

A serial broader run passed its XCTest phase: **1,063 tests, 45 skipped, 0 failures** after excluding three observed failures outside this diff. The later Swift Testing phase reported failures in other source-contract/runtime tests and aborted in an unchanged prompt-tail test. The full package suite is therefore **not reported green**. The stale README assertion was also reproduced on `origin/main`; the remaining suite failures were not repaired or attributed to this PR.

## External review

- Grok 4.5 high found the missing plural `shared_experts` gate/up spelling; the regression failed before that addition and passed after it. Its clean-commit rereview found no remaining actionable issue.
- Fable max verified manifest priority, semantic-width priority, singular/plural shared-expert gate/up coverage, and skip/alias behavior. It found no demonstrated defect in those properties.

Fable raised two residual hypotheses: suffix-only matching could affect a quantized vision projection whose packed geometry also realizes the language hidden width, and other known-width output/down projections still remain declaration-first. A scan of the available JANG VLM bundles found no vision tensor that both matched this semantic suffix class and realized the language hidden width. No code change is made for either unproven mechanism. Shared-expert down projections also need a role-specific intermediate-width hint before plural matching can be promoted safely.
