### PR TITLE
Fix Bonsai hybrid cache replay and disk quota

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -2674,6 +2674,25 @@ public actor BatchEngine {
                 cache.map(\.offset).max() ?? 0 >= tokenCount
             }
 
+            let sharedPromptStripBoundary: Int? = {
+                guard ProcessInfo.processInfo.environment["VMLX_HYBRID_STRIPPED_STORE"] != "0",
+                    coordinator.isHybrid,
+                    let turnStartToken = coordinator.genPromptSuffixTokens.first,
+                    let stripAt = promptTokens.lastIndex(of: turnStartToken),
+                    stripAt > 0,
+                    stripAt < promptTokens.count - 1,
+                    slot.originalInput.canCaptureHybridStripBoundary(
+                        promptTokenIds: promptTokens,
+                        boundary: stripAt)
+                else { return nil }
+                return stripAt
+            }()
+            var sharedPromptRederivedStates: [Int: [MLXArray]]?
+            let sharedPromptAdditionalBoundaries = Array(Set(
+                slot.originalInput.cachePrefixTokenCounts
+                    + [sharedPromptStripBoundary].compactMap { $0 }
+            ))
+
             func storeCacheEntry(tokens: [Int], snapshot: [KVCache], label: String) {
                 guard !tokens.isEmpty else { return }
                 // Serialising the cache materialises it again (host `Data` for the
@@ -2710,6 +2729,23 @@ public actor BatchEngine {
                     if coordinator.config.enableSSMReDerive &&
                         !slot.originalInput.hasMediaContent
                     {
+                        let isPromptPrefix = tokens.count <= promptTokens.count
+                            && tokens.elementsEqual(promptTokens.prefix(tokens.count))
+                        if isPromptPrefix {
+                            if sharedPromptRederivedStates == nil {
+                                sharedPromptRederivedStates =
+                                    reDeriveAndStoreSSMStatesAtPromptBoundaries(
+                                        coordinator: coordinator,
+                                        model: context.model,
+                                        promptTokenIds: promptTokens,
+                                        mediaSalt: slot.mediaSalt,
+                                        additionalBoundaries: sharedPromptAdditionalBoundaries,
+                                        prefillStepSize: slot.parameters.prefillStepSize)
+                            }
+                            if let shared = sharedPromptRederivedStates?[tokens.count] {
+                                return shared
+                            }
+                        }
                         return reDeriveAndStoreSSMStatesForPromptBoundaries(
                             coordinator: coordinator,
                             model: context.model,
@@ -2893,13 +2929,7 @@ public actor BatchEngine {
                 // the store entirely (the re-derive here is the only writer).
                 if ProcessInfo.processInfo.environment["VMLX_HYBRID_STRIPPED_STORE"] != "0",
                    coordinator.isHybrid,
-                   let turnStartToken = coordinator.genPromptSuffixTokens.first,
-                   let stripAt = promptTokens.lastIndex(of: turnStartToken),
-                   stripAt > 0,
-                   stripAt < promptTokens.count - 1,
-                   slot.originalInput.canCaptureHybridStripBoundary(
-                       promptTokenIds: promptTokens,
-                       boundary: stripAt)
+                   let stripAt = sharedPromptStripBoundary
                 {
                     let strippedTokens = Array(promptTokens.prefix(stripAt))
                     if let snapshot = boundarySnapshot(

--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -2076,7 +2076,8 @@ public actor BatchEngine {
                             ssmStates: ssmStates,
                             tokens: promptTokens,
                             boundary: promptTokens.count,
-                            mediaSalt: slot.mediaSalt
+                            mediaSalt: slot.mediaSalt,
+                            persistToDisk: false
                         )
                         Self.logger.debug(
                             "Slot \(slot.id.description, privacy: .public): stored SSM seed at boundary=\(promptTokens.count) (\(ssmStates.count) state arrays)"
@@ -2740,6 +2741,7 @@ public actor BatchEngine {
                                         promptTokenIds: promptTokens,
                                         mediaSalt: slot.mediaSalt,
                                         additionalBoundaries: sharedPromptAdditionalBoundaries,
+                                        persistCapturedStatesToDisk: false,
                                         prefillStepSize: slot.parameters.prefillStepSize)
                             }
                             if let shared = sharedPromptRederivedStates?[tokens.count] {
@@ -2751,6 +2753,7 @@ public actor BatchEngine {
                             model: context.model,
                             promptTokenIds: tokens,
                             mediaSalt: slot.mediaSalt,
+                            persistCapturedStatesToDisk: false,
                             prefillStepSize: slot.parameters.prefillStepSize)
                     }
                     return extractSSMStates(from: snapshot)

--- a/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
@@ -4,6 +4,13 @@ import Foundation
 @preconcurrency import MLX
 import os
 
+/// Serializes process-wide combined disk-quota reconciliation. Individual KV
+/// and companion stores already own their IO locks; this lock only protects
+/// the cross-store snapshot/eviction decision.
+private enum CombinedDiskCacheQuotaLock {
+    static let shared = OSAllocatedUnfairLock()
+}
+
 // MARK: - CacheDetail
 
 /// Identifies which cache tier satisfied a lookup.
@@ -184,6 +191,8 @@ public final class CacheCoordinator: @unchecked Sendable {
                 modelKey: config.modelKey,
                 maxBytes: ssmMaxBytes)
         }
+
+        enforceCombinedDiskQuota()
     }
 
     // MARK: - Hybrid Flag
@@ -532,6 +541,7 @@ public final class CacheCoordinator: @unchecked Sendable {
             tokens: tokens,
             boundary: boundary,
             mediaSalt: mediaSalt)
+        enforceCombinedDiskQuota()
         return folded
     }
 
@@ -675,6 +685,115 @@ public final class CacheCoordinator: @unchecked Sendable {
                 mediaSalt: mediaSalt
             )
         }
+
+        enforceCombinedDiskQuota()
+    }
+
+    /// Enforce `diskCacheMaxGB` across the whole persistent cache root, not
+    /// once for KV payloads and again for recurrent companion payloads.
+    ///
+    /// New companion sidecars record their matching KV hash, allowing an old
+    /// hybrid entry to be evicted as a unit. Legacy sidecars remain readable;
+    /// under quota pressure they retire before indexed KV because they cannot
+    /// prove which durable KV payload can still reach them. Companions whose
+    /// recorded KV payload is already gone are removed immediately.
+    func enforceCombinedDiskQuota() {
+        guard config.enableDiskCache,
+              let diskCache,
+              let companionStore = ssmStateCache.diskStore
+        else { return }
+
+        let maxBytes = Int64(max(1, Int(config.diskCacheMaxGB * 1_073_741_824)))
+        CombinedDiskCacheQuotaLock.shared.lock()
+        defer { CombinedDiskCacheQuotaLock.shared.unlock() }
+
+        let kvEntries = diskCache.quotaEntries()
+        let kvHashes = Set(kvEntries.map(\.hash))
+        var companionEntries = companionStore.quotaEntries()
+
+        let orphaned = companionEntries.filter {
+            guard let kvHash = $0.kvHash else { return false }
+            return !kvHashes.contains(kvHash)
+        }
+        if !orphaned.isEmpty {
+            companionStore.removeQuotaEntries(hashes: Set(orphaned.map(\.hash)))
+            let orphanHashes = Set(orphaned.map(\.hash))
+            companionEntries.removeAll { orphanHashes.contains($0.hash) }
+        }
+
+        struct EvictionGroup {
+            let sortKey: String
+            let kvHashes: Set<String>
+            let companionHashes: Set<String>
+            let bytes: Int64
+            let createdAt: Date
+            /// Legacy companions predate the KV-link sidecar. They cannot
+            /// prove that an indexed KV payload can still reach them, so quota
+            /// pressure retires them before directly addressable KV groups.
+            let priority: Int
+        }
+
+        let companionsByKVHash = Dictionary(grouping: companionEntries.compactMap { entry in
+            entry.kvHash.map { ($0, entry) }
+        }, by: { $0.0 })
+        var groupedCompanionHashes = Set<String>()
+        var groups: [EvictionGroup] = []
+
+        for kv in kvEntries {
+            let companions = companionsByKVHash[kv.hash]?.map(\.1) ?? []
+            groupedCompanionHashes.formUnion(companions.map(\.hash))
+            groups.append(EvictionGroup(
+                sortKey: "kv:\(kv.hash)",
+                kvHashes: [kv.hash],
+                companionHashes: Set(companions.map(\.hash)),
+                bytes: kv.bytes + companions.reduce(0) { $0 + $1.bytes },
+                createdAt: companions.reduce(kv.createdAt) {
+                    min($0, $1.modifiedAt)
+                },
+                priority: 1))
+        }
+
+        for companion in companionEntries
+        where !groupedCompanionHashes.contains(companion.hash)
+        {
+            groups.append(EvictionGroup(
+                sortKey: "ssm:\(companion.hash)",
+                kvHashes: [],
+                companionHashes: [companion.hash],
+                bytes: companion.bytes,
+                createdAt: companion.modifiedAt,
+                priority: companion.kvHash == nil ? 0 : 1))
+        }
+
+        let totalBefore = groups.reduce(Int64(0)) { $0 + $1.bytes }
+        guard totalBefore > maxBytes else { return }
+
+        var remaining = totalBefore
+        var evictKV = Set<String>()
+        var evictCompanion = Set<String>()
+        for group in groups.sorted(by: {
+            if $0.priority != $1.priority { return $0.priority < $1.priority }
+            if $0.createdAt == $1.createdAt { return $0.sortKey < $1.sortKey }
+            return $0.createdAt < $1.createdAt
+        }) where remaining > maxBytes {
+            evictKV.formUnion(group.kvHashes)
+            evictCompanion.formUnion(group.companionHashes)
+            remaining -= group.bytes
+        }
+
+        diskCache.removeQuotaEntries(hashes: evictKV)
+        companionStore.removeQuotaEntries(hashes: evictCompanion)
+
+        let legacyCompanionEvicted = companionEntries.reduce(into: 0) { count, entry in
+            if entry.kvHash == nil, evictCompanion.contains(entry.hash) {
+                count += 1
+            }
+        }
+
+        if ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1" {
+            FileHandle.standardError.write(Data(
+                "[vmlx][cache/disk-quota] before=\(totalBefore) after=\(max(0, remaining)) max=\(maxBytes) kvEvicted=\(evictKV.count) companionEvicted=\(evictCompanion.count) legacyCompanionEvicted=\(legacyCompanionEvicted) orphanCompanionEvicted=\(orphaned.count)\n".utf8))
+        }
     }
 
     /// Split full-sequence per-layer KV data into block-sized chunks.
@@ -736,5 +855,6 @@ public final class CacheCoordinator: @unchecked Sendable {
     public func clear() {
         releaseVolatile()
         diskCache?.clear()
+        ssmStateCache.diskStore?.clear()
     }
 }

--- a/Libraries/MLXLMCommon/Cache/DiskCache.swift
+++ b/Libraries/MLXLMCommon/Cache/DiskCache.swift
@@ -14,6 +14,14 @@ public struct DiskCacheStats: Sendable {
     public let maxSizeBytes: Int
 }
 
+/// One indexed KV payload used by the coordinator's shared disk-quota pass.
+/// `createdAt` mirrors the existing oldest-entry eviction order.
+struct DiskCacheQuotaEntry: Sendable {
+    let hash: String
+    let bytes: Int64
+    let createdAt: Date
+}
+
 /// Process-wide guard for MLX safetensors disk-cache IO.
 ///
 /// Each model owns its own ``DiskCache`` instance, so an instance-local lock
@@ -307,6 +315,53 @@ public final class DiskCache: @unchecked Sendable {
         }
         sqlite3_finalize(stmt)
         return counts
+    }
+
+    /// Snapshot indexed KV payloads for the coordinator's combined KV +
+    /// recurrent-companion quota. Database/WAL bookkeeping is intentionally
+    /// excluded, matching this cache's existing `SUM(file_size)` contract.
+    func quotaEntries() -> [DiskCacheQuotaEntry] {
+        guard let db else { return [] }
+        lock.lock()
+        defer { lock.unlock() }
+
+        var entries: [DiskCacheQuotaEntry] = []
+        var stmt: OpaquePointer?
+        let sql = "SELECT hash, file_size, created_at FROM cache_entries"
+        guard sqlite3_prepare_v2(db, sql, -1, &stmt, nil) == SQLITE_OK else {
+            return []
+        }
+        defer { sqlite3_finalize(stmt) }
+
+        while sqlite3_step(stmt) == SQLITE_ROW {
+            guard let cHash = sqlite3_column_text(stmt, 0) else { continue }
+            let hash = String(cString: cHash)
+            let bytes = max(0, sqlite3_column_int64(stmt, 1))
+            let julianDay = sqlite3_column_double(stmt, 2)
+            let unixTime = (julianDay - 2_440_587.5) * 86_400
+            entries.append(DiskCacheQuotaEntry(
+                hash: hash,
+                bytes: bytes,
+                createdAt: Date(timeIntervalSince1970: unixTime)))
+        }
+        return entries
+    }
+
+    /// Remove indexed KV payloads selected by the combined quota pass.
+    /// The process-wide IO lock prevents another cache instance from loading
+    /// a file while it is removed; the SQLite row is deleted atomically with
+    /// respect to this instance's fetch/candidate queries.
+    func removeQuotaEntries(hashes: Set<String>) {
+        guard !hashes.isEmpty else { return }
+        MLXDiskCacheIOLock.shared.lock()
+        defer { MLXDiskCacheIOLock.shared.unlock() }
+        lock.lock()
+        defer { lock.unlock() }
+
+        for hash in hashes {
+            try? FileManager.default.removeItem(at: safetensorsURL(for: hash))
+            _deleteEntryLocked(hash: hash)
+        }
     }
 
     /// Remove all cached entries and safetensors files.

--- a/Libraries/MLXLMCommon/Cache/SSMCompanionDiskStore.swift
+++ b/Libraries/MLXLMCommon/Cache/SSMCompanionDiskStore.swift
@@ -41,6 +41,16 @@ import Foundation
 import MLX
 import os
 
+/// One recurrent companion payload used by the coordinator's shared quota.
+/// New sidecars carry the hash of their matching KV payload so eviction can
+/// remove an old hybrid entry as one unit instead of orphaning half of it.
+struct SSMCompanionQuotaEntry: Sendable {
+    let hash: String
+    let kvHash: String?
+    let bytes: Int64
+    let modifiedAt: Date
+}
+
 /// Disk-backed extension to the in-memory `SSMStateCache`. See header
 /// comment for storage format + concurrency model.
 public final class SSMCompanionDiskStore: @unchecked Sendable {
@@ -123,6 +133,10 @@ public final class SSMCompanionDiskStore: @unchecked Sendable {
             "num_states": ssmStates.count,
             "model_key": modelKey ?? "",
             "boundary": boundary,
+            "kv_hash": DiskCache.hashTokens(
+                Array(tokens.prefix(boundary)),
+                modelKey: modelKey,
+                mediaSalt: mediaSalt),
         ]
         let sidecarData = try JSONSerialization.data(
             withJSONObject: sidecar, options: [.sortedKeys])
@@ -206,6 +220,36 @@ public final class SSMCompanionDiskStore: @unchecked Sendable {
         }
     }
 
+    /// Snapshot recurrent payloads for the coordinator's combined KV +
+    /// companion quota. Legacy sidecars have no `kv_hash`; they remain valid
+    /// for reads, but quota pressure retires them before indexed KV because
+    /// they cannot prove which durable KV payload can still reach them.
+    func quotaEntries() -> [SSMCompanionQuotaEntry] {
+        lock.lock()
+        defer { lock.unlock() }
+        return diskEntriesLocked().map { hash, entry in
+            SSMCompanionQuotaEntry(
+                hash: hash,
+                kvHash: entry.kvHash,
+                bytes: Int64(entry.bytes),
+                modifiedAt: entry.modified)
+        }
+    }
+
+    /// Remove recurrent payloads selected by the combined quota pass.
+    func removeQuotaEntries(hashes: Set<String>) {
+        guard !hashes.isEmpty else { return }
+        MLXDiskCacheIOLock.shared.lock()
+        defer { MLXDiskCacheIOLock.shared.unlock() }
+        lock.lock()
+        defer { lock.unlock() }
+
+        for hash in hashes {
+            try? FileManager.default.removeItem(at: safetensorsURL(for: hash))
+            try? FileManager.default.removeItem(at: sidecarURL(for: hash))
+        }
+    }
+
     // MARK: - Helpers
 
     private func safetensorsURL(for hash: String) -> URL {
@@ -220,18 +264,17 @@ public final class SSMCompanionDiskStore: @unchecked Sendable {
         var urls: [URL] = []
         var bytes: Int = 0
         var modified: Date = .distantPast
+        var kvHash: String?
     }
 
-    private func evictIfNeededLocked() {
-        guard maxBytes > 0 else { return }
+    private func diskEntriesLocked() -> [String: DiskEntry] {
         guard let urls = try? FileManager.default.contentsOfDirectory(
             at: cacheDir,
             includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey],
             options: [.skipsHiddenFiles])
-        else { return }
+        else { return [:] }
 
         var entries: [String: DiskEntry] = [:]
-        var totalBytes = 0
         for url in urls {
             guard let hash = entryHash(for: url) else { continue }
             let values = try? url.resourceValues(forKeys: [
@@ -239,7 +282,6 @@ public final class SSMCompanionDiskStore: @unchecked Sendable {
             ])
             let bytes = values?.fileSize ?? 0
             let modified = values?.contentModificationDate ?? .distantPast
-            totalBytes += bytes
 
             var entry = entries[hash] ?? DiskEntry()
             entry.urls.append(url)
@@ -247,8 +289,23 @@ public final class SSMCompanionDiskStore: @unchecked Sendable {
             if entry.modified == .distantPast || modified < entry.modified {
                 entry.modified = modified
             }
+            if url.pathExtension == "json",
+               let data = try? Data(contentsOf: url),
+               let sidecar = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let kvHash = sidecar["kv_hash"] as? String,
+               !kvHash.isEmpty
+            {
+                entry.kvHash = kvHash
+            }
             entries[hash] = entry
         }
+        return entries
+    }
+
+    private func evictIfNeededLocked() {
+        guard maxBytes > 0 else { return }
+        let entries = diskEntriesLocked()
+        var totalBytes = entries.values.reduce(0) { $0 + $1.bytes }
 
         guard totalBytes > maxBytes else { return }
 

--- a/Libraries/MLXLMCommon/Cache/SSMReDerive.swift
+++ b/Libraries/MLXLMCommon/Cache/SSMReDerive.swift
@@ -337,6 +337,7 @@ public func reDeriveSSMStatesAtBoundaries(
     var out: [Int: [MLXArray]] = [:]
     var cursor = 0
     let step = max(1, prefillStepSize)
+    var needsFreshReplayPreparation = true
 
     for boundary in captureBoundaries {
         while cursor < boundary {
@@ -344,7 +345,36 @@ public func reDeriveSSMStatesAtBoundaries(
             let chunk = Array(tokens[cursor..<end])
             let tokenArray = MLXArray(chunk.map { Int32($0) })
                 .reshaped([1, chunk.count])
-            _ = model.callAsFunction(tokenArray, cache: freshCache)
+
+            if needsFreshReplayPreparation {
+                // A fresh cache is not sufficient to start an independent
+                // replay for every architecture. Qwen 3.5 VL, for example,
+                // keeps MRoPE position arrays on the model object as well as
+                // recurrent state in its cache. Calling `callAsFunction`
+                // directly can therefore slice position IDs left by the
+                // preceding user generation; once that stale array ends, its
+                // sequence dimension is shorter than this replay chunk and
+                // attention fails before the companion state can be stored.
+                //
+                // Route the first chunk through the model's normal `prepare`
+                // contract. Architectures with request-scoped state reset it
+                // there, while default LLM implementations return an
+                // unconsumed token tail that we explicitly forward below.
+                // Subsequent chunks continue through the same fresh cache so
+                // every recorded boundary remains one continuous replay.
+                let input = LMInput(text: LMInput.Text(tokens: tokenArray))
+                let prepared = try model.prepare(
+                    input, cache: freshCache, windowSize: step)
+                if case .tokens(let tail) = prepared, tail.tokens.size > 0 {
+                    let tailInput = tail.tokens.ndim >= 2
+                        ? tail.tokens
+                        : tail.tokens.reshaped([1, tail.tokens.size])
+                    _ = model.callAsFunction(tailInput, cache: freshCache)
+                }
+                needsFreshReplayPreparation = false
+            } else {
+                _ = model.callAsFunction(tokenArray, cache: freshCache)
+            }
             MLX.eval(freshCache)
             cursor = end
             Memory.clearCache()

--- a/Libraries/MLXLMCommon/Cache/SSMReDerive.swift
+++ b/Libraries/MLXLMCommon/Cache/SSMReDerive.swift
@@ -407,6 +407,33 @@ public func reDeriveAndStoreSSMStatesForPromptBoundaries(
     mediaSalt: String? = nil,
     prefillStepSize: Int = 512
 ) -> [MLXArray]? {
+    reDeriveAndStoreSSMStatesAtPromptBoundaries(
+        coordinator: coordinator,
+        model: model,
+        promptTokenIds: promptTokenIds,
+        mediaSalt: mediaSalt,
+        prefillStepSize: prefillStepSize
+    )[promptTokenIds.count]
+}
+
+/// Re-derive one prompt while capturing every companion boundary needed by
+/// all cache entries written for that prompt.
+///
+/// A generation commonly stores both the full rendered prompt and a shorter
+/// generation-prompt-stripped prefix. Replaying each prefix independently is
+/// redundant: both are boundaries of the same token sequence. Callers that
+/// write multiple entries can pass those extra boundary lengths here, share
+/// the returned snapshots, and keep the recurrent state byte-identical to a
+/// single continuous prompt pass.
+@discardableResult
+public func reDeriveAndStoreSSMStatesAtPromptBoundaries(
+    coordinator: CacheCoordinator,
+    model: any LanguageModel,
+    promptTokenIds: [Int],
+    mediaSalt: String? = nil,
+    additionalBoundaries: [Int] = [],
+    prefillStepSize: Int = 512
+) -> [Int: [MLXArray]] {
     func trace(_ message: String) {
         guard ProcessInfo.processInfo.environment["VMLINUX_SSM_REDERIVE_TRACE"] == "1"
             || ProcessInfo.processInfo.environment["VMLX_SSM_REDERIVE_TRACE"] == "1"
@@ -414,9 +441,11 @@ public func reDeriveAndStoreSSMStatesForPromptBoundaries(
         FileHandle.standardError.write(
             Data("[vmlx][cache/ssm-rederive] prompt-boundaries/\(message) hybrid=\(coordinator.isHybrid) promptLen=\(promptTokenIds.count)\n".utf8))
     }
-    guard coordinator.isHybrid, !promptTokenIds.isEmpty else { return nil }
+    guard coordinator.isHybrid, !promptTokenIds.isEmpty else { return [:] }
 
-    var boundaries = Set<Int>()
+    var boundaries = Set(additionalBoundaries.filter {
+        $0 > 0 && $0 <= promptTokenIds.count
+    })
     boundaries.insert(promptTokenIds.count)
     if promptTokenIds.count > 1 {
         boundaries.insert(promptTokenIds.count - 1)
@@ -453,10 +482,10 @@ public func reDeriveAndStoreSSMStatesForPromptBoundaries(
         if !statesByBoundary.isEmpty {
             coordinator.ssmStateCache.markReDeriveFired()
         }
-        return statesByBoundary[promptTokenIds.count]
+        return statesByBoundary
     } catch {
         let line = "[vmlx][cache/ssm-rederive] prompt-boundaries/fail \(error) promptLen=\(promptTokenIds.count)\n"
         FileHandle.standardError.write(Data(line.utf8))
-        return nil
+        return [:]
     }
 }

--- a/Libraries/MLXLMCommon/Cache/SSMReDerive.swift
+++ b/Libraries/MLXLMCommon/Cache/SSMReDerive.swift
@@ -222,7 +222,8 @@ public func captureCleanSSMStateInline(
     coordinator.ssmStateCache.store(
         ssmStates: states,
         tokens: stripped,
-        boundary: stripped.count
+        boundary: stripped.count,
+        persistToDisk: false
     )
     coordinator.ssmStateCache.markReDeriveFired()
     log("ok/captured stateCount=\(states.count)")
@@ -405,6 +406,7 @@ public func reDeriveAndStoreSSMStatesForPromptBoundaries(
     model: any LanguageModel,
     promptTokenIds: [Int],
     mediaSalt: String? = nil,
+    persistCapturedStatesToDisk: Bool = true,
     prefillStepSize: Int = 512
 ) -> [MLXArray]? {
     reDeriveAndStoreSSMStatesAtPromptBoundaries(
@@ -412,6 +414,7 @@ public func reDeriveAndStoreSSMStatesForPromptBoundaries(
         model: model,
         promptTokenIds: promptTokenIds,
         mediaSalt: mediaSalt,
+        persistCapturedStatesToDisk: persistCapturedStatesToDisk,
         prefillStepSize: prefillStepSize
     )[promptTokenIds.count]
 }
@@ -432,6 +435,7 @@ public func reDeriveAndStoreSSMStatesAtPromptBoundaries(
     promptTokenIds: [Int],
     mediaSalt: String? = nil,
     additionalBoundaries: [Int] = [],
+    persistCapturedStatesToDisk: Bool = true,
     prefillStepSize: Int = 512
 ) -> [Int: [MLXArray]] {
     func trace(_ message: String) {
@@ -476,7 +480,8 @@ public func reDeriveAndStoreSSMStatesAtPromptBoundaries(
                 ssmStates: states,
                 tokens: promptTokenIds,
                 boundary: boundary,
-                mediaSalt: mediaSalt)
+                mediaSalt: mediaSalt,
+                persistToDisk: persistCapturedStatesToDisk)
         }
 
         if !statesByBoundary.isEmpty {

--- a/Libraries/MLXLMCommon/Cache/SSMStateCache.swift
+++ b/Libraries/MLXLMCommon/Cache/SSMStateCache.swift
@@ -126,7 +126,8 @@ public final class SSMStateCache: @unchecked Sendable {
         tokens: [Int],
         boundary: Int,
         mediaSalt: String? = nil,
-        isComplete: Bool = true
+        isComplete: Bool = true,
+        persistToDisk: Bool = true
     ) {
         let key = Self.makeKey(tokens: tokens, boundary: boundary, mediaSalt: mediaSalt, modelKey: modelKey)
 
@@ -183,7 +184,7 @@ public final class SSMStateCache: @unchecked Sendable {
         // Omni hybrid prefixes don't collide with text-only prefixes
         // sharing the same token sequence. Previously hardcoded nil
         // here → silent L2 alias on cold start of the next session.
-        if let disk {
+        if persistToDisk, let disk {
             try? disk.store(
                 ssmStates: copies,
                 tokens: tokens,

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -2173,6 +2173,11 @@ public struct TokenIterator: TokenIteratorProtocol {
             return
         }
 
+        var sharedPromptRederivedStates: [Int: [MLXArray]]?
+        let sharedPromptAdditionalBoundaries = Array(Set(
+            cachePrefixTokenCounts + [hybridStripBoundary].compactMap { $0 }
+        ))
+
         func store(
             tokens: [Int],
             cache cacheToStore: [KVCache],
@@ -2218,6 +2223,22 @@ public struct TokenIterator: TokenIteratorProtocol {
                     !originalInput.hasMediaContent
                 else {
                     return extractSSMStates(from: snapshot)
+                }
+                let isPromptPrefix = tokens.count <= promptTokenIds.count
+                    && tokens.elementsEqual(promptTokenIds.prefix(tokens.count))
+                if isPromptPrefix {
+                    if sharedPromptRederivedStates == nil {
+                        sharedPromptRederivedStates =
+                            reDeriveAndStoreSSMStatesAtPromptBoundaries(
+                                coordinator: coordinator,
+                                model: model,
+                                promptTokenIds: promptTokenIds,
+                                mediaSalt: mediaSalt,
+                                additionalBoundaries: sharedPromptAdditionalBoundaries)
+                    }
+                    if let shared = sharedPromptRederivedStates?[tokens.count] {
+                        return shared
+                    }
                 }
                 return reDeriveAndStoreSSMStatesForPromptBoundaries(
                     coordinator: coordinator,

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -2234,7 +2234,8 @@ public struct TokenIterator: TokenIteratorProtocol {
                                 model: model,
                                 promptTokenIds: promptTokenIds,
                                 mediaSalt: mediaSalt,
-                                additionalBoundaries: sharedPromptAdditionalBoundaries)
+                                additionalBoundaries: sharedPromptAdditionalBoundaries,
+                                persistCapturedStatesToDisk: false)
                     }
                     if let shared = sharedPromptRederivedStates?[tokens.count] {
                         return shared
@@ -2244,7 +2245,8 @@ public struct TokenIterator: TokenIteratorProtocol {
                     coordinator: coordinator,
                     model: model,
                     promptTokenIds: tokens,
-                    mediaSalt: mediaSalt)
+                    mediaSalt: mediaSalt,
+                    persistCapturedStatesToDisk: false)
             }()
             let diskStoreCache = makeDiskStoreCache(
                 fromPromptBoundary: snapshot,

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -419,6 +419,22 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
            !promptTokenIds.isEmpty,
            let promptCacheSnapshot
         {
+            let sharedPromptStripBoundary: Int? = {
+                guard ProcessInfo.processInfo.environment["VMLX_HYBRID_STRIPPED_STORE"] != "0",
+                    coordinator.isHybrid,
+                    !originalInput.hasMediaContent,
+                    let turnStartToken = coordinator.genPromptSuffixTokens.first,
+                    let stripAt = promptTokenIds.lastIndex(of: turnStartToken),
+                    stripAt > 0,
+                    stripAt < promptTokenIds.count - 1
+                else { return nil }
+                return stripAt
+            }()
+            var sharedPromptRederivedStates: [Int: [MLXArray]]?
+            let sharedPromptAdditionalBoundaries = Array(Set(
+                cachePrefixTokenCounts + [sharedPromptStripBoundary].compactMap { $0 }
+            ))
+
             func store(tokens: [Int], snapshot: [KVCache], label _: String) {
                 guard !tokens.isEmpty else { return }
                 // Same guard as the other store paths: saving a cache materialises
@@ -448,6 +464,23 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                         !originalInput.hasMediaContent
                     else {
                         return extractSSMStates(from: cacheSnapshot)
+                    }
+                    let isPromptPrefix = tokens.count <= promptTokenIds.count
+                        && tokens.elementsEqual(promptTokenIds.prefix(tokens.count))
+                    if isPromptPrefix {
+                        if sharedPromptRederivedStates == nil {
+                            sharedPromptRederivedStates =
+                                reDeriveAndStoreSSMStatesAtPromptBoundaries(
+                                    coordinator: coordinator,
+                                    model: model,
+                                    promptTokenIds: promptTokenIds,
+                                    mediaSalt: mediaSalt,
+                                    additionalBoundaries: sharedPromptAdditionalBoundaries,
+                                    prefillStepSize: cacheInitParameters.prefillStepSize)
+                        }
+                        if let shared = sharedPromptRederivedStates?[tokens.count] {
+                            return shared
+                        }
                     }
                     return reDeriveAndStoreSSMStatesForPromptBoundaries(
                         coordinator: coordinator,
@@ -498,10 +531,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 if ProcessInfo.processInfo.environment["VMLX_HYBRID_STRIPPED_STORE"] != "0",
                    coordinator.isHybrid,
                    !originalInput.hasMediaContent,
-                   let turnStartToken = coordinator.genPromptSuffixTokens.first,
-                   let stripAt = promptTokenIds.lastIndex(of: turnStartToken),
-                   stripAt > 0,
-                   stripAt < promptTokenIds.count - 1
+                   let stripAt = sharedPromptStripBoundary
                 {
                     // NOTE: intentionally NOT gated on
                     // `!cachePrefixTokenCounts.contains(stripAt)` — see the solo

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -476,6 +476,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                                     promptTokenIds: promptTokenIds,
                                     mediaSalt: mediaSalt,
                                     additionalBoundaries: sharedPromptAdditionalBoundaries,
+                                    persistCapturedStatesToDisk: false,
                                     prefillStepSize: cacheInitParameters.prefillStepSize)
                         }
                         if let shared = sharedPromptRederivedStates?[tokens.count] {
@@ -487,6 +488,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                         model: model,
                         promptTokenIds: tokens,
                         mediaSalt: mediaSalt,
+                        persistCapturedStatesToDisk: false,
                         prefillStepSize: cacheInitParameters.prefillStepSize)
                 }()
                 let diskStoreCache = makeDiskStoreCache(

--- a/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
@@ -34,6 +34,7 @@ struct BatchEngineGrowingChatCacheSourceTests {
         #expect(exactSnapshot.lowerBound < rederive.lowerBound)
         #expect(source.contains("var sharedPromptRederivedStates"))
         #expect(source.contains("reDeriveAndStoreSSMStatesAtPromptBoundaries("))
+        #expect(source.contains("persistCapturedStatesToDisk: false"))
         #expect(source.contains("let unsafeFullHit ="))
         #expect(source.contains("remaining.isEmpty && requiresDiskBackedRestore"))
         #expect(source.contains("let seedBoundary = promptLen - 1"))
@@ -71,6 +72,7 @@ struct BatchEngineGrowingChatCacheSourceTests {
         #expect(exactSnapshot.lowerBound < rederive.lowerBound)
         #expect(source.contains("var sharedPromptRederivedStates"))
         #expect(source.contains("reDeriveAndStoreSSMStatesAtPromptBoundaries("))
+        #expect(source.contains("persistCapturedStatesToDisk: false"))
         #expect(source.contains("let seedBoundary = promptLen - 1"))
         #expect(source.contains("seedSSM, into: self.cache, boundary: seedBoundary"))
         #expect(source.contains("boundary: seedBoundary"))
@@ -96,6 +98,7 @@ struct BatchEngineGrowingChatCacheSourceTests {
         #expect(exactSnapshot.lowerBound < rederive.lowerBound)
         #expect(source.contains("var sharedPromptRederivedStates"))
         #expect(source.contains("reDeriveAndStoreSSMStatesAtPromptBoundaries("))
+        #expect(source.contains("persistCapturedStatesToDisk: false"))
     }
 
     @Test("token iterator drains MLX around cache store before completion info")

--- a/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
@@ -32,6 +32,8 @@ struct BatchEngineGrowingChatCacheSourceTests {
         let exactSnapshot = try #require(source.range(of: "exactBoundarySSMStatesFromSnapshotIfSufficient("))
         let rederive = try #require(source.range(of: "return reDeriveAndStoreSSMStatesForPromptBoundaries("))
         #expect(exactSnapshot.lowerBound < rederive.lowerBound)
+        #expect(source.contains("var sharedPromptRederivedStates"))
+        #expect(source.contains("reDeriveAndStoreSSMStatesAtPromptBoundaries("))
         #expect(source.contains("let unsafeFullHit ="))
         #expect(source.contains("remaining.isEmpty && requiresDiskBackedRestore"))
         #expect(source.contains("let seedBoundary = promptLen - 1"))
@@ -67,6 +69,8 @@ struct BatchEngineGrowingChatCacheSourceTests {
         let exactSnapshot = try #require(source.range(of: "exactBoundarySSMStatesFromSnapshotIfSufficient("))
         let rederive = try #require(source.range(of: "return reDeriveAndStoreSSMStatesForPromptBoundaries("))
         #expect(exactSnapshot.lowerBound < rederive.lowerBound)
+        #expect(source.contains("var sharedPromptRederivedStates"))
+        #expect(source.contains("reDeriveAndStoreSSMStatesAtPromptBoundaries("))
         #expect(source.contains("let seedBoundary = promptLen - 1"))
         #expect(source.contains("seedSSM, into: self.cache, boundary: seedBoundary"))
         #expect(source.contains("boundary: seedBoundary"))
@@ -90,6 +94,8 @@ struct BatchEngineGrowingChatCacheSourceTests {
         let exactSnapshot = try #require(source.range(of: "exactBoundarySSMStatesFromSnapshotIfSufficient("))
         let rederive = try #require(source.range(of: "return reDeriveAndStoreSSMStatesForPromptBoundaries("))
         #expect(exactSnapshot.lowerBound < rederive.lowerBound)
+        #expect(source.contains("var sharedPromptRederivedStates"))
+        #expect(source.contains("reDeriveAndStoreSSMStatesAtPromptBoundaries("))
     }
 
     @Test("token iterator drains MLX around cache store before completion info")

--- a/Tests/MLXLMTests/DiskCacheTests.swift
+++ b/Tests/MLXLMTests/DiskCacheTests.swift
@@ -106,3 +106,105 @@ import Testing
     let hash3 = DiskCache.hashTokens([42, 43, 44, 46])
     #expect(hash1 != hash3)
 }
+
+@Test func coordinatorEnforcesOneQuotaAcrossKVAndCompanionPayloads() async throws {
+    try await MLXMetalTestLock.withLock {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vmlx-combined-disk-quota-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let companionDir = root.appendingPathComponent("ssm_companion")
+        let modelKey = "combined-quota-model"
+        let tokens = [1, 2, 3, 4]
+
+        let disk = DiskCache(cacheDir: root, maxSizeGB: 1, modelKey: modelKey)
+        let companion = try SSMCompanionDiskStore(
+            cacheDir: companionDir,
+            modelKey: modelKey,
+            maxBytes: 1_000_000)
+        disk.store(
+            tokens: tokens,
+            arrays: ["data": MLXArray.ones([1_024])])
+        try companion.store(
+            ssmStates: [MLXArray.ones([1_024])],
+            tokens: tokens,
+            boundary: tokens.count)
+
+        let kvEntry = try #require(disk.quotaEntries().first)
+        let companionEntry = try #require(companion.quotaEntries().first)
+        #expect(companionEntry.kvHash == kvEntry.hash)
+
+        let smallerEntry = min(kvEntry.bytes, companionEntry.bytes)
+        let combinedBytes = kvEntry.bytes + companionEntry.bytes
+        let capBytes = combinedBytes - max(1, smallerEntry / 2)
+        #expect(capBytes > kvEntry.bytes)
+        #expect(capBytes > companionEntry.bytes)
+        #expect(capBytes < combinedBytes)
+
+        let coordinator = CacheCoordinator(config: CacheCoordinatorConfig(
+            usePagedCache: false,
+            enableDiskCache: true,
+            diskCacheMaxGB: Float(capBytes) / 1_073_741_824,
+            diskCacheDir: root,
+            modelKey: modelKey))
+        coordinator.enforceCombinedDiskQuota()
+
+        #expect(coordinator.diskCache?.quotaEntries().isEmpty == true)
+        #expect(coordinator.ssmStateCache.diskStore?.quotaEntries().isEmpty == true)
+        #expect(disk.fetch(tokens: tokens) == nil)
+        #expect(companion.fetch(tokens: tokens, boundary: tokens.count) == nil)
+    }
+}
+
+@Test func combinedQuotaRetiresUnlinkedLegacyCompanionBeforeIndexedKV() async throws {
+    try await MLXMetalTestLock.withLock {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vmlx-legacy-companion-quota-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let companionDir = root.appendingPathComponent("ssm_companion")
+        let modelKey = "legacy-companion-quota-model"
+        let tokens = [8, 6, 7, 5, 3, 0, 9]
+
+        let disk = DiskCache(cacheDir: root, maxSizeGB: 1, modelKey: modelKey)
+        let companion = try SSMCompanionDiskStore(
+            cacheDir: companionDir,
+            modelKey: modelKey,
+            maxBytes: 1_000_000)
+        disk.store(
+            tokens: tokens,
+            arrays: ["data": MLXArray.ones([1_024])])
+        try companion.store(
+            ssmStates: [MLXArray.ones([1_024])],
+            tokens: tokens,
+            boundary: tokens.count)
+
+        let kvEntry = try #require(disk.quotaEntries().first)
+        let companionEntry = try #require(companion.quotaEntries().first)
+        let sidecarURL = companionDir
+            .appendingPathComponent("ssm-\(companionEntry.hash).json")
+        let sidecarData = try Data(contentsOf: sidecarURL)
+        var sidecar = try #require(
+            JSONSerialization.jsonObject(with: sidecarData) as? [String: Any])
+        sidecar.removeValue(forKey: "kv_hash")
+        try JSONSerialization.data(withJSONObject: sidecar, options: [.sortedKeys])
+            .write(to: sidecarURL, options: [.atomic])
+
+        let legacyEntry = try #require(companion.quotaEntries().first)
+        #expect(legacyEntry.kvHash == nil)
+        let combinedBytes = kvEntry.bytes + legacyEntry.bytes
+        let capBytes = combinedBytes - max(1, min(kvEntry.bytes, legacyEntry.bytes) / 2)
+        #expect(capBytes > kvEntry.bytes)
+        #expect(capBytes > legacyEntry.bytes)
+
+        let coordinator = CacheCoordinator(config: CacheCoordinatorConfig(
+            usePagedCache: false,
+            enableDiskCache: true,
+            diskCacheMaxGB: Float(capBytes) / 1_073_741_824,
+            diskCacheDir: root,
+            modelKey: modelKey))
+
+        #expect(coordinator.diskCache?.quotaEntries().count == 1)
+        #expect(coordinator.ssmStateCache.diskStore?.quotaEntries().isEmpty == true)
+        #expect(disk.fetch(tokens: tokens) != nil)
+        #expect(companion.fetch(tokens: tokens, boundary: tokens.count) == nil)
+    }
+}

--- a/Tests/MLXLMTests/SSMReDeriveParityTests.swift
+++ b/Tests/MLXLMTests/SSMReDeriveParityTests.swift
@@ -160,6 +160,44 @@ final class SSMReDeriveParityTests: XCTestCase {
         XCTAssertEqual(coordinator.ssmStateCache.reDerives, 1)
     }
 
+    func testOneReplayCapturesAdditionalPromptStoreBoundary() throws {
+        let model = TinyHybridSSMModel()
+        let tokens = [7, 8, 9, 10, 11, 12, 13]
+        let strippedBoundary = 5
+
+        let coordinator = CacheCoordinator(config: CacheCoordinatorConfig(
+            usePagedCache: true,
+            enableDiskCache: false,
+            pagedBlockSize: 2,
+            modelKey: "tiny-hybrid|shared-store-replay"))
+        coordinator.setHybrid(true)
+
+        let statesByBoundary = reDeriveAndStoreSSMStatesAtPromptBoundaries(
+            coordinator: coordinator,
+            model: model,
+            promptTokenIds: tokens,
+            additionalBoundaries: [strippedBoundary],
+            prefillStepSize: 2)
+
+        XCTAssertEqual(
+            model.prepareCalls,
+            1,
+            "Full and stripped prompt stores must share one continuous replay")
+        XCTAssertEqual(coordinator.ssmStateCache.reDerives, 1)
+
+        let exact = try XCTUnwrap(statesByBoundary[tokens.count])
+        let stripped = try XCTUnwrap(statesByBoundary[strippedBoundary])
+        assertStatesEqual(
+            exact,
+            try warmPassStates(model: model, tokens: tokens, prefillStepSize: 2))
+        assertStatesEqual(
+            stripped,
+            try warmPassStates(
+                model: model,
+                tokens: Array(tokens.prefix(strippedBoundary)),
+                prefillStepSize: 2))
+    }
+
     func testLegacyMaybeRederiveWrapperStoresPagedBlockAndExactBoundaries() throws {
         let model = TinyHybridSSMModel()
         let promptOnly = [3, 5, 7, 11, 13]

--- a/Tests/MLXLMTests/SSMReDeriveParityTests.swift
+++ b/Tests/MLXLMTests/SSMReDeriveParityTests.swift
@@ -8,11 +8,14 @@ import MLXNN
 import XCTest
 
 private final class TinyHybridSSMModel: Module, LanguageModel, @unchecked Sendable {
+    private(set) var prepareCalls = 0
+
     func newCache(parameters: GenerateParameters?) -> [KVCache] {
         [MambaCache()]
     }
 
     func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult {
+        prepareCalls += 1
         let step = max(1, windowSize ?? 512)
         var flatTokens = input.text.tokens.reshaped([-1])
 
@@ -110,6 +113,10 @@ final class SSMReDeriveParityTests: XCTestCase {
                 model: model,
                 promptTokenIds: tokens,
                 prefillStepSize: 2))
+        XCTAssertEqual(
+            model.prepareCalls,
+            1,
+            "A boundary replay must enter through model.prepare once so request-scoped model state is reset")
         let warm = try warmPassStates(model: model, tokens: tokens, prefillStepSize: 2)
         let fetched = try XCTUnwrap(
             coordinator.ssmStateCache.fetch(tokens: tokens, boundary: tokens.count))

--- a/Tests/MLXLMTests/SSMStateCacheTests.swift
+++ b/Tests/MLXLMTests/SSMStateCacheTests.swift
@@ -177,4 +177,51 @@ struct SSMStateCacheTests {
     let fetched = store.fetch(tokens: [1, 2, 3, 4], boundary: 4)
     #expect(fetched == nil)
 }
+
+@Test func transientPagedCompanionStateDoesNotWriteThroughToDisk() throws {
+    let dir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("ssm-companion-transient-\(UUID().uuidString)")
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    let disk = try SSMCompanionDiskStore(
+        cacheDir: dir,
+        modelKey: "test-model",
+        maxBytes: 10_000_000)
+    let cache = SSMStateCache(maxEntries: 4, modelKey: "test-model")
+    cache.diskStore = disk
+    let tokens = [1, 2, 3, 4]
+
+    cache.store(
+        ssmStates: [MLXArray.ones([4, 4])],
+        tokens: tokens,
+        boundary: tokens.count,
+        persistToDisk: false)
+
+    #expect(cache.contains(tokens: tokens, boundary: tokens.count))
+    #expect(disk.fetch(tokens: tokens, boundary: tokens.count) == nil)
+}
+
+@Test func coordinatorClearRemovesPersistentCompanionPayloads() throws {
+    let root = FileManager.default.temporaryDirectory
+        .appendingPathComponent("ssm-companion-clear-\(UUID().uuidString)")
+    defer { try? FileManager.default.removeItem(at: root) }
+    let tokens = [5, 6, 7, 8]
+
+    let coordinator = CacheCoordinator(config: CacheCoordinatorConfig(
+        usePagedCache: false,
+        enableDiskCache: true,
+        diskCacheMaxGB: 0.1,
+        diskCacheDir: root,
+        modelKey: "clear-test"))
+    coordinator.ssmStateCache.store(
+        ssmStates: [MLXArray.ones([4, 4])],
+        tokens: tokens,
+        boundary: tokens.count)
+    let disk = try #require(coordinator.ssmStateCache.diskStore)
+    #expect(disk.fetch(tokens: tokens, boundary: tokens.count) != nil)
+
+    coordinator.clear()
+
+    #expect(disk.fetch(tokens: tokens, boundary: tokens.count) == nil)
+}
 }

--- a/docs/BONSAI_27B_AFFINE1_READINESS_2026-07-14.md
+++ b/docs/BONSAI_27B_AFFINE1_READINESS_2026-07-14.md
@@ -122,3 +122,55 @@ These items must not be described as complete until their own evidence lands:
 7. Separate automatic model routing and clearer hardware guidance work in the
    preserved Osaurus routing lane. That work is intentionally paused until the
    runtime and pin chain is merged.
+
+## 2026-07-19 Bonsai cache regression checkpoint
+
+This follow-up uses the locally installed JANG bundle
+`/Users/eric/models/dealign.ai/Bonsai-27b-1bit-JANG-CRACK`, not an MXFP4
+bundle. It is a Qwen 3.5 hybrid with 16 attention-KV layers and 48
+GatedDeltaNet/Mamba companion layers. No model-behavior guard, forced marker,
+sampler override, prompt rewrite, or output cap is part of this checkpoint.
+
+### Current evidence
+
+| Gate | Current result | Status |
+| --- | --- | --- |
+| Default cache policy | Isolated Release Osaurus UI and `/admin/cache-stats` showed prefix ON, paged RAM OFF, disk L2 ON, and engine-selected KV | VERIFIED-LIVE baseline |
+| Disk-only native restart | Thinking off stayed off; exact short answers remained coherent; a fresh-process disk/SSM hit restored the stored prefix | VERIFIED-LIVE baseline |
+| Disk-only TurboQuant 4/4 restart | Telemetry showed exactly 16 converted TurboQuant KV layers plus 48 native Mamba layers; warm and fresh-process answers remained coherent with disk and companion hits | VERIFIED-LIVE / PERFORMANCE-PARTIAL |
+| TurboQuant performance | Native decode measured 36.9-39.3 tok/s; TurboQuant 4/4 measured 11.3-14.4 tok/s in the same Release app lane | OPEN root cause |
+| Paged RAM + TurboQuant + SSM rederive | Real Settings UI enabled paged RAM with two blocks, disk L2, TurboQuant 4/4, prefix, and SSM rederive. The same stored chat crashed after a 2,923-token disk hit and full-prefill fallback | REPRODUCED-LIVE baseline |
+| Fresh replay lifecycle patch | `reDeriveSSMStatesAtBoundaries` now enters the first independent replay chunk through `LanguageModel.prepare`, then preserves one continuous fresh cache for later boundaries | SOURCE-TESTED / LIVE-OPEN |
+| Focused regression suite | Xcode 26.6 / Swift 6.3.3 `SSMReDeriveParityTests`: 7 tests, 0 failures. The new assertion proves exactly one `prepare` entry and existing tests preserve boundary-state parity | PASS |
+| Total disk cap | Main BlockDisk records respected the configured 10 GB cap, but `ssm_companion` added about 2.35 GB outside the accounting, growing the root to about 12 GB | REPRODUCED-LIVE / OPEN |
+
+### Paged crash root trace
+
+The Release app was rerun under LLDB against the same stored cache. It restored
+the 2,923-token disk boundary, rejected the full hybrid hit because the seed
+boundary SSM state was missing, and entered prompt-boundary SSM rederivation.
+The crash stack was:
+
+`reDeriveSSMStatesAtBoundaries` -> Qwen 3.5 VLM/text forward ->
+`GatedDeltaNet.callAsFunction` -> MLX indexing precondition.
+
+Immediately before the precondition, MLX reported incompatible shapes
+`(1,24,16,64)` and `(1,1,3,64)`. The rederive helper allocated a fresh cache
+but called the model forward directly. Qwen 3.5 VLM also retains
+request-scoped MRoPE position arrays on the model object, and its normal
+text-only `prepare` path resets that state. Bypassing `prepare` therefore
+replayed a long prompt against stale, three-token position state. The patch
+restores the architecture's normal fresh-request lifecycle instead of
+changing generated content.
+
+### Required live closure
+
+The source test does not close the user-facing row. An isolated signed Release
+Osaurus build consuming the exact candidate vMLX revision must reopen the
+previously crashing disk cache with the same visible settings, complete the
+automatic warmup and user turn without a stale-position shape error, visibly
+remain coherent, report token/s, and show truthful paged/disk/SSM/TurboQuant
+counters. Paged OFF and engine-selected KV must then be restored through the
+UI and confirmed in effective server settings. The TurboQuant slowdown and
+companion-sidecar disk-cap defect remain separate open rows until their own
+source and live evidence exists.

--- a/docs/BONSAI_27B_AFFINE1_READINESS_2026-07-14.md
+++ b/docs/BONSAI_27B_AFFINE1_READINESS_2026-07-14.md
@@ -135,14 +135,17 @@ sampler override, prompt rewrite, or output cap is part of this checkpoint.
 
 | Gate | Current result | Status |
 | --- | --- | --- |
-| Default cache policy | Isolated Release Osaurus UI and `/admin/cache-stats` showed prefix ON, paged RAM OFF, disk L2 ON, and engine-selected KV | VERIFIED-LIVE baseline |
-| Disk-only native restart | Thinking off stayed off; exact short answers remained coherent; a fresh-process disk/SSM hit restored the stored prefix | VERIFIED-LIVE baseline |
-| Disk-only TurboQuant 4/4 restart | Telemetry showed exactly 16 converted TurboQuant KV layers plus 48 native Mamba layers; warm and fresh-process answers remained coherent with disk and companion hits | VERIFIED-LIVE / PERFORMANCE-PARTIAL |
-| TurboQuant performance | Native decode measured 36.9-39.3 tok/s; TurboQuant 4/4 measured 11.3-14.4 tok/s in the same Release app lane | OPEN root cause |
-| Paged RAM + TurboQuant + SSM rederive | Real Settings UI enabled paged RAM with two blocks, disk L2, TurboQuant 4/4, prefix, and SSM rederive. The same stored chat crashed after a 2,923-token disk hit and full-prefill fallback | REPRODUCED-LIVE baseline |
-| Fresh replay lifecycle patch | `reDeriveSSMStatesAtBoundaries` now enters the first independent replay chunk through `LanguageModel.prepare`, then preserves one continuous fresh cache for later boundaries | SOURCE-TESTED / LIVE-OPEN |
-| Focused regression suite | Xcode 26.6 / Swift 6.3.3 `SSMReDeriveParityTests`: 7 tests, 0 failures. The new assertion proves exactly one `prepare` entry and existing tests preserve boundary-state parity | PASS |
-| Total disk cap | Main BlockDisk records respected the configured 10 GB cap, but `ssm_companion` added about 2.35 GB outside the accounting, growing the root to about 12 GB | REPRODUCED-LIVE / OPEN |
+| Isolated app identity | Release app at `/private/tmp/osaurus-bonsai-cache-candidate-derived-20260719/Build/Products/Release/osaurus.app`; bundle ID `com.dinoki.osaurus.bonsaicachestateproof`; binary SHA-256 `de00ead1be7f6681bbbe2a46965c2074d55d90e9a4b4df2512277f9685bee7b9`; ad-hoc signature verified with `codesign --verify --deep --strict` | VERIFIED-BUILD |
+| Default cache policy | Real Settings UI showed prefix ON, paged RAM OFF, disk L2 ON, engine-selected KV, and SSM rederive ON. After saving and reloading the model, `/admin/cache-stats` reported `effective_kv_mode=fp16`, 16 KV + 48 Mamba layers, zero TurboQuant compressions, and paged cache disabled | VERIFIED-LIVE |
+| Disk-only native restart | A fresh app process restored a 4,669-token disk boundary plus SSM companion state, then answered the visible continuation coherently at TTFT 0.72s / 56.6 tok/s. After the Settings round-trip back to engine-selected, a later 4,943-token hit plus 454-token replay answered coherently at TTFT 2.05s / 54.7 tok/s | VERIFIED-LIVE |
+| Explicit TurboQuant 4/4 | The real Settings UI rejected TurboQuant until explicit key/value widths were entered, saved 4/4, unloaded the model, and reloaded it. Telemetry showed `turbo_quant_compressions=2`, exactly 16 converted KV layers, 48 native Mamba layers, paged hits remaining zero, disk-L2 hits 1 -> 3, and SSM hits 1 -> 3 | VERIFIED-LIVE / PERFORMANCE-PARTIAL |
+| TurboQuant behavior and speed | The first explicit-TurboQuant answer was coherent at TTFT 10.79s / 39.3 tok/s. A disk-only partial continuation hit boundary 5,301 with 30 tokens replayed and answered coherently at TTFT 1.76s / 17.0 tok/s. Functional cache conversion/reuse is proven; the decode slowdown versus the restored fp16/default row remains open | PERFORMANCE-PARTIAL |
+| Paged RAM + TurboQuant + SSM rederive baseline | Before the lifecycle fix, the same stored chat crashed after a 2,923-token disk hit and full-prefill fallback with real Settings enabling paged RAM (two blocks), disk L2, TurboQuant 4/4, prefix, and SSM rederive | REPRODUCED-LIVE baseline |
+| Fresh replay lifecycle patch | `reDeriveSSMStatesAtBoundaries` enters the first independent replay chunk through `LanguageModel.prepare`, clearing request-scoped Qwen 3.5 position state, then preserves one continuous fresh cache while capturing later boundaries. The candidate crossed the prior crash boundary repeatedly, including more than 5,000 prompt tokens, without the stale-position shape failure | VERIFIED-LIVE |
+| Focused regression suites | Xcode 26.6 / Swift 6.3.3: `SSMReDeriveParityTests` 8/8; filtered DiskCache, SSMStateCache, and BatchEngine cache coverage 33/33. The CommandLineTools-only invocation cannot import Swift Testing; the same current source passed under the full Xcode toolchain | PASS |
+| Total disk cap migration | A clean exact-model root migrated from 21,120,148,753 bytes to 10,685,640,588 bytes under a 10 GiB cap by retiring 133 unlinked legacy companions and zero indexed KV entries. After the live matrix it held 18 indexed KV payloads (8,994,768,622 bytes) and 18 linked companion pairs (1,412,190,222 bytes), total 10,406,958,844 bytes; every companion `kv_hash` resolved to a current SQLite row | VERIFIED-LIVE |
+| Transient companion writes | Replay, paged-boundary, first-token, inline-capture, and native-MTP seed paths now retain transient SSM state only in memory. Only durable exact generation boundaries write companion files; the live root no longer accumulated hundreds of per-16-token sidecars | VERIFIED-LIVE |
+| Visible instruction following | One earlier two-sentence recall omitted the requested arithmetic confirmation; a corrective turn and all restart/TurboQuant/default-restored continuations answered the requested facts coherently. This is recorded as model-level variance, not hidden with a prompt, sampler, marker, or output guard | PARTIAL, transparent |
 
 ### Paged crash root trace
 
@@ -163,14 +166,19 @@ replayed a long prompt against stale, three-token position state. The patch
 restores the architecture's normal fresh-request lifecycle instead of
 changing generated content.
 
-### Required live closure
+### Current closure and remaining limitation
 
-The source test does not close the user-facing row. An isolated signed Release
-Osaurus build consuming the exact candidate vMLX revision must reopen the
-previously crashing disk cache with the same visible settings, complete the
-automatic warmup and user turn without a stale-position shape error, visibly
-remain coherent, report token/s, and show truthful paged/disk/SSM/TurboQuant
-counters. Paged OFF and engine-selected KV must then be restored through the
-UI and confirmed in effective server settings. The TurboQuant slowdown and
-companion-sidecar disk-cap defect remain separate open rows until their own
-source and live evidence exists.
+The stale-position crash and the companion-sidecar quota defect now have both
+owning-layer source fixes and live proof in the isolated signed Release app.
+The UI was returned to prefix ON, paged RAM OFF, disk L2 ON, engine-selected KV,
+and SSM rederive ON; effective runtime telemetry confirmed fp16 KV and zero
+TurboQuant conversions after that restoration. No MXFP4 bundle was loaded or
+used as evidence.
+
+The explicit TurboQuant 4/4 path is functionally coherent and its hybrid cache
+topology, partial disk reuse, and SSM companion reuse are proven, but its
+17.0 tok/s continuation is materially slower than the 54.7 tok/s restored
+default row. That performance issue remains separate follow-up work and must
+not be described as fixed by this checkpoint. The first multi-clause recall's
+omission is likewise retained above rather than masked by a forced behavior
+guard.


### PR DESCRIPTION
## Scope

This PR contains only the Bonsai/Qwen 3.5 hybrid-cache correctness and storage fixes:

- reset request-scoped model state by entering independent SSM replay through the normal LanguageModel.prepare lifecycle;
- share one continuous replay across required hybrid prompt boundaries;
- keep transient replay/paged/seed companion state in memory instead of writing per-boundary SSD sidecars;
- enforce one configured disk cap across indexed KV and linked SSM companion payloads, with legacy/orphan migration and paired eviction;
- clear persistent companion payloads with the coordinator cache.

No automatic model-routing, hardware-guidance, AppleScript, Sentry, Nemotron multimodal, or unrelated feature changes are included. No MXFP4 model was used.

## Source verification

- Xcode 26.6 / Swift 6.3.3 SSMReDeriveParityTests: 8/8.
- Filtered DiskCache, SSMStateCache, and BatchEngine cache coverage: 33/33.
- git diff --check: clean.

## Live Osaurus verification

Isolated signed Release app:

- bundle ID: com.dinoki.osaurus.bonsaicachestateproof
- binary SHA-256: de00ead1be7f6681bbbe2a46965c2074d55d90e9a4b4df2512277f9685bee7b9
- exact model: /Users/eric/models/dealign.ai/Bonsai-27b-1bit-JANG-CRACK

Computer Use and live /admin/cache-stats evidence:

- fresh-process disk/SSM restore remained coherent at TTFT 0.72s / 56.6 tok/s;
- restored default policy is prefix ON, paged RAM OFF, disk L2 ON, engine-selected KV, SSM rederive ON; effective KV is fp16 with 16 KV + 48 Mamba layers and zero TurboQuant compressions;
- explicit Settings TurboQuant 4/4 converted exactly the 16 KV layers while retaining 48 Mamba layers, and coherent disk-only partial reuse increased disk/SSM hits with paged hits at zero;
- clean-root quota migration reduced 21,120,148,753 bytes to 10,685,640,588 bytes by retiring 133 unlinked legacy companions and zero indexed KV entries;
- final live root held 8,994,768,622 KV bytes + 1,412,190,222 linked companion bytes = 10,406,958,844 bytes under the 10 GiB cap, with 18/18 companion hashes linked to live SQLite rows;
- Activity Monitor showed 2.27 GB during the default restart turn and 3.84 GB during the explicit-TurboQuant reload/turn.

## Transparent limitations

Explicit TurboQuant is functionally correct but performance remains partial: one continuation measured 17.0 tok/s versus 54.7 tok/s after restoring default fp16. One earlier multi-clause recall omitted the arithmetic clause; the corrective and restart rows were coherent. Neither behavior is masked with prompt coercion, sampler changes, forced reasoning markers, or output guards.