### PR TITLE
Preserve paged cache chains under eviction

### DIFF
--- a/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
@@ -285,7 +285,9 @@ public final class CacheCoordinator: @unchecked Sendable {
     /// a no-op for non-paged tiers.
     public func release(blocks: [CacheBlock]) {
         guard let pagedCache, !blocks.isEmpty else { return }
-        for block in blocks {
+        // Release leaves before roots. A child cannot be restored after its
+        // parent is evicted, so roots must remain the newest LRU candidates.
+        for block in blocks.reversed() {
             pagedCache.freeBlock(block)
         }
     }

--- a/Libraries/MLXLMCommon/Cache/PagedCacheManager.swift
+++ b/Libraries/MLXLMCommon/Cache/PagedCacheManager.swift
@@ -234,6 +234,19 @@ public final class PagedCacheManager: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
 
+        // Keep the whole chain pinned until the store is complete. Releasing
+        // each block immediately lets a small/pressured pool recycle a parent
+        // while its child is still being built, leaving only an orphaned chain
+        // hash that can never satisfy a prefix walk.
+        var pinnedBlocks: [CacheBlock] = []
+        defer {
+            // Leaves are least useful without their parents, so place them at
+            // the front of the LRU queue and keep roots newest.
+            for block in pinnedBlocks.reversed() {
+                _freeBlock(block)
+            }
+        }
+
         var parentHash: String? = nil
         var chunkIndex = 0
         var offset = 0
@@ -245,8 +258,17 @@ public final class PagedCacheManager: @unchecked Sendable {
                 parentHash: parentHash, tokenIds: chunk,
                 modelKey: modelKey, mediaSalt: mediaSalt)
 
-            // Skip if this block already exists in the cache.
-            if hashMap.find(hash: hash) != nil {
+            // Reuse and pin an existing chain member. It must leave the free
+            // queue while descendants are stored, otherwise allocation could
+            // reset it before the chain is complete.
+            if let existing = hashMap.find(hash: hash) {
+                if existing.refCount == 0 {
+                    _ = freeQueue.remove(existing)
+                    stats.allocatedBlocks += 1
+                    stats.freeBlocks -= 1
+                }
+                existing.incrementRef()
+                pinnedBlocks.append(existing)
                 parentHash = hash
                 offset = end
                 chunkIndex += 1
@@ -269,14 +291,7 @@ public final class PagedCacheManager: @unchecked Sendable {
 
             block.blockHash = hash
             hashMap.insert(block)
-
-            // The stored block is now available for future prefix hits,
-            // but no live generation owns it. Drop the store-time ref and
-            // re-enqueue it so the pool remains reusable under pressure.
-            block.decrementRef()
-            stats.allocatedBlocks -= 1
-            stats.freeBlocks += 1
-            freeQueue.append(block)
+            pinnedBlocks.append(block)
 
             parentHash = hash
             offset = end

--- a/Libraries/MLXLMCommon/Cache/SSMReDerive.swift
+++ b/Libraries/MLXLMCommon/Cache/SSMReDerive.swift
@@ -457,8 +457,21 @@ public func reDeriveAndStoreSSMStatesAtPromptBoundaries(
 
     if coordinator.pagedCache != nil, !coordinator.isPagedIncompatible {
         let blockSize = max(1, coordinator.config.pagedBlockSize)
+        // Block zero is the sentinel. The paged tier cannot retain companion
+        // boundaries beyond the KV blocks its pool can actually keep, and
+        // deriving those states creates expensive, immediately-unusable work
+        // for long prompts or intentionally small eviction-test pools.
+        let usableBlocks = coordinator.config.maxCacheBlocks > 1
+            ? coordinator.config.maxCacheBlocks - 1
+            : 0
+        let retainedCapacity = usableBlocks.multipliedReportingOverflow(by: blockSize)
+        let maximumRetainedTokens = retainedCapacity.overflow
+            ? Int.max
+            : retainedCapacity.partialValue
         var boundary = blockSize
-        while boundary < promptTokenIds.count {
+        while boundary < promptTokenIds.count,
+              boundary <= maximumRetainedTokens
+        {
             boundaries.insert(boundary)
             boundary += blockSize
         }

--- a/Tests/MLXLMTests/PagedCacheTests.swift
+++ b/Tests/MLXLMTests/PagedCacheTests.swift
@@ -113,3 +113,49 @@ import Testing
     #expect(result == nil, "Completely different tokens should produce no match")
     #expect(manager.stats.cacheMisses > 0)
 }
+
+@Test func pagedCacheTinyPoolKeepsLongestUsablePrefixInsteadOfOrphanLeaf() {
+    let blockSize = 2
+    let manager = PagedCacheManager(blockSize: blockSize, maxBlocks: 2)
+    let dummyLayer: [(keys: MLXArray, values: MLXArray)] = [
+        (keys: MLXArray.zeros([1, 1, blockSize, 8]),
+         values: MLXArray.zeros([1, 1, blockSize, 8]))
+    ]
+
+    manager.storeTokenSequence(
+        tokens: [1, 2, 3, 4, 5, 6],
+        layerData: [dummyLayer, dummyLayer, dummyLayer])
+
+    let result = manager.fetchPrefix(tokens: [1, 2, 3, 4, 5, 6, 7])
+    #expect(result?.matchedTokens == blockSize)
+    #expect(result?.remainingTokens == [3, 4, 5, 6, 7])
+    #expect(result?.blocks.count == 1)
+}
+
+@Test func pagedCacheCoordinatorReleasesLeavesBeforeRootsUnderEviction() throws {
+    let blockSize = 2
+    let coordinator = CacheCoordinator(config: CacheCoordinatorConfig(
+        usePagedCache: true,
+        enableDiskCache: false,
+        pagedBlockSize: blockSize,
+        maxCacheBlocks: 4,
+        modelKey: "leaf-first-release"))
+    let manager = try #require(coordinator.pagedCache)
+    let dummyLayer: [(keys: MLXArray, values: MLXArray)] = [
+        (keys: MLXArray.zeros([1, 1, blockSize, 8]),
+         values: MLXArray.zeros([1, 1, blockSize, 8]))
+    ]
+    let original = [1, 2, 3, 4, 5, 6]
+
+    manager.storeTokenSequence(
+        tokens: original,
+        layerData: [dummyLayer, dummyLayer, dummyLayer])
+    let pinned = try #require(manager.fetchPrefix(tokens: original))
+    coordinator.release(blocks: pinned.blocks)
+
+    manager.storeTokenSequence(tokens: [9, 10], layerData: [dummyLayer])
+
+    let retained = manager.fetchPrefix(tokens: original)
+    #expect(retained?.matchedTokens == 4)
+    #expect(retained?.remainingTokens == [5, 6])
+}

--- a/Tests/MLXLMTests/SSMReDeriveParityTests.swift
+++ b/Tests/MLXLMTests/SSMReDeriveParityTests.swift
@@ -198,6 +198,29 @@ final class SSMReDeriveParityTests: XCTestCase {
                 prefillStepSize: 2))
     }
 
+    func testPromptBoundaryReplayDoesNotCaptureBeyondPagedPoolCapacity() throws {
+        let model = TinyHybridSSMModel()
+        let tokens = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        let coordinator = CacheCoordinator(config: CacheCoordinatorConfig(
+            usePagedCache: true,
+            enableDiskCache: false,
+            pagedBlockSize: 2,
+            maxCacheBlocks: 3,
+            modelKey: "tiny-hybrid|bounded-paged-replay"))
+        coordinator.setHybrid(true)
+
+        let statesByBoundary = reDeriveAndStoreSSMStatesAtPromptBoundaries(
+            coordinator: coordinator,
+            model: model,
+            promptTokenIds: tokens,
+            additionalBoundaries: [7],
+            prefillStepSize: 2)
+
+        XCTAssertEqual(Set(statesByBoundary.keys), Set([2, 4, 7, 8, 9]))
+        XCTAssertNil(statesByBoundary[6])
+        XCTAssertEqual(model.prepareCalls, 1)
+    }
+
     func testLegacyMaybeRederiveWrapperStoresPagedBlockAndExactBoundaries() throws {
         let model = TinyHybridSSMModel()
         let promptOnly = [3, 5, 7, 11, 13]


### PR DESCRIPTION
## Root cause

`PagedCacheManager.storeTokenSequence` released each block while descendants were still being constructed. Under a tiny or pressured pool, allocation could recycle a parent and leave only an orphaned child hash, so the later root-to-leaf prefix walk missed. Fetch release was also root-first, making the indispensable root the oldest eviction candidate.

For hybrid SSM/GDN models, prompt-boundary replay additionally derived every paged boundary even when the configured pool could retain only one useful KV block. Those companion states were immediately unusable and produced a large post-generation/warmup tail.

## Owning-layer fix

- pin the complete paged chain until storage finishes
- re-pin an existing free chain member before constructing descendants
- release stored and fetched chains leaf-to-root so roots remain newest
- cap automatic hybrid companion boundaries to `(maxCacheBlocks - 1) * blockSize`
- retain exact, prompt-minus-one, history, and explicit boundaries
- add tiny-pool eviction and bounded hybrid-replay regressions

This changes no prompt, template, reasoning marker, sampler, stop/EOS behavior, output limit, tool schema, streaming parser, model route, or hardware policy.

## Current-source proof

- Exact commit: `24ce87c5ef812f816a242459aec50e544fd228f4`
- Xcode Swift toolchain focused suite: 21 XCTest + 88 Swift Testing cases = 109 selected cache/TurboQuant/disk/SSM/paged/multi-turn tests, zero failures
- `git diff --check`: passed
- Diff: only `PagedCacheManager`, `CacheCoordinator`, `SSMReDerive`, and two test files
- Fork workflow jobs are skipped by the workflow's existing `github.repository == 'ml-explore/mlx-swift'` condition; they are not being represented as green CI evidence

## Live Release-app proof

Real model: `/Users/eric/models/dealign.ai/Bonsai-27b-1bit-JANG-CRACK`. No MXFP4 bundle was downloaded or tested.

Pre-fix, with Thinking off, Prefix on, Paged on, max blocks 2, SSD L2 on, explicit TurboQuant 4/4, and SSM rederive on:

- 46.7 tok/s, 2.73 s TTFT, coherent output
- about 2,923 prompt tokens took 41.04 s in warmup/maintenance
- disk and SSM hits occurred, but no paged prefix hit survived the store

Post-fix in the actual isolated Release Osaurus UI:

- paged hits 4, misses 6, evictions 1, total blocks 2, free blocks 1
- disk hits 4, misses 12, stores 12; SSM hits 4, rederives 6
- exact topology: 16 ordinary KV layers converted to TQ-KV while all 48 Mamba layers remained native companion state
- automatic boundaries reduced to `[16, 2920, 2922, 2923]`
- visible rows: 2.69 s / 45.3 tok/s and 1.40 s / 18.6 tok/s
- Activity Monitor: 2.49 GB
- post-answer maintenance observed below 18.3 s versus the pre-fix 41.04 s; this is a coarse bound, not a precision benchmark

Paged-off SSD-only restart also restored a 2,923-token boundary and then a 2,923-token partial prefix with 36 tokens remaining. Fresh-process counters were disk hits 3 and SSM hits 3 with paged hits/misses both zero; the visible row was 1.16 s TTFT, 44.0 tok/s, and Activity Monitor 2.27 GB.

An Engine Selected/FP16 control produced the same model misconception as the explicit-TQ row, while telemetry showed 16 KV + 48 Mamba, zero TQ layers, and no TQ transition. The semantic failures are retained as model-quality failures and are not hidden by any runtime guard.

Final rebased Osaurus smoke used the same exact vMLX commit: Thinking visibly off; defaults Prefix on, Paged off, SSD L2 on, TurboQuant off; disk and SSM partial hits; 1.06 s / 54.0 tok/s then 1.10 s / 52.5 tok/s on a correction turn; Activity Monitor 2.30 GB. The first answer missed a two-sentence constraint, so model semantic quality remains partial even though the cache defect is live-verified.

The documentation-only final Osaurus head was rebuilt and launched again with
this same vMLX commit. A fair two-item control returned the correct arithmetic
and alphabetical answers on separate lines at 1.09 s TTFT and 36.0 tok/s;
Activity Monitor showed 2.31 GB. Disk/SSM partial hits reached 4 each with
paged and TurboQuant still off. A separate ungrounded question about the
unpublished source change hallucinated the release order, so that model-quality
row is explicitly failed rather than hidden or used as cache proof.

## Verdict

The narrow paged-chain eviction and bounded hybrid-replay fix is source-tested and live-verified. This PR does not claim that all Bonsai semantic/tool behavior is fixed.
