### PR TITLE
Fix Zaya XML parameter resynchronization

### DIFF
--- a/Libraries/MLXLMCommon/Tool/Parsers/XMLFunctionParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/XMLFunctionParser.swift
@@ -140,7 +140,41 @@ public struct XMLFunctionParser: ToolCallParser, Sendable {
                     of: "</parameter>", range: nameEnd.upperBound ..< paramSection.endIndex)
             else { break }
 
-            var paramValue = String(paramSection[nameEnd.upperBound ..< paramEnd.lowerBound])
+            // A quantized ZAYA row can start the next attribute-style
+            // parameter without closing the current one:
+            //
+            //   <parameter=verb>open
+            //   <parameter=app>TextEdit</parameter>
+            //
+            // The old scan consumed the second opener/value into `verb` and
+            // then skipped `app` entirely. Resynchronize only when the nested
+            // opener names a *different parameter declared by this tool's
+            // schema*. Unknown tag-looking text remains literal, and callers
+            // without a schema keep the strict historical behavior.
+            let nestedParameterStart = paramSection.range(
+                of: "<parameter=", range: nameEnd.upperBound ..< paramEnd.lowerBound)
+            var valueEnd = paramEnd.lowerBound
+            var nextSearchStart: String.Index? = nil
+            if let nestedParameterStart,
+                let nestedNameEnd = paramSection.range(
+                    of: ">",
+                    range: nestedParameterStart.upperBound ..< paramEnd.lowerBound)
+            {
+                let nestedName = String(
+                    paramSection[nestedParameterStart.upperBound ..< nestedNameEnd.lowerBound]
+                ).trimmingCharacters(in: .whitespacesAndNewlines)
+                if nestedName != paramName,
+                    isDeclaredParameter(
+                        nestedName,
+                        functionName: funcName,
+                        tools: tools)
+                {
+                    valueEnd = nestedParameterStart.lowerBound
+                    nextSearchStart = nestedParameterStart.lowerBound
+                }
+            }
+
+            var paramValue = String(paramSection[nameEnd.upperBound ..< valueEnd])
 
             // Trim leading/trailing newlines (matching Python behavior)
             paramValue = trimBoundaryNewlines(paramValue)
@@ -159,7 +193,7 @@ public struct XMLFunctionParser: ToolCallParser, Sendable {
             arguments[paramName] = convertParameterValue(
                 paramValue, paramName: paramName, funcName: funcName, tools: tools)
 
-            searchRange = paramEnd.upperBound ..< paramSection.endIndex
+            searchRange = (nextSearchStart ?? paramEnd.upperBound) ..< paramSection.endIndex
         }
 
         if let invalidArguments = schemaValidationFailure(
@@ -300,6 +334,20 @@ public struct XMLFunctionParser: ToolCallParser, Sendable {
             }
         }
         return nil
+    }
+
+    private func isDeclaredParameter(
+        _ parameterName: String,
+        functionName: String,
+        tools: [[String: any Sendable]]?
+    ) -> Bool {
+        guard !parameterName.isEmpty,
+            let tools,
+            let functionSpec = functionSpec(named: functionName, in: tools),
+            let parameters = sendableObject(functionSpec["parameters"]),
+            let properties = sendableObject(parameters["properties"])
+        else { return false }
+        return properties[parameterName] != nil
     }
 
     private func invalidToolArguments(

--- a/Tests/MLXLMCommonToolParserFocusedTests/ZayaNestedToolArgTests.swift
+++ b/Tests/MLXLMCommonToolParserFocusedTests/ZayaNestedToolArgTests.swift
@@ -28,6 +28,23 @@ struct ZayaNestedToolArgTests {
         ]
     ]
 
+    private let agentAction: [[String: any Sendable]] = [
+        [
+            "type": "function",
+            "function": [
+                "name": "agent_action",
+                "parameters": [
+                    "type": "object",
+                    "properties": [
+                        "verb": ["type": "string"],
+                        "app": ["type": "string"],
+                    ] as [String: any Sendable],
+                    "required": ["verb"],
+                ] as [String: any Sendable],
+            ] as [String: any Sendable],
+        ]
+    ]
+
     private func zayaParser() -> XMLFunctionParser {
         XMLFunctionParser(
             startTag: "<zyphra_tool_call>",
@@ -184,6 +201,62 @@ struct ZayaNestedToolArgTests {
         let call = try #require(zayaParser().parse(content: content, tools: tools))
         #expect(call.function.name == "line_count")
         #expect(call.function.arguments["text"] == .string("hi there"))
+    }
+
+    /// VERBATIM structural shape recovered from the AppleScript 8B JANG_6M
+    /// Computer Use row: the model started `app` before closing `verb`. The
+    /// old attribute scanner consumed the second opener/value into `verb`, so
+    /// the host saw `open\n<parameter=app>\nTextEdit` and rejected the enum.
+    @Test("attribute body resynchronizes at a recognized next parameter")
+    func attributeBodyRecoversMissingParameterCloser() throws {
+        let content = """
+            <zyphra_tool_call>
+            <function=agent_action>
+            <parameter=verb>
+            open
+            <parameter=app>
+            TextEdit
+            </parameter>
+            </function>
+            </zyphra_tool_call>
+            """
+        let call = try #require(zayaParser().parse(content: content, tools: agentAction))
+        #expect(call.function.name == "agent_action")
+        #expect(call.function.arguments["verb"] == .string("open"))
+        #expect(call.function.arguments["app"] == .string("TextEdit"))
+        #expect(call.function.arguments["_error"] == nil)
+    }
+
+    /// A string that merely contains a tag-looking sequence must not be split
+    /// unless the nested name is another declared parameter for this tool.
+    @Test("unknown tag-looking text inside a string remains literal")
+    func unknownParameterLikeTextRemainsLiteral() throws {
+        let tools: [[String: any Sendable]] = [
+            [
+                "type": "function",
+                "function": [
+                    "name": "echo",
+                    "parameters": [
+                        "type": "object",
+                        "properties": ["content": ["type": "string"]] as [String: any Sendable],
+                        "required": ["content"],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable],
+            ]
+        ]
+        let content = """
+            <zyphra_tool_call>
+            <function=echo>
+            <parameter=content>
+            literal <parameter=not_a_declared_field> text
+            </parameter>
+            </function>
+            </zyphra_tool_call>
+            """
+        let call = try #require(zayaParser().parse(content: content, tools: tools))
+        #expect(
+            call.function.arguments["content"]
+                == .string("literal <parameter=not_a_declared_field> text"))
     }
 
     /// REGRESSION GUARD: ordinary prose (no tool markers) never becomes a call.


### PR DESCRIPTION
## Root cause

AppleScript 8B JANG_6M sometimes emits the next Zaya XML parameter before closing the current parameter. The live diagnostic decoded the malformed payload as:

    verb = "open\n<parameter=app>\nTextEdit"

The attribute-style XML parser consumed the recognized app parameter into verb and then skipped app. Osaurus correctly rejected the contaminated verb enum. This is a parser resynchronization defect triggered by malformed model XML, not content-delta streaming and not a need to accept arbitrary verb aliases.

## Change

- Resynchronize only when a nested parameter opener names a different parameter declared by the active tool schema.
- Keep unknown tag-looking text literal.
- Keep callers without a schema on the previous strict behavior.
- Add the exact AppleScript Computer Use regression and a literal-text negative control.

## Evidence

- Current-main isolated Release UI reproduced the TextEdit Computer Use failure in 13.3 seconds with the invalid verb enum error.
- Direct diagnostic with enum validation removed exposed the contaminated verb above.
- Red test reproduced the exact contaminated verb and missing app before the source change.
- After the change, all 9 Zaya XML extraction tests pass.
- Neighboring Zaya/XML/Qwen/Step/Gemma/streaming sweep: 79 relevant rows passed. One unrelated LFM2 newline assertion also fails unchanged on main and is not caused by this diff.
- git diff --check passes.

## Live gate

PARTIAL: the patched vMLX revision still needs to be pinned into an isolated Osaurus Release build and the TextEdit, Calculator, Safari, completion, failure, and feedback-only rows must be rerun visually before merge.
