### PR TITLE
Fix stale live cache reuse after coordinator miss

### DIFF
--- a/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
@@ -14,7 +14,14 @@ import MLX
 /// valid while carrying generated-token state under a prompt-only key.
 func makePromptBoundaryCacheSnapshot(from cache: [any KVCache]) -> [any KVCache] {
     let snapshot = cache.map { $0.copy() }
-    if snapshot.contains(where: { $0 is HybridPoolCache }) {
+    // ArraysCache/MambaCache update their recurrent tensors in place. Their
+    // copy implementations create independent `* 1` graph nodes; materialize
+    // the whole list before decode mutates the live cache so the prompt
+    // snapshot cannot inherit later tool/output state. One batched eval keeps
+    // this substantially cheaper than synchronizing every recurrent layer.
+    if snapshot.contains(where: {
+        $0 is HybridPoolCache || cacheContainsPathDependentState([$0])
+    }) {
         MLX.eval(snapshot)
     }
     return snapshot

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1108,6 +1108,14 @@ private final class SoloPrefillProgressAccumulator: @unchecked Sendable {
     }
 }
 
+/// A coordinator miss is authoritative for the request's token and semantic
+/// scope. A caller-owned cache with any populated layer therefore cannot be
+/// reused by numeric offset alone.
+@inline(__always)
+func populatedCacheRequiresResetAfterCoordinatorMiss(_ cache: [KVCache]) -> Bool {
+    cache.contains { $0.offset > 0 }
+}
+
 public struct TokenIterator: TokenIteratorProtocol {
 
     private static let logger = Logger(subsystem: "vmlx", category: "TokenIterator")
@@ -1617,70 +1625,24 @@ public struct TokenIterator: TokenIteratorProtocol {
                     let count = cacheLookupTokenIds.count
                     Self.logger.debug("Cache miss for \(count) prompt tokens")
 
-                // 2026-05-05 (Ling-2.6-flash multi-turn fix): coordinator
-                // missed but the cache may already hold a previous turn's
-                // state (e.g. ChatSession reuse path with a hybrid
-                // KVCache + ArraysCache that the multi-tier disk/paged
-                // coordinator can't yet round-trip). Without correcting,
-                // the model double-feeds previously-prefilled tokens onto
-                // the populated cache → wrong RoPE positions on KVCache
-                // layers AND duplicated GLA recurrence on ArraysCache
-                // (Linear-Attn) layers → NaN logits → fatalError SIGKILL.
-                //
-                // We can only safely trim if the new prompt's prefix
-                // matches the cached tokens. Some chat templates (Bailing,
-                // DeepSeek-R1, Qwen3 reasoning) STRIP `<think>...</think>`
-                // content from past assistant turns when re-rendering for
-                // the next turn — so the input on Turn 2 is SHORTER than
-                // what's actually cached (cache still holds the reasoning
-                // tokens that were generated and decoded on Turn 1).
-                //
-                // Detection: if cacheOffset > promptTokenIds.count, the
-                // cache holds content the new prompt doesn't include
-                // (chat-template stripping). We can't safely trim — the
-                // recurrent state encodes context the model would need
-                // to "forget". Reset the cache and prefill the full new
-                // prompt from scratch.
-                if let cacheOffset = self.cache.first?.offset, cacheOffset > 0 {
-                    if cacheOffset > cacheLookupTokenIds.count {
-                        // Reasoning-strip mismatch — replace cache entirely.
-                        // Some chat templates (Bailing, DeepSeek-R1, Qwen3
-                        // reasoning) drop `<think>...</think>` blocks from
-                        // past assistant turns when re-rendering for the
-                        // next turn, so the new prompt is SHORTER than what
-                        // was cached. We can't safely trim because we don't
-                        // know exactly which positions to drop. Replace the
-                        // cache with a fresh one — full re-prefill is
-                        // O(prompt) but correct, vs producing garbage.
-                        let resetMsg = "Populated-cache miss: cache offset (\(cacheOffset)) > prompt length (\(cacheLookupTokenIds.count)) — likely reasoning-strip in chat template; reset cache for full prefill"
+                    // The coordinator hashes the actual prompt tokens plus
+                    // reasoning/tool/media/KV-policy salt. A miss therefore
+                    // proves that a populated caller-owned cache has no
+                    // verified identity for this request. Offset equality or
+                    // ordering is not token-prefix proof: after an Off→On
+                    // reasoning change, Ornith/Qwen 3.5 reused the prior
+                    // turn's ArraysCache state and replayed its old tool call
+                    // before following the new prompt. Reusing any part of
+                    // that unverified KV/recurrent state is incorrect. Reset
+                    // and full-prefill; the .hit branch above remains the only
+                    // prefix-reuse path.
+                    if populatedCacheRequiresResetAfterCoordinatorMiss(self.cache) {
                         self.cache = self.model.newCache(parameters: effectiveParameters)
-                        Self.logger.info("\(resetMsg)")
-                    } else if cacheOffset == cacheLookupTokenIds.count,
-                              let last = cacheLookupTokenIds.last
-                    {
-                        let lastToken = MLXArray([Int32(last)])
-                            .expandedDimensions(axis: 0)
-                        inputForPrepare = LMInput(
-                            text: LMInput.Text(tokens: lastToken),
-                            image: nil, video: nil)
+                        inputForPrepare = input
                         Self.logger.info(
-                            "Populated-cache miss: full prefix matches cache (offset=\(cacheOffset)), seeding with last token only"
-                        )
-                    } else {
-                        // cacheOffset < promptTokenIds.count — assume
-                        // prefix matches (safe for templates that don't
-                        // strip past content). Trim and prefill remainder.
-                        let remaining = Array(cacheLookupTokenIds[cacheOffset...])
-                        let remainingArray = MLXArray(remaining.map { Int32($0) })
-                            .expandedDimensions(axis: 0)
-                        inputForPrepare = LMInput(
-                            text: LMInput.Text(tokens: remainingArray),
-                            image: nil, video: nil)
-                        Self.logger.info(
-                            "Populated-cache miss: trimmed \(cacheOffset) cached tokens, prefilling \(remaining.count) remaining"
+                            "Populated-cache coordinator miss: reset unverified cache for full prefill"
                         )
                     }
-                }
                 }
             }
         } else if cacheCoordinator != nil,

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -1211,7 +1211,15 @@ public class ArraysCache: BaseKVCache {
         let new = ArraysCache(size: cache.count)
         let s = self.state
         if !s.isEmpty {
-            new.state = s.map { $0[.ellipsis] }
+            // ArraysCache users (Qwen 3.5/Ornith GatedDeltaNet among them)
+            // replace their recurrent tensor in place on every forward. An
+            // ellipsis slice is only a view of that storage, so a purported
+            // prompt-boundary `copy()` was later overwritten by tool/decode
+            // tokens and could be stored under the earlier prompt hash.
+            // Build fresh buffers here. Snapshot call sites materialize the
+            // complete cache list in one MLX.eval below, avoiding one GPU
+            // synchronization per layer.
+            new.state = s.map { $0 * 1 }
         }
         new.offset = self.offset
         new.leftPadding = self.leftPadding
@@ -1262,7 +1270,9 @@ public class MambaCache: ArraysCache {
 
     public func recordPrefixCommitState(length: Int, arrays: [MLXArray], offset: Int) {
         guard length > 0, !arrays.isEmpty else { return }
-        let snapshotArrays = arrays.map { $0[.ellipsis] }
+        // Prefix checkpoints must be independent of the next recurrent
+        // update for the same reason as `copy()` above.
+        let snapshotArrays = arrays.map { $0 * 1 }
         MLX.eval(snapshotArrays)
         prefixCommitStates[length] = PrefixCommitState(
             arrays: snapshotArrays,
@@ -1271,7 +1281,9 @@ public class MambaCache: ArraysCache {
 
     public func commitRecordedPrefix(length: Int) -> Bool {
         guard let snapshot = prefixCommitStates[length] else { return false }
-        self.state = snapshot.arrays.map { $0[.ellipsis] }
+        let restored = snapshot.arrays.map { $0 * 1 }
+        MLX.eval(restored)
+        self.state = restored
         self.offset = snapshot.offset
         clearRecordedPrefixes()
         return true
@@ -1285,7 +1297,7 @@ public class MambaCache: ArraysCache {
         let new = MambaCache()
         let s = self.state
         if !s.isEmpty {
-            new.state = s.map { $0[.ellipsis] }
+            new.state = s.map { $0 * 1 }
         }
         new.offset = self.offset
         new.leftPadding = self.leftPadding

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -288,7 +288,15 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                     }
                 }
             case .miss:
-                break
+                // Match TokenIterator's correctness invariant: a coordinator
+                // miss means this request's token/scope identity did not match
+                // any stored prefix. A caller-provided populated cache cannot
+                // be safely reused from offsets alone (reasoning/tool/media
+                // salts may have changed), so discard it before full prefill.
+                if populatedCacheRequiresResetAfterCoordinatorMiss(self.cache) {
+                    self.cache = model.newCache(parameters: effectiveParameters)
+                    inputForPrepare = input
+                }
             }
         }
 

--- a/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
@@ -1,10 +1,21 @@
 // Copyright © 2026 Osaurus AI. All rights reserved.
 
 import Foundation
+@testable import MLXLMCommon
 import Testing
 
 @Suite("BatchEngine growing-chat cache source coverage")
 struct BatchEngineGrowingChatCacheSourceTests {
+    @Test("coordinator miss resets only populated caller-owned caches")
+    func coordinatorMissResetRequiresPopulatedCache() {
+        let empty = KVCacheSimple()
+        #expect(!populatedCacheRequiresResetAfterCoordinatorMiss([empty]))
+
+        let populated = KVCacheSimple()
+        populated.offset = 37
+        #expect(populatedCacheRequiresResetAfterCoordinatorMiss([empty, populated]))
+    }
+
     @Test("batch engine stores post-answer cache boundaries and keeps hybrid full-hit guard")
     func batchEngineStoresPostAnswerBoundaryForGrowingChat() throws {
         let source = try String(
@@ -78,6 +89,10 @@ struct BatchEngineGrowingChatCacheSourceTests {
         #expect(source.contains("boundary: seedBoundary"))
         #expect(!source.contains("disk-backed full cache hit: re-feeding last token can corrupt path-dependent or rotating state"))
         #expect(source.contains("cacheContainsPathDependentState(self.cache)"))
+        #expect(source.contains(
+            "Populated-cache coordinator miss: reset unverified cache for full prefill"))
+        #expect(!source.contains("Populated-cache miss: full prefix matches cache"))
+        #expect(!source.contains("Populated-cache miss: trimmed"))
         #expect(!source.contains("let hasPathDependentLayer = self.cache.contains"))
         #expect(source.contains("shouldSkipHistoryBoundaryRederiveAfterTrimMiss(promptSnapshot)"))
         #expect(source.contains("TokenIterator: skipped history-boundary cache rederive after trim miss"))
@@ -91,6 +106,10 @@ struct BatchEngineGrowingChatCacheSourceTests {
             encoding: .utf8)
 
         #expect(source.contains("shouldSkipHistoryBoundaryRederiveAfterTrimMiss(promptSnapshot)"))
+        #expect(source.contains(
+            "a coordinator\n                // miss means this request's token/scope identity did not match"))
+        #expect(source.contains("self.cache = model.newCache(parameters: effectiveParameters)"))
+        #expect(source.contains("inputForPrepare = input"))
         #expect(source.contains("return nil"))
         #expect(!source.contains("!requiresDiskBackedRestore,\n                        !originalInput.hasMediaContent"))
         let exactSnapshot = try #require(source.range(of: "exactBoundarySSMStatesFromSnapshotIfSufficient("))

--- a/Tests/MLXLMCommonFocusedTests/CacheCoordinatorTopologyFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/CacheCoordinatorTopologyFocusedTests.swift
@@ -493,6 +493,32 @@ struct CacheCoordinatorTopologyFocusedTests {
         }
     }
 
+    @Test("prompt snapshot detaches Ornith GDN state from later in-place updates")
+    func promptSnapshotDetachesArraysCacheState() {
+        FocusedMLXTestSupport.withLock {
+            let live = ArraysCache(size: 1)
+            live[0] = MLXArray.ones([1, 4], dtype: .float32)
+            live.offset = 4
+            MLX.eval(live)
+
+            let snapshot = makePromptBoundaryCacheSnapshot(from: [live])
+            let detached = snapshot[0] as? ArraysCache
+            #expect(detached != nil)
+            #expect(detached?.offset == 4)
+
+            // Ornith's GatedDeltaNet path uses the same setter after every
+            // forward; with the old ellipsis-view copy this overwrote the
+            // prompt snapshot as well.
+            live[0] = MLXArray.ones([1, 4], dtype: .float32) * Float(9)
+            live.offset = 5
+            MLX.eval(live)
+
+            #expect(detached?.offset == 4)
+            #expect(detached?.state[0].sum().item(Float.self) == 4)
+            #expect(live.state[0].sum().item(Float.self) == 36)
+        }
+    }
+
     @Test("Nemotron Omni Mamba plus TurboQuant topology restores a paged partial prefix atomically")
     func nemotronOmniTurboQuantPagedPartialRestore() {
         FocusedMLXTestSupport.withLock {


### PR DESCRIPTION
## Scope

Reset a populated caller-owned KV or recurrent cache whenever CacheCoordinator returns a miss. Numeric cache offsets are not token-prefix identity. The same invariant now applies to TokenIterator and NativeMTPTokenIterator; verified coordinator hits remain the only prefix-reuse path.

## Root evidence

The existing cache key already hashes prompt tokens plus reasoning, tool, media, and effective KV-policy salt. In an isolated Osaurus Release UI run with /Users/eric/models/JANGQ-AI/Ornith-1.0-9B-JANG_4M, a same-chat Thinking OFF to ON switch correctly produced a coordinator miss but the old offset fallback retained Qwen 3.5 ArraysCache state. The first ON tool call replayed the prior OFF request args for lines 20-22 before executing the newly requested lines 70-72 call. A fresh-chat ON control did not replay the stale args.

This changes the owning cache layer only. It does not alter prompts, templates, parsers, sampler defaults, stop tokens, or reasoning markers.

## Current verification

- MLXLMCommon target compiled with the full Xcode toolchain.
- BatchEngineGrowingChatCacheSourceTests: 17/17 passed, including populated versus empty miss-reset behavior and Native MTP source parity.
- CacheCoordinatorModeKeyIsolationTests: 9/9 passed after staging the package metallib beside the XCTest host. Reasoning, effort, media, and KV-policy keys remain isolated.
- git diff --check passed.

## Required live gate

Status is PARTIAL until an Osaurus Release app pinned to this exact commit repeats the real model-picker and tool UI matrix. The required same-chat OFF to ON row must execute only the newly requested tool arguments, with no stale prior call replay.