### PR TITLE
Add Gemma mixed-cache L2 restore regression

### DIFF
--- a/Tests/MLXLMCommonFocusedTests/CacheCoordinatorTopologyFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/CacheCoordinatorTopologyFocusedTests.swift
@@ -247,6 +247,131 @@ struct CacheCoordinatorTopologyFocusedTests {
         }
     }
 
+    @Test("Gemma mixed TQ and wrapped rotating cache bypasses paged RAM and resumes from L2")
+    func gemmaMixedTurboQuantWrappedRotatingResumesFromDisk() {
+        FocusedMLXTestSupport.withLock {
+        let tmp = makeTempDir("gemma-mixed-tq-rotating-disk")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let modelKey = "gemma-mixed-tq-rotating-disk-focused"
+        let tokens = Array(1...96)
+
+        let simple = KVCacheSimple()
+        _ = simple.update(
+            keys: MLXArray.ones([1, 1, tokens.count, 16], dtype: .bfloat16),
+            values: MLXArray.ones([1, 1, tokens.count, 16], dtype: .bfloat16)
+                * Float(0.5))
+        let turboQuant = TurboQuantKVCache.fromSimpleCache(
+            simple,
+            keyBits: 4,
+            valueBits: 4,
+            sinkTokens: 4)
+        #expect(turboQuant.phase == .compressed)
+
+        // Use repeated multi-token prefill chunks so the rotating cache crosses
+        // its window before the prompt-boundary snapshot, matching Gemma's
+        // chunked-prefill lifecycle rather than only testing an unwrapped ring.
+        let rotating = RotatingKVCache(maxSize: 16, keep: 0, step: 4)
+        for chunkStart in stride(from: 0, to: tokens.count, by: 12) {
+            let marker = Float(chunkStart / 12 + 1)
+            _ = rotating.update(
+                keys: MLXArray.ones([1, 1, 12, 16], dtype: .bfloat16) * marker,
+                values: MLXArray.ones([1, 1, 12, 16], dtype: .bfloat16)
+                    * (marker + Float(0.25)))
+        }
+        MLX.eval(turboQuant, rotating)
+        #expect(rotating.offset == tokens.count)
+        #expect(rotating.offset > (rotating.maxSize ?? 0))
+
+        do {
+            let writer = makeCoordinator(
+                usePagedCache: true,
+                enableDiskCache: true,
+                diskCacheDir: tmp,
+                modelKey: modelKey,
+                blockSize: 8)
+            writer.setPagedIncompatible(true)
+            writer.storeAfterGeneration(
+                promptTokens: tokens,
+                perLayerData: [],
+                ssmStates: nil,
+                cache: [turboQuant, rotating])
+
+            let stats = writer.snapshotStats()
+            #expect(!stats.pagedEnabled)
+            #expect(stats.isPagedIncompatible)
+            #expect((writer.pagedCache?.snapshotStats().allocatedBlocks ?? -1) == 0)
+            #expect((stats.diskStats?.stores ?? 0) > 0)
+        }
+
+        // A fresh coordinator models an app/model restart: no in-memory paged
+        // blocks survive, so the only valid prefix source is the typed SSD L2
+        // payload containing TQ attention KV plus rotating SWA ring metadata.
+        let reader = makeCoordinator(
+            usePagedCache: true,
+            enableDiskCache: true,
+            diskCacheDir: tmp,
+            modelKey: modelKey,
+            blockSize: 8)
+        reader.setPagedIncompatible(true)
+        let growingPrompt = tokens + [97, 98]
+        switch reader.fetch(tokens: growingPrompt, skipExactDiskBoundary: true) {
+        case .hit(let matched, let remaining, let detail, let blocks, _, let arrays):
+            #expect(matched == tokens.count)
+            #expect(remaining == [97, 98])
+            #expect(detail == .disk)
+            #expect(blocks.isEmpty)
+            guard let arrays else {
+                Issue.record("Gemma mixed L2 hit must carry typed cache arrays")
+                return
+            }
+
+            var restored: [any KVCache] = [
+                KVCacheSimple(),
+                RotatingKVCache(maxSize: 16, keep: 0, step: 4),
+            ]
+            let restoredTokens = restoreFromDiskArrays(arrays, into: &restored)
+            MLX.eval(restored)
+            #expect(restoredTokens == tokens.count)
+            #expect(restored[0] is TurboQuantKVCache)
+            #expect(restored[1] is RotatingKVCache)
+            #expect(ModelCacheTopologySnapshot(cache: restored).turboQuantKVLayerCount == 1)
+            #expect(ModelCacheTopologySnapshot(cache: restored).rotatingKVLayerCount == 1)
+
+            guard let restoredRotating = restored[1] as? RotatingKVCache else {
+                return
+            }
+            #expect(restoredRotating.metaState == rotating.metaState)
+            #expect(restoredRotating.state.count == rotating.state.count)
+            for (actual, expected) in zip(restoredRotating.state, rotating.state) {
+                #expect(actual.shape == expected.shape)
+                #expect(allClose(actual, expected).item(Bool.self))
+            }
+
+            // Resume both copies with the same suffix token. Exact state and
+            // temporal ordering prove the restored ring is synchronized, not
+            // merely shape-compatible telemetry.
+            let nextKeys = MLXArray.ones([1, 1, 1, 16], dtype: .bfloat16) * Float(99)
+            let nextValues = MLXArray.ones([1, 1, 1, 16], dtype: .bfloat16) * Float(99.25)
+            _ = rotating.update(keys: nextKeys, values: nextValues)
+            _ = restoredRotating.update(keys: nextKeys, values: nextValues)
+            MLX.eval(rotating, restoredRotating)
+            #expect(restoredRotating.metaState == rotating.metaState)
+            guard let expectedOrdered = rotating.temporallyOrderedKV(),
+                  let actualOrdered = restoredRotating.temporallyOrderedKV()
+            else {
+                Issue.record("continued rotating caches must expose temporal KV")
+                return
+            }
+            #expect(allClose(actualOrdered.keys, expectedOrdered.keys).item(Bool.self))
+            #expect(allClose(actualOrdered.values, expectedOrdered.values).item(Bool.self))
+            #expect((reader.diskCache?.snapshotStats().hits ?? 0) > 0)
+            #expect((reader.pagedCache?.snapshotStats().cacheHits ?? 0) == 0)
+        case .miss:
+            Issue.record("fresh Gemma coordinator should resume the wrapped mixed cache from SSD L2")
+        }
+        }
+    }
+
     @Test("hybrid disk hit rejects partial companion state")
     func hybridDiskHitRejectsPartialSSMCompanion() {
         FocusedMLXTestSupport.withLock {

--- a/docs/GEMMA4_QAT_CACHE_CORRECTNESS_CHECKPOINT_2026-07-19.md
+++ b/docs/GEMMA4_QAT_CACHE_CORRECTNESS_CHECKPOINT_2026-07-19.md
@@ -1,11 +1,20 @@
 # Gemma 4 QAT cache correctness checkpoint — 2026-07-19
 
-Status: **PARTIAL — the exact current vMLX `bbc0b20d` pin is live-proven in an
-isolated Release Osaurus build for the Gemma 4 12B JANG_4M and MXFP8 native,
-TurboQuant, SSD-only restart/partial-restore, explicit SSD-Off, and settings
-default rows. The 31B RAM-override control works, but its Activity Monitor
-Memory column exceeded the bundle's on-disk size, so the low-footprint row is
-failed rather than release-cleared.**
+Status: **PARTIAL — the exact current merged vMLX tree is reconfirmed in an
+isolated Release Osaurus build with the local Gemma 4 12B JANG_4M bundle for
+native cache, explicit TurboQuant 4/4, SSD-only restart/partial restore, long
+rotating-window recall, visible prefill progress, and the safe rejection of an
+explicit paged-RAM request. The current 12B Activity Monitor Memory row is
+9.48 GB and remains a failed low-footprint gate. A controlled built-in web-tool
+continuation is now live-proven with native cache and explicit TQ 4/4, but the
+Thinking on/off tool-loop propagation is only partial: both UI states completed
+one controlled tool continuation, but the thinking-on Gemma row emitted no
+visible reasoning block. The admin generation-settings ownership defect is now
+source-fixed and live-proven in a rebuilt isolated Release app: the automatic
+one-token chat-prefill warm-up no longer overwrites the last visible request.
+The full parser/tool-error matrix and the wider API/stop matrix remain open.
+Historical MXFP8 evidence below is retained but was not rerun on
+2026-07-20.**
 
 This checkpoint is intentionally limited to locally installed Gemma 4 MXFP8
 and JANG_4M bundles through the real Osaurus/vMLX Swift runtime. MXFP4 is not a
@@ -55,6 +64,70 @@ substitute test artifact and is not part of this checkpoint.
 | RAM safety refusal/override | Strict custom 10% visibly refused the 31B JANG_4M at a 12.8 GiB budget before load. No Automatic Limits then loaded the same model and visibly emitted `RAM-OVERRIDE-3179` at 12.2 tok/s. Endpoint reported `automatic_memory_limits_disabled=true` and allowed the estimated 30.9 GiB request. Safe Auto was restored and saved | VERIFIED-LIVE for control behavior |
 | Activity Monitor footprint | Exact proof executable inspected. 31B JANG_4M: main Memory 28.37 GB; inspector Real Memory 19.30 GB, Private 996 MB. Bundle is 25G on disk (25,926,564 KiB). Main Memory exceeded full bundle size, so this does not satisfy the low-footprint gate | FAILED-LIVE |
 
+## 2026-07-20 current merged-tree reconfirmation
+
+This run used only
+`/Users/eric/models/OsaurusAI/OsaurusAI--gemma-4-12B-it-qat-JANG_4M`.
+No MXFP4 bundle was loaded or used as a substitute.
+
+- vMLX remote-main merge commit: `364eab42`.
+- Osaurus current main: `9b0331fd4`; its package pin is vMLX `4b431c6a`.
+- `364eab42` and `4b431c6a` resolve to the identical vMLX tree
+  `8f52a9fb0f72694fc7f03f06b017a93c12924886`; their tree diff is empty.
+- Isolated Release app:
+  `/private/tmp/osaurus-gemma4-closeout-baseline-release-derived/Build/Products/Release/osaurus.app`,
+  bundle id `com.dinoki.osaurus.gemma4closeoutbaseline`, ad-hoc-signed executable
+  SHA-256 `7253244d2e06e6ef92c9d53a23e6fe36284d27a1ac54f72173d4044ede160158`.
+- The app used an isolated test root and keychain-free UI. The production app
+  and its preferences were not used for these rows.
+
+| Row | Visible app evidence | Runtime/source evidence | Status |
+|---|---|---|---|
+| Fresh settings | Server -> Settings -> Cache visibly showed Prefix On, GPU Cache Off, Disk Cache On, Codec Engine Selected, and SSM rederive On; Thinking was visibly Off in chat | Fresh isolated preferences; no production `UserDefaults` reuse | VERIFIED-LIVE |
+| Native long-window cold prefill | An 8,635-token ledger visibly showed `Prefill 0/8635` and `8192/8635`, then emitted `START=amber-17; MIDDLE=cobalt-88; END=jade-42`; TTFT 7.39 s, 38.1 tok/s, 25 tokens | Topology 48 layers = 8 native full KV + 40 rotating SWA; TQ layer count 0; paged counters 0 | VERIFIED-LIVE |
+| Native partial prefix | Same live conversation emitted `R037=river-37-quartz; R219=river-219-quartz`; TTFT 0.94 s, 41.3 tok/s, 28 tokens | Partial-prefix lookup used disk while paged remained disabled | VERIFIED-LIVE |
+| Native fresh-process L2 | After quitting and relaunching only the isolated app, it emitted `R005=river-5-quartz; R200=river-200-quartz`; TTFT 0.92 s, 41.6 tok/s, 27 tokens | Fresh-process counters reached disk hits 4 / stores 5 / misses 8; paged hits/misses stayed 0 | VERIFIED-LIVE |
+| Explicit TQ 4/4 validation | Selecting TurboQuant without widths visibly produced a blocking validation message; entering 4/4 saved and unloaded the model | Settings require explicit key and value widths; codec remains opt-in | VERIFIED-LIVE |
+| TQ 4/4 cold/warm | Cold reload emitted `R011=river-11-quartz; R188=river-188-quartz` at TTFT 9.06 s, 14.9 tok/s; warm partial reuse emitted `R042=river-42-quartz; R177=river-177-quartz` at TTFT 1.33 s, 28.8 tok/s | Exactly 8 full-KV layers converted to TQ; all 40 rotating layers stayed native | VERIFIED-LIVE |
+| TQ 4/4 fresh-process L2 | After full isolated-app restart, it emitted `R073=river-73-quartz; R231=river-231-quartz`; TTFT 1.44 s, 27.4 tok/s, 28 tokens | Disk hits 3 / misses 8 / stores 4; before topology 8 KV + 40 rotating, after 8 TQ + 40 rotating; paged 0 | VERIFIED-LIVE |
+| Explicit paged request on mixed SWA | With GPU Cache visibly enabled in Settings, chat emitted `R099=river-99-quartz; R204=river-204-quartz`; TTFT 2.37 s, 29.3 tok/s, 28 tokens | Configured paged true, effective paged false, `is_paged_incompatible=true`, paged hits/misses 0, disk hits 2; TQ 8 + rotating 40 | VERIFIED-SOURCE + VERIFIED-LIVE |
+| Defaults restored | The same isolated UI visibly saved GPU Cache Off and Codec Engine Selected; Prefix and Disk remained On. A cold reload then emitted `NATIVE-DEFAULTS-RESTORED-2041`; TTFT 14.91 s, 29.3 tok/s, 19 tokens | Endpoint returned fp16, transition null, 8 KV + 40 rotating, configured/effective paged false, disk hits 1, and MLXPress disabled | VERIFIED-LIVE |
+| Native built-in tool continuation | With Thinking visibly Off and Codec Engine Selected, the model called built-in web search exactly once for `Osaurus GitHub repository`, then emitted exactly `TOOL-CONTINUED-NATIVE`; TTFT 1.68 s, 39.0 tok/s, 11 tokens | The UI rendered one search tool card followed by one assistant content turn; no protocol marker, raw tool JSON, loop, or empty post-tool answer leaked | VERIFIED-LIVE |
+| TQ 4/4 built-in tool continuation | Settings visibly saved TurboQuant 4/4 and unloaded the model. After the cold reload, with Thinking still visibly Off, the model called built-in web search exactly once for `vMLX Swift GitHub repository`, then emitted exactly `TOOL-CONTINUED-TQ44`; TTFT 2.18 s, 14.2 tok/s, 12 tokens | `/admin/cache-stats` reported `effective_kv_mode=turbo(4,4)`, an exact 8 native-KV to 8 TQ transition, 40 rotating layers preserved, paged disabled/incompatible, disk hits 2 / misses 8 / stores 3, and MLXPress disabled | VERIFIED-SOURCE + VERIFIED-LIVE |
+| Thinking-on built-in tool continuation | The model popover visibly reported Thinking On. Gemma called built-in web search exactly once for `Gemma 4 model family`, then emitted exactly `THINKING-ON-TOOL-CONTINUED`; TTFT 2.08 s, 38.5 tok/s, 14 tokens. The popover was then visibly restored to Thinking Off | `ChatTurnGenerationControls` freezes the explicit UI choice and applies it to every loop request and cap finalizer; `ChatEngine` maps it into `disableThinking`; `MLXBatchAdapter.additionalContext` maps that to `enable_thinking`. No reasoning block was visible, so semantic reasoning emission is not claimed | PARTIAL-SOURCE + VERIFIED-LIVE continuation |
+| Last effective generation telemetry | The baseline app incorrectly reported the chat-prefill warm-up's `max_tokens=1`, `temperature=0`. In rebuilt Release executable SHA-256 `fc49aba748ef4c0388ddfbcbc2458663efd0b0e6b190a7de1cd77a72fa18a76b`, the exact JANG_4M UI turn visibly emitted `USER-VISIBLE-TELEMETRY-7319` at TTFT 1.27 s, 38.8 tok/s, 16 tokens. A second UI turn called built-in web search exactly once and emitted `TOOL-TELEMETRY-8842` at TTFT 2.02 s, 33.1 tok/s, 14 tokens. Logs then recorded a sentinel-only warm-up, while `/admin/cache-stats` still reported the visible request's bundle-owned `max_tokens=16384`, `temperature=1`, `top_k=64`, and `top_p=0.95` | Source trace found both pending and submitted settings recorders accepted `generation.warmupPrefill`; the Osaurus patch now excludes those housekeeping requests at both record sites and adds a focused classification test. The exact app used isolated bundle ID `com.dinoki.osaurus.gemma4telemetryproof` and fresh preferences | VERIFIED-SOURCE + VERIFIED-LIVE |
+| Unavailable calculator request | The same UI prompt requested a calculator call, but Agent -> Abilities -> Tools visibly reported `0 of 0 assigned` and `No tools available`. Auto-discovery instead called time, built-in web search, and capability search before emitting the correct arithmetic result | This row cannot diagnose a calculator JSON schema because no calculator schema was assigned. It is retained as an Osaurus tool-availability/fallback UX finding, not classified as a Gemma parser failure | FAILED-LIVE / OUT OF CHECKPOINT |
+| 12B physical footprint | Activity Monitor visibly showed the exact PID 23207 at 9.48 GB. `footprint` measured 9,712 MB current / 12 GB peak, including 8,634 MB dirty IOAccelerator memory. The model's weight files total 10,135,442,741 bytes | This is close to full weight residency and does not meet the repository's strict low-physical-footprint criterion | FAILED-LIVE |
+
+The explicit TurboQuant mode reduced steady warm decode from about 41 tok/s to
+27-29 tok/s in this run. That is recorded as an opt-in tradeoff, not used to
+change the default or to hide a correctness issue.
+
+### Current RAM root-cause classification
+
+This is not a growing KV-cache or MLXPress leak:
+
+- After the settings save unloaded the model, the same process fell to a
+  1,015 MB physical footprint. After the default native reload it returned to
+  9,712 MB, isolating the increase to model residency.
+- Runtime telemetry reported MLXPress `enabled=false`, backend `none`, cold
+  fraction null, routed bytes 0, and tiles 0. The load decision reported mmap
+  requested and the ordinary Safe Auto 70% memory budget.
+- This exact 12B bundle is dense: the decoded Gemma configuration has no routed
+  experts. Osaurus/vMLX source allows experimental MLXPress only for explicitly
+  opted-in routed bundles, so enabling the user toggle cannot create inactive
+  expert pages for this model.
+- The safetensors mmap loader wraps mapped shard memory in no-copy Metal
+  buffers. Gemma's dense decode touches every decoder layer; the live VM map
+  consequently attributed 8.4 GB to resident dirty IOAccelerator buffers while
+  only 63 MB remained categorized as resident mapped-file pages.
+
+Therefore the current evidence points to dense weight residency, not a cache
+ownership bug that can be fixed with a cache guard. Meeting the strict
+below-full-bundle footprint criterion would require a separately designed and
+live-proven dense-weight streaming/offload path, with its decode-speed cost
+measured. No such behavior is being silently enabled in this correctness patch.
+
 ## Required live closure matrix
 
 Every row must use a fresh Release development build with an isolated bundle
@@ -69,17 +142,18 @@ telemetry are both required.
 | SSD L2 with paged off | Both 12B formats restored partial prefixes from disk after process restart while paged counters remained zero | VERIFIED-LIVE |
 | Explicit SSD L2 off | Visible SSD-Off save plus endpoint false/zero-counter proof | VERIFIED-LIVE |
 | Fresh-process L2 restore | Both 12B formats showed post-restart disk hits and coherent changed-prefix continuations | VERIFIED-LIVE |
-| Raw-prefill fallback | Use a cache-salted or genuinely new prefix absent from both tiers; paged/disk miss counters increase, real prefill progress is visible, output remains coherent | OPEN |
+| Raw-prefill fallback | Fresh isolated storage had no prior cache entry. The new 8,635-token ledger visibly progressed from `Prefill 0/8635` through `8192/8635`, returned all three exact sentinels, and later telemetry showed disk misses while paged remained off | VERIFIED-LIVE |
 | TurboQuant after L2 restore | Post-restart MXFP8 and JANG_4M rows re-established 8 TQ layers while preserving 40 rotating layers | VERIFIED-LIVE |
 | TurboQuant off control | Current restored-default MXFP8 endpoint reported fp16, transition null, and zero TQ topology | VERIFIED-LIVE |
-| Long rotating-window sentinel | Cross the 1,024-token SWA window, reuse prefix/L2, and reproduce exact early/middle/tail facts without a loop or truncated tail | OPEN |
-| Ten-turn coherence | Ten visible turns with cache reuse, measured TTFT/tok/s on every generated turn, no marker leakage, no hidden-only answer, no looping | OPEN |
-| Tool/parser continuation | Required tool, auto tool, no tool, tool-result continuation, tool error recovery, and post-tool text turn with TQ off/on | OPEN |
-| Reasoning/template state | UI Thinking off/on/auto maps to the emitted reasoning/content channels and model-owned generation config; no prompt or sampler masking | OPEN |
+| Long rotating-window sentinel | Current JANG_4M run crossed the 1,024-token SWA window with an 8,635-token ledger, reproduced exact early/middle/tail sentinels, then performed coherent partial and post-restart L2 continuations | VERIFIED-LIVE |
+| Ten-turn coherence | Twelve visible generated turns covered native cold/partial/restart, TQ cold/partial/restart, explicit paged request, restored defaults, an unavailable-tool fallback, and native/TQ/thinking-on web-tool continuations. Every turn exposed TTFT/tokens and recorded tok/s; all ended with visible content, with no protocol-marker leakage or loop | VERIFIED-LIVE |
+| Tool/parser continuation | Native and explicit TQ 4/4 each completed one built-in web-search call plus an exact post-tool content turn with Thinking off. Required-tool enforcement across an assigned non-search schema, auto/no-tool, tool-error recovery, and a further post-tool user turn remain untested | PARTIAL |
+| Reasoning/template state | Thinking Off and On were visibly toggled in the real model popover, source trace carries the explicit choice through every chat tool-loop reconstruction, and both modes produced exact post-tool content. The thinking-on Gemma row showed no reasoning block, so template/rendered-prompt or reasoning-channel proof is still missing; final UI state is Off | PARTIAL |
+| Generation telemetry ownership | `last_effective_generation` must describe the last visible user/API request, not a discarded warm-up | Baseline failed; two-site source fix plus rebuilt Release UI and post-warm-up endpoint proof are current | VERIFIED-SOURCE + VERIFIED-LIVE |
 | API parity | Chat Completions stream/non-stream, Responses stream/non-stream, Anthropic, and Ollama reconstruct the same visible content and finish reason | OPEN |
 | Stop/cancel cleanup | Cancel during prefill and decode; next warm turn neither restores a poisoned partial boundary nor leaks stale output | OPEN |
 | Memory settings next-load semantics | Strict custom 10% refusal and No Automatic Limits success are live-proven on the same 31B bundle; Safe Auto restored. Performance/Balanced modes remain open | PARTIAL |
-| Low-RAM physical footprint | Activity Monitor main Memory must remain below full bundle size during load/generation | FAILED-LIVE on 31B: 28.37 GB versus 25G bundle |
+| Low-RAM physical footprint | Activity Monitor main Memory must remain below full bundle size during load/generation | FAILED-LIVE on current 12B: 9.48 GB versus 10.14 GB weights, with 8.4 GB resident dirty IOAccelerator; historical 31B row also failed |
 | Delegation/admission | Local text subagent, Computer Use/AppleScript, image generation/edit, and concurrent delegation receive the same memory admission decision before model eviction | OPEN; Osaurus-level row |
 
 ## Non-Gemma rows retained for the wider campaign
@@ -119,3 +193,29 @@ older `automaticRuntimeCachePolicyCoversDownloadedArchitectureFamilies`
 matrix still contains a separate stale Hunyuan reasoning expectation
 (`think_xml` while the current source returns `hy_v3`). That unrelated row is
 not changed or counted as Gemma cache proof in this checkpoint.
+
+The 2026-07-20 patch adds
+`gemmaMixedTurboQuantWrappedRotatingResumesFromDisk`. Its focused current-source
+run passed 1/1 in 4.586 seconds. The test crosses a rotating window, persists a
+mixed compressed-TQ/native-rotating snapshot with paged requested but marked
+incompatible, starts a fresh coordinator, restores only from typed SSD L2,
+compares rotating metadata and tensors, appends the same suffix to both source
+and restored rings, and compares their temporally ordered KV exactly. This is a
+focused regression result only; the full Swift suite has not yet been rerun.
+
+Two wider test invocations are not counted as passes. The command-line-tools
+Swift 6.3.1 graph stopped while compiling the unrelated `MLXPressPolicyTests`
+target because that toolchain could not import `Testing`. Retrying with Xcode
+26.6 / Swift 6.3.3 built the package but the selected test executable stopped
+before assertions because it could not find MLX's default Metal library. The
+exact focused cache regression above remains the only new current-source test
+result until the package test graph is run with both Swift Testing and the MLX
+Metal library available.
+
+The companion Osaurus telemetry patch was built in the Xcode workspace's Debug
+test graph and then executed from that exact build with the enumerated Swift
+Testing identifier
+`OsaurusCoreTests/MLXBatchAdapterTests/lastEffectiveGenerationTelemetry_excludesChatPrefillWarmups()`.
+It passed 1/1 in 0.000 seconds. The first invocation omitted the identifier's
+trailing parentheses and therefore selected no leaf test; that invocation is
+not counted.


### PR DESCRIPTION
## Summary

- Add a focused Gemma mixed-cache regression for explicit TurboQuant full-attention KV plus wrapped rotating SWA state.
- Prove paged RAM is bypassed when the topology is incompatible, the typed snapshot is stored to SSD L2, and a fresh coordinator resumes from disk with exact rotating metadata/tensors and correct temporal ordering after a suffix append.
- Update the checkpoint ledger with the exact current JANG_4M live UI evidence and keep unresolved gates explicitly PARTIAL or FAILED.

This PR changes no vMLX production source. It contains one focused test and one evidence document.

## Current source proof

- Base is current `vmlx-origin/main` at `364eab42a91664ca92299b9fc1d49f1e15238bbc`.
- The Osaurus pin used for live proof is `4b431c6a`; it and `364eab42` resolve to the identical vMLX tree `8f52a9fb0f72694fc7f03f06b017a93c12924886`.
- `gemmaMixedTurboQuantWrappedRotatingResumesFromDisk` passed 1/1 in 4.586 seconds.
- The test crosses the rotating window, requests paged cache while marking the topology incompatible, verifies zero paged allocation, persists mixed TQ/native rotating state, restores through a fresh SSD-only coordinator, and compares the continued temporal KV tensors exactly.
- `git diff --check` is clean.

## Live Osaurus evidence recorded

- Only `/Users/eric/models/OsaurusAI/OsaurusAI--gemma-4-12B-it-qat-JANG_4M` was used for the 2026-07-20 reconfirmation; no MXFP4 bundle was loaded.
- Real isolated Release UI covered native and explicit TQ 4/4 cold/partial/restart paths, paged-request rejection, SSD L2 with paged RAM off, long prefill progress, rotating-window sentinel recall, default restoration, multi-turn output, and native/TQ tool continuation.
- A rebuilt isolated Osaurus app also live-proved that internal one-token chat warmups no longer overwrite `last_effective_generation`, including after an exact one-tool agent continuation.

## Honest remaining gates

- Overall status remains PARTIAL, not release-ready.
- Current 12B Activity Monitor row was 9.48 GB versus 10.14 GB of weights, with 8.4 GB resident dirty IOAccelerator memory: strict low-footprint gate FAILED-LIVE.
- Required non-search tool enforcement, tool-error recovery, full reasoning-channel proof, wider API parity, and cancellation recovery remain open.
- Wider package attempts are not counted as passes: one command-line-tools graph could not import Swift Testing, and one Xcode package test executable could not locate the MLX default Metal library.
