### PR TITLE
guard qwen3.5 gated-delta-net against incompatible restored cache shapes

### DIFF
--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -254,6 +254,22 @@ final class Qwen35GatedDeltaNet: Module {
         super.init()
     }
 
+    /// One-shot (per process) diagnostic for a discarded incompatible cache
+    /// slot — the reset self-heals, but a silent reset would hide the
+    /// upstream restore bug that produced the bad shape.
+    private static let discardedCacheWarningLock = NSLock()
+    private nonisolated(unsafe) static var didWarnDiscardedCache = false
+
+    static func warnDiscardedCacheState(slot: String, shape: [Int]) {
+        discardedCacheWarningLock.lock()
+        defer { discardedCacheWarningLock.unlock() }
+        guard !didWarnDiscardedCache else { return }
+        didWarnDiscardedCache = true
+        print(
+            "[Qwen35] GatedDeltaNet discarded incompatible \(slot) cache state "
+                + "(shape \(shape)); resetting linear-attention state")
+    }
+
     func callAsFunction(
         _ inputs: MLXArray,
         mask: MLXArray? = nil,
@@ -268,10 +284,20 @@ final class Qwen35GatedDeltaNet: Module {
         let b = inProjB(inputs)
         let a = inProjA(inputs)
 
+        // A restored cache (paged/hybrid restore, prefix commit) can hand back
+        // a slot whose shape no longer matches this layer — an over- or
+        // under-rank array here trips the MLXArray subscript rank precondition
+        // below and aborts the app. Discard the slot and restart from zero
+        // state instead: one degraded generation beats a crash.
         let convState: MLXArray
-        if let cacheState = cache?[0] {
+        if let cacheState = cache?[0],
+            cacheState.ndim == 3, cacheState.dim(0) == B, cacheState.dim(2) == convDim
+        {
             convState = cacheState
         } else {
+            if let cacheState = cache?[0] {
+                Self.warnDiscardedCacheState(slot: "conv", shape: cacheState.shape)
+            }
             convState = MLXArray.zeros([B, convKernelSize - 1, convDim], dtype: inputs.dtype)
         }
 
@@ -300,7 +326,23 @@ final class Qwen35GatedDeltaNet: Module {
         let k = convSplit[1].reshaped(B, S, numKHeads, headKDim)
         let v = convSplit[2].reshaped(B, S, numVHeads, headVDim)
 
-        let initialState = cache?[1]
+        // Same defense as the conv slot: a mis-restored recurrent state with
+        // the wrong rank/head dims crashes inside `gatedDeltaUpdate`
+        // subscripts. Expected shape is [B, Hv, Dv, Dk].
+        let initialState: MLXArray?
+        if let cachedState = cache?[1] {
+            if cachedState.ndim == 4, cachedState.dim(0) == B,
+                cachedState.dim(1) == numVHeads, cachedState.dim(2) == headVDim,
+                cachedState.dim(3) == headKDim
+            {
+                initialState = cachedState
+            } else {
+                Self.warnDiscardedCacheState(slot: "recurrent", shape: cachedState.shape)
+                initialState = nil
+            }
+        } else {
+            initialState = nil
+        }
         var state = initialState
         // Fused scaled rms_norm: bake the per-head-dim scale into the rms_norm
         // weight vector so MLXFast.rmsNorm does (scale * normed) in one Metal

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -926,6 +926,22 @@ enum Qwen35Language {
             super.init()
         }
 
+        /// One-shot (per process) diagnostic for a discarded incompatible
+        /// cache slot — the reset self-heals, but a silent reset would hide
+        /// the upstream restore bug that produced the bad shape.
+        private static let discardedCacheWarningLock = NSLock()
+        private nonisolated(unsafe) static var didWarnDiscardedCache = false
+
+        static func warnDiscardedCacheState(slot: String, shape: [Int]) {
+            discardedCacheWarningLock.lock()
+            defer { discardedCacheWarningLock.unlock() }
+            guard !didWarnDiscardedCache else { return }
+            didWarnDiscardedCache = true
+            print(
+                "[Qwen35] GatedDeltaNet discarded incompatible \(slot) cache state "
+                    + "(shape \(shape)); resetting linear-attention state")
+        }
+
         func callAsFunction(
             _ inputs: MLXArray,
             mask: MLXArray? = nil,
@@ -940,10 +956,21 @@ enum Qwen35Language {
             let b = inProjB(inputs)
             let a = inProjA(inputs)
 
+            // A restored cache (paged/hybrid restore, prefix commit) can hand
+            // back a slot whose shape no longer matches this layer — an
+            // over- or under-rank array here trips the MLXArray subscript
+            // rank precondition below and aborts the app. Discard the slot
+            // and restart from zero state instead: one degraded generation
+            // beats a crash.
             let convState: MLXArray
-            if let cacheState = cache?[0] {
+            if let cacheState = cache?[0],
+                cacheState.ndim == 3, cacheState.dim(0) == B, cacheState.dim(2) == convDim
+            {
                 convState = cacheState
             } else {
+                if let cacheState = cache?[0] {
+                    Self.warnDiscardedCacheState(slot: "conv", shape: cacheState.shape)
+                }
                 convState = MLXArray.zeros(
                     [B, max(0, convKernelSize - 1), convDim], dtype: inputs.dtype)
             }
@@ -966,7 +993,23 @@ enum Qwen35Language {
             let k = split[1].reshaped(B, S, numKHeads, headKDim)
             let v = split[2].reshaped(B, S, numVHeads, headVDim)
 
-            let initialState = cache?[1]
+            // Same defense as the conv slot: a mis-restored recurrent state
+            // with the wrong rank/head dims crashes inside `gatedDeltaUpdate`
+            // subscripts. Expected shape is [B, Hv, Dv, Dk].
+            let initialState: MLXArray?
+            if let cachedState = cache?[1] {
+                if cachedState.ndim == 4, cachedState.dim(0) == B,
+                    cachedState.dim(1) == numVHeads, cachedState.dim(2) == headVDim,
+                    cachedState.dim(3) == headKDim
+                {
+                    initialState = cachedState
+                } else {
+                    Self.warnDiscardedCacheState(slot: "recurrent", shape: cachedState.shape)
+                    initialState = nil
+                }
+            } else {
+                initialState = nil
+            }
             var state = initialState
             let invScale = pow(Float(headKDim), -0.5)
             let qNormed =


### PR DESCRIPTION
## Summary

- Production crash reports show a fatal precondition failure in `getItemND` (MLXArray subscript rank check), reached from `GatedDeltaNet.callAsFunction` via `TokenIterator.prepareRemainder` in the batch engine solo fast path.
- The slice at the crash site always operates on a rank-3 array when state is built fresh, so the only way to trap there is a `MambaCache` slot restored with a stale or mismatched shape (paged/hybrid cache restore, prefix commit).
- This validates both cache slots before use in `GatedDeltaNet` (MLXVLM) and `Qwen35GatedDeltaNet` (MLXLLM):
  - Conv slot must be rank 3 with matching batch size and `convDim`.
  - Recurrent slot must be rank 4 with shape `[B, numVHeads, headVDim, headKDim]`.
- An incompatible slot is discarded and generation restarts from zero linear-attention state instead of aborting the process.
- A one-shot warning logs the discarded slot name and shape so the upstream restore bug is not silently masked.

## Notes

- This is a defensive guard; the producer of the bad shape is somewhere in the cache restore path, and the new log line will fingerprint it if it fires again.
- One degraded generation after a bad restore is the accepted tradeoff versus a hard crash on launch.

## Test plan

- Build MLXLLM and MLXVLM.
- Run a Qwen3.5 generation with cache reuse and confirm output is unchanged.
- Optionally corrupt a cache slot shape in a debug build and confirm the reset path logs and continues instead of trapping.

## Checklist

Put an `x` in the boxes that apply.

- [ ] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
