### PR TITLE
Restore safe hybrid SSD prefix reuse without cache rewrites

### DIFF
--- a/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
@@ -554,6 +554,17 @@ public final class CacheCoordinator: @unchecked Sendable {
             }
 
             for boundary in diskCache.candidateTokenCounts(maxTokens: tokens.count) {
+                // `skipExactDiskBoundary` is a correctness requirement for
+                // path-dependent hybrid caches, not merely a preference for
+                // the first two probes above. The indexed fallback used to
+                // re-admit `tokens.count`, so Qwen 3.5 / Ornith restored an
+                // exact GDN boundary, failed to find the N-1 seed state, and
+                // discarded the restore for a full prompt prefill. Keep the
+                // exact boundary excluded across every probe source so the
+                // longest safe partial boundary is selected instead.
+                guard !skipExactDiskBoundary || boundary != tokens.count else {
+                    continue
+                }
                 guard tried.insert(boundary).inserted else { continue }
                 if let hit = diskHit(boundary: boundary) {
                     return hit

--- a/Libraries/MLXLMCommon/Cache/DiskCache.swift
+++ b/Libraries/MLXLMCommon/Cache/DiskCache.swift
@@ -11,6 +11,7 @@ public struct DiskCacheStats: Sendable {
     public let hits: Int
     public let misses: Int
     public let stores: Int
+    public let storeSkips: Int
     public let maxSizeBytes: Int
 }
 
@@ -69,6 +70,11 @@ public enum MLXCacheIOLock {
 /// likewise synchronous since they typically feed directly into model inference.
 public final class DiskCache: @unchecked Sendable {
 
+    private struct ValidatedFileFingerprint: Equatable {
+        let size: Int
+        let modificationDate: Date
+    }
+
     // MARK: - Properties
 
     /// Root directory for cache files and the SQLite index.
@@ -95,6 +101,15 @@ public final class DiskCache: @unchecked Sendable {
     /// Number of store operations initiated.
     public private(set) var stores: Int = 0
 
+    /// Number of store operations that reused an already validated file.
+    public private(set) var storeSkips: Int = 0
+
+    /// Files successfully written or deserialized in this process. A matching
+    /// fingerprint lets `store` avoid realizing and rewriting the same large
+    /// prompt boundary after a cache hit, while a fresh process still validates
+    /// an inherited file before it can take the fast path.
+    private var validatedFiles: [String: ValidatedFileFingerprint] = [:]
+
     /// Thread-safe copy of current disk-cache counters.
     public func snapshotStats() -> DiskCacheStats {
         lock.lock()
@@ -103,6 +118,7 @@ public final class DiskCache: @unchecked Sendable {
             hits: hits,
             misses: misses,
             stores: stores,
+            storeSkips: storeSkips,
             maxSizeBytes: maxSizeBytes)
     }
 
@@ -153,7 +169,7 @@ public final class DiskCache: @unchecked Sendable {
     /// Store token arrays to disk as a safetensors file.
     ///
     /// Arrays are evaluated on the calling thread, then the file write and
-    /// SQLite insert are dispatched to a background task.
+    /// SQLite insert complete synchronously under the process-wide IO lock.
     ///
     /// - Parameters:
     ///   - tokens: Token IDs used to compute the cache key hash.
@@ -200,6 +216,32 @@ public final class DiskCache: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         stores += 1
+
+        // A normal warm request fetches an L2 entry and then publishes the
+        // same prompt boundary again at completion. Rewriting it used to
+        // synchronize Metal, realize every cache tensor, write hundreds of MB,
+        // and churn quota eviction even though the content-addressed key had
+        // just been validated. Only skip files successfully loaded or written
+        // by this process, and only while their size + mtime and SQLite row
+        // still match. A fresh process, changed/corrupt file, missing index, or
+        // format migration therefore takes the full write path and heals the
+        // entry instead of preserving an assumption.
+        if let validated = validatedFiles[hash],
+           let current = _fileFingerprint(url: url),
+           current == validated,
+           let indexed = _entryMetadataLocked(hash: hash),
+           indexed.tokenCount == tokenCount,
+           indexed.fileSize == current.size,
+           current.size > 0
+        {
+            storeSkips += 1
+            _touchEntryLocked(hash: hash)
+            if ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1" {
+                FileHandle.standardError.write(Data(
+                    "[vmlx][cache/disk-store] SKIP validated hash=\(hash) count=\(tokenCount) bytes=\(current.size)\n".utf8))
+            }
+            return
+        }
         // Pre-realize arrays under the lock so Metal work completes
         // before the writer hits the C++ save path AND no other thread
         // can interleave MLX ops on the same device during this window.
@@ -226,6 +268,11 @@ public final class DiskCache: @unchecked Sendable {
             }
 
             _insertEntryLocked(hash: hash, tokenCount: tokenCount, fileSize: fileSize)
+            if let fingerprint = _fileFingerprint(url: url), fingerprint.size > 0 {
+                validatedFiles[hash] = fingerprint
+            } else {
+                validatedFiles.removeValue(forKey: hash)
+            }
             _evictIfNeededLocked()
         } catch {
             // Best-effort: swallow so a write failure doesn't fail
@@ -252,16 +299,21 @@ public final class DiskCache: @unchecked Sendable {
         defer { lock.unlock() }
 
         guard FileManager.default.fileExists(atPath: url.path) else {
+            validatedFiles.removeValue(forKey: hash)
             misses += 1
             return nil
         }
 
         do {
             let (arrays, _) = try loadArraysAndMetadata(url: url)
+            if let fingerprint = _fileFingerprint(url: url), fingerprint.size > 0 {
+                validatedFiles[hash] = fingerprint
+            }
             hits += 1
             return arrays
         } catch {
             misses += 1
+            validatedFiles.removeValue(forKey: hash)
             // A failed deserialize is almost always a corrupt safetensors
             // file — a 0-byte leftover from the pre-synchronous-store
             // bug, a partial write from an earlier crash, disk full
@@ -361,6 +413,7 @@ public final class DiskCache: @unchecked Sendable {
         for hash in hashes {
             try? FileManager.default.removeItem(at: safetensorsURL(for: hash))
             _deleteEntryLocked(hash: hash)
+            validatedFiles.removeValue(forKey: hash)
         }
     }
 
@@ -392,6 +445,8 @@ public final class DiskCache: @unchecked Sendable {
         hits = 0
         misses = 0
         stores = 0
+        storeSkips = 0
+        validatedFiles.removeAll(keepingCapacity: true)
     }
 
     // MARK: - Hashing
@@ -438,6 +493,16 @@ public final class DiskCache: @unchecked Sendable {
         cacheDir.appendingPathComponent("\(hash).safetensors")
     }
 
+    private func _fileFingerprint(url: URL) -> ValidatedFileFingerprint? {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: url.path),
+              let sizeNumber = attributes[.size] as? NSNumber,
+              let modificationDate = attributes[.modificationDate] as? Date
+        else { return nil }
+        return ValidatedFileFingerprint(
+            size: sizeNumber.intValue,
+            modificationDate: modificationDate)
+    }
+
     /// Execute a simple SQL statement with no bindings.
     private func executeSQL(_ sql: String) {
         guard let db else { return }
@@ -468,6 +533,45 @@ public final class DiskCache: @unchecked Sendable {
             sqlite3_step(stmt)
         }
         sqlite3_finalize(stmt)
+    }
+
+    private func _entryMetadataLocked(hash: String) -> (tokenCount: Int, fileSize: Int)? {
+        guard let db else { return nil }
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(
+            db,
+            "SELECT token_count, file_size FROM cache_entries WHERE hash = ?",
+            -1,
+            &stmt,
+            nil) == SQLITE_OK
+        else { return nil }
+        defer { sqlite3_finalize(stmt) }
+        _ = hash.withCString { cStr in
+            sqlite3_bind_text(stmt, 1, cStr, -1, nil)
+        }
+        guard sqlite3_step(stmt) == SQLITE_ROW else { return nil }
+        return (
+            tokenCount: Int(sqlite3_column_int64(stmt, 0)),
+            fileSize: Int(sqlite3_column_int64(stmt, 1)))
+    }
+
+    /// Refresh the existing eviction timestamp without replacing the row or
+    /// rewriting the payload. Caller MUST hold `lock`.
+    private func _touchEntryLocked(hash: String) {
+        guard let db else { return }
+        var stmt: OpaquePointer?
+        guard sqlite3_prepare_v2(
+            db,
+            "UPDATE cache_entries SET created_at = julianday('now') WHERE hash = ?",
+            -1,
+            &stmt,
+            nil) == SQLITE_OK
+        else { return }
+        defer { sqlite3_finalize(stmt) }
+        hash.withCString { cStr in
+            sqlite3_bind_text(stmt, 1, cStr, -1, nil)
+            sqlite3_step(stmt)
+        }
     }
 
     /// Delete a single `cache_entries` row by hash. Caller MUST hold `lock`.
@@ -527,6 +631,7 @@ public final class DiskCache: @unchecked Sendable {
         for entry in toEvict {
             let url = safetensorsURL(for: entry.hash)
             try? FileManager.default.removeItem(at: url)
+            validatedFiles.removeValue(forKey: entry.hash)
 
             entry.hash.withCString { cStr in
                 if sqlite3_prepare_v2(db, "DELETE FROM cache_entries WHERE hash = ?", -1, &stmt, nil) == SQLITE_OK {

--- a/Libraries/MLXLMCommon/Cache/SSMCompanionDiskStore.swift
+++ b/Libraries/MLXLMCommon/Cache/SSMCompanionDiskStore.swift
@@ -55,6 +55,20 @@ struct SSMCompanionQuotaEntry: Sendable {
 /// comment for storage format + concurrency model.
 public final class SSMCompanionDiskStore: @unchecked Sendable {
 
+    private struct FileFingerprint: Equatable {
+        let size: Int
+        let modificationDate: Date
+    }
+
+    private struct ValidatedEntry: Equatable {
+        let safetensors: FileFingerprint
+        let sidecar: FileFingerprint
+        let isComplete: Bool
+        let numStates: Int
+        let boundary: Int
+        let kvHash: String
+    }
+
     // MARK: - Properties
 
     private let lock = OSAllocatedUnfairLock()
@@ -62,6 +76,15 @@ public final class SSMCompanionDiskStore: @unchecked Sendable {
     private let modelKey: String?
     /// Maximum total disk bytes before oldest-entry eviction. 0 = unlimited.
     private let maxBytes: Int
+
+    /// Companion pairs successfully written or deserialized by this process.
+    /// The process-local validation requirement prevents an inherited corrupt
+    /// pair from being trusted merely because both pathnames exist.
+    private var validatedEntries: [String: ValidatedEntry] = [:]
+
+    /// Number of full companion rewrites avoided after current-process
+    /// validation. Exposed as a locked snapshot for tests and telemetry.
+    private var storeSkips: Int = 0
 
     // MARK: - Initialization
 
@@ -74,6 +97,12 @@ public final class SSMCompanionDiskStore: @unchecked Sendable {
     }
 
     // MARK: - Public API
+
+    func snapshotStoreSkips() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return storeSkips
+    }
 
     /// Persist SSM layer states for a given token prefix. Mirrors
     /// `SSMStateCache.store(ssmStates:tokens:boundary:)` with the
@@ -96,11 +125,63 @@ public final class SSMCompanionDiskStore: @unchecked Sendable {
         let key = Self.keyFor(
             tokens: tokens, boundary: boundary,
             mediaSalt: mediaSalt, modelKey: modelKey)
+        let safetensorsURL = self.safetensorsURL(for: key)
+        let sidecarURL = self.sidecarURL(for: key)
+        let kvHash = DiskCache.hashTokens(
+            Array(tokens.prefix(boundary)),
+            modelKey: modelKey,
+            mediaSalt: mediaSalt)
 
         MLXDiskCacheIOLock.shared.lock()
         defer { MLXDiskCacheIOLock.shared.unlock() }
         lock.lock()
         defer { lock.unlock() }
+
+        // A normal warm hybrid request fetches a companion and publishes the
+        // same prompt boundary again after generation. Avoid synchronizing the
+        // GPU and rewriting the full recurrent-state payload when this process
+        // has already validated the exact tensor/metadata pair. Completeness,
+        // state count, boundary, and linked KV hash must all still match; a
+        // changed file or metadata contract falls through to a healing write.
+        if let validated = validatedEntries[key],
+           validated.isComplete == isComplete,
+           validated.numStates == ssmStates.count,
+           validated.boundary == boundary,
+           validated.kvHash == kvHash,
+           let currentSafetensors = fileFingerprint(at: safetensorsURL),
+           let currentSidecar = fileFingerprint(at: sidecarURL),
+           currentSafetensors == validated.safetensors,
+           currentSidecar == validated.sidecar
+        {
+            let now = Date()
+            do {
+                try FileManager.default.setAttributes(
+                    [.modificationDate: now], ofItemAtPath: safetensorsURL.path)
+                try FileManager.default.setAttributes(
+                    [.modificationDate: now], ofItemAtPath: sidecarURL.path)
+                if let touchedSafetensors = fileFingerprint(at: safetensorsURL),
+                   let touchedSidecar = fileFingerprint(at: sidecarURL)
+                {
+                    validatedEntries[key] = ValidatedEntry(
+                        safetensors: touchedSafetensors,
+                        sidecar: touchedSidecar,
+                        isComplete: isComplete,
+                        numStates: ssmStates.count,
+                        boundary: boundary,
+                        kvHash: kvHash)
+                } else {
+                    validatedEntries.removeValue(forKey: key)
+                }
+                storeSkips += 1
+                if ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1" {
+                    FileHandle.standardError.write(Data(
+                        "[vmlx][cache/ssm-store] SKIP validated key=\(key) boundary=\(boundary) states=\(ssmStates.count)\n".utf8))
+                }
+                return
+            } catch {
+                validatedEntries.removeValue(forKey: key)
+            }
+        }
 
         // Pre-realize on calling thread — same rationale as
         // DiskCache.swift:148-157. GPU work must complete before the
@@ -118,9 +199,6 @@ public final class SSMCompanionDiskStore: @unchecked Sendable {
             arrays["state_\(i)"] = arr
         }
 
-        let safetensorsURL = self.safetensorsURL(for: key)
-        let sidecarURL = self.sidecarURL(for: key)
-
         // Sync write — same rationale as DiskCache.swift:122-130.
         // Async dispatch races with SIGTERM on short-lived sessions,
         // leaving zero-byte files. Costs ~ms on already-realized arrays.
@@ -133,14 +211,25 @@ public final class SSMCompanionDiskStore: @unchecked Sendable {
             "num_states": ssmStates.count,
             "model_key": modelKey ?? "",
             "boundary": boundary,
-            "kv_hash": DiskCache.hashTokens(
-                Array(tokens.prefix(boundary)),
-                modelKey: modelKey,
-                mediaSalt: mediaSalt),
+            "kv_hash": kvHash,
         ]
         let sidecarData = try JSONSerialization.data(
             withJSONObject: sidecar, options: [.sortedKeys])
         try sidecarData.write(to: sidecarURL, options: [.atomic])
+
+        if let writtenSafetensors = fileFingerprint(at: safetensorsURL),
+           let writtenSidecar = fileFingerprint(at: sidecarURL)
+        {
+            validatedEntries[key] = ValidatedEntry(
+                safetensors: writtenSafetensors,
+                sidecar: writtenSidecar,
+                isComplete: isComplete,
+                numStates: ssmStates.count,
+                boundary: boundary,
+                kvHash: kvHash)
+        } else {
+            validatedEntries.removeValue(forKey: key)
+        }
 
         evictIfNeededLocked()
     }
@@ -170,7 +259,10 @@ public final class SSMCompanionDiskStore: @unchecked Sendable {
 
         guard FileManager.default.fileExists(atPath: safetensorsURL.path),
               FileManager.default.fileExists(atPath: sidecarURL.path)
-        else { return nil }
+        else {
+            validatedEntries.removeValue(forKey: key)
+            return nil
+        }
 
         // Decode sidecar first — cheap, validates the entry shape.
         guard let sidecarData = try? Data(contentsOf: sidecarURL),
@@ -179,13 +271,19 @@ public final class SSMCompanionDiskStore: @unchecked Sendable {
               let isComplete = sidecar["is_complete"] as? Bool,
               let numStates = sidecar["num_states"] as? Int,
               numStates > 0
-        else { return nil }
+        else {
+            validatedEntries.removeValue(forKey: key)
+            return nil
+        }
 
         // Decode safetensors. A failed deserialize is most often a
         // truncated file (process killed mid-write, rare on sync IO
         // but possible). Treat as miss.
         guard let arraysAndMeta = try? loadArraysAndMetadata(url: safetensorsURL)
-        else { return nil }
+        else {
+            validatedEntries.removeValue(forKey: key)
+            return nil
+        }
         let arrays = arraysAndMeta.0
 
         // Reassemble in positional order. Bail if any `state_<idx>` is
@@ -194,8 +292,37 @@ public final class SSMCompanionDiskStore: @unchecked Sendable {
         var states: [MLXArray] = []
         states.reserveCapacity(numStates)
         for i in 0 ..< numStates {
-            guard let arr = arrays["state_\(i)"] else { return nil }
+            guard let arr = arrays["state_\(i)"] else {
+                validatedEntries.removeValue(forKey: key)
+                return nil
+            }
             states.append(arr)
+        }
+
+        // Legacy sidecars remain readable, but only a complete current-format
+        // metadata match is eligible to suppress the next write-through.
+        let expectedKVHash = DiskCache.hashTokens(
+            Array(tokens.prefix(boundary)),
+            modelKey: modelKey,
+            mediaSalt: mediaSalt)
+        if let storedBoundary = sidecar["boundary"] as? Int,
+           let storedKVHash = sidecar["kv_hash"] as? String,
+           let storedModelKey = sidecar["model_key"] as? String,
+           storedBoundary == boundary,
+           storedKVHash == expectedKVHash,
+           storedModelKey == (modelKey ?? ""),
+           let fetchedSafetensors = fileFingerprint(at: safetensorsURL),
+           let fetchedSidecar = fileFingerprint(at: sidecarURL)
+        {
+            validatedEntries[key] = ValidatedEntry(
+                safetensors: fetchedSafetensors,
+                sidecar: fetchedSidecar,
+                isComplete: isComplete,
+                numStates: numStates,
+                boundary: boundary,
+                kvHash: storedKVHash)
+        } else {
+            validatedEntries.removeValue(forKey: key)
         }
 
         return SSMStateCache.FetchResult(states: states, isComplete: isComplete)
@@ -218,6 +345,7 @@ public final class SSMCompanionDiskStore: @unchecked Sendable {
                 try? FileManager.default.removeItem(at: url)
             }
         }
+        validatedEntries.removeAll(keepingCapacity: true)
     }
 
     /// Snapshot recurrent payloads for the coordinator's combined KV +
@@ -247,6 +375,7 @@ public final class SSMCompanionDiskStore: @unchecked Sendable {
         for hash in hashes {
             try? FileManager.default.removeItem(at: safetensorsURL(for: hash))
             try? FileManager.default.removeItem(at: sidecarURL(for: hash))
+            validatedEntries.removeValue(forKey: hash)
         }
     }
 
@@ -258,6 +387,17 @@ public final class SSMCompanionDiskStore: @unchecked Sendable {
 
     private func sidecarURL(for hash: String) -> URL {
         cacheDir.appendingPathComponent("ssm-\(hash).json")
+    }
+
+    private func fileFingerprint(at url: URL) -> FileFingerprint? {
+        guard let values = try? url.resourceValues(forKeys: [
+            .contentModificationDateKey, .fileSizeKey,
+        ]),
+            let size = values.fileSize,
+            size > 0,
+            let modificationDate = values.contentModificationDate
+        else { return nil }
+        return FileFingerprint(size: size, modificationDate: modificationDate)
     }
 
     private struct DiskEntry {
@@ -309,10 +449,11 @@ public final class SSMCompanionDiskStore: @unchecked Sendable {
 
         guard totalBytes > maxBytes else { return }
 
-        for entry in entries.values.sorted(by: { $0.modified < $1.modified }) {
+        for (hash, entry) in entries.sorted(by: { $0.value.modified < $1.value.modified }) {
             for url in entry.urls {
                 try? FileManager.default.removeItem(at: url)
             }
+            validatedEntries.removeValue(forKey: hash)
             totalBytes -= entry.bytes
             if totalBytes <= maxBytes { break }
         }

--- a/Tests/MLXLMTests/CacheCoordinatorTests.swift
+++ b/Tests/MLXLMTests/CacheCoordinatorTests.swift
@@ -328,6 +328,53 @@ import Testing
     }
 }
 
+@Test func coordinatorSkipExactDiskBoundaryAlsoAppliesToIndexedCandidates() {
+    let mlxTestLock = lockSerializedMLXTest()
+    defer { mlxTestLock.unlock() }
+
+    let tmp = FileManager.default.temporaryDirectory
+        .appendingPathComponent("disk-skip-exact-indexed-\(UUID().uuidString)")
+    defer { try? FileManager.default.removeItem(at: tmp) }
+
+    let coordinator = CacheCoordinator(config: CacheCoordinatorConfig(
+        usePagedCache: false,
+        enableDiskCache: true,
+        diskCacheMaxGB: 1.0,
+        diskCacheDir: tmp,
+        modelKey: "disk-skip-exact-indexed-contract"))
+    let exact = [1, 2, 3, 4, 5]
+    let safePrefix = Array(exact.prefix(3))
+
+    func store(_ tokens: [Int]) {
+        coordinator.storeAfterGeneration(
+            promptTokens: tokens,
+            perLayerData: [(
+                keys: MLXArray.ones([1, 1, tokens.count, 4]),
+                values: MLXArray.ones([1, 1, tokens.count, 4]) * 2)],
+            ssmStates: nil)
+    }
+    store(exact)
+    store(safePrefix)
+
+    switch coordinator.fetch(tokens: exact, skipExactDiskBoundary: true) {
+    case .hit(let matched, let remaining, let detail, _, _, _):
+        #expect(matched == safePrefix.count)
+        #expect(remaining == [4, 5])
+        #expect(detail == .disk)
+    case .miss:
+        Issue.record("skip-exact lookup should use the longest safe indexed prefix")
+    }
+
+    switch coordinator.fetch(tokens: exact) {
+    case .hit(let matched, let remaining, let detail, _, _, _):
+        #expect(matched == exact.count)
+        #expect(remaining.isEmpty)
+        #expect(detail == .disk)
+    case .miss:
+        Issue.record("ordinary lookup should still admit the exact disk boundary")
+    }
+}
+
 @Test func coordinatorSSMCompanion() {
     let mlxTestLock = lockSerializedMLXTest()
     defer { mlxTestLock.unlock() }

--- a/Tests/MLXLMTests/DiskCacheTests.swift
+++ b/Tests/MLXLMTests/DiskCacheTests.swift
@@ -30,6 +30,54 @@ import Testing
     }
 }
 
+@Test func diskCacheSkipsRewriteOnlyAfterCurrentProcessValidation() async throws {
+    try await MLXMetalTestLock.withLock {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vmlx_dedup_\(UUID())")
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let tokens = [31, 41, 59, 26]
+        let arrays = ["data": MLXArray.ones([8, 8])]
+        let hash = DiskCache.hashTokens(tokens, modelKey: "dedup-model")
+        let file = tempDir.appendingPathComponent("\(hash).safetensors")
+
+        do {
+            let first = DiskCache(
+                cacheDir: tempDir, maxSizeGB: 0.1, modelKey: "dedup-model")
+            first.store(tokens: tokens, arrays: arrays)
+            #expect(first.snapshotStats().storeSkips == 0)
+        }
+
+        // A fresh process/cache instance must validate an inherited payload
+        // before it is eligible for the no-rewrite path.
+        let warm = DiskCache(
+            cacheDir: tempDir, maxSizeGB: 0.1, modelKey: "dedup-model")
+        let inheritedModification = try #require(
+            (try FileManager.default.attributesOfItem(atPath: file.path))[.modificationDate]
+                as? Date)
+        #expect(warm.fetch(tokens: tokens) != nil)
+        warm.store(tokens: tokens, arrays: arrays)
+        let deduplicatedModification = try #require(
+            (try FileManager.default.attributesOfItem(atPath: file.path))[.modificationDate]
+                as? Date)
+        #expect(deduplicatedModification == inheritedModification)
+        #expect(warm.snapshotStats().stores == 1)
+        #expect(warm.snapshotStats().storeSkips == 1)
+
+        // External replacement invalidates the fingerprint and forces a real
+        // healing write instead of preserving the changed file.
+        let changedDate = Date(timeIntervalSince1970: 1)
+        try FileManager.default.setAttributes(
+            [.modificationDate: changedDate], ofItemAtPath: file.path)
+        warm.store(tokens: tokens, arrays: arrays)
+        let healedModification = try #require(
+            (try FileManager.default.attributesOfItem(atPath: file.path))[.modificationDate]
+                as? Date)
+        #expect(healedModification != changedDate)
+        #expect(warm.snapshotStats().stores == 2)
+        #expect(warm.snapshotStats().storeSkips == 1)
+    }
+}
+
 @Test func diskCacheMiss() {
     let tempDir = FileManager.default.temporaryDirectory
         .appendingPathComponent("vmlx_test_\(UUID())")

--- a/Tests/MLXLMTests/SSMStateCacheTests.swift
+++ b/Tests/MLXLMTests/SSMStateCacheTests.swift
@@ -159,6 +159,70 @@ struct SSMStateCacheTests {
     #expect(saltedMiss == nil)
 }
 
+@Test func ssmCompanionDiskStoreSkipsRewriteOnlyAfterValidation() async throws {
+    try await MLXMetalTestLock.withLock {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ssm-companion-dedup-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let modelKey = "ssm-dedup-model"
+        let tokens = [2, 7, 1, 8, 2, 8]
+        let states = [MLXArray.ones([2, 4])]
+
+        do {
+            let first = try SSMCompanionDiskStore(
+                cacheDir: dir, modelKey: modelKey, maxBytes: 10_000_000)
+            try first.store(
+                ssmStates: states,
+                tokens: tokens,
+                boundary: tokens.count,
+                isComplete: true)
+            #expect(first.snapshotStoreSkips() == 0)
+        }
+
+        // A new instance must deserialize both files before it may suppress a
+        // write. The subsequent identical write-through should take the fast
+        // path without evaluating or serializing the companion tensors.
+        let warm = try SSMCompanionDiskStore(
+            cacheDir: dir, modelKey: modelKey, maxBytes: 10_000_000)
+        let fetched = warm.fetch(tokens: tokens, boundary: tokens.count)
+        #expect(fetched?.states.count == 1)
+        try warm.store(
+            ssmStates: states,
+            tokens: tokens,
+            boundary: tokens.count,
+            isComplete: true)
+        #expect(warm.snapshotStoreSkips() == 1)
+
+        // A completeness change is a semantic change even under the same
+        // token key, so it must rewrite the sidecar instead of being skipped.
+        try warm.store(
+            ssmStates: states,
+            tokens: tokens,
+            boundary: tokens.count,
+            isComplete: false)
+        #expect(warm.snapshotStoreSkips() == 1)
+        #expect(warm.fetch(tokens: tokens, boundary: tokens.count)?.isComplete == false)
+
+        // External mutation invalidates the process-local fingerprint and
+        // forces another healing write.
+        let entry = try #require(warm.quotaEntries().first)
+        let tensorURL = dir.appendingPathComponent("ssm-\(entry.hash).safetensors")
+        let changedDate = Date(timeIntervalSince1970: 1)
+        try FileManager.default.setAttributes(
+            [.modificationDate: changedDate], ofItemAtPath: tensorURL.path)
+        try warm.store(
+            ssmStates: states,
+            tokens: tokens,
+            boundary: tokens.count,
+            isComplete: false)
+        let healedDate = try #require(
+            (try FileManager.default.attributesOfItem(atPath: tensorURL.path))[.modificationDate]
+                as? Date)
+        #expect(healedDate != changedDate)
+        #expect(warm.snapshotStoreSkips() == 1)
+    }
+}
+
 @Test func ssmCompanionDiskStoreEvictsOverCap() throws {
     let dir = FileManager.default.temporaryDirectory
         .appendingPathComponent("ssm-companion-\(UUID().uuidString)")

--- a/docs/VMLX_OSAURUS_POST_GEMMA_LIVE_MATRIX_2026_07_20.md
+++ b/docs/VMLX_OSAURUS_POST_GEMMA_LIVE_MATRIX_2026_07_20.md
@@ -1,0 +1,145 @@
+# vMLX Swift / Osaurus post-Gemma live model matrix — 2026-07-20
+
+## Proof contract
+
+This ledger is for the real Release-config Osaurus UI. Source inspection,
+focused tests, CLI harnesses, API calls, and old artifacts may diagnose a row,
+but they do not close it. A closed user-facing row requires all of:
+
+- the exact model bundle and quant/runtime identified;
+- the effective app settings shown in the UI;
+- visible load and response behavior in the app;
+- persisted turn/tool data checked when streaming or parsing is in doubt;
+- TTFT, token/s, response-token count, and Activity Monitor `phys_footprint`;
+- the applicable prefix, paged-RAM, SSD L2, SSM/linear-state, and TurboQuant
+  counters before and after the request;
+- coherent multi-turn behavior, not load-only or one short completion;
+- real image/video/audio payloads for advertised media capabilities.
+
+`VERIFIED-LIVE` is reserved for rows meeting that contract. `PARTIAL` names
+the evidence that exists and the missing gate. `BROKEN` names a reproduced
+failure. `OPEN` means no current-source live UI proof yet.
+
+## Default policy that every model row must re-check
+
+- Prefix cache: on.
+- Paged RAM cache: off. It may be enabled explicitly for a separate UI row.
+- SSD block cache: on and independently usable while paged RAM is off.
+- Live TurboQuant KV encoding: off (`engine_selected` resolves to native KV in
+  Osaurus). It may be enabled explicitly for a separate UI row and must be
+  restored to off afterward.
+- TurboQuant must apply only to compatible KV attention state. Hybrid
+  SSM/GDN/linear-attention, rotating SWA, recurrent, CCA/DSA/MLA, and other
+  companion state must retain the architecture's native typed state and its
+  proven prompt-boundary restore/re-derive contract.
+- DSV4 Flash and OpenPangu must not receive generic TurboQuant KV merely from a
+  name or model-family guess.
+- No forced thinking tags, prompt coercion, sampler clamps, EOS bias, hidden
+  repetition penalties, synthetic defaults, or output-length masking may be
+  used to make a model appear coherent.
+
+## Current Release UI evidence
+
+Proof app:
+
+- bundle id: `com.dinoki.osaurus.gemma4alignmentproof20260720`
+- app: `/private/tmp/osaurus-gemma4-alignment-release-derived-20260720/Build/Products/Release/osaurus.app`
+- isolated root: `/private/tmp/osaurus-gemma4-alignment-proof-root-20260720-1414`
+- Osaurus source tree: merged `main` at `59334020f54950f16247a2b60474de7b11fbb54b`
+- vMLX Swift pin: `f2b184841e98d969e46dec83109f27cd7bb57357`
+- production Osaurus preferences/keychain were not used.
+
+### New-chat SSD checkpoint reproduction
+
+A later isolated Release app used bundle id
+`com.dinoki.osaurus.applescriptemergency20260720`, SHA-256
+`114fbe282e9e2872abe88ca8c991da6ebc1b7c9e19f0ef5029bd94c54511fd9b`,
+root `/private/tmp/osaurus-applescript-emergency-live-root-20260720`, and the
+same exact vMLX pin. The real UI showed Prefix On, paged RAM Off, Disk Cache
+On, Engine Selected/native, and SSM rederive On with exact `Ornith 1.0 9B
+MXFP8` and Thinking Off.
+
+SSD persistence itself worked: a fresh process and new chat restored a
+2,201-token boundary with 48 recurrent companion states. The reported
+from-zero behavior was also reproduced. A later new-chat request logged
+`HIT disk boundary=2234 remaining=0 ssm=48 fmtV=2 ... skipExactDisk=true`,
+then the UI visibly advanced raw prefill from zero in 512-token chunks. Source
+root: `CacheCoordinator.fetch` omits N in its preferred probes but re-admits N
+from `candidateTokenCounts`; the hybrid GDN full-hit guard then lacks an N-1
+seed and rolls back to full prefill. The candidate excludes N from every probe
+when `skipExactDiskBoundary` is set, selecting the longest safe partial
+boundary instead.
+
+The same trace showed repeated synchronous rewrites of 125-143 MB KV files
+and 26 MB recurrent sidecars plus eviction churn at the 10 GB cap. The
+candidate adds current-process-validated no-rewrite paths for both payload
+types. KV files require matching size, mtime, token count, and SQLite size.
+SSM pairs require matching tensor and sidecar fingerprints plus completeness,
+state-count, boundary, model-key, and linked-KV metadata. Changed, missing,
+corrupt, unindexed, or unvalidated inherited files still take the healing
+write. Skipped SSM stores touch only filesystem metadata so the paired quota's
+recency remains aligned without evaluating or serializing recurrent tensors.
+
+Current Xcode 26.6 / Swift 6.3.3 Metal-backed source tests:
+
+- seven `MLXLMTests.diskCache*` tests passed in 1.051 seconds;
+- all ten `SSMStateCacheTests` passed in 0.039 seconds;
+- all 29 `CacheCoordinatorTopologyFocusedTests` passed in 9.548 seconds,
+  including Gemma mixed rotating/TQ, Nemotron Mamba/TQ, DSV4 typed disk,
+  ZAYA CCA, paged eviction, paged-off partial SSD restore, and Ornith GDN
+  snapshot-detachment contracts;
+- the new exact indexed-boundary exclusion passed independently in 0.038
+  seconds before the suite run.
+
+These changes still have source and focused-test candidate evidence only. The
+row stays **PARTIAL** until a rebuilt Release app visibly proves suffix-only
+prefill, coherent output, both `disk-store SKIP` and `ssm-store SKIP`
+telemetry, and stable payload bytes.
+
+| Family / bundle | Architecture and runtime | Current result | Current evidence | Missing before closure |
+|---|---|---|---|---|
+| Qwen 3.5 dense — `dealign.ai/Qwen3.6-27B-JANG_4M-CRACK` | 64 layers: 48 linear-attention + 16 full-attention; JANG_4M | PARTIAL | Thinking visibly off. Bundle-default row returned the requested two lines at TTFT 1.78 s, 22.5 tok/s, 22 tokens. Explicit greedy Settings row returned the requested two lines at TTFT 1.87 s, 22.5 tok/s, 24 tokens. No tool calls or reasoning deltas. | Multi-turn, required/automatic/no-tool/tool-error rows; real image/video; SSD cold/full/partial/restart; paged-on hot/eviction; explicit TQ on/off; Activity Monitor per row. |
+| Qwen 3.5 dense — `dealign.ai/Qwen3.6-27B-MXFP8-CRACK-MTP` | Same hybrid topology; MXFP8; MTP tensors preserved | BROKEN for agent tools; PARTIAL for plain chat | Live Activity showed Native MTP **Not active**. With bundle defaults and Thinking off it made three unsolicited valid `todo` calls, then persisted only `# Qw` (3 tokens) at TTFT 0.82 s and 15.6 tok/s. A second sampled run echoed the instruction. With explicit greedy settings (`temperature=0`, `top-p=1`, `top-k=0`, `min-p=0`, penalty 1) and Tools on, it again made three unsolicited `todo` calls plus `share_artifact`, then produced the requested two lines at TTFT 2.55 s, 15.1 tok/s, 24 tokens. With the agent's Tools switch visibly off, the same greedy model produced exactly the requested two lines at TTFT 2.48 s, 15.7 tok/s, 27 tokens. SQLite contains the same tool calls and final content shown in the Tools-on runs, so the first truncation is not only a SwiftUI content-delta display loss. | Capture raw emitted token/stop reason after tool continuation; test the bundle's `[248046,248044]` effective EOS against its `<|endoftext|>` emission without mutating the bundle; compare another MXFP8 Qwen artifact; audit tool prompt/description pressure and continuation history. Do not attribute this to MTP or plain content streaming. |
+| Qwen 3.5/3.6 MoE MXFP8/JANG/JANGTQ | 30 linear-attention + 10 full-attention for local 35B A3B bundles | OPEN | Metadata inventory only. | Full live matrix; do not inherit dense proof. |
+| Qwen 3.5 VL | Vision/video path plus hybrid text cache | OPEN | The selected local dense bundles advertise Vision in the picker; no current payload row. | Real image, same-image reuse, different-image salt, video, post-media text/tool continuation, restart/L2 restore. |
+| Ornith / Bonsai Qwen aliases | Qwen hybrid backbone with family-specific templates/tools | PARTIAL-LIVE on Ornith; Bonsai remains OPEN in this matrix | Ornith fresh-process/new-chat SSD hits carried 48 recurrent states, but an exact indexed candidate bypassed the skip-exact contract and forced visible full prefill. Two AppleScript parent turns stayed coherent with Thinking visibly Off. | Rebuild with the cache candidate and prove suffix-only partial restore, no duplicate write, same-chat/new-chat/restart coherence; then separate Bonsai, paged/TQ, and media rows. |
+| LFM2.5 8B A1B MXFP8 — `dealign.ai/LFM2.5-8B-A1B-MXFP8-CRACK` | `lfm2_moe`; 24-layer Conv1d + full-attention hybrid, ~1B-active MoE; MXFP8 | **BROKEN** for automatic tools and cross-session prompt/cache isolation; PARTIAL for one cold plain-chat row | The Release UI loaded the exact local bundle. Its model picker exposed no Thinking switch because the bundled template contains `<think>` replay markers but no `enable_thinking` kwarg. A no-tool prompt produced the exact two requested lines at TTFT 0.90 s and 179.1 tok/s, but also 442 persisted reasoning characters (162 total generated tokens). An explicit `todo` request spent 9.4 s / 1,611 tokens at 170.7 tok/s with 6,251 persisted reasoning characters, emitted `{"markdown":"Create task LFM25-TOOL-7319"}` as visible content, and executed no tool. Runtime logs recorded 1,583 reasoning deltas, 19 tool-progress/sentinel hints, and `capturedTools=0`; SQLite confirms `tool_calls` is NULL, so this is not only a SwiftUI display issue. A fresh-chat repeat of the original plain prompt then answered with `LFM25-TOOL-DONE-7319`, copied from the intervening tool chat, instead of the requested `LFM25-MXFP8-DEFAULT-7318`; the persisted reasoning likewise states that it saw the wrong prior string while the persisted user turn contains the correct new prompt. During that bad row the UI showed a full `0→3104`-token prefill, and Live Activity stayed at prefix `0/0`, L2 `0/8` while stores rose `16→23`, and SSM `0/0/0`: no hit was reported, so this currently points to in-process hybrid/session state or prompt-materialization contamination rather than a proven SSD restore. Source trace confirms `.lfm2` format inference and the `LFM2ToolMinimal` fallback were selected by `model_type=lfm2_moe`; the bundle itself advertises native tagged Python-call syntax but has no generation-time thinking-off branch. Activity Monitor showed 2.27 GB `phys_footprint` for the isolated proof app after these rows (production Osaurus remained a separate 942.2 MB process). | Trace the exact rendered-token boundary from `ChatSessionWarmup` through `BatchEngine.stepPrefill`; prove whether the wrong suffix originates in warmup/session cache, recurrent companion state, or input-token mutation. Capture the exact raw tagged buffer that produced 19 progress hints but no parsed call. Test the JANG_2L control only after isolating this contamination, then real post-tool continuation, multi-turn, SSD partial restore, explicit paged/TQ, and companion-state correctness. Do not invent an `enable_thinking` toggle the bundle does not implement. |
+| MiniMax M2.7 JANG_K | Full-KV MoE | OPEN | Local 80 GB bundle is visible in the picker. Old harness evidence is diagnostic only. | Load/RAM override, coherent multi-turn, full-KV TQ on/off, prefix/paged/L2 partial/eviction/restart, usable speed. |
+| MiniMax M2.7 Small JANGTQ | Routed JANGTQ runtime; distinct from TQ KV encoding | OPEN | Local 37 GB bundle is visible in the picker. | Low-footprint active-streaming runtime, output coherency/speed, then independent TQ-KV on/off and cache stack. |
+| DSV4 Flash JANG | Native DSV4 hybrid cache topology; local bundle ~97 GB | OPEN | Bundle is visible in the picker. No current live load/decode proof. | Confirm supported artifact/profile first, then RAM override, long coherent multi-turn, prefix/SSD restore, typed cache behavior, and measured speed. The requested near-20 tok/s target is UNVERIFIED. Generic TQ must remain inapplicable unless source and live topology prove otherwise. |
+| Nemotron Omni Nano JANGTQ4 | Hybrid/recurrent plus advertised multimodal | OPEN | Bundle is visible in the picker. | Image/video/audio payloads, text/tool continuation, typed companion cache, SSD partial/restart, RAM/speed. |
+| ZAYA / AppleScript 16B JANG_4M and curated ZAYA 8B JANG_6M | Tool-specialized agent models; the installed curated 8B bundle is `model_type=zaya`, while the locally named 16B bundle is actually `model_type=gemma4` | PARTIAL-LIVE for the supported dedicated 16B route; 8B remains BROKEN/OPEN | In the current isolated Release UI, exact parent Ornith MXFP8 Thinking Off plus exact dedicated `JANGQ-AI/AppleScript-16B-A4B-JANG_4M` changed visible unsaved `Hello World`→`Hello from OracHQ` once, then in a new chat changed `Hello from OracHQ`→`Hello again` once. Each ended with grounded parent success at 49.9 tok/s (TTFT 1.45 s / 1.41 s), no duplicate mutation, and no Save workflow; the second used one mutation plus one read-only verification. The literal-field validation was in this binary and the former generated-script-in-`content` failure did not recur. | Run exact JANGQ 8B cold/warm controls after the hybrid SSD fix; requested Save, larger-document substring, already-correct text, denial/cancel/error recovery, acknowledgement-only, reasoning on/off, spawn/delegation, footprint, and cache policy rows. Dedicated helpers remain excluded from generic Computer Use's different `agent_action` schema. |
+
+## Required cache sequence per compatible model
+
+1. Confirm the default UI state: paged off, TurboQuant off, prefix on, SSD L2 on.
+2. Cold prompt A; record TTFT/tok/s/tokens/footprint and all cache counters.
+3. Exact warm prompt A; require a truthful prefix or SSD hit and coherent output.
+4. Partial-prefix prompt A+B; require the longest safe block match, not an unsafe
+   full hit; record restored token/block counts and architecture companion state.
+5. Evict/unload/restart, then repeat A+B with paged still off; require direct SSD
+   reuse when a compatible disk block exists, otherwise a truthful cold prefill.
+6. Enable paged RAM in the UI; repeat exact and partial prompts; prove RAM hot-tier
+   hits, bounded eviction, and SSD fallback after the RAM block is absent.
+7. Restore paged off.
+8. For compatible models only, explicitly select TurboQuant in the UI and repeat
+   cold/exact/partial/restart rows. Record actual compressed layer count, bit
+   widths, cache bytes/GB growth, and companion-state restore/re-derive counters.
+9. Restore TurboQuant to off/native and repeat one coherence row.
+10. Change the memory-safety setting through the UI, save, and prove that a model
+    rejected under the conservative setting can load under the explicit user
+    override without silently changing unrelated engine limits.
+
+## Immediate investigation order
+
+1. Qwen dense MXFP8 tool/EOS failure versus JANG_4M control.
+2. Qwen 35B A3B MoE MXFP8/JANG or JANGTQ control.
+3. Qwen VL image/video and hybrid cache-salt/restore rows.
+4. LFM2.5 MXFP8 companion-state/cache/tool rows.
+5. MiniMax M2.7 full-KV JANG_K, then MiniMax Small JANGTQ runtime.
+6. DSV4 Flash supported-artifact/load/speed/cache row.
+7. Nemotron Omni multimodal and AppleScript/ZAYA agent completion rows.
+
+No row above is release-ready merely because it appears in the model picker or
+loads. The current broad campaign status is **PARTIAL / OPEN**, with the Qwen
+27B MXFP8 agent behavior explicitly **BROKEN**.


### PR DESCRIPTION
## Root cause

Hybrid Qwen/Ornith requests set skipExactDiskBoundary, but the indexed disk-candidate fallback re-admitted the exact token count. The runtime restored the exact GDN/KV entry, could not satisfy the required earlier recurrent seed, discarded the restore, and visibly prefetched from zero. Warm requests also synchronously rewrote already-validated KV and SSM payloads.

## Changes

- exclude the exact disk boundary from every candidate source when the path-dependent cache contract requires it
- skip KV rewrites only after current-process deserialize/write validation and matching file/index metadata
- apply the same current-process validation to paired SSM tensor/sidecar entries, including completeness, state count, boundary, model key, and linked KV hash
- preserve healing writes for inherited, changed, corrupt, missing, or unindexed payloads
- add focused regression coverage and the live proof matrix

## Current evidence

- 7 disk-cache tests passed
- 10 SSM-state tests passed
- 29 cache-topology tests passed, including Gemma rotating/TQ, Nemotron Mamba/TQ, DSV4 typed disk, ZAYA CCA, paged eviction, and paged-off partial SSD restore
- prior isolated Release Osaurus UI reproduced the exact failure with Disk Cache visibly On: the trace hit boundary 2234 with skipExactDisk=true, then the UI prefetched from 0

## Gate

PARTIAL: source tests pass, but the candidate is not being called user-facing verified until the rebuilt Release Osaurus app visibly restores a safe partial boundary, processes only the suffix, stays coherent, and emits the validated KV/SSM skip telemetry. That UI run is in progress.