### PR TITLE
Block-diffusion: guard against an empty (all-EOS) first canvas, and seed the three RNG draws

### DIFF
--- a/Libraries/MLXLMCommon/Diffusion/BlockDiffusionTokenIterator.swift
+++ b/Libraries/MLXLMCommon/Diffusion/BlockDiffusionTokenIterator.swift
@@ -376,10 +376,36 @@ public struct BlockDiffusionTokenIterator: TokenIteratorProtocol {
                 tMin: options.tMin, tMax: options.tMax)
             let processed = logits.asType(.float32) / temperature
 
+            // No-empty-response guard. Block-diffusion collapses terse prompts (e.g. boolq's
+            // "Respond with one of: yes, no.") to an all-EOS first canvas → empty output, even
+            // though the model answers correctly whenever it emits anything. On the FIRST canvas,
+            // forbid EOS at position 0 so at least one content token is produced; later canvases
+            // end normally, so a genuinely complete reply can still stop. (-1e9, not -inf, keeps
+            // entropy finite.)
+            //
+            // The write is IN PLACE, and that is load-bearing rather than accidental. `MLXArray` is
+            // a `final class`, so `var sampled = processed` binds a second reference to the same
+            // object and `sampled[0, 0, eos] = …` rewrites `processed` too (`_updateInternal` →
+            // `mlx_array_set`). The suppression therefore also reaches `selfConditioning =
+            // processed` below, and persists across denoising steps.
+            //
+            // That persistence is what makes the guard work. Building the mask out-of-place — e.g.
+            // `sampled = processed + bias` — leaves self-conditioning unmasked, the model re-asserts
+            // its EOS preference on the next step, and the canvas collapses again: MEASURED at
+            // boolq gen-nothink 70.0% (35/50, in place) versus 0.0% with 8/8 extraction failures
+            // (out of place). An earlier version of this comment claimed self-conditioning kept the
+            // UNMASKED logits; that was false, and making it true broke the guard.
+            var sampled = processed
+            if canvasesEmitted == 0 {
+                for eos in options.eosTokenIds {
+                    sampled[0, 0, eos] = MLXArray(Float(-1e9))
+                }
+            }
+
             let denoiserKey = nextRandomKey()
-            let denoiserCanvas = MLX.categorical(processed, key: denoiserKey).asType(.int32)
-            let argmaxCanvas = argMax(processed, axis: -1).asType(.int32)
-            let entropy = canvasTokenEntropy(processedLogits: processed)
+            let denoiserCanvas = MLX.categorical(sampled, key: denoiserKey).asType(.int32)
+            let argmaxCanvas = argMax(sampled, axis: -1).asType(.int32)
+            let entropy = canvasTokenEntropy(processedLogits: sampled)
             let acceptMask = entropyBoundAcceptMask(
                 tokenEntropy: entropy, entropyBound: options.entropyBound)
 


### PR DESCRIPTION
On terse prompts — e.g. a bare `Respond with one of: yes, no.` — block-diffusion frequently denoises the **entire first canvas to EOS**, so the model emits nothing. It isn't a comprehension failure: the same model answers correctly whenever it emits anything, and its explain-then-answer MC is strong. But an empty response to a direct question is a degenerate output for a server / agentic caller.

**Fix:** on the first canvas, forbid EOS at position 0 (mask those logits in the *sampled* copy only) so at least one content token is produced. Later canvases end normally, so a complete reply can still stop. Self-conditioning keeps the unmasked logits, so denoising dynamics are unchanged — and it is a no-op whenever position 0 would already be content.

**Validated:** a terse yes/no benchmark goes from ~16% (all-empty) to ~62%; open-ended generation (gsm8k etc.) is unchanged. (The residual isn't the mask — when forced off EOS the model tends to emit its channel-format scaffolding rather than a bare token, which is a real property of the model, not something this guard should paper over.)

**Depends on the seeding change** (same code region, so it can't be a standalone branch): this branch carries that commit first. When the seeding PR merges, this rebases cleanly and that commit collapses to a no-op.

**It's a decode policy**, so it's your call whether it should be unconditional or flag-gated. The evidence — a terse-prompt collapse to *silence*, recoverable to a real answer — argues for unconditional, but I'm happy to gate it behind a config flag if you'd prefer.

---

### Update: the aliasing note was correct, and the suggested remedy breaks the guard

You were right on every premise. `MLXArray` is a `final class`, subscript assignment goes through
`_updateInternal` → `mlx_array_set`, and `var sampled = processed` therefore aliases: the mask does
reach `selfConditioning = processed`. The comment claiming self-conditioning kept the UNMASKED
logits was false.

I applied the additive form you suggested, then measured it. Same binary, same 8 items,
`diffusiongemma-26B-A4B-it-MXFP4`, boolq gen-nothink:

| | boolq |
|---|---|
| out-of-place (`sampled = processed + bias`) | **0/8 = 0.0%**, 8/8 extraction failures |
| in-place (original) | **6/8 = 75.0%**, 1/8 extraction failures |
| in-place, banked full run (n=50) | 35/50 = 70.0% |

Making the stated invariant true is what breaks the guard. The suppression reaching
self-conditioning is not incidental — it is the mechanism. Masking only the sampled copy lets the
model re-assert its EOS preference at the next denoising step, and the canvas collapses to all-EOS
again, which is exactly the failure this patch exists to prevent.

So I have taken your other option — keep the in-place write, drop the false claim — and the comment
now states what the code does, why the aliasing is deliberate, and carries the 70% vs 0% numbers so
the next reader does not "fix" it back. Your review found a genuine defect; it was in the comment
rather than the code.

Also noted for the description, as you asked: this diff additionally threads a per-request PRNG key
through canvas init, the denoiser draw, and renoise, so seeded block-diffusion is reproducible.
Those three draws previously used the global unseeded RNG, which made temperature-0 runs
non-reproducible.
