### PR TITLE
Persist stable system and tool prefixes in SSD cache

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -1198,7 +1198,8 @@ private struct LLMUserInputProcessor: UserInputProcessor {
         do {
             let promptTokens = try tokenizer.applyChatTemplate(
                 messages: messages, tools: input.tools, additionalContext: additionalContext)
-            let cachePrefixTokenCounts = canonicalHistoryCacheBoundaries(
+            let cacheBoundaries = canonicalChatCacheBoundaries(
+                tokenizer: tokenizer,
                 messages: messages,
                 tools: input.tools,
                 additionalContext: additionalContext,
@@ -1208,7 +1209,8 @@ private struct LLMUserInputProcessor: UserInputProcessor {
                 tokens: MLXArray(promptTokens),
                 tokenIds: promptTokens,
                 cacheScopeSalt: cacheScopeSalt(from: additionalContext),
-                cachePrefixTokenCounts: cachePrefixTokenCounts,
+                cachePrefixTokenCounts: cacheBoundaries.all,
+                cacheStablePrefixTokenCounts: cacheBoundaries.stable,
                 toolSchemas: input.tools)
         } catch TokenizerError.missingChatTemplate {
             print(
@@ -1290,32 +1292,6 @@ private struct LLMUserInputProcessor: UserInputProcessor {
             compacted.append(contentsOf: messages[(latestUserIndex + 1)...])
         }
         return compacted
-    }
-
-    private func canonicalHistoryCacheBoundaries(
-        messages: [[String: any Sendable]],
-        tools: [[String: any Sendable]]?,
-        additionalContext: [String: any Sendable]?,
-        promptTokens: [Int]
-    ) -> [Int] {
-        guard let controllable = tokenizer as? any GenerationPromptControllableTokenizer else {
-            return []
-        }
-        guard let historyTokens = try? controllable.applyChatTemplate(
-            messages: messages,
-            tools: tools,
-            additionalContext: additionalContext,
-            addGenerationPrompt: false)
-        else {
-            return []
-        }
-        guard !historyTokens.isEmpty,
-              historyTokens.count < promptTokens.count,
-              promptTokens.prefix(historyTokens.count).elementsEqual(historyTokens)
-        else {
-            return []
-        }
-        return [historyTokens.count]
     }
 
     static func defaultContext(

--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -1664,7 +1664,9 @@ public actor BatchEngine {
                 let result = coordinator.fetch(
                     tokens: tokenIds,
                     mediaSalt: slot.mediaSalt,
-                    skipExactDiskBoundary: requiresDiskBackedRestore)
+                    skipExactDiskBoundary: requiresDiskBackedRestore,
+                    preferredDiskBoundaries: slot.originalInput
+                        .cacheStablePrefixTokenCounts)
                 if case .hit(
                     let matchedTokens, let remaining, let detail, let blocks,
                     let ssmStates, let diskArrays) = result
@@ -2893,13 +2895,29 @@ public actor BatchEngine {
                 }
                 for boundary in Set(slot.originalInput.cachePrefixTokenCounts).sorted()
                 where boundary > 0 && boundary < promptTokens.count {
+                    let isStableBoundary = slot.originalInput
+                        .cacheStablePrefixTokenCounts.contains(boundary)
+                    let boundaryTokens = Array(promptTokens.prefix(boundary))
+                    if isStableBoundary,
+                       coordinator.hasValidatedDiskEntry(
+                        tokens: boundaryTokens,
+                        mediaSalt: slot.mediaSalt)
+                    {
+                        Self.logger.debug(
+                            "Skipped already-validated stable system/tool cache boundary for slot \(slot.id.description, privacy: .public): \(boundary, privacy: .public) tokens"
+                        )
+                        continue
+                    }
                     if let snapshot = boundarySnapshot(
-                        tokens: Array(promptTokens.prefix(boundary)))
+                        tokens: boundaryTokens,
+                        forceRederive: isStableBoundary)
                     {
                         storeCacheEntry(
-                            tokens: Array(promptTokens.prefix(boundary)),
+                            tokens: boundaryTokens,
                             snapshot: snapshot,
-                            label: "history-boundary")
+                            label: isStableBoundary
+                                ? "stable-system-tool-boundary"
+                                : "history-boundary")
                     }
                 }
 

--- a/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
@@ -417,7 +417,8 @@ public final class CacheCoordinator: @unchecked Sendable {
     public func fetch(
         tokens: [Int],
         mediaSalt: String? = nil,
-        skipExactDiskBoundary: Bool = false
+        skipExactDiskBoundary: Bool = false,
+        preferredDiskBoundaries: [Int] = []
     ) -> CacheFetchResult {
         func ftrace(_ msg: String) {
             if ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1" {
@@ -553,7 +554,16 @@ public final class CacheCoordinator: @unchecked Sendable {
                 }
             }
 
-            for boundary in diskCache.candidateTokenCounts(maxTokens: tokens.count) {
+            // Indexed lookup is intentionally bounded, so a frequently reused
+            // stable system/tool boundary can eventually fall below the 128
+            // largest historical prompt lengths. Merge processor-proven
+            // boundaries back into the probe set before sorting; each remains
+            // content-address checked against this request's exact token prefix.
+            let candidateBoundaries = Set(
+                diskCache.candidateTokenCounts(maxTokens: tokens.count)
+                    + preferredDiskBoundaries
+            ).sorted(by: >)
+            for boundary in candidateBoundaries {
                 // `skipExactDiskBoundary` is a correctness requirement for
                 // path-dependent hybrid caches, not merely a preference for
                 // the first two probes above. The indexed fallback used to
@@ -575,6 +585,26 @@ public final class CacheCoordinator: @unchecked Sendable {
         // All tiers missed
         ftrace("MISS all tiers")
         return .miss
+    }
+
+    /// True only after the current process has deserialized or written the
+    /// exact L2 entry and its on-disk fingerprint still matches the index.
+    public func hasValidatedDiskEntry(
+        tokens: [Int],
+        mediaSalt: String? = nil
+    ) -> Bool {
+        guard diskCache?.hasValidatedEntry(
+            tokens: tokens, mediaSalt: mediaSalt) == true
+        else {
+            return false
+        }
+        if isHybrid, requiresRecurrentSSMCompanion {
+            return ssmStateCache.hasValidatedCompleteDiskEntry(
+                tokens: tokens,
+                boundary: tokens.count,
+                mediaSalt: mediaSalt)
+        }
+        return true
     }
 
     /// Resolve SSM companion state for a disk-cache hit on a hybrid model.

--- a/Libraries/MLXLMCommon/Cache/DiskCache.swift
+++ b/Libraries/MLXLMCommon/Cache/DiskCache.swift
@@ -336,6 +336,33 @@ public final class DiskCache: @unchecked Sendable {
         }
     }
 
+    /// Whether this process has already proved that the content-addressed
+    /// entry is intact and matches its SQLite metadata.
+    ///
+    /// This is intentionally stricter than a filename/index existence check.
+    /// A fresh process returns `false` until `fetch` deserializes the payload;
+    /// a successful store also validates it. Stable system/tool boundaries can
+    /// use this to avoid a second architecture rederive and serialization at
+    /// the end of every warm request without trusting inherited or stale files.
+    public func hasValidatedEntry(tokens: [Int], mediaSalt: String? = nil) -> Bool {
+        let hash = DiskCache.hashTokens(tokens, modelKey: modelKey, mediaSalt: mediaSalt)
+        let url = safetensorsURL(for: hash)
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard let validated = validatedFiles[hash],
+              let current = _fileFingerprint(url: url),
+              current == validated,
+              current.size > 0,
+              let indexed = _entryMetadataLocked(hash: hash),
+              indexed.tokenCount == tokens.count,
+              indexed.fileSize == current.size
+        else {
+            return false
+        }
+        return true
+    }
+
     /// Candidate prompt-boundary lengths currently present in the disk index.
     ///
     /// The disk tier is content-addressed by the full token prefix hash, so a

--- a/Libraries/MLXLMCommon/Cache/SSMCompanionDiskStore.swift
+++ b/Libraries/MLXLMCommon/Cache/SSMCompanionDiskStore.swift
@@ -104,6 +104,43 @@ public final class SSMCompanionDiskStore: @unchecked Sendable {
         return storeSkips
     }
 
+    /// Whether the current process has validated a complete companion pair for
+    /// this exact content-addressed boundary. Used with the KV validation gate
+    /// so a valid KV file cannot suppress healing a missing/corrupt recurrent
+    /// sidecar after a hybrid cache miss.
+    func hasValidatedCompleteEntry(
+        tokens: [Int],
+        boundary: Int,
+        mediaSalt: String? = nil
+    ) -> Bool {
+        guard boundary > 0, boundary <= tokens.count else { return false }
+        let key = Self.keyFor(
+            tokens: tokens, boundary: boundary,
+            mediaSalt: mediaSalt, modelKey: modelKey)
+        let expectedKVHash = DiskCache.hashTokens(
+            Array(tokens.prefix(boundary)),
+            modelKey: modelKey,
+            mediaSalt: mediaSalt)
+        let safetensorsURL = self.safetensorsURL(for: key)
+        let sidecarURL = self.sidecarURL(for: key)
+
+        lock.lock()
+        defer { lock.unlock() }
+        guard let validated = validatedEntries[key],
+              validated.isComplete,
+              validated.numStates > 0,
+              validated.boundary == boundary,
+              validated.kvHash == expectedKVHash,
+              let currentSafetensors = fileFingerprint(at: safetensorsURL),
+              let currentSidecar = fileFingerprint(at: sidecarURL),
+              currentSafetensors == validated.safetensors,
+              currentSidecar == validated.sidecar
+        else {
+            return false
+        }
+        return true
+    }
+
     /// Persist SSM layer states for a given token prefix. Mirrors
     /// `SSMStateCache.store(ssmStates:tokens:boundary:)` with the
     /// addition of an `isComplete` flag (parity with Python tuple).

--- a/Libraries/MLXLMCommon/Cache/SSMStateCache.swift
+++ b/Libraries/MLXLMCommon/Cache/SSMStateCache.swift
@@ -288,6 +288,17 @@ public final class SSMStateCache: @unchecked Sendable {
         return entries.contains { $0.key == key && !$0.states.isEmpty }
     }
 
+    /// Current-process validation state for the disk-backed complete companion
+    /// pair, without deserializing or copying its tensors.
+    public func hasValidatedCompleteDiskEntry(
+        tokens: [Int], boundary: Int, mediaSalt: String? = nil
+    ) -> Bool {
+        diskStore?.hasValidatedCompleteEntry(
+            tokens: tokens,
+            boundary: boundary,
+            mediaSalt: mediaSalt) ?? false
+    }
+
     /// Remove all entries and reset hit/miss/re-derive statistics.
     public func clear() {
         lock.lock()

--- a/Libraries/MLXLMCommon/Diffusion/BlockDiffusionTokenIterator.swift
+++ b/Libraries/MLXLMCommon/Diffusion/BlockDiffusionTokenIterator.swift
@@ -149,7 +149,11 @@ public struct BlockDiffusionTokenIterator: TokenIteratorProtocol {
             // prior turns and must not be overwritten.
             self.cache.allSatisfy({ $0.offset == 0 })
         {
-            switch coordinator.fetch(tokens: promptTokenIds, mediaSalt: mediaSalt) {
+            switch coordinator.fetch(
+                tokens: promptTokenIds,
+                mediaSalt: mediaSalt,
+                preferredDiskBoundaries: input.cacheStablePrefixTokenCounts
+            ) {
             case .hit(let matchedTokens, let remainingTokens, _, let blocks, _, let diskArrays):
                 var restored = false
                 if !blocks.isEmpty {

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1444,7 +1444,9 @@ public struct TokenIterator: TokenIteratorProtocol {
                 let result = coordinator.fetch(
                     tokens: cacheLookupTokenIds,
                     mediaSalt: mediaSalt,
-                    skipExactDiskBoundary: requiresDiskBackedRestore)
+                    skipExactDiskBoundary: requiresDiskBackedRestore,
+                    preferredDiskBoundaries: originalInput
+                        .cacheStablePrefixTokenCounts)
                 switch result {
                 case .hit(
                     let matchedTokens, let remainingTokens, let detail, let blocks,
@@ -2325,9 +2327,22 @@ public struct TokenIterator: TokenIteratorProtocol {
                 for boundary in Set(cachePrefixTokenCounts).sorted()
                 where boundary > 0 && boundary < promptTokenIds.count {
                     let boundaryTokens = Array(promptTokenIds.prefix(boundary))
+                    let isStableBoundary = originalInput
+                        .cacheStablePrefixTokenCounts.contains(boundary)
+                    if isStableBoundary,
+                       coordinator.hasValidatedDiskEntry(
+                        tokens: boundaryTokens,
+                        mediaSalt: mediaSalt)
+                    {
+                        Self.logger.debug(
+                            "TokenIterator: skipped already-validated stable system/tool cache boundary at \(boundary, privacy: .public) tokens"
+                        )
+                        continue
+                    }
                     if let boundarySnapshot = cacheSnapshotForBoundary(
                         tokens: boundaryTokens,
-                        promptSnapshot: promptCacheSnapshot)
+                        promptSnapshot: promptCacheSnapshot,
+                        allowDiskBackedRederive: isStableBoundary)
                     {
                         store(
                             tokens: boundaryTokens,
@@ -2352,7 +2367,8 @@ public struct TokenIterator: TokenIteratorProtocol {
 
     private func cacheSnapshotForBoundary(
         tokens: [Int],
-        promptSnapshot: [KVCache]
+        promptSnapshot: [KVCache],
+        allowDiskBackedRederive: Bool = false
     ) -> [KVCache]? {
         guard !tokens.isEmpty, tokens.count < promptTokenIds.count else {
             return nil
@@ -2366,7 +2382,8 @@ public struct TokenIterator: TokenIteratorProtocol {
             return trimmed
         }
 
-        if shouldSkipHistoryBoundaryRederiveAfterTrimMiss(promptSnapshot) {
+        if !allowDiskBackedRederive,
+           shouldSkipHistoryBoundaryRederiveAfterTrimMiss(promptSnapshot) {
             Self.logger.debug(
                 "TokenIterator: skipped history-boundary cache rederive after trim miss for disk-backed cache topology"
             )

--- a/Libraries/MLXLMCommon/LanguageModel.swift
+++ b/Libraries/MLXLMCommon/LanguageModel.swift
@@ -73,6 +73,12 @@ public struct LMInput {
     /// actually contains.
     public let cachePrefixTokenCounts: [Int]
 
+    /// Subset of ``cachePrefixTokenCounts`` representing stable leading
+    /// system/developer instructions and tool schemas. These boundaries are
+    /// deliberately persisted for reuse by unrelated new chat sessions and may
+    /// require an architecture-native rederive when a cache cannot be trimmed.
+    public let cacheStablePrefixTokenCounts: [Int]
+
     /// Representation of tokenized input text.
     public struct Text {
 
@@ -180,12 +186,14 @@ public struct LMInput {
         tokenIds: [Int]? = nil,
         cacheScopeSalt: String? = nil,
         cachePrefixTokenCounts: [Int] = [],
+        cacheStablePrefixTokenCounts: [Int] = [],
         toolSchemas: [ToolSpec]? = nil
     ) {
         self.init(
             text: .init(tokens: tokens, mask: mask, tokenIds: tokenIds),
             cacheScopeSalt: cacheScopeSalt,
             cachePrefixTokenCounts: cachePrefixTokenCounts,
+            cacheStablePrefixTokenCounts: cacheStablePrefixTokenCounts,
             toolSchemas: toolSchemas)
     }
 
@@ -196,6 +204,7 @@ public struct LMInput {
         mediaTokenIds: [Int]? = nil,
         cacheScopeSalt: String? = nil,
         cachePrefixTokenCounts: [Int] = [],
+        cacheStablePrefixTokenCounts: [Int] = [],
         toolSchemas: [ToolSpec]? = nil
     ) {
         self.text = text
@@ -205,6 +214,7 @@ public struct LMInput {
         self.mediaTokenIds = mediaTokenIds
         self.cacheScopeSalt = cacheScopeSalt
         self.cachePrefixTokenCounts = cachePrefixTokenCounts
+        self.cacheStablePrefixTokenCounts = cacheStablePrefixTokenCounts
         self.toolSchemas = toolSchemas
     }
 
@@ -217,6 +227,7 @@ public struct LMInput {
             mediaTokenIds: mediaTokenIds,
             cacheScopeSalt: cacheScopeSalt,
             cachePrefixTokenCounts: cachePrefixTokenCounts,
+            cacheStablePrefixTokenCounts: cacheStablePrefixTokenCounts,
             toolSchemas: schemas)
     }
 }

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -221,7 +221,11 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                     coordinator.setPagedIncompatible(true)
                 }
             }
-            switch coordinator.fetch(tokens: cacheLookupTokenIds, mediaSalt: mediaSalt) {
+            switch coordinator.fetch(
+                tokens: cacheLookupTokenIds,
+                mediaSalt: mediaSalt,
+                preferredDiskBoundaries: originalInput.cacheStablePrefixTokenCounts
+            ) {
             case .hit(
                 let matchedTokens, let remainingTokens, _, let blocks,
                 let ssmStates, let diskArrays):
@@ -523,9 +527,19 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 for boundary in Set(cachePrefixTokenCounts).sorted()
                 where boundary > 0 && boundary < promptTokenIds.count {
                     let boundaryTokens = Array(promptTokenIds.prefix(boundary))
+                    let isStableBoundary = originalInput
+                        .cacheStablePrefixTokenCounts.contains(boundary)
+                    if isStableBoundary,
+                       coordinator.hasValidatedDiskEntry(
+                        tokens: boundaryTokens,
+                        mediaSalt: mediaSalt)
+                    {
+                        continue
+                    }
                     if let boundarySnapshot = cacheSnapshotForBoundary(
                         tokens: boundaryTokens,
-                        promptSnapshot: promptCacheSnapshot)
+                        promptSnapshot: promptCacheSnapshot,
+                        allowDiskBackedRederive: isStableBoundary)
                     {
                         store(
                             tokens: boundaryTokens,

--- a/Libraries/MLXLMCommon/Tokenizer.swift
+++ b/Libraries/MLXLMCommon/Tokenizer.swift
@@ -36,6 +36,79 @@ public protocol GenerationPromptControllableTokenizer: Tokenizer {
     ) throws -> [Int]
 }
 
+/// Exact chat-template prefix boundaries that can be persisted independently.
+///
+/// `all` includes the canonical no-generation-prompt history boundary used by a
+/// growing conversation. `stable` is the subset rendered from only the leading
+/// system/developer instructions plus the request's tool schemas. Because the
+/// stable boundary excludes the current user turn, a different new chat can
+/// reuse the shared system/tool prefill from L2 instead of warming from token
+/// zero again.
+///
+/// Every returned boundary is proven by token equality to be an actual prefix
+/// of the active prompt. Templates that conditionally reorder or rewrite that
+/// material therefore fail closed and return no such boundary.
+public struct CanonicalChatCacheBoundaries: Sendable, Equatable {
+    public let all: [Int]
+    public let stable: [Int]
+
+    public init(all: [Int], stable: [Int]) {
+        self.all = all
+        self.stable = stable
+    }
+}
+
+/// Derive safe cache boundaries from the exact active chat template.
+public func canonicalChatCacheBoundaries(
+    tokenizer: any Tokenizer,
+    messages: [[String: any Sendable]],
+    tools: [[String: any Sendable]]?,
+    additionalContext: [String: any Sendable]?,
+    promptTokens: [Int]
+) -> CanonicalChatCacheBoundaries {
+    guard let controllable = tokenizer as? any GenerationPromptControllableTokenizer else {
+        return CanonicalChatCacheBoundaries(all: [], stable: [])
+    }
+
+    func exactPrefixBoundary(
+        messages boundaryMessages: [[String: any Sendable]]
+    ) -> Int? {
+        guard let tokens = try? controllable.applyChatTemplate(
+            messages: boundaryMessages,
+            tools: tools,
+            additionalContext: additionalContext,
+            addGenerationPrompt: false),
+            !tokens.isEmpty,
+            tokens.count < promptTokens.count,
+            promptTokens.prefix(tokens.count).elementsEqual(tokens)
+        else {
+            return nil
+        }
+        return tokens.count
+    }
+
+    // Only the leading instruction rail is stable across unrelated chats.
+    // Tool schemas remain present because they are a separate template input;
+    // this also permits a tool-only stable prefix when a template emits one for
+    // an empty message list. Exact-prefix validation below is the safety gate.
+    let stableMessages = Array(messages.prefix { message in
+        guard let role = message["role"] as? String else { return false }
+        return role == "system" || role == "developer"
+    })
+    let hasStableMaterial = !stableMessages.isEmpty || tools?.isEmpty == false
+    let stable = hasStableMaterial
+        ? exactPrefixBoundary(messages: stableMessages).map { [$0] } ?? []
+        : []
+    let history = exactPrefixBoundary(messages: messages).map { [$0] } ?? []
+    let all = Array(Set(stable + history)).sorted()
+    if ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1" {
+        FileHandle.standardError.write(Data(
+            "[vmlx][cache/boundaries] prompt=\(promptTokens.count) stable=\(stable) all=\(all)\n".utf8
+        ))
+    }
+    return CanonicalChatCacheBoundaries(all: all, stable: stable)
+}
+
 extension Tokenizer {
     public func encode(text: String) -> [Int] {
         encode(text: text, addSpecialTokens: true)

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -1545,6 +1545,19 @@ public struct Gemma4Processor: UserInputProcessor {
             tools: chatTemplateTools,
             additionalContext: input.additionalContext
         )
+        // Text-only Gemma 4 requests share the same stable system/tool rail
+        // across unrelated chats. Derive it through the exact active template
+        // and fail closed unless it is a real token prefix. Media requests are
+        // intentionally excluded: their placeholder expansion and media salt
+        // require separate live cache proof before any cross-session claim.
+        let cacheBoundaries = input.images.isEmpty && input.audios.isEmpty
+            ? canonicalChatCacheBoundaries(
+                tokenizer: tokenizer,
+                messages: messages,
+                tools: chatTemplateTools,
+                additionalContext: input.additionalContext,
+                promptTokens: tokens)
+            : CanonicalChatCacheBoundaries(all: [], stable: [])
 
         var processedImage: LMInput.ProcessedImage?
         if !input.images.isEmpty {
@@ -1657,6 +1670,8 @@ public struct Gemma4Processor: UserInputProcessor {
             image: processedImage,
             audio: processedAudio,
             cacheScopeSalt: cacheScopeSalt(from: input.additionalContext),
+            cachePrefixTokenCounts: cacheBoundaries.all,
+            cacheStablePrefixTokenCounts: cacheBoundaries.stable,
             toolSchemas: input.tools)
     }
 

--- a/Libraries/MLXVLM/Models/Qwen3VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen3VL.swift
@@ -24,32 +24,6 @@ public struct Qwen3VLProcessor: UserInputProcessor {
         self.tokenizer = tokenizer
     }
 
-    private func canonicalHistoryCacheBoundaries(
-        messages: [[String: any Sendable]],
-        tools: [[String: any Sendable]]?,
-        additionalContext: [String: any Sendable]?,
-        promptTokens: [Int]
-    ) -> [Int] {
-        guard let controllable = tokenizer as? any GenerationPromptControllableTokenizer else {
-            return []
-        }
-        guard let historyTokens = try? controllable.applyChatTemplate(
-            messages: messages,
-            tools: tools,
-            additionalContext: additionalContext,
-            addGenerationPrompt: false)
-        else {
-            return []
-        }
-        guard !historyTokens.isEmpty,
-              historyTokens.count < promptTokens.count,
-              promptTokens.prefix(historyTokens.count).elementsEqual(historyTokens)
-        else {
-            return []
-        }
-        return [historyTokens.count]
-    }
-
     private func preprocess(image: CIImage, resizedSize: CGSize) -> CIImage {
         image
             .toSRGB()
@@ -167,7 +141,8 @@ public struct Qwen3VLProcessor: UserInputProcessor {
         if input.images.isEmpty, input.videos.isEmpty {
             let promptArray = MLXArray(promptTokens).expandedDimensions(axis: 0)
             let mask = ones(like: promptArray).asType(.int8)
-            let cachePrefixTokenCounts = canonicalHistoryCacheBoundaries(
+            let cacheBoundaries = canonicalChatCacheBoundaries(
+                tokenizer: tokenizer,
                 messages: messages,
                 tools: input.tools,
                 additionalContext: input.additionalContext,
@@ -175,7 +150,8 @@ public struct Qwen3VLProcessor: UserInputProcessor {
             return LMInput(
                 text: .init(tokens: promptArray, mask: mask, tokenIds: promptTokens),
                 cacheScopeSalt: cacheScopeSalt(from: input.additionalContext),
-                cachePrefixTokenCounts: cachePrefixTokenCounts,
+                cachePrefixTokenCounts: cacheBoundaries.all,
+                cacheStablePrefixTokenCounts: cacheBoundaries.stable,
                 toolSchemas: input.tools)
         }
 

--- a/Package.swift
+++ b/Package.swift
@@ -828,6 +828,7 @@ let package = Package(
                 "DSMLToolCallParserFocusedTests.swift",
                 "ToolCallProgressRoutingTests.swift",
                 "FocusedMLXTestSupport.swift",
+                "CanonicalChatCacheBoundariesTests.swift",
                 "BatchEngineGrowingChatCacheSourceTests.swift",
                 "CacheCoordinatorTopologyFocusedTests.swift",
                 "VMLXUmbrellaProductTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
@@ -56,6 +56,10 @@ struct BatchEngineGrowingChatCacheSourceTests {
         #expect(!source.contains("let hasPathDependentLayer = slot.cache.contains"))
         #expect(source.contains("shouldSkipHistoryBoundaryRederiveAfterTrimMiss(promptCacheSnapshot)"))
         #expect(source.contains("Skipped history-boundary cache rederive after trim miss for slot"))
+        #expect(source.contains("cacheStablePrefixTokenCounts.contains(boundary)"))
+        #expect(source.contains("forceRederive: isStableBoundary"))
+        #expect(source.contains(#""stable-system-tool-boundary""#))
+        #expect(source.contains("coordinator.hasValidatedDiskEntry("))
         #expect(!source.contains("let unsafePartial = !remaining.isEmpty &&\n                        (hasMediaContent || hasSSMLayer)"))
     }
 
@@ -96,6 +100,9 @@ struct BatchEngineGrowingChatCacheSourceTests {
         #expect(!source.contains("let hasPathDependentLayer = self.cache.contains"))
         #expect(source.contains("shouldSkipHistoryBoundaryRederiveAfterTrimMiss(promptSnapshot)"))
         #expect(source.contains("TokenIterator: skipped history-boundary cache rederive after trim miss"))
+        #expect(source.contains("cacheStablePrefixTokenCounts.contains(boundary)"))
+        #expect(source.contains("allowDiskBackedRederive: isStableBoundary"))
+        #expect(source.contains("coordinator.hasValidatedDiskEntry("))
         #expect(!source.contains("let unsafePartial = !remainingTokens.isEmpty &&\n                        (hasMediaContent || hasSSMLayer)"))
     }
 
@@ -118,6 +125,9 @@ struct BatchEngineGrowingChatCacheSourceTests {
         #expect(source.contains("var sharedPromptRederivedStates"))
         #expect(source.contains("reDeriveAndStoreSSMStatesAtPromptBoundaries("))
         #expect(source.contains("persistCapturedStatesToDisk: false"))
+        #expect(source.contains("cacheStablePrefixTokenCounts.contains(boundary)"))
+        #expect(source.contains("allowDiskBackedRederive: isStableBoundary"))
+        #expect(source.contains("coordinator.hasValidatedDiskEntry("))
     }
 
     @Test("token iterator drains MLX around cache store before completion info")

--- a/Tests/MLXLMCommonFocusedTests/CacheCoordinatorTopologyFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/CacheCoordinatorTopologyFocusedTests.swift
@@ -1207,8 +1207,8 @@ struct CacheCoordinatorTopologyFocusedTests {
         return url
     }
 
-    @Test("Gemma4 processor normalizes tool schemas before applying chat template")
-    func gemma4ProcessorNormalizesToolSchemasBeforeChatTemplate() throws {
+    @Test("Gemma4 processor normalizes tools and wires text-only stable boundaries")
+    func gemma4ProcessorNormalizesToolsAndWiresStableBoundaries() throws {
         let sourceURL = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
@@ -1217,6 +1217,10 @@ struct CacheCoordinatorTopologyFocusedTests {
         let source = try String(contentsOf: sourceURL)
         #expect(source.contains("normalizedToolsForChatTemplate(input.tools)"))
         #expect(source.contains("tools: chatTemplateTools"))
+        #expect(source.contains("input.images.isEmpty && input.audios.isEmpty"))
+        #expect(source.contains("canonicalChatCacheBoundaries("))
+        #expect(source.contains("cachePrefixTokenCounts: cacheBoundaries.all"))
+        #expect(source.contains("cacheStablePrefixTokenCounts: cacheBoundaries.stable"))
     }
 }
 

--- a/Tests/MLXLMCommonFocusedTests/CanonicalChatCacheBoundariesTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/CanonicalChatCacheBoundariesTests.swift
@@ -1,0 +1,182 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+
+@testable import MLXLMCommon
+import Testing
+
+@Suite("Canonical chat cache boundaries")
+struct CanonicalChatCacheBoundariesTests {
+    private struct BoundaryTokenizer: GenerationPromptControllableTokenizer {
+        let breakStablePrefix: Bool
+
+        var bosToken: String? { nil }
+        var eosToken: String? { nil }
+        var unknownToken: String? { nil }
+
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+        func convertTokenToId(_ token: String) -> Int? { nil }
+        func convertIdToToken(_ id: Int) -> String? { nil }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] {
+            try applyChatTemplate(
+                messages: messages,
+                tools: tools,
+                additionalContext: additionalContext,
+                addGenerationPrompt: true)
+        }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?,
+            addGenerationPrompt: Bool
+        ) throws -> [Int] {
+            var result = [1]
+            let leadingInstructions = messages.prefix {
+                let role = $0["role"] as? String
+                return role == "system" || role == "developer"
+            }
+            if breakStablePrefix, messages.count == leadingInstructions.count {
+                result = [7]
+            }
+            for message in leadingInstructions {
+                result.append((message["role"] as? String) == "system" ? 10 : 11)
+            }
+            if tools?.isEmpty == false {
+                result.append(20)
+            }
+            if let thinking = additionalContext?["enable_thinking"] as? Bool {
+                result.append(thinking ? 21 : 22)
+            }
+            for message in messages.dropFirst(leadingInstructions.count) {
+                switch message["role"] as? String {
+                case "user": result.append(30)
+                case "assistant": result.append(40)
+                default: result.append(50)
+                }
+            }
+            if addGenerationPrompt {
+                result.append(99)
+            }
+            return result
+        }
+    }
+
+    private let tools: [[String: any Sendable]] = [["type": "function"]]
+
+    @Test("stable system and tool prefix is distinct from full history")
+    func stableSystemToolPrefix() throws {
+        let tokenizer = BoundaryTokenizer(breakStablePrefix: false)
+        let messages: [[String: any Sendable]] = [
+            ["role": "system", "content": "rules"],
+            ["role": "user", "content": "first task"],
+        ]
+        let prompt = try tokenizer.applyChatTemplate(
+            messages: messages, tools: tools, additionalContext: nil)
+        let boundaries = canonicalChatCacheBoundaries(
+            tokenizer: tokenizer,
+            messages: messages,
+            tools: tools,
+            additionalContext: nil,
+            promptTokens: prompt)
+
+        #expect(prompt == [1, 10, 20, 30, 99])
+        #expect(boundaries.stable == [3])
+        #expect(boundaries.all == [3, 4])
+    }
+
+    @Test("tool-only stable prefix is reusable when the template proves it")
+    func toolOnlyStablePrefix() throws {
+        let tokenizer = BoundaryTokenizer(breakStablePrefix: false)
+        let messages: [[String: any Sendable]] = [
+            ["role": "user", "content": "first task"]
+        ]
+        let prompt = try tokenizer.applyChatTemplate(
+            messages: messages, tools: tools, additionalContext: nil)
+        let boundaries = canonicalChatCacheBoundaries(
+            tokenizer: tokenizer,
+            messages: messages,
+            tools: tools,
+            additionalContext: nil,
+            promptTokens: prompt)
+
+        #expect(prompt == [1, 20, 30, 99])
+        #expect(boundaries.stable == [2])
+        #expect(boundaries.all == [2, 3])
+    }
+
+    @Test("template rewrites fail closed instead of storing a false prefix")
+    func nonPrefixStableRenderIsRejected() throws {
+        let tokenizer = BoundaryTokenizer(breakStablePrefix: true)
+        let messages: [[String: any Sendable]] = [
+            ["role": "system", "content": "rules"],
+            ["role": "user", "content": "first task"],
+        ]
+        let prompt = try tokenizer.applyChatTemplate(
+            messages: messages, tools: tools, additionalContext: nil)
+        let boundaries = canonicalChatCacheBoundaries(
+            tokenizer: tokenizer,
+            messages: messages,
+            tools: tools,
+            additionalContext: nil,
+            promptTokens: prompt)
+
+        #expect(boundaries.stable.isEmpty)
+        #expect(boundaries.all == [4])
+    }
+
+    @Test("a bare BOS without system instructions or tools is not persisted")
+    func noStableMaterialDoesNotCreateBoundary() throws {
+        let tokenizer = BoundaryTokenizer(breakStablePrefix: false)
+        let messages: [[String: any Sendable]] = [
+            ["role": "user", "content": "first task"]
+        ]
+        let prompt = try tokenizer.applyChatTemplate(
+            messages: messages, tools: nil, additionalContext: nil)
+        let boundaries = canonicalChatCacheBoundaries(
+            tokenizer: tokenizer,
+            messages: messages,
+            tools: nil,
+            additionalContext: nil,
+            promptTokens: prompt)
+
+        #expect(boundaries.stable.isEmpty)
+        #expect(boundaries.all == [2])
+    }
+
+    @Test("template configuration changes produce a different stable token prefix")
+    func configurationChangeInvalidatesStablePrefix() throws {
+        let tokenizer = BoundaryTokenizer(breakStablePrefix: false)
+        let messages: [[String: any Sendable]] = [
+            ["role": "system", "content": "rules"],
+            ["role": "user", "content": "first task"],
+        ]
+        let enabledContext: [String: any Sendable] = ["enable_thinking": true]
+        let disabledContext: [String: any Sendable] = ["enable_thinking": false]
+        let enabledPrompt = try tokenizer.applyChatTemplate(
+            messages: messages, tools: tools, additionalContext: enabledContext)
+        let disabledPrompt = try tokenizer.applyChatTemplate(
+            messages: messages, tools: tools, additionalContext: disabledContext)
+        let enabled = canonicalChatCacheBoundaries(
+            tokenizer: tokenizer,
+            messages: messages,
+            tools: tools,
+            additionalContext: enabledContext,
+            promptTokens: enabledPrompt)
+        let disabled = canonicalChatCacheBoundaries(
+            tokenizer: tokenizer,
+            messages: messages,
+            tools: tools,
+            additionalContext: disabledContext,
+            promptTokens: disabledPrompt)
+
+        let enabledBoundary = try #require(enabled.stable.first)
+        let disabledBoundary = try #require(disabled.stable.first)
+        #expect(Array(enabledPrompt.prefix(enabledBoundary))
+            != Array(disabledPrompt.prefix(disabledBoundary)))
+    }
+}

--- a/Tests/MLXLMTests/CacheCoordinatorTests.swift
+++ b/Tests/MLXLMTests/CacheCoordinatorTests.swift
@@ -6,6 +6,125 @@ import Testing
 
 // MARK: - CacheCoordinator Tests
 
+@Test func coordinatorValidatedDiskEntryRequiresCurrentProcessProof() throws {
+    try MLXMetalTestLock.withLock {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("validated-stable-prefix-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let config = CacheCoordinatorConfig(
+            usePagedCache: false,
+            enableDiskCache: true,
+            diskCacheMaxGB: 1.0,
+            diskCacheDir: tmp,
+            modelKey: "validated-stable-prefix")
+        let tokens = [71, 72, 73, 74]
+        let keys = MLXArray.ones([1, 1, tokens.count, 4])
+        let values = MLXArray.ones([1, 1, tokens.count, 4]) * 2.0
+
+        let writer = CacheCoordinator(config: config)
+        #expect(!writer.hasValidatedDiskEntry(tokens: tokens))
+        writer.storeAfterGeneration(
+            promptTokens: tokens,
+            perLayerData: [(keys: keys, values: values)],
+            ssmStates: nil,
+            cache: nil)
+        #expect(writer.hasValidatedDiskEntry(tokens: tokens))
+
+        let restarted = CacheCoordinator(config: config)
+        #expect(!restarted.hasValidatedDiskEntry(tokens: tokens),
+            "an inherited filename/index is not current-process validation")
+        guard case .hit = restarted.fetch(tokens: tokens) else {
+            Issue.record("the inherited stable prefix should deserialize from L2")
+            return
+        }
+        #expect(restarted.hasValidatedDiskEntry(tokens: tokens))
+
+        let files = try FileManager.default.contentsOfDirectory(
+            at: restarted.diskCache!.cacheDir,
+            includingPropertiesForKeys: nil)
+        let payload = try #require(files.first { $0.pathExtension == "safetensors" })
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSinceNow: 5)],
+            ofItemAtPath: payload.path)
+        #expect(!restarted.hasValidatedDiskEntry(tokens: tokens),
+            "a changed file fingerprint must revoke the warm-store fast path")
+    }
+}
+
+@Test func coordinatorValidatedHybridEntryRequiresCompleteCompanionPair() {
+    MLXMetalTestLock.withLock {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("validated-hybrid-prefix-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let coordinator = CacheCoordinator(config: CacheCoordinatorConfig(
+            usePagedCache: false,
+            enableDiskCache: true,
+            diskCacheMaxGB: 1.0,
+            diskCacheDir: tmp,
+            modelKey: "validated-hybrid-prefix"))
+        coordinator.setHybrid(true, requiresRecurrentSSMCompanion: true)
+        let tokens = [81, 82, 83, 84]
+        let keys = MLXArray.ones([1, 1, tokens.count, 4])
+        let values = MLXArray.ones([1, 1, tokens.count, 4]) * 2.0
+        coordinator.storeAfterGeneration(
+            promptTokens: tokens,
+            perLayerData: [(keys: keys, values: values)],
+            ssmStates: nil,
+            cache: nil)
+        #expect(!coordinator.hasValidatedDiskEntry(tokens: tokens),
+            "validated KV alone must not hide a missing recurrent companion")
+
+        coordinator.storeAfterGeneration(
+            promptTokens: tokens,
+            perLayerData: [(keys: keys, values: values)],
+            ssmStates: [MLXArray.ones([1, 4])],
+            cache: nil)
+        #expect(coordinator.hasValidatedDiskEntry(tokens: tokens))
+    }
+}
+
+@Test func coordinatorPreferredStableBoundarySurvivesBoundedDiskIndex() throws {
+    try MLXMetalTestLock.withLock {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("preferred-stable-prefix-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let coordinator = CacheCoordinator(config: CacheCoordinatorConfig(
+            usePagedCache: false,
+            enableDiskCache: true,
+            diskCacheMaxGB: 0.1,
+            diskCacheDir: tmp,
+            modelKey: "preferred-stable-prefix"))
+        let disk = try #require(coordinator.diskCache)
+        let arrays = ["data": MLXArray.ones([1, 1])]
+        let requestTokens = Array(0 ..< 160)
+        let stableBoundary = 8
+        disk.store(
+            tokens: Array(requestTokens.prefix(stableBoundary)),
+            arrays: arrays)
+
+        // More than the index probe's 128 distinct larger lengths makes the
+        // stable entry disappear from the ordinary candidate-length query.
+        // None of these decoys matches the active request prefix.
+        for count in 9 ... 137 {
+            disk.store(tokens: Array(repeating: -count, count: count), arrays: arrays)
+        }
+        #expect(!disk.candidateTokenCounts(maxTokens: requestTokens.count)
+            .contains(stableBoundary))
+
+        guard case .hit(let matched, let remaining, let detail, _, _, _) =
+            coordinator.fetch(
+                tokens: requestTokens,
+                preferredDiskBoundaries: [stableBoundary])
+        else {
+            Issue.record("processor-proven stable boundary should bypass the bounded index window")
+            return
+        }
+        #expect(matched == stableBoundary)
+        #expect(remaining == Array(requestTokens.dropFirst(stableBoundary)))
+        #expect(detail == .disk)
+    }
+}
+
 /// 2026-05-04 (DSV4 SWA/CSA/HSA correctness pass):
 /// Verify the paged-incompatible short-circuit. With `setPagedIncompatible(true)`
 /// a fetch should miss the paged tier even when an exact-prefix block

--- a/docs/VMLX_OSAURUS_POST_GEMMA_LIVE_MATRIX_2026_07_20.md
+++ b/docs/VMLX_OSAURUS_POST_GEMMA_LIVE_MATRIX_2026_07_20.md
@@ -120,6 +120,9 @@ closed. The stable boundary is passed explicitly to the disk probe so it cannot
 fall out of the index's 128-largest-length scan. Dense caches trim to it.
 Disk-backed rotating Gemma SWA and Qwen/Ornith/Bonsai GDN/SSM topologies force
 an architecture-native boundary rederive rather than flattening typed state.
+Gemma 4 is wired explicitly through its custom `Gemma4Processor` for text-only
+requests; Qwen3VL is likewise wired only on its text branch. Their image/audio
+placeholder paths remain excluded until separate media-salt restore proof.
 After an entry has actually been written or deserialized in the current
 process, matching file fingerprint plus SQLite metadata suppresses redundant
 warm-turn rederive/write; inherited filenames alone are not trusted.
@@ -141,7 +144,9 @@ Current edited-tree evidence:
   proves the stable boundary is absent from the normal scan, and restores it
   only through the processor-proven preferred-boundary path;
 - 42/42 cache-topology tests, 10/10 recurrent companion tests, and 8/8 disk
-  cache tests pass after the validation-pair change.
+  cache tests pass after the validation-pair change; the Gemma processor source
+  row additionally proves normalized tools and both text-only boundary fields
+  reach `LMInput`.
 
 Status remains **PARTIAL**. Required live closure is an isolated Release app on
 the exact candidate pin showing cold store, unrelated-new-chat partial L2 hit,

--- a/docs/VMLX_OSAURUS_POST_GEMMA_LIVE_MATRIX_2026_07_20.md
+++ b/docs/VMLX_OSAURUS_POST_GEMMA_LIVE_MATRIX_2026_07_20.md
@@ -96,6 +96,60 @@ row stays **PARTIAL** until a rebuilt Release app visibly proves suffix-only
 prefill, coherent output, both `disk-store SKIP` and `ssm-store SKIP`
 telemetry, and stable payload bytes.
 
+### Stable system/tool prefix across unrelated new chats
+
+The same isolated Release app subsequently reproduced a second, independent
+SSD miss after the exact-boundary rollback was removed. With Prefix On, paged
+RAM Off, Disk Cache On, native KV, SSM rederive On, Ornith MXFP8, and Thinking
+Off visible in the UI, an unrelated new chat showed `Prefill 1536/2420` and
+logged `MISS all tiers tokens=2420 skipExactDisk=true`. Prior turns had stored
+their complete prompt/history boundaries, but none had stored the leading
+system instructions plus tool schemas without the previous user message.
+Content-addressed lookup therefore had no prefix shared by the new session and
+correctly prefetched from zero.
+
+The current candidate derives two separate exact chat-template boundaries:
+
+- canonical full history without the assistant generation rail; and
+- the leading system/developer instructions plus the same tool schemas, also
+  without the generation rail.
+
+Both are accepted only when their token IDs are a byte-for-byte prefix of the
+active prompt; templates that reorder or conditionally rewrite the content fail
+closed. The stable boundary is passed explicitly to the disk probe so it cannot
+fall out of the index's 128-largest-length scan. Dense caches trim to it.
+Disk-backed rotating Gemma SWA and Qwen/Ornith/Bonsai GDN/SSM topologies force
+an architecture-native boundary rederive rather than flattening typed state.
+After an entry has actually been written or deserialized in the current
+process, matching file fingerprint plus SQLite metadata suppresses redundant
+warm-turn rederive/write; inherited filenames alone are not trusted.
+
+Current edited-tree evidence:
+
+- 5/5 canonical-template boundary tests pass: system+tools, tools-only,
+  non-prefix fail-closed behavior, no bare-BOS persistence when neither stable
+  instruction nor tool material exists, and distinct stable token prefixes
+  after a template configuration change;
+- 17/17 BatchEngine/TokenIterator/Native-MTP cache wiring tests pass;
+- the Metal-backed current-process validation test passes, including fresh
+  process false-before-fetch, true-after-deserialize, and false-after external
+  fingerprint mutation;
+- the hybrid validation test proves a current-process-validated KV file alone
+  cannot suppress healing when the matching complete recurrent sidecar is
+  absent, then accepts the same boundary after the companion pair is stored;
+- the bounded-index regression stores more than 128 larger candidate lengths,
+  proves the stable boundary is absent from the normal scan, and restores it
+  only through the processor-proven preferred-boundary path;
+- 42/42 cache-topology tests, 10/10 recurrent companion tests, and 8/8 disk
+  cache tests pass after the validation-pair change.
+
+Status remains **PARTIAL**. Required live closure is an isolated Release app on
+the exact candidate pin showing cold store, unrelated-new-chat partial L2 hit,
+full app restart partial L2 hit, truthful visible suffix-only prefill/TTFT, and
+coherent output on Ornith/Qwen hybrid plus Gemma 4 JANG_4M rotating-SWA. Qwen
+3.5 VL media reuse remains a separate media-salt/placeholder row; the text path
+shares the stable-boundary implementation, but no media claim is made here.
+
 | Family / bundle | Architecture and runtime | Current result | Current evidence | Missing before closure |
 |---|---|---|---|---|
 | Qwen 3.5 dense — `dealign.ai/Qwen3.6-27B-JANG_4M-CRACK` | 64 layers: 48 linear-attention + 16 full-attention; JANG_4M | PARTIAL | Thinking visibly off. Bundle-default row returned the requested two lines at TTFT 1.78 s, 22.5 tok/s, 22 tokens. Explicit greedy Settings row returned the requested two lines at TTFT 1.87 s, 22.5 tok/s, 24 tokens. No tool calls or reasoning deltas. | Multi-turn, required/automatic/no-tool/tool-error rows; real image/video; SSD cold/full/partial/restart; paged-on hot/eviction; explicit TQ on/off; Activity Monitor per row. |


### PR DESCRIPTION
## Scope\n\nFix unrelated new chat sessions warming from token zero even when SSD L2 is enabled. This is limited to reusable chat-template prefix boundaries and their architecture-correct disk payload validation.\n\n## Root cause\n\nThe runtime persisted complete prompt and conversation-history boundaries, but not the leading system/developer instructions plus tool schemas shared by unrelated chats. Disk lookup therefore had no content-addressed boundary common to a fresh session. Qwen hybrid families also require the recurrent GDN/SSM companion to be valid with the KV payload.\n\n## Changes\n\n- derive a stable boundary through the active chat template and accept it only when its token IDs are an exact prefix of the active prompt\n- include active tools and template context so schema/config changes produce a different cache key\n- persist through BatchEngine, solo TokenIterator, Native MTP, text-only Qwen3VL, and text-only Gemma 4\n- rederive architecture-native state for non-trimmable Gemma rotating-SWA and Qwen hybrid caches\n- keep processor-proven stable boundaries discoverable beyond the bounded 128-length disk index scan\n- skip redundant writes only after current-process validation of KV and required recurrent companion state\n- leave Qwen VL media-prefix behavior unchanged pending separate media proof\n\n## Source and focused-test evidence\n\n- CanonicalChatCacheBoundariesTests: 5/5\n- BatchEngineGrowingChatCacheSourceTests: 17/17\n- CacheCoordinatorTopologyFocusedTests: 42/42\n- SSMStateCacheTests: 10/10\n- DiskCacheTests: 8/8\n- hybrid KV-without-companion validation regression: pass\n- preferred stable boundary beyond 128 indexed lengths: pass\n- swift build --jobs 1: pass\n- GitHub workflow jobs are SKIPPED by the inherited upstream-only repository condition; they are not counted as CI passes\n\n## Release-app proof at head 2fad1f6847461f159c2e21b98de7d26f3358ba3c\n\nIsolated Release app com.dinoki.osaurus.ssdstableproof20260721 was operated through the UI with Prefix On, Disk Cache On, Paged/GPU Cache Off, Engine Selected codec, and SSM rederive On.\n\n- Gemma 4 E2B QAT JANG_4M: cold stored stable 1630 plus prompt 1633; unrelated new chat restored 1630 then 1633 and visibly completed at TTFT 0.67s / 67.2 tok/s; full app restart restored the same boundaries and completed at TTFT 0.41s / 95.6 tok/s.\n- Ornith 1.0 9B MXFP8, Qwen 3.5-derived hybrid: unrelated new chat restored recurrent-compatible 1731 then 1734 with ssm=48 and visibly completed at TTFT 0.55s / 92.7 tok/s; restart restored the same boundaries and completed at TTFT 0.56s / 89.7 tok/s.\n\nNo TurboQuant, VL/media, or unsupported-family claim is made by this PR.