### PR TITLE
Budget SSD cache stores by physical footprint

### DIFF
--- a/Libraries/MLXLMCommon/Cache/CacheStoreBudget.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheStoreBudget.swift
@@ -3,6 +3,10 @@
 import Foundation
 import MLX
 
+#if canImport(Darwin)
+    import Darwin
+#endif
+
 /// How much of the host's remaining memory a single prefix-cache store may take.
 ///
 /// This is the engine-side projection of the user's memory-safety level. The
@@ -107,7 +111,47 @@ public enum CacheStoreBudget {
     public static func canStore(_ cache: [KVCache]) -> Bool {
         let liveBytes = cacheBytes(cache)
         guard liveBytes > 0 else { return true }
-        return canStore(cacheBytes: liveBytes)
+        let physicalFootprint = currentProcessPhysicalFootprintBytes()
+        let activeBytes = activeBytesForStoreBudget(
+            physicalFootprintBytes: physicalFootprint,
+            mlxActiveBytes: max(0, MLX.Memory.activeMemory)
+        )
+        let budgetBytes = Int(exactly: ProcessInfo.processInfo.physicalMemory)
+        let allowed = canStore(
+            cacheBytes: liveBytes,
+            activeBytes: activeBytes,
+            budgetBytes: budgetBytes
+        )
+        if ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1" {
+            let source = physicalFootprint == nil ? "mlx_active_fallback" : "phys_footprint"
+            let budget = budgetBytes.map(String.init) ?? "unknown"
+            FileHandle.standardError.write(
+                Data(
+                    "[vmlx][cache/store-budget] cache=\(liveBytes) active=\(activeBytes) budget=\(budget) source=\(source) fraction=\(policy.headroomFraction) allowed=\(allowed)\n"
+                        .utf8
+                ))
+        }
+        return allowed
+    }
+
+    /// Resolve the process occupancy used by the store guard.
+    ///
+    /// `MLX.Memory.activeMemory` is allocator bookkeeping, not Activity Monitor
+    /// memory. With mmap-backed/JANG models it can remain near the logical model
+    /// size while macOS has reclaimed most cold pages. Charging that number as
+    /// physical occupancy silently disabled Safe Auto SSD checkpoints even when
+    /// the process had ample real headroom. `phys_footprint` is the kernel's
+    /// resident + compressed + IOKit accounting and is the number the host's RAM
+    /// safety gate and Activity Monitor expose. Keep MLX accounting only as a
+    /// conservative fallback on platforms where the kernel query is unavailable.
+    static func activeBytesForStoreBudget(
+        physicalFootprintBytes: UInt64?,
+        mlxActiveBytes: Int
+    ) -> Int {
+        if let physicalFootprintBytes {
+            return Int(clamping: physicalFootprintBytes)
+        }
+        return max(0, mlxActiveBytes)
     }
 
     /// Testable core: no MLX state, just the arithmetic.
@@ -118,7 +162,10 @@ public enum CacheStoreBudget {
     /// the host still has free.
     static func canStore(
         cacheBytes liveBytes: Int,
-        activeBytes: Int = max(0, MLX.Memory.activeMemory),
+        activeBytes: Int = activeBytesForStoreBudget(
+            physicalFootprintBytes: currentProcessPhysicalFootprintBytes(),
+            mlxActiveBytes: max(0, MLX.Memory.activeMemory)
+        ),
         budgetBytes: Int? = Int(exactly: ProcessInfo.processInfo.physicalMemory),
         policy: CacheStorePolicy = CacheStoreBudget.policy
     ) -> Bool {
@@ -138,3 +185,28 @@ public enum CacheStoreBudget {
         return liveBytes <= allowance / materializationFactor
     }
 }
+
+#if canImport(Darwin)
+    private func currentProcessPhysicalFootprintBytes() -> UInt64? {
+        var info = task_vm_info_data_t()
+        var count = mach_msg_type_number_t(
+            MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<integer_t>.size
+        )
+        let result = withUnsafeMutablePointer(to: &info) { pointer in
+            pointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                task_info(
+                    mach_task_self_,
+                    task_flavor_t(TASK_VM_INFO),
+                    $0,
+                    &count
+                )
+            }
+        }
+        guard result == KERN_SUCCESS else { return nil }
+        return UInt64(info.phys_footprint)
+    }
+#else
+    private func currentProcessPhysicalFootprintBytes() -> UInt64? {
+        nil
+    }
+#endif

--- a/Tests/MLXLMTests/CacheStoreBudgetTests.swift
+++ b/Tests/MLXLMTests/CacheStoreBudgetTests.swift
@@ -26,6 +26,28 @@ struct CacheStoreBudgetTests {
     /// the default is what the assertions are really about.
     private static let safeAuto = CacheStorePolicy.safeAuto
 
+    /// MLX allocator accounting can describe the logical/mapped model while
+    /// Activity Monitor shows the much smaller set of pages actually charged to
+    /// the process. RAM safety must use the latter or it rejects harmless SSD
+    /// checkpoints for reclaimed JANG models.
+    @Test("Physical footprint wins over inflated MLX allocator accounting")
+    func physicalFootprintWinsOverMLXAccounting() {
+        let active = CacheStoreBudget.activeBytesForStoreBudget(
+            physicalFootprintBytes: UInt64(19 * Self.gib),
+            mlxActiveBytes: 96 * Self.gib
+        )
+        #expect(active == 19 * Self.gib)
+    }
+
+    @Test("MLX active memory remains the fallback when footprint is unavailable")
+    func mlxAccountingIsThePortableFallback() {
+        let active = CacheStoreBudget.activeBytesForStoreBudget(
+            physicalFootprintBytes: nil,
+            mlxActiveBytes: 37 * Self.gib
+        )
+        #expect(active == 37 * Self.gib)
+    }
+
     /// The reported panic, in numbers: a 70B 8-bit model already holds ~70 GB of
     /// weights, the 64K-token KV cache is ~20 GiB more, and the store then wants
     /// another copy of that cache. It does not fit, and must be refused.
@@ -231,7 +253,8 @@ struct MemorySafetyLevelTests {
     func decodingPrefersModeOverStaleSlider() throws {
         // Written by a build where the slider was stored and inert: the user dragged
         // it to Performance (0) but the engine kept running Strict.
-        let json = #"{"mode":"strict","slider":0,"allowExperimentalMLXPress":false,"failClosedWhenEstimateUnknown":false}"#
+        let json =
+            #"{"mode":"strict","slider":0,"allowExperimentalMLXPress":false,"failClosedWhenEstimateUnknown":false}"#
         let decoded = try JSONDecoder().decode(
             VMLXMemorySafetySettings.self, from: Data(json.utf8))
         #expect(decoded.mode == .strict, "the level actually in force must survive the upgrade")


### PR DESCRIPTION
## Root cause

`CacheStoreBudget` charged `MLX.Memory.activeMemory` as physical process occupancy. For mmap-backed/JANG models that allocator number can stay near logical model scale after macOS has reclaimed cold pages, so Safe Auto rejected small SSD checkpoints despite ample real RAM.

Live Osaurus Release A/B on Qwen3.6 27B JANG_4M:
- Safe Auto: exact coherent response, but no Qwen row in the L2 SQLite index.
- Process `phys_footprint`: 19 GB.
- Performance mode after a real model reload: 3,868 and 3,865-token snapshots written, about 410 MB each.

## Change

Use Darwin `task_vm_info.phys_footprint`, the same measurement Activity Monitor exposes, for current process occupancy. Fall back to MLX active accounting only when the kernel probe is unavailable. Trace mode now reports source, cache bytes, active bytes, budget, policy fraction, and verdict.

The existing headroom fractions and one-copy materialization gate are unchanged, including the 70B/64K refusal case.

## Verification

- `swift format lint --strict` on both changed files
- `swift test --filter CacheStoreBudgetTests`
- 17 tests passed, including the old 70B/64K OOM refusal, small-host cache, safety-level ordering, physical-footprint preference, and MLX fallback rows.

Live post-fix Osaurus Safe Auto proof is the merge gate and will be attached after the app pins this commit.