### PR TITLE
Restore stable SSD prefixes for Qwen templates requiring a user turn

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -2697,6 +2697,19 @@ public actor BatchEngine {
                 slot.originalInput.cachePrefixTokenCounts
                     + [sharedPromptStripBoundary].compactMap { $0 }
             ))
+            // A path-dependent hybrid chat prompt has one canonical reusable
+            // boundary: the prompt with its trailing generation scaffold
+            // removed.  The exact prompt boundary is deliberately rejected on
+            // restore for these topologies, while the generated/post-answer
+            // tokens are not guaranteed to match the template's historical
+            // assistant rendering.  Persisting all three used to serialize
+            // several almost-identical full snapshots at every turn (hundreds
+            // of MB each for Bonsai) even though only this stripped boundary is
+            // required by the next turn.  Dense/rotating, media-unsafe, raw,
+            // and non-chat prompts have no proven strip boundary and keep the
+            // existing prompt/post-answer policy.
+            let usesCanonicalHybridBoundary =
+                coordinator.isHybrid && sharedPromptStripBoundary != nil
 
             func storeCacheEntry(tokens: [Int], snapshot: [KVCache], label: String) {
                 guard !tokens.isEmpty else { return }
@@ -2780,6 +2793,10 @@ public actor BatchEngine {
                     cache: diskStoreCache,
                     mediaSalt: slot.mediaSalt
                 )
+                if ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1" {
+                    FileHandle.standardError.write(Data(
+                        "[vmlx][cache/store] label=\(label) count=\(tokens.count)\n".utf8))
+                }
                 Self.logger.debug(
                     "Stored \(label, privacy: .public) cache entry for slot \(slot.id.description, privacy: .public): \(tokens.count) tokens"
                 )
@@ -2869,15 +2886,18 @@ public actor BatchEngine {
                 }
             }
 
-            storeCacheEntry(
-                tokens: promptTokens,
-                snapshot: promptCacheSnapshot,
-                label: "prompt-boundary")
+            if !usesCanonicalHybridBoundary {
+                storeCacheEntry(
+                    tokens: promptTokens,
+                    snapshot: promptCacheSnapshot,
+                    label: "prompt-boundary")
+            }
 
             if !slot.cachePromptUsesPostPrepareKey {
                 let requiresDiskBackedRestore =
                     cacheRequiresDiskBackedCoordinatorRestore(promptCacheSnapshot)
-                if requiresDiskBackedRestore,
+                if !usesCanonicalHybridBoundary,
+                   requiresDiskBackedRestore,
                    !shouldSkipDiskBackedToolPromptSeedBoundary(for: slot),
                    promptTokens.count > 1,
                    let snapshot = boundarySnapshot(tokens: Array(promptTokens.dropLast()))
@@ -2897,6 +2917,9 @@ public actor BatchEngine {
                 where boundary > 0 && boundary < promptTokens.count {
                     let isStableBoundary = slot.originalInput
                         .cacheStablePrefixTokenCounts.contains(boundary)
+                    if usesCanonicalHybridBoundary, !isStableBoundary {
+                        continue
+                    }
                     let boundaryTokens = Array(promptTokens.prefix(boundary))
                     if isStableBoundary,
                        coordinator.hasValidatedDiskEntry(
@@ -2955,7 +2978,14 @@ public actor BatchEngine {
                    let stripAt = sharedPromptStripBoundary
                 {
                     let strippedTokens = Array(promptTokens.prefix(stripAt))
-                    if let snapshot = boundarySnapshot(
+                    if coordinator.hasValidatedDiskEntry(
+                        tokens: strippedTokens,
+                        mediaSalt: slot.mediaSalt)
+                    {
+                        Self.logger.debug(
+                            "Skipped already-validated gen-suffix-stripped cache boundary for slot \(slot.id.description, privacy: .public): \(stripAt, privacy: .public) tokens"
+                        )
+                    } else if let snapshot = boundarySnapshot(
                         tokens: strippedTokens, forceRederive: true)
                     {
                         storeCacheEntry(
@@ -2977,7 +3007,8 @@ public actor BatchEngine {
             // Store the growing-chat boundary only when the cache offset proves
             // it covers prompt + generated tokens exactly enough to resume.
             let generatedBoundaryTokens = promptTokens + slot.generatedTokenIds
-            if reason == .stop,
+            if !usesCanonicalHybridBoundary,
+               reason == .stop,
                !slot.disablesGeneratedCacheBoundary,
                !containsUnprovenZayaTurboQuantDiskState(slot.cache),
                !slot.generatedTokenIds.isEmpty,

--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -2920,7 +2920,18 @@ public actor BatchEngine {
                     if usesCanonicalHybridBoundary, !isStableBoundary {
                         continue
                     }
-                    let boundaryTokens = Array(promptTokens.prefix(boundary))
+                    // Exact disk restores are deliberately rejected for
+                    // path-dependent hybrid caches: GDN/Mamba/CCA needs an
+                    // N-1 recurrent seed before the final token is re-fed.
+                    // Persist the processor-proven stable prefix one token
+                    // short so a brand-new chat can warm from SSD immediately
+                    // instead of doing one full cold prefill just to create
+                    // that seed for the *next* chat.
+                    let storeBoundary = isStableBoundary
+                        && requiresDiskBackedRestore && boundary > 1
+                        ? boundary - 1
+                        : boundary
+                    let boundaryTokens = Array(promptTokens.prefix(storeBoundary))
                     if isStableBoundary,
                        coordinator.hasValidatedDiskEntry(
                         tokens: boundaryTokens,
@@ -2939,7 +2950,9 @@ public actor BatchEngine {
                             tokens: boundaryTokens,
                             snapshot: snapshot,
                             label: isStableBoundary
-                                ? "stable-system-tool-boundary"
+                                ? (storeBoundary == boundary
+                                    ? "stable-system-tool-boundary"
+                                    : "stable-system-tool-safe-seed")
                                 : "history-boundary")
                     }
                 }

--- a/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
@@ -559,9 +559,20 @@ public final class CacheCoordinator: @unchecked Sendable {
             // largest historical prompt lengths. Merge processor-proven
             // boundaries back into the probe set before sorting; each remains
             // content-address checked against this request's exact token prefix.
+            // A path-dependent hybrid restore cannot consume an exact prompt
+            // boundary without an N-1 recurrent seed. Stable system/tool
+            // checkpoints are therefore persisted one token short. Keep that
+            // processor-proven seed in the probe set even after the bounded
+            // disk index has accumulated more than 128 larger entries.
+            let preferredSafeSeeds = skipExactDiskBoundary
+                ? preferredDiskBoundaries.compactMap { boundary in
+                    boundary > 1 ? boundary - 1 : nil
+                }
+                : []
             let candidateBoundaries = Set(
                 diskCache.candidateTokenCounts(maxTokens: tokens.count)
                     + preferredDiskBoundaries
+                    + preferredSafeSeeds
             ).sorted(by: >)
             for boundary in candidateBoundaries {
                 // `skipExactDiskBoundary` is a correctness requirement for

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -2336,12 +2336,20 @@ public struct TokenIterator: TokenIteratorProtocol {
 
                 for boundary in Set(cachePrefixTokenCounts).sorted()
                 where boundary > 0 && boundary < promptTokenIds.count {
-                    let boundaryTokens = Array(promptTokenIds.prefix(boundary))
                     let isStableBoundary = originalInput
                         .cacheStablePrefixTokenCounts.contains(boundary)
                     if usesCanonicalHybridBoundary, !isStableBoundary {
                         continue
                     }
+                    // Path-dependent hybrid caches reject exact disk restores
+                    // unless an N-1 recurrent seed exists. Store the stable
+                    // system/tool prefix one token short so the first new-chat
+                    // warmup can restore it instead of starting at token zero.
+                    let storeBoundary = isStableBoundary
+                        && requiresDiskBackedRestore && boundary > 1
+                        ? boundary - 1
+                        : boundary
+                    let boundaryTokens = Array(promptTokenIds.prefix(storeBoundary))
                     if isStableBoundary,
                        coordinator.hasValidatedDiskEntry(
                         tokens: boundaryTokens,

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -2146,6 +2146,13 @@ public struct TokenIterator: TokenIteratorProtocol {
         let sharedPromptAdditionalBoundaries = Array(Set(
             cachePrefixTokenCounts + [hybridStripBoundary].compactMap { $0 }
         ))
+        // When a hybrid prompt exposes a generation-suffix-stripped boundary,
+        // that is the canonical cross-turn checkpoint.  Full-prompt and
+        // post-answer snapshots are both larger and not the boundary the next
+        // templated turn is guaranteed to contain.  Prompts without this
+        // processor-proven boundary keep the existing storage policy.
+        let usesCanonicalHybridBoundary =
+            coordinator.isHybrid && hybridStripBoundary != nil
 
         func store(
             tokens: [Int],
@@ -2245,16 +2252,19 @@ public struct TokenIterator: TokenIteratorProtocol {
             let promptDiskKVMode = selectivePromptBoundaryDiskKVMode(
                 cache: promptCacheSnapshot,
                 requested: kvMode)
-            store(
-                tokens: promptTokenIds,
-                cache: promptCacheSnapshot,
-                kvBits: nil,
-                kvMode: promptDiskKVMode)
+            if !usesCanonicalHybridBoundary {
+                store(
+                    tokens: promptTokenIds,
+                    cache: promptCacheSnapshot,
+                    kvBits: nil,
+                    kvMode: promptDiskKVMode)
+            }
 
             if !originalInput.requiresPostPrepareCacheKey {
                 let requiresDiskBackedRestore =
                     cacheRequiresDiskBackedCoordinatorRestore(promptCacheSnapshot)
-                if requiresDiskBackedRestore,
+                if !usesCanonicalHybridBoundary,
+                   requiresDiskBackedRestore,
                    !skipDiskBackedToolPromptSeedBoundary,
                    promptTokenIds.count > 1,
                    let boundarySnapshot = cacheSnapshotForBoundary(
@@ -2329,6 +2339,9 @@ public struct TokenIterator: TokenIteratorProtocol {
                     let boundaryTokens = Array(promptTokenIds.prefix(boundary))
                     let isStableBoundary = originalInput
                         .cacheStablePrefixTokenCounts.contains(boundary)
+                    if usesCanonicalHybridBoundary, !isStableBoundary {
+                        continue
+                    }
                     if isStableBoundary,
                        coordinator.hasValidatedDiskEntry(
                         tokens: boundaryTokens,
@@ -2356,7 +2369,9 @@ public struct TokenIterator: TokenIteratorProtocol {
             }
         }
 
-        guard includeGeneratedBoundary, !generatedTokenIds.isEmpty else { return }
+        guard !usesCanonicalHybridBoundary,
+            includeGeneratedBoundary, !generatedTokenIds.isEmpty
+        else { return }
         guard !needsCacheQuantization else { return }
         guard !containsUnprovenZayaTurboQuantDiskState(cache) else { return }
         let generatedBoundaryTokens = promptTokenIds + generatedTokenIds

--- a/Libraries/MLXLMCommon/Tokenizer.swift
+++ b/Libraries/MLXLMCommon/Tokenizer.swift
@@ -87,6 +87,54 @@ public func canonicalChatCacheBoundaries(
         return tokens.count
     }
 
+    /// Some otherwise valid chat templates refuse to render instructions and
+    /// tools without a user query (Qwen 3.5 / Ornith / Bonsai raise
+    /// `No user query found in messages.`). Derive the stable boundary without
+    /// assuming a template shape: append two user probes whose first content
+    /// tokens differ, then keep only the token prefix shared by both probes and
+    /// the real prompt. The first probe divergence proves that no user content
+    /// is included; the real-prompt comparison proves the result is reusable by
+    /// this request.
+    func probeDerivedStableBoundary(
+        messages stableMessages: [[String: any Sendable]]
+    ) -> Int? {
+        func renderProbe(_ content: String) -> [Int]? {
+            var probeMessages = stableMessages
+            probeMessages.append(["role": "user", "content": content])
+            return try? controllable.applyChatTemplate(
+                messages: probeMessages,
+                tools: tools,
+                additionalContext: additionalContext,
+                addGenerationPrompt: false)
+        }
+
+        guard let probeA = renderProbe("0"),
+              let probeB = renderProbe("z"),
+              !probeA.isEmpty,
+              !probeB.isEmpty
+        else {
+            return nil
+        }
+
+        let limit = min(probeA.count, probeB.count, promptTokens.count)
+        var boundary = 0
+        while boundary < limit,
+              probeA[boundary] == probeB[boundary],
+              probeA[boundary] == promptTokens[boundary]
+        {
+            boundary += 1
+        }
+
+        guard boundary > 0,
+              boundary < probeA.count,
+              boundary < probeB.count,
+              boundary < promptTokens.count
+        else {
+            return nil
+        }
+        return boundary
+    }
+
     // Only the leading instruction rail is stable across unrelated chats.
     // Tool schemas remain present because they are a separate template input;
     // this also permits a tool-only stable prefix when a template emits one for
@@ -96,9 +144,11 @@ public func canonicalChatCacheBoundaries(
         return role == "system" || role == "developer"
     })
     let hasStableMaterial = !stableMessages.isEmpty || tools?.isEmpty == false
-    let stable = hasStableMaterial
-        ? exactPrefixBoundary(messages: stableMessages).map { [$0] } ?? []
-        : []
+    let stableBoundary = hasStableMaterial
+        ? exactPrefixBoundary(messages: stableMessages)
+            ?? probeDerivedStableBoundary(messages: stableMessages)
+        : nil
+    let stable = stableBoundary.map { [$0] } ?? []
     let history = exactPrefixBoundary(messages: messages).map { [$0] } ?? []
     let all = Array(Set(stable + history)).sorted()
     if ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1" {

--- a/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
@@ -59,6 +59,8 @@ struct BatchEngineGrowingChatCacheSourceTests {
         #expect(source.contains("cacheStablePrefixTokenCounts.contains(boundary)"))
         #expect(source.contains("forceRederive: isStableBoundary"))
         #expect(source.contains(#""stable-system-tool-boundary""#))
+        #expect(source.contains("let storeBoundary = isStableBoundary"))
+        #expect(source.contains(#""stable-system-tool-safe-seed""#))
         #expect(source.contains("coordinator.hasValidatedDiskEntry("))
         #expect(!source.contains("let unsafePartial = !remaining.isEmpty &&\n                        (hasMediaContent || hasSSMLayer)"))
     }
@@ -102,6 +104,7 @@ struct BatchEngineGrowingChatCacheSourceTests {
         #expect(source.contains("TokenIterator: skipped history-boundary cache rederive after trim miss"))
         #expect(source.contains("cacheStablePrefixTokenCounts.contains(boundary)"))
         #expect(source.contains("allowDiskBackedRederive: isStableBoundary"))
+        #expect(source.contains("let storeBoundary = isStableBoundary"))
         #expect(source.contains("coordinator.hasValidatedDiskEntry("))
         #expect(!source.contains("let unsafePartial = !remainingTokens.isEmpty &&\n                        (hasMediaContent || hasSSMLayer)"))
     }

--- a/Tests/MLXLMCommonFocusedTests/CanonicalChatCacheBoundariesTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/CanonicalChatCacheBoundariesTests.swift
@@ -5,6 +5,10 @@ import Testing
 
 @Suite("Canonical chat cache boundaries")
 struct CanonicalChatCacheBoundariesTests {
+    private enum RequiredUserError: Error {
+        case missingUser
+    }
+
     private struct BoundaryTokenizer: GenerationPromptControllableTokenizer {
         let breakStablePrefix: Bool
 
@@ -67,6 +71,65 @@ struct CanonicalChatCacheBoundariesTests {
     }
 
     private let tools: [[String: any Sendable]] = [["type": "function"]]
+
+    /// Minimal Qwen 3.5-shaped tokenizer: system/tool-only renders are
+    /// rejected, while a user query makes the same leading instruction rail
+    /// renderable. The user content token is deliberately different for each
+    /// probe so the stable boundary stops before user-controlled text.
+    private struct RequiredUserTokenizer: GenerationPromptControllableTokenizer {
+        var bosToken: String? { nil }
+        var eosToken: String? { nil }
+        var unknownToken: String? { nil }
+
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+        func convertTokenToId(_ token: String) -> Int? { nil }
+        func convertIdToToken(_ id: Int) -> String? { nil }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] {
+            try applyChatTemplate(
+                messages: messages,
+                tools: tools,
+                additionalContext: additionalContext,
+                addGenerationPrompt: true)
+        }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?,
+            addGenerationPrompt: Bool
+        ) throws -> [Int] {
+            guard let user = messages.first(where: { $0["role"] as? String == "user" }),
+                  let content = user["content"] as? String
+            else {
+                throw RequiredUserError.missingUser
+            }
+
+            var result = [1]
+            if messages.first?["role"] as? String == "system" {
+                result.append(10)
+            }
+            if tools?.isEmpty == false {
+                result.append(20)
+            }
+            result.append(30) // user-turn header
+            switch content.first {
+            case "0": result.append(60)
+            case "z": result.append(61)
+            default: result.append(62)
+            }
+            result.append(31) // user-turn close
+            if addGenerationPrompt {
+                result.append(99)
+            }
+            return result
+        }
+    }
 
     @Test("stable system and tool prefix is distinct from full history")
     func stableSystemToolPrefix() throws {
@@ -146,6 +209,29 @@ struct CanonicalChatCacheBoundariesTests {
 
         #expect(boundaries.stable.isEmpty)
         #expect(boundaries.all == [2])
+    }
+
+    @Test("required-user templates derive a stable prefix without user content")
+    func requiredUserTemplateUsesProbeDerivedStablePrefix() throws {
+        let tokenizer = RequiredUserTokenizer()
+        let messages: [[String: any Sendable]] = [
+            ["role": "system", "content": "rules"],
+            ["role": "user", "content": "actual request"],
+        ]
+        let prompt = try tokenizer.applyChatTemplate(
+            messages: messages, tools: tools, additionalContext: nil)
+        let boundaries = canonicalChatCacheBoundaries(
+            tokenizer: tokenizer,
+            messages: messages,
+            tools: tools,
+            additionalContext: nil,
+            promptTokens: prompt)
+
+        #expect(prompt == [1, 10, 20, 30, 62, 31, 99])
+        #expect(boundaries.stable == [4])
+        #expect(boundaries.all == [4, 6])
+        #expect(Array(prompt.prefix(try #require(boundaries.stable.first)))
+            == [1, 10, 20, 30])
     }
 
     @Test("template configuration changes produce a different stable token prefix")

--- a/Tests/MLXLMTests/CacheCoordinatorTests.swift
+++ b/Tests/MLXLMTests/CacheCoordinatorTests.swift
@@ -308,7 +308,7 @@ import Testing
         modelKey: "zaya-cca-cache-contract-test"
     )
     let coordinator = CacheCoordinator(config: config)
-    coordinator.setHybrid(true)
+    coordinator.setHybrid(true, requiresRecurrentSSMCompanion: false)
     coordinator.setPagedIncompatible(true)
 
     let tokens = [201, 202, 203, 204]

--- a/Tests/MLXLMTests/HybridStripBoundaryPrefillTests.swift
+++ b/Tests/MLXLMTests/HybridStripBoundaryPrefillTests.swift
@@ -161,6 +161,45 @@ final class HybridStripBoundaryPrefillTests: XCTestCase {
         XCTAssertEqual(detail, .disk)
     }
 
+    func testHybridStableBoundaryPublishesWarmupSafeSeed() throws {
+        let lock = lockSerializedMLXTest()
+        defer { lock.unlock() }
+
+        let model = RecordingHybridModel()
+        let coordinator = makeCoordinator()
+        coordinator.setGenPromptSuffixTokens(genPromptSuffix)
+
+        let stable = [1, 2, 3, 4, 5]
+        let prompt = stable + userTurn + genPromptSuffix
+        let input = LMInput(
+            tokens: MLXArray(prompt.map { Int32($0) }).expandedDimensions(axis: 0),
+            tokenIds: prompt,
+            cachePrefixTokenCounts: [stable.count],
+            cacheStablePrefixTokenCounts: [stable.count])
+        let parameters = GenerateParameters(maxTokens: 1, temperature: 0)
+        let mediaSalt = computeCacheSalt(for: input, parameters: parameters)
+        var iterator = try TokenIterator(
+            input: input,
+            model: model,
+            parameters: parameters,
+            cacheCoordinator: coordinator)
+
+        iterator.storeCacheAfterGeneration(
+            generatedTokenIds: [42], includeGeneratedBoundary: true)
+
+        let restored = coordinator.fetch(
+            tokens: stable,
+            mediaSalt: mediaSalt,
+            skipExactDiskBoundary: true,
+            preferredDiskBoundaries: [stable.count])
+        guard case .hit(let matched, let remaining, let detail, _, _, _) = restored else {
+            return XCTFail("first new-chat warmup should restore the stable N-1 seed")
+        }
+        XCTAssertEqual(matched, stable.count - 1)
+        XCTAssertEqual(remaining, [stable.last!])
+        XCTAssertEqual(detail, .disk)
+    }
+
     func testPrefillSplitsAtTheTurnStartToken() throws {
         let lock = lockSerializedMLXTest()
         defer { lock.unlock() }

--- a/Tests/MLXLMTests/HybridStripBoundaryPrefillTests.swift
+++ b/Tests/MLXLMTests/HybridStripBoundaryPrefillTests.swift
@@ -123,6 +123,44 @@ final class HybridStripBoundaryPrefillTests: XCTestCase {
         XCTAssertEqual(model.prepareCalls, prepareCallsAfterPrefill)
     }
 
+    func testHybridStorePublishesOnlyCanonicalStrippedBoundary() throws {
+        let lock = lockSerializedMLXTest()
+        defer { lock.unlock() }
+
+        let model = RecordingHybridModel()
+        let coordinator = makeCoordinator()
+        coordinator.setGenPromptSuffixTokens(genPromptSuffix)
+
+        let prompt = userTurn + genPromptSuffix
+        let input = LMInput(
+            tokens: MLXArray(prompt.map { Int32($0) }).expandedDimensions(axis: 0))
+        let parameters = GenerateParameters(maxTokens: 1, temperature: 0)
+        let mediaSalt = computeCacheSalt(for: input, parameters: parameters)
+        var iterator = try TokenIterator(
+            input: input,
+            model: model,
+            parameters: parameters,
+            cacheCoordinator: coordinator)
+
+        iterator.storeCacheAfterGeneration(
+            generatedTokenIds: [42], includeGeneratedBoundary: true)
+
+        let stats = coordinator.snapshotStats().diskStats
+        XCTAssertEqual(
+            stats?.stores, 1,
+            "hybrid chat must not serialize prompt + stripped + post-answer full snapshots")
+        let restored = coordinator.fetch(
+            tokens: prompt + [77],
+            mediaSalt: mediaSalt,
+            skipExactDiskBoundary: true)
+        guard case .hit(let matched, let remaining, let detail, _, _, _) = restored else {
+            return XCTFail("canonical stripped boundary should be restorable")
+        }
+        XCTAssertEqual(matched, userTurn.count)
+        XCTAssertEqual(remaining, genPromptSuffix + [77])
+        XCTAssertEqual(detail, .disk)
+    }
+
     func testPrefillSplitsAtTheTurnStartToken() throws {
         let lock = lockSerializedMLXTest()
         defer { lock.unlock() }

--- a/docs/SSD_L2_NEW_CHAT_PARTIAL_RESTORE_GATE_2026_07_21.md
+++ b/docs/SSD_L2_NEW_CHAT_PARTIAL_RESTORE_GATE_2026_07_21.md
@@ -2,7 +2,35 @@
 
 ## Status
 
-`PARTIAL — SOURCE TESTS PASS; UPDATED STORAGE POLICY NOT RELEASE-PROVEN`
+`VERIFIED-LIVE — FEB35555 N-1 HYBRID SEED; BROADER FAMILY MATRIX PARTIAL`
+
+## Current `feb35555` isolated Release proof
+
+The exact vMLX head `feb35555900398dc638c82a3e13e98f8b1adbf41` was
+consumed by all four package-pin surfaces of a fresh Release Osaurus build.
+The app was ad-hoc signed as
+`com.dinoki.osaurus.ssdwarmfeb355proof20260721`; its executable SHA-256 was
+`488b2ce7106cb8e85bb3f27e69d4db7941abb6f977bc3174e09131169d22a3ea`.
+It was operated through Computer Use with an isolated test root and the local
+bundles under `/Users/eric/models`.
+
+Settings visibly showed Prefix Cache On, GPU/paged cache Off, Disk Cache On,
+codec `Engine Selected`, SSM re-derive On, and Thinking Off. The Disk toggle
+was changed and saved in the UI for the negative control, then restored On and
+saved before the topology regressions.
+
+| Model / request | Request-attributed cache trace | Visible result |
+| --- | --- | --- |
+| Qwen AgentWorld 35B A3B MXFP8, first new-chat warm-up | disk boundary 2,992, one token remaining, 60 recurrent states | warm-up first delta 0.36 s |
+| Same Qwen bundle after quit/relaunch | disk boundary 2,992, one token remaining, 60 recurrent states | warm-up first delta 0.21 s; `Au`, TTFT 0.49 s, 47.8 tok/s |
+| Same Qwen request with Disk Cache Off | `MISS all tiers`; UI visibly advanced through `Prefill 1024/3010` | `Au`, TTFT 1.89 s, 47.9 tok/s |
+| Gemma 4 12B QAT JANG_4M, later new chat | disk boundary 1,629, four tokens remaining, `ssm=-1` | warm-up 0.28 s; `Au`, TTFT 0.41 s, 35.3 tok/s |
+| Bonsai 27B Ternary JANG, later new chat | disk boundary 2,922, one token remaining, 96 recurrent states | warm-up 0.20 s; prior visible `Au`, TTFT 0.50 s, 30.7 tok/s |
+
+This closes the emergency N-1 safe-seed defect on the real Qwen 3.5 hybrid
+path and shows that the scoped change does not replace rotating-SWA semantics
+or lose Bonsai companion state. It does not close the separate TurboQuant,
+media, paged-hot-tier, quota-pressure, or all-family campaign.
 
 This gate tracks a report that Bonsai appears to prefill from zero in each new
 Osaurus chat while paged RAM cache is **Off** and SSD/Disk L2 is **On**. A valid

--- a/docs/SSD_L2_NEW_CHAT_PARTIAL_RESTORE_GATE_2026_07_21.md
+++ b/docs/SSD_L2_NEW_CHAT_PARTIAL_RESTORE_GATE_2026_07_21.md
@@ -1,0 +1,151 @@
+# SSD L2 new-chat partial-restore gate — 2026-07-21
+
+## Status
+
+`PARTIAL — SOURCE TESTS PASS; UPDATED STORAGE POLICY NOT RELEASE-PROVEN`
+
+This gate tracks a report that Bonsai appears to prefill from zero in each new
+Osaurus chat while paged RAM cache is **Off** and SSD/Disk L2 is **On**. A valid
+partial hit does not require identical prompts: the coordinator must restore
+the longest content-verified stored token prefix and prefill only the unmatched
+suffix. Aggregate counters alone are not proof for a specific request.
+
+## Current Release-app evidence
+
+The isolated Release app at
+`/private/tmp/osaurus-applescript16-main-release-derived-20260721/Build/Products/Release/osaurus.app`
+(bundle `com.dinoki.osaurus.applescript16mainproof20260721`, executable SHA-256
+`14fe951e7befc7c26329e3140c0525117a12aa7a23ddc2fc26b0f6eb9328dab1`)
+was operated through the UI with the exact local
+`/Users/eric/models/dealign.ai/Bonsai-27b-Ternary-JANG-CRACK` bundle. Settings
+visibly showed Prefix On, Paged RAM Off, Disk L2 On, TurboQuant not enabled,
+SSM re-derive On, and all changes saved. Thinking was visibly Off.
+
+Observed with vMLX `a37e09d2e4304e3eaa0836b4cb1941da86bcaeb7`:
+
+| Row | Runtime trace | Visible result |
+| --- | --- | --- |
+| First blank new chat | Disk miss for 3,897 tokens; 5.34 s | Cold baseline. |
+| First `hey` | Disk hit at 3,897, 71 tokens remaining | Coherent answer; 0.80 s TTFT, 31.4 tok/s. |
+| Second blank new chat | Disk hit at 3,894, 3 tokens remaining | 0.20 s warm-up. |
+| Repeated `hey` | Disk hit at 3,961, 7 tokens remaining | Coherent answer; 0.61 s TTFT, 31.4 tok/s. |
+
+This is live proof that disk-only partial restore can work for Bonsai. It does
+not close the reporter's 8,741-token row or the cross-session stable-prefix
+case below.
+
+## Root cause isolated in current source
+
+`canonicalChatCacheBoundaries` first renders only leading system/developer
+messages plus tools with `add_generation_prompt=false` to derive the reusable
+new-chat boundary. Bonsai's Qwen 3.5 template rejects that legal boundary probe
+with `No user query found in messages.` The helper therefore returned
+`stable=[]`; current live traces confirmed that exact empty value.
+
+The full warm-up boundary can still hit when subsequent new chats have the
+same rendered prefix. It cannot provide a shorter independent system/tool
+checkpoint when legitimate chat/session context changes before the stored
+full boundary. That explains why a user can see both real disk-hit counters
+and an apparently cold new-chat transition.
+
+The source candidate in this branch remains model-name agnostic and fails
+closed:
+
+1. Prefer the existing system/tools-only exact-prefix render.
+2. Only if that render fails, append two different synthetic user probes and
+   render both with the model's own template and active context.
+3. Retain only the token prefix shared by both probes and the actual request.
+4. Require the boundary to be nonzero and strictly before every rendered
+   sequence ends. Any render failure, no divergence, or mismatch returns no
+   stable boundary.
+
+No user content, generated text, sampler override, model-name rule, or forced
+reasoning state is stored by this fallback. The probes derive a boundary only;
+they are never submitted to the model.
+
+## Separate Osaurus telemetry defect
+
+vMLX emits `.cacheLookup(completed=0,total=N)` before SSD lookup and then a
+`.cacheRestore(completed=matched,total=N)` event on a hit. The current Osaurus
+badge labels every stage `Prefill`, so the first frame appears as
+`Prefill 0/N` even when a disk hit follows. The supplied screenshot is
+therefore ambiguous, not proof of a cold transformer prefill. Osaurus must show
+cache lookup, restore, and actual prefill as distinct stages in the rebuilt UI.
+
+## Required current-source live acceptance
+
+Do not promote this branch from `PARTIAL` until a newly pinned, isolated
+Release Osaurus app proves all of the following through visible user actions:
+
+1. Paged RAM Off, Disk L2 On, TurboQuant Off, settings saved.
+2. The exact local Bonsai bundle and Thinking Off.
+3. Current traces show a nonempty `stable=[...]` boundary for the Qwen
+   user-required template.
+4. A cold chat persists that stable boundary.
+5. A new chat with different legitimate history/context restores that shorter
+   disk boundary and prefills only the suffix.
+6. The UI first says it is checking cache, then credits restored tokens, and
+   labels only remaining transformer work as prefill.
+7. TTFT is materially below the matched cold control, output is coherent and
+   non-looping, and hybrid SSM companion restore/re-derive telemetry is valid.
+8. Disk L2 Off returns to the cold behavior; changing a cache-affecting model
+   or reasoning configuration intentionally misses.
+
+After Bonsai, the same contract still needs topology-specific live rows for
+Ornith/Qwen 3.5, Qwen VL media salts, Gemma mixed rotating-SWA/full attention,
+full-KV models, and the other supported families. TurboQuant-on rows remain a
+separate opt-in matrix; JANGTQ weights are not TurboQuant KV cache encoding.
+
+## Current pinned-app partial-restore proof and newly isolated write stall
+
+The next isolated Release app pinned vMLX
+`ad786d77952d368c84f8cf1800eef77184308ee7` and was operated through the
+Osaurus UI with the same local Bonsai bundle, Thinking Off, Prefix On, Paged
+RAM Off, Disk L2 On, TurboQuant not selected, and SSM re-derive On.
+
+The new stable-boundary code produced `stable=[3798]` instead of `stable=[]`.
+The UI and request-local traces recorded:
+
+| Request | Disk result | Visible result |
+| --- | --- | --- |
+| Cold prompt A | miss/store | coherent three-bullet answer; 1.41 s TTFT, 40.7 tok/s |
+| Same-chat A2 | hit 3,958 / 3,981; 23-token suffix | coherent `Anthocyanins.`; 0.82 s TTFT, 24.9 tok/s |
+| Different blank new chat | hit 3,795 with 3 remaining | sentinel-only warm-up completed in 0.29 s |
+| Different new-chat prompt B | hit 3,798 / 3,816; 18-token suffix | coherent `Au`; 0.58 s TTFT, 27.9 tok/s |
+| Quit/relaunch warm-up | disk hit 3,795 with 3 remaining | persisted restore, not paged/process-local reuse |
+| Same prompt with Disk L2 Off | `MISS all tiers` for 3,816 | coherent `Au`; 9.16 s TTFT, 29.4 tok/s |
+
+This proves the read/partial-restore path and the UI toggle are effective. It
+also exposed a separate storage defect: the short session created 18 complete
+KV safetensor entries totaling 8.7 GB. Adjacent entries differed by only 1–7
+tokens but each occupied roughly 406–418 MB. A one-token answer surfaced its
+first token in under a second, then kept the stream/Metal lease open for about
+16 seconds while three full hybrid snapshots were serialized. Its automatic
+post-turn warm-up spent about 12 seconds serializing two more snapshots.
+
+The disk tier is currently checkpoint/snapshot based; it is not
+block-deduplicated storage. Partial lookup is real, but it selects the longest
+content-addressed checkpoint and then prefills the suffix. The UI must not
+describe these files as independently deduplicated disk blocks.
+
+## Scoped hybrid storage candidate
+
+Source comments and tests already define the generation-suffix-stripped
+boundary as the only boundary the next path-dependent hybrid chat turn is
+guaranteed to contain. The candidate therefore changes only requests where a
+hybrid coordinator has that processor-proven boundary:
+
+- keep stable system/tool checkpoints;
+- publish the canonical stripped checkpoint;
+- do not also serialize the unusable exact-prompt, non-stable history, or
+  generated/post-answer full snapshots;
+- retain the existing full prompt/post-answer policy for dense, rotating-SWA,
+  media-unsafe, raw, and non-chat paths.
+
+`HybridStripBoundaryPrefillTests` now executes 7 tests with 0 failures after
+the package metallib is installed beside the test binary. The added test
+asserts one disk-store attempt and a real partial restore from that canonical
+boundary. This is source/test evidence only. A newly pinned Release Osaurus
+build still has to show the lower store count, lower end-of-stream/warm-up
+latency, partial disk hit, coherent answer, and correct settings through the
+live UI before the policy can be called verified.


### PR DESCRIPTION
## Scope

- preserve the existing exact system/tool boundary path
- when a template rejects a system/tools-only render, derive a stable boundary from two divergent user probes plus the actual prompt
- fail closed unless all three token streams prove the same non-user prefix
- for path-dependent hybrid chat with a processor-proven generation-suffix-stripped boundary, persist that canonical boundary and stable system/tool checkpoints without also serializing redundant exact-prompt, non-stable history, and post-answer full snapshots
- keep existing full prompt/post-answer behavior for dense, rotating-SWA, media-unsafe, raw, and non-chat paths

## Source and tests

- `Libraries/MLXLMCommon/Tokenizer.swift`: required-user stable-prefix derivation
- `Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift` and `Libraries/MLXLMCommon/Evaluate.swift`: canonical hybrid storage policy
- `CanonicalChatCacheBoundariesTests`: 6/6 passed
- `HybridStripBoundaryPrefillTests`: 7/7 passed, including a one-store assertion and real partial disk restore from the stripped boundary
- CI jobs on the current head are skipped, not counted as passing

## Live evidence and remaining gate

PARTIAL. An isolated Release Osaurus app pinned the prior PR head and was operated through the UI with the exact local Bonsai-27b-Ternary-JANG-CRACK bundle, Thinking Off, Prefix On, Paged RAM Off, Disk L2 On, TurboQuant not selected, and SSM re-derive On.

- the required-user template changed from `stable=[]` to `stable=[3798]`
- different-new-chat prompt: disk hit 3798/3816, coherent `Au`, 0.58 s visible TTFT
- quit/relaunch warm-up: disk hit 3795 with 3 remaining
- Disk L2 Off control: `MISS all tiers`, same coherent `Au`, 9.16 s visible TTFT
- the UI toggle was restored to Disk L2 On and showed Settings saved successfully

That run also isolated the storage problem addressed by the current head: 18 full safetensor checkpoints occupied 8.7 GB, and a one-token response held the stream open about 16 seconds while three roughly 406-407 MB near-duplicate snapshots were written. The updated storage policy is source-tested but has not yet been consumed by a rebuilt Release Osaurus app. Do not merge until that build visibly proves fewer stores, lower end-of-stream/warm-up latency, partial restore, and coherent output.
