### PR TITLE
Add Laguna S2.1 runtime and persistent cache reuse

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -132,15 +132,12 @@ public enum LLMTypeRegistry {
             "smollm3": create(SmolLM3Configuration.self, SmolLM3Model.init),
             "ernie4_5": create(Ernie45Configuration.self, Ernie45Model.init),
             "lfm2": create(LFM2Configuration.self, LFM2Model.init),
-            // Laguna (Poolside agentic-coding 33B/3B-active MoE). 40-layer
-            // hybrid SWA + full attention with per-layer head count
-            // (48 full / 64 SWA), dual RoPE, q_norm/k_norm, sigmoid +
-            // bias-corrected routing over 256 routed experts top-8 + 1
-            // shared. See `Models/Laguna.swift`. JANGTQ variant (paired
-            // JANGTQDenseLinear port) follows the Mistral 3 family
-            // pattern in a follow-up.
+            // Laguna is config-driven: S-2.1 uses 48 layers, alternating
+            // full/SWA attention, 48/72 query heads, dual RoPE, 256 routed
+            // experts with top-10 selection, and one shared expert. Older
+            // Laguna variants continue to decode their bundle-specific arrays.
             "laguna": { data in
-                // 2026-05-01: Real Laguna mxtq bundles are MIXED-QUANT.
+                // Legacy Laguna mxtq bundles are mixed-format.
                 //
                 //   - Dense paths (attention Q/K/V/O, layer-0 dense MLP
                 //     gate/up/down, shared expert, router gate) ship as
@@ -160,15 +157,14 @@ public enum LLMTypeRegistry {
                 //     and the model's `sanitize` splits the fused tensor
                 //     at load time.
                 //
-                // 2026-05-02 update: also support **mxfp4** Laguna bundles.
-                // Those ship the routed experts as MLX standard affine
-                // quant (`weight` + `scales` + `biases` per gate_up_proj /
-                // down_proj — gate_up still FUSED on the out-dim axis).
+                // Current JANG_2L/JANG_4M bundles ship routed experts as
+                // MLX standard per-module affine quant (`weight` + `scales`
+                // + `biases` on separate gate/up/down projections).
                 // Detect by `weight_format != "mxtq"` AND no `mxtq_bits`
                 // top-level key; route to the affine `SwitchGLU` MoE path
                 // (jangtq=nil) instead of the codebook
                 // `TurboQuantSwitchGLU` path. Sanitize splits the fused
-                // gate_up_proj for both formats.
+                // gate_up_proj only for legacy bundles that use it.
                 struct LagunaProbe: Codable {
                     let weightFormat: String?
                     let mxtqBits: Int?
@@ -198,7 +194,7 @@ public enum LLMTypeRegistry {
                         bits: probe?.mxtqBits ?? 2,
                         mxtqSeed: probe?.mxtqSeed ?? 42)
                 } else {
-                    // mxfp4 / affine bundle: nil context → SwitchGLU path.
+                    // Affine mixed-bit bundle: nil context → SwitchGLU path.
                     jangtqContext = nil
                 }
                 return LagunaModel(cfg, jangtq: jangtqContext)
@@ -1156,6 +1152,31 @@ public class LLMRegistry: AbstractModelRegistry, @unchecked Sendable {
 @available(*, deprecated, renamed: "LLMRegistry", message: "Please use LLMRegistry directly.")
 public typealias ModelRegistry = LLMRegistry
 
+internal func llmDefaultAdditionalContext(
+    modelType: String?,
+    capabilities: JangCapabilities?,
+    generationConfig: GenerationConfigFile?,
+    chatConfig: JangChatConfig?
+) -> [String: any Sendable]? {
+    var context: [String: any Sendable] = [:]
+
+    // Trust the bundle's capability stamp. A bundle that explicitly declares
+    // no thinking wins over stale template metadata. Otherwise use the
+    // model-authored default from generation_config.json, falling back to the
+    // mirrored JANG chat stamp. Request/UI context is merged later and wins.
+    if capabilities?.supportsThinking == false {
+        context["enable_thinking"] = false
+    } else if let enableThinking =
+        generationConfig?.defaultChatTemplateKwargs?.enableThinking
+            ?? chatConfig?.templateKwargsDefaults?.enableThinking
+    {
+        context["enable_thinking"] = enableThinking
+    }
+
+    _ = modelType  // intentionally unused: no family-name coercion
+    return context.isEmpty ? nil : context
+}
+
 private struct LLMUserInputProcessor: UserInputProcessor {
 
     let tokenizer: Tokenizer
@@ -1296,27 +1317,15 @@ private struct LLMUserInputProcessor: UserInputProcessor {
 
     static func defaultContext(
         modelType: String?,
-        capabilities: JangCapabilities?
+        capabilities: JangCapabilities?,
+        generationConfig: GenerationConfigFile?,
+        chatConfig: JangChatConfig?
     ) -> [String: any Sendable]? {
-        var context: [String: any Sendable] = [:]
-
-        // Trust the bundle's capability stamp. The runtime must NOT
-        // auto-rewrite or apply family-based default-template overrides
-        // by model_type prefix — that hides bundle-metadata bugs and
-        // contradicts a properly-stamped bundle's declaration. Fix bundle
-        // metadata at the source instead.
-        //
-        // The one universal rule that DOES belong here: a bundle that
-        // explicitly stamps `supports_thinking == false` (Ling/Bailing-style
-        // non-thinking models) gets `enable_thinking=false` seeded so a
-        // stale chat template can't produce noise. Per-request overrides
-        // are still respected.
-        if capabilities?.supportsThinking == false {
-            context["enable_thinking"] = false
-        }
-
-        _ = modelType  // intentionally unused — see above
-        return context.isEmpty ? nil : context
+        llmDefaultAdditionalContext(
+            modelType: modelType,
+            capabilities: capabilities,
+            generationConfig: generationConfig,
+            chatConfig: chatConfig)
     }
 }
 
@@ -1921,7 +1930,9 @@ public final class LLMModelFactory: ModelFactory {
             messageGenerator: messageGenerator,
             defaultAdditionalContext: LLMUserInputProcessor.defaultContext(
                 modelType: baseConfig.modelType,
-                capabilities: jangConfig?.capabilities))
+                capabilities: jangConfig?.capabilities,
+                generationConfig: generationConfig,
+                chatConfig: jangConfig?.chat))
 
         return .init(
             configuration: modelConfig, model: model, processor: processor,

--- a/Libraries/MLXLLM/Models/Laguna.swift
+++ b/Libraries/MLXLLM/Models/Laguna.swift
@@ -1,32 +1,28 @@
 //
-// Laguna — Poolside agentic-coding 33B/3B-active MoE.
+// Laguna — Poolside agentic-coding hybrid-attention MoE family.
 //
 // Architecture (from jang_tools/laguna/{config,model}.py @ jang-tools 2.5.x):
-//   - 40 hybrid layers: layer 0 dense MLP, layers 1..39 sparse MoE
-//   - Per-layer attention head count: 48 (full) or 64 (SWA), via
+//   - Bundle-configured hybrid layers: layer 0 dense MLP, remaining sparse MoE
+//   - Per-layer attention head count (S-2.1: 48 full / 72 SWA), via
 //     `num_attention_heads_per_layer`
 //   - 8 KV heads (constant across layers)
 //   - head_dim 128
 //   - Hybrid mask: `full_attention` layers use causal mask; `sliding_attention`
 //     layers use windowed causal mask (`sliding_window` = 512)
 //   - Dual RoPE per `rope_parameters[layer_type]`:
-//       full_attention    → YaRN base 500K factor 32 partial 0.5
+//       full_attention    → YaRN base 500K, bundle factor, partial 0.5
 //       sliding_attention → default base 10K partial 1.0
 //   - q_norm / k_norm: per-head RMSNorm applied AFTER projection,
 //     BEFORE rope/SDPA. Norm dim = head_dim (128).
-//   - `g_proj` per-head sigmoid gating: gates SDPA output
+//   - `g_proj` per-head softplus gating: gates SDPA output
 //     element-wise per attention head before o_proj
-//   - MoE topology: 256 routed experts top-8, expert dim 512, plus
-//     1 shared expert with separate intermediate size 512
+//   - Bundle-configured routed-expert top-k plus one shared expert
 //   - Sigmoid routing with `e_score_correction_bias` (DeepSeek-V3 recipe)
 //   - `moe_routed_scaling_factor`: 2.5
 //   - `tie_word_embeddings`: false (separate lm_head)
 //
-// MXFP4 bundles route through this class via vanilla `Linear` weight
-// loading. JANGTQ bundles need a paired `LagunaJANGTQ.swift` port that
-// swaps each `Linear` for `JANGTQDenseLinear` (same pattern as
-// Mistral3TextJANGTQ.swift). End-to-end weight-load + decode quality
-// verification gated on a real bundle on disk.
+// Affine mixed-bit JANG bundles route through this class via `SwitchGLU`.
+// Legacy JANGTQ bundles use the same math with `TurboQuantSwitchGLU`.
 //
 
 import Foundation
@@ -117,7 +113,7 @@ internal enum StringOrNumberOrDict: Codable {
 // MARK: - Configuration
 
 /// Attention-output gate mode. The bundle's `gating` field is a Bool on the
-/// poolside XS.2 line (legacy per-head) and a String on Laguna-M.1
+/// poolside Laguna line (legacy Bool per-head) and a String on Laguna-M.1/S2.1
 /// (`"per-element"`). `none` disables the gate.
 public enum LagunaGateMode: String, Codable, Sendable {
     case perElement = "per_element"
@@ -327,7 +323,7 @@ internal final class LagunaAttention: Module {
     @ModuleInfo(key: "g_proj") var gProj: Linear?
 
     // 2026-05-01: Use the dispatching `RoPELayer` so YaRN-scaled
-    // full-attention layers get their factor=32 / mscale stretch
+    // full-attention layers get their bundle-configured YaRN factor / mscale
     // applied. Plain `RoPE` for full_attention destroyed long-context
     // accuracy on prompts > 4096 tokens (Laguna's
     // original_max_position_embeddings) — same class of bug as the
@@ -471,7 +467,7 @@ internal final class LagunaDenseMLP: Module, UnaryLayer {
 //
 // 2026-05-01: rewritten to match real Laguna bundle layout.
 //
-// On-disk routed-expert tensors at `layers.<i>.mlp.experts.*`:
+// Legacy on-disk routed-expert tensors at `layers.<i>.mlp.experts.*`:
 //
 //   experts.gate_up_proj.tq_packed : (n_exp, 2 × moe_inter, packed_in_hidden)
 //   experts.gate_up_proj.tq_norms  : (n_exp, 2 × moe_inter)
@@ -501,17 +497,17 @@ internal final class LagunaDenseMLP: Module, UnaryLayer {
 // splits the fused `gate_up_proj` tensor at sanitize time into the
 // `gate_proj` / `up_proj` halves the primitive expects.
 //
-// 2026-05-02: also support **mxfp4** Laguna bundles. Those ship the
+// Current affine mixed-bit Laguna bundles ship the
 // routed experts as MLX standard affine quant (`weight` + `scales` +
 // `biases` per gate_up_proj/down_proj), NOT TurboQuant codebook. Add
 // a polymorphic `LagunaSwitchMLPLayer` protocol and dispatch the
 // experts module to either `TurboQuantSwitchGLU` (mxtq) or a
-// standard `SwitchGLU` (mxfp4) at construction time. Mirrors the
+// standard `SwitchGLU` (affine mixed-bit) at construction time. Mirrors the
 // `NemotronHJANGTQContext` pattern in NemotronH.
 
 /// Type-erased switch-MLP forward. Both `TurboQuantSwitchGLU` (codebook
 /// MoE used for JANGTQ Laguna bundles) and `SwitchGLU` (affine-quant MoE
-/// used for mxfp4 Laguna bundles) implement
+/// used for affine mixed-bit Laguna bundles) implement
 /// `callAsFunction(_ x: MLXArray, _ indices: MLXArray) -> MLXArray`.
 internal protocol LagunaSwitchMLPLayer: Module {
     func callAsFunction(_ x: MLXArray, _ indices: MLXArray) -> MLXArray
@@ -522,7 +518,7 @@ extension SwitchGLU: LagunaSwitchMLPLayer {}
 
 /// Bundle-format hint for Laguna's MoE. Non-nil → JANGTQ codebook path
 /// via `TurboQuantSwitchGLU` with the supplied `bits` / `seed`. Nil →
-/// affine mxfp4 path via standard `SwitchGLU` (per-Linear quant info
+/// affine mixed-bit path via standard `SwitchGLU` (per-Linear quant info
 /// auto-substituted by MLX from `config.json::quantization.{bits,
 /// group_size}` at load time).
 public struct LagunaMoEContext: Sendable {
@@ -540,10 +536,11 @@ internal final class LagunaMoE: Module, UnaryLayer {
 
     @ModuleInfo(key: "gate") var gate: Linear
     @ParameterInfo(key: "e_score_correction_bias") var eScoreCorrectionBias: MLXArray
-    /// `experts` is type-erased so JANGTQ bundles can hold a
-    /// `TurboQuantSwitchGLU` (codebook) and mxfp4 bundles can hold a
+    /// `switch_mlp` matches current Laguna S-2.1 weight and per-module
+    /// quantization paths. It is type-erased so legacy JANGTQ bundles can hold a
+    /// `TurboQuantSwitchGLU` (codebook) and affine bundles can hold a
     /// `SwitchGLU` (affine). Dispatched via `LagunaSwitchMLPLayer`.
-    @ModuleInfo(key: "experts") var experts: Module
+    @ModuleInfo(key: "switch_mlp") var switchMLP: Module
     @ModuleInfo(key: "shared_expert") var sharedExpert: LagunaDenseMLP
 
     init(_ cfg: LagunaConfiguration, layerIndex: Int, jangtq: LagunaMoEContext?) {
@@ -552,17 +549,17 @@ internal final class LagunaMoE: Module, UnaryLayer {
         self._gate.wrappedValue = Linear(cfg.hiddenSize, cfg.numExperts, bias: false)
         self._eScoreCorrectionBias.wrappedValue = MLXArray.zeros([cfg.numExperts])
         // Routed experts: codebook MoE via TurboQuantSwitchGLU when the
-        // bundle stamps mxtq; affine mxfp4 path via standard SwitchGLU
+        // bundle stamps mxtq; affine mixed-bit path via standard SwitchGLU
         // otherwise. inputDims == hiddenSize (gate/up in_dim == down
         // out_dim); hiddenDims == moeIntermediateSize.
         if let jangtq {
-            self._experts.wrappedValue = TurboQuantSwitchGLU(
+            self._switchMLP.wrappedValue = TurboQuantSwitchGLU(
                 inputDims: cfg.hiddenSize,
                 hiddenDims: cfg.moeIntermediateSize,
                 numExperts: cfg.numExperts,
                 bits: jangtq.bits, seed: jangtq.mxtqSeed)
         } else {
-            self._experts.wrappedValue = SwitchGLU(
+            self._switchMLP.wrappedValue = SwitchGLU(
                 inputDims: cfg.hiddenSize,
                 hiddenDims: cfg.moeIntermediateSize,
                 numExperts: cfg.numExperts)
@@ -604,15 +601,15 @@ internal final class LagunaMoE: Module, UnaryLayer {
         JangPressCanonicalExpertAdvisor.shared.observe(layer: layerIndex, indices: topkIdx)
         let topkW = routed[1]                                         // (B, T, K) — un-biased!
 
-        // SwitchGLU dispatch: returns (B, T, K, H). `experts` is
+        // SwitchGLU dispatch: returns (B, T, K, H). `switchMLP` is
         // type-erased — TurboQuantSwitchGLU (mxtq) and SwitchGLU
-        // (mxfp4) both implement the same `(x, indices)` shape
+        // (affine mixed-bit) both implement the same `(x, indices)` shape
         // contract via `LagunaSwitchMLPLayer`.
-        guard let switchLayer = experts as? LagunaSwitchMLPLayer else {
+        guard let switchLayer = switchMLP as? LagunaSwitchMLPLayer else {
             fatalError(
-                "LagunaMoE.experts must conform to LagunaSwitchMLPLayer "
-                + "(got \(type(of: experts))). Bundle weight_format may be "
-                + "unsupported — only mxtq (codebook) and mxfp4 (affine) "
+                "LagunaMoE.switch_mlp must conform to LagunaSwitchMLPLayer "
+                + "(got \(type(of: switchMLP))). Bundle weight format may be "
+                + "unsupported — only mxtq (codebook) and affine mixed-bit "
                 + "are wired today.")
         }
         if let streaming = switchLayer as? StreamingTurboQuantSwitchGLU {
@@ -684,12 +681,13 @@ public class LagunaModel: Module, LLMModel, KVCacheDimensionProvider {
 
     /// `jangtq != nil` selects the `TurboQuantSwitchGLU` codebook MoE
     /// path with the supplied `bits` / `mxtqSeed`. `jangtq == nil`
-    /// selects the affine `SwitchGLU` mxfp4 path. The factory
+    /// selects the affine `SwitchGLU` path. The factory
     /// (`LLMModelFactory.swift`) reads `weight_format` and `mxtq_bits`
     /// from `config.json` and threads the right context here. Default
-    /// is JANGTQ-2L (the canonical Laguna distribution) for backwards
-    /// compatibility with existing call sites.
-    public init(_ cfg: LagunaConfiguration, jangtq: LagunaMoEContext? = LagunaMoEContext(bits: 2, mxtqSeed: 42)) {
+    /// is affine because current JANG_2L/JANG_4M distributions use ordinary
+    /// per-module affine weights; legacy codebook bundles pass an explicit
+    /// context from the factory.
+    public init(_ cfg: LagunaConfiguration, jangtq: LagunaMoEContext? = nil) {
         self.cfg = cfg
         self.vocabularySize = cfg.vocabularySize
         self.kvHeads = (0..<cfg.numHiddenLayers).map { _ in cfg.numKeyValueHeads }
@@ -710,18 +708,10 @@ public class LagunaModel: Module, LLMModel, KVCacheDimensionProvider {
     public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
         var h = embedTokens(inputs)
         let cacheArr = cache ?? []
-
-        let fullMask = createAttentionMask(h: h, cache: cacheArr.isEmpty ? nil : cacheArr[faIdx])
-        let swaMask: MLXFast.ScaledDotProductAttentionMaskMode
-        if let swaIdx, !cacheArr.isEmpty {
-            swaMask = createAttentionMask(
-                h: h, cache: cacheArr[swaIdx], windowSize: cfg.slidingWindow)
-        } else {
-            swaMask = .none
-        }
+        let masks = attentionMasks(h: h, cache: cache)
 
         for (i, layer) in layers.enumerated() {
-            h = layer(h, fullMask: fullMask, swaMask: swaMask,
+            h = layer(h, fullMask: masks.full, swaMask: masks.sliding,
                 cache: cacheArr.isEmpty ? nil : cacheArr[i])
         }
 
@@ -734,52 +724,42 @@ public class LagunaModel: Module, LLMModel, KVCacheDimensionProvider {
         return out
     }
 
+    /// Build masks from a representative cache of each attention type. This
+    /// remains callable by focused tests so the no-cache `T > window` path is
+    /// guarded as strongly as cached prefill.
+    internal func attentionMasks(
+        h: MLXArray,
+        cache: [KVCache]?
+    ) -> (
+        full: MLXFast.ScaledDotProductAttentionMaskMode,
+        sliding: MLXFast.ScaledDotProductAttentionMaskMode
+    ) {
+        let cacheArr = cache ?? []
+        let fullMask = createAttentionMask(
+            h: h, cache: cacheArr.isEmpty ? nil : cacheArr[faIdx])
+        let slidingMask: MLXFast.ScaledDotProductAttentionMaskMode
+        if let swaIdx {
+            slidingMask = createAttentionMask(
+                h: h,
+                cache: cacheArr.isEmpty ? nil : cacheArr[swaIdx],
+                windowSize: cfg.slidingWindow)
+        } else {
+            slidingMask = .none
+        }
+        return (fullMask, slidingMask)
+    }
+
     public func newCache(parameters: GenerateParameters?) -> [KVCache] {
-        // 2026-05-01: pick full-attention cache class based on
-        // caller-supplied `kvMode` to avoid clobbering TurboQuant.
-        //
-        //   - When `kvMode == .turboQuant(...)` is set: keep
-        //     `KVCacheSimple()` for full layers. `BatchQuantize.maybeCompress`
-        //     in BatchEngine then promotes those Simple layers to
-        //     `TurboQuantKVCache` once offset > `quantizedKVStart`,
-        //     giving 4.7-5x memory savings. The cache family becomes
-        //     heterogeneous (TurboQuantKVCache + RotatingKVCache) and
-        //     compile is correctly skipped — the user picked memory
-        //     over compile speed.
-        //
-        //   - Otherwise (no kvMode, or `.none`): route full-attention
-        //     through `RotatingKVCache(maxSize: cfg.maxPositionEmbeddings,
-        //     keep: 4)`. All 40 layers are now `RotatingKVCache` →
-        //     `CacheFamily.classify` returns `.rotating` →
-        //     `BatchCompile` Stage 3 promotes to
-        //     `CompilableRotatingKVCache` and traces the forward.
-        //     Decode speedup +15-25 % vs the heterogeneous baseline
-        //     (verified against BENCH_BATCH_CHAT compile turns).
-        //     For chat workloads < trained context the rotation never
-        //     fires, so this is bit-identical to `KVCacheSimple` —
-        //     same memory semantics, just a different concrete class.
-        //
-        // This mirrors the Stage-3 / Stage-2 compile-eligibility split
-        // documented in `BatchEngine.swift:1140-1247`. Gemma4 still
-        // takes the heterogeneous path by default because its
-        // unbounded full-attention cache predates this knob; if/when
-        // Gemma4's full layers also adopt this gating it'll get the
-        // same speedup without losing TQ optionality.
-        let callerWantsTQ: Bool = {
-            guard let p = parameters else { return false }
-            if case .turboQuant = p.kvMode { return true }
-            return false
-        }()
-        let fullKVSize = parameters?.maxKVSize ?? cfg.maxPositionEmbeddings
+        // S-2.1 has no attention sinks. Full-attention layers grow normally;
+        // SWA layers retain exactly the latest window with keep=0. Keeping
+        // full layers as KVCacheSimple also preserves the opt-in TurboQuant
+        // promotion path without changing the default cache representation.
+        _ = parameters
         return cfg.layerTypes.map { layerType in
             if layerType == "sliding_attention" {
-                return RotatingKVCache(maxSize: cfg.slidingWindow)
+                return RotatingKVCache(maxSize: cfg.slidingWindow, keep: 0)
             }
-            if callerWantsTQ {
-                // Preserve `maybeQuantizeKVCache` promotion path.
-                return KVCacheSimple()
-            }
-            return RotatingKVCache(maxSize: fullKVSize, keep: 4)
+            return KVCacheSimple()
         }
     }
 
@@ -814,6 +794,13 @@ public class LagunaModel: Module, LLMModel, KVCacheDimensionProvider {
                 of: ".mlp.experts.e_score_correction_bias",
                 with: ".mlp.e_score_correction_bias"
             )
+            // Current S-2.1 affine bundles already use `switch_mlp`.
+            // Normalize legacy JANGTQ expert payloads to that same module
+            // path so both formats share one production model topology.
+            k = k.replacingOccurrences(
+                of: ".mlp.experts.",
+                with: ".mlp.switch_mlp."
+            )
             // Drop unused / config-only keys.
             if k.contains("self_attn.rotary_emb.inv_freq") { continue }
             if k.hasSuffix(".tq_bits") { continue }
@@ -822,7 +809,7 @@ public class LagunaModel: Module, LLMModel, KVCacheDimensionProvider {
         }
 
         // Second pass: split fused gate_up_proj for routed experts.
-        // Both JANGTQ (codebook: tq_packed/tq_norms) and mxfp4 (affine:
+        // Both JANGTQ (codebook: tq_packed/tq_norms) and affine mixed-bit
         // weight/scales/biases) bundles ship the routed expert gate+up
         // FUSED on the out-dim axis. SwitchGLU (affine) and
         // TurboQuantSwitchGLU (codebook) both expect the two halves at
@@ -833,35 +820,35 @@ public class LagunaModel: Module, LLMModel, KVCacheDimensionProvider {
         // Tensor shapes (verified on real bundles):
         //   JANGTQ tq_packed : (n_exp, 2 × mid, packed_in)  → split axis=1
         //   JANGTQ tq_norms  : (n_exp, 2 × mid)             → split axis=1
-        //   mxfp4 weight     : (n_exp, 2 × mid, packed_in)  → split axis=1
-        //   mxfp4 scales     : (n_exp, 2 × mid, in/gs)      → split axis=1
-        //   mxfp4 biases     : (n_exp, 2 × mid, in/gs)      → split axis=1
+        //   affine weight    : (n_exp, 2 × mid, packed_in)  → split axis=1
+        //   affine scales    : (n_exp, 2 × mid, in/gs)      → split axis=1
+        //   affine biases    : (n_exp, 2 × mid, in/gs)      → split axis=1
         let mid = cfg.moeIntermediateSize
         var out: [String: MLXArray] = [:]
         for (k, v) in firstPass {
-            // Match `layers.<i>.mlp.experts.gate_up_proj.<param>` exactly —
-            // the fused tensor lives only on the routed-expert MoE
-            // (`experts`), never on the shared expert (which has separate
+            // Match the normalized routed-expert `switch_mlp` path exactly.
+            // The fused tensor lives only on the routed-expert MoE,
+            // never on the shared expert (which has separate
             // gate_proj / up_proj keys per the affine-quant scheme).
-            if k.contains(".mlp.experts.gate_up_proj.tq_packed") {
+            if k.contains(".mlp.switch_mlp.gate_up_proj.tq_packed") {
                 let gateK = k.replacingOccurrences(
                     of: ".gate_up_proj.tq_packed", with: ".gate_proj.tq_packed")
                 let upK = k.replacingOccurrences(
                     of: ".gate_up_proj.tq_packed", with: ".up_proj.tq_packed")
                 out[gateK] = v[0..., ..<mid, 0...]
                 out[upK]   = v[0..., mid..., 0...]
-            } else if k.contains(".mlp.experts.gate_up_proj.tq_norms") {
+            } else if k.contains(".mlp.switch_mlp.gate_up_proj.tq_norms") {
                 let gateK = k.replacingOccurrences(
                     of: ".gate_up_proj.tq_norms", with: ".gate_proj.tq_norms")
                 let upK = k.replacingOccurrences(
                     of: ".gate_up_proj.tq_norms", with: ".up_proj.tq_norms")
                 out[gateK] = v[0..., ..<mid]
                 out[upK]   = v[0..., mid...]
-            } else if k.contains(".mlp.experts.gate_up_proj.weight")
-                || k.contains(".mlp.experts.gate_up_proj.scales")
-                || k.contains(".mlp.experts.gate_up_proj.biases")
+            } else if k.contains(".mlp.switch_mlp.gate_up_proj.weight")
+                || k.contains(".mlp.switch_mlp.gate_up_proj.scales")
+                || k.contains(".mlp.switch_mlp.gate_up_proj.biases")
             {
-                // mxfp4 affine path — split the same out-dim axis (axis=1
+                // Legacy fused affine path — split the same out-dim axis (axis=1
                 // of the (n_exp, 2×mid, …) tensor) into gate / up halves.
                 let suffix: String
                 if k.hasSuffix(".weight") { suffix = ".weight" }

--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -2900,7 +2900,15 @@ public actor BatchEngine {
                    requiresDiskBackedRestore,
                    !shouldSkipDiskBackedToolPromptSeedBoundary(for: slot),
                    promptTokens.count > 1,
-                   let snapshot = boundarySnapshot(tokens: Array(promptTokens.dropLast()))
+                   let snapshot = boundarySnapshot(
+                    tokens: Array(promptTokens.dropLast()),
+                    // Direct full-KV + rotating-SWA stacks are fully typed on
+                    // disk but stop being trimmable once the ring wraps. Their
+                    // exact N-1 seed is still safe to rebuild synchronously;
+                    // persisting it lets a fresh process re-feed only the final
+                    // prompt token instead of cold-prefilling the whole chat.
+                    forceRederive: cacheCanUsePagedWithRotatingCompanion(
+                        promptCacheSnapshot))
                 {
                     storeCacheEntry(
                         tokens: Array(promptTokens.dropLast()),

--- a/Libraries/MLXLMCommon/BatchEngine/CompilableTurboQuantKVCache.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/CompilableTurboQuantKVCache.swift
@@ -144,15 +144,19 @@ public final class CompilableTurboQuantKVCache: TurboQuantKVCache, @unchecked Se
         // is slightly wasteful (re-decodes the compressed prefix) but
         // happens exactly once per promotion and preserves correctness.
         if let ck = tq.compressedKeys, let cv = tq.compressedValues {
+            let window = tq.serializedWindowState
             self.restoreCompressed(
-                encodedKeys: ck, encodedValues: cv, sourceOffset: tq.offset)
+                encodedKeys: ck,
+                encodedValues: cv,
+                sourceOffset: tq.offset,
+                windowKeys: window?.keys,
+                windowValues: window?.values)
         }
 
-        // After restoreCompressed, `unifiedKeys` is re-allocated at the
-        // same shape as before. windowOffset is reset to 0. Our
-        // MLXArray counters track from this reset baseline.
-        self.writePosArray = MLXArray([Int32(0)])
-        self.offsetArray = MLXArray([Int32(self.prefixTokenCount)])
+        // Restore seats both the encoded prefix and any exact live window.
+        // The trace counters must begin at that same logical boundary.
+        self.writePosArray = MLXArray([Int32(self.windowOffset)])
+        self.offsetArray = MLXArray([Int32(self.offset)])
         // `offset` (super, Int) was set to `tq.offset` by restoreCompressed.
     }
 

--- a/Libraries/MLXLMCommon/Cache/BlockHashMap.swift
+++ b/Libraries/MLXLMCommon/Cache/BlockHashMap.swift
@@ -31,6 +31,44 @@ public final class BlockHashMap: @unchecked Sendable {
         map[hash]
     }
 
+    /// Find the longest stored partial leaf whose tokens are an exact prefix
+    /// of the query chunk and whose chained hash belongs to `parentHash`.
+    ///
+    /// A growing prompt changes the hash of its final, non-block-aligned chunk:
+    /// a stored 12-token leaf and a later 39-token query chunk have different
+    /// hashes even though the first 12 tokens (and their KV) are identical.
+    /// Full blocks continue to use the O(1) exact-hash path; this bounded scan
+    /// is reached only after that lookup misses at a partial leaf.
+    public func findLongestPartialPrefix(
+        parentHash: String?,
+        tokenIds: [Int],
+        modelKey: String?,
+        mediaSalt: String?
+    ) -> CacheBlock? {
+        var best: CacheBlock?
+        for block in map.values {
+            let stored = block.tokenIds
+            guard !stored.isEmpty,
+                  stored.count < block.blockSize,
+                  stored.count < tokenIds.count,
+                  tokenIds.prefix(stored.count).elementsEqual(stored),
+                  block.blockHash == CacheBlock.computeBlockHash(
+                      parentHash: parentHash,
+                      tokenIds: stored,
+                      modelKey: modelKey,
+                      mediaSalt: mediaSalt)
+            else { continue }
+
+            if best == nil
+                || stored.count > best!.tokenCount
+                || (stored.count == best!.tokenCount && block.blockId < best!.blockId)
+            {
+                best = block
+            }
+        }
+        return best
+    }
+
     /// Remove the entry for a block (keyed by its ``CacheBlock/blockHash``).
     /// No-op if the block's hash is `nil` or not present.
     public func remove(_ block: CacheBlock) {

--- a/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
@@ -702,6 +702,8 @@ public final class CacheCoordinator: @unchecked Sendable {
     ) {
         let totalTokens = promptTokens.count
         let blockSize = config.pagedBlockSize
+        let traceCacheStore =
+            ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1"
 
         // Older generation call sites intentionally supplied an empty paged
         // payload for every cache that also needed typed disk persistence.
@@ -738,6 +740,21 @@ public final class CacheCoordinator: @unchecked Sendable {
         }
         let hasRequiredPagedCompanion = !requiresPagedBoundaryCompanion
             || pagedBoundaryCompanion != nil
+
+        if traceCacheStore {
+            let rotatingOffsets = cache?.compactMap {
+                ($0 as? RotatingKVCache)?.offset
+            } ?? []
+            let uniqueRotatingOffsets = Array(Set(rotatingOffsets)).sorted()
+            let effectiveKVLayerCount = effectivePerLayerData.compactMap { $0 }.count
+            let message = "[vmlx][cache/paged-store] tokens=\(totalTokens) "
+                + "requiredCompanion=\(requiresPagedBoundaryCompanion) "
+                + "effectiveKVLayers=\(effectiveKVLayerCount) "
+                + "blocks=\(blockLayerData.count) payload=\(hasPagedKVPayload) "
+                + "companion=\(pagedBoundaryCompanion != nil) "
+                + "rotatingOffsets=\(uniqueRotatingOffsets)\n"
+            FileHandle.standardError.write(Data(message.utf8))
+        }
 
         // Store in paged cache (skip when the model is paged-incompatible —
         // see `isPagedIncompatible` above). Recurrent-only/state-only caches

--- a/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
@@ -1052,7 +1052,9 @@ private func restoreTQLayer(
         tq.restoreCompressed(
             encodedKeys: comp.encodedKeys,
             encodedValues: comp.encodedValues,
-            sourceOffset: comp.offset
+            sourceOffset: comp.offset,
+            windowKeys: comp.windowKeys,
+            windowValues: comp.windowValues
         )
         return tq.offset > 0
     }
@@ -1061,7 +1063,9 @@ private func restoreTQLayer(
         tq.restoreCompressed(
             encodedKeys: comp.encodedKeys,
             encodedValues: comp.encodedValues,
-            sourceOffset: comp.offset
+            sourceOffset: comp.offset,
+            windowKeys: comp.windowKeys,
+            windowValues: comp.windowValues
         )
         guard tq.offset > 0 else { return false }
         layer = tq
@@ -1073,7 +1077,9 @@ private func restoreTQLayer(
                 tq.restoreCompressed(
                     encodedKeys: comp.encodedKeys,
                     encodedValues: comp.encodedValues,
-                    sourceOffset: comp.offset
+                    sourceOffset: comp.offset,
+                    windowKeys: comp.windowKeys,
+                    windowValues: comp.windowValues
                 )
                 return tq.offset > 0
             }
@@ -1082,7 +1088,9 @@ private func restoreTQLayer(
                 tq.restoreCompressed(
                     encodedKeys: comp.encodedKeys,
                     encodedValues: comp.encodedValues,
-                    sourceOffset: comp.offset
+                    sourceOffset: comp.offset,
+                    windowKeys: comp.windowKeys,
+                    windowValues: comp.windowValues
                 )
                 guard tq.offset > 0 else { return false }
                 cacheList.caches[i] = tq
@@ -1247,7 +1255,9 @@ private func restoreZayaCCATQLayer(
           zaya.restoreTurboQuantAttentionKV(
               encodedKeys: comp.tq.encodedKeys,
               encodedValues: comp.tq.encodedValues,
-              sourceOffset: comp.tq.offset)
+              sourceOffset: comp.tq.offset,
+              windowKeys: comp.tq.windowKeys,
+              windowValues: comp.tq.windowValues)
     else { return false }
     zaya.writeCCA(conv: comp.convState, prev: comp.prevHS)
     return zaya.offset == comp.tq.offset && zaya.usesTurboQuantKV

--- a/Libraries/MLXLMCommon/Cache/PagedCacheManager.swift
+++ b/Libraries/MLXLMCommon/Cache/PagedCacheManager.swift
@@ -331,8 +331,15 @@ public final class PagedCacheManager: @unchecked Sendable {
             let hash = CacheBlock.computeBlockHash(
                 parentHash: parentHash, tokenIds: chunk,
                 modelKey: modelKey, mediaSalt: mediaSalt)
+            let exact = hashMap.find(hash: hash)
+            let block = exact ?? hashMap.findLongestPartialPrefix(
+                parentHash: parentHash,
+                tokenIds: chunk,
+                modelKey: modelKey,
+                mediaSalt: mediaSalt)
 
-            if let block = _findCachedBlock(hash: hash) {
+            if let block {
+                stats.cacheHits += 1
                 // Pin the cached-free block while the caller restores KV.
                 // If it remains in the free queue, a concurrent allocator
                 // could pop and reset it while restore reads `cacheData`.
@@ -343,9 +350,15 @@ public final class PagedCacheManager: @unchecked Sendable {
                 }
                 block.incrementRef()
                 matchedBlocks.append(block)
-                parentHash = hash
-                offset = end
+                parentHash = block.blockHash
+                offset += block.tokenCount
+                // A stored partial leaf is a complete cache boundary. It can
+                // seed the remaining prompt, but no later fixed-size block can
+                // be chained after it because block partitioning restarts from
+                // token zero for every stored sequence.
+                if exact == nil { break }
             } else {
+                stats.cacheMisses += 1
                 break
             }
         }

--- a/Libraries/MLXLMCommon/Cache/TQDiskSerializer.swift
+++ b/Libraries/MLXLMCommon/Cache/TQDiskSerializer.swift
@@ -35,6 +35,8 @@ import MLX
 ///       tq_{i}_ck_vec_norms     — EncodedKeys.vectorNorms (float16)
 ///       tq_{i}_ck_sink          — EncodedKeys.sinkData (float16, optional)
 ///       tq_{i}_ck_tail          — EncodedKeys.tailData (float16, optional)
+///       tq_{i}_window_keys      — exact tokens appended after compression (optional)
+///       tq_{i}_window_values    — exact tokens appended after compression (optional)
 ///       __tq_{i}_ck_shape__     — original compressed key shape (int32 array)
 ///       __tq_{i}_ck_index_bits__— key index bits (int32 scalar)
 ///       __tq_{i}_ck_seed__      — key encoding seed (int32 scalar)
@@ -218,7 +220,11 @@ public enum TQDiskSerializer {
         result[legacyMarkerKey] = MLXArray([Int32(1)])
 
         for (i, layer) in cache.enumerated() {
-            if let tq = layer as? TurboQuantKVCache, tq.phase == .compressed {
+            if let tq = layer as? TurboQuantKVCache,
+               tq.phase == .compressed,
+               tq.compressedKeys != nil,
+               tq.compressedValues != nil
+            {
                 serializeTQLayer(tq, index: i, into: &result)
                 result[kindKey(for: i)] = kindArray(.tq)
             } else if let mamba = layer as? MambaCache {
@@ -253,7 +259,11 @@ public enum TQDiskSerializer {
                 // empty caches as `.skip` instead of `.qkv`.
             } else if layer is KVCacheSimple || layer is TurboQuantKVCache {
                 // KVCacheSimple always, plus TurboQuantKVCache in fill phase.
-                // Both expose `state` as a 2-array [keys, values] pair.
+                // A compressed TQ layer restored from paged decoded KV also
+                // lands here because it has no native encoded payload. Store
+                // that decoded state as exact standard KV rather than writing
+                // a false TQ record or repeatedly re-quantizing it.
+                // All variants expose `state` as [keys, values].
                 let state = layer.state
                 if state.count >= 2 {
                     result["kv_\(i)_keys"] = state[0]
@@ -375,6 +385,20 @@ public enum TQDiskSerializer {
         // this the restored cache would report offset 0 and the next
         // generate() call would clobber the prefix on its first append.
         result["__tq_\(i)_offset__"] = metaInt32(Int32(tq.offset))
+
+        let compressedShape = tq.compressedKeys?.shape ?? []
+        let compressedMiddleCount = compressedShape.count >= 3 ? compressedShape[2] : 0
+        let compressedCount = compressedMiddleCount
+            + (tq.compressedKeys?.sinkCount ?? 0)
+            + (tq.compressedKeys?.tailCount ?? 0)
+        let liveWindowCount = tq.offset - compressedCount
+        if liveWindowCount > 0, let window = tq.serializedWindowState {
+            guard window.keys.dim(2) == liveWindowCount,
+                  window.values.dim(2) == liveWindowCount
+            else { return }
+            result["tq_\(i)_window_keys"] = window.keys
+            result["tq_\(i)_window_values"] = window.values
+        }
     }
 
     /// Serialize a single MambaCache layer's state (conv state + ssm state).
@@ -703,6 +727,9 @@ public enum TQDiskSerializer {
     public struct TQLayerComponents {
         public let encodedKeys: EncodedKeys
         public let encodedValues: EncodedValues
+        /// Exact full-precision tokens appended after the encoded snapshot.
+        public let windowKeys: MLXArray?
+        public let windowValues: MLXArray?
         /// Token offset the compressed prefix represents. Falls back to 0
         /// for legacy entries that pre-date the offset metadata key.
         public let offset: Int
@@ -898,7 +925,10 @@ public enum TQDiskSerializer {
                 if let components = deserializeTQLayer(index: i, from: arrays) {
                     out.append(IndexedLayerData(index: i, data: .tq(components)))
                 } else {
-                    out.append(IndexedLayerData(index: i, data: .skip))
+                    // A typed TQ layer is required state. Treat an incomplete
+                    // payload as an atomic miss so a rotating companion cannot
+                    // turn it into a false mixed-topology hit.
+                    out.append(IndexedLayerData(index: i, data: .requiredMiss))
                 }
             case .kv:
                 if let keys = arrays["kv_\(i)_keys"],
@@ -1092,9 +1122,32 @@ public enum TQDiskSerializer {
             offset = ckShape.count >= 3 ? ckShape[2] : 0
         }
 
+        let encodedKeyCount = ckShape.count >= 3
+            ? ckShape[2] + encodedKeys.sinkCount + encodedKeys.tailCount : 0
+        let encodedValueCount = cvShape.count >= 3
+            ? cvShape[2] + encodedValues.sinkCount + encodedValues.tailCount : 0
+        guard encodedKeyCount > 0,
+              encodedKeyCount == encodedValueCount,
+              offset >= encodedKeyCount
+        else { return nil }
+        let windowCount = offset - encodedKeyCount
+        let windowKeys = arrays["tq_\(i)_window_keys"]
+        let windowValues = arrays["tq_\(i)_window_values"]
+        if windowCount == 0 {
+            guard windowKeys == nil, windowValues == nil else { return nil }
+        } else {
+            guard let windowKeys, let windowValues,
+                  windowKeys.ndim == 4, windowValues.ndim == 4,
+                  windowKeys.dim(2) == windowCount,
+                  windowValues.dim(2) == windowCount
+            else { return nil }
+        }
+
         return TQLayerComponents(
             encodedKeys: encodedKeys,
             encodedValues: encodedValues,
+            windowKeys: windowKeys,
+            windowValues: windowValues,
             offset: offset
         )
     }

--- a/Libraries/MLXLMCommon/Cache/ZayaCCACache.swift
+++ b/Libraries/MLXLMCommon/Cache/ZayaCCACache.swift
@@ -111,7 +111,9 @@ public final class ZayaCCACache: KVCache {
     public func restoreTurboQuantAttentionKV(
         encodedKeys: EncodedKeys,
         encodedValues: EncodedValues,
-        sourceOffset: Int
+        sourceOffset: Int,
+        windowKeys: MLXArray? = nil,
+        windowValues: MLXArray? = nil
     ) -> Bool {
         let keyBits = encodedKeys.indexBits + 1
         let valueBits = encodedValues.indexBits
@@ -128,7 +130,9 @@ public final class ZayaCCACache: KVCache {
         restored.restoreCompressed(
             encodedKeys: encodedKeys,
             encodedValues: encodedValues,
-            sourceOffset: sourceOffset)
+            sourceOffset: sourceOffset,
+            windowKeys: windowKeys,
+            windowValues: windowValues)
         guard restored.phase == .compressed, restored.offset == sourceOffset else {
             return false
         }

--- a/Libraries/MLXLMCommon/ChatTemplates/ChatTemplateFallbacks.swift
+++ b/Libraries/MLXLMCommon/ChatTemplates/ChatTemplateFallbacks.swift
@@ -671,41 +671,34 @@ value_1
 {{- "〈|EOS|〉" -}}
 {%- set enable_thinking = enable_thinking | default(false) -%}
 {%- set add_generation_prompt = add_generation_prompt | default(false) -%}
-{%- set system_message = "" -%}
+{%- set system_message = "You are a helpful, conversationally-fluent assistant made by Poolside. You are here to be helpful to users through natural language conversations." -%}
 {%- if messages and messages[0].role == "system" -%}
   {%- set system_message = messages[0].content -%}
 {%- endif -%}
-{%- if (system_message and system_message.strip()) or tools -%}
-  {{- "<system>\n" -}}
+{%- set has_sys = system_message and system_message.strip() -%}
+{%- if has_sys or tools or enable_thinking -%}
+  {{- "<system>" -}}
   {%- if system_message and system_message.strip() -%}
-    {{- "\n" -}}{{- system_message.rstrip() -}}
+    {{- system_message.rstrip() -}}
+    {%- if tools -%}{{- "\n\n" -}}{%- endif -%}
   {%- endif -%}
   {%- if tools -%}
-    {{- "\n\n### Tools\n\n" -}}
+    {{- "### Tools\n\n" -}}
     {{- "You may call functions to assist with the user query.\n" -}}
     {{- "All available function signatures are listed below:\n" -}}
     {{- "<available_tools>\n" -}}
     {%- for tool in tools -%}
       {{- tool | tojson -}}{{- "\n" -}}
     {%- endfor -%}
-    {{- "</available_tools>\n" -}}
-    {{- "\nFor each function call, reply only with an XML object in this format:\n" -}}
-    {{- "<tool_call>function-name\n<arg_key>argument-key</arg_key>\n<arg_value>value-of-argument-key</arg_value>\n</tool_call>\n" -}}
-    {%- if tool_choice is defined and tool_choice == "required" -%}
-      {{- "\nThe current assistant response MUST be a function call. Do not answer in prose before the tool result." -}}
-      {%- if tool_choice_name is defined and tool_choice_name -%}
-        {{- " Use the `" ~ tool_choice_name ~ "` function." -}}
-      {%- endif -%}
-      {{- " Include every required argument exactly as requested by the current user turn.\n" -}}
-    {%- endif -%}
+    {{- "</available_tools>" -}}
   {%- endif -%}
-  {{- "\n</system>\n" -}}
+  {{- "</system>\n" -}}
 {%- endif -%}
 {%- for message in messages -%}
   {%- if message.role == "system" -%}
     {#- handled above -#}
   {%- elif message.role == "user" -%}
-    {{- "<user>\n" -}}
+    {{- "<user>" -}}
     {%- if message.content is string -%}
       {{- message.content -}}
     {%- else -%}
@@ -713,9 +706,9 @@ value_1
         {%- if item.type == "text" -%}{{- item.text -}}{%- endif -%}
       {%- endfor -%}
     {%- endif -%}
-    {{- "\n</user>\n" -}}
+    {{- "</user>\n" -}}
   {%- elif message.role == "assistant" -%}
-    {{- "<assistant>\n" -}}
+    {{- "<assistant>" -}}
     {%- set content = message.content if message.content is string else "" -%}
     {%- set reasoning_content = "" -%}
     {%- if message['reasoning'] is string -%}
@@ -729,35 +722,46 @@ value_1
       {%- endif -%}
       {%- set content = content.split('</think>')[-1].lstrip('\n') -%}
     {%- endif -%}
-    {%- if reasoning_content -%}
-      {{- "<think>\n" -}}{{- reasoning_content.strip() -}}{{- "\n</think>\n" -}}
+    {%- if enable_thinking -%}
+      {{- "<think>" -}}{{- reasoning_content -}}{{- "</think>" -}}
     {%- else -%}
-      {{- "</think>\n" -}}
+      {{- "</think>" -}}
     {%- endif -%}
-    {%- if content.strip() -%}
-      {{- content.strip() -}}
+    {%- if content -%}
+      {{- content -}}
     {%- else -%}
       {%- for item in message.content -%}
         {%- if item.type == "text" -%}{{- item.text -}}{%- endif -%}
       {%- endfor -%}
     {%- endif -%}
-    {{- "\n</assistant>\n" -}}
+    {%- if message.tool_calls -%}
+      {%- for tool_call in message.tool_calls -%}
+        {%- set function_data = tool_call.function -%}
+        {{- "<tool_call>" ~ function_data.name -}}
+        {%- for k, v in function_data.arguments.items() -%}
+          {{- "<arg_key>" ~ k ~ "</arg_key>" -}}
+          {{- "<arg_value>" -}}{{- v | tojson if v is not string else v -}}{{- "</arg_value>" -}}
+        {%- endfor -%}
+        {{- "</tool_call>" -}}
+      {%- endfor -%}
+    {%- endif -%}
+    {{- "</assistant>\n" -}}
   {%- elif message.role == "tool" -%}
-    {{- "<tool_response>\n" -}}
+    {{- "<tool_response>" -}}
     {%- if message.content is string -%}
       {{- message.content -}}
     {%- else -%}
       {{- message.content | tojson -}}
     {%- endif -%}
-    {{- "\n</tool_response>\n" -}}
+    {{- "</tool_response>\n" -}}
   {%- endif -%}
 {%- endfor -%}
 {%- if add_generation_prompt -%}
-  {{- "<assistant>\n" -}}
+  {{- "<assistant>" -}}
   {%- if enable_thinking -%}
-    {{- "<think>\n" -}}
+    {{- "<think>" -}}
   {%- else -%}
-    {{- "</think>\n" -}}
+    {{- "</think>" -}}
   {%- endif -%}
 {%- endif -%}
 """#

--- a/Libraries/MLXLMCommon/GenerationConfigFile.swift
+++ b/Libraries/MLXLMCommon/GenerationConfigFile.swift
@@ -2,6 +2,22 @@
 
 import Foundation
 
+/// Declarative defaults passed to a tokenizer chat template when a request
+/// does not provide an explicit value. Hugging Face bundles currently use
+/// this object primarily for `enable_thinking`; keeping it typed prevents an
+/// engine from silently dropping a model-authored reasoning default.
+public struct ChatTemplateKwargsDefaults: Codable, Equatable, Sendable {
+    public var enableThinking: Bool?
+
+    public init(enableThinking: Bool? = nil) {
+        self.enableThinking = enableThinking
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case enableThinking = "enable_thinking"
+    }
+}
+
 /// JSON wrapper for `generation_config.json` file.
 ///
 /// This file can override values from `config.json`, particularly `eos_token_id`.
@@ -17,6 +33,7 @@ public struct GenerationConfigFile: Codable, Equatable, Sendable {
     public var repetitionPenalty: Float?
     public var doSample: Bool?
     public var suppressTokens: [Int]?
+    public var defaultChatTemplateKwargs: ChatTemplateKwargsDefaults?
 
     // Block-diffusion fields (DiffusionGemma). HF serializes the sampler
     // config as a nested object with a `_cls_name` discriminator; only the
@@ -51,6 +68,7 @@ public struct GenerationConfigFile: Codable, Equatable, Sendable {
         repetitionPenalty: Float? = nil,
         doSample: Bool? = nil,
         suppressTokens: [Int]? = nil,
+        defaultChatTemplateKwargs: ChatTemplateKwargsDefaults? = nil,
         maxDenoisingSteps: Int? = nil,
         tMin: Float? = nil,
         tMax: Float? = nil,
@@ -68,6 +86,7 @@ public struct GenerationConfigFile: Codable, Equatable, Sendable {
         self.repetitionPenalty = repetitionPenalty
         self.doSample = doSample
         self.suppressTokens = suppressTokens
+        self.defaultChatTemplateKwargs = defaultChatTemplateKwargs
         self.maxDenoisingSteps = maxDenoisingSteps
         self.tMin = tMin
         self.tMax = tMax
@@ -87,6 +106,7 @@ public struct GenerationConfigFile: Codable, Equatable, Sendable {
         case repetitionPenalty = "repetition_penalty"
         case doSample = "do_sample"
         case suppressTokens = "suppress_tokens"
+        case defaultChatTemplateKwargs = "default_chat_template_kwargs"
         case maxDenoisingSteps = "max_denoising_steps"
         case tMin = "t_min"
         case tMax = "t_max"

--- a/Libraries/MLXLMCommon/JangLoader.swift
+++ b/Libraries/MLXLMCommon/JangLoader.swift
@@ -740,6 +740,7 @@ public struct JangChatConfig: Sendable, Equatable {
     public let reasoning: JangChatReasoning?
     public let toolCalling: JangChatToolCalling?
     public let samplingDefaults: JangChatSamplingDefaults?
+    public let templateKwargsDefaults: ChatTemplateKwargsDefaults?
 
     public init(
         encoder: String? = nil,
@@ -751,7 +752,8 @@ public struct JangChatConfig: Sendable, Equatable {
         roleTokens: [String: String]? = nil,
         reasoning: JangChatReasoning? = nil,
         toolCalling: JangChatToolCalling? = nil,
-        samplingDefaults: JangChatSamplingDefaults? = nil
+        samplingDefaults: JangChatSamplingDefaults? = nil,
+        templateKwargsDefaults: ChatTemplateKwargsDefaults? = nil
     ) {
         self.encoder = encoder
         self.hasTokenizerChatTemplate = hasTokenizerChatTemplate
@@ -763,6 +765,7 @@ public struct JangChatConfig: Sendable, Equatable {
         self.reasoning = reasoning
         self.toolCalling = toolCalling
         self.samplingDefaults = samplingDefaults
+        self.templateKwargsDefaults = templateKwargsDefaults
     }
 }
 
@@ -1782,6 +1785,14 @@ public struct JangLoader: Sendable {
                 )
             } else { sampling = nil }
 
+            let templateKwargsDefaults: ChatTemplateKwargsDefaults?
+            if let defaults = chDict["template_kwargs_defaults"] as? [String: Any] {
+                templateKwargsDefaults = ChatTemplateKwargsDefaults(
+                    enableThinking: defaults["enable_thinking"] as? Bool)
+            } else {
+                templateKwargsDefaults = nil
+            }
+
             chat = JangChatConfig(
                 encoder: chDict["encoder"] as? String,
                 hasTokenizerChatTemplate:
@@ -1793,7 +1804,8 @@ public struct JangLoader: Sendable {
                 roleTokens: chDict["role_tokens"] as? [String: String],
                 reasoning: reasoning,
                 toolCalling: toolCalling,
-                samplingDefaults: sampling
+                samplingDefaults: sampling,
+                templateKwargsDefaults: templateKwargsDefaults
             )
         } else {
             chat = nil

--- a/Libraries/MLXLMCommon/TurboQuant/TurboQuantKVCache.swift
+++ b/Libraries/MLXLMCommon/TurboQuant/TurboQuantKVCache.swift
@@ -170,7 +170,9 @@ public class TurboQuantKVCache: BaseKVCache, @unchecked Sendable {
     public func restoreCompressed(
         encodedKeys: EncodedKeys,
         encodedValues: EncodedValues,
-        sourceOffset: Int
+        sourceOffset: Int,
+        windowKeys: MLXArray? = nil,
+        windowValues: MLXArray? = nil
     ) {
         let keyDim = encodedKeys.shape.last ?? 0
         let valueDim = encodedValues.shape.last ?? 0
@@ -208,10 +210,56 @@ public class TurboQuantKVCache: BaseKVCache, @unchecked Sendable {
         self.windowOffset = 0
 
         self.phase = .compressed
-        self.offset = sourceOffset
+        self.offset = self.prefixTokenCount
 
         self.floatKeys = nil
         self.floatValues = nil
+
+        // The encoded payload is an immutable compression snapshot. Tokens
+        // generated after that transition live in the full-precision window.
+        // Disk restore must carry both pieces: assigning the later logical
+        // offset while discarding the window makes attention see fewer KV
+        // entries than its causal mask advertises.
+        let expectedWindowCount = sourceOffset - self.prefixTokenCount
+        guard expectedWindowCount >= 0 else {
+            resetToEmpty()
+            return
+        }
+        if expectedWindowCount == 0 {
+            guard windowKeys == nil, windowValues == nil else {
+                resetToEmpty()
+                return
+            }
+            return
+        }
+        guard let windowKeys, let windowValues,
+              windowKeys.ndim == 4, windowValues.ndim == 4,
+              windowKeys.dim(2) == expectedWindowCount,
+              windowValues.dim(2) == expectedWindowCount
+        else {
+            resetToEmpty()
+            return
+        }
+        _ = appendDecodeTokens(keys: windowKeys, values: windowValues)
+    }
+
+    /// Exact full-precision tokens appended after the immutable compressed
+    /// payload was created. The disk serializer stores this beside the encoded
+    /// prefix rather than re-encoding an already lossy decoded prefix.
+    internal var serializedWindowState: (keys: MLXArray, values: MLXArray)? {
+        guard phase == .compressed,
+              windowOffset > 0,
+              let unifiedKeys, let unifiedValues
+        else { return nil }
+        let end = prefixTokenCount + windowOffset
+        guard end == offset,
+              unifiedKeys.dim(2) >= end,
+              unifiedValues.dim(2) >= end
+        else { return nil }
+        return (
+            unifiedKeys[.ellipsis, prefixTokenCount..<end, 0...],
+            unifiedValues[.ellipsis, prefixTokenCount..<end, 0...]
+        )
     }
 
     /// Restore from already-decoded float keys/values (paged-cache fast path).

--- a/RunBench/Bench.swift
+++ b/RunBench/Bench.swift
@@ -301,6 +301,10 @@ struct Bench {
             try await runDSV4AgenticToolCheck(modelPath: modelPath, maxNew: maxNew)
             return
         }
+        if (env["BENCH_AGENTIC_TOOL"] ?? "0") == "1" {
+            try await runDSV4AgenticToolCheck(modelPath: modelPath, maxNew: maxNew)
+            return
+        }
 
         // BENCH_REASONING_TURN_MATRIX=1: generic BatchEngine multi-turn
         // reasoning gate. It keeps one loaded model, appends assistant
@@ -2700,15 +2704,20 @@ func runGrowingChatCacheReuse(modelPath: String, maxNew: Int) async throws {
     print("Reasoning stamp: \(context.configuration.reasoningParserName ?? "nil")")
     print("Native MTP depth: \(nativeMTPDepth.map(String.init) ?? "off")")
 
+    let usePagedCache = env["BENCH_GROWING_CACHE_PAGED"] != "0"
+    let enableDiskCache = env["BENCH_GROWING_CACHE_DISK"] != "0"
     let coordinator = CacheCoordinator(config: CacheCoordinatorConfig(
-        usePagedCache: true,
-        enableDiskCache: true,
+        usePagedCache: usePagedCache,
+        enableDiskCache: enableDiskCache,
         pagedBlockSize: 64,
         maxCacheBlocks: 512,
         diskCacheMaxGB: 4.0,
         diskCacheDir: cacheDir,
         ssmMaxEntries: 64,
         modelKey: modelName))
+    print(
+        "Cache policy: paged=\(usePagedCache) disk=\(enableDiskCache) "
+            + "blockSize=64 maxBlocks=512")
 
     let budget = max(maxNew, 48)
     var params: GenerateParameters
@@ -2730,9 +2739,25 @@ func runGrowingChatCacheReuse(modelPath: String, maxNew: Int) async throws {
     if let nativeMTPDepth {
         params.draftStrategy = .nativeMTP(depth: nativeMTPDepth)
     }
+    let growingKVMode: String
+    switch (env["BENCH_GROWING_KV_MODE"] ?? "none").lowercased() {
+    case "tq", "tq44", "turboquant":
+        params.kvMode = .turboQuant(keyBits: 4, valueBits: 4)
+        params.quantizedKVStart =
+            Int(env["BENCH_GROWING_TQ_START"] ?? "8") ?? 8
+        growingKVMode = "turboquant-4/4"
+    case "tq33":
+        params.kvMode = .turboQuant(keyBits: 3, valueBits: 3)
+        params.quantizedKVStart =
+            Int(env["BENCH_GROWING_TQ_START"] ?? "8") ?? 8
+        growingKVMode = "turboquant-3/3"
+    default:
+        growingKVMode = "none"
+    }
     print(String(format:
-        "Sampling: mode=%@ maxTokens=%d temp=%.3f topP=%.3f topK=%d minP=%.3f rep=%@",
+        "Sampling: mode=%@ kvMode=%@ maxTokens=%d temp=%.3f topP=%.3f topK=%d minP=%.3f rep=%@",
         env["BENCH_GROWING_BUNDLE_DEFAULTS"] == "1" ? "bundle-defaults" : "explicit-greedy",
+        growingKVMode,
         params.maxTokens ?? -1,
         Double(params.temperature),
         Double(params.topP),
@@ -2784,7 +2809,8 @@ func runGrowingChatCacheReuse(modelPath: String, maxNew: Int) async throws {
     let turn1 = LMInput(
         text: LMInput.Text(tokens: promptArray),
         cacheScopeSalt: cacheScopeSalt(from: ["enable_thinking": false]),
-        cachePrefixTokenCounts: cachePrefixTokenCounts)
+        cachePrefixTokenCounts: cachePrefixTokenCounts,
+        cacheStablePrefixTokenCounts: cachePrefixTokenCounts)
     print("  Cache history-boundary counts: \(cachePrefixTokenCounts)")
 
     func run(label: String, input: sending LMInput) async throws
@@ -2792,6 +2818,7 @@ func runGrowingChatCacheReuse(modelPath: String, maxNew: Int) async throws {
     {
         let promptSize = input.text.tokens.size
         let t0 = CFAbsoluteTimeGetCurrent()
+        var firstTokenWall: Double?
         var out: [Int] = []
         var info: GenerateCompletionInfo?
 
@@ -2804,6 +2831,9 @@ func runGrowingChatCacheReuse(modelPath: String, maxNew: Int) async throws {
             for await event in stream {
                 switch event {
                 case .token(let id):
+                    if firstTokenWall == nil {
+                        firstTokenWall = CFAbsoluteTimeGetCurrent() - t0
+                    }
                     out.append(id)
                 case .prefillProgress:
 
@@ -2818,6 +2848,9 @@ func runGrowingChatCacheReuse(modelPath: String, maxNew: Int) async throws {
             for await event in stream {
                 switch event {
                 case .token(let id):
+                    if firstTokenWall == nil {
+                        firstTokenWall = CFAbsoluteTimeGetCurrent() - t0
+                    }
                     out.append(id)
                 case .prefillProgress:
 
@@ -2831,12 +2864,13 @@ func runGrowingChatCacheReuse(modelPath: String, maxNew: Int) async throws {
         let text = context.tokenizer.decode(tokenIds: out)
         let tokps = wall > 0 ? Double(out.count) / wall : 0
         print(String(format:
-            "  %@: prompt=%d gen=%d finish=%@ promptTime=%.3fs wall=%.2fs tokps=%.2f text=\"%@\"",
+            "  %@: prompt=%d gen=%d finish=%@ promptTime=%.3fs ttft=%.3fs wall=%.2fs tokps=%.2f text=\"%@\"",
             label,
             promptSize,
             out.count,
             String(describing: info?.stopReason ?? .cancelled),
             info?.promptTime ?? -1,
+            firstTokenWall ?? -1,
             wall,
             tokps,
             String(text.prefix(120)).replacingOccurrences(of: "\n", with: "\\n")))
@@ -2845,6 +2879,14 @@ func runGrowingChatCacheReuse(modelPath: String, maxNew: Int) async throws {
 
     nonisolated(unsafe) let t1Send = turn1
     let r1 = try await run(label: "Turn 1 cold", input: t1Send)
+    if let transition = await engine.lastTurboQuantCacheTransitionForDiagnostics {
+        print(
+            "  TurboQuant transition: before{\(transition.before.topologyTags.joined(separator: ","))} "
+                + "after{\(transition.after.topologyTags.joined(separator: ","))}")
+    }
+    print(
+        "  TurboQuant compressions: "
+            + "\(await engine.turboQuantCompressionCountForDiagnostics)")
     guard let info1 = r1.info else {
         throw NSError(domain: "BENCH_GROWING_CHAT_CACHE", code: 1,
             userInfo: [NSLocalizedDescriptionKey: "turn 1 emitted no completion info"])
@@ -2880,7 +2922,7 @@ func runGrowingChatCacheReuse(modelPath: String, maxNew: Int) async throws {
 
     func describeProbe(_ label: String, tokens: [Int], mediaSalt: String?) {
         switch coordinator.fetch(tokens: tokens, mediaSalt: mediaSalt) {
-        case .hit(let matched, let remaining, let detail, _, _, let diskArrays):
+        case .hit(let matched, let remaining, let detail, let blocks, _, let diskArrays):
             writeDiagnostic(String(format:
                 "  %@: HIT tier=%@ matched=%d/%d remaining=%d diskArrays=%@",
                 label,
@@ -2889,6 +2931,7 @@ func runGrowingChatCacheReuse(modelPath: String, maxNew: Int) async throws {
                 tokens.count,
                 remaining.count,
                 diskArraySummary(diskArrays)))
+            coordinator.release(blocks: blocks)
         case .miss:
             writeDiagnostic("  \(label): MISS tokens=\(tokens.count)")
         }
@@ -2913,6 +2956,21 @@ func runGrowingChatCacheReuse(modelPath: String, maxNew: Int) async throws {
         throw NSError(domain: "BENCH_GROWING_CHAT_CACHE", code: 10,
             userInfo: [NSLocalizedDescriptionKey:
                 "turn 1 did not emit recall phrase \(recallPhrase.debugDescription); got \(String(turn1Text.prefix(160)).debugDescription)"])
+    }
+    if env["BENCH_GROWING_FORCE_PAGED_EVICTION"] == "1",
+       let paged = coordinator.pagedCache
+    {
+        var pressureBlocks: [CacheBlock] = []
+        while let block = paged.allocateBlock() {
+            pressureBlocks.append(block)
+        }
+        for block in pressureBlocks.reversed() {
+            paged.freeBlock(block)
+        }
+        let stats = paged.snapshotStats()
+        print(
+            "  Forced paged eviction: pressureBlocks=\(pressureBlocks.count) "
+                + "evictions=\(stats.evictions)")
     }
     let turn2Messages: [[String: any Sendable]] = [
         ["role": "user", "content": firstTurnPrompt],
@@ -2983,7 +3041,7 @@ func runGrowingChatCacheReuse(modelPath: String, maxNew: Int) async throws {
     printCoordinatorStats("Before turn 2")
     let probe = coordinator.fetch(tokens: turn2Tokens, mediaSalt: turn2Salt)
     switch probe {
-    case .hit(let matched, let remaining, let detail, _, _, let diskArrays):
+    case .hit(let matched, let remaining, let detail, let blocks, _, let diskArrays):
         print(String(format:
             "  Coordinator probe before turn 2: HIT tier=%@ matched=%d/%d remaining=%d diskArrays=%@",
             detail.rawValue,
@@ -2991,6 +3049,7 @@ func runGrowingChatCacheReuse(modelPath: String, maxNew: Int) async throws {
             turn2Tokens.count,
             remaining.count,
             diskArraySummary(diskArrays)))
+        coordinator.release(blocks: blocks)
         let expectedPromptBoundary = promptCommon < promptTokens.count
             ? (cachePrefixTokenCounts.max() ?? promptTokens.count)
             : promptTokens.count
@@ -7088,11 +7147,16 @@ func runDSV4CoherenceGate(modelPath: String, maxNew: Int) async throws {
 func runDSV4AgenticToolCheck(modelPath: String, maxNew: Int) async throws {
     let modelDir = URL(fileURLWithPath: modelPath)
     let env = ProcessInfo.processInfo.environment
+    let genericAgentic = (env["BENCH_AGENTIC_TOOL"] ?? "0") == "1"
+    let rowName = genericAgentic ? "BENCH_AGENTIC_TOOL" : "BENCH_DSV4_AGENTIC_TOOL"
+    let launchID = genericAgentic ? "LAGUNA-77" : "DSV4-77"
     let maxTokens = max(96, min(maxNew, 192))
-    let cacheDir = URL(fileURLWithPath: env["BENCH_DSV4_AGENTIC_CACHE_DIR"]
-        ?? "/tmp/vmlx-dsv4-agentic-cache/\(modelDir.lastPathComponent)")
+    let cacheDir = URL(fileURLWithPath:
+        (genericAgentic ? env["BENCH_AGENTIC_CACHE_DIR"] : nil)
+            ?? env["BENCH_DSV4_AGENTIC_CACHE_DIR"]
+            ?? "/tmp/vmlx-agentic-cache/\(modelDir.lastPathComponent)")
 
-    print("\n=== BENCH_DSV4_AGENTIC_TOOL: DSML tool + chat history coherence ===")
+    print("\n=== \(rowName): structured tool + chat history coherence ===")
     let loadStart = CFAbsoluteTimeGetCurrent()
     let context = try await MLXLMCommon.loadModel(
         from: modelDir, using: #huggingFaceTokenizerLoader())
@@ -7100,7 +7164,7 @@ func runDSV4AgenticToolCheck(modelPath: String, maxNew: Int) async throws {
     print("Model: \(type(of: context.model))")
     print("Tool format: \(context.configuration.toolCallFormat.map { "\($0)" } ?? "json (default)")")
     print("Reasoning stamp: \(context.configuration.reasoningParserName ?? "nil")")
-    guard context.configuration.toolCallFormat == .dsml else {
+    guard genericAgentic || context.configuration.toolCallFormat == .dsml else {
         throw NSError(
             domain: "BENCH_DSV4_AGENTIC_TOOL",
             code: 1,
@@ -7109,7 +7173,7 @@ func runDSV4AgenticToolCheck(modelPath: String, maxNew: Int) async throws {
                     "DSV4 agentic row requires DSML tool-call format, got \(context.configuration.toolCallFormat.map { "\($0)" } ?? "nil")",
             ])
     }
-    guard context.configuration.reasoningParserName == "think_xml" else {
+    guard genericAgentic || context.configuration.reasoningParserName == "think_xml" else {
         throw NSError(
             domain: "BENCH_DSV4_AGENTIC_TOOL",
             code: 2,
@@ -7127,7 +7191,7 @@ func runDSV4AgenticToolCheck(modelPath: String, maxNew: Int) async throws {
     coordConfig.diskCacheMaxGB = 4
     coordConfig.pagedBlockSize = 256
     coordConfig.maxCacheBlocks = 1024
-    coordConfig.modelKey = "\(modelDir.lastPathComponent)|dsv4-agentic-tool"
+    coordConfig.modelKey = "\(modelDir.lastPathComponent)|\(rowName.lowercased())"
     let coordinator = CacheCoordinator(config: coordConfig)
     let engine = BatchEngine(context: ctx, maxBatchSize: 1, cacheCoordinator: coordinator)
     defer { Task { await engine.shutdown() } }
@@ -7258,7 +7322,7 @@ func runDSV4AgenticToolCheck(modelPath: String, maxNew: Int) async throws {
 
     var chat: [Chat.Message] = [
         .system("You are a concise assistant. Use tools when requested."),
-        .user("Use lookup_launch_status for launch_id DSV4-77. Emit only the tool call."),
+        .user("Use lookup_launch_status for launch_id \(launchID). Emit only the tool call."),
     ]
     let toolTurn = try await runTurn(
         label: "turn1-tool-call",
@@ -7281,7 +7345,7 @@ func runDSV4AgenticToolCheck(modelPath: String, maxNew: Int) async throws {
     }
     let toolArgs = toolCall.function.arguments.mapValues { $0.anyValue }
     print("DSV4_AGENTIC_TOOL_CALL name=\(toolCall.function.name) id=\(toolCallId) args=\(toolArgs)")
-    let toolResultJSON = #"{"launch_id":"DSV4-77","status":"green","window":"04:30Z"}"#
+    let toolResultJSON = "{\"launch_id\":\"\(launchID)\",\"status\":\"green\",\"window\":\"04:30Z\"}"
     chat.append(.assistant(toolText, toolCalls: toolCalls))
     chat.append(.tool(toolResultJSON, toolCallId: toolCallId))
     chat.append(.user("Summarize the launch status and window from the tool result. Answer in one short sentence."))
@@ -7306,8 +7370,8 @@ func runDSV4AgenticToolCheck(modelPath: String, maxNew: Int) async throws {
         chat: chat,
         enableThinking: false)
     printBlock("DSV4_AGENTIC_T3_TEXT", recallTurn.text)
-    if !recallTurn.text.uppercased().contains("DSV4-77") {
-        try fail(31, "turn3 did not recall DSV4-77 from tool history")
+    if !recallTurn.text.uppercased().contains(launchID) {
+        try fail(31, "turn3 did not recall \(launchID) from tool history")
     }
 
     let snapshot = coordinator.snapshotStats()
@@ -7321,7 +7385,7 @@ func runDSV4AgenticToolCheck(modelPath: String, maxNew: Int) async throws {
     print(
         "DSV4_AGENTIC_CACHE_STATS hybrid=\(snapshot.isHybrid) pagedIncompatible=\(snapshot.isPagedIncompatible) paged{\(paged)} disk{\(disk)} ssm{hits=\(ssm.hits),misses=\(ssm.misses),reDerives=\(ssm.reDerives)}"
     )
-    guard snapshot.isPagedIncompatible else {
+    if !genericAgentic, !snapshot.isPagedIncompatible {
         try fail(40, "DSV4 agentic row did not mark cache as paged-incompatible")
     }
     guard let diskStats = snapshot.diskStats else {
@@ -7330,11 +7394,16 @@ func runDSV4AgenticToolCheck(modelPath: String, maxNew: Int) async throws {
     guard diskStats.stores > 0 else {
         try fail(42, "DSV4 agentic row did not store any disk L2 cache entries")
     }
-    guard diskStats.hits > 0 else {
+    if genericAgentic {
+        let pagedHits = snapshot.pagedStats?.cacheHits ?? 0
+        guard pagedHits > 0 || diskStats.hits > 0 else {
+            try fail(43, "generic agentic row did not observe paged or disk cache reuse")
+        }
+    } else if diskStats.hits == 0 {
         try fail(43, "DSV4 agentic row did not observe any disk L2 cache hits")
     }
     await engine.shutdown()
-    print("=== BENCH_DSV4_AGENTIC_TOOL: PASS ===")
+    print("=== \(rowName): PASS ===")
 }
 
 /// Side-by-side decode on the same simple factual prompt across DSV4's

--- a/Tests/MLXLMCommonFocusedTests/CacheCoordinatorTopologyFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/CacheCoordinatorTopologyFocusedTests.swift
@@ -253,7 +253,10 @@ struct CacheCoordinatorTopologyFocusedTests {
         let tmp = makeTempDir("gemma-mixed-tq-rotating-tiered")
         defer { try? FileManager.default.removeItem(at: tmp) }
         let modelKey = "gemma-mixed-tq-rotating-tiered-focused"
-        let tokens = Array(1...24)
+        // Deliberately stop between 8-token block boundaries. Growing chat
+        // must reuse the stored 6-token partial leaf instead of falling
+        // through to disk merely because the next prompt extends that chunk.
+        let tokens = Array(1...22)
 
         let simple = KVCacheSimple()
         _ = simple.update(
@@ -274,9 +277,10 @@ struct CacheCoordinatorTopologyFocusedTests {
         let rotating = RotatingKVCache(maxSize: 8, keep: 0, step: 4)
         for chunkStart in stride(from: 0, to: tokens.count, by: 6) {
             let marker = Float(chunkStart / 6 + 1)
+            let chunkCount = min(6, tokens.count - chunkStart)
             _ = rotating.update(
-                keys: MLXArray.ones([1, 1, 6, 16], dtype: .bfloat16) * marker,
-                values: MLXArray.ones([1, 1, 6, 16], dtype: .bfloat16)
+                keys: MLXArray.ones([1, 1, chunkCount, 16], dtype: .bfloat16) * marker,
+                values: MLXArray.ones([1, 1, chunkCount, 16], dtype: .bfloat16)
                     * (marker + Float(0.25)))
         }
         MLX.eval(turboQuant, rotating)
@@ -303,11 +307,11 @@ struct CacheCoordinatorTopologyFocusedTests {
         #expect(storedStats.requiresPagedBoundaryCompanion)
         #expect((storedStats.diskStats?.stores ?? 0) > 0)
 
-        let growingPrompt = tokens + [25, 26]
+        let growingPrompt = tokens + [23, 24]
         switch coordinator.fetch(tokens: growingPrompt, skipExactDiskBoundary: true) {
         case .hit(let matched, let remaining, let detail, let blocks, _, let arrays):
             #expect(matched == tokens.count)
-            #expect(remaining == [25, 26])
+            #expect(remaining == [23, 24])
             #expect(detail == .paged)
             #expect(blocks.count == 3)
             #expect(arrays == nil)
@@ -353,7 +357,7 @@ struct CacheCoordinatorTopologyFocusedTests {
         switch coordinator.fetch(tokens: growingPrompt, skipExactDiskBoundary: true) {
         case .hit(let matched, let remaining, let detail, let blocks, _, let arrays):
             #expect(matched == tokens.count)
-            #expect(remaining == [25, 26])
+            #expect(remaining == [23, 24])
             #expect(detail == .disk)
             #expect(blocks.isEmpty)
             guard let arrays else {

--- a/Tests/MLXLMCommonFocusedTests/NoHiddenReasoningCloseBiasFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NoHiddenReasoningCloseBiasFocusedTests.swift
@@ -1623,9 +1623,9 @@ struct LagunaFocusedContractsTests {
             "enable_thinking": false,
         ])
 
-        #expect(rendered.contains("<system>\n\nYou are a helpful"))
-        #expect(rendered.contains("<user>\nhi\n</user>\n"))
-        #expect(rendered.hasSuffix("<assistant>\n</think>\n"))
+        #expect(rendered.hasPrefix("〈|EOS|〉<system>You are a helpful"))
+        #expect(rendered.contains("<user>hi</user>\n"))
+        #expect(rendered.hasSuffix("<assistant></think>"))
         #expect(!rendered.contains("<|im_start|>"))
 
         var parser = ReasoningParser.forPrompt(
@@ -1646,7 +1646,7 @@ struct LagunaFocusedContractsTests {
             "enable_thinking": true,
         ])
 
-        #expect(rendered.hasSuffix("<assistant>\n<think>\n"))
+        #expect(rendered.hasSuffix("<assistant><think>"))
 
         var parser = ReasoningParser.forPrompt(
             stampName: "laguna",
@@ -1672,12 +1672,12 @@ struct LagunaFocusedContractsTests {
                 ["role": "user", "content": "again"],
             ],
             "add_generation_prompt": true,
-            "enable_thinking": false,
+            "enable_thinking": true,
         ])
 
-        #expect(rendered.contains("<think>\nbrief internal note\n</think>\nHello!\n</assistant>\n"))
-        #expect(rendered.contains("<user>\nagain\n</user>\n"))
-        #expect(rendered.hasSuffix("<assistant>\n</think>\n"))
+        #expect(rendered.contains("<think>brief internal note</think>Hello!</assistant>\n"))
+        #expect(rendered.contains("<user>again</user>\n"))
+        #expect(rendered.hasSuffix("<assistant><think>"))
     }
 
     @Test("Laguna mixed rope_parameters decodes dict entries only")

--- a/Tests/MLXLMTests/GenerationConfigDefaultsTests.swift
+++ b/Tests/MLXLMTests/GenerationConfigDefaultsTests.swift
@@ -19,6 +19,7 @@ final class GenerationConfigDefaultsTests: XCTestCase {
           "min_p": 0.05,
           "repetition_penalty": 1.05,
           "do_sample": true,
+          "default_chat_template_kwargs": {"enable_thinking": true},
           "suppress_tokens": [258883, 258882]
         }
         """
@@ -34,6 +35,7 @@ final class GenerationConfigDefaultsTests: XCTestCase {
         XCTAssertEqual(config.minP, 0.05)
         XCTAssertEqual(config.repetitionPenalty, 1.05)
         XCTAssertEqual(config.doSample, true)
+        XCTAssertEqual(config.defaultChatTemplateKwargs?.enableThinking, true)
         XCTAssertEqual(config.suppressTokens, [258883, 258882])
     }
 

--- a/Tests/MLXLMTests/JangConfigChatSchemaTests.swift
+++ b/Tests/MLXLMTests/JangConfigChatSchemaTests.swift
@@ -52,6 +52,9 @@ struct JangConfigChatSchemaTests {
                     "top_p": 0.95,
                     "max_new_tokens": 300,
                 ] as [String: Any],
+                "template_kwargs_defaults": [
+                    "enable_thinking": true
+                ],
             ] as [String: Any],
         ]
 
@@ -88,6 +91,7 @@ struct JangConfigChatSchemaTests {
         #expect(sd.temperature == 0.6)
         #expect(sd.topP == 0.95)
         #expect(sd.maxNewTokens == 300)
+        #expect(chat.templateKwargsDefaults?.enableThinking == true)
     }
 
     @Test("Missing chat block leaves JangConfig.chat nil (pre-DSV4 bundle)")

--- a/Tests/MLXLMTests/LagunaChatTemplateFallbackTests.swift
+++ b/Tests/MLXLMTests/LagunaChatTemplateFallbackTests.swift
@@ -27,10 +27,10 @@ final class LagunaChatTemplateFallbackTests: XCTestCase {
         ])
 
         XCTAssertTrue(
-            rendered.hasPrefix("〈|EOS|〉<system>\n\nYou are a helpful"),
+            rendered.hasPrefix("〈|EOS|〉<system>You are a helpful"),
             rendered.debugDescription)
-        XCTAssertTrue(rendered.contains("<user>\nhi\n</user>\n"), rendered.debugDescription)
-        XCTAssertTrue(rendered.hasSuffix("<assistant>\n</think>\n"), rendered.debugDescription)
+        XCTAssertTrue(rendered.contains("<user>hi</user>\n"), rendered.debugDescription)
+        XCTAssertTrue(rendered.hasSuffix("<assistant></think>"), rendered.debugDescription)
         XCTAssertFalse(rendered.contains("<|im_start|>"))
     }
 
@@ -44,7 +44,7 @@ final class LagunaChatTemplateFallbackTests: XCTestCase {
             "enable_thinking": true,
         ])
 
-        XCTAssertTrue(rendered.hasSuffix("<assistant>\n<think>\n"), rendered.debugDescription)
+        XCTAssertTrue(rendered.hasSuffix("<assistant><think>"), rendered.debugDescription)
     }
 
     func testLagunaMinimalAssistantHistoryPreservesReasoningAndContent() throws {
@@ -60,17 +60,17 @@ final class LagunaChatTemplateFallbackTests: XCTestCase {
                 ["role": "user", "content": "again"],
             ],
             "add_generation_prompt": true,
-            "enable_thinking": false,
+            "enable_thinking": true,
         ])
 
         XCTAssertTrue(
-            rendered.contains("<think>\nbrief internal note\n</think>\nHello!\n</assistant>\n"),
+            rendered.contains("<think>brief internal note</think>Hello!</assistant>\n"),
             rendered.debugDescription)
-        XCTAssertTrue(rendered.contains("<user>\nagain\n</user>\n"), rendered.debugDescription)
-        XCTAssertTrue(rendered.hasSuffix("<assistant>\n</think>\n"), rendered.debugDescription)
+        XCTAssertTrue(rendered.contains("<user>again</user>\n"), rendered.debugDescription)
+        XCTAssertTrue(rendered.hasSuffix("<assistant><think>"), rendered.debugDescription)
     }
 
-    func testLagunaRequiredToolChoiceRendersFunctionCallOnlyContract() throws {
+    func testLagunaToolsMatchBundleContractWithoutPromptCoercion() throws {
         let template = try Template(ChatTemplateFallbacks.lagunaMinimal)
         let rendered = try template.renderLaguna([
             "messages": [
@@ -101,13 +101,8 @@ final class LagunaChatTemplateFallbackTests: XCTestCase {
 
         XCTAssertTrue(rendered.contains("<available_tools>"), rendered.debugDescription)
         XCTAssertTrue(rendered.contains("\"name\":\"line_count\""), rendered.debugDescription)
-        XCTAssertTrue(rendered.contains("<tool_call>function-name"), rendered.debugDescription)
-        XCTAssertTrue(rendered.contains("<arg_key>argument-key</arg_key>"), rendered.debugDescription)
-        XCTAssertTrue(rendered.contains("<arg_value>value-of-argument-key</arg_value>"), rendered.debugDescription)
-        XCTAssertTrue(rendered.contains("The current assistant response MUST be a function call."), rendered.debugDescription)
-        XCTAssertTrue(rendered.contains("Use the `line_count` function."), rendered.debugDescription)
-        XCTAssertTrue(rendered.contains("Include every required argument exactly as requested"), rendered.debugDescription)
-        XCTAssertFalse(rendered.contains("Reply with prose"), rendered.debugDescription)
-        XCTAssertTrue(rendered.hasSuffix("<assistant>\n</think>\n"), rendered.debugDescription)
+        XCTAssertFalse(rendered.contains("The current assistant response MUST be a function call."), rendered.debugDescription)
+        XCTAssertFalse(rendered.contains("function-name"), rendered.debugDescription)
+        XCTAssertTrue(rendered.hasSuffix("<assistant></think>"), rendered.debugDescription)
     }
 }

--- a/Tests/MLXLMTests/LagunaRopeParametersDecodeTests.swift
+++ b/Tests/MLXLMTests/LagunaRopeParametersDecodeTests.swift
@@ -16,6 +16,49 @@ import Testing
 @Suite("Laguna rope_parameters — mixed-shape decode")
 struct LagunaRopeParametersDecodeTests {
 
+    private static let s21TinyConfig = #"""
+    {
+      "model_type": "laguna",
+      "hidden_size": 8,
+      "intermediate_size": 16,
+      "num_hidden_layers": 2,
+      "num_attention_heads": 2,
+      "num_key_value_heads": 1,
+      "num_attention_heads_per_layer": [2, 4],
+      "head_dim": 4,
+      "max_position_embeddings": 64,
+      "vocab_size": 32,
+      "rms_norm_eps": 1.0e-5,
+      "tie_word_embeddings": true,
+      "layer_types": ["full_attention", "sliding_attention"],
+      "mlp_layer_types": ["dense", "sparse"],
+      "sliding_window": 4,
+      "moe_intermediate_size": 4,
+      "shared_expert_intermediate_size": 4,
+      "num_experts": 4,
+      "num_experts_per_tok": 2,
+      "gating": "per-head",
+      "rope_parameters": {
+        "full_attention": {
+          "rope_theta": 500000.0,
+          "rope_type": "default",
+          "partial_rotary_factor": 0.5
+        },
+        "sliding_attention": {
+          "rope_theta": 10000.0,
+          "rope_type": "default",
+          "partial_rotary_factor": 1.0
+        }
+      }
+    }
+    """#
+
+    private func s21TinyModel() throws -> LagunaModel {
+        let cfg = try JSONDecoder().decode(
+            LagunaConfiguration.self, from: Data(Self.s21TinyConfig.utf8))
+        return LagunaModel(cfg, jangtq: nil)
+    }
+
     /// Minimum-viable Laguna config covering all required fields plus the
     /// problematic `rope_parameters` shape. Only the rope decode is
     /// asserted — the rest of the config is supplied so JSON decoding
@@ -177,5 +220,137 @@ struct LagunaRopeParametersDecodeTests {
         #expect(sanitized["layers.0.self_attn.q_proj.weight"] == nil)
         #expect(sanitized["layers.0.self_attn.k_proj.weight"] == nil)
         #expect(sanitized["layers.0.self_attn.v_proj.weight"] == nil)
+    }
+
+    @Test("S-2.1 uses released switch_mlp module path")
+    func s21UsesSwitchMLPPath() throws {
+        let model = try s21TinyModel()
+        let leaves = Dictionary(uniqueKeysWithValues: model.leafModules().flattened())
+
+        #expect(leaves["layers.1.mlp.switch_mlp.gate_proj"] is SwitchLinear)
+        #expect(leaves["layers.1.mlp.switch_mlp.up_proj"] is SwitchLinear)
+        #expect(leaves["layers.1.mlp.switch_mlp.down_proj"] is SwitchLinear)
+        #expect(leaves["layers.1.mlp.experts.gate_proj"] == nil)
+    }
+
+    @Test("sanitize preserves S-2.1 switch_mlp and normalizes legacy experts")
+    func sanitizeNormalizesRoutedExpertPaths() throws {
+        let model = try s21TinyModel()
+        let current = model.sanitize(weights: [
+            "model.layers.1.mlp.switch_mlp.gate_proj.weight": MLXArray.ones([4, 4, 2]),
+            "model.layers.1.mlp.switch_mlp.up_proj.weight": MLXArray.ones([4, 4, 2]),
+            "model.layers.1.mlp.switch_mlp.down_proj.weight": MLXArray.ones([4, 8, 1]),
+        ])
+        #expect(current["layers.1.mlp.switch_mlp.gate_proj.weight"] != nil)
+        #expect(current["layers.1.mlp.switch_mlp.up_proj.weight"] != nil)
+        #expect(current["layers.1.mlp.switch_mlp.down_proj.weight"] != nil)
+
+        let legacy = model.sanitize(weights: [
+            "model.layers.1.mlp.experts.gate_up_proj.weight": MLXArray.ones([4, 8, 2]),
+            "model.layers.1.mlp.experts.down_proj.weight": MLXArray.ones([4, 8, 1]),
+            "model.layers.1.mlp.experts.e_score_correction_bias": MLXArray.ones([4]),
+        ])
+        #expect(legacy["layers.1.mlp.switch_mlp.gate_proj.weight"]?.shape == [4, 4, 2])
+        #expect(legacy["layers.1.mlp.switch_mlp.up_proj.weight"]?.shape == [4, 4, 2])
+        #expect(legacy["layers.1.mlp.switch_mlp.down_proj.weight"] != nil)
+        #expect(legacy["layers.1.mlp.e_score_correction_bias"] != nil)
+    }
+
+    @Test("S-2.1 no-cache prefill uses a banded SWA mask")
+    func s21NoCacheUsesSlidingMaskPastWindow() throws {
+        let model = try s21TinyModel()
+        let masks = model.attentionMasks(
+            h: MLXArray.zeros([1, 9, 8]), cache: nil)
+
+        if case .causal = masks.full {
+            // expected
+        } else {
+            Issue.record("full-attention prefill must use the causal fast path")
+        }
+        if case .array(let mask) = masks.sliding {
+            #expect(mask.shape == [9, 9])
+        } else {
+            Issue.record("SWA prefill longer than the window must use a band mask")
+        }
+    }
+
+    @Test("S-2.1 cache topology is full KV plus keep-zero rotating SWA")
+    func s21CacheTopology() throws {
+        let model = try s21TinyModel()
+        for parameters in [
+            nil,
+            GenerateParameters(kvMode: .turboQuant(keyBits: 4, valueBits: 4)),
+        ] {
+            let cache = model.newCache(parameters: parameters)
+            #expect(cache.count == 2)
+            #expect(cache[0] is KVCacheSimple)
+            let sliding = try #require(cache[1] as? RotatingKVCache)
+            #expect(sliding.maxSize == 4)
+            #expect(sliding.keep == 0)
+        }
+    }
+
+    @Test("S-2.1 per-module affine widths retain 2/3/6/8-bit declarations")
+    func s21PerModuleQuantizationWidths() throws {
+        let json = #"""
+        {
+          "model_type": "laguna",
+          "quantization": {
+            "bits": 8,
+            "group_size": 64,
+            "model.embed_tokens": {"bits": 6},
+            "model.layers.1.mlp.switch_mlp.gate_proj": {"bits": 2},
+            "model.layers.1.mlp.switch_mlp.down_proj": {"bits": 3},
+            "model.layers.1.self_attn.q_proj": {"bits": 8}
+          }
+        }
+        """#
+        let base = try JSONDecoder.json5().decode(
+            BaseConfiguration.self, from: Data(json.utf8))
+        let perLayer = try #require(base.quantizationContainer?.perLayerQuantization)
+
+        #expect(perLayer.quantization(layer: "model.embed_tokens")?.bits == 6)
+        #expect(perLayer.quantization(
+            layer: "model.layers.1.mlp.switch_mlp.gate_proj")?.bits == 2)
+        #expect(perLayer.quantization(
+            layer: "model.layers.1.mlp.switch_mlp.down_proj")?.bits == 3)
+        #expect(perLayer.quantization(
+            layer: "model.layers.1.self_attn.q_proj")?.bits == 8)
+        #expect(perLayer.quantization(
+            layer: "model.layers.1.mlp.switch_mlp.up_proj")?.bits == 8)
+    }
+
+    @Test("Laguna thinking default is declarative and request-overridable")
+    func lagunaThinkingDefaultComesFromBundleMetadata() throws {
+        let caps = JangCapabilities(
+            thinkInTemplate: true, supportsThinking: true, family: "laguna")
+        let jangChat = JangChatConfig(
+            templateKwargsDefaults: ChatTemplateKwargsDefaults(enableThinking: true))
+
+        let jangFallback = try #require(llmDefaultAdditionalContext(
+            modelType: "laguna", capabilities: caps,
+            generationConfig: nil, chatConfig: jangChat))
+        #expect(jangFallback["enable_thinking"] as? Bool == true)
+
+        let generationWins = try #require(llmDefaultAdditionalContext(
+            modelType: "laguna", capabilities: caps,
+            generationConfig: GenerationConfigFile(
+                defaultChatTemplateKwargs: ChatTemplateKwargsDefaults(
+                    enableThinking: false)),
+            chatConfig: jangChat))
+        #expect(generationWins["enable_thinking"] as? Bool == false)
+
+        var requestMerged = generationWins
+        requestMerged["enable_thinking"] = true
+        #expect(requestMerged["enable_thinking"] as? Bool == true)
+
+        let nonThinking = try #require(llmDefaultAdditionalContext(
+            modelType: "example", capabilities: JangCapabilities(
+                supportsThinking: false),
+            generationConfig: GenerationConfigFile(
+                defaultChatTemplateKwargs: ChatTemplateKwargsDefaults(
+                    enableThinking: true)),
+            chatConfig: nil))
+        #expect(nonThinking["enable_thinking"] as? Bool == false)
     }
 }

--- a/Tests/MLXLMTests/PagedCacheTests.swift
+++ b/Tests/MLXLMTests/PagedCacheTests.swift
@@ -96,6 +96,31 @@ import Testing
     #expect(result!.blocks.count == 1)
 }
 
+@Test func pagedCacheReusesStoredPartialLeafForGrowingPrompt() throws {
+    let blockSize = 4
+    let manager = PagedCacheManager(blockSize: blockSize, maxBlocks: 20)
+    let fullLayer: [(keys: MLXArray, values: MLXArray)] = [
+        (keys: MLXArray.zeros([1, 1, 4, 8]),
+         values: MLXArray.zeros([1, 1, 4, 8]))
+    ]
+    let partialLayer: [(keys: MLXArray, values: MLXArray)] = [
+        (keys: MLXArray.zeros([1, 1, 2, 8]),
+         values: MLXArray.zeros([1, 1, 2, 8]))
+    ]
+
+    manager.storeTokenSequence(
+        tokens: [1, 2, 3, 4, 5, 6],
+        layerData: [fullLayer, partialLayer])
+
+    let result = try #require(manager.fetchPrefix(
+        tokens: [1, 2, 3, 4, 5, 6, 7, 8]))
+    #expect(result.matchedTokens == 6)
+    #expect(result.remainingTokens == [7, 8])
+    #expect(result.blocks.count == 2)
+    manager.freeBlock(result.blocks[1])
+    manager.freeBlock(result.blocks[0])
+}
+
 @Test func pagedCacheMiss() {
     let manager = PagedCacheManager(blockSize: 4, maxBlocks: 20)
 

--- a/Tests/MLXLMTests/TQDiskSerializerTests.swift
+++ b/Tests/MLXLMTests/TQDiskSerializerTests.swift
@@ -175,6 +175,117 @@ func testTQDiskRestoreMaterializesFreshSimpleCache() async throws {
     #expect(tq.compressedKeys?.tailCount == TurboQuantKVCache.defaultResidualTokens)
 }
 
+@Test
+func testTQDiskRestorePreservesPostCompressionWindow() async throws {
+    let mlxTestLock = lockSerializedMLXTest()
+    defer { mlxTestLock.unlock() }
+
+    let sourceSimple = KVCacheSimple()
+    let (prefixKeys, prefixValues) = smallKV(seqLen: 96)
+    _ = sourceSimple.update(keys: prefixKeys, values: prefixValues)
+    let sourceTQ = TurboQuantKVCache.fromSimpleCache(
+        sourceSimple,
+        keyBits: 4,
+        valueBits: 4,
+        sinkTokens: 4)
+    let windowKeys = MLXArray.ones([1, 4, 4, 16], dtype: .bfloat16) * Float(0.75)
+    let windowValues = MLXArray.ones([1, 4, 4, 16], dtype: .bfloat16) * Float(0.25)
+    _ = sourceTQ.update(keys: windowKeys, values: windowValues)
+    MLX.eval(sourceTQ)
+
+    #expect(sourceTQ.offset == 100)
+    #expect(sourceTQ.state[0].dim(2) == 100)
+
+    let dict = TQDiskSerializer.serialize(cache: [sourceTQ])
+    #expect(dict["tq_0_window_keys"]?.dim(2) == 4)
+    #expect(dict["tq_0_window_values"]?.dim(2) == 4)
+
+    var restored: [any KVCache] = [KVCacheSimple()]
+    let restoredTokens = restoreFromDiskArrays(dict, into: &restored)
+    guard let restoredTQ = restored[0] as? TurboQuantKVCache else {
+        Issue.record("Expected a TurboQuantKVCache restore")
+        return
+    }
+    MLX.eval(restoredTQ)
+    #expect(restoredTokens == 100)
+    #expect(restoredTQ.offset == 100)
+    #expect(restoredTQ.state[0].dim(2) == 100)
+    #expect(allClose(
+        restoredTQ.state[0][.ellipsis, 96..<100, 0...],
+        windowKeys).item(Bool.self))
+    #expect(allClose(
+        restoredTQ.state[1][.ellipsis, 96..<100, 0...],
+        windowValues).item(Bool.self))
+}
+
+@Test
+func testTQDiskRestoreRejectsMissingPostCompressionWindow() async throws {
+    let mlxTestLock = lockSerializedMLXTest()
+    defer { mlxTestLock.unlock() }
+
+    let sourceSimple = KVCacheSimple()
+    let (prefixKeys, prefixValues) = smallKV(seqLen: 96)
+    _ = sourceSimple.update(keys: prefixKeys, values: prefixValues)
+    let sourceTQ = TurboQuantKVCache.fromSimpleCache(
+        sourceSimple, keyBits: 4, valueBits: 4, sinkTokens: 4)
+    let (windowKeys, windowValues) = smallKV(seqLen: 4)
+    _ = sourceTQ.update(keys: windowKeys, values: windowValues)
+
+    var incomplete = TQDiskSerializer.serialize(cache: [sourceTQ])
+    incomplete.removeValue(forKey: "tq_0_window_values")
+    var restored: [any KVCache] = [KVCacheSimple()]
+    let restoredTokens = restoreFromDiskArrays(incomplete, into: &restored)
+
+    #expect(restoredTokens == 0)
+    #expect(restored[0].offset == 0)
+}
+
+@Test
+func testCompilableTQPromotionPreservesPostCompressionWindow() async throws {
+    let mlxTestLock = lockSerializedMLXTest()
+    defer { mlxTestLock.unlock() }
+
+    let sourceSimple = KVCacheSimple()
+    let (prefixKeys, prefixValues) = smallKV(seqLen: 96)
+    _ = sourceSimple.update(keys: prefixKeys, values: prefixValues)
+    let sourceTQ = TurboQuantKVCache.fromSimpleCache(
+        sourceSimple, keyBits: 4, valueBits: 4, sinkTokens: 4)
+    let (windowKeys, windowValues) = smallKV(seqLen: 4)
+    _ = sourceTQ.update(keys: windowKeys, values: windowValues)
+
+    let promoted = CompilableTurboQuantKVCache(from: sourceTQ)
+    MLX.eval(promoted)
+    #expect(promoted.offset == 100)
+    #expect(promoted.state[0].dim(2) == 100)
+    #expect(allClose(
+        promoted.state[0][.ellipsis, 96..<100, 0...],
+        windowKeys).item(Bool.self))
+}
+
+@Test
+func testPagedDecodedTQPersistsAsRestorableStandardKV() async throws {
+    let mlxTestLock = lockSerializedMLXTest()
+    defer { mlxTestLock.unlock() }
+
+    let (keys, values) = smallKV(seqLen: 96)
+    let pagedRestored = TurboQuantKVCache(keyBits: 4, valueBits: 4)
+    pagedRestored.restoreFromDecodedKV(
+        keys: keys, values: values, sourceOffset: 96)
+    #expect(pagedRestored.phase == .compressed)
+    #expect(pagedRestored.compressedKeys == nil)
+
+    let dict = TQDiskSerializer.serialize(cache: [pagedRestored])
+    #expect(dict["__layer_kind_0__"]?.item(Int32.self)
+        == TQDiskSerializer.LayerKind.kv.rawValue)
+    #expect(dict["kv_0_keys"]?.dim(2) == 96)
+
+    var restored: [any KVCache] = [KVCacheSimple()]
+    let restoredTokens = restoreFromDiskArrays(dict, into: &restored)
+    #expect(restoredTokens == 96)
+    #expect(restored[0] is KVCacheSimple)
+    #expect(restored[0].offset == 96)
+}
+
 // MARK: - Hybrid mix (KV + Mamba) + SSM companion state
 
 @Test

--- a/docs/LAGUNA_S21_RUNTIME_GATE_2026_07_21.md
+++ b/docs/LAGUNA_S21_RUNTIME_GATE_2026_07_21.md
@@ -1,0 +1,197 @@
+# Laguna S 2.1 vMLX Swift runtime gate (2026-07-21)
+
+Status: **PARTIAL — focused source tests and direct actual-weight 2L/4M
+cache/tool/reasoning runs have evidence; no Osaurus Release UI row is accepted
+yet, and 4M has not emitted a non-empty reasoning delta in the thinking-on
+probe.**
+
+This lane targets the local released text-only bundles:
+
+- `/Users/eric/models/JANGQ-AI/Laguna-S-2.1-JANG_2L`
+- `/Users/eric/models/JANGQ-AI/Laguna-S-2.1-JANG_4M`
+
+The authoritative port contract is
+`/Users/eric/jang/docs/runtime/laguna-s21/NOTES.md`, with the Swift-specific
+ordering in `SWIFT.md`. MXFP4 is not part of this gate.
+
+## Current bundle truth
+
+- 48 layers: 12 full attention / 36 sliding-window attention.
+- Full layers use 48 query heads, YaRN theta 500k, factor 128, and 64/128
+  rotary dimensions. SWA layers use 72 query heads, theta 10k, full rotary,
+  and window 512.
+- Layer 0 is dense. Layers 1...47 use 256 routed experts, top 10, plus one
+  shared expert.
+- Router math is sigmoid in fp32, correction bias for selection only,
+  normalized unbiased selected weights, routed contribution times 2.5, shared
+  contribution unscaled.
+- `g_proj` is per-head and uses fp32 softplus.
+- Activation stream must be bfloat16. Float16 overflows near layer 46 and the
+  characteristic failure is repeated unknown tokens.
+- EOS is `[2, 24]`; the chat template owns BOS token 2.
+- Vendor thinking default is on through
+  `generation_config.default_chat_template_kwargs.enable_thinking=true`, also
+  mirrored in `jang_config.chat.template_kwargs_defaults`.
+- Tool parser is `glm47` (Swift `.glm4`); reasoning parser is `deepseek_r1`.
+- JANG_2L is affine mixed 2/3/6/8-bit. JANG_4M is affine mixed 4/6/8-bit.
+- Full attention owns ordinary growing KV state. SWA owns rotating KV state
+  with `maxSize=512, keep=0`. TurboQuant KV is optional and may compress only
+  the compatible full-attention KV component.
+
+## Root causes found in the pre-fix Swift source
+
+1. `LagunaMoE` registered its routed expert leaf under `mlp.experts`, while
+   the released S-2.1 tensors and per-module quantization declarations use
+   `mlp.switch_mlp`. This prevents the production loader from pairing the
+   released weights with the model leaves.
+2. `LagunaModel.callAsFunction` returned `.none` for the SWA mask whenever
+   `cache == nil`. Prompts longer than 512 therefore let SWA layers attend the
+   full prefix on the no-cache path.
+3. Default no-TurboQuant cache construction used a full-attention rotating
+   cache with `keep=4`. The S-2.1 reference has no attention sinks; full
+   attention grows normally and SWA alone rotates with `keep=0`.
+4. `generation_config.default_chat_template_kwargs` and
+   `jang_config.chat.template_kwargs_defaults` were not decoded or passed to
+   tokenizer rendering. A silent request therefore selected the Jinja
+   fallback (thinking off) instead of the bundle's declared default (on).
+5. The tokenizer bridge deliberately replaces Laguna's unresolved
+   `{% include 'chat_template.jinja' %}` with `lagunaMinimal`, but that Swift
+   fallback had drifted from S-2.1: it omitted Poolside's default system
+   message, changed trained turn whitespace, exposed stored reasoning while
+   thinking was off, and injected required-tool instructions absent from the
+   bundle template.
+
+## Candidate source changes
+
+- Make `switch_mlp` the canonical routed-expert module path. Normalize legacy
+  `experts.*` JANGTQ payloads during Laguna sanitization.
+- Build the SWA band mask for no-cache and cached prefills through one tested
+  production helper.
+- Construct `KVCacheSimple` for full layers and explicit
+  `RotatingKVCache(maxSize: 512, keep: 0)` for SWA.
+- Decode typed chat-template defaults from both bundle metadata files. Apply
+  generation config first, JANG mirror second, and let request/UI context
+  overwrite either value. `supports_thinking=false` remains authoritative.
+- Align the Laguna-only Swift-Jinja fallback to the released S-2.1 template
+  contract while retaining exactly one template-owned BOS and removing only
+  the unsupported `{% generation %}` wrapper. Do not add synthetic tool or
+  sampler instructions.
+
+## Current evidence
+
+- `/tmp/vmlx-laguna-model-tests-20260721.log`: 10 Laguna configuration,
+  sanitization, mask, cache-topology, quant-declaration, and thinking-default
+  tests executed and passed after the Metal test library was installed beside
+  the XCTest runner.
+- `/tmp/vmlx-laguna-source-tests-20260721.log`: 14 XCTest plus 16
+  Swift-Testing cases executed and passed after the fallback was aligned.
+- `/tmp/vmlx-laguna-2l-config-smoke-20260721.log`: actual JANG_2L metadata
+  resolved `model_type=laguna`, 48 layers, effective EOS `[2,24]`, tokenizer
+  BOS/EOS id 2, affine `JANG_2L`, and no JANGTQ tensors.
+- `/tmp/vmlx-laguna-2l-template-smoke-20260721.log`: actual JANG_2L tokenizer
+  exercised plain, explicit thinking off/on, two- and nine-tool schemas,
+  multi-turn thinking-off history, and reasoning history. Every row passed;
+  rendered prompts contain one leading `〈|EOS|〉` and the expected Poolside
+  assistant rail.
+- `/tmp/vmlx-laguna-focused-current-v2-20260721.log`: the current-source
+  focused gate executed 15 XCTest cases and 102 Swift Testing cases with zero
+  failures. This includes Laguna module/mask/template contracts, non-aligned
+  partial-leaf lookup, paged eviction to disk, mixed TQ+rotating restore,
+  ZAYA CCA restore, and other hybrid companion regressions.
+- `/tmp/vmlx-laguna-release-build-current-20260721.log`: the current source
+  builds the Release `RunBench` product successfully. The three emitted
+  unhandled-file warnings pre-exist this lane and are recorded rather than
+  treated as test execution.
+- Default KV, paged RAM off, SSD L2 on:
+  `/tmp/vmlx-laguna-2l-defaultkv-safe-seed-{cold,restart}-20260721.log` and
+  `/tmp/vmlx-laguna-4m-defaultkv-safe-seed-{cold,restart}-20260721.log` show
+  fresh-process disk matches at 607/608 prompt tokens and coherent
+  `vmlx-cache-green` output. 2L prompt processing changed 3.302s cold to
+  1.426s after restart; 4M changed 6.983s to 3.646s. TurboQuant compression
+  remained zero in these default rows.
+- Explicit TQ KV, paged RAM off, SSD L2 on:
+  `/tmp/vmlx-laguna-2l-tq44-safe-seed-{cold-v2,restart-v2}-20260721.log` and
+  `/tmp/vmlx-laguna-4m-tq44-safe-seed-{cold,restart}-20260721.log` show only
+  the 12 full-KV layers transitioning to TurboQuant while all 36 SWA layers
+  remain rotating. Fresh processes restore 607/608 tokens from disk and the
+  output remains coherent.
+- Explicit TQ KV with paged RAM on:
+  `/tmp/vmlx-laguna-{2l,4m}-tq44-paged-hot-20260721.log` records a paged
+  612/635 partial hit. The paired `paged-evict` logs force 13 evictions and
+  then record a disk 612/635 fallback, demonstrating RAM-hot / SSD-warm tier
+  order in the direct runtime.
+- `/tmp/vmlx-laguna-2l-reasoning-matrix-20260721.log`: direct 2L weight run
+  exercised thinking off/low/max. Off emitted zero reasoning; both on rows
+  emitted 1,042 reasoning characters, kept visible content separate, and had
+  344-353ms warm TTFT.
+- `/tmp/vmlx-laguna-4m-reasoning-matrix-20260721.log` did not satisfy the
+  strict reasoning-on gate because both on rows emitted zero reasoning.
+  `/tmp/vmlx-laguna-4m-think-raw-route-20260721.log` shows a clean immediate
+  reasoning close followed by content with no marker leakage, so this is not
+  evidence of a content-delta routing loss, but non-empty 4M reasoning remains
+  unproven.
+- `/tmp/vmlx-laguna-{2l,4m}-toolcall-current-20260721.log` contains parsed
+  `get_weather({"location":"Tokyo"})` calls without raw protocol markers.
+  `/tmp/vmlx-laguna-2l-agentic-tool-v2-20260721.log` and
+  `/tmp/vmlx-laguna-4m-agentic-tool-20260721.log` contain parsed tool calls,
+  supplied-result continuations, and later `LAGUNA-77` recall. These are
+  direct runtime rows, not Osaurus UI proof.
+- Direct cache-store budget telemetry during the actual-weight rows reported
+  roughly 68-70 GB process physical footprint for both bundles. This is not
+  being promoted as a low-memory pass; the isolated app must show the resident
+  process in Activity Monitor and the app memory UI before the row can close.
+- `/tmp/vmlx-laguna-full-swift-test-20260721.log` is not a passing full-suite
+  artifact. The XCTest phase progressed, but the Swift Testing phase stopped
+  making progress after starting concurrent MLX tests. A process sample at
+  `/tmp/vmlx-laguna-full-test-sample-20260721.txt` shows a lock-order deadlock:
+  legacy `lockSerializedMLXTest()` owns `mlx.metal.test.serializer` while
+  waiting for its token, and `MLXMetalTestLock` owns the process-wide POSIX
+  semaphore while waiting for that same dispatch queue. The run was
+  terminated and must not be counted as green.
+
+## Required proof matrix
+
+No row may move to verified without its named artifact and measured output.
+
+| Row | Required evidence | Status |
+|---|---|---|
+| Focused config/module/mask/cache/parser tests | Test log with actual pass markers | VERIFIED-SOURCE (`/tmp/vmlx-laguna-model-tests-20260721.log`, `/tmp/vmlx-laguna-source-tests-20260721.log`) |
+| Actual 2L config + tokenizer/template contract | Local bundle metadata and rendered prompt rows | VERIFIED-RUNTIME-NO-WEIGHTS (`/tmp/vmlx-laguna-2l-config-smoke-20260721.log`, `/tmp/vmlx-laguna-2l-template-smoke-20260721.log`) |
+| Full Swift test/build regression gate | Complete test/build log | BLOCKED — existing test-lock inversion; focused current-source gate passes, full run was terminated (`/tmp/vmlx-laguna-full-swift-test-20260721.log`, `/tmp/vmlx-laguna-full-test-sample-20260721.txt`) |
+| 2L no-cache short smoke | Coherent text, no unknown-token spam, token/s, physical footprint | OPEN |
+| 2L cached short smoke | Coherent text, token/s, cache topology | VERIFIED-DIRECT; UI/footprint pending |
+| 2L >512 teacher-forced cache parity | Pre/post-window agreement, not only greedy text equality | OPEN |
+| 2L multi-turn chat, thinking default/on/off | Visible reasoning/content separation and token/s | VERIFIED-DIRECT; UI pending |
+| 2L GLM tool call and post-tool continuation | Parsed call, clean deltas, coherent continuation | VERIFIED-DIRECT; UI pending |
+| 2L SSD L2 cold/store/restart/partial restore | Counters, restored token count, TTFT/prefill | VERIFIED-DIRECT; UI pending |
+| 2L paged RAM off/on | Effective setting and cache telemetry | VERIFIED-DIRECT; UI pending |
+| 2L TurboQuant KV off/on | Only compatible full KV encoded; SWA remains rotating | VERIFIED-DIRECT; UI pending |
+| 4M repeat of correctness/cache/tool rows | Same evidence plus token/s/footprint | PARTIAL — cache/tool direct rows pass; non-empty thinking-on reasoning and UI/footprint pending |
+| Isolated Release Osaurus build and pin | Exact vMLX revision in resolved graph | OPEN |
+| Live Osaurus UI settings/model/chat/tool matrix | Computer Use screenshots/telemetry/log artifacts | OPEN |
+
+Expected reference throughput on the local 128 GB M5 Max is approximately
+48.3 token/s for 2L and 32.6 token/s for 4M with the wired-memory policy in
+effect. Those are Python reference measurements, not Swift results. Swift
+numbers will be recorded rather than assumed.
+
+## Regression questions to answer before promotion
+
+- Does canonicalizing `switch_mlp` preserve legacy Laguna JANGTQ fused expert
+  payloads and their per-projection bit widths?
+- Does the banded no-cache mask agree with cached prefill across token 512?
+- Does `keep=0` remove boundary divergence without changing full-attention
+  history?
+- Do generation-config defaults reach ordinary chat, agent/tool continuation,
+  and spawned/delegated requests, while explicit UI on/off wins every turn?
+- Does EOS 24 stop both ordinary answers and post-tool continuations without
+  leaking protocol markers?
+- Does bfloat16 remain the effective activation/quant-metadata stream through
+  layer 46 on both 2L and 4M?
+- With paged RAM cache off, can disk L2 restore full and partial stable prompt
+  blocks after a new chat and process restart?
+- With paged RAM cache on, does RAM act as hot tier and SSD as warm fallback?
+- With TurboQuant KV on, are only the 12 full-attention KV layers compressed,
+  with the 36 SWA layers and disk restore remaining coherent?
+- Does the wired-memory setting improve decode without violating Osaurus RAM
+  safety or changing bundle generation parameters?


### PR DESCRIPTION
## Scope

- port the released Laguna S 2.1 JANG_2L/JANG_4M model contract into the Swift runtime
- preserve the bundle's declarative thinking default while allowing request/UI overrides
- restore growing-prompt reuse of stored non-block-aligned cache leaves
- persist and restore TurboQuant KV's post-compression live window atomically
- seed safe N-1 prompt boundaries for full-KV + rotating-SWA stacks so fresh sessions/processes can reuse SSD L2
- add direct runtime diagnostics and a source/live proof ledger

This does not use or validate MXFP4, MLXPress, or JangPress. The tested local bundles are:

- `JANGQ-AI/Laguna-S-2.1-JANG_2L`
- `JANGQ-AI/Laguna-S-2.1-JANG_4M`

## Root causes

1. Laguna S 2.1 weights use `mlp.switch_mlp`, while the Swift module registered routed experts under `mlp.experts`.
2. The no-cache Laguna path omitted the SWA band mask, so prompts beyond the 512-token window used full-prefix attention in SWA layers.
3. Default Laguna cache construction used rotating full-attention KV with attention sinks; S 2.1 requires ordinary growing full KV and `RotatingKVCache(keep: 0)` only for SWA.
4. `default_chat_template_kwargs.enable_thinking` and the JANG mirror were decoded but not carried into the tokenizer context.
5. The Laguna fallback template had drifted from the released Poolside turn format.
6. Growing prompts changed the hash of the final partial cache leaf, preventing exact stored prefixes from being reused.
7. TurboQuant disk records preserved the encoded snapshot and logical offset but discarded full-precision tokens appended after compression, producing KV/mask length mismatches on restore.
8. After the SWA ring wrapped, a safe N-1 prompt seed was not persisted for direct full-KV + rotating-SWA stacks, forcing fresh sessions/processes to cold prefill.

## Current evidence

- `swift test --filter 'Laguna|TQDiskSerializer|PagedCache|GenerationConfigDefaults|JangConfigChat|CacheCoordinatorTopology'`: 15 XCTest + 102 Swift Testing cases passed.
- Release `RunBench` build completed.
- Both local bundles loaded in resident mode and produced coherent multi-turn output.
- SSD-only, fresh-process runs restored 607/608 prompt tokens with paged RAM disabled.
- Paged/TQ runs hit 612/635 from paged RAM; after 13 forced evictions they hit the same 612/635 boundary from SSD.
- TQ transition telemetry reports 12 full-attention TQ layers and 36 rotating SWA layers; default rows report zero TQ compressions.
- Both bundles produced structured GLM tool calls, accepted supplied tool results, and recalled the result in a later turn.
- 2L thinking-off emitted no reasoning; thinking-on emitted separate reasoning/content without marker leakage.
- 4M accepted the thinking-on prompt rail and cleanly closed it, but did not emit a non-empty reasoning delta in the strict probe. That row remains partial.

## Not yet accepted

- Isolated Release Osaurus UI proof is still required for real Settings toggles, model load, new-chat/restart SSD reuse, visible TTFT/prefill, cache counters, TurboQuant off/on, tool continuation, and Activity Monitor footprint.
- The all-tests Swift invocation is not counted as green. It deadlocked in existing test serialization: the legacy `mlx.metal.test.serializer` lock and `MLXMetalTestLock` acquired the serial queue/POSIX semaphore in opposite order. Focused current-source suites pass; the full invocation was terminated and documented in the gate file.

The PR remains draft until the Osaurus UI matrix is complete.
