### PR TITLE
Preserve numeric tool arguments during Foundation JSON bridging

### DIFF
--- a/Libraries/MLXLMCommon/Tool/Value.swift
+++ b/Libraries/MLXLMCommon/Tool/Value.swift
@@ -60,12 +60,21 @@ public enum JSONValue: Hashable, Codable, Sendable {
         switch value {
         case is NSNull:
             return .null
-        case let bool as Bool:
-            return .bool(bool)
-        case let int as Int:
-            return .int(int)
-        case let double as Double:
-            return .double(double)
+        case let number as NSNumber:
+            // Foundation bridges every Swift numeric scalar through NSNumber,
+            // and `NSNumber(value: 1) as? Bool` succeeds. Testing Bool before
+            // NSNumber therefore changed a valid JSON integer `1` into `true`
+            // while building ToolCall arguments (for example
+            // `target: {"mark": 1}` became `target: {"mark": true}`). Use the
+            // CoreFoundation type id to distinguish real JSON booleans, then
+            // preserve integral and floating-point numbers as numbers.
+            if CFGetTypeID(number) == CFBooleanGetTypeID() {
+                return .bool(number.boolValue)
+            }
+            if CFNumberIsFloatType(number) {
+                return .double(number.doubleValue)
+            }
+            return .int(number.intValue)
         case let string as String:
             return .string(string)
         case let array as [Any]:

--- a/Package.swift
+++ b/Package.swift
@@ -844,6 +844,7 @@ let package = Package(
                 "DeepseekV4ReasoningPolicyTests.swift",
                 "Gemma4ZyphraToolParserFocusedTests.swift",
                 "GemmaNestedObjectArgumentFocusedTests.swift",
+                "JSONValueFoundationNumberFocusedTests.swift",
                 "Gemma4ThoughtChannelParserFocusedTests.swift",
                 "Gemma3nTextSanitizeFocusedTests.swift",
                 "MediaCachePlaceholderTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/JSONValueFoundationNumberFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/JSONValueFoundationNumberFocusedTests.swift
@@ -1,0 +1,61 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import Testing
+@testable import MLXLMCommon
+
+@Suite("Foundation JSON number bridge contracts")
+struct JSONValueFoundationNumberFocusedTests {
+    @Test("Foundation integer one stays an integer instead of becoming true")
+    func foundationIntegerOneStaysInteger() {
+        #expect(JSONValue.from(NSNumber(value: 1)) == .int(1))
+        #expect(JSONValue.from(NSNumber(value: 0)) == .int(0))
+        #expect(JSONValue.from(NSNumber(value: 23)) == .int(23))
+        #expect(JSONValue.from(NSNumber(value: -1)) == .int(-1))
+        #expect(JSONValue.from(NSNumber(value: Int.max)) == .int(Int.max))
+        #expect(JSONValue.from(NSNumber(value: 1.0)) == .double(1.0))
+        #expect(JSONValue.from(NSNumber(value: 1.5)) == .double(1.5))
+        #expect(JSONValue.from(NSNumber(value: true)) == .bool(true))
+        #expect(JSONValue.from(NSNumber(value: false)) == .bool(false))
+    }
+
+    @Test("Qwen XML nested target mark one survives tool parsing")
+    func qwenXMLTargetMarkOneSurvivesToolParsing() throws {
+        let output = """
+            <tool_call><function=agent_action><parameter=target>{"mark":1}</parameter><parameter=verb>click</parameter></function></tool_call>
+            """
+        let call = try #require(
+            ToolCallFormat.xmlFunction.createParser().parse(
+                content: output,
+                tools: [agentActionToolSpec()]
+            )
+        )
+
+        #expect(call.function.name == "agent_action")
+        #expect(call.function.arguments["target"] == .object(["mark": .int(1)]))
+        #expect(call.function.arguments["verb"] == .string("click"))
+    }
+
+    private func agentActionToolSpec() -> [String: any Sendable] {
+        [
+            "type": "function",
+            "function": [
+                "name": "agent_action",
+                "parameters": [
+                    "type": "object",
+                    "properties": [
+                        "verb": ["type": "string"] as [String: any Sendable],
+                        "target": [
+                            "type": "object",
+                            "properties": [
+                                "mark": ["type": "integer"] as [String: any Sendable]
+                            ] as [String: any Sendable],
+                        ] as [String: any Sendable],
+                    ] as [String: any Sendable],
+                    "required": ["verb"],
+                ] as [String: any Sendable],
+            ] as [String: any Sendable],
+        ]
+    }
+}


### PR DESCRIPTION
## Summary

- distinguish Foundation `CFBoolean` values from numeric `NSNumber` values before constructing `JSONValue`
- preserve integer versus floating-point identity with `CFNumberIsFloatType`
- add focused coverage for the exact Qwen XML nested `target.mark = 1` envelope and integer/float/bool controls

## Root cause

Foundation JSON deserialization bridges integers through `NSNumber`. In Swift, `NSNumber(value: 1) as? Bool` succeeds, so the old Bool-first cast changed a model-emitted integer tool target into `true` before Osaurus schema validation. That produced live `{"target":{"mark":true}}` calls even though the raw Qwen tool envelope contained mark `1`.

## Verification

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter JSONValueFoundationNumberFocusedTests`: 2 passed, 0 failed
- Osaurus Release UI, exact Bonsai 27B 1-bit JANG CRACK: raw invocation and canonical invocation retained real integer targets including `{"target":{"mark":13}}` and `{"target":{"mark":1}}`
- the strict action schema remains unchanged; independently model-emitted scalar strings and scalar `roles` are still rejected

Osaurus integration/evidence ledger: `docs/COMPUTER_USE_BONSAI_PRIORITY_GATE_2026-07-22.md` on the companion Osaurus branch.
