### PR TITLE
Restore LFM tool prompt prefixes from disk

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -950,30 +950,10 @@ public actor BatchEngine {
             return false
         }
         let modelName = context.configuration.name.lowercased()
-        if modelName.contains("lfm2.5") && modelName.contains("mxfp8") {
-            return true
-        }
         if modelName.contains("gemma-4") && modelName.contains("mxfp4") {
             return true
         }
         return false
-    }
-
-    private func shouldDisableDiskBackedRequiredToolRestore(for slot: BatchSlot) -> Bool {
-        shouldDisableDiskBackedRequiredToolRestore(
-            toolSchemas: slot.originalInput.toolSchemas,
-            disablesGeneratedCacheBoundary: slot.disablesGeneratedCacheBoundary)
-    }
-
-    private func shouldDisableDiskBackedRequiredToolRestore(
-        toolSchemas: [ToolSpec]?,
-        disablesGeneratedCacheBoundary: Bool
-    ) -> Bool {
-        guard disablesGeneratedCacheBoundary || toolSchemas?.isEmpty == false else {
-            return false
-        }
-        let modelName = context.configuration.name.lowercased()
-        return modelName.contains("lfm2.5") && modelName.contains("mxfp8")
     }
 
     /// Clamps prefill-progress frames so the reported completed count never
@@ -1006,9 +986,6 @@ public actor BatchEngine {
         let promptTokenCount = input.text.tokens.size
         let hasMediaContent = input.hasMediaContent
         let toolSchemas = input.toolSchemas
-        let disableDiskBackedRequiredToolRestore = shouldDisableDiskBackedRequiredToolRestore(
-            toolSchemas: toolSchemas,
-            disablesGeneratedCacheBoundary: false)
         let skipDiskBackedToolPromptSeedBoundary = shouldSkipDiskBackedToolPromptSeedBoundary(
             toolSchemas: toolSchemas,
             disablesGeneratedCacheBoundary: false)
@@ -1121,7 +1098,6 @@ public actor BatchEngine {
                 // when progress frames reach the consumer changes.
                 let promptTokenIdsForTail = input.text.tokens.reshaped(-1).asArray(Int.self)
                 let deferredParameters = soloParameters
-                let deferredDisableRestore = disableDiskBackedRequiredToolRestore
                 let deferredSkipSeedBoundary = skipDiskBackedToolPromptSeedBoundary
                 let deferredInputs = SendableBox(
                     (input, context.model, cacheCoordinator))
@@ -1135,7 +1111,6 @@ public actor BatchEngine {
                         cache: nil,
                         parameters: deferredParameters,
                         cacheCoordinator: deferredCoordinator,
-                        disableDiskBackedRequiredToolRestore: deferredDisableRestore,
                         skipDiskBackedToolPromptSeedBoundary: deferredSkipSeedBoundary,
                         prefillProgressHandler: { progress in
                             deferredContinuation.yield(.prefillProgress(prefillGate.clamp(progress)))
@@ -1654,13 +1629,10 @@ public actor BatchEngine {
                 return stepPrefillAfterCacheLookup(slotIndex: slotIndex, inputForPrepare: inputForPrepare)
             }
             let requiresDiskBackedRestore = cacheRequiresDiskBackedCoordinatorRestore(slot.cache)
-            if requiresDiskBackedRestore,
-               shouldDisableDiskBackedRequiredToolRestore(for: slot)
-            {
-                Self.logger.info(
-                    "Skipped disk-backed required-tool cache restore for \(self.context.configuration.name, privacy: .public): warm restore is not proven safe for this topology"
-                )
-            } else {
+            // Scope the fetch result to this coordinator branch. Disk-backed
+            // topologies must all attempt restore; safety is decided by the
+            // topology-aware restore path below, not a model-name denylist.
+            do {
                 let result = coordinator.fetch(
                     tokens: tokenIds,
                     mediaSalt: slot.mediaSalt,

--- a/Tests/MLXLMCommonFocusedTests/CacheCoordinatorTopologyFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/CacheCoordinatorTopologyFocusedTests.swift
@@ -1075,8 +1075,8 @@ struct CacheCoordinatorTopologyFocusedTests {
                 parameters: GenerateParameters()))
     }
 
-    @Test("Known unsafe required-tool rows skip disk-backed prompt seed boundary")
-    func knownUnsafeRequiredToolRowsSkipDiskBackedPromptSeedBoundary() throws {
+    @Test("LFM tool prompts use disk restore while the unproven Gemma MXFP4 seed exception remains")
+    func lfmToolPromptsUseDiskRestore() throws {
         let batchSource = try String(
             contentsOfFile: "Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift",
             encoding: .utf8)
@@ -1086,15 +1086,18 @@ struct CacheCoordinatorTopologyFocusedTests {
 
         #expect(batchSource.contains("shouldSkipDiskBackedToolPromptSeedBoundary"))
         #expect(batchSource.contains("slot.disablesGeneratedCacheBoundary"))
-        #expect(batchSource.contains(#"modelName.contains("lfm2.5")"#))
-        #expect(batchSource.contains(#"modelName.contains("mxfp8")"#))
+        #expect(!batchSource.contains(#"modelName.contains("lfm2.5")"#))
+        #expect(!batchSource.contains(#"modelName.contains("mxfp8")"#))
         #expect(batchSource.contains(#"modelName.contains("gemma-4")"#))
         #expect(batchSource.contains(#"modelName.contains("mxfp4")"#))
         #expect(batchSource.contains("!shouldSkipDiskBackedToolPromptSeedBoundary(for: slot)"))
-        #expect(batchSource.contains("shouldDisableDiskBackedRequiredToolRestore"))
-        #expect(batchSource.contains("disableDiskBackedRequiredToolRestore: deferredDisableRestore"))
-        #expect(batchSource.contains("Skipped disk-backed required-tool cache restore"))
+        #expect(!batchSource.contains("shouldDisableDiskBackedRequiredToolRestore"))
+        #expect(!batchSource.contains("disableDiskBackedRequiredToolRestore: deferredDisableRestore"))
+        #expect(!batchSource.contains("Skipped disk-backed required-tool cache restore"))
         #expect(batchSource.contains("Skipped disk-backed tool prompt seed boundary"))
+        // Keep the explicit iterator parameter source-compatible for callers
+        // that have their own measured safety policy. BatchEngine must not set
+        // it from a model-name heuristic.
         #expect(evaluateSource.contains("disableDiskBackedRequiredToolRestore"))
         #expect(evaluateSource.contains("TokenIterator: skipped disk-backed required-tool cache restore"))
         #expect(evaluateSource.contains("requiresDiskBackedRestore && disableDiskBackedRequiredToolRestore"))

--- a/docs/LFM25_DISK_RESTORE_GATE_2026_07_22.md
+++ b/docs/LFM25_DISK_RESTORE_GATE_2026_07_22.md
@@ -1,0 +1,77 @@
+# LFM2.5 Disk Restore Gate — 2026-07-22
+
+Status: **VERIFIED-LIVE for the scoped LFM2.5 MXFP8 disk-restore defect;
+broader all-family runtime correctness remains PARTIAL.**
+
+## Root cause
+
+Normal Osaurus chats include tool schemas. `BatchEngine` used the display-name
+pair `lfm2.5` + `mxfp8` to disable disk-backed restore and suppress the
+tool-prompt seed boundary whenever tools were present. LFM therefore wrote
+typed format-v2 checkpoints but did not fetch them in the ordinary app path.
+The cache topology itself was not the failing condition.
+
+The patch removes the LFM display-name gates from both the solo iterator path
+and the batched coordinator path. The topology-aware restore code remains the
+owner of restore safety. The explicit `TokenIterator` opt-out is retained for
+callers with a measured safety policy. The existing unproven Gemma-4 MXFP4
+seed-boundary exception is intentionally unchanged and was not tested here.
+
+Source revision before patch: `bbbf49e090449bb42f6cde8f50b6f230e3578aec`.
+
+## Focused source verification
+
+Command:
+
+```text
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
+  xcrun swift test --filter lfmToolPromptsUseDiskRestore
+```
+
+Result: one test in one suite passed in 0.021 seconds after rebuilding
+`BatchEngine.swift`. The contract asserts that the LFM/MXFP8 denylist and its
+BatchEngine propagation are absent, while the Gemma-4 MXFP4 exception and the
+public iterator opt-out remain.
+
+The wider topology suite was attempted earlier but aborted while constructing
+unrelated Metal-backed cache objects because the command-line test process
+could not load the default metallib. It is not counted as a pass.
+
+## Isolated Release Osaurus proof
+
+App bundle: `com.dinoki.osaurus.prefillqueueproof20260722`.
+
+Visible settings: Prefix Cache On, GPU/Paged Cache Off, Disk Cache On, codec
+`Engine Selected`, SSM re-derive On. The UI reported all changes saved.
+
+Model: LFM2.5 8B A1B MXFP8.
+
+| Scenario | Runtime evidence | Visible result |
+|---|---|---|
+| New chat | Disk hit boundary `1747/1768`; `MambaCache:18`, `KVCacheSimple:6` | Exact sentence; TTFT 0.41s; 270.0 tok/s |
+| Grounded follow-up | Disk hit boundary `1793/1815` | `Rayleigh scattering`; TTFT 0.32s; 221.5 tok/s |
+| Another new chat | Disk hit boundary `1765/1777` | `oxygen`; TTFT 0.49s; 239.1 tok/s |
+| Relaunch/startup prefix | Disk hit boundary `1747/1750` | Restore occurred before remaining prefill |
+
+These rows prove that ordinary tool-bearing Osaurus requests now attempt and
+use partial SSD restore with paged RAM cache disabled. They do not establish
+TurboQuant behavior, media paths, or every model family's output correctness.
+
+## Representative non-regression evidence
+
+The same isolated Release app, with the same visible cache settings, completed:
+
+- Bonsai 27B hybrid Qwen: exact multi-turn, warm-up race, 13,596-token partial
+  restore, and restart restore with recurrent companion state.
+- Gemma 4 12B QAT JANG_4M: 8 full-KV plus 40 rotating-SWA layers; exact
+  two-turn output with no reasoning leak while Thinking was Off.
+- Laguna S2.1 JANG_2L: 12 full-attention plus 36 rotating layers; cross-chat
+  disk restore and exact output at 44.2 tok/s.
+- VibeThinker 3B MXFP8: full-KV disk hits worked, but the second turn exposed
+  visible deliberation. Cache-path PASS; model coherence FAIL.
+- ZAYA1 VL 8B JANGTQ4: 40 CCA layers restored from disk, but the generic
+  Assistant surface hallucinated after search. Cache-path evidence only.
+- Nemotron Audex 2B: load blocked as unsupported by the pinned runtime.
+
+Therefore this change is scoped to the proven LFM restore defect. It must not
+be described as universal family correctness or release readiness.


### PR DESCRIPTION
## Root cause

Ordinary Osaurus chats carry tool schemas. BatchEngine used the display-name pair `lfm2.5` + `mxfp8` to bypass disk restore and suppress the tool-prompt seed boundary, which made the family write typed checkpoints but never fetch them in the normal app path.

## Change

- remove the LFM display-name restore denylist from solo and batched BatchEngine paths
- let the topology-aware restore path decide safety
- retain the public TokenIterator opt-out for explicit caller policy
- leave the existing Gemma-4 MXFP4 seed exception unchanged and untested
- add a focused source contract and an evidence checkpoint

## Verification

- `swift test --filter lfmToolPromptsUseDiskRestore`: 1 test / 1 suite passed after rebuilding BatchEngine
- isolated Release Osaurus app, bundle `com.dinoki.osaurus.prefillqueueproof20260722`
- visually confirmed Prefix Cache On, GPU/Paged Cache Off, Disk Cache On, SSM re-derive On, all changes saved
- LFM2.5 8B A1B MXFP8 partial disk hits: 1747/1768, 1793/1815, 1765/1777, and startup 1747/1750
- coherent visible results at 0.41s / 270.0 tok/s, 0.32s / 221.5 tok/s, and 0.49s / 239.1 tok/s
- representative cache-path non-regression rows: Bonsai hybrid Qwen, Gemma 4 rotating-SWA, Laguna mixed full/rotating, Vibe full KV, and ZAYA CCA

## Limits

This is not an all-family correctness claim. Vibe exposed a separate second-turn reasoning leak, ZAYA generic Assistant output was incoherent after search, and Audex is unsupported by the pinned runtime. TurboQuant and paged-RAM-on rows remain outside this emergency patch. The wider topology suite was attempted but aborted because the command-line test process could not load the default metallib; it is not counted as passing.