### PR TITLE
Drain cancelled solo generation before model reuse

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -1183,6 +1183,31 @@ public actor BatchEngine {
         }
     }
 
+    /// Cancel the active direct B=1 generation and wait until its producer
+    /// has stopped touching the shared MLX/Metal stream.
+    ///
+    /// A serving layer that wraps ``generate(input:parameters:)`` in another
+    /// `AsyncStream` cannot safely infer this drain point from its own
+    /// consumer termination: dropping the wrapper must cancel the underlying
+    /// solo task, but releasing the next-request gate before that task exits
+    /// can overlap the cancelled prefill with the next prompt's cache restore.
+    /// This method provides the missing cancellation-and-drain handshake.
+    /// It is idempotent and is a no-op when no solo generation is active.
+    public func cancelActiveSoloGenerationAndWait() async {
+        guard let task = soloFastPathTask else { return }
+        let id = soloFastPathID
+        task.cancel()
+        await task.value
+
+        // The bridge that forwards the producer stream normally clears solo
+        // ownership. It may not have reached that actor hop yet when
+        // `task.value` resumes, so clear the same id here as well. The helper
+        // is idempotent; the bridge's later call becomes a no-op.
+        if let id {
+            finishSoloFastPath(id: id)
+        }
+    }
+
     /// Cancel a specific request by ID.
     ///
     /// If the request is still in the wait queue, it is removed immediately.

--- a/Tests/MLXLMTests/BatchEngineTests.swift
+++ b/Tests/MLXLMTests/BatchEngineTests.swift
@@ -991,6 +991,52 @@ class BatchEngineIntegrationTests: XCTestCase {
         XCTAssertFalse(finalRunning)
     }
 
+    /// Regression for an Osaurus Stop -> New Chat race: the serving wrapper
+    /// needs an awaited cancellation boundary before it can release its
+    /// process-wide solo lease. Cancelling only the wrapper consumer left a
+    /// long prefill running with the next request stuck at `Queued 0/N`.
+    func testCancelActiveSoloGenerationAndWaitDrainsBeforeNextGenerate() async throws {
+        let engine = makeSlowPrefillEngine(
+            prefillDelayMicroseconds: 100_000,
+            maxBatchSize: 1)
+        try await MLXMetalTestLock.withLock { [engine] in
+            let first = await engine.generate(
+                input: LMInput(tokens: MLXArray(Int32(1) ..< Int32(256))),
+                parameters: GenerateParameters(maxTokens: 1_000, temperature: 0)
+            )
+            let firstConsumer = Task { @Sendable [first] in
+                var info: GenerateCompletionInfo?
+                for await event in first {
+                    if case .info(let completion) = event {
+                        info = completion
+                    }
+                }
+                return info
+            }
+
+            let soloActive = await engine.isSoloFastPathActiveForTesting
+            XCTAssertTrue(soloActive)
+
+            await engine.cancelActiveSoloGenerationAndWait()
+            let cancelled = await firstConsumer.value
+            XCTAssertEqual(cancelled?.stopReason, .cancelled)
+            let activeAfterCancel = await engine.isSoloFastPathActiveForTesting
+            XCTAssertFalse(activeAfterCancel)
+
+            let second = await engine.generate(
+                input: LMInput(tokens: MLXArray(Int32(9) ..< Int32(13))),
+                parameters: GenerateParameters(maxTokens: 2, temperature: 0)
+            )
+            var completed: GenerateCompletionInfo?
+            for await event in second {
+                if case .info(let completion) = event {
+                    completed = completion
+                }
+            }
+            XCTAssertEqual(completed?.stopReason, .length)
+        }
+    }
+
     /// Runtime resizing must not wake the batch scheduler while a B=1 direct
     /// generate owns the model. The queued request can start only after the
     /// solo task drains or cancels.


### PR DESCRIPTION
## Problem

A serving wrapper can cancel its consumer while vMLX direct B=1 generation is still prefilling or decoding. Without an awaited engine drain boundary, the wrapper may release its model gate while the old producer still owns MLX/Metal and the next request remains queued.

## Change

- add an idempotent `cancelActiveSoloGenerationAndWait()` actor API
- cancel and await the active direct-generation task
- clear solo ownership only after producer drain
- add a regression that cancels a long solo request and immediately completes a second request

## Focused verification

- `BatchEngineIntegrationTests/testCancelActiveSoloGenerationAndWaitDrainsBeforeNextGenerate`: passed, 0.241s
- `BatchEngineIntegrationTests/testGenerateSoloFastPathConsumerCancellationReleasesQueuedSubmit`: passed
- `BatchEngineIntegrationTests/testShutdownDuringGenerateStreamFinishesTextPath`: passed
- `git diff --check`: passed

Release Osaurus UI proof is tracked in the consuming app PR and is not claimed by these package tests alone.