### PR TITLE
Preserve SSD prefix reuse across tool choice

### DIFF
--- a/Libraries/MLXLMCommon/Cache/MediaSalt.swift
+++ b/Libraries/MLXLMCommon/Cache/MediaSalt.swift
@@ -118,14 +118,13 @@ private func hashMLXArray(_ array: MLXArray, into hasher: inout SHA256) {
 /// Derive a cache-scope salt string from a request's `additionalContext`.
 ///
 /// Recognized scopes are intentionally narrow: only context keys that can
-/// change prompt rendering or model behavior are folded into the cache key.
+/// change KV state without being represented by the concrete token prefix are
+/// folded into the cache key.
 ///
 /// - Returns:
 ///   - `"reasoning=off"` when `enable_thinking == false`
 ///   - `"reasoning=on"`  when `enable_thinking == true`
 ///   - `"effort=<value>"` when `reasoning_effort` is present
-///   - `"tool=required"` when `tool_choice == "required"`
-///   - `"tool_name=<value>"` when `tool_choice_name` is present
 ///   - a `|`-joined composition when multiple keys are present
 ///   - `nil` when no recognized semantic key is present (so unrelated metadata
 ///     in `additionalContext` does not fragment cache keys)
@@ -145,18 +144,6 @@ public func cacheScopeSalt(from additionalContext: [String: any Sendable]?) -> S
             parts.append("effort=\(normalized)")
         }
     }
-    if let toolChoice = additionalContext["tool_choice"] as? String {
-        let normalized = toolChoice.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        if normalized == "required" {
-            parts.append("tool=required")
-        }
-    }
-    if let toolChoiceName = additionalContext["tool_choice_name"] as? String {
-        let normalized = toolChoiceName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        if !normalized.isEmpty {
-            parts.append("tool_name=\(normalized)")
-        }
-    }
     return parts.isEmpty ? nil : parts.joined(separator: "|")
 }
 
@@ -169,8 +156,8 @@ public func cacheScopeSalt(from additionalContext: [String: any Sendable]?) -> S
 ///
 /// When either side is present the result is a stable hex SHA256 over a
 /// tag-prefixed concatenation, so:
-/// - identical media + identical scope → identical salt (cache hit),
-/// - identical media + different scope → different salt (key isolation),
+/// - identical media + identical reasoning scope → identical salt (cache hit),
+/// - identical media + different reasoning scope → different salt (key isolation),
 /// - identical scope + different media → different salt (false-positive
 ///   protection that already existed via `computeMediaSalt`).
 public func computeCacheSalt(for input: LMInput) -> String? {

--- a/Libraries/MLXLMCommon/ChatTemplates/ChatTemplateFallbacks.swift
+++ b/Libraries/MLXLMCommon/ChatTemplates/ChatTemplateFallbacks.swift
@@ -669,7 +669,13 @@ value_1
     unaffected because encode(addSpecialTokens:true) adds the BOS itself — which is
     what previously masked this bug.) -#}
 {{- "〈|EOS|〉" -}}
-{%- set enable_thinking = enable_thinking | default(false) -%}
+{#- Laguna S 2.1 serving defaults thinking ON through
+    generation_config.default_chat_template_kwargs.enable_thinking=true.
+    The raw sidecar Jinja fallback is false, but this production fallback is
+    used when the include-based sidecar cannot be rendered by the Swift bridge;
+    it must preserve the bundle/runtime serving contract when the caller omits
+    an explicit override. -#}
+{%- set enable_thinking = enable_thinking | default(true) -%}
 {%- set add_generation_prompt = add_generation_prompt | default(false) -%}
 {%- set system_message = "You are a helpful, conversationally-fluent assistant made by Poolside. You are here to be helpful to users through natural language conversations." -%}
 {%- if messages and messages[0].role == "system" -%}

--- a/Libraries/MLXLMCommon/ReasoningParser.swift
+++ b/Libraries/MLXLMCommon/ReasoningParser.swift
@@ -728,6 +728,8 @@ extension ReasoningParser {
             || compact.hasPrefix("glm5")
             || normalized.hasPrefix("deepseek")
             || normalized.hasPrefix("laguna")
+            || normalized == "poolside_v1"
+            || normalized.hasPrefix("poolside_v1_")
         {
             return ReasoningParser(startInReasoning: true)
         }
@@ -800,7 +802,7 @@ extension ReasoningParser {
             "deepseek_r1", "deepseek-r1", "deepseek", "glm", "glm4", "glm5",
             "nemotron", "nemotron_h", "minimax", "minimax_m2",
             "kimi", "kimi_k2", "kimik2",
-            "laguna", "laguna_xs", "laguna_s",
+            "laguna", "laguna_xs", "laguna_s", "poolside_v1",
             "zaya", "zaya1", "zaya2",
             "step", "stepfun", "step3p5", "step3p7", "step3_5", "step3_7":
             // Start inside the reasoning block — matches the Qwen 3.x

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -561,6 +561,7 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
             || compact.hasPrefix("glm47")
             || compact.hasPrefix("deepseek")
             || compact.hasPrefix("laguna")
+            || compact.hasPrefix("poolsidev1")
         {
             return .glm4
         }
@@ -629,7 +630,7 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
         // the direct lookup above, but is listed here for parity with
         // `glm4_moe` / `glm47` family aliases.
         case "glm4", "glm47", "glm5", "glm4_moe", "deepseek",
-            "laguna", "laguna_xs", "laguna_s":
+            "laguna", "laguna_xs", "laguna_s", "poolside_v1":
             return .glm4
         // Nemotron-H / Cascade — canonical templates use Qwen-style XML
         // function calls, but live Omni/JANGTQ rows can emit DSML protocol

--- a/Tests/MLXLMCommonFocusedTests/CacheCoordinatorTopologyFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/CacheCoordinatorTopologyFocusedTests.swift
@@ -1031,8 +1031,8 @@ struct CacheCoordinatorTopologyFocusedTests {
                 modelKey: "other-model") != diskKey)
     }
 
-    @Test("cache scope salt includes semantic reasoning and tool-choice keys")
-    func cacheScopeSaltIncludesSemanticReasoningAndToolChoiceKeys() {
+    @Test("cache scope salt includes semantic reasoning but not tool-choice keys")
+    func cacheScopeSaltIncludesSemanticReasoningButNotToolChoiceKeys() {
         #expect(cacheScopeSalt(from: ["reasoning_effort": "high"]) == "effort=high")
         #expect(cacheScopeSalt(from: ["reasoning_effort": " No_Think "]) == "effort=no_think")
         #expect(cacheScopeSalt(from: [
@@ -1046,12 +1046,12 @@ struct CacheCoordinatorTopologyFocusedTests {
         #expect(cacheScopeSalt(from: [
             "tool_choice": "required",
             "tool_choice_name": "Line_Count",
-        ]) == "tool=required|tool_name=line_count")
+        ]) == nil)
         #expect(cacheScopeSalt(from: [
             "enable_thinking": false,
             "tool_choice": "required",
             "tool_choice_name": "file_read",
-        ]) == "reasoning=off|tool=required|tool_name=file_read")
+        ]) == "reasoning=off")
         #expect(cacheScopeSalt(from: [
             "tool_choice": "auto",
             "ui_panel": "visible",

--- a/Tests/MLXLMCommonFocusedTests/NoHiddenReasoningCloseBiasFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NoHiddenReasoningCloseBiasFocusedTests.swift
@@ -1611,6 +1611,8 @@ struct LagunaFocusedContractsTests {
             #expect(ToolCallFormat.infer(from: stamp) == .glm4)
             #expect(ToolCallFormat.fromCapabilityName(stamp) == .glm4)
         }
+        #expect(ReasoningParser.fromCapabilityName("poolside_v1") != nil)
+        #expect(ToolCallFormat.fromCapabilityName("poolside_v1") == .glm4)
     }
 
     @Test("Laguna minimal template thinking off closes reasoning in prompt")
@@ -1657,6 +1659,28 @@ struct LagunaFocusedContractsTests {
         #expect(reasoning == "private plan")
         #expect(content == "Visible answer.")
         #expect(!content.contains("</think>"))
+    }
+
+    @Test("Laguna Poolside vendor stamp opens reasoning from prompt tail")
+    func lagunaPoolsideVendorStampOpensReasoning() throws {
+        let rendered = try renderLaguna([
+            "messages": [
+                ["role": "user", "content": "hi"],
+            ],
+            "add_generation_prompt": true,
+            "enable_thinking": true,
+        ])
+
+        #expect(rendered.hasSuffix("<assistant><think>"))
+
+        var parser = ReasoningParser.forPrompt(
+            stampName: "poolside_v1",
+            promptTail: String(rendered.suffix(128)))!
+        let (reasoning, content) = collectParser(
+            &parser,
+            "private plan</think>Visible answer.")
+        #expect(reasoning == "private plan")
+        #expect(content == "Visible answer.")
     }
 
     @Test("Laguna minimal template omitted thinking follows vendor default ON")

--- a/Tests/MLXLMCommonFocusedTests/NoHiddenReasoningCloseBiasFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NoHiddenReasoningCloseBiasFocusedTests.swift
@@ -1659,6 +1659,27 @@ struct LagunaFocusedContractsTests {
         #expect(!content.contains("</think>"))
     }
 
+    @Test("Laguna minimal template omitted thinking follows vendor default ON")
+    func lagunaTemplateOmittedThinkingOpensReasoning() throws {
+        let rendered = try renderLaguna([
+            "messages": [
+                ["role": "user", "content": "hi"],
+            ],
+            "add_generation_prompt": true,
+        ])
+
+        #expect(rendered.hasSuffix("<assistant><think>"))
+
+        var parser = ReasoningParser.forPrompt(
+            stampName: "laguna",
+            promptTail: String(rendered.suffix(128)))!
+        let (reasoning, content) = collectParser(
+            &parser,
+            "private plan</think>Visible answer.")
+        #expect(reasoning == "private plan")
+        #expect(content == "Visible answer.")
+    }
+
     @Test("Laguna assistant history preserves reasoning and content")
     func lagunaAssistantHistoryPreservesReasoningAndContent() throws {
         let rendered = try renderLaguna([

--- a/Tests/MLXLMTests/LagunaChatTemplateFallbackTests.swift
+++ b/Tests/MLXLMTests/LagunaChatTemplateFallbackTests.swift
@@ -16,6 +16,18 @@ private extension Template {
 }
 
 final class LagunaChatTemplateFallbackTests: XCTestCase {
+    func testLagunaMinimalOmittedThinkingUsesVendorDefaultOn() throws {
+        let template = try Template(ChatTemplateFallbacks.lagunaMinimal)
+        let rendered = try template.renderLaguna([
+            "messages": [
+                ["role": "user", "content": "hi"],
+            ],
+            "add_generation_prompt": true,
+        ])
+
+        XCTAssertTrue(rendered.hasSuffix("<assistant><think>"), rendered.debugDescription)
+    }
+
     func testLagunaMinimalThinkingOffUsesPoolsideTurns() throws {
         let template = try Template(ChatTemplateFallbacks.lagunaMinimal)
         let rendered = try template.renderLaguna([

--- a/Tests/MLXLMTests/Mistral3LagunaCoverageTests.swift
+++ b/Tests/MLXLMTests/Mistral3LagunaCoverageTests.swift
@@ -79,6 +79,7 @@ struct Mistral3LagunaCoverageTests {
         #expect(ToolCallFormat.fromCapabilityName("laguna") == .glm4)
         #expect(ToolCallFormat.fromCapabilityName("laguna_xs") == .glm4)
         #expect(ToolCallFormat.fromCapabilityName("laguna_s") == .glm4)
+        #expect(ToolCallFormat.fromCapabilityName("poolside_v1") == .glm4)
     }
 
     @Test("Mistral 4 → .mistral (sibling family, same parser)")

--- a/Tests/MLXLMTests/ReasoningParserTests.swift
+++ b/Tests/MLXLMTests/ReasoningParserTests.swift
@@ -391,7 +391,7 @@ struct ReasoningParserTests {
     // MARK: - Capability-name resolution
 
     @Test func capabilityAliasesQwen3() {
-        for name in ["qwen3", "qwen3_5", "qwen3_6", "think_xml", "deepseek_r1"] {
+        for name in ["qwen3", "qwen3_5", "qwen3_6", "think_xml", "deepseek_r1", "poolside_v1"] {
             #expect(
                 ReasoningParser.fromCapabilityName(name) != nil,
                 "\(name) should resolve to a parser")


### PR DESCRIPTION
## Summary
- keep disk/prefix cache scope stable across `tool_choice` shape changes while preserving semantic salt keys like reasoning and media policy
- honor Laguna bundle metadata default thinking in fallback template handling
- add focused coverage for cache salt and Laguna omitted-thinking defaults

## Evidence
- `git diff --check` passed locally on `/private/tmp/vmlx-swift-ssd-tool-salt-20260722-000559`
- local `swift test` is currently blocked before focused tests by unrelated package-wide `XCTest`/`Testing` module import failures in existing test targets; not counted as passing
- Osaurus Release UI proof at pinned `3d5aa12be1ad4a7e1492e062e6d136a4f31c7dfb` showed SSD partial restore for Gemma 4 MXFP8, Bonsai 27B Ternary JANG, Ornith 1.0 9B JANG_4M, and Laguna S 2.1 JANG_2L with paged RAM cache Off and Disk Cache On
- Laguna prompt dumps showed Thinking On rendered `<assistant><think>`; the model immediately emitted `</think>` and placed text on the visible rail, so no forced parser workaround is included
