### PR TITLE
Recover schema-bound Qwen string-array tool arguments

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -1224,7 +1224,8 @@ private struct LLMUserInputProcessor: UserInputProcessor {
                 messages: messages,
                 tools: input.tools,
                 additionalContext: additionalContext,
-                promptTokens: promptTokens)
+                promptTokens: promptTokens,
+                staticSystemPrefix: input.cacheStableSystemPrefix)
 
             return LMInput(
                 tokens: MLXArray(promptTokens),

--- a/Libraries/MLXLMCommon/ReasoningParser.swift
+++ b/Libraries/MLXLMCommon/ReasoningParser.swift
@@ -236,7 +236,8 @@ public struct ReasoningParser: Sendable {
         let gptMessage = "<|message|>"
         let gptStartControl = "<|start|>"
         let gptEndTags = ["<|end|>", "<|return|>"]
-        let openerTags = [gemmaStart, gptStart]
+        let gemmaStartTags = [gemmaStart] + startTagAliases
+        let openerTags = gemmaStartTags + [gptStart]
         let holdTags = openerTags + [gptMessage, gptStartControl, endTag] + gptEndTags
 
         var out: [ReasoningSegment] = []
@@ -352,7 +353,7 @@ public struct ReasoningParser: Sendable {
             insideHarmonyChannel = true
             harmonyChannelIsReasoning = true
             harmonyChannelEndTags = [endTag]
-            harmonyChannelShouldStripName = true
+            harmonyChannelShouldStripName = tag == gemmaStart
             harmonyChannelNameBuffer.removeAll(keepingCapacity: false)
             insideReasoning = true
         }
@@ -714,7 +715,16 @@ extension ReasoningParser {
         let normalized = normalizedReasoningAlias(n)
         let compact = compactReasoningAlias(n)
 
-        if compact.hasPrefix("gemma4") || compact.hasPrefix("gptoss") {
+        if compact.hasPrefix("gemma4") {
+            return ReasoningParser(
+                startTag: "<|channel>",
+                endTag: "<channel|>",
+                startInReasoning: false,
+                stripStrayTags: false,
+                startTagAliases: ["\u{2B55}thought\n"])
+        }
+
+        if compact.hasPrefix("gptoss") {
             return ReasoningParser(
                 startTag: "<|channel>",
                 endTag: "<channel|>",
@@ -829,7 +839,8 @@ extension ReasoningParser {
                 // content per the legacy A2/A3 contract. The bare
                 // `<channel|>` close marker is rare enough mid-content
                 // that we don't want to silently strip it.
-                stripStrayTags: false)
+                stripStrayTags: false,
+                startTagAliases: ["\u{2B55}thought\n"])
         case "none", "off", "disabled", "mistral", "gemma":
             return nil
         default:

--- a/Libraries/MLXLMCommon/Tokenizer.swift
+++ b/Libraries/MLXLMCommon/Tokenizer.swift
@@ -64,7 +64,8 @@ public func canonicalChatCacheBoundaries(
     messages: [[String: any Sendable]],
     tools: [[String: any Sendable]]?,
     additionalContext: [String: any Sendable]?,
-    promptTokens: [Int]
+    promptTokens: [Int],
+    staticSystemPrefix: String? = nil
 ) -> CanonicalChatCacheBoundaries {
     guard let controllable = tokenizer as? any GenerationPromptControllableTokenizer else {
         return CanonicalChatCacheBoundaries(all: [], stable: [])
@@ -135,6 +136,69 @@ public func canonicalChatCacheBoundaries(
         return boundary
     }
 
+    /// Osaurus composes the reusable static prompt prefix and the mutable
+    /// database/sandbox state as separate manifest sections, then renders them
+    /// into one system message for model compatibility. A changed dynamic
+    /// section therefore invalidates the tokenizer-derived "whole system"
+    /// boundary even though the leading static bytes are still reusable.
+    ///
+    /// Derive that earlier boundary with the same LCP proof used for required
+    /// user templates: replace the current system message with the static
+    /// prefix plus two divergent tails, then keep only token positions shared
+    /// by both probes and the real prompt. This makes the boundary independent
+    /// of the mutable suffix and of BPE merges across the split point.
+    func hintedStaticSystemBoundary(_ staticPrefix: String?) -> Int? {
+        guard let staticPrefix,
+              !staticPrefix.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              let systemIndex = messages.firstIndex(where: { message in
+                  guard let role = message["role"] as? String else { return false }
+                  return role == "system" || role == "developer"
+              }),
+              let originalContent = messages[systemIndex]["content"] as? String,
+              originalContent.hasPrefix(staticPrefix)
+        else {
+            return nil
+        }
+
+        func renderProbe(_ tail: String) -> [Int]? {
+            var probeMessages = Array(messages.prefix(systemIndex + 1))
+            var systemMessage = probeMessages[systemIndex]
+            systemMessage["content"] = staticPrefix + tail
+            probeMessages[systemIndex] = systemMessage
+            return try? controllable.applyChatTemplate(
+                messages: probeMessages,
+                tools: tools,
+                additionalContext: additionalContext,
+                addGenerationPrompt: false)
+        }
+
+        guard let probeA = renderProbe("\n0"),
+              let probeB = renderProbe("\nz"),
+              !probeA.isEmpty,
+              !probeB.isEmpty
+        else {
+            return nil
+        }
+
+        let limit = min(probeA.count, probeB.count, promptTokens.count)
+        var boundary = 0
+        while boundary < limit,
+              probeA[boundary] == probeB[boundary],
+              probeA[boundary] == promptTokens[boundary]
+        {
+            boundary += 1
+        }
+
+        guard boundary > 0,
+              boundary < probeA.count,
+              boundary < probeB.count,
+              boundary < promptTokens.count
+        else {
+            return nil
+        }
+        return boundary
+    }
+
     // Only the leading instruction rail is stable across unrelated chats.
     // Tool schemas remain present because they are a separate template input;
     // this also permits a tool-only stable prefix when a template emits one for
@@ -148,7 +212,12 @@ public func canonicalChatCacheBoundaries(
         ? exactPrefixBoundary(messages: stableMessages)
             ?? probeDerivedStableBoundary(messages: stableMessages)
         : nil
-    let stable = stableBoundary.map { [$0] } ?? []
+    let stable = Array(
+        Set(
+            [stableBoundary, hintedStaticSystemBoundary(staticSystemPrefix)]
+                .compactMap { $0 }
+        )
+    ).sorted()
     let history = exactPrefixBoundary(messages: messages).map { [$0] } ?? []
     let all = Array(Set(stable + history)).sorted()
     if ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1" {

--- a/Libraries/MLXLMCommon/Tool/Parsers/ParserUtilities.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/ParserUtilities.swift
@@ -56,16 +56,28 @@ func isStringType(funcName: String, argName: String, tools: [[String: any Sendab
 func getParameterType(
     funcName: String, paramName: String, tools: [[String: any Sendable]]?
 ) -> String? {
+    getParameterSchema(funcName: funcName, paramName: paramName, tools: tools)?["type"] as? String
+}
+
+/// Get the full parameter schema for a specific function argument.
+///
+/// Collection conversion needs more than the top-level `type`: an unquoted
+/// bracket list is only safe to recover when the schema explicitly declares
+/// an array whose ITEMS are strings. Keeping that check here prevents the XML
+/// parser from applying a string-list heuristic to object arrays or ordinary
+/// string parameters.
+func getParameterSchema(
+    funcName: String, paramName: String, tools: [[String: any Sendable]]?
+) -> [String: any Sendable]? {
     guard let tools else { return nil }
     for tool in tools {
         guard let function = tool["function"] as? [String: any Sendable],
             function["name"] as? String == funcName,
             let parameters = function["parameters"] as? [String: any Sendable],
             let properties = parameters["properties"] as? [String: any Sendable],
-            let param = properties[paramName] as? [String: any Sendable],
-            let type = param["type"] as? String
+            let param = properties[paramName] as? [String: any Sendable]
         else { continue }
-        return type
+        return param
     }
     return nil
 }
@@ -233,14 +245,67 @@ func convertParameterValue(
             value.lowercased().trimmingCharacters(in: .whitespaces))
     }
 
-    // Object/Array types - JSON decode
+    // Object/Array types - JSON decode.
     if ["object", "array"].contains(type) || type.hasPrefix("dict") || type.hasPrefix("list") {
         if let json = tryParseJSON(value) {
             return json
         }
+        // Qwen XML tool calls occasionally render a schema-declared string
+        // array as an unquoted bracket list:
+        //
+        //   <parameter=ids>[skill/One, skill/Two]</parameter>
+        //
+        // That is neither valid JSON nor a scalar value. Recover only the
+        // unambiguous shape: the parameter must be an ARRAY, its item schema
+        // must be STRING, the outer brackets must be present, and every
+        // comma-delimited member must be a non-empty plain scalar. Object
+        // arrays, nested arrays, and arbitrary bare strings remain untouched
+        // and reach the normal schema error path.
+        if type == "array",
+            let schema = getParameterSchema(
+                funcName: funcName,
+                paramName: paramName,
+                tools: tools
+            ),
+            let recovered = parseUnquotedStringArray(value, schema: schema)
+        {
+            return recovered
+        }
     }
 
     return value
+}
+
+/// Parse the exact plain `[alpha, beta]` fallback shape for `array<string>`.
+private func parseUnquotedStringArray(
+    _ value: String,
+    schema: [String: any Sendable]
+) -> [String]? {
+    guard schema["type"] as? String == "array",
+        let items = schema["items"] as? [String: any Sendable],
+        items["type"] as? String == "string"
+    else { return nil }
+
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard trimmed.count >= 2, trimmed.first == "[", trimmed.last == "]" else {
+        return nil
+    }
+    let body = trimmed.dropFirst().dropLast()
+    guard !body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        return []
+    }
+
+    let forbidden = CharacterSet(charactersIn: "[]{}<>\"'")
+        .union(.controlCharacters)
+    var result: [String] = []
+    for rawMember in body.split(separator: ",", omittingEmptySubsequences: false) {
+        let member = rawMember.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !member.isEmpty,
+            member.rangeOfCharacter(from: forbidden) == nil
+        else { return nil }
+        result.append(member)
+    }
+    return result
 }
 
 private func unescapeJSONStringScalar(_ value: String) -> String {

--- a/Libraries/MLXLMCommon/UserInput.swift
+++ b/Libraries/MLXLMCommon/UserInput.swift
@@ -209,6 +209,12 @@ public struct UserInput {
 
     /// Additional values provided for the chat template rendering context
     public var additionalContext: [String: any Sendable]?
+
+    /// Runtime-only cache hint for a byte-stable leading system-prompt
+    /// segment. This is deliberately separate from ``additionalContext`` so it
+    /// is never exposed to chat templates or model-visible prompt text.
+    public var cacheStableSystemPrefix: String?
+
     public var processing: Processing = .init()
 
     /// Initialize the `UserInput` with a single text prompt.
@@ -226,13 +232,15 @@ public struct UserInput {
         prompt: String, images: [Image] = [Image](), videos: [Video] = [Video](),
         audios: [Audio] = [Audio](),
         tools: [ToolSpec]? = nil,
-        additionalContext: [String: any Sendable]? = nil
+        additionalContext: [String: any Sendable]? = nil,
+        cacheStableSystemPrefix: String? = nil
     ) {
         self.prompt = .chat([
             .user(prompt, images: images, videos: videos, audios: audios)
         ])
         self.tools = tools
         self.additionalContext = additionalContext
+        self.cacheStableSystemPrefix = cacheStableSystemPrefix
         // Swift init semantics: `didSet` on `prompt` does not fire during
         // initialisation, so the top-level `images` / `videos` properties
         // would otherwise stay empty even though the chat messages carry
@@ -282,7 +290,8 @@ public struct UserInput {
         messages: [Message], images: [Image] = [Image](), videos: [Video] = [Video](),
         audios: [Audio] = [Audio](),
         tools: [ToolSpec]? = nil,
-        additionalContext: [String: any Sendable]? = nil
+        additionalContext: [String: any Sendable]? = nil,
+        cacheStableSystemPrefix: String? = nil
     ) {
         self.prompt = .messages(messages)
         self.images = images
@@ -290,6 +299,7 @@ public struct UserInput {
         self.audios = audios
         self.tools = tools
         self.additionalContext = additionalContext
+        self.cacheStableSystemPrefix = cacheStableSystemPrefix
     }
 
     /// Initialize the `UserInput` with a model agnostic structured context.
@@ -319,7 +329,8 @@ public struct UserInput {
         chat: [Chat.Message],
         processing: Processing = .init(),
         tools: [ToolSpec]? = nil,
-        additionalContext: [String: any Sendable]? = nil
+        additionalContext: [String: any Sendable]? = nil,
+        cacheStableSystemPrefix: String? = nil
     ) {
         self.prompt = .chat(chat)
 
@@ -337,6 +348,7 @@ public struct UserInput {
         self.processing = processing
         self.tools = tools
         self.additionalContext = additionalContext
+        self.cacheStableSystemPrefix = cacheStableSystemPrefix
     }
 
     /// Initialize the `UserInput` with a preconfigured ``Prompt-swift.enum``.
@@ -360,7 +372,8 @@ public struct UserInput {
         videos: [Video] = [Video](),
         audios: [Audio] = [Audio](),
         processing: Processing = .init(),
-        tools: [ToolSpec]? = nil, additionalContext: [String: any Sendable]? = nil
+        tools: [ToolSpec]? = nil, additionalContext: [String: any Sendable]? = nil,
+        cacheStableSystemPrefix: String? = nil
     ) {
         self.prompt = prompt
         switch prompt {
@@ -382,6 +395,7 @@ public struct UserInput {
         self.processing = processing
         self.tools = tools
         self.additionalContext = additionalContext
+        self.cacheStableSystemPrefix = cacheStableSystemPrefix
     }
 }
 

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -1556,7 +1556,8 @@ public struct Gemma4Processor: UserInputProcessor {
                 messages: messages,
                 tools: chatTemplateTools,
                 additionalContext: input.additionalContext,
-                promptTokens: tokens)
+                promptTokens: tokens,
+                staticSystemPrefix: input.cacheStableSystemPrefix)
             : CanonicalChatCacheBoundaries(all: [], stable: [])
 
         var processedImage: LMInput.ProcessedImage?

--- a/Libraries/MLXVLM/Models/Qwen3VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen3VL.swift
@@ -146,7 +146,8 @@ public struct Qwen3VLProcessor: UserInputProcessor {
                 messages: messages,
                 tools: input.tools,
                 additionalContext: input.additionalContext,
-                promptTokens: promptTokens)
+                promptTokens: promptTokens,
+                staticSystemPrefix: input.cacheStableSystemPrefix)
             return LMInput(
                 text: .init(tokens: promptArray, mask: mask, tokenIds: promptTokens),
                 cacheScopeSalt: cacheScopeSalt(from: input.additionalContext),

--- a/Tests/MLXLMCommonFocusedTests/CanonicalChatCacheBoundariesTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/CanonicalChatCacheBoundariesTests.swift
@@ -70,6 +70,69 @@ struct CanonicalChatCacheBoundariesTests {
         }
     }
 
+    private struct ContentBoundaryTokenizer: GenerationPromptControllableTokenizer {
+        var bosToken: String? { nil }
+        var eosToken: String? { nil }
+        var unknownToken: String? { nil }
+
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+        func convertTokenToId(_ token: String) -> Int? { nil }
+        func convertIdToToken(_ id: Int) -> String? { nil }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] {
+            try applyChatTemplate(
+                messages: messages,
+                tools: tools,
+                additionalContext: additionalContext,
+                addGenerationPrompt: true)
+        }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?,
+            addGenerationPrompt: Bool
+        ) throws -> [Int] {
+            var result = [1]
+            for message in messages {
+                switch message["role"] as? String {
+                case "system":
+                    result.append(10)
+                    result.append(contentsOf: contentTokens(message))
+                case "developer":
+                    result.append(11)
+                    result.append(contentsOf: contentTokens(message))
+                case "user":
+                    result.append(30)
+                    result.append(contentsOf: contentTokens(message))
+                case "assistant":
+                    result.append(40)
+                    result.append(contentsOf: contentTokens(message))
+                default:
+                    result.append(50)
+                    result.append(contentsOf: contentTokens(message))
+                }
+            }
+            if tools?.isEmpty == false {
+                result.append(20)
+            }
+            if addGenerationPrompt {
+                result.append(99)
+            }
+            return result
+        }
+
+        private func contentTokens(_ message: [String: any Sendable]) -> [Int] {
+            let content = message["content"] as? String ?? ""
+            return content.unicodeScalars.map { 1_000 + Int($0.value) }
+        }
+    }
+
     private let tools: [[String: any Sendable]] = [["type": "function"]]
 
     /// Minimal Qwen 3.5-shaped tokenizer: system/tool-only renders are
@@ -232,6 +295,38 @@ struct CanonicalChatCacheBoundariesTests {
         #expect(boundaries.all == [4, 6])
         #expect(Array(prompt.prefix(try #require(boundaries.stable.first)))
             == [1, 10, 20, 30])
+    }
+
+    @Test("static system hint preserves an earlier reusable boundary inside a mutable system message")
+    func staticSystemHintAddsEarlierBoundaryInsideMutableSystemMessage() throws {
+        let tokenizer = ContentBoundaryTokenizer()
+        let staticPrefix = "STATIC PROMPT"
+        let messages: [[String: any Sendable]] = [
+            ["role": "system", "content": staticPrefix + "\nmutable-db-schema-v1"],
+            ["role": "user", "content": "create the next table"],
+        ]
+        let prompt = try tokenizer.applyChatTemplate(
+            messages: messages, tools: tools, additionalContext: nil)
+        let withoutHint = canonicalChatCacheBoundaries(
+            tokenizer: tokenizer,
+            messages: messages,
+            tools: tools,
+            additionalContext: nil,
+            promptTokens: prompt)
+        let withHint = canonicalChatCacheBoundaries(
+            tokenizer: tokenizer,
+            messages: messages,
+            tools: tools,
+            additionalContext: nil,
+            promptTokens: prompt,
+            staticSystemPrefix: staticPrefix)
+
+        let hintedBoundary = try #require(withHint.stable.first)
+        let fullSystemBoundary = try #require(withoutHint.stable.first)
+        #expect(hintedBoundary < fullSystemBoundary)
+        #expect(withHint.stable.contains(fullSystemBoundary))
+        #expect(withHint.all.contains(hintedBoundary))
+        #expect(Array(prompt.prefix(hintedBoundary)).last == 1_010)
     }
 
     @Test("template configuration changes produce a different stable token prefix")

--- a/Tests/MLXLMCommonFocusedTests/NoHiddenReasoningCloseBiasFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NoHiddenReasoningCloseBiasFocusedTests.swift
@@ -531,6 +531,23 @@ struct HarmonyParserFocusedTests {
         #expect(!visible.contains("<|tool_call>"))
     }
 
+    @Test("Gemma4 decoded thought-channel opener routes to reasoning")
+    func gemma4DecodedThoughtChannelOpenerRoutesToReasoning() {
+        var parser = ReasoningParser.fromCapabilityName("gemma4")
+        let stream = "pre\u{2B55}thought\nhidden<channel|>answer"
+        var segments: [ReasoningSegment] = []
+        for chunk in chunked(stream, by: 3) {
+            segments.append(contentsOf: parser?.feed(chunk) ?? [])
+        }
+        segments.append(contentsOf: parser?.flush() ?? [])
+
+        let (reasoning, content) = collect(segments)
+        #expect(reasoning == "hidden")
+        #expect(content == "preanswer")
+        #expect(!content.contains("\u{2B55}thought"))
+        #expect(!content.contains("<channel|>"))
+    }
+
     @Test("BatchEngine tool-call live probe supplies tools and rejects empty rows")
     func batchEngineToolCallProbeRequiresBehavioralEvidence() throws {
         let bench = try String(contentsOfFile: "RunBench/Bench.swift", encoding: .utf8)
@@ -556,13 +573,14 @@ struct HarmonyParserFocusedTests {
         #expect(function.body.contains("Tool schema was supplied, but the generation produced no structured .toolCall event."))
     }
 
-    @Test("Gemma4 VLM processor preserves tools into LMInput schemas")
-    func gemma4VLMProcessorPreservesToolsIntoLMInputSchemas() throws {
+    @Test("Gemma4 VLM processor renders normalized tools and preserves raw schemas")
+    func gemma4VLMProcessorRendersNormalizedToolsAndPreservesRawSchemas() throws {
         let source = try String(
             contentsOfFile: "Libraries/MLXVLM/Models/Gemma4.swift",
             encoding: .utf8)
 
-        #expect(source.contains("tools: input.tools"))
+        #expect(source.contains("normalizedToolsForChatTemplate(input.tools)"))
+        #expect(source.contains("tools: chatTemplateTools"))
         #expect(source.contains("toolSchemas: input.tools"))
     }
 

--- a/Tests/MLXLMTests/ToolTests.swift
+++ b/Tests/MLXLMTests/ToolTests.swift
@@ -634,6 +634,105 @@ struct ToolTests {
         #expect(toolCall.function.arguments["enabled"] == .bool(true))
     }
 
+    @Test("XML Function Parser recovers schema-bound unquoted string array")
+    func testXMLFunctionParserUnquotedStringArrayRecovery() throws {
+        let parser = XMLFunctionParser(startTag: "<tool_call>", endTag: "</tool_call>")
+        let tools: [[String: any Sendable]] = [
+            [
+                "function": [
+                    "name": "capabilities_load",
+                    "parameters": [
+                        "type": "object",
+                        "properties": [
+                            "ids": [
+                                "type": "array",
+                                "items": ["type": "string"] as [String: any Sendable],
+                            ] as [String: any Sendable]
+                        ] as [String: any Sendable],
+                        "required": ["ids"],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable]
+            ]
+        ]
+        let content = """
+            <tool_call>
+            <function=capabilities_load>
+            <parameter=ids>
+            [skill/Autonomous Scheduler, skill/Data Keeper]
+            </parameter>
+            </function>
+            </tool_call>
+            """
+
+        let call = try #require(parser.parse(content: content, tools: tools))
+
+        #expect(call.function.name == "capabilities_load")
+        #expect(
+            call.function.arguments["ids"]
+                == .array([
+                    .string("skill/Autonomous Scheduler"),
+                    .string("skill/Data Keeper"),
+                ])
+        )
+    }
+
+    @Test("XML Function Parser does not apply string-array recovery to object arrays")
+    func testXMLFunctionParserUnquotedStringArrayRecoveryIsSchemaBound() throws {
+        let parser = XMLFunctionParser(startTag: "<tool_call>", endTag: "</tool_call>")
+        let tools: [[String: any Sendable]] = [
+            [
+                "function": [
+                    "name": "store_rows",
+                    "parameters": [
+                        "type": "object",
+                        "properties": [
+                            "rows": [
+                                "type": "array",
+                                "items": ["type": "object"] as [String: any Sendable],
+                            ] as [String: any Sendable]
+                        ] as [String: any Sendable],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable]
+            ]
+        ]
+        let content =
+            "<function=store_rows><parameter=rows>[first, second]</parameter></function>"
+
+        let call = try #require(parser.parse(content: content, tools: tools))
+
+        #expect(call.function.arguments["rows"] == .string("[first, second]"))
+    }
+
+    @Test("XML Function Parser rejects ambiguous nested unquoted string arrays")
+    func testXMLFunctionParserUnquotedStringArrayRecoveryRejectsNestedSyntax() throws {
+        let parser = XMLFunctionParser(startTag: "<tool_call>", endTag: "</tool_call>")
+        let tools: [[String: any Sendable]] = [
+            [
+                "function": [
+                    "name": "capabilities_load",
+                    "parameters": [
+                        "type": "object",
+                        "properties": [
+                            "ids": [
+                                "type": "array",
+                                "items": ["type": "string"] as [String: any Sendable],
+                            ] as [String: any Sendable]
+                        ] as [String: any Sendable],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable]
+            ]
+        ]
+        let content =
+            "<function=capabilities_load><parameter=ids>[[skill/One], skill/Two]</parameter></function>"
+
+        let call = try #require(parser.parse(content: content, tools: tools))
+
+        #expect(
+            call.function.arguments["ids"]
+                == .string("[[skill/One], skill/Two]")
+        )
+    }
+
     @Test("Test XML Function Parser - Multiline Content (Qwen3.5 style)")
     func testXMLFunctionParserMultiline() throws {
         let parser = XMLFunctionParser(startTag: "<tool_call>", endTag: "</tool_call>")

--- a/Tests/MLXLMTests/ToolTests.swift
+++ b/Tests/MLXLMTests/ToolTests.swift
@@ -3,6 +3,29 @@ import MLXLMCommon
 import Testing
 
 struct ToolTests {
+    private func stringArrayTools(
+        functionName: String = "capabilities_load",
+        parameterName: String = "ids"
+    ) -> [[String: any Sendable]] {
+        [
+            [
+                "function": [
+                    "name": functionName,
+                    "parameters": [
+                        "type": "object",
+                        "properties": [
+                            parameterName: [
+                                "type": "array",
+                                "items": ["type": "string"] as [String: any Sendable],
+                            ] as [String: any Sendable]
+                        ] as [String: any Sendable],
+                        "required": [parameterName],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable]
+            ]
+        ]
+    }
+
     private func lineCountTools() -> [ToolSpec] {
         [
             [
@@ -637,23 +660,7 @@ struct ToolTests {
     @Test("XML Function Parser recovers schema-bound unquoted string array")
     func testXMLFunctionParserUnquotedStringArrayRecovery() throws {
         let parser = XMLFunctionParser(startTag: "<tool_call>", endTag: "</tool_call>")
-        let tools: [[String: any Sendable]] = [
-            [
-                "function": [
-                    "name": "capabilities_load",
-                    "parameters": [
-                        "type": "object",
-                        "properties": [
-                            "ids": [
-                                "type": "array",
-                                "items": ["type": "string"] as [String: any Sendable],
-                            ] as [String: any Sendable]
-                        ] as [String: any Sendable],
-                        "required": ["ids"],
-                    ] as [String: any Sendable],
-                ] as [String: any Sendable]
-            ]
-        ]
+        let tools = stringArrayTools()
         let content = """
             <tool_call>
             <function=capabilities_load>
@@ -672,6 +679,25 @@ struct ToolTests {
                 == .array([
                     .string("skill/Autonomous Scheduler"),
                     .string("skill/Data Keeper"),
+                ])
+        )
+    }
+
+    @Test("XML Function Parser keeps valid JSON string arrays on the normal path")
+    func testXMLFunctionParserValidJSONStringArrayUnchanged() throws {
+        let parser = XMLFunctionParser(startTag: "<tool_call>", endTag: "</tool_call>")
+        let content =
+            #"<function=capabilities_load><parameter=ids>["skill/One","skill/Two"]</parameter></function>"#
+
+        let call = try #require(
+            parser.parse(content: content, tools: stringArrayTools())
+        )
+
+        #expect(
+            call.function.arguments["ids"]
+                == .array([
+                    .string("skill/One"),
+                    .string("skill/Two"),
                 ])
         )
     }
@@ -706,22 +732,7 @@ struct ToolTests {
     @Test("XML Function Parser rejects ambiguous nested unquoted string arrays")
     func testXMLFunctionParserUnquotedStringArrayRecoveryRejectsNestedSyntax() throws {
         let parser = XMLFunctionParser(startTag: "<tool_call>", endTag: "</tool_call>")
-        let tools: [[String: any Sendable]] = [
-            [
-                "function": [
-                    "name": "capabilities_load",
-                    "parameters": [
-                        "type": "object",
-                        "properties": [
-                            "ids": [
-                                "type": "array",
-                                "items": ["type": "string"] as [String: any Sendable],
-                            ] as [String: any Sendable]
-                        ] as [String: any Sendable],
-                    ] as [String: any Sendable],
-                ] as [String: any Sendable]
-            ]
-        ]
+        let tools = stringArrayTools()
         let content =
             "<function=capabilities_load><parameter=ids>[[skill/One], skill/Two]</parameter></function>"
 
@@ -730,6 +741,33 @@ struct ToolTests {
         #expect(
             call.function.arguments["ids"]
                 == .string("[[skill/One], skill/Two]")
+        )
+    }
+
+    @Test("Qwen XML streaming recovers split schema-bound string array")
+    func testQwenXMLStreamingUnquotedStringArrayRecovery() throws {
+        let processor = ToolCallProcessor(
+            format: .xmlFunction,
+            tools: stringArrayTools()
+        )
+        let chunks = [
+            "<tool", "_call>\n<function=capabilities_load>\n<parameter=ids>\n[skill/",
+            "Autonomous Scheduler, skill/Data ",
+            "Keeper]\n</parameter>\n</function>\n</tool_call>",
+        ]
+
+        for chunk in chunks {
+            _ = processor.processChunk(chunk)
+        }
+
+        let call = try #require(processor.toolCalls.first)
+        #expect(processor.toolCalls.count == 1)
+        #expect(
+            call.function.arguments["ids"]
+                == .array([
+                    .string("skill/Autonomous Scheduler"),
+                    .string("skill/Data Keeper"),
+                ])
         )
     }
 


### PR DESCRIPTION
## Problem

Bonsai/Qwen XML tool output can emit a schema-declared `array<string>` as an unquoted bracket list, for example `[skill/Autonomous Scheduler, skill/Data Keeper]`. The parser left that value as a scalar string, so Osaurus rejected `capabilities_load.ids` before execution.

The same emergency lane exposed two adjacent engine issues: split XML tool-call deltas needed the same schema-bound array recovery, Gemma decoded thought-channel openers needed to route into reasoning deltas, and Osaurus mutable DB/tool state could invalidate the full rendered system-message cache boundary even when the leading static system prefix was byte-identical and safe to reuse.

## Change

- retain the full parameter schema during XML conversion
- recover only an outer-bracketed, comma-delimited plain list when the declared schema is exactly `array<string>`
- leave object arrays, nested collection syntax, quotes, control characters, and ordinary strings on the existing validation path
- cover split Qwen XML array deltas
- route Gemma decoded thought-channel openers into reasoning
- add `UserInput.cacheStableSystemPrefix` and tokenizer-probed static-prefix boundaries for LLM, Gemma 4, and Qwen3VL processors

## Evidence

Source/local tests:
- `MLXLMTests.ToolTests/testXMLFunctionParser*`: 11 passed for the original array parser fix, including exact Bonsai arguments and negative controls
- `/tmp/vmlx-static-prefix-boundary-tests-20260723.log`: `CanonicalChatCacheBoundariesTests`, including `staticSystemHintAddsEarlierBoundaryInsideMutableSystemMessage`

Downstream Osaurus proof at this head (`91933aef193cab180b821bad1f4b4cc8ad753107`):
- focused source/pin test: `/tmp/osaurus-static-prefix-source-tests-91933aef-rerun-20260723.log`
- focused DB/tool-loop tests: `/tmp/osaurus-db-toolloop-static-prefix-91933aef-20260723.log`
- focused TurboQuant policy tests: `/tmp/osaurus-tq-default-policy-tests-91933aef-20260723.log`
- Release UI proof app: `com.dinoki.osaurus.staticprefixproof20260723`, executable SHA-256 `f110b825de75dfae41e288a6215080e5f1e3ba468f1f25ea1203434e8fc6d9ce`
- live Settings/Live Activity showed paged RAM KV Off, SSD cache On, `liveKVCodec=engine_selected`, `storedKVCodec=auto`, `TurboQuant compressions 0`
- live Gemma 4 12B MXFP8 and Bonsai 27B Ternary JANG CRACK fresh-chat rows both completed, unlocked input, and logged SSD disk restores; Bonsai showed hybrid/SSM restores with `ssm=96`

## Scope boundary

This PR does not claim all model families, AppleScript, Laguna, Qwen VL media, or full DB-tool dynamic-suffix workflows are verified. Those rows remain tracked in the downstream Osaurus gate doc.
