### PR TITLE
Fix nested LFM/DSML tool arguments and quantized LFM loads

### DIFF
--- a/Libraries/MLXLLM/Models/LFM2MoE.swift
+++ b/Libraries/MLXLLM/Models/LFM2MoE.swift
@@ -450,10 +450,15 @@ public class LFM2MoEModel: Module, LLMModel, KVCacheDimensionProvider {
                 }
             }
 
+            // Older LFM checkpoints use w1/w2/w3 module names. Rename the
+            // module path, not only `.weight`: quantized checkpoints carry
+            // sibling `.scales` and `.biases` tensors that must follow the
+            // same destination module or Module.update reports stale
+            // w1/w2/w3 children as unhandled.
             let replacements = [
-                "w1.weight": "gate_proj.weight",
-                "w2.weight": "down_proj.weight",
-                "w3.weight": "up_proj.weight",
+                ".w1.": ".gate_proj.",
+                ".w2.": ".down_proj.",
+                ".w3.": ".up_proj.",
             ]
             var updatedName = name
             for (old, new) in replacements where updatedName.contains(old) {
@@ -472,12 +477,18 @@ public class LFM2MoEModel: Module, LLMModel, KVCacheDimensionProvider {
             }
 
             for name in ["gate_proj", "down_proj", "up_proj"] {
-                let key = "\(expertPrefix).0.\(name).weight"
-                guard sanitized[key] != nil else { continue }
-                let stacked = (0 ..< configuration.numExperts).map { expert -> MLXArray in
-                    sanitized.removeValue(forKey: "\(expertPrefix).\(expert).\(name).weight")!
+                for leaf in ["weight", "scales", "biases"] {
+                    let keys = (0 ..< configuration.numExperts).map {
+                        "\(expertPrefix).\($0).\(name).\(leaf)"
+                    }
+                    guard keys.allSatisfy({ sanitized[$0] != nil }) else {
+                        continue
+                    }
+                    let stacked = keys.map { sanitized.removeValue(forKey: $0)! }
+                    sanitized[
+                        "\(prefix).feed_forward.switch_mlp.\(name).\(leaf)"
+                    ] = MLX.stacked(stacked)
                 }
-                sanitized["\(prefix).feed_forward.switch_mlp.\(name).weight"] = MLX.stacked(stacked)
             }
         }
 

--- a/Libraries/MLXLMCommon/Tool/Parsers/DSMLToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/DSMLToolCallParser.swift
@@ -109,8 +109,7 @@ public struct DSMLToolCallParser: ToolCallParser, Sendable {
         return parseInlineJSONToolFallback(in: text, tools: tools)
     }
 
-    public func parseEOS(_ toolCallBuffer: String, tools: [[String: any Sendable]]?) -> [ToolCall]
-    {
+    public func parseEOS(_ toolCallBuffer: String, tools: [[String: any Sendable]]?) -> [ToolCall] {
         // DSML can carry multiple invokes within a single
         // <｜DSML｜tool_calls> block, so the default `components(by:
         // startTag)` strategy won't round-trip — each multi-invoke
@@ -211,7 +210,8 @@ public struct DSMLToolCallParser: ToolCallParser, Sendable {
                 break
             }
             let paramConfig = parameterSchema(for: funcName, tools: tools)
-            let args = parseParameters(in: body, schema: paramConfig, allowPartialEOF: allowPartialEOF)
+            let args = parseParameters(
+                in: body, schema: paramConfig, allowPartialEOF: allowPartialEOF)
             results.append(
                 ToolCall(function: .init(name: funcName, arguments: args)))
             cursor = nextCursor
@@ -243,8 +243,7 @@ public struct DSMLToolCallParser: ToolCallParser, Sendable {
     private func removingCompletedTags(withPrefix prefix: String, from content: String) -> String {
         var text = content
         var searchStart = text.startIndex
-        while
-            let prefixRange = text.range(of: prefix, range: searchStart ..< text.endIndex),
+        while let prefixRange = text.range(of: prefix, range: searchStart ..< text.endIndex),
             let close = text[prefixRange.upperBound...].firstIndex(of: ">")
         {
             let removalEnd = text.index(after: close)
@@ -341,7 +340,8 @@ public struct DSMLToolCallParser: ToolCallParser, Sendable {
         range: Range<String.Index>
     ) -> String.Index {
         let markers = ["</", Self.dsmlPrefix, Self.dsmlPrefixClose]
-        return markers
+        return
+            markers
             .compactMap { body.range(of: $0, range: range)?.lowerBound }
             .min() ?? range.upperBound
     }
@@ -499,7 +499,8 @@ public struct DSMLToolCallParser: ToolCallParser, Sendable {
             }
         }
         if let functionRange = text.range(of: #""function""#),
-            let value = firstJSONStringValue(for: "name", in: String(text[functionRange.upperBound...]))
+            let value = firstJSONStringValue(
+                for: "name", in: String(text[functionRange.upperBound...]))
         {
             return value
         }
@@ -507,7 +508,8 @@ public struct DSMLToolCallParser: ToolCallParser, Sendable {
     }
 
     private func firstJSONStringValue(for key: String, in text: String) -> String? {
-        let pattern = #""# + NSRegularExpression.escapedPattern(for: key)
+        let pattern =
+            #""# + NSRegularExpression.escapedPattern(for: key)
             + #""\s*:\s*"((?:[^"\\]|\\.)*)""#
         guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
         let range = NSRange(text.startIndex ..< text.endIndex, in: text)
@@ -534,7 +536,12 @@ public struct DSMLToolCallParser: ToolCallParser, Sendable {
             let candidate = firstPythonStyleToolCallCandidate(in: text, tools: tools)
         else { return nil }
 
-        let args = normalizePythonStyleArguments(candidate.arguments)
+        guard
+            let args = normalizePythonStyleArguments(
+                candidate.arguments,
+                funcName: candidate.name,
+                tools: tools)
+        else { return nil }
         if let tools, !tools.isEmpty {
             guard let spec = functionSpec(named: candidate.name, in: tools) else { return nil }
             if let invalidArgs = inlineSchemaValidationFailure(
@@ -564,11 +571,14 @@ public struct DSMLToolCallParser: ToolCallParser, Sendable {
     ) -> ToolCall? {
         guard
             let invokeStart = text.range(of: "<invoke>"),
-            let invokeEnd = text.range(of: "</invoke>", range: invokeStart.upperBound ..< text.endIndex)
+            let invokeEnd = text.range(
+                of: "</invoke>", range: invokeStart.upperBound ..< text.endIndex)
         else { return nil }
 
         let body = String(text[invokeStart.upperBound ..< invokeEnd.lowerBound])
-        guard let name = firstXMLBody(in: body, tags: [("target_name", "target"), ("target", "target")]),
+        guard
+            let name = firstXMLBody(
+                in: body, tags: [("target_name", "target"), ("target", "target")]),
             !name.isEmpty
         else { return nil }
 
@@ -622,16 +632,17 @@ public struct DSMLToolCallParser: ToolCallParser, Sendable {
                     offsetBy: name.count,
                     limitedBy: trimmed.endIndex)
             else { continue }
-            guard afterName == trimmed.endIndex
-                || isInlineFallbackWhitespace(trimmed[afterName])
-                || trimmed[afterName] == "{"
-                || trimmed[afterName] == ":"
+            guard
+                afterName == trimmed.endIndex
+                    || isInlineFallbackWhitespace(trimmed[afterName])
+                    || trimmed[afterName] == "{"
+                    || trimmed[afterName] == ":"
             else { continue }
 
             let cursor = bareNameJSONTailObjectStart(in: trimmed, afterName: afterName)
             guard cursor < trimmed.endIndex, trimmed[cursor] == "{" else { continue }
             guard let jsonObject = firstBalancedJSONObject(in: trimmed[cursor...]) else {
-                if (allowMalformedEOF || jsonBracesBalanced(String(trimmed[cursor...]))),
+                if allowMalformedEOF || jsonBracesBalanced(String(trimmed[cursor...])),
                     let tools, !tools.isEmpty,
                     functionSpec(named: name, in: tools) != nil
                 {
@@ -690,7 +701,9 @@ public struct DSMLToolCallParser: ToolCallParser, Sendable {
         return sawOpen && depth == 0
     }
 
-    private func parseJSONObjectAllowingLiteralInvalidEscapes(_ jsonObject: String) -> [String: Any]? {
+    private func parseJSONObjectAllowingLiteralInvalidEscapes(_ jsonObject: String) -> [String:
+        Any]?
+    {
         if let object = parseJSONObject(jsonObject) {
             return object
         }
@@ -960,7 +973,7 @@ public struct DSMLToolCallParser: ToolCallParser, Sendable {
         guard text[cursor...].hasPrefix("```") else { return cursor }
 
         var fenceCursor = cursor
-        for _ in 0..<3 {
+        for _ in 0 ..< 3 {
             guard fenceCursor < text.endIndex else { return cursor }
             fenceCursor = text.index(after: fenceCursor)
         }
@@ -976,7 +989,8 @@ public struct DSMLToolCallParser: ToolCallParser, Sendable {
         return fenceCursor
     }
 
-    private func consumeOptionalJSONLabel(in text: String, at cursor: String.Index) -> String.Index {
+    private func consumeOptionalJSONLabel(in text: String, at cursor: String.Index) -> String.Index
+    {
         guard cursor < text.endIndex, text[cursor] == ":" else { return cursor }
         var labelStart = text.index(after: cursor)
         while labelStart < text.endIndex, isInlineFallbackWhitespace(text[labelStart]) {
@@ -1053,10 +1067,11 @@ public struct DSMLToolCallParser: ToolCallParser, Sendable {
     }
 
     private func pythonStyleToolNames(from tools: [[String: any Sendable]]?) -> [String] {
-        let schemaNames = tools?.compactMap { tool -> String? in
-            let function = (tool["function"] as? [String: any Sendable]) ?? tool
-            return function["name"] as? String
-        } ?? []
+        let schemaNames =
+            tools?.compactMap { tool -> String? in
+                let function = (tool["function"] as? [String: any Sendable]) ?? tool
+                return function["name"] as? String
+            } ?? []
         if !schemaNames.isEmpty {
             return schemaNames.sorted { $0.count > $1.count }
         }
@@ -1134,7 +1149,7 @@ public struct DSMLToolCallParser: ToolCallParser, Sendable {
             } else if ch == "}" {
                 depth -= 1
                 if depth == 0 {
-                    return String(text[open...cursor])
+                    return String(text[open ... cursor])
                 }
                 if depth < 0 { return nil }
             }
@@ -1148,7 +1163,11 @@ public struct DSMLToolCallParser: ToolCallParser, Sendable {
         }
     }
 
-    private func normalizePythonStyleArguments(_ arguments: String) -> [String: any Sendable] {
+    private func normalizePythonStyleArguments(
+        _ arguments: String,
+        funcName: String,
+        tools: [[String: any Sendable]]?
+    ) -> [String: any Sendable]? {
         let trimmed = arguments.trimmingCharacters(in: .whitespacesAndNewlines)
         if let data = "{\(trimmed)}".data(using: .utf8),
             let object = try? JSONSerialization.jsonObject(with: data),
@@ -1156,31 +1175,10 @@ public struct DSMLToolCallParser: ToolCallParser, Sendable {
         {
             return normalized
         }
-        return normalizePythonKeywordArguments(trimmed)
-    }
-
-    private func normalizePythonKeywordArguments(_ arguments: String) -> [String: any Sendable] {
-        var result: [String: any Sendable] = [:]
-        let pattern = #"(\w+)\s*=\s*('(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|[^,\)]+)"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return result }
-        let range = NSRange(arguments.startIndex ..< arguments.endIndex, in: arguments)
-        for match in regex.matches(in: arguments, range: range) {
-            guard
-                let keyRange = Range(match.range(at: 1), in: arguments),
-                let valueRange = Range(match.range(at: 2), in: arguments)
-            else { continue }
-            let key = String(arguments[keyRange])
-            var value = String(arguments[valueRange]).trimmingCharacters(in: .whitespaces)
-            if (value.hasPrefix("'") && value.hasSuffix("'"))
-                || (value.hasPrefix("\"") && value.hasSuffix("\""))
-            {
-                value = String(value.dropFirst().dropLast())
-                result[key] = value
-            } else {
-                result[key] = decodeJSONValue(value, fallbackString: value)
-            }
-        }
-        return result
+        return PythonicToolCallParser().parseArguments(
+            trimmed,
+            funcName: funcName,
+            tools: tools)
     }
 
     private func fallbackToolName(in object: [String: Any], allowBareName: Bool) -> String? {
@@ -1236,7 +1234,8 @@ public struct DSMLToolCallParser: ToolCallParser, Sendable {
             let open = "<\(tag.open)>"
             let close = "</\(tag.close)>"
             guard let openRange = text.range(of: open),
-                let closeRange = text.range(of: close, range: openRange.upperBound ..< text.endIndex)
+                let closeRange = text.range(
+                    of: close, range: openRange.upperBound ..< text.endIndex)
             else { continue }
             return String(text[openRange.upperBound ..< closeRange.lowerBound])
         }

--- a/Libraries/MLXLMCommon/Tool/Parsers/PythonicToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/PythonicToolCallParser.swift
@@ -44,37 +44,13 @@ public struct PythonicToolCallParser: ToolCallParser, Sendable {
             return jsonToolCall
         }
 
-        let funcName: String
-        let argsString: String
-
-        // Required brackets pattern (matches Python reference: r"\[(\w+)\((.*?)\)\]")
-        // The required \] forces .*? to backtrack past nested ) inside argument values.
-        let bracketPattern = #"\[(\w+)\((.*?)\)\]"#
-        if let regex = try? NSRegularExpression(
-            pattern: bracketPattern, options: [.dotMatchesLineSeparators]),
-            let match = regex.firstMatch(
-                in: text, options: [], range: NSRange(text.startIndex..., in: text)),
-            let nameRange = Range(match.range(at: 1), in: text),
-            let argsRange = Range(match.range(at: 2), in: text)
-        {
-            funcName = String(text[nameRange])
-            argsString = String(text[argsRange])
-        } else {
-            // Fallback for without-brackets case: use string indices to find the
-            // outermost parentheses, avoiding the greedy/non-greedy regex pitfall.
-            guard let openParen = text.firstIndex(of: "("),
-                let closeParen = text.lastIndex(of: ")")
-            else { return nil }
-
-            let name = text[text.startIndex ..< openParen]
-            guard !name.isEmpty, name.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "_" })
-            else { return nil }
-
-            funcName = String(name)
-            argsString = String(text[text.index(after: openParen) ..< closeParen])
-        }
-
-        let arguments = parseArguments(argsString, funcName: funcName, tools: tools)
+        guard let invocation = balancedFunctionInvocations(in: text).first,
+            let arguments = parseArguments(
+                invocation.arguments,
+                funcName: invocation.name,
+                tools: tools)
+        else { return nil }
+        let funcName = invocation.name
         guard acceptsToolCall(name: funcName, arguments: arguments, tools: tools) else {
             return nil
         }
@@ -84,8 +60,9 @@ public struct PythonicToolCallParser: ToolCallParser, Sendable {
     /// At end-of-sequence, extract every pythonic call in the buffer —
     /// Pythonic models legitimately emit multiple `name(args)` invocations
     /// inside one `[...]` block, and the default protocol `parseEOS` only
-    /// surfaces the first. Byte-compatible with upstream
-    /// ml-explore/mlx-swift-lm so `LFM2` streams behave identically.
+    /// surfaces the first. Parsing is balanced rather than regular-expression
+    /// based so parentheses inside nested values or quoted strings cannot
+    /// truncate a call or consume a following call.
     public func parseEOS(_ toolCallBuffer: String, tools: [[String: any Sendable]]?) -> [ToolCall] {
         if let startTag {
             let calls =
@@ -118,87 +95,445 @@ public struct PythonicToolCallParser: ToolCallParser, Sendable {
 
         text = text.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        // Match every `name(args)` — NSRegularExpression (not Swift regex
-        // literal) keeps us compatible with older Swift toolchains that
-        // don't parse `#/(?s)(\w+)\((.*?)\)/#` at compile time. The `(?s)`
-        // dotall flag is expressed via `.dotMatchesLineSeparators`.
-        let pattern = #"(\w+)\(([^)]*(?:\)[^)]*)*?)\)"#
-        guard let regex = try? NSRegularExpression(
-            pattern: pattern, options: [.dotMatchesLineSeparators])
-        else { return [] }
-        let matches = regex.matches(
-            in: text, options: [], range: NSRange(text.startIndex..., in: text))
-
         var results: [ToolCall] = []
-        for match in matches {
-            guard let nameRange = Range(match.range(at: 1), in: text),
-                let argsRange = Range(match.range(at: 2), in: text)
-            else { continue }
-            let funcName = String(text[nameRange])
-            let argsString = String(text[argsRange])
-            let arguments = parseArguments(argsString, funcName: funcName, tools: tools)
-            guard acceptsToolCall(name: funcName, arguments: arguments, tools: tools) else {
+        for invocation in balancedFunctionInvocations(in: text) {
+            guard
+                let arguments = parseArguments(
+                    invocation.arguments,
+                    funcName: invocation.name,
+                    tools: tools),
+                acceptsToolCall(
+                    name: invocation.name,
+                    arguments: arguments,
+                    tools: tools)
+            else {
                 continue
             }
-            results.append(ToolCall(function: .init(name: funcName, arguments: arguments)))
+            results.append(
+                ToolCall(function: .init(name: invocation.name, arguments: arguments)))
         }
         return results
     }
 
-    /// Parse Pythonic keyword arguments: arg1='value1', arg2="value2", arg3=123
-    private func parseArguments(
+    private struct FunctionInvocation {
+        let name: String
+        let arguments: String
+    }
+
+    /// Find `name(...)` invocations while respecting nested parentheses and
+    /// quoted strings. A truncated invocation is never returned. When the
+    /// native bracket-list wrapper is present, it must also be complete.
+    private func balancedFunctionInvocations(in input: String) -> [FunctionInvocation] {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+
+        let text: String
+        if trimmed.hasPrefix("[") {
+            guard trimmed.hasSuffix("]") else { return [] }
+            text = String(trimmed.dropFirst().dropLast())
+        } else {
+            text = trimmed
+        }
+
+        var invocations: [FunctionInvocation] = []
+        var cursor = text.startIndex
+        while cursor < text.endIndex {
+            guard text[cursor].isLetter || text[cursor] == "_" else {
+                cursor = text.index(after: cursor)
+                continue
+            }
+
+            let nameStart = cursor
+            cursor = text.index(after: cursor)
+            while cursor < text.endIndex,
+                text[cursor].isLetter || text[cursor].isNumber || text[cursor] == "_"
+            {
+                cursor = text.index(after: cursor)
+            }
+            let nameEnd = cursor
+            while cursor < text.endIndex,
+                text[cursor].unicodeScalars.allSatisfy({
+                    CharacterSet.whitespacesAndNewlines.contains($0)
+                })
+            {
+                cursor = text.index(after: cursor)
+            }
+            guard cursor < text.endIndex, text[cursor] == "(" else {
+                continue
+            }
+
+            let openParen = cursor
+            let argumentsStart = text.index(after: openParen)
+            cursor = argumentsStart
+            var depth = 1
+            var quote: Character?
+            var escaped = false
+            var closeParen: String.Index?
+
+            while cursor < text.endIndex {
+                let character = text[cursor]
+                if let activeQuote = quote {
+                    if escaped {
+                        escaped = false
+                    } else if character == "\\" {
+                        escaped = true
+                    } else if character == activeQuote {
+                        quote = nil
+                    }
+                } else {
+                    switch character {
+                    case "'", "\"":
+                        quote = character
+                    case "(":
+                        depth += 1
+                    case ")":
+                        depth -= 1
+                        if depth == 0 {
+                            closeParen = cursor
+                        }
+                    default:
+                        break
+                    }
+                }
+
+                cursor = text.index(after: cursor)
+                if closeParen != nil { break }
+            }
+
+            guard let closeParen, quote == nil, !escaped else {
+                return invocations
+            }
+            invocations.append(
+                FunctionInvocation(
+                    name: String(text[nameStart ..< nameEnd]),
+                    arguments: String(text[argumentsStart ..< closeParen])))
+        }
+        return invocations
+    }
+
+    /// Parse one Pythonic keyword-argument list.
+    ///
+    /// This is internal so parser families that explicitly recover the same
+    /// native syntax can share one balanced implementation. It intentionally
+    /// accepts only keyword arguments or the existing single-string
+    /// positional form; malformed mixed fields are rejected as a whole.
+    func parseArguments(
         _ argsString: String,
         funcName: String,
         tools: [[String: any Sendable]]?
-    ) -> [String: any Sendable] {
-        var arguments: [String: any Sendable] = [:]
-
-        // Pattern for key=value pairs, handling quoted strings with possible commas inside
-        // This handles: key='value', key="value", key=123, key=True, key=None
-        let argPattern = #"(\w+)\s*=\s*('(?:[^'\\]|\\.)*'|"(?:[^"\\]|\\.)*"|[^,\)]+)"#
-
-        guard let regex = try? NSRegularExpression(pattern: argPattern, options: []) else {
-            return arguments
+    ) -> [String: any Sendable]? {
+        guard let fields = splitTopLevelArguments(argsString) else {
+            return nil
         }
 
-        let matches = regex.matches(
-            in: argsString, options: [], range: NSRange(argsString.startIndex..., in: argsString))
+        if fields.count == 1,
+            splitKeywordArgument(fields[0]) == nil,
+            let positionalString = parseSinglePositionalString(argsString),
+            let firstRequiredParameter = requiredParameterNames(funcName: funcName, tools: tools)
+                .first
+        {
+            return [
+                firstRequiredParameter: convertParameterValue(
+                    positionalString, paramName: firstRequiredParameter, funcName: funcName,
+                    tools: tools)
+            ]
+        }
 
-        for match in matches {
-            guard let keyRange = Range(match.range(at: 1), in: argsString),
-                let valueRange = Range(match.range(at: 2), in: argsString)
-            else { continue }
+        var arguments: [String: any Sendable] = [:]
+        for field in fields {
+            guard let (key, rawValue) = splitKeywordArgument(field),
+                arguments[key] == nil
+            else {
+                // Do not silently discard malformed or duplicate fields while
+                // returning a superficially valid required-argument set.
+                return nil
+            }
+            arguments[key] = decodeArgumentValue(
+                rawValue,
+                paramName: key,
+                funcName: funcName,
+                tools: tools)
+        }
+        return arguments
+    }
 
-            let key = String(argsString[keyRange])
-            var value = String(argsString[valueRange]).trimmingCharacters(in: .whitespaces)
+    /// Split at commas only when outside strings and balanced containers.
+    /// The previous regular expression stopped at the first comma inside a
+    /// list or dictionary, corrupting nested `rows=[{...}]` arguments.
+    private func splitTopLevelArguments(_ input: String) -> [String]? {
+        let trimmed = input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
 
-            // Remove surrounding quotes if present
-            if (value.hasPrefix("'") && value.hasSuffix("'"))
-                || (value.hasPrefix("\"") && value.hasSuffix("\""))
-            {
-                value = String(value.dropFirst().dropLast())
-                // Unescape escaped quotes
-                value = value.replacingOccurrences(of: "\\'", with: "'")
-                value = value.replacingOccurrences(of: "\\\"", with: "\"")
-                value = value.replacingOccurrences(of: "\\n", with: "\n")
-                value = value.replacingOccurrences(of: "\\t", with: "\t")
-                value = value.replacingOccurrences(of: "\\\\", with: "\\")
+        var fields: [String] = []
+        var start = input.startIndex
+        var index = input.startIndex
+        var quote: Character?
+        var escaped = false
+        var roundDepth = 0
+        var squareDepth = 0
+        var curlyDepth = 0
+
+        while index < input.endIndex {
+            let character = input[index]
+            if let activeQuote = quote {
+                if escaped {
+                    escaped = false
+                } else if character == "\\" {
+                    escaped = true
+                } else if character == activeQuote {
+                    quote = nil
+                }
+            } else {
+                switch character {
+                case "'", "\"":
+                    quote = character
+                case "(":
+                    roundDepth += 1
+                case ")":
+                    roundDepth -= 1
+                case "[":
+                    squareDepth += 1
+                case "]":
+                    squareDepth -= 1
+                case "{":
+                    curlyDepth += 1
+                case "}":
+                    curlyDepth -= 1
+                case "," where roundDepth == 0 && squareDepth == 0 && curlyDepth == 0:
+                    fields.append(String(input[start ..< index]))
+                    start = input.index(after: index)
+                default:
+                    break
+                }
+
+                guard roundDepth >= 0, squareDepth >= 0, curlyDepth >= 0 else {
+                    return nil
+                }
+            }
+            index = input.index(after: index)
+        }
+
+        guard quote == nil,
+            !escaped,
+            roundDepth == 0,
+            squareDepth == 0,
+            curlyDepth == 0
+        else {
+            return nil
+        }
+        fields.append(String(input[start ..< input.endIndex]))
+        return fields
+    }
+
+    private func splitKeywordArgument(_ field: String) -> (String, String)? {
+        let trimmed = field.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        var index = trimmed.startIndex
+        var quote: Character?
+        var escaped = false
+        var roundDepth = 0
+        var squareDepth = 0
+        var curlyDepth = 0
+
+        while index < trimmed.endIndex {
+            let character = trimmed[index]
+            if let activeQuote = quote {
+                if escaped {
+                    escaped = false
+                } else if character == "\\" {
+                    escaped = true
+                } else if character == activeQuote {
+                    quote = nil
+                }
+            } else {
+                switch character {
+                case "'", "\"":
+                    quote = character
+                case "(":
+                    roundDepth += 1
+                case ")":
+                    roundDepth -= 1
+                case "[":
+                    squareDepth += 1
+                case "]":
+                    squareDepth -= 1
+                case "{":
+                    curlyDepth += 1
+                case "}":
+                    curlyDepth -= 1
+                case "=" where roundDepth == 0 && squareDepth == 0 && curlyDepth == 0:
+                    let key = trimmed[..<index]
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard let first = key.first,
+                        first.isLetter || first == "_",
+                        key.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "_" })
+                    else {
+                        return nil
+                    }
+                    let valueStart = trimmed.index(after: index)
+                    let value = trimmed[valueStart...]
+                        .trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !value.isEmpty else { return nil }
+                    return (key, value)
+                default:
+                    break
+                }
+            }
+            index = trimmed.index(after: index)
+        }
+        return nil
+    }
+
+    private func decodeArgumentValue(
+        _ rawValue: String,
+        paramName: String,
+        funcName: String,
+        tools: [[String: any Sendable]]?
+    ) -> any Sendable {
+        var value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if (value.hasPrefix("'") && value.hasSuffix("'"))
+            || (value.hasPrefix("\"") && value.hasSuffix("\""))
+        {
+            value = String(value.dropFirst().dropLast())
+            value = value.replacingOccurrences(of: "\\'", with: "'")
+            value = value.replacingOccurrences(of: "\\\"", with: "\"")
+            value = value.replacingOccurrences(of: "\\n", with: "\n")
+            value = value.replacingOccurrences(of: "\\r", with: "\r")
+            value = value.replacingOccurrences(of: "\\t", with: "\t")
+            value = value.replacingOccurrences(of: "\\\\", with: "\\")
+            return convertParameterValue(
+                value, paramName: paramName, funcName: funcName, tools: tools)
+        }
+
+        let schemaType = getParameterType(
+            funcName: funcName, paramName: paramName, tools: tools
+        )?.lowercased()
+        if schemaType != "string",
+            schemaType == nil
+                || schemaType == "array"
+                || schemaType == "object"
+                || schemaType?.hasPrefix("list") == true
+                || schemaType?.hasPrefix("dict") == true,
+            let container = parsePythonContainerLiteral(value)
+        {
+            return container
+        }
+
+        if schemaType != "string" {
+            switch value {
+            case "True": return true
+            case "False": return false
+            case "None": return NSNull()
+            default: break
+            }
+        }
+        return convertParameterValue(
+            value, paramName: paramName, funcName: funcName, tools: tools)
+    }
+
+    private func parsePythonContainerLiteral(_ value: String) -> (any Sendable)? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard
+            (trimmed.first == "[" && trimmed.last == "]")
+                || (trimmed.first == "{" && trimmed.last == "}")
+        else {
+            return nil
+        }
+        guard let normalized = normalizePythonLiteralAsJSON(trimmed),
+            let data = normalized.data(using: .utf8)
+        else {
+            return nil
+        }
+        return deserializeJSON(data)
+    }
+
+    /// Convert only the literal subset emitted by native Python-style tool
+    /// templates: quoted strings, JSON containers, numbers, and the exact
+    /// `True`/`False`/`None` scalars. This is not source evaluation.
+    private func normalizePythonLiteralAsJSON(_ value: String) -> String? {
+        let characters = Array(value)
+        var output = ""
+        var index = 0
+        var quote: Character?
+        var escaped = false
+
+        while index < characters.count {
+            let character = characters[index]
+            if let activeQuote = quote {
+                if escaped {
+                    switch character {
+                    case "'" where activeQuote == "'":
+                        output.append("'")
+                    case "'" where activeQuote == "\"":
+                        output.append("'")
+                    case "\"":
+                        output.append("\\\"")
+                    case "\\", "/", "b", "f", "n", "r", "t", "u":
+                        output.append("\\")
+                        output.append(character)
+                    default:
+                        return nil
+                    }
+                    escaped = false
+                } else if character == "\\" {
+                    escaped = true
+                } else if character == activeQuote {
+                    output.append("\"")
+                    quote = nil
+                } else if character == "\n" {
+                    output.append("\\n")
+                } else if character == "\r" {
+                    output.append("\\r")
+                } else if character == "\t" {
+                    output.append("\\t")
+                } else if character == "\"" {
+                    output.append("\\\"")
+                } else {
+                    output.append(character)
+                }
+                index += 1
+                continue
             }
 
-            // Convert value based on schema type if available
-            arguments[key] = convertParameterValue(
-                value, paramName: key, funcName: funcName, tools: tools)
+            if character == "'" || character == "\"" {
+                quote = character
+                output.append("\"")
+                index += 1
+                continue
+            }
+
+            if character.isLetter || character == "_" {
+                let start = index
+                index += 1
+                while index < characters.count,
+                    characters[index].isLetter
+                        || characters[index].isNumber
+                        || characters[index] == "_"
+                {
+                    index += 1
+                }
+                let token = String(characters[start ..< index])
+                switch token {
+                case "True": output.append("true")
+                case "False": output.append("false")
+                case "None": output.append("null")
+                case "true", "false", "null": output.append(token)
+                default:
+                    // Bare identifiers and executable expressions are outside
+                    // the literal grammar and must not be guessed.
+                    return nil
+                }
+                continue
+            }
+
+            output.append(character)
+            index += 1
         }
 
-        if arguments.isEmpty,
-            let positionalString = parseSinglePositionalString(argsString),
-            let firstRequiredParameter = requiredParameterNames(funcName: funcName, tools: tools).first
-        {
-            arguments[firstRequiredParameter] = convertParameterValue(
-                positionalString, paramName: firstRequiredParameter, funcName: funcName, tools: tools)
-        }
-
-        return arguments
+        guard quote == nil, !escaped else { return nil }
+        return output
     }
 
     private func parseSinglePositionalString(_ argsString: String) -> String? {
@@ -206,7 +541,7 @@ public struct PythonicToolCallParser: ToolCallParser, Sendable {
         guard trimmed.count >= 2 else { return nil }
 
         let quote = trimmed.first
-        guard (quote == "'" || quote == "\""), trimmed.last == quote else { return nil }
+        guard quote == "'" || quote == "\"", trimmed.last == quote else { return nil }
 
         var value = String(trimmed.dropFirst().dropLast())
         value = value.replacingOccurrences(of: "\\'", with: "'")

--- a/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
@@ -111,9 +111,11 @@ public class ToolCallProcessor {
         guard !registered.isEmpty else { return call }
         let name = call.function.name
         if registered.contains(name) { return call }
-        guard let canonical = registered.first(where: {
-            $0.compare(name, options: .caseInsensitive) == .orderedSame
-        }) else { return call }
+        guard
+            let canonical = registered.first(where: {
+                $0.compare(name, options: .caseInsensitive) == .orderedSame
+            })
+        else { return call }
         return ToolCall(
             id: call.id,
             function: .init(name: canonical, arguments: call.function.arguments))
@@ -301,7 +303,8 @@ public class ToolCallProcessor {
                     state = .normal
                     suppressingTextAfterInlineToolCall = true
                 }
-                return visibleInlineLeading(leading)
+                return visibleInlineLeading(
+                    leading, afterConfirmedToolCall: state == .normal)
             }
 
             if let pendingIndex = partialInlineActionJSONToolCallStart(in: inlineText) {
@@ -324,7 +327,8 @@ public class ToolCallProcessor {
                     state = .normal
                     suppressingTextAfterInlineToolCall = true
                 }
-                return visibleInlineLeading(leading)
+                return visibleInlineLeading(
+                    leading, afterConfirmedToolCall: state == .normal)
             }
 
             if let pendingIndex = partialInlineEmbeddedAPIToolJSONStart(in: inlineText) {
@@ -345,7 +349,8 @@ public class ToolCallProcessor {
                     state = .normal
                     suppressingTextAfterInlineToolCall = true
                 }
-                return visibleInlineLeading(leading)
+                return visibleInlineLeading(
+                    leading, afterConfirmedToolCall: state == .normal)
             }
 
             if let pendingIndex = partialInlinePythonicCallListStart(in: inlineText) {
@@ -366,7 +371,8 @@ public class ToolCallProcessor {
                     state = .normal
                     suppressingTextAfterInlineToolCall = true
                 }
-                return visibleInlineLeading(leading)
+                return visibleInlineLeading(
+                    leading, afterConfirmedToolCall: state == .normal)
             }
 
             if let pendingIndex = partialInlineFunctionToolCallStart(in: inlineText) {
@@ -389,7 +395,8 @@ public class ToolCallProcessor {
                     state = .normal
                     suppressingTextAfterInlineToolCall = true
                 }
-                return visibleInlineLeading(leading)
+                return visibleInlineLeading(
+                    leading, afterConfirmedToolCall: state == .normal)
             }
 
             if let pendingIndex = partialInlineRequestToolXMLToolCallStart(in: inlineText) {
@@ -410,7 +417,8 @@ public class ToolCallProcessor {
                     state = .normal
                     suppressingTextAfterInlineToolCall = true
                 }
-                return visibleInlineLeading(leading)
+                return visibleInlineLeading(
+                    leading, afterConfirmedToolCall: state == .normal)
             }
 
             if let pendingIndex = partialInlineBareNameJSONToolCallStart(in: inlineText) {
@@ -433,7 +441,8 @@ public class ToolCallProcessor {
                     state = .normal
                     suppressingTextAfterInlineToolCall = true
                 }
-                return visibleInlineLeading(leading)
+                return visibleInlineLeading(
+                    leading, afterConfirmedToolCall: state == .normal)
             }
 
             if let pendingIndex = partialInlineBareNameKeyValueToolCallStart(in: inlineText) {
@@ -454,7 +463,7 @@ public class ToolCallProcessor {
                     recordToolCall(toolCall)
                     toolCallBuffer = ""
                     state = .normal
-                    return visibleInlineLeading(leading)
+                    return visibleInlineLeading(leading, afterConfirmedToolCall: true)
                 }
 
                 // Still collecting — check if braces are balanced (would mean parse
@@ -796,7 +805,7 @@ public class ToolCallProcessor {
         var searchStart = text.startIndex
         while let range = text.range(of: "call:", range: searchStart ..< text.endIndex) {
             if isInlineFunctionBoundary(text, before: range.lowerBound),
-               bareCallTailStartsKnownTool(in: text, afterPrefix: range.upperBound)
+                bareCallTailStartsKnownTool(in: text, afterPrefix: range.upperBound)
             {
                 return range.lowerBound
             }
@@ -814,7 +823,7 @@ public class ToolCallProcessor {
             }
         }
         guard let range = text.range(of: prefix),
-              isInlineFunctionBoundary(text, before: range.lowerBound)
+            isInlineFunctionBoundary(text, before: range.lowerBound)
         else {
             return nil
         }
@@ -1087,7 +1096,8 @@ public class ToolCallProcessor {
             if isInlineFunctionBoundary(text, before: cursor) {
                 let suffix = String(text[cursor...])
                 for name in inlineFunctionToolNames() {
-                    if inlineFunctionNamePrefix(suffix, matches: name) && suffix.count < name.count {
+                    if inlineFunctionNamePrefix(suffix, matches: name) && suffix.count < name.count
+                    {
                         best = cursor
                         break
                     }
@@ -1118,7 +1128,7 @@ public class ToolCallProcessor {
         while cursor < text.endIndex, isInlineKeyValueIdentifierCharacter(text[cursor]) {
             cursor = text.index(after: cursor)
         }
-        return (String(text[start..<cursor]), cursor)
+        return (String(text[start ..< cursor]), cursor)
     }
 
     private func minIndex(_ lhs: String.Index?, _ rhs: String.Index) -> String.Index {
@@ -1414,7 +1424,7 @@ public class ToolCallProcessor {
         guard text[cursor...].hasPrefix("```") else { return cursor }
 
         var fenceCursor = cursor
-        for _ in 0..<3 {
+        for _ in 0 ..< 3 {
             guard fenceCursor < text.endIndex else { return cursor }
             fenceCursor = text.index(after: fenceCursor)
         }
@@ -1430,7 +1440,8 @@ public class ToolCallProcessor {
         return fenceCursor
     }
 
-    private func consumeOptionalJSONLabel(in text: String, at cursor: String.Index) -> String.Index {
+    private func consumeOptionalJSONLabel(in text: String, at cursor: String.Index) -> String.Index
+    {
         guard cursor < text.endIndex, text[cursor] == ":" else { return cursor }
         var labelStart = text.index(after: cursor)
         while labelStart < text.endIndex, isInlineWhitespace(text[labelStart]) {
@@ -1467,10 +1478,11 @@ public class ToolCallProcessor {
     }
 
     private func inlineFunctionToolNames() -> [String] {
-        let schemaNames = tools?.compactMap { tool -> String? in
-            let function = (tool["function"] as? [String: any Sendable]) ?? tool
-            return function["name"] as? String
-        } ?? []
+        let schemaNames =
+            tools?.compactMap { tool -> String? in
+                let function = (tool["function"] as? [String: any Sendable]) ?? tool
+                return function["name"] as? String
+            } ?? []
         if !schemaNames.isEmpty {
             return schemaNames.sorted { $0.count > $1.count }
         }
@@ -1487,19 +1499,28 @@ public class ToolCallProcessor {
         ]
     }
 
-    private func visibleInlineLeading(_ leading: String) -> String? {
-        // Emit leading text verbatim. Returning nil only for *empty* leading
-        // (never for whitespace-only) keeps ordinary prose byte-exact: a chunk
-        // like " {" must not lose its leading space when the brace triggers a
-        // (possibly false) inline tool-call probe.
-        leading.isEmpty ? nil : leading
+    private func visibleInlineLeading(
+        _ leading: String,
+        afterConfirmedToolCall: Bool = false
+    ) -> String? {
+        // During an ambiguous inline-tool probe, emit leading text verbatim:
+        // a chunk like " {" must not lose its leading space if the brace later
+        // proves to be ordinary prose. Once a tool call has actually parsed,
+        // whitespace-only leading bytes are envelope formatting rather than a
+        // visible assistant message.
+        if afterConfirmedToolCall,
+            leading.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            return nil
+        }
+        return leading.isEmpty ? nil : leading
     }
 
     /// Process chunk for tagged formats.
     private func processTaggedChunk(_ chunk: String, allowInlineFallback: Bool) -> String? {
         let startTags = parser.startTagAliases
         let startTagPrefixes = parser.startTagPrefixes
-        guard (!startTags.isEmpty || !startTagPrefixes.isEmpty),
+        guard !startTags.isEmpty || !startTagPrefixes.isEmpty,
             let startChar = startTagFirstChar
         else {
             return chunk
@@ -1564,14 +1585,15 @@ public class ToolCallProcessor {
                     state = .collectingInlineToolCall
 
                     if shouldAttemptInlineToolParse(toolCallBuffer),
-                       let toolCall = parser.parse(content: toolCallBuffer, tools: tools)
+                        let toolCall = parser.parse(content: toolCallBuffer, tools: tools)
                     {
                         recordToolCall(toolCall)
                         toolCallBuffer = ""
                         state = .normal
                         suppressingTextAfterInlineToolCall = true
                     }
-                    return visibleInlineLeading(leading)
+                    return visibleInlineLeading(
+                        leading, afterConfirmedToolCall: state == .normal)
                 }
                 if let fragmentIndex = partialInlineBareNameJSONToolCallStart(in: candidate) {
                     let leading = String(candidate[..<fragmentIndex])
@@ -1586,14 +1608,15 @@ public class ToolCallProcessor {
                     state = .collectingInlineToolCall
 
                     if shouldAttemptInlineToolParse(toolCallBuffer),
-                       let toolCall = parser.parse(content: toolCallBuffer, tools: tools)
+                        let toolCall = parser.parse(content: toolCallBuffer, tools: tools)
                     {
                         recordToolCall(toolCall)
                         toolCallBuffer = ""
                         state = .normal
                         suppressingTextAfterInlineToolCall = true
                     }
-                    return visibleInlineLeading(leading)
+                    return visibleInlineLeading(
+                        leading, afterConfirmedToolCall: state == .normal)
                 }
                 if let fragmentIndex = partialBareCallToolCallStart(in: candidate) {
                     let leading = String(candidate[..<fragmentIndex])
@@ -1624,7 +1647,8 @@ public class ToolCallProcessor {
             return processInlineChunk(chunk)
         }
 
-        if allowInlineFallback && parser.supportsInlineJSONToolFallback && !hasTaggedStartCandidate {
+        if allowInlineFallback && parser.supportsInlineJSONToolFallback && !hasTaggedStartCandidate
+        {
             switch state {
             case .collectingInlineToolCall:
                 return processInlineChunk(chunk)
@@ -1724,7 +1748,9 @@ public class ToolCallProcessor {
             fallthrough
         case .potentialToolCall:
             if partialMatch(buffer: toolCallBuffer, tags: startTags, prefixes: startTagPrefixes) {
-                if startsWithCompleteTag(buffer: toolCallBuffer, tags: startTags, prefixes: startTagPrefixes) {
+                if startsWithCompleteTag(
+                    buffer: toolCallBuffer, tags: startTags, prefixes: startTagPrefixes)
+                {
                     state = .collectingToolCall
                     fallthrough
                 } else {
@@ -1858,9 +1884,10 @@ public class ToolCallProcessor {
                 if let trailingToken, let startChar = startTagFirstChar,
                     trailingToken.contains(startChar)
                 {
-                    let trailing = processTaggedChunk(
-                        trailingToken,
-                        allowInlineFallback: allowInlineFallback) ?? ""
+                    let trailing =
+                        processTaggedChunk(
+                            trailingToken,
+                            allowInlineFallback: allowInlineFallback) ?? ""
                     let visible = leading + trailing
                     return visible.isEmpty ? nil : visible
                 } else {
@@ -1909,6 +1936,12 @@ public class ToolCallProcessor {
     }
 
     private func visibleLeadingTextBeforeToolCall(parsedToolCalls: [ToolCall]) -> String {
+        if !parsedToolCalls.isEmpty,
+            leadingTextBeforeToolCall
+                .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+            return ""
+        }
         guard parser.supportsInlineJSONToolFallback,
             let fragment = bareToolMarkerFragment(in: leadingTextBeforeToolCall),
             parsedToolCalls.contains(where: { $0.function.name == fragment })
@@ -1963,7 +1996,9 @@ public class ToolCallProcessor {
 
     private func partialMatch(buffer: String, tags: [String], prefixes: [String]) -> Bool {
         tags.contains { partialMatch(buffer: buffer, tag: $0) }
-            || prefixes.contains { partialMatch(buffer: buffer, tag: $0) || buffer.starts(with: $0) }
+            || prefixes.contains {
+                partialMatch(buffer: buffer, tag: $0) || buffer.starts(with: $0)
+            }
     }
 
     private func partialMatch(buffer: String, tag: String) -> Bool {
@@ -1992,13 +2027,15 @@ public class ToolCallProcessor {
     }
 
     private func firstTag(in text: String, tags: [String], prefixes: [String]) -> String? {
-        let exactMatch = tags
+        let exactMatch =
+            tags
             .compactMap { tag -> (String, Range<String.Index>)? in
                 text.range(of: tag).map { (tag, $0) }
             }
             .min { $0.1.lowerBound < $1.1.lowerBound }
 
-        let prefixedMatch = prefixes
+        let prefixedMatch =
+            prefixes
             .compactMap { prefix -> (String, Range<String.Index>)? in
                 guard
                     let match = completedPrefixedTag(
@@ -2014,11 +2051,11 @@ public class ToolCallProcessor {
         switch (exactMatch, prefixedMatch) {
         case (nil, nil):
             return nil
-        case let (exact?, nil):
+        case (let exact?, nil):
             return exact.0
-        case let (nil, prefixed?):
+        case (nil, let prefixed?):
             return prefixed.0
-        case let (exact?, prefixed?):
+        case (let exact?, let prefixed?):
             return exact.1.lowerBound <= prefixed.1.lowerBound ? exact.0 : prefixed.0
         }
     }

--- a/Tests/MLXLMCommonFocusedTests/DSMLInlineJSONToolFallbackFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/DSMLInlineJSONToolFallbackFocusedTests.swift
@@ -22,10 +22,16 @@ struct DSMLInlineJSONToolFallbackFocusedTests {
         #expect(lmInput.contains("public let toolSchemas: [ToolSpec]?"))
         #expect(lmInput.contains("public func withToolSchemas"))
         #expect(batchEngine.contains("let toolSchemas = input.toolSchemas"))
-        #expect(batchEngine.contains("let activeToolSchemas = toolSchemas?.isEmpty == false ? toolSchemas : nil"))
-        #expect(batchEngine.contains("ToolCallProcessor(format: toolCallFormat, tools: $0)"))
+        #expect(
+            batchEngine.contains(
+                "let activeToolSchemas = toolSchemas?.isEmpty == false ? toolSchemas : nil"))
+        #expect(batchEngine.contains("if let activeToolSchemas"))
+        #expect(
+            batchEngine.contains(
+                "ToolCallProcessor(format: toolCallFormat, tools: activeToolSchemas)"))
         #expect(evaluate.contains("let activeTools = tools?.isEmpty == false ? tools : nil"))
-        #expect(evaluate.contains("ToolCallProcessor(format: format, tools: $0)"))
+        #expect(evaluate.contains("if let activeTools"))
+        #expect(evaluate.contains("ToolCallProcessor(format: format, tools: activeTools)"))
     }
 
     @Test("decode loop disables tool parser without active schemas")
@@ -45,11 +51,18 @@ struct DSMLInlineJSONToolFallbackFocusedTests {
 
         #expect(routing.contains("through toolCallProcessor: ToolCallProcessor?"))
         #expect(routing.contains("guard let toolCallProcessor else"))
-        #expect(batchEngine.contains("let activeToolSchemas = toolSchemas?.isEmpty == false ? toolSchemas : nil"))
+        #expect(
+            batchEngine.contains(
+                "let activeToolSchemas = toolSchemas?.isEmpty == false ? toolSchemas : nil"))
         #expect(evaluate.contains("let activeTools = tools?.isEmpty == false ? tools : nil"))
-        #expect(specDec.contains("let activeToolSchemas = toolSchemas?.isEmpty == false ? toolSchemas : nil"))
-        #expect(!batchEngine.contains("ToolCallProcessor(format: toolCallFormat, tools: toolSchemas)"))
-        #expect(!evaluate.contains("toolCallProcessor = ToolCallProcessor(format: format, tools: tools)"))
+        #expect(
+            specDec.contains(
+                "let activeToolSchemas = toolSchemas?.isEmpty == false ? toolSchemas : nil"))
+        #expect(
+            !batchEngine.contains("ToolCallProcessor(format: toolCallFormat, tools: toolSchemas)"))
+        #expect(
+            !evaluate.contains(
+                "toolCallProcessor = ToolCallProcessor(format: format, tools: tools)"))
     }
 
     @Test("registered top-level JSON tool fallback is parsed without visible leakage")
@@ -67,7 +80,9 @@ struct DSMLInlineJSONToolFallbackFocusedTests {
         #expect(processor.toolCalls.count == 1)
         #expect(processor.toolCalls.first?.function.name == "file_read")
         #expect(processor.toolCalls.first?.function.arguments["path"] == nil)
-        #expect(processor.toolCalls.first?.function.arguments["_error"] == .string("invalid_tool_arguments"))
+        #expect(
+            processor.toolCalls.first?.function.arguments["_error"]
+                == .string("invalid_tool_arguments"))
         #expect(processor.toolCalls.first?.function.arguments["_field"] == .string("path"))
         #expect(processor.toolCalls.first?.function.arguments["r"] == nil)
         #expect(visible.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
@@ -122,7 +137,8 @@ struct DSMLInlineJSONToolFallbackFocusedTests {
 
             #expect(processor.toolCalls.count == 1, "\(toolName) should emit a tool attempt")
             #expect(processor.toolCalls.first?.function.name == toolName)
-            #expect(processor.toolCalls.first?.function.arguments["path"] == .string("mandelbrot.py"))
+            #expect(
+                processor.toolCalls.first?.function.arguments["path"] == .string("mandelbrot.py"))
             #expect(
                 visible.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
                 "\(toolName) JSON tool attempt leaked visible text: \(visible)"
@@ -353,7 +369,8 @@ struct DSMLInlineJSONToolFallbackFocusedTests {
         #expect(call?.function.arguments["start_line"] == .int(33))
         #expect(call?.function.arguments["end_line"] == .int(39))
         #expect(visible.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-        #expect(processor.processEOS()?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+        #expect(
+            processor.processEOS()?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
         #expect(!visible.contains("file_read"))
         #expect(!visible.contains("```json"))
         #expect(!visible.contains("DSV4_UI_TOUT_OK"))

--- a/Tests/MLXLMTests/LFM2MoESanitizeTests.swift
+++ b/Tests/MLXLMTests/LFM2MoESanitizeTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import MLX
+import MLXLLM
+import Testing
+
+@Suite("LFM2 MoE legacy quantized weight sanitization")
+struct LFM2MoESanitizeTests {
+    private func model() throws -> LFM2MoEModel {
+        let config = """
+            {
+              "model_type": "lfm2_moe",
+              "vocab_size": 16,
+              "hidden_size": 4,
+              "intermediate_size": 8,
+              "moe_intermediate_size": 2,
+              "num_hidden_layers": 2,
+              "num_experts": 2,
+              "num_experts_per_tok": 1,
+              "norm_topk_prob": true,
+              "num_attention_heads": 1,
+              "num_key_value_heads": 1,
+              "max_position_embeddings": 128,
+              "use_expert_bias": false,
+              "num_dense_layers": 1,
+              "norm_eps": 0.00001,
+              "conv_bias": false,
+              "conv_L_cache": 3,
+              "layer_types": ["conv", "conv"]
+            }
+            """
+        let configuration = try JSONDecoder().decode(
+            LFM2MoEConfiguration.self,
+            from: Data(config.utf8))
+        return LFM2MoEModel(configuration)
+    }
+
+    private func scalar(_ value: Float) -> MLXArray {
+        MLXArray([value])
+    }
+
+    @Test("dense w1/w2/w3 quantization sidecars follow renamed modules")
+    func denseQuantizationSidecarsAreRenamed() throws {
+        try MLXMetalTestLock.withLock {
+            let weights = [
+                "model.layers.0.feed_forward.w1.weight": scalar(1),
+                "model.layers.0.feed_forward.w1.scales": scalar(2),
+                "model.layers.0.feed_forward.w1.biases": scalar(3),
+                "model.layers.0.feed_forward.w2.weight": scalar(4),
+                "model.layers.0.feed_forward.w2.scales": scalar(5),
+                "model.layers.0.feed_forward.w3.weight": scalar(6),
+                "model.layers.0.feed_forward.w3.scales": scalar(7),
+            ]
+
+            let sanitized = try model().sanitize(weights: weights)
+
+            #expect(sanitized["model.layers.0.feed_forward.gate_proj.weight"] != nil)
+            #expect(sanitized["model.layers.0.feed_forward.gate_proj.scales"] != nil)
+            #expect(sanitized["model.layers.0.feed_forward.gate_proj.biases"] != nil)
+            #expect(sanitized["model.layers.0.feed_forward.down_proj.weight"] != nil)
+            #expect(sanitized["model.layers.0.feed_forward.down_proj.scales"] != nil)
+            #expect(sanitized["model.layers.0.feed_forward.up_proj.weight"] != nil)
+            #expect(sanitized["model.layers.0.feed_forward.up_proj.scales"] != nil)
+            #expect(sanitized.keys.allSatisfy { !$0.contains(".w1.") })
+            #expect(sanitized.keys.allSatisfy { !$0.contains(".w2.") })
+            #expect(sanitized.keys.allSatisfy { !$0.contains(".w3.") })
+        }
+    }
+
+    @Test("per-expert quantization sidecars stack with expert weights")
+    func expertQuantizationSidecarsAreStacked() throws {
+        try MLXMetalTestLock.withLock {
+            var weights: [String: MLXArray] = [:]
+            for expert in 0 ..< 2 {
+                for (projection, base) in [("w1", 10), ("w2", 20), ("w3", 30)] {
+                    let prefix =
+                        "model.layers.1.feed_forward.experts.\(expert).\(projection)"
+                    weights["\(prefix).weight"] = scalar(Float(base + expert))
+                    weights["\(prefix).scales"] = scalar(Float(base + expert + 2))
+                    weights["\(prefix).biases"] = scalar(Float(base + expert + 4))
+                }
+            }
+
+            let sanitized = try model().sanitize(weights: weights)
+
+            for (projection, base) in [
+                ("gate_proj", 10),
+                ("down_proj", 20),
+                ("up_proj", 30),
+            ] {
+                for (leaf, offset) in [
+                    ("weight", 0),
+                    ("scales", 2),
+                    ("biases", 4),
+                ] {
+                    let key =
+                        "model.layers.1.feed_forward.switch_mlp.\(projection).\(leaf)"
+                    #expect(sanitized[key]?.shape == [2, 1])
+                    #expect(
+                        sanitized[key]?.asArray(Float.self)
+                            == [Float(base + offset), Float(base + offset + 1)])
+                }
+            }
+            #expect(sanitized.keys.allSatisfy { !$0.contains(".experts.") })
+        }
+    }
+}

--- a/Tests/MLXLMTests/PythonicNestedToolArgumentTests.swift
+++ b/Tests/MLXLMTests/PythonicNestedToolArgumentTests.swift
@@ -1,0 +1,283 @@
+import MLXLMCommon
+import Testing
+
+@Suite("LFM and DSML nested Pythonic tool arguments")
+struct PythonicNestedToolArgumentTests {
+    private func databaseTools() -> [ToolSpec] {
+        [
+            [
+                "type": "function",
+                "function": [
+                    "name": "db_insert",
+                    "parameters": [
+                        "type": "object",
+                        "properties": [
+                            "rows": [
+                                "type": "array",
+                                "items": ["type": "object"] as [String: any Sendable],
+                            ] as [String: any Sendable],
+                            "table": ["type": "string"] as [String: any Sendable],
+                            "replace": ["type": "boolean"] as [String: any Sendable],
+                        ] as [String: any Sendable],
+                        "required": ["rows", "table"] as [String],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable],
+            ] as ToolSpec
+        ]
+    }
+
+    @Test("LFM preserves nested row objects instead of splitting at inner commas")
+    func lfmPreservesNestedRows() throws {
+        let output =
+            #"<|tool_call_start|>[db_insert(rows=[{'id': 11, 'label': 'lfm-eleven'}], table='proof_lfm')]<|tool_call_end|>"#
+
+        let call = try #require(
+            LFM2ToolCallParser().parse(content: output, tools: databaseTools()))
+
+        #expect(call.function.name == "db_insert")
+        #expect(call.function.arguments["table"] == .string("proof_lfm"))
+        #expect(
+            call.function.arguments["rows"]
+                == .array([
+                    .object([
+                        "id": .int(11),
+                        "label": .string("lfm-eleven"),
+                    ])
+                ]))
+    }
+
+    @Test("LFM preserves Unicode, booleans, nulls, numbers, and nested containers")
+    func lfmPreservesTypedNestedValues() throws {
+        let output =
+            #"<|tool_call_start|>[db_insert(rows=[{'id': 12, 'label': 'Привет, 世界', 'active': True, 'note': None, 'metrics': {'score': 2.5}}], table='proof_unicode', replace=False)]<|tool_call_end|>"#
+
+        let call = try #require(
+            LFM2ToolCallParser().parse(content: output, tools: databaseTools()))
+
+        #expect(call.function.arguments["replace"] == .bool(false))
+        #expect(
+            call.function.arguments["rows"]
+                == .array([
+                    .object([
+                        "id": .int(12),
+                        "label": .string("Привет, 世界"),
+                        "active": .bool(true),
+                        "note": .null,
+                        "metrics": .object(["score": .double(2.5)]),
+                    ])
+                ]))
+    }
+
+    @Test("DSML Pythonic fallback shares the nested typed-argument contract")
+    func dsmlFallbackPreservesNestedRows() throws {
+        let output =
+            #"db_insert(rows=[{'id': 21, 'label': 'dsml-twenty-one'}], table='proof_dsml', replace=True)"#
+
+        let call = try #require(
+            DSMLToolCallParser().parse(content: output, tools: databaseTools()))
+
+        #expect(call.function.name == "db_insert")
+        #expect(call.function.arguments["table"] == .string("proof_dsml"))
+        #expect(call.function.arguments["replace"] == .bool(true))
+        #expect(
+            call.function.arguments["rows"]
+                == .array([
+                    .object([
+                        "id": .int(21),
+                        "label": .string("dsml-twenty-one"),
+                    ])
+                ]))
+    }
+
+    @Test("DSML keeps its observed JSON-label function fallback")
+    func dsmlJSONLabelFallbackRemainsSupported() throws {
+        let output =
+            #"db_insert("rows": [{"id": 22, "label": "colon-style"}], "table": "proof_dsml_colon", "replace": true)"#
+
+        let call = try #require(
+            DSMLToolCallParser().parse(content: output, tools: databaseTools()))
+
+        #expect(call.function.name == "db_insert")
+        #expect(call.function.arguments["table"] == .string("proof_dsml_colon"))
+        #expect(call.function.arguments["replace"] == .bool(true))
+        #expect(
+            call.function.arguments["rows"]
+                == .array([
+                    .object([
+                        "id": .int(22),
+                        "label": .string("colon-style"),
+                    ])
+                ]))
+    }
+
+    @Test("Nested strings keep commas, equals signs, quotes, and multiple rows")
+    func nestedStringsAndMultipleRowsRemainIntact() throws {
+        let output =
+            #"<|tool_call_start|>[db_insert(rows=[{'id': 31, 'label': 'a,b=c'}, {'id': 32, 'label': 'Eric\'s "row"'}], table='proof_complex', replace=True)]<|tool_call_end|>"#
+
+        let call = try #require(
+            LFM2ToolCallParser().parse(content: output, tools: databaseTools()))
+
+        #expect(call.function.arguments["replace"] == .bool(true))
+        #expect(
+            call.function.arguments["rows"]
+                == .array([
+                    .object([
+                        "id": .int(31),
+                        "label": .string("a,b=c"),
+                    ]),
+                    .object([
+                        "id": .int(32),
+                        "label": .string(#"Eric's "row""#),
+                    ]),
+                ]))
+    }
+
+    @Test("Unbalanced nested arguments never become a structured call")
+    func unbalancedNestedArgumentsAreRejected() {
+        let output =
+            #"<|tool_call_start|>[db_insert(rows=[{'id': 11, 'label': 'broken'}], table='proof_lfm')<|tool_call_end|>"#
+
+        #expect(LFM2ToolCallParser().parse(content: output, tools: databaseTools()) == nil)
+    }
+
+    @Test("Malformed mixed keyword fields do not get silently discarded")
+    func malformedMixedKeywordFieldsAreRejected() {
+        let output =
+            #"<|tool_call_start|>[db_insert(rows=[{'id': 41}], invented positional junk, table='proof_lfm')]<|tool_call_end|>"#
+
+        #expect(LFM2ToolCallParser().parse(content: output, tools: databaseTools()) == nil)
+    }
+
+    @Test("Malformed arguments cannot become an empty call for a no-argument tool")
+    func malformedArgumentsDoNotMasqueradeAsEmptyCall() {
+        let tools: [ToolSpec] = [
+            [
+                "type": "function",
+                "function": [
+                    "name": "ping",
+                    "parameters": [
+                        "type": "object",
+                        "properties": [:] as [String: any Sendable],
+                        "required": [] as [String],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable],
+            ] as ToolSpec
+        ]
+
+        #expect(
+            PythonicToolCallParser().parse(
+                content: "ping(invented positional junk)",
+                tools: tools) == nil)
+    }
+
+    @Test("Balanced multi-call parsing preserves nested punctuation in every call")
+    func balancedMultipleCallsPreserveNestedValues() throws {
+        let output =
+            #"<|tool_call_start|>[db_insert(rows=[{'id': 51, 'label': '(first), still first'}], table='proof_one'), db_insert(rows=[{'id': 52, 'label': 'second) value'}], table='proof_two')]<|tool_call_end|>"#
+
+        let calls = LFM2ToolCallParser().parseEOS(output, tools: databaseTools())
+
+        #expect(calls.count == 2)
+        let first = try #require(calls.first)
+        let second = try #require(calls.last)
+        #expect(first.function.arguments["table"] == .string("proof_one"))
+        #expect(
+            first.function.arguments["rows"]
+                == .array([
+                    .object([
+                        "id": .int(51),
+                        "label": .string("(first), still first"),
+                    ])
+                ]))
+        #expect(second.function.arguments["table"] == .string("proof_two"))
+        #expect(
+            second.function.arguments["rows"]
+                == .array([
+                    .object([
+                        "id": .int(52),
+                        "label": .string("second) value"),
+                    ])
+                ]))
+    }
+
+    @Test("LFM nested call is stable at every legal stream boundary")
+    func lfmNestedCallSurvivesEveryStreamBoundary() throws {
+        let output =
+            #"<|tool_call_start|>[db_insert(rows=[{'id': 61, 'label': 'Привет, (stream)'}], table='proof_stream', replace=True)]<|tool_call_end|>"#
+        var boundaries = Array(output.indices.dropFirst())
+        boundaries.append(output.endIndex)
+
+        for boundary in boundaries {
+            let processor = ToolCallProcessor(
+                format: .lfm2,
+                tools: databaseTools())
+            var visible = ""
+            visible += processor.processChunk(String(output[..<boundary])) ?? ""
+            visible += processor.processChunk(String(output[boundary...])) ?? ""
+            visible += processor.processEOS() ?? ""
+
+            #expect(visible.isEmpty)
+            #expect(processor.toolCalls.count == 1)
+            let call = try #require(processor.toolCalls.first)
+            #expect(call.function.name == "db_insert")
+            #expect(call.function.arguments["table"] == .string("proof_stream"))
+            #expect(call.function.arguments["replace"] == .bool(true))
+            #expect(
+                call.function.arguments["rows"]
+                    == .array([
+                        .object([
+                            "id": .int(61),
+                            "label": .string("Привет, (stream)"),
+                        ])
+                    ]))
+        }
+    }
+
+    @Test("Malformed turn does not poison a corrected retry turn")
+    func malformedThenCorrectedTurnRecovers() throws {
+        let malformed =
+            #"<|tool_call_start|>[db_insert(rows=[{'id': 71}], junk, table='proof_retry')]<|tool_call_end|>"#
+        let corrected =
+            #"<|tool_call_start|>[db_insert(rows=[{'id': 71, 'label': 'recovered'}], table='proof_retry')]<|tool_call_end|>"#
+
+        let failedTurn = ToolCallProcessor(
+            format: .lfm2,
+            tools: databaseTools())
+        _ = failedTurn.processChunk(malformed)
+        _ = failedTurn.processEOS()
+        #expect(failedTurn.toolCalls.isEmpty)
+
+        let retryTurn = ToolCallProcessor(
+            format: .lfm2,
+            tools: databaseTools())
+        let visible =
+            (retryTurn.processChunk(corrected) ?? "")
+            + (retryTurn.processEOS() ?? "")
+        #expect(visible.isEmpty)
+        #expect(retryTurn.toolCalls.count == 1)
+        let call = try #require(retryTurn.toolCalls.first)
+        #expect(call.function.arguments["table"] == .string("proof_retry"))
+        #expect(
+            call.function.arguments["rows"]
+                == .array([
+                    .object([
+                        "id": .int(71),
+                        "label": .string("recovered"),
+                    ])
+                ]))
+    }
+
+    @Test("Ambiguous inline probe keeps ordinary whitespace and prose byte-exact")
+    func ambiguousInlineProbePreservesWhitespace() {
+        let processor = ToolCallProcessor(
+            format: .lfm2,
+            tools: databaseTools())
+
+        let visible = processor.processChunk(" \n{") ?? ""
+        let eosVisible = processor.processEOS() ?? ""
+
+        #expect(processor.toolCalls.isEmpty)
+        #expect(visible + eosVisible == " \n{")
+    }
+}


### PR DESCRIPTION
Scope
- replace comma-regex Pythonic argument parsing with balanced quote/container scanning
- share that strict literal parser only with the explicit DSML Python-style fallback
- suppress whitespace-only envelope bytes only after a registered tool call is confirmed
- move legacy LFM quantization weight/scales/biases sidecars together and stack per-expert sidecars

Source evidence on commit 2e9e4fc2
- nested/malformed/multi-call/stream-boundary suite: 12/12
- LFM sanitizer value suite: 2/2
- ToolTests: 68/68
- ToolCallEdgeCasesTests: 48/48
- DSML suites: 58/58
- deterministic prose-fidelity matrix: 3600/3600

Direct diagnostics, not release proof
- clean LFM2.5 8B completed a closed reasoning/final turn at 87.83 tok/s
- AppleScript 8B and Laguna XS Thinking Off loaded with visible output and low physical footprints
- Qwen2, Nemotron, and MiniMax loaded/cohered; their memory rows are documented separately
- the local LFM 230M directory is a mixed 1/1 plus incomplete 5/6 artifact and is not treated as runtime proof

Still required before ready/merge
- pin this exact commit into a fresh isolated Release Osaurus build
- operate real tool turns through the UI with Computer Use
- verify nested database args, malformed-call recovery, interleaved calls, Qwen/Gemma controls, EOS completion, telemetry, and no binary evidence in either PR