### PR TITLE
Preserve reusable disk cache checkpoints under quota

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -1669,6 +1669,7 @@ public actor BatchEngine {
                     let ssmStates, let diskArrays) = result
                 {
                     var restored = false
+                    var retainedDiskRestore = false
                     if !blocks.isEmpty {
                         let restoredTokens = restoreLayerData(from: blocks, into: slot.cache)
                         coordinator.release(blocks: blocks)
@@ -1847,6 +1848,7 @@ public actor BatchEngine {
                                 inputForPrepare = LMInput(
                                     text: LMInput.Text(tokens: lastToken),
                                     image: nil, video: nil)
+                                retainedDiskRestore = diskArrays != nil
                             } else {
                                 let slotIDStr = slot.id.description
                                 Self.logger.info(
@@ -1914,6 +1916,7 @@ public actor BatchEngine {
                             inputForPrepare = LMInput(
                                 text: LMInput.Text(tokens: lastToken),
                                 image: nil, video: nil)
+                            retainedDiskRestore = diskArrays != nil
                         } else if remaining.isEmpty {
                             // Defensive fallback: no last token → roll back.
                             slot.cache = context.model.newCache(parameters: slot.parameters)
@@ -1928,6 +1931,16 @@ public actor BatchEngine {
                             inputForPrepare = LMInput(
                                 text: LMInput.Text(tokens: remainingArray),
                                 image: nil, video: nil)
+                            retainedDiskRestore = diskArrays != nil
+                        }
+                        if retainedDiskRestore {
+                            coordinator.touchStableDiskCheckpointsAfterRetainedRestore(
+                                requestTokens: tokenIds,
+                                matchedTokenCount: matchedTokens,
+                                preferredDiskBoundaries: slot.originalInput
+                                    .cacheStablePrefixTokenCounts,
+                                skipExactDiskBoundary: requiresDiskBackedRestore,
+                                mediaSalt: slot.mediaSalt)
                         }
                     }
                 }

--- a/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
@@ -533,9 +533,6 @@ public final class CacheCoordinator: @unchecked Sendable {
                     touchSuccessfulDiskRestore(
                         matchedTokens: prefix,
                         matchedBoundary: boundary,
-                        requestTokens: tokens,
-                        preferredDiskBoundaries: preferredDiskBoundaries,
-                        skipExactDiskBoundary: skipExactDiskBoundary,
                         mediaSalt: mediaSalt)
                     ftrace("HIT disk boundary=\(boundary) remaining=\(tokens.count - boundary) ssm=\(ssmStates?.count ?? -1) fmtV=\(TQDiskSerializer.formatVersion(of: arrays))")
                     return .hit(
@@ -674,54 +671,62 @@ public final class CacheCoordinator: @unchecked Sendable {
         return entry.isComplete ? entry.states : nil
     }
 
-    /// Refresh durable entries that the accepted restore made logically hot.
+    /// Keep the exact hybrid KV + recurrent companion pair on one recency.
     ///
     /// The directly served boundary was already touched by `DiskCache.fetch`.
-    /// Hybrid caches still need their linked recurrent companion touched with
-    /// the same timestamp. A growing tool/chat turn normally restores a newer,
-    /// longer boundary, but its processor-proven stable system/tool prefix is
-    /// also part of every request and is the checkpoint a new chat needs.
-    /// Refresh that stable prefix too so a long tool loop does not fill the
-    /// quota with one-off growing snapshots and evict the reusable warm-start
-    /// checkpoint merely because the longer entry served the current request.
+    /// Hybrid caches need their linked recurrent companion touched with the
+    /// same timestamp before quota can observe the pair. Stable checkpoints are
+    /// deliberately excluded here because the runtime has not yet proved that
+    /// it retained the fetched arrays.
+    private func touchSuccessfulDiskRestore(
+        matchedTokens: [Int],
+        matchedBoundary: Int,
+        mediaSalt: String?
+    ) {
+        guard isHybrid, let diskCache else { return }
+        let recency = Date()
+        CombinedDiskCacheQuotaLock.shared.lock()
+        defer { CombinedDiskCacheQuotaLock.shared.unlock() }
+
+        _ = diskCache.touchRecency(
+            tokens: matchedTokens,
+            mediaSalt: mediaSalt,
+            at: recency)
+        _ = ssmStateCache.diskStore?.touchRecency(
+            tokens: matchedTokens,
+            boundary: matchedBoundary,
+            mediaSalt: mediaSalt,
+            at: recency)
+    }
+
+    /// Refresh only processor-proven stable checkpoints after a caller has
+    /// retained a disk restore. Calling this before architecture-specific
+    /// restore validation can keep an entry hot even when the runtime rolls
+    /// back to full prefill, so every production caller invokes it only from
+    /// its retained `diskArrays` branch.
     ///
     /// Path-dependent hybrid caches persist the stable checkpoint one token
     /// short, matching the safe-seed rule used by fetch/store. Every touch is
     /// content-addressed with the active model/media namespace and updates only
     /// an existing entry; no missing or incompatible checkpoint is invented.
-    private func touchSuccessfulDiskRestore(
-        matchedTokens: [Int],
-        matchedBoundary: Int,
+    func touchStableDiskCheckpointsAfterRetainedRestore(
         requestTokens: [Int],
+        matchedTokenCount: Int,
         preferredDiskBoundaries: [Int],
         skipExactDiskBoundary: Bool,
         mediaSalt: String?
     ) {
-        guard let diskCache else { return }
+        guard let diskCache,
+              matchedTokenCount > 0,
+              matchedTokenCount <= requestTokens.count
+        else { return }
         let recency = Date()
         CombinedDiskCacheQuotaLock.shared.lock()
         defer { CombinedDiskCacheQuotaLock.shared.unlock() }
 
-        if isHybrid {
-            // `DiskCache.fetch` already touched this row, but that happened
-            // before the coordinator validated the companion topology and
-            // outside the combined quota lock. Re-touch the linked pair with
-            // one timestamp so quota never observes a hot KV row paired with
-            // a stale recurrent companion.
-            _ = diskCache.touchRecency(
-                tokens: matchedTokens,
-                mediaSalt: mediaSalt,
-                at: recency)
-            _ = ssmStateCache.diskStore?.touchRecency(
-                tokens: matchedTokens,
-                boundary: matchedBoundary,
-                mediaSalt: mediaSalt,
-                at: recency)
-        }
-
         let stableBoundaries = Set(preferredDiskBoundaries.compactMap { boundary in
             let storedBoundary = skipExactDiskBoundary ? boundary - 1 : boundary
-            return storedBoundary > 0 && storedBoundary <= matchedBoundary
+            return storedBoundary > 0 && storedBoundary <= matchedTokenCount
                 ? storedBoundary
                 : nil
         })

--- a/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
@@ -530,6 +530,12 @@ public final class CacheCoordinator: @unchecked Sendable {
                     diskArrays: arrays,
                     mediaSalt: mediaSalt)
                 if hasRequiredHybridSSM(ssmStates, diskArrays: arrays) {
+                    if isHybrid {
+                        touchSuccessfulHybridDiskRestore(
+                            tokens: prefix,
+                            boundary: boundary,
+                            mediaSalt: mediaSalt)
+                    }
                     ftrace("HIT disk boundary=\(boundary) remaining=\(tokens.count - boundary) ssm=\(ssmStates?.count ?? -1) fmtV=\(TQDiskSerializer.formatVersion(of: arrays))")
                     return .hit(
                         matchedTokens: boundary,
@@ -665,6 +671,34 @@ public final class CacheCoordinator: @unchecked Sendable {
             return nil
         }
         return entry.isComplete ? entry.states : nil
+    }
+
+    /// Refresh the complete persistent hybrid group after the coordinator has
+    /// accepted a disk restore. Combined quota sorts a linked group by the
+    /// older of its KV-row timestamp and companion-file timestamp, so touching
+    /// only whichever tier physically served recurrent state can still evict a
+    /// hot prefix. Hold the quota lock across both metadata updates and use one
+    /// timestamp. This also covers an L1 recurrent-state hit or folded v2
+    /// payload that did not call `SSMCompanionDiskStore.fetch`.
+    private func touchSuccessfulHybridDiskRestore(
+        tokens: [Int],
+        boundary: Int,
+        mediaSalt: String?
+    ) {
+        guard let diskCache else { return }
+        let recency = Date()
+        CombinedDiskCacheQuotaLock.shared.lock()
+        defer { CombinedDiskCacheQuotaLock.shared.unlock() }
+
+        _ = diskCache.touchRecency(
+            tokens: tokens,
+            mediaSalt: mediaSalt,
+            at: recency)
+        _ = ssmStateCache.diskStore?.touchRecency(
+            tokens: tokens,
+            boundary: boundary,
+            mediaSalt: mediaSalt,
+            at: recency)
     }
 
     // MARK: - Store

--- a/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
@@ -530,12 +530,13 @@ public final class CacheCoordinator: @unchecked Sendable {
                     diskArrays: arrays,
                     mediaSalt: mediaSalt)
                 if hasRequiredHybridSSM(ssmStates, diskArrays: arrays) {
-                    if isHybrid {
-                        touchSuccessfulHybridDiskRestore(
-                            tokens: prefix,
-                            boundary: boundary,
-                            mediaSalt: mediaSalt)
-                    }
+                    touchSuccessfulDiskRestore(
+                        matchedTokens: prefix,
+                        matchedBoundary: boundary,
+                        requestTokens: tokens,
+                        preferredDiskBoundaries: preferredDiskBoundaries,
+                        skipExactDiskBoundary: skipExactDiskBoundary,
+                        mediaSalt: mediaSalt)
                     ftrace("HIT disk boundary=\(boundary) remaining=\(tokens.count - boundary) ssm=\(ssmStates?.count ?? -1) fmtV=\(TQDiskSerializer.formatVersion(of: arrays))")
                     return .hit(
                         matchedTokens: boundary,
@@ -673,16 +674,27 @@ public final class CacheCoordinator: @unchecked Sendable {
         return entry.isComplete ? entry.states : nil
     }
 
-    /// Refresh the complete persistent hybrid group after the coordinator has
-    /// accepted a disk restore. Combined quota sorts a linked group by the
-    /// older of its KV-row timestamp and companion-file timestamp, so touching
-    /// only whichever tier physically served recurrent state can still evict a
-    /// hot prefix. Hold the quota lock across both metadata updates and use one
-    /// timestamp. This also covers an L1 recurrent-state hit or folded v2
-    /// payload that did not call `SSMCompanionDiskStore.fetch`.
-    private func touchSuccessfulHybridDiskRestore(
-        tokens: [Int],
-        boundary: Int,
+    /// Refresh durable entries that the accepted restore made logically hot.
+    ///
+    /// The directly served boundary was already touched by `DiskCache.fetch`.
+    /// Hybrid caches still need their linked recurrent companion touched with
+    /// the same timestamp. A growing tool/chat turn normally restores a newer,
+    /// longer boundary, but its processor-proven stable system/tool prefix is
+    /// also part of every request and is the checkpoint a new chat needs.
+    /// Refresh that stable prefix too so a long tool loop does not fill the
+    /// quota with one-off growing snapshots and evict the reusable warm-start
+    /// checkpoint merely because the longer entry served the current request.
+    ///
+    /// Path-dependent hybrid caches persist the stable checkpoint one token
+    /// short, matching the safe-seed rule used by fetch/store. Every touch is
+    /// content-addressed with the active model/media namespace and updates only
+    /// an existing entry; no missing or incompatible checkpoint is invented.
+    private func touchSuccessfulDiskRestore(
+        matchedTokens: [Int],
+        matchedBoundary: Int,
+        requestTokens: [Int],
+        preferredDiskBoundaries: [Int],
+        skipExactDiskBoundary: Bool,
         mediaSalt: String?
     ) {
         guard let diskCache else { return }
@@ -690,15 +702,45 @@ public final class CacheCoordinator: @unchecked Sendable {
         CombinedDiskCacheQuotaLock.shared.lock()
         defer { CombinedDiskCacheQuotaLock.shared.unlock() }
 
-        _ = diskCache.touchRecency(
-            tokens: tokens,
-            mediaSalt: mediaSalt,
-            at: recency)
-        _ = ssmStateCache.diskStore?.touchRecency(
-            tokens: tokens,
-            boundary: boundary,
-            mediaSalt: mediaSalt,
-            at: recency)
+        if isHybrid {
+            // `DiskCache.fetch` already touched this row, but that happened
+            // before the coordinator validated the companion topology and
+            // outside the combined quota lock. Re-touch the linked pair with
+            // one timestamp so quota never observes a hot KV row paired with
+            // a stale recurrent companion.
+            _ = diskCache.touchRecency(
+                tokens: matchedTokens,
+                mediaSalt: mediaSalt,
+                at: recency)
+            _ = ssmStateCache.diskStore?.touchRecency(
+                tokens: matchedTokens,
+                boundary: matchedBoundary,
+                mediaSalt: mediaSalt,
+                at: recency)
+        }
+
+        let stableBoundaries = Set(preferredDiskBoundaries.compactMap { boundary in
+            let storedBoundary = skipExactDiskBoundary ? boundary - 1 : boundary
+            return storedBoundary > 0 && storedBoundary <= matchedBoundary
+                ? storedBoundary
+                : nil
+        })
+        for boundary in stableBoundaries {
+            let tokens = boundary == requestTokens.count
+                ? requestTokens
+                : Array(requestTokens.prefix(boundary))
+            let touchedKV = diskCache.touchRecency(
+                tokens: tokens,
+                mediaSalt: mediaSalt,
+                at: recency)
+            if touchedKV, isHybrid {
+                _ = ssmStateCache.diskStore?.touchRecency(
+                    tokens: tokens,
+                    boundary: boundary,
+                    mediaSalt: mediaSalt,
+                    at: recency)
+            }
+        }
     }
 
     // MARK: - Store

--- a/Libraries/MLXLMCommon/Cache/DiskCache.swift
+++ b/Libraries/MLXLMCommon/Cache/DiskCache.swift
@@ -428,10 +428,13 @@ public final class DiskCache: @unchecked Sendable {
         return entries
     }
 
-    /// Refresh one indexed payload's eviction recency without reading or
-    /// rewriting its safetensors file. CacheCoordinator uses the explicit
-    /// timestamp form to touch a linked KV + recurrent-companion group under
-    /// one combined-quota critical section.
+    /// Refresh one indexed payload's eviction recency without decoding or
+    /// rewriting its safetensors file. The file must still exist and its size
+    /// and token count must match the index; an orphan or stale row is not
+    /// allowed to become hot merely because its content hash still exists in
+    /// SQLite. CacheCoordinator uses the explicit timestamp form to touch a
+    /// linked KV + recurrent-companion group under one combined-quota critical
+    /// section.
     @discardableResult
     func touchRecency(
         tokens: [Int],
@@ -440,8 +443,20 @@ public final class DiskCache: @unchecked Sendable {
     ) -> Bool {
         let hash = DiskCache.hashTokens(
             tokens, modelKey: modelKey, mediaSalt: mediaSalt)
+        let url = safetensorsURL(for: hash)
+        MLXDiskCacheIOLock.shared.lock()
+        defer { MLXDiskCacheIOLock.shared.unlock() }
         lock.lock()
         defer { lock.unlock() }
+        guard let current = _fileFingerprint(url: url),
+              current.size > 0,
+              let indexed = _entryMetadataLocked(hash: hash),
+              indexed.tokenCount == tokens.count,
+              indexed.fileSize == current.size
+        else {
+            validatedFiles.removeValue(forKey: hash)
+            return false
+        }
         return _touchEntryLocked(hash: hash, at: date)
     }
 

--- a/Libraries/MLXLMCommon/Cache/DiskCache.swift
+++ b/Libraries/MLXLMCommon/Cache/DiskCache.swift
@@ -16,7 +16,8 @@ public struct DiskCacheStats: Sendable {
 }
 
 /// One indexed KV payload used by the coordinator's shared disk-quota pass.
-/// `createdAt` mirrors the existing oldest-entry eviction order.
+/// `createdAt` is the entry's eviction recency timestamp. The SQLite column
+/// retains its historical `created_at` name for on-disk schema compatibility.
 struct DiskCacheQuotaEntry: Sendable {
     let hash: String
     let bytes: Int64
@@ -309,6 +310,7 @@ public final class DiskCache: @unchecked Sendable {
             if let fingerprint = _fileFingerprint(url: url), fingerprint.size > 0 {
                 validatedFiles[hash] = fingerprint
             }
+            _touchEntryLocked(hash: hash)
             hits += 1
             return arrays
         } catch {
@@ -424,6 +426,23 @@ public final class DiskCache: @unchecked Sendable {
                 createdAt: Date(timeIntervalSince1970: unixTime)))
         }
         return entries
+    }
+
+    /// Refresh one indexed payload's eviction recency without reading or
+    /// rewriting its safetensors file. CacheCoordinator uses the explicit
+    /// timestamp form to touch a linked KV + recurrent-companion group under
+    /// one combined-quota critical section.
+    @discardableResult
+    func touchRecency(
+        tokens: [Int],
+        mediaSalt: String? = nil,
+        at date: Date
+    ) -> Bool {
+        let hash = DiskCache.hashTokens(
+            tokens, modelKey: modelKey, mediaSalt: mediaSalt)
+        lock.lock()
+        defer { lock.unlock() }
+        return _touchEntryLocked(hash: hash, at: date)
     }
 
     /// Remove indexed KV payloads selected by the combined quota pass.
@@ -584,21 +603,28 @@ public final class DiskCache: @unchecked Sendable {
 
     /// Refresh the existing eviction timestamp without replacing the row or
     /// rewriting the payload. Caller MUST hold `lock`.
-    private func _touchEntryLocked(hash: String) {
-        guard let db else { return }
+    @discardableResult
+    private func _touchEntryLocked(
+        hash: String,
+        at date: Date = Date()
+    ) -> Bool {
+        guard let db else { return false }
         var stmt: OpaquePointer?
         guard sqlite3_prepare_v2(
             db,
-            "UPDATE cache_entries SET created_at = julianday('now') WHERE hash = ?",
+            "UPDATE cache_entries SET created_at = ? WHERE hash = ?",
             -1,
             &stmt,
             nil) == SQLITE_OK
-        else { return }
+        else { return false }
         defer { sqlite3_finalize(stmt) }
-        hash.withCString { cStr in
-            sqlite3_bind_text(stmt, 1, cStr, -1, nil)
-            sqlite3_step(stmt)
+        let julianDay = date.timeIntervalSince1970 / 86_400 + 2_440_587.5
+        sqlite3_bind_double(stmt, 1, julianDay)
+        _ = hash.withCString { cStr in
+            sqlite3_bind_text(stmt, 2, cStr, -1, nil)
         }
+        guard sqlite3_step(stmt) == SQLITE_DONE else { return false }
+        return sqlite3_changes(db) > 0
     }
 
     /// Delete a single `cache_entries` row by hash. Caller MUST hold `lock`.

--- a/Libraries/MLXLMCommon/Cache/SSMCompanionDiskStore.swift
+++ b/Libraries/MLXLMCommon/Cache/SSMCompanionDiskStore.swift
@@ -190,34 +190,26 @@ public final class SSMCompanionDiskStore: @unchecked Sendable {
            currentSafetensors == validated.safetensors,
            currentSidecar == validated.sidecar
         {
-            let now = Date()
-            do {
-                try FileManager.default.setAttributes(
-                    [.modificationDate: now], ofItemAtPath: safetensorsURL.path)
-                try FileManager.default.setAttributes(
-                    [.modificationDate: now], ofItemAtPath: sidecarURL.path)
-                if let touchedSafetensors = fileFingerprint(at: safetensorsURL),
-                   let touchedSidecar = fileFingerprint(at: sidecarURL)
-                {
-                    validatedEntries[key] = ValidatedEntry(
-                        safetensors: touchedSafetensors,
-                        sidecar: touchedSidecar,
-                        isComplete: isComplete,
-                        numStates: ssmStates.count,
-                        boundary: boundary,
-                        kvHash: kvHash)
-                } else {
-                    validatedEntries.removeValue(forKey: key)
-                }
+            if let touched = touchEntryFilesLocked(
+                safetensorsURL: safetensorsURL,
+                sidecarURL: sidecarURL,
+                at: Date())
+            {
+                validatedEntries[key] = ValidatedEntry(
+                    safetensors: touched.safetensors,
+                    sidecar: touched.sidecar,
+                    isComplete: isComplete,
+                    numStates: ssmStates.count,
+                    boundary: boundary,
+                    kvHash: kvHash)
                 storeSkips += 1
                 if ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1" {
                     FileHandle.standardError.write(Data(
                         "[vmlx][cache/ssm-store] SKIP validated key=\(key) boundary=\(boundary) states=\(ssmStates.count)\n".utf8))
                 }
                 return
-            } catch {
-                validatedEntries.removeValue(forKey: key)
             }
+            validatedEntries.removeValue(forKey: key)
         }
 
         // Pre-realize on calling thread — same rationale as
@@ -336,6 +328,15 @@ public final class SSMCompanionDiskStore: @unchecked Sendable {
             states.append(arr)
         }
 
+        // Reads, not only repeated stores, make an entry hot. Refresh both
+        // files to the same timestamp so quota observes the pair as one
+        // recency unit. This changes filesystem metadata only; tensor and JSON
+        // payload bytes remain untouched.
+        let touchedFingerprints = touchEntryFilesLocked(
+            safetensorsURL: safetensorsURL,
+            sidecarURL: sidecarURL,
+            at: Date())
+
         // Legacy sidecars remain readable, but only a complete current-format
         // metadata match is eligible to suppress the next write-through.
         let expectedKVHash = DiskCache.hashTokens(
@@ -348,8 +349,10 @@ public final class SSMCompanionDiskStore: @unchecked Sendable {
            storedBoundary == boundary,
            storedKVHash == expectedKVHash,
            storedModelKey == (modelKey ?? ""),
-           let fetchedSafetensors = fileFingerprint(at: safetensorsURL),
-           let fetchedSidecar = fileFingerprint(at: sidecarURL)
+           let fetchedSafetensors = touchedFingerprints?.safetensors
+                ?? fileFingerprint(at: safetensorsURL),
+           let fetchedSidecar = touchedFingerprints?.sidecar
+                ?? fileFingerprint(at: sidecarURL)
         {
             validatedEntries[key] = ValidatedEntry(
                 safetensors: fetchedSafetensors,
@@ -363,6 +366,52 @@ public final class SSMCompanionDiskStore: @unchecked Sendable {
         }
 
         return SSMStateCache.FetchResult(states: states, isComplete: isComplete)
+    }
+
+    /// Refresh one linked recurrent companion's eviction recency without
+    /// decoding or rewriting either payload. CacheCoordinator calls this with
+    /// the same timestamp as the matching KV row, including when recurrent
+    /// state was satisfied from the in-memory L1 or folded disk payload.
+    @discardableResult
+    func touchRecency(
+        tokens: [Int],
+        boundary: Int,
+        mediaSalt: String? = nil,
+        at date: Date
+    ) -> Bool {
+        guard boundary > 0, boundary <= tokens.count else { return false }
+        let key = Self.keyFor(
+            tokens: tokens,
+            boundary: boundary,
+            mediaSalt: mediaSalt,
+            modelKey: modelKey)
+        let safetensorsURL = self.safetensorsURL(for: key)
+        let sidecarURL = self.sidecarURL(for: key)
+
+        MLXDiskCacheIOLock.shared.lock()
+        defer { MLXDiskCacheIOLock.shared.unlock() }
+        lock.lock()
+        defer { lock.unlock() }
+
+        guard let touched = touchEntryFilesLocked(
+            safetensorsURL: safetensorsURL,
+            sidecarURL: sidecarURL,
+            at: date)
+        else {
+            validatedEntries.removeValue(forKey: key)
+            return false
+        }
+
+        if let validated = validatedEntries[key] {
+            validatedEntries[key] = ValidatedEntry(
+                safetensors: touched.safetensors,
+                sidecar: touched.sidecar,
+                isComplete: validated.isComplete,
+                numStates: validated.numStates,
+                boundary: validated.boundary,
+                kvHash: validated.kvHash)
+        }
+        return true
     }
 
     /// Remove all entries for a given model key. Called on model
@@ -435,6 +484,33 @@ public final class SSMCompanionDiskStore: @unchecked Sendable {
             let modificationDate = values.contentModificationDate
         else { return nil }
         return FileFingerprint(size: size, modificationDate: modificationDate)
+    }
+
+    /// Touch a companion pair without changing either payload. Caller MUST
+    /// hold `lock`; cross-model safetensors serialization is owned by the
+    /// public caller or the already-locked store/fetch path.
+    private func touchEntryFilesLocked(
+        safetensorsURL: URL,
+        sidecarURL: URL,
+        at date: Date
+    ) -> (safetensors: FileFingerprint, sidecar: FileFingerprint)? {
+        guard FileManager.default.fileExists(atPath: safetensorsURL.path),
+              FileManager.default.fileExists(atPath: sidecarURL.path)
+        else { return nil }
+        do {
+            try FileManager.default.setAttributes(
+                [.modificationDate: date],
+                ofItemAtPath: safetensorsURL.path)
+            try FileManager.default.setAttributes(
+                [.modificationDate: date],
+                ofItemAtPath: sidecarURL.path)
+            guard let safetensors = fileFingerprint(at: safetensorsURL),
+                  let sidecar = fileFingerprint(at: sidecarURL)
+            else { return nil }
+            return (safetensors: safetensors, sidecar: sidecar)
+        } catch {
+            return nil
+        }
     }
 
     private struct DiskEntry {

--- a/Libraries/MLXLMCommon/Cache/SSMCompanionDiskStore.swift
+++ b/Libraries/MLXLMCommon/Cache/SSMCompanionDiskStore.swift
@@ -393,6 +393,23 @@ public final class SSMCompanionDiskStore: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
 
+        let expectedKVHash = DiskCache.hashTokens(
+            Array(tokens.prefix(boundary)),
+            modelKey: modelKey,
+            mediaSalt: mediaSalt)
+        guard let sidecarData = try? Data(contentsOf: sidecarURL),
+              let sidecar = try? JSONSerialization.jsonObject(with: sidecarData)
+                as? [String: Any],
+              sidecar["is_complete"] as? Bool == true,
+              (sidecar["num_states"] as? Int ?? 0) > 0,
+              sidecar["boundary"] as? Int == boundary,
+              sidecar["kv_hash"] as? String == expectedKVHash,
+              sidecar["model_key"] as? String == (modelKey ?? "")
+        else {
+            validatedEntries.removeValue(forKey: key)
+            return false
+        }
+
         guard let touched = touchEntryFilesLocked(
             safetensorsURL: safetensorsURL,
             sidecarURL: sidecarURL,

--- a/Libraries/MLXLMCommon/Diffusion/BlockDiffusionTokenIterator.swift
+++ b/Libraries/MLXLMCommon/Diffusion/BlockDiffusionTokenIterator.swift
@@ -178,6 +178,15 @@ public struct BlockDiffusionTokenIterator: TokenIteratorProtocol {
                 {
                     tokensToEncode = remainingTokens
                     prefixCacheRestoredTokens = matchedTokens
+                    if diskArrays != nil {
+                        coordinator.touchStableDiskCheckpointsAfterRetainedRestore(
+                            requestTokens: promptTokenIds,
+                            matchedTokenCount: matchedTokens,
+                            preferredDiskBoundaries: input
+                                .cacheStablePrefixTokenCounts,
+                            skipExactDiskBoundary: false,
+                            mediaSalt: mediaSalt)
+                    }
                     if matchedTokens > 0 {
                         prefillProgressHandler?(
                             PrefillProgress(

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1452,6 +1452,7 @@ public struct TokenIterator: TokenIteratorProtocol {
                     let matchedTokens, let remainingTokens, let detail, let blocks,
                     let ssmStates, let diskArrays):
                 var restored = false
+                var retainedDiskRestore = false
                 if !blocks.isEmpty {
                     let restoredTokens = restoreLayerData(from: blocks, into: self.cache)
                     coordinator.release(blocks: blocks)
@@ -1581,6 +1582,7 @@ public struct TokenIterator: TokenIteratorProtocol {
                             inputForPrepare = LMInput(
                                 text: LMInput.Text(tokens: lastToken),
                                 image: nil, video: nil)
+                            retainedDiskRestore = diskArrays != nil
                         } else {
                             Self.logger.info(
                                 "TokenIterator: cache hit rolling back to full prefill (path-dependent full cache hit missing seed-boundary SSM state)"
@@ -1626,6 +1628,16 @@ public struct TokenIterator: TokenIteratorProtocol {
                                 text: LMInput.Text(tokens: remainingArray),
                                 image: nil, video: nil)
                         }
+                        retainedDiskRestore = diskArrays != nil
+                    }
+                    if retainedDiskRestore {
+                        coordinator.touchStableDiskCheckpointsAfterRetainedRestore(
+                            requestTokens: cacheLookupTokenIds,
+                            matchedTokenCount: matchedTokens,
+                            preferredDiskBoundaries: originalInput
+                                .cacheStablePrefixTokenCounts,
+                            skipExactDiskBoundary: requiresDiskBackedRestore,
+                            mediaSalt: mediaSalt)
                     }
                 }
                 case .miss:

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -230,6 +230,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 let matchedTokens, let remainingTokens, _, let blocks,
                 let ssmStates, let diskArrays):
                 var restored = false
+                var retainedDiskRestore = false
                 if !blocks.isEmpty {
                     let restoredTokens = restoreLayerData(from: blocks, into: self.cache)
                     coordinator.release(blocks: blocks)
@@ -288,11 +289,22 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                             let lastToken = MLXArray([Int32(last)])
                                 .expandedDimensions(axis: 0)
                             inputForPrepare = LMInput(text: LMInput.Text(tokens: lastToken))
+                            retainedDiskRestore = diskArrays != nil
                         }
                     } else {
                         let remainingArray = MLXArray(remainingTokens.map { Int32($0) })
                             .expandedDimensions(axis: 0)
                         inputForPrepare = LMInput(text: LMInput.Text(tokens: remainingArray))
+                        retainedDiskRestore = diskArrays != nil
+                    }
+                    if retainedDiskRestore {
+                        coordinator.touchStableDiskCheckpointsAfterRetainedRestore(
+                            requestTokens: cacheLookupTokenIds,
+                            matchedTokenCount: matchedTokens,
+                            preferredDiskBoundaries: originalInput
+                                .cacheStablePrefixTokenCounts,
+                            skipExactDiskBoundary: false,
+                            mediaSalt: mediaSalt)
                     }
                 }
             case .miss:

--- a/Tests/MLXLMTests/DiskCacheTests.swift
+++ b/Tests/MLXLMTests/DiskCacheTests.swift
@@ -385,6 +385,12 @@ import Testing
         default:
             Issue.record("expected growing dense disk restore")
         }
+        coordinator.touchStableDiskCheckpointsAfterRetainedRestore(
+            requestTokens: requestTokens,
+            matchedTokenCount: growingTokens.count,
+            preferredDiskBoundaries: [stableTokens.count],
+            skipExactDiskBoundary: false,
+            mediaSalt: nil)
 
         try await Task.sleep(nanoseconds: 50_000_000)
         disk.store(tokens: newTokens, arrays: arrays)
@@ -506,6 +512,12 @@ import Testing
         default:
             Issue.record("expected growing hybrid disk restore")
         }
+        coordinator.touchStableDiskCheckpointsAfterRetainedRestore(
+            requestTokens: requestTokens,
+            matchedTokenCount: growingTokens.count,
+            preferredDiskBoundaries: [stableBoundary],
+            skipExactDiskBoundary: true,
+            mediaSalt: nil)
 
         try await Task.sleep(nanoseconds: 50_000_000)
         disk.store(tokens: newTokens, arrays: kvArrays)

--- a/Tests/MLXLMTests/DiskCacheTests.swift
+++ b/Tests/MLXLMTests/DiskCacheTests.swift
@@ -30,6 +30,48 @@ import Testing
     }
 }
 
+@Test func diskCacheFetchRefreshesRecencyWithoutRewritingPayload() async throws {
+    try await MLXMetalTestLock.withLock {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vmlx-disk-fetch-recency-\(UUID())")
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let modelKey = "disk-fetch-recency-model"
+        let hotTokens = [1, 2, 3, 4]
+        let coldTokens = [5, 6, 7, 8]
+        let hotHash = DiskCache.hashTokens(hotTokens, modelKey: modelKey)
+        let cache = DiskCache(
+            cacheDir: tempDir, maxSizeGB: 0.1, modelKey: modelKey)
+        let arrays = ["data": MLXArray.ones([64])]
+
+        cache.store(tokens: hotTokens, arrays: arrays)
+        try await Task.sleep(nanoseconds: 50_000_000)
+        cache.store(tokens: coldTokens, arrays: arrays)
+
+        let hotBefore = try #require(
+            cache.quotaEntries().first { $0.hash == hotHash })
+        let coldBefore = try #require(
+            cache.quotaEntries().first {
+                $0.hash == DiskCache.hashTokens(coldTokens, modelKey: modelKey)
+            })
+        #expect(hotBefore.createdAt < coldBefore.createdAt)
+
+        let payloadURL = tempDir.appendingPathComponent("\(hotHash).safetensors")
+        let payloadBefore = try Data(contentsOf: payloadURL)
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        #expect(cache.fetch(tokens: hotTokens) != nil)
+
+        let hotAfter = try #require(
+            cache.quotaEntries().first { $0.hash == hotHash })
+        let coldAfter = try #require(
+            cache.quotaEntries().first {
+                $0.hash == DiskCache.hashTokens(coldTokens, modelKey: modelKey)
+            })
+        #expect(hotAfter.createdAt > coldAfter.createdAt)
+        #expect(try Data(contentsOf: payloadURL) == payloadBefore)
+    }
+}
+
 @Test func diskCacheSkipsRewriteOnlyAfterCurrentProcessValidation() async throws {
     try await MLXMetalTestLock.withLock {
         let tempDir = FileManager.default.temporaryDirectory
@@ -75,6 +117,211 @@ import Testing
         #expect(healedModification != changedDate)
         #expect(warm.snapshotStats().stores == 2)
         #expect(warm.snapshotStats().storeSkips == 1)
+    }
+}
+
+@Test func ssmCompanionFetchRefreshesRecencyWithoutRewritingPayload() async throws {
+    try await MLXMetalTestLock.withLock {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vmlx-ssm-fetch-recency-\(UUID())")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let modelKey = "ssm-fetch-recency-model"
+        let hotTokens = [11, 12, 13, 14]
+        let coldTokens = [21, 22, 23, 24]
+        let store = try SSMCompanionDiskStore(
+            cacheDir: dir,
+            modelKey: modelKey,
+            maxBytes: 10_000_000)
+        let states = [MLXArray.ones([64])]
+
+        try store.store(
+            ssmStates: states,
+            tokens: hotTokens,
+            boundary: hotTokens.count)
+        try await Task.sleep(nanoseconds: 50_000_000)
+        try store.store(
+            ssmStates: states,
+            tokens: coldTokens,
+            boundary: coldTokens.count)
+
+        let hotHash = SSMCompanionDiskStore.keyFor(
+            tokens: hotTokens,
+            boundary: hotTokens.count,
+            modelKey: modelKey)
+        let coldHash = SSMCompanionDiskStore.keyFor(
+            tokens: coldTokens,
+            boundary: coldTokens.count,
+            modelKey: modelKey)
+        let hotBefore = try #require(
+            store.quotaEntries().first { $0.hash == hotHash })
+        let coldBefore = try #require(
+            store.quotaEntries().first { $0.hash == coldHash })
+        #expect(hotBefore.modifiedAt < coldBefore.modifiedAt)
+
+        let tensorURL = dir.appendingPathComponent("ssm-\(hotHash).safetensors")
+        let sidecarURL = dir.appendingPathComponent("ssm-\(hotHash).json")
+        let tensorBefore = try Data(contentsOf: tensorURL)
+        let sidecarBefore = try Data(contentsOf: sidecarURL)
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        #expect(
+            store.fetch(
+                tokens: hotTokens,
+                boundary: hotTokens.count) != nil)
+
+        let hotAfter = try #require(
+            store.quotaEntries().first { $0.hash == hotHash })
+        let coldAfter = try #require(
+            store.quotaEntries().first { $0.hash == coldHash })
+        #expect(hotAfter.modifiedAt > coldAfter.modifiedAt)
+        #expect(try Data(contentsOf: tensorURL) == tensorBefore)
+        #expect(try Data(contentsOf: sidecarURL) == sidecarBefore)
+    }
+}
+
+@Test func successfulHybridDiskRestoreTouchesWholeGroupForLRUEviction() async throws {
+    try await MLXMetalTestLock.withLock {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vmlx-hybrid-group-lru-\(UUID())")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let modelKey = "hybrid-group-lru-model"
+        let hotTokens = [31, 32, 33, 34]
+        let coldTokens = [41, 42, 43, 44]
+        let newTokens = [51, 52, 53, 54]
+        let kvArrays = ["data": MLXArray.ones([8])]
+        let ssmStates = [MLXArray.ones([1_024])]
+        let hotKVHash = DiskCache.hashTokens(hotTokens, modelKey: modelKey)
+        let coldKVHash = DiskCache.hashTokens(coldTokens, modelKey: modelKey)
+        let newKVHash = DiskCache.hashTokens(newTokens, modelKey: modelKey)
+        let hotSSMHash = SSMCompanionDiskStore.keyFor(
+            tokens: hotTokens,
+            boundary: hotTokens.count,
+            modelKey: modelKey)
+        let coldSSMHash = SSMCompanionDiskStore.keyFor(
+            tokens: coldTokens,
+            boundary: coldTokens.count,
+            modelKey: modelKey)
+        let newSSMHash = SSMCompanionDiskStore.keyFor(
+            tokens: newTokens,
+            boundary: newTokens.count,
+            modelKey: modelKey)
+
+        var capBytes: Int64 = 0
+        do {
+            let seed = CacheCoordinator(config: CacheCoordinatorConfig(
+                usePagedCache: false,
+                enableDiskCache: true,
+                diskCacheMaxGB: 1,
+                diskCacheDir: root,
+                modelKey: modelKey))
+            seed.setHybrid(true, requiresRecurrentSSMCompanion: true)
+            let disk = try #require(seed.diskCache)
+
+            disk.store(tokens: hotTokens, arrays: kvArrays)
+            seed.ssmStateCache.store(
+                ssmStates: ssmStates,
+                tokens: hotTokens,
+                boundary: hotTokens.count)
+            try await Task.sleep(nanoseconds: 50_000_000)
+            disk.store(tokens: coldTokens, arrays: kvArrays)
+            seed.ssmStateCache.store(
+                ssmStates: ssmStates,
+                tokens: coldTokens,
+                boundary: coldTokens.count)
+
+            let hotKV = try #require(
+                disk.quotaEntries().first { $0.hash == hotKVHash })
+            let coldKV = try #require(
+                disk.quotaEntries().first { $0.hash == coldKVHash })
+            let companion = try #require(seed.ssmStateCache.diskStore)
+            let hotSSM = try #require(
+                companion.quotaEntries().first { $0.hash == hotSSMHash })
+            let coldSSM = try #require(
+                companion.quotaEntries().first { $0.hash == coldSSMHash })
+            let hotGroupBytes = hotKV.bytes + hotSSM.bytes
+            let coldGroupBytes = coldKV.bytes + coldSSM.bytes
+            // A + B fit before the access. Adding C must exceed the cap so
+            // combined quota has to choose exactly one linked group to evict.
+            capBytes = hotGroupBytes + coldGroupBytes
+        }
+
+        let capGB = Float(capBytes) / 1_073_741_824
+        let coordinator = CacheCoordinator(config: CacheCoordinatorConfig(
+            usePagedCache: false,
+            enableDiskCache: true,
+            diskCacheMaxGB: capGB,
+            diskCacheDir: root,
+            modelKey: modelKey))
+        coordinator.setHybrid(true, requiresRecurrentSSMCompanion: true)
+        let disk = try #require(coordinator.diskCache)
+        let companion = try #require(coordinator.ssmStateCache.diskStore)
+
+        // Keep hot recurrent state in L1 so the accepted disk restore does not
+        // call companion.fetch. The coordinator-level group touch must still
+        // refresh the linked on-disk sidecar.
+        coordinator.ssmStateCache.store(
+            ssmStates: ssmStates,
+            tokens: hotTokens,
+            boundary: hotTokens.count,
+            persistToDisk: false)
+
+        let hotTensorURL = root
+            .appendingPathComponent("ssm_companion")
+            .appendingPathComponent("ssm-\(hotSSMHash).safetensors")
+        let hotSidecarURL = root
+            .appendingPathComponent("ssm_companion")
+            .appendingPathComponent("ssm-\(hotSSMHash).json")
+        let hotTensorBefore = try Data(contentsOf: hotTensorURL)
+        let hotSidecarBefore = try Data(contentsOf: hotSidecarURL)
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        switch coordinator.fetch(tokens: hotTokens) {
+        case .hit(
+            let matchedTokens,
+            let remainingTokens,
+            .disk,
+            _,
+            let restoredStates,
+            _):
+            #expect(matchedTokens == hotTokens.count)
+            #expect(remainingTokens.isEmpty)
+            #expect(restoredStates?.count == 1)
+        default:
+            Issue.record("expected accepted hybrid disk restore for hot group")
+        }
+
+        let hotKVAfter = try #require(
+            disk.quotaEntries().first { $0.hash == hotKVHash })
+        let coldKVAfter = try #require(
+            disk.quotaEntries().first { $0.hash == coldKVHash })
+        let hotSSMAfter = try #require(
+            companion.quotaEntries().first { $0.hash == hotSSMHash })
+        let coldSSMAfter = try #require(
+            companion.quotaEntries().first { $0.hash == coldSSMHash })
+        let hotGroupRecency = min(
+            hotKVAfter.createdAt, hotSSMAfter.modifiedAt)
+        let coldGroupRecency = min(
+            coldKVAfter.createdAt, coldSSMAfter.modifiedAt)
+        #expect(hotGroupRecency > coldGroupRecency)
+        #expect(try Data(contentsOf: hotTensorURL) == hotTensorBefore)
+        #expect(try Data(contentsOf: hotSidecarURL) == hotSidecarBefore)
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+        disk.store(tokens: newTokens, arrays: kvArrays)
+        coordinator.ssmStateCache.store(
+            ssmStates: ssmStates,
+            tokens: newTokens,
+            boundary: newTokens.count)
+        coordinator.enforceCombinedDiskQuota()
+
+        let remainingKV = Set(disk.quotaEntries().map(\.hash))
+        let remainingSSM = Set(companion.quotaEntries().map(\.hash))
+        #expect(remainingKV.contains(hotKVHash))
+        #expect(remainingKV.contains(newKVHash))
+        #expect(!remainingKV.contains(coldKVHash))
+        #expect(remainingSSM.contains(hotSSMHash))
+        #expect(remainingSSM.contains(newSSMHash))
+        #expect(!remainingSSM.contains(coldSSMHash))
     }
 }
 

--- a/Tests/MLXLMTests/DiskCacheTests.swift
+++ b/Tests/MLXLMTests/DiskCacheTests.swift
@@ -302,6 +302,9 @@ import Testing
             hotKVAfter.createdAt, hotSSMAfter.modifiedAt)
         let coldGroupRecency = min(
             coldKVAfter.createdAt, coldSSMAfter.modifiedAt)
+        #expect(
+            abs(hotKVAfter.createdAt.timeIntervalSince(hotSSMAfter.modifiedAt))
+                < 0.01)
         #expect(hotGroupRecency > coldGroupRecency)
         #expect(try Data(contentsOf: hotTensorURL) == hotTensorBefore)
         #expect(try Data(contentsOf: hotSidecarURL) == hotSidecarBefore)
@@ -322,6 +325,206 @@ import Testing
         #expect(remainingSSM.contains(hotSSMHash))
         #expect(remainingSSM.contains(newSSMHash))
         #expect(!remainingSSM.contains(coldSSMHash))
+    }
+}
+
+@Test func growingDenseRestoreKeepsStableCheckpointHotUnderQuota() async throws {
+    try await MLXMetalTestLock.withLock {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vmlx-dense-stable-checkpoint-lru-\(UUID())")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let modelKey = "dense-stable-checkpoint-lru-model"
+        let stableTokens = [1, 2, 3, 4]
+        let coldTokens = [21, 22, 23, 24]
+        let growingTokens = [1, 2, 3, 4, 5, 6]
+        let requestTokens = [1, 2, 3, 4, 5, 6, 7]
+        let newTokens = [31, 32, 33, 34]
+        let arrays = ["data": MLXArray.ones([8])]
+
+        func hash(_ tokens: [Int]) -> String {
+            DiskCache.hashTokens(tokens, modelKey: modelKey)
+        }
+
+        var capBytes: Int64 = 0
+        do {
+            let seed = CacheCoordinator(config: CacheCoordinatorConfig(
+                usePagedCache: false,
+                enableDiskCache: true,
+                diskCacheMaxGB: 1,
+                diskCacheDir: root,
+                modelKey: modelKey))
+            let disk = try #require(seed.diskCache)
+            for tokens in [stableTokens, coldTokens, growingTokens] {
+                disk.store(tokens: tokens, arrays: arrays)
+                try await Task.sleep(nanoseconds: 50_000_000)
+            }
+            for tokens in [stableTokens, coldTokens, growingTokens] {
+                capBytes += try #require(
+                    disk.quotaEntries().first { $0.hash == hash(tokens) }).bytes
+            }
+            // Three existing payloads fit; four do not. Leave half an
+            // average entry of rounding headroom for the Float GB setting.
+            capBytes += capBytes / 6
+        }
+
+        let coordinator = CacheCoordinator(config: CacheCoordinatorConfig(
+            usePagedCache: false,
+            enableDiskCache: true,
+            diskCacheMaxGB: Float(capBytes) / 1_073_741_824,
+            diskCacheDir: root,
+            modelKey: modelKey))
+        let disk = try #require(coordinator.diskCache)
+
+        switch coordinator.fetch(
+            tokens: requestTokens,
+            preferredDiskBoundaries: [stableTokens.count])
+        {
+        case .hit(let matched, let remaining, .disk, _, _, _):
+            #expect(matched == growingTokens.count)
+            #expect(remaining == [7])
+        default:
+            Issue.record("expected growing dense disk restore")
+        }
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+        disk.store(tokens: newTokens, arrays: arrays)
+        coordinator.enforceCombinedDiskQuota()
+
+        let remaining = Set(disk.quotaEntries().map(\.hash))
+        #expect(remaining.contains(hash(stableTokens)))
+        #expect(remaining.contains(hash(growingTokens)))
+        #expect(remaining.contains(hash(newTokens)))
+        #expect(!remaining.contains(hash(coldTokens)))
+    }
+}
+
+@Test func diskCacheTouchDoesNotRefreshMissingPayloadRow() async throws {
+    try await MLXMetalTestLock.withLock {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vmlx-missing-payload-touch-\(UUID())")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let modelKey = "missing-payload-touch-model"
+        let tokens = [41, 42, 43, 44]
+        let hash = DiskCache.hashTokens(tokens, modelKey: modelKey)
+        let disk = DiskCache(cacheDir: root, maxSizeGB: 1, modelKey: modelKey)
+
+        disk.store(tokens: tokens, arrays: ["data": MLXArray.ones([8])])
+        let before = try #require(
+            disk.quotaEntries().first { $0.hash == hash }).createdAt
+        try FileManager.default.removeItem(
+            at: root.appendingPathComponent("\(hash).safetensors"))
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        #expect(!disk.touchRecency(tokens: tokens, at: Date()))
+        let after = try #require(
+            disk.quotaEntries().first { $0.hash == hash }).createdAt
+        #expect(after == before)
+    }
+}
+
+@Test func growingHybridRestoreKeepsStableCheckpointHotUnderQuota() async throws {
+    try await MLXMetalTestLock.withLock {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vmlx-stable-checkpoint-lru-\(UUID())")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let modelKey = "stable-checkpoint-lru-model"
+        let stableSeed = [1, 2, 3, 4]
+        let coldTokens = [21, 22, 23, 24]
+        let growingTokens = [1, 2, 3, 4, 5, 6]
+        let requestTokens = [1, 2, 3, 4, 5, 6, 7]
+        let newTokens = [31, 32, 33, 34]
+        let stableBoundary = stableSeed.count + 1
+        let kvArrays = ["data": MLXArray.ones([8])]
+        let ssmStates = [MLXArray.ones([1_024])]
+
+        func kvHash(_ tokens: [Int]) -> String {
+            DiskCache.hashTokens(tokens, modelKey: modelKey)
+        }
+        func ssmHash(_ tokens: [Int]) -> String {
+            SSMCompanionDiskStore.keyFor(
+                tokens: tokens,
+                boundary: tokens.count,
+                modelKey: modelKey)
+        }
+
+        var capBytes: Int64 = 0
+        do {
+            let seed = CacheCoordinator(config: CacheCoordinatorConfig(
+                usePagedCache: false,
+                enableDiskCache: true,
+                diskCacheMaxGB: 1,
+                diskCacheDir: root,
+                modelKey: modelKey))
+            seed.setHybrid(true, requiresRecurrentSSMCompanion: true)
+            let disk = try #require(seed.diskCache)
+            let companion = try #require(seed.ssmStateCache.diskStore)
+
+            for tokens in [stableSeed, coldTokens, growingTokens] {
+                disk.store(tokens: tokens, arrays: kvArrays)
+                seed.ssmStateCache.store(
+                    ssmStates: ssmStates,
+                    tokens: tokens,
+                    boundary: tokens.count)
+                try await Task.sleep(nanoseconds: 50_000_000)
+            }
+
+            let seededTokens = [stableSeed, coldTokens, growingTokens]
+            for tokens in seededTokens {
+                capBytes += try #require(
+                    disk.quotaEntries().first { $0.hash == kvHash(tokens) }).bytes
+                capBytes += try #require(
+                    companion.quotaEntries().first { $0.hash == ssmHash(tokens) }).bytes
+            }
+            // Leave room for SQLite/Float rounding, but not another linked
+            // cache group. Adding the fourth group must still force eviction.
+            capBytes += 4_096
+        }
+
+        let coordinator = CacheCoordinator(config: CacheCoordinatorConfig(
+            usePagedCache: false,
+            enableDiskCache: true,
+            diskCacheMaxGB: Float(capBytes) / 1_073_741_824,
+            diskCacheDir: root,
+            modelKey: modelKey))
+        coordinator.setHybrid(true, requiresRecurrentSSMCompanion: true)
+        let disk = try #require(coordinator.diskCache)
+        let companion = try #require(coordinator.ssmStateCache.diskStore)
+
+        // The current growing turn restores the longest six-token entry. The
+        // four-token seed is the path-dependent N-1 form of the processor's
+        // five-token stable system/tool boundary. It is not the served entry,
+        // but it is logically reused by this request and must remain hot for a
+        // subsequent new chat.
+        switch coordinator.fetch(
+            tokens: requestTokens,
+            skipExactDiskBoundary: true,
+            preferredDiskBoundaries: [stableBoundary])
+        {
+        case .hit(let matched, let remaining, .disk, _, _, _):
+            #expect(matched == growingTokens.count)
+            #expect(remaining == [7])
+        default:
+            Issue.record("expected growing hybrid disk restore")
+        }
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+        disk.store(tokens: newTokens, arrays: kvArrays)
+        coordinator.ssmStateCache.store(
+            ssmStates: ssmStates,
+            tokens: newTokens,
+            boundary: newTokens.count)
+        coordinator.enforceCombinedDiskQuota()
+
+        let remainingKV = Set(disk.quotaEntries().map(\.hash))
+        let remainingSSM = Set(companion.quotaEntries().map(\.hash))
+        #expect(remainingKV.contains(kvHash(stableSeed)))
+        #expect(remainingKV.contains(kvHash(growingTokens)))
+        #expect(remainingKV.contains(kvHash(newTokens)))
+        #expect(!remainingKV.contains(kvHash(coldTokens)))
+        #expect(remainingSSM.contains(ssmHash(stableSeed)))
+        #expect(remainingSSM.contains(ssmHash(growingTokens)))
+        #expect(remainingSSM.contains(ssmHash(newTokens)))
+        #expect(!remainingSSM.contains(ssmHash(coldTokens)))
     }
 }
 


### PR DESCRIPTION
## Problem

Validated SSD-L2 reads did not make the durable entry hot. Under quota pressure, long/growing tool or chat snapshots could therefore evict a recently reused stable system/tool prefix. Hybrid entries were especially exposed because quota ordering treats the KV payload and recurrent companion as one group. The next compatible chat then had no disk boundary and legitimately fell back to a cold `0/N` prefill, matching the intermittent report after Stop/new-chat activity.

## Source changes

Head: `7aa42711407d59dbd7e371a05c65396ff0f3855a` (baseline `f50853514ee00365837be3301c91850ca7ed5877`).

- Refresh a validated indexed KV entry's durable recency without rewriting its safetensors payload.
- Refresh both files of a validated recurrent companion without rewriting payload bytes.
- Touch an accepted hybrid KV+companion group with one timestamp under the combined-quota lock, preserving atomic eviction and model/media isolation.
- Touch only existing processor-proven stable checkpoints, and only after solo, batch, native-MTP, or diffusion runtime code has retained the restored disk state; rollback paths are not promoted.
- Add dense/hybrid quota, paired-recency, corruption/missing-metadata, and retained-restore coverage in the existing disk-cache test suite.

## Verification

### Source and focused tests

- At the preceding recency checkpoint, `DiskCacheTests`: 14/14 passed.
- At final head `7aa4271`, the retained-restore LRU subset: 3/3 passed, 0 failures:
  - `growingDenseRestoreKeepsStableCheckpointHotUnderQuota`
  - `growingHybridRestoreKeepsStableCheckpointHotUnderQuota`
  - `successfulHybridDiskRestoreTouchesWholeGroupForLRUEviction`
- `xcrun swift build --target MLXLMCommon`: passed with the final solo, batch, native-MTP, and diffusion call sites.
- `git diff --check`: passed.

### Exact isolated Release app

- App: `/private/tmp/osaurus-bonsai-final-7aa-app/osaurus.app`
- Bundle ID: `com.dinoki.osaurus.bonsaissdfinal7aa20260724`
- Isolated root: `/private/tmp/osaurus-bonsai-ssd-final-7aa-root-20260724`
- Executable SHA-256: `17b9e27abfb8d74ad670e56e41851a45708b68f6ea1723a4295bc306f0aa44ba`
- Runtime log: `/private/tmp/osaurus-bonsai-ssd-final-7aa-live-20260724.log`

Computer Use visibly saved and re-read: Prefix Cache On; GPU/Paged Cache Off; Disk Cache On; Disk Cache Size 1.5 GB; Codec `Engine Selected` (TurboQuant was not forced); SSM re-derive On.

### Live paged-Off SSD-L2 matrix

Every traced store reported `effectiveKVLayers=0 blocks=0 payload=false`; these were disk restores, not GPU-paged hits.

| Live UI row | Exact disk restore | Visible terminal result |
| --- | --- | --- |
| Bonsai Ternary initial | boundary 3,005; 24 remaining; `ssm=96` | `BONSAI_FINAL_A`; TTFT 1.21 s; 31.4 tok/s |
| Bonsai new chat | warm-up 3,007/1; request 3,007/22; `ssm=96` | `BONSAI_FINAL_B`; TTFT 0.62 s; 31.6 tok/s |
| Bonsai Stop -> immediate New Chat | long answer produced 643 visible deltas before Stop; incoming warm-up 3,007/1; request 3,007/23; `ssm=96` | `BONSAI_FINAL_CANCEL_OK`; TTFT 0.70 s; 27.8 tok/s; Stop disappeared and input unlocked |
| Bonsai full app restart, same root | first new-process warm-up 3,007/1; request 3,007/24; `ssm=96` | `BONSAI_FINAL_RESTART_OK`; TTFT 0.69 s; 32.3 tok/s; proves disk rather than process-memory reuse |
| Ornith 9B JANG_4M | warm-up 3,007/1; request 3,007/22; `ssm=48` | coherent factual answer; TTFT 0.37 s; 66.8 tok/s; terminal UI |
| Gemma 4 E2B 8-bit rotating SWA | warm-up 1,091/4; request 1,095/19; `ssm=-1`; required rotating companion offsets retained | `GEMMA4_FINAL_A` at 0.42 s/43.2 tok/s; new-chat `GEMMA4_FINAL_B` at 0.20 s/82.9 tok/s |
| Laguna S 2.1 JANG_2L mixed full/rotating | warm-up 2,841/3; request 2,844/19; `ssm=-1`; required rotating companion offsets retained | `LAGUNA_FINAL_A` at 2.43 s/42.4 tok/s; new-chat `LAGUNA_FINAL_B` at 0.77 s/43.2 tok/s |

The constrained quota actively evicted complete groups during this matrix. One Bonsai post-cancel row recorded `before=1736333694 after=1302905630 max=1610612736 kvEvicted=1 companionEvicted=1`; later compatible requests and the fresh process still restored the stable boundary. No tested row remained stuck at yellow `Queued 0/N` or `Prefill 0/N` after its terminal answer.

## CI caveat

PR #181 currently reports `mergeStateStatus=CLEAN`, but all four GitHub `Build and Test` jobs at `7aa4271` are **SKIPPED**: `lint`, `mac_build_and_test`, Linux container CMake, and Linux CUDA CMake. They are not executed CI evidence and must not be described as green. The evidence above is local source/focused-test plus isolated Release UI proof.

## Explicit limits

- This proves the product-default paged-RAM-Off SSD-L2 lane, not paged-RAM-On recency/eviction.
- TurboQuant KV On was not tested or forced; codec remained Engine Selected.
- The final candidate did not repeat a separate Bonsai 1-bit live row.
- Broad failed-tool/parser behavior, AppleScript/Computer Use, media, batching/delegation, Gemma 4 QAT, routing, and hardware guidance are outside this emergency engine PR.
- `LAGUNA_FINAL_A` included a retryable invalid `todo` detour before recovery; this is not claimed as clean broad tool-parser proof.
- The Osaurus pre-send lifecycle/handshake fix used by the Stop -> New Chat stress is a separate Osaurus-side change, not part of this vMLX diff.
- If PR #181 is squash-merged, Osaurus must be repinned to the resulting squash SHA, rebuilt, and smoke-tested before its consuming PR merges.

No image evidence is included in this PR.
