### PR TITLE
Defer disk recency until hybrid restore is valid

### DIFF
--- a/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
@@ -521,7 +521,14 @@ public final class CacheCoordinator: @unchecked Sendable {
             func diskHit(boundary: Int) -> CacheFetchResult? {
                 guard boundary > 0, boundary <= tokens.count else { return nil }
                 let prefix = boundary == tokens.count ? tokens : Array(tokens.prefix(boundary))
-                guard let arrays = diskCache.fetch(tokens: prefix, mediaSalt: mediaSalt) else {
+                // A deserializable KV payload is only a candidate until
+                // architecture-specific companion state is validated below.
+                // Do not make rejected hybrid candidates hot.
+                guard let arrays = diskCache.fetch(
+                    tokens: prefix,
+                    mediaSalt: mediaSalt,
+                    touchRecency: false
+                ) else {
                     return nil
                 }
                 let ssmStates = resolveSSMStates(
@@ -671,11 +678,13 @@ public final class CacheCoordinator: @unchecked Sendable {
         return entry.isComplete ? entry.states : nil
     }
 
-    /// Keep the exact hybrid KV + recurrent companion pair on one recency.
+    /// Refresh an accepted disk restore's eviction recency.
     ///
-    /// The directly served boundary was already touched by `DiskCache.fetch`.
-    /// Hybrid caches need their linked recurrent companion touched with the
-    /// same timestamp before quota can observe the pair. Stable checkpoints are
+    /// Candidate KV payloads are deliberately fetched without a recency touch
+    /// because hybrid validation may reject them for missing or incomplete
+    /// companion state. Dense restores touch KV only after acceptance; hybrid
+    /// restores touch KV and their linked recurrent companion with one
+    /// timestamp so quota observes the pair atomically. Stable checkpoints are
     /// deliberately excluded here because the runtime has not yet proved that
     /// it retained the fetched arrays.
     private func touchSuccessfulDiskRestore(
@@ -683,7 +692,7 @@ public final class CacheCoordinator: @unchecked Sendable {
         matchedBoundary: Int,
         mediaSalt: String?
     ) {
-        guard isHybrid, let diskCache else { return }
+        guard let diskCache else { return }
         let recency = Date()
         CombinedDiskCacheQuotaLock.shared.lock()
         defer { CombinedDiskCacheQuotaLock.shared.unlock() }
@@ -692,11 +701,13 @@ public final class CacheCoordinator: @unchecked Sendable {
             tokens: matchedTokens,
             mediaSalt: mediaSalt,
             at: recency)
-        _ = ssmStateCache.diskStore?.touchRecency(
-            tokens: matchedTokens,
-            boundary: matchedBoundary,
-            mediaSalt: mediaSalt,
-            at: recency)
+        if isHybrid {
+            _ = ssmStateCache.diskStore?.touchRecency(
+                tokens: matchedTokens,
+                boundary: matchedBoundary,
+                mediaSalt: mediaSalt,
+                at: recency)
+        }
     }
 
     /// Refresh only processor-proven stable checkpoints after a caller has

--- a/Libraries/MLXLMCommon/Cache/DiskCache.swift
+++ b/Libraries/MLXLMCommon/Cache/DiskCache.swift
@@ -288,9 +288,19 @@ public final class DiskCache: @unchecked Sendable {
 
     /// Fetch cached arrays for the given token sequence.
     ///
-    /// - Parameter tokens: Token IDs to look up.
+    /// - Parameters:
+    ///   - tokens: Token IDs to look up.
+    ///   - mediaSalt: Optional media fingerprint mixed into the cache key.
+    ///   - touchRecency: Whether a successful fetch refreshes eviction
+    ///     recency. Defaults to `true` for direct callers. CacheCoordinator
+    ///     disables it while validating architecture-specific companion state,
+    ///     then touches only a restore it actually accepts.
     /// - Returns: The cached arrays if found, or `nil` on a miss.
-    public func fetch(tokens: [Int], mediaSalt: String? = nil) -> [String: MLXArray]? {
+    public func fetch(
+        tokens: [Int],
+        mediaSalt: String? = nil,
+        touchRecency: Bool = true
+    ) -> [String: MLXArray]? {
         let hash = DiskCache.hashTokens(tokens, modelKey: modelKey, mediaSalt: mediaSalt)
         let url = safetensorsURL(for: hash)
 
@@ -310,7 +320,9 @@ public final class DiskCache: @unchecked Sendable {
             if let fingerprint = _fileFingerprint(url: url), fingerprint.size > 0 {
                 validatedFiles[hash] = fingerprint
             }
-            _touchEntryLocked(hash: hash)
+            if touchRecency {
+                _touchEntryLocked(hash: hash)
+            }
             hits += 1
             return arrays
         } catch {

--- a/Tests/MLXLMTests/DiskCacheTests.swift
+++ b/Tests/MLXLMTests/DiskCacheTests.swift
@@ -30,7 +30,7 @@ import Testing
     }
 }
 
-@Test func diskCacheFetchRefreshesRecencyWithoutRewritingPayload() async throws {
+@Test func diskCacheDefaultFetchRefreshesRecencyWithoutRewritingPayload() async throws {
     try await MLXMetalTestLock.withLock {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("vmlx-disk-fetch-recency-\(UUID())")
@@ -69,6 +69,90 @@ import Testing
             })
         #expect(hotAfter.createdAt > coldAfter.createdAt)
         #expect(try Data(contentsOf: payloadURL) == payloadBefore)
+    }
+}
+
+@Test func rejectedHybridDiskRestoreWithMissingCompanionDoesNotTouchKVRecency() async throws {
+    try await MLXMetalTestLock.withLock {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vmlx-rejected-missing-companion-lru-\(UUID())")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let modelKey = "rejected-missing-companion-lru-model"
+        let tokens = [61, 62, 63, 64]
+        let hash = DiskCache.hashTokens(tokens, modelKey: modelKey)
+        let coordinator = CacheCoordinator(config: CacheCoordinatorConfig(
+            usePagedCache: false,
+            enableDiskCache: true,
+            diskCacheMaxGB: 1,
+            diskCacheDir: root,
+            modelKey: modelKey))
+        coordinator.setHybrid(true, requiresRecurrentSSMCompanion: true)
+        let disk = try #require(coordinator.diskCache)
+
+        disk.store(tokens: tokens, arrays: ["data": MLXArray.ones([8])])
+        let before = try #require(
+            disk.quotaEntries().first { $0.hash == hash }).createdAt
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        if case .miss = coordinator.fetch(tokens: tokens) {
+            // Expected: usable hybrid state requires the missing companion.
+        } else {
+            Issue.record("hybrid KV without its recurrent companion must be rejected")
+        }
+
+        let after = try #require(
+            disk.quotaEntries().first { $0.hash == hash }).createdAt
+        #expect(after == before)
+    }
+}
+
+@Test func rejectedHybridDiskRestoreWithIncompleteCompanionDoesNotTouchKVRecency() async throws {
+    try await MLXMetalTestLock.withLock {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vmlx-rejected-incomplete-companion-lru-\(UUID())")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let modelKey = "rejected-incomplete-companion-lru-model"
+        let tokens = [71, 72, 73, 74]
+        let hash = DiskCache.hashTokens(tokens, modelKey: modelKey)
+
+        do {
+            let seed = CacheCoordinator(config: CacheCoordinatorConfig(
+                usePagedCache: false,
+                enableDiskCache: true,
+                diskCacheMaxGB: 1,
+                diskCacheDir: root,
+                modelKey: modelKey))
+            seed.setHybrid(true, requiresRecurrentSSMCompanion: true)
+            let disk = try #require(seed.diskCache)
+            disk.store(tokens: tokens, arrays: ["data": MLXArray.ones([8])])
+            seed.ssmStateCache.store(
+                ssmStates: [MLXArray.ones([16])],
+                tokens: tokens,
+                boundary: tokens.count,
+                isComplete: false)
+        }
+
+        let coordinator = CacheCoordinator(config: CacheCoordinatorConfig(
+            usePagedCache: false,
+            enableDiskCache: true,
+            diskCacheMaxGB: 1,
+            diskCacheDir: root,
+            modelKey: modelKey))
+        coordinator.setHybrid(true, requiresRecurrentSSMCompanion: true)
+        let disk = try #require(coordinator.diskCache)
+        let before = try #require(
+            disk.quotaEntries().first { $0.hash == hash }).createdAt
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        if case .miss = coordinator.fetch(tokens: tokens) {
+            // Expected: partial recurrent state is unsafe to extend.
+        } else {
+            Issue.record("hybrid KV with an incomplete recurrent companion must be rejected")
+        }
+
+        let after = try #require(
+            disk.quotaEntries().first { $0.hash == hash }).createdAt
+        #expect(after == before)
     }
 }
 


### PR DESCRIPTION
## Root cause

`CacheCoordinator` treated a deserializable KV disk payload as a successful
restore for eviction recency before validating the required hybrid recurrent
companion. A missing or incomplete SSM/GDN companion therefore rejected the
candidate, but the unusable KV entry had already been made hot and could
displace a valid linked cache group under quota.

## Change

- let direct `DiskCache.fetch` callers retain the existing read-touch default;
- let `CacheCoordinator` deserialize candidates without touching recency;
- after companion validation succeeds, touch dense KV or the linked hybrid
  KV-plus-companion group with one timestamp under the combined quota lock;
- cover missing and incomplete companion rejection explicitly.

## Source and test evidence

- Exact baseline: `c6a2b4d05bec0958146d26fd351782b2fc3e2b13`.
- Red proof with baseline production source plus the new tests: 2 tests ran,
  both failed because the rejected candidate changed KV recency.
- Patched focused run: 2/2 passed.
- Broader `DiskCache` selection: 17/17 passed.
- `swift build --target MLXLMCommon`: completed.
- `git diff --check`: clean.

This PR contains source/test proof only. Exact isolated Release Osaurus UI
proof will be performed after Osaurus pins the resulting squash commit.

No model-name checks, sampler changes, prompt coercion, TurboQuant-default
changes, or image evidence are included.
