### PR TITLE
Count only accepted hybrid cache restores

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -1827,10 +1827,11 @@ public actor BatchEngine {
                             let seedBoundary = promptLen - 1
                             if seedBoundary > 0,
                                let last = tokenIds.last,
-                               let seedSSM = coordinator.ssmStateCache.fetch(
+                               let seedSSM = coordinator.ssmStateCache.fetchEntry(
                                 tokens: tokenIds,
                                 boundary: seedBoundary,
-                                mediaSalt: slot.mediaSalt)
+                                mediaSalt: slot.mediaSalt,
+                                requireComplete: true)?.states
                             {
                                 let cacheOffset = slot.cache.first?.offset ?? promptLen
                                 let trimNeeded = cacheOffset - seedBoundary

--- a/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
@@ -527,7 +527,8 @@ public final class CacheCoordinator: @unchecked Sendable {
                 guard let arrays = diskCache.fetch(
                     tokens: prefix,
                     mediaSalt: mediaSalt,
-                    touchRecency: false
+                    touchRecency: false,
+                    countHit: false
                 ) else {
                     return nil
                 }
@@ -644,7 +645,8 @@ public final class CacheCoordinator: @unchecked Sendable {
         if let l1 = fetchCompleteSSMStates(
             tokens: tokens,
             boundary: boundary,
-            mediaSalt: mediaSalt)
+            mediaSalt: mediaSalt,
+            touchDiskRecency: false)
         {
             return l1
         }
@@ -666,12 +668,15 @@ public final class CacheCoordinator: @unchecked Sendable {
     private func fetchCompleteSSMStates(
         tokens: [Int],
         boundary: Int,
-        mediaSalt: String? = nil
+        mediaSalt: String? = nil,
+        touchDiskRecency: Bool = true
     ) -> [MLXArray]? {
         guard let entry = ssmStateCache.fetchEntry(
             tokens: tokens,
             boundary: boundary,
-            mediaSalt: mediaSalt)
+            mediaSalt: mediaSalt,
+            touchDiskRecency: touchDiskRecency,
+            requireComplete: true)
         else {
             return nil
         }
@@ -701,6 +706,7 @@ public final class CacheCoordinator: @unchecked Sendable {
             tokens: matchedTokens,
             mediaSalt: mediaSalt,
             at: recency)
+        diskCache.recordAcceptedHit()
         if isHybrid {
             _ = ssmStateCache.diskStore?.touchRecency(
                 tokens: matchedTokens,

--- a/Libraries/MLXLMCommon/Cache/DiskCache.swift
+++ b/Libraries/MLXLMCommon/Cache/DiskCache.swift
@@ -295,11 +295,15 @@ public final class DiskCache: @unchecked Sendable {
     ///     recency. Defaults to `true` for direct callers. CacheCoordinator
     ///     disables it while validating architecture-specific companion state,
     ///     then touches only a restore it actually accepts.
+    ///   - countHit: Whether a successful fetch increments hit telemetry.
+    ///     Defaults to `true` for direct callers. CacheCoordinator disables it
+    ///     for candidate reads and records only an accepted restore.
     /// - Returns: The cached arrays if found, or `nil` on a miss.
     public func fetch(
         tokens: [Int],
         mediaSalt: String? = nil,
-        touchRecency: Bool = true
+        touchRecency: Bool = true,
+        countHit: Bool = true
     ) -> [String: MLXArray]? {
         let hash = DiskCache.hashTokens(tokens, modelKey: modelKey, mediaSalt: mediaSalt)
         let url = safetensorsURL(for: hash)
@@ -323,7 +327,9 @@ public final class DiskCache: @unchecked Sendable {
             if touchRecency {
                 _touchEntryLocked(hash: hash)
             }
-            hits += 1
+            if countHit {
+                hits += 1
+            }
             return arrays
         } catch {
             misses += 1
@@ -348,6 +354,14 @@ public final class DiskCache: @unchecked Sendable {
             _deleteEntryLocked(hash: hash)
             return nil
         }
+    }
+
+    /// Record a deserialized candidate that CacheCoordinator accepted after
+    /// validating any architecture-specific companion state.
+    func recordAcceptedHit() {
+        lock.lock()
+        hits += 1
+        lock.unlock()
     }
 
     /// Whether this process has already proved that the content-addressed

--- a/Libraries/MLXLMCommon/Cache/SSMCompanionDiskStore.swift
+++ b/Libraries/MLXLMCommon/Cache/SSMCompanionDiskStore.swift
@@ -264,7 +264,12 @@ public final class SSMCompanionDiskStore: @unchecked Sendable {
     }
 
     /// Look up SSM layer states for a given token prefix + boundary.
-    /// Returns nil on miss / corruption / decode failure.
+    /// Returns nil on miss / corruption / decode failure. Direct reads refresh
+    /// recency by default; CacheCoordinator disables that while it validates a
+    /// candidate and touches the companion only after accepting the restore.
+    /// Reusable-boundary callers can require a complete snapshot; incomplete
+    /// entries are then rejected from sidecar metadata before tensor decode or
+    /// recency mutation.
     ///
     /// Iter 143: `mediaSalt` mirror of the store-side change. Pass the
     /// same salt the L1 store consumed (typically derived from
@@ -272,7 +277,9 @@ public final class SSMCompanionDiskStore: @unchecked Sendable {
     public func fetch(
         tokens: [Int],
         boundary: Int,
-        mediaSalt: String? = nil
+        mediaSalt: String? = nil,
+        touchRecency: Bool = true,
+        requireComplete: Bool = false
     ) -> SSMStateCache.FetchResult? {
         guard boundary > 0, boundary <= tokens.count else { return nil }
         let key = Self.keyFor(
@@ -305,6 +312,10 @@ public final class SSMCompanionDiskStore: @unchecked Sendable {
             return nil
         }
 
+        guard !requireComplete || isComplete else {
+            return nil
+        }
+
         // Decode safetensors. A failed deserialize is most often a
         // truncated file (process killed mid-write, rare on sync IO
         // but possible). Treat as miss.
@@ -328,14 +339,18 @@ public final class SSMCompanionDiskStore: @unchecked Sendable {
             states.append(arr)
         }
 
-        // Reads, not only repeated stores, make an entry hot. Refresh both
-        // files to the same timestamp so quota observes the pair as one
-        // recency unit. This changes filesystem metadata only; tensor and JSON
-        // payload bytes remain untouched.
-        let touchedFingerprints = touchEntryFilesLocked(
-            safetensorsURL: safetensorsURL,
-            sidecarURL: sidecarURL,
-            at: Date())
+        // Accepted/direct reads, not only repeated stores, make an entry hot.
+        // Refresh both files to the same timestamp so quota observes the pair
+        // as one recency unit. Candidate validation disables this and lets the
+        // coordinator touch only an accepted KV + companion group. This
+        // changes filesystem metadata only; tensor and JSON payload bytes
+        // remain untouched.
+        let touchedFingerprints = touchRecency
+            ? touchEntryFilesLocked(
+                safetensorsURL: safetensorsURL,
+                sidecarURL: sidecarURL,
+                at: Date())
+            : nil
 
         // Legacy sidecars remain readable, but only a complete current-format
         // metadata match is eligible to suppress the next write-through.

--- a/Libraries/MLXLMCommon/Cache/SSMStateCache.swift
+++ b/Libraries/MLXLMCommon/Cache/SSMStateCache.swift
@@ -215,9 +215,17 @@ public final class SSMStateCache: @unchecked Sendable {
     /// Fetch with completeness flag. Returns `FetchResult.isComplete=false`
     /// for partial-prefix entries that callers must NOT extend (re-derive
     /// instead). Mirrors Python's `(states, is_complete)` tuple semantics
-    /// from `vmlx_engine/utils/ssm_companion_cache.py`.
+    /// from `vmlx_engine/utils/ssm_companion_cache.py`. Disk reads refresh
+    /// recency by default; coordinator candidate validation can defer that
+    /// touch until it accepts the linked KV + companion restore. Callers that
+    /// require a reusable prompt boundary can reject incomplete entries before
+    /// they count as hits or hydrate the in-memory LRU.
     public func fetchEntry(
-        tokens: [Int], boundary: Int, mediaSalt: String? = nil
+        tokens: [Int],
+        boundary: Int,
+        mediaSalt: String? = nil,
+        touchDiskRecency: Bool = true,
+        requireComplete: Bool = false
     ) -> FetchResult? {
         let key = Self.makeKey(tokens: tokens, boundary: boundary, mediaSalt: mediaSalt, modelKey: modelKey)
 
@@ -233,7 +241,11 @@ public final class SSMStateCache: @unchecked Sendable {
             // from any lazy graph.
             if let disk = diskStore,
                let result = disk.fetch(
-                   tokens: tokens, boundary: boundary, mediaSalt: mediaSalt)
+                   tokens: tokens,
+                   boundary: boundary,
+                   mediaSalt: mediaSalt,
+                   touchRecency: touchDiskRecency,
+                   requireComplete: requireComplete)
             {
                 // Hydrate into LRU. Subtract the miss we just bumped
                 // because the disk lookup found it — this is a hit
@@ -254,6 +266,14 @@ public final class SSMStateCache: @unchecked Sendable {
         }
 
         let entry = entries[index]
+
+        // An incomplete snapshot is physically present but cannot satisfy a
+        // reusable prompt-boundary lookup. Keep the existing entry in place,
+        // count the attempted restore as a miss, and do not make it hotter.
+        guard !requireComplete || entry.isComplete else {
+            misses += 1
+            return nil
+        }
 
         // Empty states array is treated as a miss (bug fix from osa-jang ba07392)
         guard !entry.states.isEmpty else {

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1562,10 +1562,11 @@ public struct TokenIterator: TokenIteratorProtocol {
                         let seedBoundary = promptLen - 1
                         if seedBoundary > 0,
                            let last = cacheLookupTokenIds.last,
-                           let seedSSM = coordinator.ssmStateCache.fetch(
+                           let seedSSM = coordinator.ssmStateCache.fetchEntry(
                                 tokens: cacheLookupTokenIds,
                                 boundary: seedBoundary,
-                                mediaSalt: mediaSalt)
+                                mediaSalt: mediaSalt,
+                                requireComplete: true)?.states
                         {
                             let cacheOffset = self.cache.first?.offset ?? promptLen
                             let trimNeeded = cacheOffset - seedBoundary

--- a/Tests/MLXLMCommonFocusedTests/CacheCoordinatorTopologyFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/CacheCoordinatorTopologyFocusedTests.swift
@@ -214,6 +214,8 @@ struct CacheCoordinatorTopologyFocusedTests {
         if case .hit = coordinator.fetch(tokens: tokens + [79]) {
             Issue.record("hybrid paged cache must not extend partial SSM companion state")
         }
+        #expect(coordinator.ssmStateCache.snapshotStats().hits == 0)
+        #expect(coordinator.ssmStateCache.snapshotStats().misses > 0)
         }
     }
 
@@ -493,6 +495,8 @@ struct CacheCoordinatorTopologyFocusedTests {
         if case .hit = coordinator.fetch(tokens: tokens + [85]) {
             Issue.record("hybrid disk cache must not extend partial SSM companion state")
         }
+        #expect(coordinator.ssmStateCache.snapshotStats().hits == 0)
+        #expect(coordinator.ssmStateCache.snapshotStats().misses > 0)
         }
     }
 

--- a/Tests/MLXLMTests/DiskCacheTests.swift
+++ b/Tests/MLXLMTests/DiskCacheTests.swift
@@ -103,6 +103,7 @@ import Testing
         let after = try #require(
             disk.quotaEntries().first { $0.hash == hash }).createdAt
         #expect(after == before)
+        #expect(disk.snapshotStats().hits == 0)
     }
 }
 
@@ -140,8 +141,16 @@ import Testing
             modelKey: modelKey))
         coordinator.setHybrid(true, requiresRecurrentSSMCompanion: true)
         let disk = try #require(coordinator.diskCache)
-        let before = try #require(
+        let companion = try #require(coordinator.ssmStateCache.diskStore)
+        let companionHash = SSMCompanionDiskStore.keyFor(
+            tokens: tokens,
+            boundary: tokens.count,
+            modelKey: modelKey)
+        let kvBefore = try #require(
             disk.quotaEntries().first { $0.hash == hash }).createdAt
+        let companionBefore = try #require(
+            companion.quotaEntries().first { $0.hash == companionHash })
+            .modifiedAt
         try await Task.sleep(nanoseconds: 50_000_000)
 
         if case .miss = coordinator.fetch(tokens: tokens) {
@@ -150,9 +159,21 @@ import Testing
             Issue.record("hybrid KV with an incomplete recurrent companion must be rejected")
         }
 
-        let after = try #require(
+        let kvAfter = try #require(
             disk.quotaEntries().first { $0.hash == hash }).createdAt
-        #expect(after == before)
+        let companionAfter = try #require(
+            companion.quotaEntries().first { $0.hash == companionHash })
+            .modifiedAt
+        #expect(kvAfter == kvBefore)
+        #expect(companionAfter == companionBefore)
+        #expect(disk.snapshotStats().hits == 0)
+        let ssmStats = coordinator.ssmStateCache.snapshotStats()
+        #expect(ssmStats.hits == 0)
+        #expect(ssmStats.misses > 0)
+        #expect(
+            !coordinator.ssmStateCache.contains(
+                tokens: tokens,
+                boundary: tokens.count))
     }
 }
 
@@ -373,6 +394,7 @@ import Testing
         default:
             Issue.record("expected accepted hybrid disk restore for hot group")
         }
+        #expect(disk.snapshotStats().hits == 1)
 
         let hotKVAfter = try #require(
             disk.quotaEntries().first { $0.hash == hotKVHash })

--- a/Tests/MLXLMTests/SSMStateCacheTests.swift
+++ b/Tests/MLXLMTests/SSMStateCacheTests.swift
@@ -159,6 +159,49 @@ struct SSMStateCacheTests {
     #expect(saltedMiss == nil)
 }
 
+@Test func incompleteDiskCompanionRejectedAsReusableDoesNotBecomeHot() throws {
+    let dir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("ssm-companion-incomplete-reject-\(UUID().uuidString)")
+    defer { try? FileManager.default.removeItem(at: dir) }
+
+    let modelKey = "incomplete-reject-model"
+    let tokens = [11, 22, 33, 44]
+    let disk = try SSMCompanionDiskStore(
+        cacheDir: dir,
+        modelKey: modelKey,
+        maxBytes: 10_000_000)
+    try disk.store(
+        ssmStates: [MLXArray.ones([1, 2])],
+        tokens: tokens,
+        boundary: tokens.count,
+        isComplete: false)
+
+    let entry = try #require(disk.quotaEntries().first)
+    let tensorURL = dir.appendingPathComponent("ssm-\(entry.hash).safetensors")
+    let sidecarURL = dir.appendingPathComponent("ssm-\(entry.hash).json")
+    let coldDate = Date(timeIntervalSince1970: 100)
+    for url in [tensorURL, sidecarURL] {
+        try FileManager.default.setAttributes(
+            [.modificationDate: coldDate],
+            ofItemAtPath: url.path)
+    }
+    let before = try #require(disk.quotaEntries().first).modifiedAt
+
+    let cache = SSMStateCache(maxEntries: 4, modelKey: modelKey)
+    cache.diskStore = disk
+    let rejected = cache.fetchEntry(
+        tokens: tokens,
+        boundary: tokens.count,
+        requireComplete: true)
+
+    #expect(rejected == nil)
+    #expect(cache.hits == 0)
+    #expect(cache.misses == 1)
+    #expect(!cache.contains(tokens: tokens, boundary: tokens.count))
+    let after = try #require(disk.quotaEntries().first).modifiedAt
+    #expect(after == before)
+}
+
 @Test func ssmCompanionDiskStoreSkipsRewriteOnlyAfterValidation() async throws {
     try await MLXMetalTestLock.withLock {
         let dir = FileManager.default.temporaryDirectory


### PR DESCRIPTION
## Root cause

Hybrid disk lookup deserialized KV and companion candidates before completeness validation. A rejected candidate could therefore increment disk/SSM hit telemetry and refresh incomplete companion recency even though the runtime fell back to prefill.

## Fix

- defer KV hit accounting until CacheCoordinator accepts the architecture-complete restore
- defer companion recency until the linked restore is accepted
- reject incomplete reusable companions before tensor decode, L1 hydration, hit accounting, or recency mutation
- require complete SSM seeds in both TokenIterator and BatchEngine paths
- preserve direct-fetch defaults for callers that consume the payload immediately

## Verification

- untouched `7545ba66` plus the new rejected-candidate rows: failed with false disk hits and advanced incomplete-companion recency
- focused rejected/accepted controls: 3/3 passed after the patch
- cache-focused tests: 28/28 passed
- `DiskCache` tests: 17/17 passed
- `MLXLMCommon` build completed
- `git diff --check` clean

Live Osaurus UI proof is intentionally tracked in osaurus PR #2161 after this PR is squash-merged and pinned. No image or binary artifacts are included.
