### PR TITLE
FalconH1: build a causal attention mask for prefill (fixes degenerate/never-stopping generation)

### DIFF
--- a/Libraries/MLXLLM/Models/FalconH1.swift
+++ b/Libraries/MLXLLM/Models/FalconH1.swift
@@ -612,14 +612,18 @@ private func createSSMMask(h: MLXArray, cache: ArraysCache?) -> MLXArray? {
 }
 
 private func createAttentionMask(h: MLXArray, cache: [KVCache]?) -> MLXArray? {
-    let N = h.dim(1)
-    // If cache exists and can make masks, use it
-    // Otherwise for single token, no mask needed
-    // For multi-token, SDPA will handle causal mask internally when nil
-    if N == 1 {
-        return nil
+    let n = h.dim(1)
+    // Multi-token prefill MUST get an explicit causal mask. MLX's scaledDotProductAttention
+    // does NOT apply causal masking for a nil MLXArray mask — nil means "no mask" (full,
+    // bidirectional attention). Returning nil here let every prompt token attend to future
+    // tokens, a train/inference mismatch that corrupts the context and produces grammatical
+    // but degenerate output that never emits eos. Single-token decode needs no mask.
+    // Mirrors the shared createAttentionMask(h:cache:) in MLXLMCommon.
+    if n > 1 {
+        let offset = cache?.first?.offset ?? 0
+        return createCausalMask(n: n, offset: offset)
     }
-    return nil  // Will be handled by SDPA internally when nil
+    return nil
 }
 
 // MARK: - Model


### PR DESCRIPTION
FalconH1's attention path shadows the shared `createAttentionMask(h:cache:)` with a private copy that returns `nil` for **every** sequence length:

```swift
private func createAttentionMask(h: MLXArray, cache: [KVCache]?) -> MLXArray? {
    let N = h.dim(1)
    if N == 1 { return nil }
    return nil  // "Will be handled by SDPA internally when nil"  ← not true
}
```

`scaledDotProductAttention` does **not** apply causal masking for a `nil` MLXArray mask — `nil` means *no mask* (full, bidirectional attention). So every multi-token prefill, and every teacher-forced logprob pass, ran **bidirectional** attention: each prompt token could attend to future tokens. That train/inference mismatch corrupts the context representation — the model still emits grammatical text but loses the thread and never produces its turn-terminator, so generation runs to the token cap (`finish=length`, empty answer) and multiple-choice accuracy collapses to chance.

FalconH1 is the **only** model in the tree that overrides `createAttentionMask`. The working hybrids (`Jamba`, `NemotronH`) use the shared helper, which returns an explicit `createCausalMask(...)` for `t > 1` and `nil` only for single-token decode. This change makes the local helper do the same.

Notably this is **weight-independent**: it reproduces on every quantization, including conversions whose muP scaling multipliers are correctly folded into the weights — so it is a pure forward-pass bug, not an eos / config / quantization issue.

**Scope:** this is one of **two** attention-correctness bugs in the Falcon-H1 port. Together with the companion fix (applying `key_multiplier` to `k_proj`, which `sanitize` was dropping), it fully restores the model: greedy GSM8K on the bf16 `tiiuae/Falcon-H1R-7B` goes from 0% to **3/3**, and a numerical layer-diff against `transformers` (float32) matches every prefill and decode intermediate to cos ≥ 0.9999. Either fix alone is insufficient (the decoder sums `residual + mamba(x) + attention(x)`, so both attention bugs corrupt the hidden state); both are needed.

Small, isolated change (one file, one function).
