### PR TITLE
FalconH1: apply key_multiplier to k_proj (silently dropped via a dead key_proj branch)

### DIFF
--- a/Libraries/MLXLLM/Models/FalconH1.swift
+++ b/Libraries/MLXLLM/Models/FalconH1.swift
@@ -717,9 +717,13 @@ public class FalconH1Model: Module, LLMModel, KVCacheDimensionProvider {
                 param = param * args.embeddingMultiplier
             } else if name.hasSuffix("lm_head.weight") {
                 param = param * args.lmHeadMultiplier
-            } else if name.hasSuffix("q_proj.weight") || name.hasSuffix("k_proj.weight") {
+            } else if name.hasSuffix("q_proj.weight") {
                 param = param * args.attentionInMultiplier
-            } else if name.hasSuffix("key_proj.weight") {
+            } else if name.hasSuffix("k_proj.weight") || name.hasSuffix("key_proj.weight") {
+                // The key weight is named `k_proj` in Falcon-H1 checkpoints, so it matched the
+                // q_proj/k_proj branch above and never received keyMultiplier — the old `key_proj`
+                // branch was dead. HF applies `key_multiplier` to the key states
+                // (modeling_falcon_h1: `key_states = k_proj(x) * key_multiplier`); fold it here.
                 param = param * args.attentionInMultiplier * args.keyMultiplier
             } else if name.hasSuffix("o_proj.weight") {
                 param = param * args.attentionOutMultiplier


### PR DESCRIPTION
`FalconH1Model.sanitize()` folds the muP `key_multiplier` only into a weight named `key_proj.weight`:

```swift
} else if name.hasSuffix("q_proj.weight") || name.hasSuffix("k_proj.weight") {
    param = param * args.attentionInMultiplier
} else if name.hasSuffix("key_proj.weight") {           // ← never matches
    param = param * args.attentionInMultiplier * args.keyMultiplier
}
```

But Falcon-H1 checkpoints name the key projection **`k_proj.weight`**, which matches the *first* branch (only `attention_in_multiplier`). The `key_proj.weight` branch is **dead**, so `key_multiplier` is **never applied** — leaving the keys `1/key_multiplier` ≈ **32×** too large for Falcon-H1R-7B (`key_multiplier` ≈ 0.031). `transformers` applies it to the key states (`modeling_falcon_h1`: `key_states = k_proj(hidden_states)... * self.key_multiplier`). Over-large keys blow up the attention scores → softmax collapses toward a hard argmax → the attention output (a full additive term in `residual + mamba + attn`) corrupts the hidden state → grammatical-but-degenerate, never-terminating generation.

This splits the branch so `k_proj.weight` receives `attention_in_multiplier * key_multiplier`.

**Verified** against `transformers` (float32) on `tiiuae/Falcon-H1R-7B`: layer-0 attention output goes from badly mis-scaled to cos **0.999998**, and with the companion causal-mask fix, greedy GSM8K goes **0% → 3/3**.

**Note for pre-quantized checkpoints:** conversions that pre-fold the muP multipliers into the weights (e.g. mlx-community 8-bit, whose MLX-layout conv1d makes `sanitize` early-return and skip folding) were produced with this same bug, so their baked-in weights are missing `key_multiplier`. Those need re-conversion; this fix corrects the fold for anything that loads through `sanitize` (bf16 originals, non-pre-folded quants).

One file, one branch.
