### PR TITLE
FalconH1: absorb a stray language_model.lm_head. prefix in sanitize()

### DIFF
--- a/Libraries/MLXLLM/Models/FalconH1.swift
+++ b/Libraries/MLXLLM/Models/FalconH1.swift
@@ -704,6 +704,11 @@ public class FalconH1Model: Module, LLMModel, KVCacheDimensionProvider {
     }
 
     public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        // Some JANG conversions emit the head under a VLM-style `language_model.lm_head.*` prefix
+        // while the body stays at `model.*`. Absorb it (scoped to the head) BEFORE the conv1d
+        // early-return below — otherwise an already-transposed checkpoint returns unchanged and
+        // fails to bind with "Unhandled keys [language_model]". Cf. Llama.sanitize.
+        let weights = Weights.stripLanguageModelPrefix(weights, only: ["lm_head."])
         let c1d = weights["model.layers.0.mamba.conv1d.weight"]!
         if c1d.dim(-1) <= c1d.dim(1) {
             return weights


### PR DESCRIPTION
Some quantized Falcon-H1 conversions emit the output projection under a VLM-style **`language_model.lm_head.*`** prefix while the body stays at `model.*`. `FalconH1Model` binds the head at the top-level `lm_head`, so those checkpoints fail to load outright:

```
unhandledKeys(path: [], modules: ["FalconH1Model"], keys: ["language_model"])
```

This absorbs the stray prefix, scoped to the head only — exactly what `Llama.sanitize` already does via `Weights.stripLanguageModelPrefix(_:only:)` (a genuine nested `language_model.*` body is not ours to rewrite).

**Placement matters:** the strip has to happen *before* the `conv1d` early-return at the top of `sanitize`. A checkpoint whose `conv1d` is already in MLX layout returns from that branch unchanged, so a strip placed after it would never run — which is precisely the case for the affected (quantized, pre-transposed) conversions.

**Verified:** an affected checkpoint goes from failing to load to loading and running; the bf16 `tiiuae/Falcon-H1R-7B` path is unaffected (still 3/3 on a greedy GSM8K spot-check).

One file, one line plus a comment.
