### PR TITLE
FalconH1: normalize RMSNormGated per group when n_groups > 1

### DIFF
--- a/Libraries/MLXLLM/Models/FalconH1.swift
+++ b/Libraries/MLXLLM/Models/FalconH1.swift
@@ -220,7 +220,22 @@ class RMSNormGated: Module {
             hiddenStates = hiddenStates * silu(gate)
         }
 
-        hiddenStates = MLXFast.rmsNorm(hiddenStates, weight: weight, eps: varianceEpsilon)
+        // Normalize PER GROUP when nGroups > 1: the reference (HF FalconH1RMSNormGated) reshapes to
+        // (..., nGroups, dim/nGroups) and takes the variance over the last axis, so each group is
+        // normalized by its own RMS. Normalizing across the whole last dim instead mixes the groups
+        // and gives a different result whenever nGroups > 1 (identical only at nGroups == 1, which is
+        // why the shipped Falcon-H1 checkpoints don't expose this).
+        if nGroups > 1 {
+            let shape = hiddenStates.shape
+            let dim = shape[shape.count - 1]
+            let grouped = hiddenStates.reshaped(shape.dropLast() + [nGroups, dim / nGroups])
+            let groupedWeight = weight.reshaped([nGroups, dim / nGroups])
+            hiddenStates = MLXFast.rmsNorm(
+                grouped, weight: groupedWeight, eps: varianceEpsilon
+            ).reshaped(shape)
+        } else {
+            hiddenStates = MLXFast.rmsNorm(hiddenStates, weight: weight, eps: varianceEpsilon)
+        }
 
         if normBeforeGate, let gate {
             hiddenStates = hiddenStates * silu(gate)


### PR DESCRIPTION
`FalconH1RMSNormGated` takes and stores `nGroups`, but never uses it — it applies `MLXFast.rmsNorm` across the entire last dimension:

```swift
hiddenStates = MLXFast.rmsNorm(hiddenStates, weight: weight, eps: varianceEpsilon)
```

The reference implementation (HF `FalconH1RMSNormGated`) reshapes to `(..., n_groups, dim // n_groups)` and takes the variance over the last axis, so **each group is normalized by its own RMS**:

```python
hidden_states = hidden_states.view(batch_size, seq_len, self.n_groups, int(dim // self.n_groups))
variance = hidden_states.pow(2).mean(-1, keepdim=True)
hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
```

The two are identical at `n_groups == 1` and differ for any `n_groups > 1`. Checked numerically against the reference on a synthetic `n_groups=2` case:

| | cos vs HF |
|---|---|
| current (whole last dim) | **0.939** |
| per-group (this PR) | **1.000000** |

This is latent rather than user-visible today — every shipped Falcon-H1 checkpoint I'm aware of uses `mamba_n_groups: 1`, so the bug can't fire — but it's a correctness trap for any future config or sibling architecture with grouped SSM norms. Note the same simplification exists in `mlx-lm`'s `falcon_h1.py`.

The `n_groups == 1` path is untouched (bf16 `tiiuae/Falcon-H1R-7B` still 3/3 on a greedy GSM8K spot-check).
