### PR TITLE
Report accepted TokenIterator cache restores

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1377,6 +1377,7 @@ public struct TokenIterator: TokenIteratorProtocol {
         // misses. Previously image/video bypassed the cache entirely,
         // wasting a full media encoder pass and prefill on every turn.
         var inputForPrepare = input
+        var acceptedCacheRestoreDetail: CacheDetail?
         // SLIDING-1 (2026-04-15): the legacy guard `!hasRotatingCache` was
         // removed once `TQDiskSerializer` v2 + `restoreRotatingLayer` /
         // `restoreFromV2Arrays` learned to round-trip the ring buffer +
@@ -1584,6 +1585,7 @@ public struct TokenIterator: TokenIteratorProtocol {
                                 text: LMInput.Text(tokens: lastToken),
                                 image: nil, video: nil)
                             retainedDiskRestore = diskArrays != nil
+                            acceptedCacheRestoreDetail = detail
                         } else {
                             Self.logger.info(
                                 "TokenIterator: cache hit rolling back to full prefill (path-dependent full cache hit missing seed-boundary SSM state)"
@@ -1630,6 +1632,7 @@ public struct TokenIterator: TokenIteratorProtocol {
                                 image: nil, video: nil)
                         }
                         retainedDiskRestore = diskArrays != nil
+                        acceptedCacheRestoreDetail = detail
                     }
                     if retainedDiskRestore {
                         coordinator.touchStableDiskCheckpointsAfterRetainedRestore(
@@ -1677,6 +1680,13 @@ public struct TokenIterator: TokenIteratorProtocol {
         // Prefill: either full input (cache miss) or remaining tokens (cache hit).
         let remainingPromptUnits = Swift.max(0, inputForPrepare.text.tokens.size)
         let completedBeforePrefill = Swift.max(0, promptTokenCount - remainingPromptUnits)
+        if let acceptedCacheRestoreDetail, completedBeforePrefill > 0 {
+            prefillProgressHandler?(PrefillProgress(
+                stage: .cacheRestore,
+                completedUnitCount: completedBeforePrefill,
+                totalUnitCount: promptTokenCount,
+                detail: acceptedCacheRestoreDetail.rawValue))
+        }
         prefillProgressHandler?(PrefillProgress(
             stage: .prefill,
             completedUnitCount: completedBeforePrefill,

--- a/Tests/MLXLMTests/TokenIteratorCacheRestoreProgressTests.swift
+++ b/Tests/MLXLMTests/TokenIteratorCacheRestoreProgressTests.swift
@@ -1,0 +1,113 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import XCTest
+
+private final class CacheRestoreProgressModel: Module, LanguageModel, @unchecked Sendable {
+    var vocabularySize: Int { 64 }
+
+    func newCache(parameters: GenerateParameters?) -> [KVCache] {
+        [KVCacheSimple()]
+    }
+
+    func prepare(
+        _ input: LMInput,
+        cache: [KVCache],
+        windowSize: Int?
+    ) throws -> PrepareResult {
+        .tokens(LMInput.Text(tokens: input.text.tokens.reshaped([-1])))
+    }
+
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        let tokenCount = inputs.reshaped([-1]).size
+        if let cache = cache?.first as? KVCacheSimple {
+            let keys = MLXArray.zeros([1, 1, tokenCount, 4])
+            let values = MLXArray.zeros([1, 1, tokenCount, 4])
+            _ = cache.update(keys: keys, values: values)
+        }
+        return MLXArray.zeros([1, max(tokenCount, 1), vocabularySize])
+    }
+}
+
+private final class CacheRestoreProgressRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [PrefillProgress] = []
+
+    func append(_ value: PrefillProgress) {
+        lock.lock()
+        values.append(value)
+        lock.unlock()
+    }
+
+    func snapshot() -> [PrefillProgress] {
+        lock.lock()
+        defer { lock.unlock() }
+        return values
+    }
+}
+
+final class TokenIteratorCacheRestoreProgressTests: XCTestCase {
+    func testAcceptedDiskPrefixRestoreEmitsStructuredProgressBeforePrefill() throws {
+        let mlxLock = lockSerializedMLXTest()
+        defer { mlxLock.unlock() }
+
+        let diskDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("token-iterator-cache-progress-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: diskDir) }
+
+        let coordinator = CacheCoordinator(config: CacheCoordinatorConfig(
+            usePagedCache: false,
+            enableDiskCache: true,
+            diskCacheDir: diskDir,
+            modelKey: "token-iterator-cache-progress"))
+        let parameters = GenerateParameters(maxTokens: 1, temperature: 0)
+        let cachedPrompt = [1, 2, 3, 4, 5, 6]
+
+        var cold = try TokenIterator(
+            input: LMInput(
+                tokens: MLXArray(cachedPrompt.map(Int32.init))
+                    .expandedDimensions(axis: 0)),
+            model: CacheRestoreProgressModel(),
+            parameters: parameters,
+            cacheCoordinator: coordinator)
+        cold.storeCacheAfterGeneration(
+            generatedTokenIds: [],
+            includeGeneratedBoundary: false)
+
+        let recorder = CacheRestoreProgressRecorder()
+        let warmPrompt = cachedPrompt + [7, 8]
+        _ = try TokenIterator(
+            input: LMInput(
+                tokens: MLXArray(warmPrompt.map(Int32.init))
+                    .expandedDimensions(axis: 0)),
+            model: CacheRestoreProgressModel(),
+            parameters: parameters,
+            cacheCoordinator: coordinator,
+            prefillProgressHandler: { recorder.append($0) })
+
+        let progress = recorder.snapshot()
+        guard let restoreIndex = progress.firstIndex(where: {
+            $0.stage == .cacheRestore
+        }) else {
+            return XCTFail("accepted disk prefix restore must emit cacheRestore progress")
+        }
+        guard let prefillIndex = progress.firstIndex(where: {
+            $0.stage == .prefill
+        }) else {
+            return XCTFail("warm suffix must still emit prefill progress")
+        }
+
+        let restore = progress[restoreIndex]
+        XCTAssertEqual(restore.detail, CacheDetail.disk.rawValue)
+        XCTAssertEqual(restore.completedUnitCount, cachedPrompt.count)
+        XCTAssertEqual(restore.totalUnitCount, warmPrompt.count)
+        XCTAssertLessThan(restoreIndex, prefillIndex)
+        XCTAssertEqual(
+            progress[prefillIndex].completedUnitCount,
+            cachedPrompt.count)
+    }
+}


### PR DESCRIPTION
## Root cause

`TokenIterator` accepted and restored paged or disk-backed prefix state, but the solo generation path skipped the structured `.cacheRestore` progress event and emitted only `.prefill`. `BatchEngine` already emitted the corresponding event. Consumers therefore could not distinguish a real warm restore from a cold prefill even when disk L2 had restored the best valid boundary.

## Fix

- emit `.cacheRestore` only after the restore survives all path-dependent rollback checks;
- report the retained restored-token count, total prompt-token count, and authoritative cache tier;
- preserve cold-prefill behavior for rejected media or incomplete companion-state restores;
- add a real disk-prefix round-trip test that requires cache restore to precede suffix prefill.

## Source verification

- `TokenIteratorCacheRestoreProgressTests`: **1/1**
- `CacheCoordinatorTests`: **13/13**
- `DiskCacheTests`: **16/16**
- `Canonical chat cache boundaries`: **7/7**
- Total scoped tests: **37/37**
- `git diff --check`: clean

The dependent Osaurus PR will pin this exact commit and include real-model CacheProof scores plus Release-app UI lifecycle evidence before merge.
