### PR TITLE
Capture rotating disk seed during prefill

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1218,6 +1218,19 @@ public struct TokenIterator: TokenIteratorProtocol {
     /// a second full prefill. Released once stored.
     var hybridStripSnapshot: [KVCache]?
 
+    /// Absolute `promptTokenIds.count - 1` boundary for text-only
+    /// standalone rotating/SWA cache topologies.
+    ///
+    /// These caches restore through the disk serializer because paged KV does
+    /// not preserve their ring metadata, and a post-prefill snapshot cannot be
+    /// trimmed across every layer when the model mixes full and rotating
+    /// attention. Capturing the seed while prefill crosses it avoids replaying
+    /// the prompt from the generation-completion path.
+    var diskSeedBoundary: Int?
+
+    /// Cache state captured during prefill at ``diskSeedBoundary``.
+    var diskSeedSnapshot: [KVCache]?
+
     /// Stable fingerprint of any request-scope or media content in the input.
     /// `nil` for ordinary text-only inputs. Mixed into cache-coordinator keys
     /// so reasoning-mode and VLM multi-turn conversations can cache-hit without
@@ -1709,6 +1722,12 @@ public struct TokenIterator: TokenIteratorProtocol {
             coordinator: self.cacheCoordinator,
             promptTokenIds: self.promptTokenIds,
             input: input)
+        self.diskSeedBoundary = Self.diskSeedBoundaryIndex(
+            coordinator: self.cacheCoordinator,
+            promptTokenIds: self.promptTokenIds,
+            input: input,
+            cache: self.cache,
+            skipBoundary: self.skipDiskBackedToolPromptSeedBoundary)
         self.promptPrefillTime = try measure {
             try MLXPressGenerationProfile.time("prompt.prepare_total") {
                 try PrefillProgressReporter.withHandler(modelPrepareProgressHandler) {
@@ -1814,26 +1833,50 @@ public struct TokenIterator: TokenIteratorProtocol {
         return stripAt
     }
 
-    /// Split `input` at the hybrid strip boundary, or `nil` when the boundary
-    /// cannot be captured from this prefill.
+    /// The prompt-minus-one seed used to make an exact disk restore safe for a
+    /// standalone rotating/SWA cache.
+    static func diskSeedBoundaryIndex(
+        coordinator: CacheCoordinator?,
+        promptTokenIds: [Int],
+        input: LMInput,
+        cache: [KVCache],
+        skipBoundary: Bool
+    ) -> Int? {
+        guard let coordinator,
+            coordinator.canPersistBoundaries,
+            !skipBoundary,
+            promptTokenIds.count > 1,
+            !input.hasMediaContent,
+            !input.requiresPostPrepareCacheKey,
+            cacheHasStandaloneRotatingWindowState(cache)
+        else { return nil }
+        return promptTokenIds.count - 1
+    }
+
+    private enum PrefillBoundaryCapture {
+        case hybridStrip
+        case diskSeed
+    }
+
+    /// Split `input` at an absolute prompt boundary, or `nil` when the
+    /// boundary is not inside the still-unprocessed prompt tail.
     ///
     /// `input` is the prompt tail still to be prefilled — the whole prompt on a
     /// cache miss, or whatever follows the restored prefix on a hit — so the
-    /// boundary's offset within it is `hybridStripBoundary` minus the tokens
-    /// already in the cache.
-    private func hybridStripSplit(
-        of input: LMInput
+    /// boundary's offset within it is the absolute boundary minus the tokens
+    /// already restored.
+    private func boundarySplit(
+        of input: LMInput,
+        at boundary: Int
     ) -> (head: LMInput?, tail: LMInput)? {
-        guard let stripAt = hybridStripBoundary,
-            hybridStripSnapshot == nil,
-            !input.requiresPostPrepareCacheKey,
+        guard !input.requiresPostPrepareCacheKey,
             // DSV4's pool cache is only correct under a single prefill forward;
             // `effectivePrefillWindow` already forces that, so don't split it.
             !cache.contains(where: { $0 is HybridPoolCache })
         else { return nil }
 
         let size = input.text.tokens.size
-        let split = stripAt - (promptTokenIds.count - size)
+        let split = boundary - (promptTokenIds.count - size)
         guard split >= 0, split < size else { return nil }
 
         // The mask, when present, is per-token (`Qwen3VLProcessor` hands the
@@ -1875,18 +1918,31 @@ public struct TokenIterator: TokenIteratorProtocol {
         return (head, tail)
     }
 
+    private func prefillBoundaryCapture(
+        of input: LMInput
+    ) -> (kind: PrefillBoundaryCapture, head: LMInput?, tail: LMInput)? {
+        if let boundary = hybridStripBoundary,
+           hybridStripSnapshot == nil,
+           let split = boundarySplit(of: input, at: boundary)
+        {
+            return (.hybridStrip, split.head, split.tail)
+        }
+        if let boundary = diskSeedBoundary,
+           diskSeedSnapshot == nil,
+           let split = boundarySplit(of: input, at: boundary)
+        {
+            return (.diskSeed, split.head, split.tail)
+        }
+        return nil
+    }
+
     mutating func prepare(input: LMInput, windowSize: Int? = nil) throws {
-        // Prefill the stripped prefix first so the cache state at the hybrid
-        // cross-turn boundary can simply be copied out, then continue with the
-        // tail. Both halves go through `model.prepare`, so this runs exactly the
-        // tokens a single prefill would, in the same order, through the same
-        // forwards — models that consume the whole prompt themselves (Qwen35 and
-        // the other hybrids, which return `.logits`) split just as cleanly as
-        // those that hand back a remainder. The alternative is reconstructing the
-        // boundary afterwards by replaying the entire stripped prefix, which is a
-        // second full prefill; see `storeCacheAfterGeneration`.
-        if let split = hybridStripSplit(of: input) {
-            if let head = split.head {
+        // Prefill to a reusable structural boundary first, copy the exact cache
+        // state, then consume the tail. Both halves run through the model's real
+        // prepare/forward path in order; this avoids a second full prefill after
+        // generation and does not alter sampler or template behavior.
+        if let capture = prefillBoundaryCapture(of: input) {
+            if let head = capture.head {
                 let preparedHead = try MLXPressGenerationProfile.time("prompt.model_prepare") {
                     try model.prepare(head, cache: cache, windowSize: windowSize)
                 }
@@ -1901,9 +1957,15 @@ public struct TokenIterator: TokenIteratorProtocol {
                 }
             }
             MLX.eval(cache)
-            hybridStripSnapshot = makePromptBoundaryCacheSnapshot(from: cache)
+            let snapshot = makePromptBoundaryCacheSnapshot(from: cache)
+            switch capture.kind {
+            case .hybridStrip:
+                hybridStripSnapshot = snapshot
+            case .diskSeed:
+                diskSeedSnapshot = snapshot
+            }
             try prepareRemainder(
-                input: split.tail, windowSize: windowSize,
+                input: capture.tail, windowSize: windowSize,
                 promptTokensForProcessor: input.text.tokens)
             return
         }
@@ -2289,19 +2351,28 @@ public struct TokenIterator: TokenIteratorProtocol {
                 if !usesCanonicalHybridBoundary,
                    requiresDiskBackedRestore,
                    !skipDiskBackedToolPromptSeedBoundary,
-                   promptTokenIds.count > 1,
-                   let boundarySnapshot = cacheSnapshotForBoundary(
-                        tokens: Array(promptTokenIds.dropLast()),
-                        promptSnapshot: promptCacheSnapshot)
+                   promptTokenIds.count > 1
                 {
-                    store(
-                        tokens: Array(promptTokenIds.dropLast()),
-                        cache: boundarySnapshot,
-                        kvBits: nil,
-                        kvMode: selectivePromptBoundaryDiskKVMode(
-                            cache: boundarySnapshot,
-                            requested: kvMode))
+                    let seedTokens = Array(promptTokenIds.dropLast())
+                    var seedSnapshot: [KVCache]?
+                    if diskSeedBoundary == seedTokens.count {
+                        seedSnapshot = diskSeedSnapshot
+                    } else {
+                        seedSnapshot = cacheSnapshotForBoundary(
+                            tokens: seedTokens,
+                            promptSnapshot: promptCacheSnapshot)
+                    }
+                    if let seedSnapshot {
+                        store(
+                            tokens: seedTokens,
+                            cache: seedSnapshot,
+                            kvBits: nil,
+                            kvMode: selectivePromptBoundaryDiskKVMode(
+                                cache: seedSnapshot,
+                                requested: kvMode))
+                    }
                 }
+                diskSeedSnapshot = nil
                 // Cross-turn reuse boundary for hybrid-SSM models (qwen3.5 /
                 // ornith GatedDeltaNet, Nemotron-H Mamba-2, LFM2, ZAYA CCA, …):
                 // store the generation-prompt-STRIPPED prompt, ending just before

--- a/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
@@ -186,6 +186,26 @@ struct BatchEngineGrowingChatCacheSourceTests {
         #expect(source.contains("Cache \\(detail.rawValue) hit: restored \\(diskRestored) tokens from disk"))
     }
 
+    @Test("solo rotating cache captures the prompt-minus-one disk seed during prefill")
+    func tokenIteratorCapturesRotatingDiskSeedDuringPrefill() throws {
+        let source = try String(
+            contentsOfFile: "Libraries/MLXLMCommon/Evaluate.swift",
+            encoding: .utf8)
+
+        #expect(source.contains("static func diskSeedBoundaryIndex("))
+        #expect(source.contains("cacheHasStandaloneRotatingWindowState(cache)"))
+        #expect(source.contains("case diskSeed"))
+        #expect(source.contains("diskSeedSnapshot = snapshot"))
+        #expect(source.contains("if diskSeedBoundary == seedTokens.count"))
+        #expect(source.contains("seedSnapshot = diskSeedSnapshot"))
+
+        let prepare = try #require(source.range(of: "if let capture = prefillBoundaryCapture(of: input)"))
+        let capture = try #require(source.range(of: "diskSeedSnapshot = snapshot"))
+        let store = try #require(source.range(of: "seedSnapshot = diskSeedSnapshot"))
+        #expect(prepare.lowerBound < capture.lowerBound)
+        #expect(capture.lowerBound < store.lowerBound)
+    }
+
     @Test("history-boundary rederive skips disk-backed cache topologies after trim miss")
     func historyBoundaryRederiveSkipsDiskBackedTopologiesAfterTrimMiss() throws {
         let helpers = try String(
@@ -215,7 +235,8 @@ struct BatchEngineGrowingChatCacheSourceTests {
         #expect(!batch.contains("skipped disk-backed fetch for active tool request"))
         #expect(evaluate.contains("skipExactDiskBoundary: requiresDiskBackedRestore"))
         #expect(batch.contains("skipExactDiskBoundary: requiresDiskBackedRestore"))
-        #expect(evaluate.contains(#"tokens: Array(promptTokenIds.dropLast())"#))
+        #expect(evaluate.contains("let seedTokens = Array(promptTokenIds.dropLast())"))
+        #expect(evaluate.contains("tokens: seedTokens"))
         #expect(batch.contains(#"tokens: Array(promptTokens.dropLast())"#))
         #expect(batch.contains(#"label: "disk-backed-safe-prompt-boundary""#))
 


### PR DESCRIPTION
## Summary

- Capture an exact prompt-minus-one SSD seed while a text-only standalone
  rotating/SWA cache is crossing that boundary during real prefill.
- Keep the existing fail-closed guard against unsafe post-hoc trimming of
  heterogeneous disk-backed cache state.
- Scope the change by cache topology and persistence/media eligibility; there
  is no model-name check, sampler override, forced reasoning behavior, or
  global cache bypass.

This closes a real disk-only L2 gap seen with paged RAM disabled: Laguna could
store the exact prompt but could not create the N-1 candidate needed for a
subsequent compatible, extended prompt. The pre-fix longest-match case scored
0/3 with no restored-token gain.

## Source and test evidence

- Source base: `64b6ca2433c12af2dd6955f317366f0f9626e061`
- Fix commit: `a4b3258c0190d4c0868c6808a9944d42596969f6`
- `BatchEngineGrowingChatCacheSourceTests`: **18/18 PASS**
- `CacheCoordinatorTopologyFocusedTests`: **42/42 PASS**
- `TokenIteratorCacheRestoreProgressTests`: **1/1 PASS**
- `CanonicalChatCacheBoundariesTests`: **7/7 PASS**

## Exact OsaurusEval score block

No external judge key was configured. These are deterministic structural,
tool, cache-counter, typed-progress, terminal-state, and coherence assertions;
no subjective judge score is claimed.

### CacheProof, paged RAM off / disk L2 on

- Laguna S 2.1 JANG_4M: **3/3 PASS** — turn 2 restored 293/715
  (422 fresh); turn 3 restored 714/715 (1 fresh); longest-candidate gain
  **+421 tokens**; disk L2 **+2 hits / +11 stores**; **27.9 tok/s**; physical
  footprint 9141 → 9179 → 9198 MB, peak 9578 MB; monotonic typed progress,
  complete terminal state, coherent visible output.
  Report:
  `/private/tmp/osaurus-evals-postseed-20260727/laguna/laguna-postseed-cacheproof.json`
- Gemma 4 26B A4B JANG_4M: **3/3 PASS** — 292/704 (412 fresh) →
  703/704 (1 fresh); gain **+411**; disk L2 **+2 hits / +13 stores**;
  **36.0 tok/s**; peak 19936 MB; typed progress, reasoning closure, and
  visible output passed.
  Report:
  `/private/tmp/osaurus-evals-postseed-20260727/gemma26/gemma26-postseed-cacheproof.json`
- Bonsai 27B Ternary JANG: **3/3 PASS** — hybrid SSM 295/716 (421 fresh) →
  709/716 (7 fresh); gain **+414**; SSM **+2 hits / 0 rederives**; disk L2
  **+2 hits / +4 stores**; **18.7 tok/s**; peak 3058 MB; typed progress,
  companion state, content, and reasoning closure passed.
  Report:
  `/private/tmp/osaurus-evals-postseed-20260727/bonsai27/bonsai27-postseed-cacheproof.json`

### AgentLoop final-after-success-with-pending-todo

- Gemma 4 26B A4B JANG_4M: **3/3 PASS** — `finalResponse`, four model
  steps, `todo → file_write → todo`, one terminal marker; **36.0 tok/s**,
  TTFT 173 ms, prefill 16419 tok/s, peak 22356 MB, disk L2 +3/+10.
  Report:
  `/private/tmp/osaurus-evals-postseed-20260727/agentloop-gemma26/gemma26-final-after-success.json`
- Ornith 9B JANG_4M: **3/3 PASS** — `finalResponse`, five model steps,
  `todo → todo → file_write → todo`, one terminal marker; **37.2 tok/s**,
  TTFT 236 ms, prefill 24653 tok/s, peak 4395 MB, SSM +4, disk L2 +4/+6.
  Report:
  `/private/tmp/osaurus-evals-postseed-20260727/agentloop-ornith9/ornith9-final-after-success.json`
- Bonsai 27B Ternary JANG: **2/3 FLAKY** — every trial still exited
  `finalResponse` without a stale-Todo repetition loop; the failed trial was
  a model-quality/tool-choice failure (`share_artifact` instead of
  `file_write`, plus `REMAINDER_CREATED` typo), not a terminal-loop failure.
  **16.6 tok/s**, TTFT 249 ms, prefill 9423 tok/s, peak 7881 MB, SSM +3,
  disk L2 +3/+5.
  Report:
  `/private/tmp/osaurus-evals-postseed-20260727/agentloop-bonsai27/bonsai27-final-after-success.json`

## Scope limits

- The scores prove the available Laguna JANG_4M, Gemma 4 26B, and Bonsai
  Ternary rows only; they do not infer sibling quant or modality compatibility.
- TurboQuant KV was not enabled for this disk-seed regression row.
- The Osaurus Release-app UI terminal/follow-up proof is tracked in the
  companion Osaurus PR rather than claimed by this engine-only PR.
