### PR TITLE
Preserve Gemma 4 text-only system prompts

### DIFF
--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -1944,6 +1944,18 @@ public struct Gemma4Processor: UserInputProcessor {
 private struct Gemma4MessageGenerator: MessageGenerator {
     func generate(message: Chat.Message) -> MLXLMCommon.Message {
         var dict = defaultMessageDict(for: message)
+        let hasMedia =
+            !message.images.isEmpty
+            || !message.videos.isEmpty
+            || !message.audios.isEmpty
+        // Keep ordinary text-only turns in the canonical scalar form. Gemma 4
+        // bundle templates read the leading system/developer content directly
+        // as a string before their generic per-turn content-parts branch. The
+        // previous unconditional array conversion silently dropped that system
+        // prompt in those real templates, making distinct settings revisions
+        // tokenize identically and allowing an incompatible disk-cache restore.
+        guard hasMedia else { return dict }
+
         var content: [[String: String]] = []
         content.append(contentsOf: message.images.map { _ in ["type": "image"] })
         content.append(contentsOf: message.videos.map { _ in ["type": "video"] })

--- a/Tests/MLXLMTests/ChatMessageToolCallTests.swift
+++ b/Tests/MLXLMTests/ChatMessageToolCallTests.swift
@@ -279,6 +279,32 @@ struct ChatMessageToolCallTests {
         #expect(tool["content"] as? [[String: String]] == [["type": "text", "text": "2"]])
     }
 
+    @Test("Gemma4 processor preserves text-only system content as a scalar string")
+    func gemma4ProcessorPreservesTextOnlySystemContent() async throws {
+        let mlxTestLock = lockSerializedMLXTest()
+        _ = mlxTestLock
+        let tokenizer = CapturingGemma4Tokenizer()
+        let processor = Gemma4Processor(
+            Self.gemma4ProcessorConfiguration(),
+            tokenizer: tokenizer
+        )
+        let revision = "REVISION-B-CURRENT-SETTINGS-MUST-WIN"
+
+        _ = try await processor.prepare(input: UserInput(chat: [
+            .system(revision),
+            .user("Reply with exactly CURRENT SETTINGS RESTORED."),
+        ]))
+
+        #expect(tokenizer.capturedMessages.count == 2)
+        #expect(tokenizer.capturedMessages[0]["role"] as? String == "system")
+        #expect(tokenizer.capturedMessages[0]["content"] as? String == revision)
+        #expect(tokenizer.capturedMessages[1]["role"] as? String == "user")
+        #expect(
+            tokenizer.capturedMessages[1]["content"] as? String
+                == "Reply with exactly CURRENT SETTINGS RESTORED."
+        )
+    }
+
     @Test("Gemma4 required tool choice compacts closed prior tool protocol before latest user")
     func gemma4RequiredToolChoiceCompactsClosedToolHistory() async throws {
         let call = ToolCall(


### PR DESCRIPTION
## Root cause

`Gemma4MessageGenerator` converted every non-empty message into a content-parts array. Real Gemma 4 templates read the leading system/developer content as a scalar before their generic multimodal branch, so prompt-affecting settings text was omitted. Distinct revisions therefore tokenized identically and an old SSD checkpoint could be restored as if it were current.

## Fix

Keep canonical scalar content for text-only turns. Build content-parts arrays only when the turn actually carries image, video, or audio media.

## Source test

- `ChatMessageToolCallTests.gemma4ProcessorPreservesTextOnlySystemContent`: 1/1 passed with the Xcode Swift toolchain.

## Real OsaurusEval proof

`cache_proof.settings-prompt-revision`, paged RAM off and disk L2 enabled, using `OsaurusAI--gemma-4-E2B-it-8bit`:

- revision A: no restore, 218 prompt tokens, 529 ms TTFT
- changed revision B: no restore, 213 prompt tokens, 215 ms TTFT
- repeated revision B: disk restored 212/213 tokens, 1 token prefilled, 203 ms TTFT
- disk L2 delta: +1 hit / +14 stores
- 43.8 decode tok/s; non-empty visible output; reasoning closed

The eval was not weakened. Before this fix, all revisions collapsed to 25 prompt tokens and changed revision B incorrectly restored 24/25 tokens from revision A.

No image or video artifacts are included.