### PR TITLE
Add Nanbeige 4.2 looped runtime

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -103,6 +103,7 @@ public enum LLMTypeRegistry {
             "mimo": create(MiMoConfiguration.self, MiMoModel.init),
             "mimo_v2": create(MiMoV2FlashConfiguration.self, MiMoV2FlashModel.init),
             "mimo_v2_flash": create(MiMoV2FlashConfiguration.self, MiMoV2FlashModel.init),
+            "nanbeige": create(NanbeigeConfiguration.self, NanbeigeModel.init),
             "minimax": create(MiniMaxConfiguration.self, MiniMaxModel.init),
             "minimax_m2": { data in
                 // Peek at weight_format — "mxtq" routes to the JANGTQ variant,

--- a/Libraries/MLXLLM/Models/Nanbeige.swift
+++ b/Libraries/MLXLLM/Models/Nanbeige.swift
@@ -300,21 +300,26 @@ public final class NanbeigeModel: Module, LLMModel, KVCacheDimensionProvider {
     @ModuleInfo(key: "lm_head") var lmHead: Linear?
 
     public init(_ configuration: NanbeigeConfiguration) {
+        let vocabularySize = configuration.vocabularySize
+        let hiddenSize = configuration.hiddenSize
+        let cacheSlots = configuration.cacheSlots
+        let runtimeCacheSlots = configuration.runtime?.cacheSlots
+        let tiedWordEmbeddings = configuration.tieWordEmbeddings
+
         self.configuration = configuration
-        vocabularySize = configuration.vocabularySize
+        self.vocabularySize = vocabularySize
         kvHeads = Array(
             repeating: configuration.kvHeads,
-            count: configuration.cacheSlots)
+            count: cacheSlots)
         model = NanbeigeModelInner(configuration)
-        if !configuration.tieWordEmbeddings {
+        if !tiedWordEmbeddings {
             _lmHead.wrappedValue = Linear(
-                configuration.hiddenSize,
-                configuration.vocabularySize,
+                hiddenSize,
+                vocabularySize,
                 bias: false)
         }
         precondition(
-            configuration.runtime?.cacheSlots == nil
-                || configuration.runtime?.cacheSlots == kvHeads.count,
+            runtimeCacheSlots == nil || runtimeCacheSlots == kvHeads.count,
             "nanbeige: bundle cache_slots does not match runtime cache topology")
     }
 

--- a/Libraries/MLXLLM/Models/Nanbeige.swift
+++ b/Libraries/MLXLLM/Models/Nanbeige.swift
@@ -1,0 +1,349 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+/// Nanbeige 4.2 is a looped Transformer: one physical stack of Llama-shaped
+/// layers is executed repeatedly with independent KV state for every
+/// (loop, layer) pair.
+public struct NanbeigeConfiguration: Codable, Sendable {
+    let hiddenSize: Int
+    let hiddenLayers: Int
+    let intermediateSize: Int
+    let attentionHeads: Int
+    let kvHeads: Int
+    let headDimensions: Int
+    let kvChannels: Int?
+    let rmsNormEps: Float
+    let vocabularySize: Int
+    let maxPositionEmbeddings: Int?
+    let ropeTheta: Float
+    let tieWordEmbeddings: Bool
+    let attentionBias: Bool
+    let mlpBias: Bool
+
+    let numLoops: Int
+    let loopLossWeights: [Float]?
+    let skipLoopFinalNorm: Bool
+
+    let enableDoubleLoopSplit: Bool?
+    let loopShareKV: Bool?
+    let enableHyperConnection: Bool?
+    let enableMHC: Bool?
+    let enableDepthAttention: Bool?
+    let qkLayerNorm: Bool?
+    let embeddingNeighborCount: Int?
+
+    let runtime: RuntimeContract?
+
+    var totalLoops: Int {
+        if let loopLossWeights, !loopLossWeights.isEmpty {
+            return loopLossWeights.count + 1
+        }
+        return max(1, numLoops)
+    }
+
+    var cacheSlots: Int {
+        hiddenLayers * totalLoops
+    }
+
+    struct RuntimeContract: Codable, Sendable {
+        let architecture: String
+        let cacheLayout: String
+        let numLoops: Int
+        let hiddenLayers: Int
+        let cacheSlots: Int
+        let cacheSlotFormula: String
+        let loopFinalNorm: String
+        let sharedLayerWeights: Bool
+        let sharedPositionIDs: Bool
+        let normConvention: String
+
+        enum CodingKeys: String, CodingKey {
+            case architecture
+            case cacheLayout = "cache_layout"
+            case numLoops = "num_loops"
+            case hiddenLayers = "num_hidden_layers"
+            case cacheSlots = "cache_slots"
+            case cacheSlotFormula = "cache_slot_formula"
+            case loopFinalNorm = "loop_final_norm"
+            case sharedLayerWeights = "shared_layer_weights_across_loops"
+            case sharedPositionIDs = "position_ids_shared_across_loops"
+            case normConvention = "norm_convention"
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case hiddenSize = "hidden_size"
+        case hiddenLayers = "num_hidden_layers"
+        case intermediateSize = "intermediate_size"
+        case attentionHeads = "num_attention_heads"
+        case kvHeads = "num_key_value_heads"
+        case headDimensions = "head_dim"
+        case kvChannels = "kv_channels"
+        case rmsNormEps = "rms_norm_eps"
+        case vocabularySize = "vocab_size"
+        case maxPositionEmbeddings = "max_position_embeddings"
+        case ropeTheta = "rope_theta"
+        case tieWordEmbeddings = "tie_word_embeddings"
+        case attentionBias = "attention_bias"
+        case mlpBias = "mlp_bias"
+        case numLoops = "num_loops"
+        case loopLossWeights = "loop_loss_weights"
+        case skipLoopFinalNorm = "skip_loop_final_norm"
+        case enableDoubleLoopSplit = "enable_double_loop_split"
+        case loopShareKV = "loop_share_kv"
+        case enableHyperConnection = "enable_hyper_connection"
+        case enableMHC = "enable_mhc"
+        case enableDepthAttention = "enable_depth_attention"
+        case qkLayerNorm = "qk_layernorm"
+        case embeddingNeighborCount = "emb_neighbor_num"
+        case runtime = "jang_runtime"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        hiddenSize = try container.decode(Int.self, forKey: .hiddenSize)
+        hiddenLayers = try container.decode(Int.self, forKey: .hiddenLayers)
+        intermediateSize = try container.decode(Int.self, forKey: .intermediateSize)
+        attentionHeads = try container.decode(Int.self, forKey: .attentionHeads)
+        kvHeads = try container.decodeIfPresent(Int.self, forKey: .kvHeads) ?? attentionHeads
+        let explicitHeadDimensions = try container.decodeIfPresent(
+            Int.self, forKey: .headDimensions)
+        kvChannels = try container.decodeIfPresent(Int.self, forKey: .kvChannels)
+        if let headDimensions = explicitHeadDimensions ?? kvChannels {
+            self.headDimensions = headDimensions
+        } else {
+            throw DecodingError.keyNotFound(
+                CodingKeys.headDimensions,
+                DecodingError.Context(
+                    codingPath: container.codingPath,
+                    debugDescription:
+                        "Nanbeige requires head_dim or kv_channels; hidden_size / heads is invalid"))
+        }
+        rmsNormEps = try container.decode(Float.self, forKey: .rmsNormEps)
+        vocabularySize = try container.decode(Int.self, forKey: .vocabularySize)
+        maxPositionEmbeddings = try container.decodeIfPresent(
+            Int.self, forKey: .maxPositionEmbeddings)
+        ropeTheta = try container.decodeIfPresent(Float.self, forKey: .ropeTheta) ?? 10_000
+        tieWordEmbeddings =
+            try container.decodeIfPresent(Bool.self, forKey: .tieWordEmbeddings) ?? true
+        attentionBias = try container.decodeIfPresent(Bool.self, forKey: .attentionBias) ?? false
+        mlpBias = try container.decodeIfPresent(Bool.self, forKey: .mlpBias) ?? false
+
+        numLoops = try container.decodeIfPresent(Int.self, forKey: .numLoops) ?? 1
+        loopLossWeights = try container.decodeIfPresent([Float].self, forKey: .loopLossWeights)
+        skipLoopFinalNorm =
+            try container.decodeIfPresent(Bool.self, forKey: .skipLoopFinalNorm) ?? false
+
+        enableDoubleLoopSplit = try container.decodeIfPresent(
+            Bool.self, forKey: .enableDoubleLoopSplit)
+        loopShareKV = try container.decodeIfPresent(Bool.self, forKey: .loopShareKV)
+        enableHyperConnection = try container.decodeIfPresent(
+            Bool.self, forKey: .enableHyperConnection)
+        enableMHC = try container.decodeIfPresent(Bool.self, forKey: .enableMHC)
+        enableDepthAttention = try container.decodeIfPresent(
+            Bool.self, forKey: .enableDepthAttention)
+        qkLayerNorm = try container.decodeIfPresent(Bool.self, forKey: .qkLayerNorm)
+        embeddingNeighborCount = try container.decodeIfPresent(
+            Int.self, forKey: .embeddingNeighborCount)
+        runtime = try container.decodeIfPresent(RuntimeContract.self, forKey: .runtime)
+
+        try validate(container: container)
+    }
+
+    private func validate(
+        container: KeyedDecodingContainer<CodingKeys>
+    ) throws {
+        func reject(_ condition: Bool, _ key: CodingKeys, _ description: String) throws {
+            if condition {
+                throw DecodingError.dataCorruptedError(
+                    forKey: key, in: container, debugDescription: description)
+            }
+        }
+
+        try reject(
+            enableDoubleLoopSplit == true, .enableDoubleLoopSplit,
+            "Nanbeige double-loop split is not implemented")
+        try reject(
+            loopShareKV == true, .loopShareKV,
+            "Nanbeige shared-KV loops are not compatible with independent loop slots")
+        try reject(
+            enableHyperConnection == true, .enableHyperConnection,
+            "Nanbeige hyper-connections are not implemented")
+        try reject(enableMHC == true, .enableMHC, "Nanbeige mHC is not implemented")
+        try reject(
+            enableDepthAttention == true, .enableDepthAttention,
+            "Nanbeige depth attention is not implemented")
+        try reject(qkLayerNorm == true, .qkLayerNorm, "Nanbeige QK layer norm is not implemented")
+        try reject(
+            (embeddingNeighborCount ?? 0) != 0, .embeddingNeighborCount,
+            "Nanbeige n-gram neighbor embeddings are not implemented")
+        try reject(numLoops < 1, .numLoops, "Nanbeige num_loops must be positive")
+
+        if let runtime {
+            try reject(
+                runtime.architecture != "looped_transformer", .runtime,
+                "Nanbeige jang_runtime architecture must be looped_transformer")
+            try reject(
+                runtime.cacheLayout != "looped_kv_v1", .runtime,
+                "Nanbeige jang_runtime cache_layout must be looped_kv_v1")
+            try reject(
+                runtime.numLoops != totalLoops, .runtime,
+                "Nanbeige jang_runtime num_loops does not match the effective loop count")
+            try reject(
+                runtime.hiddenLayers != hiddenLayers, .runtime,
+                "Nanbeige jang_runtime num_hidden_layers does not match config")
+            try reject(
+                runtime.cacheSlots != cacheSlots, .runtime,
+                "Nanbeige jang_runtime cache_slots must equal layers * loops")
+            try reject(
+                runtime.cacheSlotFormula != "layer_idx + loop_idx * num_hidden_layers", .runtime,
+                "Nanbeige jang_runtime cache_slot_formula is unsupported")
+            try reject(
+                runtime.loopFinalNorm
+                    != (skipLoopFinalNorm ? "after_all_loops" : "every_loop"),
+                .runtime,
+                "Nanbeige jang_runtime loop_final_norm does not match skip_loop_final_norm")
+            try reject(
+                !runtime.sharedLayerWeights, .runtime,
+                "Nanbeige requires shared layer weights across loops")
+            try reject(
+                !runtime.sharedPositionIDs, .runtime,
+                "Nanbeige requires shared positions across loops")
+            try reject(
+                runtime.normConvention != "llama_rmsnorm_no_plus_one", .runtime,
+                "Nanbeige requires plain Llama RMSNorm weights")
+        }
+    }
+
+    var llamaConfiguration: LlamaConfiguration {
+        LlamaConfiguration(
+            hiddenSize: hiddenSize,
+            hiddenLayers: hiddenLayers,
+            intermediateSize: intermediateSize,
+            attentionHeads: attentionHeads,
+            headDimensions: headDimensions,
+            rmsNormEps: rmsNormEps,
+            vocabularySize: vocabularySize,
+            kvHeads: kvHeads,
+            maxPositionEmbeddings: maxPositionEmbeddings,
+            ropeTheta: ropeTheta,
+            ropeTraditional: false,
+            tieWordEmbeddings: tieWordEmbeddings,
+            attentionBias: attentionBias,
+            mlpBias: mlpBias)
+    }
+}
+
+public final class NanbeigeModelInner: Module {
+    @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
+
+    let layers: [LlamaTransformerBlock]
+    let norm: RMSNorm
+    let totalLoops: Int
+    let skipLoopFinalNorm: Bool
+
+    init(_ configuration: NanbeigeConfiguration) {
+        precondition(configuration.vocabularySize > 0)
+        let llama = configuration.llamaConfiguration
+        _embedTokens.wrappedValue = Embedding(
+            embeddingCount: configuration.vocabularySize,
+            dimensions: configuration.hiddenSize)
+        layers = (0 ..< configuration.hiddenLayers).map { _ in
+            LlamaTransformerBlock(llama)
+        }
+        norm = RMSNorm(
+            dimensions: configuration.hiddenSize,
+            eps: configuration.rmsNormEps)
+        totalLoops = configuration.totalLoops
+        skipLoopFinalNorm = configuration.skipLoopFinalNorm
+    }
+
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]? = nil) -> MLXArray {
+        var hidden = embedTokens(inputs)
+        let expectedCacheSlots = layers.count * totalLoops
+        precondition(
+            cache == nil || cache?.count == expectedCacheSlots,
+            "nanbeige: expected \(expectedCacheSlots) cache slots, got \(cache?.count ?? 0)")
+
+        // Every loop processes the same token positions. Compute the mask once,
+        // before any loop advances its independent cache.
+        let mask = createAttentionMask(h: hidden, cache: cache?.first)
+
+        for loopIndex in 0 ..< totalLoops {
+            for (layerIndex, layer) in layers.enumerated() {
+                let cacheIndex = layerIndex + loopIndex * layers.count
+                hidden = layer(hidden, mask: mask, cache: cache?[cacheIndex])
+            }
+            if !skipLoopFinalNorm {
+                hidden = norm(hidden)
+            }
+        }
+        if skipLoopFinalNorm {
+            hidden = norm(hidden)
+        }
+        return hidden
+    }
+}
+
+public final class NanbeigeModel: Module, LLMModel, KVCacheDimensionProvider {
+    public let vocabularySize: Int
+    public let kvHeads: [Int]
+    public let model: NanbeigeModelInner
+    let configuration: NanbeigeConfiguration
+
+    @ModuleInfo(key: "lm_head") var lmHead: Linear?
+
+    public init(_ configuration: NanbeigeConfiguration) {
+        self.configuration = configuration
+        vocabularySize = configuration.vocabularySize
+        kvHeads = Array(
+            repeating: configuration.kvHeads,
+            count: configuration.cacheSlots)
+        model = NanbeigeModelInner(configuration)
+        if !configuration.tieWordEmbeddings {
+            _lmHead.wrappedValue = Linear(
+                configuration.hiddenSize,
+                configuration.vocabularySize,
+                bias: false)
+        }
+        precondition(
+            configuration.runtime?.cacheSlots == nil
+                || configuration.runtime?.cacheSlots == kvHeads.count,
+            "nanbeige: bundle cache_slots does not match runtime cache topology")
+    }
+
+    public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        let output = model(inputs, cache: cache)
+        if let lmHead {
+            return lmHead(output)
+        }
+        return model.embedTokens.asLinear(output)
+    }
+
+    public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        weights.filter { !$0.key.contains("self_attn.rotary_emb.inv_freq") }
+    }
+
+    public func messageGenerator(tokenizer: any Tokenizer) -> any MessageGenerator {
+        do {
+            _ = try tokenizer.applyChatTemplate(messages: [
+                ["role": "system", "content": "test"]
+            ])
+            return DefaultMessageGenerator()
+        } catch {
+            return NoSystemMessageGenerator()
+        }
+    }
+}
+
+extension NanbeigeModel: LoRAModel {
+    public var loraLayers: [Module] {
+        model.layers
+    }
+}

--- a/Tests/MLXLMTests/NanbeigeRuntimeTests.swift
+++ b/Tests/MLXLMTests/NanbeigeRuntimeTests.swift
@@ -1,0 +1,167 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import MLX
+@testable import MLXLLM
+import MLXLMCommon
+import Testing
+
+@Suite("Nanbeige 4.2 looped runtime", .serialized)
+struct NanbeigeRuntimeTests {
+    private static func configuration(runtimeCacheSlots: Int = 4) -> Data {
+        """
+        {
+          "model_type": "nanbeige",
+          "vocab_size": 32,
+          "hidden_size": 8,
+          "intermediate_size": 16,
+          "num_hidden_layers": 2,
+          "num_attention_heads": 2,
+          "num_key_value_heads": 1,
+          "head_dim": 4,
+          "kv_channels": 4,
+          "rms_norm_eps": 1e-5,
+          "rope_theta": 70000000,
+          "max_position_embeddings": 1024,
+          "tie_word_embeddings": false,
+          "num_loops": 2,
+          "loop_loss_weights": [],
+          "skip_loop_final_norm": false,
+          "jang_runtime": {
+            "architecture": "looped_transformer",
+            "cache_layout": "looped_kv_v1",
+            "num_loops": 2,
+            "num_hidden_layers": 2,
+            "cache_slots": \(runtimeCacheSlots),
+            "cache_slot_formula": "layer_idx + loop_idx * num_hidden_layers",
+            "loop_final_norm": "every_loop",
+            "shared_layer_weights_across_loops": true,
+            "position_ids_shared_across_loops": true,
+            "norm_convention": "llama_rmsnorm_no_plus_one"
+          }
+        }
+        """.data(using: .utf8)!
+    }
+
+    @Test("factory registers Nanbeige and the model creates one cache per loop-layer slot")
+    func registryAndCacheTopologyUseEffectiveDepth() async throws {
+        let config = try JSONDecoder.json5().decode(
+            NanbeigeConfiguration.self,
+            from: Self.configuration())
+        #expect(config.hiddenLayers == 2)
+        #expect(config.totalLoops == 2)
+        #expect(config.cacheSlots == 4)
+        #expect(config.headDimensions == 4)
+
+        let model = NanbeigeModel(config)
+        #expect(model.kvHeads == [1, 1, 1, 1])
+        #expect(model.newCache(parameters: nil).count == 4)
+        #expect(model.newCache(parameters: nil).count == config.runtime?.cacheSlots)
+
+        let created = try await LLMTypeRegistry.shared.createModel(
+            configuration: Self.configuration(),
+            modelType: "nanbeige")
+        #expect(created is NanbeigeModel)
+    }
+
+    @Test("every loop owns independent KV slots and all offsets advance together")
+    func everyLoopAdvancesItsOwnCacheSlots() throws {
+        try MLXMetalTestLock.withLock {
+            let config = try JSONDecoder.json5().decode(
+                NanbeigeConfiguration.self,
+                from: Self.configuration())
+            let model = NanbeigeModel(config)
+            let cache = model.newCache(parameters: nil)
+            let input = MLXArray([1, 2, 3])[.newAxis, .ellipsis]
+
+            let logits = model(input, cache: cache)
+            MLX.eval(logits)
+
+            #expect(logits.shape == [1, 3, 32])
+            #expect(cache.map(\.offset) == [3, 3, 3, 3])
+        }
+    }
+
+    @Test("loop loss weights override num_loops with count plus one")
+    func loopLossWeightsOverrideLoopCount() throws {
+        let data = """
+        {
+          "vocab_size": 32,
+          "hidden_size": 8,
+          "intermediate_size": 16,
+          "num_hidden_layers": 2,
+          "num_attention_heads": 2,
+          "num_key_value_heads": 1,
+          "head_dim": 4,
+          "rms_norm_eps": 1e-5,
+          "num_loops": 9,
+          "loop_loss_weights": [0.25, 0.5],
+          "skip_loop_final_norm": false
+        }
+        """.data(using: .utf8)!
+        let config = try JSONDecoder.json5().decode(
+            NanbeigeConfiguration.self,
+            from: data)
+        #expect(config.totalLoops == 3)
+        #expect(config.cacheSlots == 6)
+    }
+
+    @Test("bundle runtime cache contract mismatch is rejected")
+    func mismatchedRuntimeCacheContractIsRejected() {
+        #expect(throws: DecodingError.self) {
+            _ = try JSONDecoder.json5().decode(
+                NanbeigeConfiguration.self,
+                from: Self.configuration(runtimeCacheSlots: 2))
+        }
+    }
+
+    @Test(
+        "future Nanbeige architecture flags are rejected instead of silently using the 4.2 path",
+        arguments: [
+            #""enable_double_loop_split": true"#,
+            #""loop_share_kv": true"#,
+            #""enable_hyper_connection": true"#,
+            #""enable_mhc": true"#,
+            #""enable_depth_attention": true"#,
+            #""qk_layernorm": true"#,
+            #""emb_neighbor_num": 2"#,
+        ])
+    func unsupportedArchitectureFlagIsRejected(flag: String) {
+        let data = """
+        {
+          "vocab_size": 32,
+          "hidden_size": 8,
+          "intermediate_size": 16,
+          "num_hidden_layers": 2,
+          "num_attention_heads": 2,
+          "num_key_value_heads": 1,
+          "head_dim": 4,
+          "rms_norm_eps": 1e-5,
+          "num_loops": 2,
+          \(flag)
+        }
+        """.data(using: .utf8)!
+
+        #expect(throws: DecodingError.self) {
+            _ = try JSONDecoder.json5().decode(
+                NanbeigeConfiguration.self,
+                from: data)
+        }
+    }
+
+    @Test("runtime source uses the non-aliasing loop-layer cache formula")
+    func sourceUsesIndependentLoopLayerCacheFormula() throws {
+        let sourcePath = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("Libraries/MLXLLM/Models/Nanbeige.swift")
+        let source = try String(contentsOf: sourcePath, encoding: .utf8)
+
+        #expect(source.contains("layerIndex + loopIndex * layers.count"))
+        #expect(!source.contains("layerIndex % layers.count"))
+        #expect(source.contains("cache == nil || cache?.count == expectedCacheSlots"))
+        #expect(source.contains("let mask = createAttentionMask(h: hidden, cache: cache?.first)"))
+    }
+}

--- a/docs/internal/live-gates/20260727_nanbeige42_runtime/README.md
+++ b/docs/internal/live-gates/20260727_nanbeige42_runtime/README.md
@@ -1,0 +1,114 @@
+# Nanbeige 4.2 vMLX Swift runtime gate — 2026-07-27
+
+Status: `PARTIAL_OSAURUS_LIVE_UI_MISSING`
+
+This note records the current vMLX Swift runtime proof for the local Nanbeige
+4.2 bundles. It is text-only; no screenshots or binary proof artifacts are
+committed.
+
+## Source contract implemented
+
+- Model registry route: `model_type = "nanbeige"` dispatches to
+  `NanbeigeModel`.
+- Runtime shape: one physical stack of 22 Llama-shaped layers runs for
+  `num_loops = 2`.
+- KV topology: 44 independent cache slots using
+  `layerIndex + loopIndex * layers.count`.
+- Bundle contract: `jang_runtime.cache_slots` must equal `layers * loops` and
+  `cache_slot_formula` must be
+  `layer_idx + loop_idx * num_hidden_layers`.
+- Head dimension: requires explicit `head_dim` or `kv_channels`; it does not
+  derive 64 from `hidden_size / num_attention_heads`.
+- Future architecture flags are rejected instead of silently using the 4.2
+  runtime path.
+- RoPE, RMSNorm, MLP, attention, and tied output projection reuse the existing
+  Llama-compatible implementations.
+
+## Local bundle metadata checked
+
+Bundle: `/Users/eric/models/JANGQ-AI/Nanbeige4.2-3B-JANG_4M`
+
+- `config.json` includes `num_loops = 2` and `jang_runtime.cache_slots = 44`.
+- `config.json` includes `jang_runtime.cache_slot_formula =
+  "layer_idx + loop_idx * num_hidden_layers"`.
+- `jang_config.json` includes `runtime.cache_slots = 44`.
+- `jang_config.json` stamps `capabilities.reasoning_parser = "qwen3"` and
+  `capabilities.tool_parser = "xml_function"`.
+- `generation_config.json` defaults are `temperature = 0.6`, `top_p = 0.95`,
+  `top_k = 20`, `do_sample = true`.
+
+## Source tests
+
+Command:
+
+```sh
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
+  xcrun swift test --no-parallel --filter NanbeigeRuntimeTests
+```
+
+Result: `PASS` — 6 tests, 1 suite.
+
+Covered:
+
+- registry dispatch to `NanbeigeModel`;
+- `newCache` creates one cache per effective loop-layer slot;
+- all four synthetic cache slots advance together in a two-layer/two-loop
+  forward pass;
+- `loop_loss_weights` override loop count as `count + 1`;
+- mismatched `jang_runtime.cache_slots` is rejected;
+- future incompatible Nanbeige flags are rejected;
+- source formula check prevents modulo/aliasing regression.
+
+## RunBench runtime probes
+
+These are runtime diagnostics, not Osaurus live UI proof.
+
+### JANG_4M
+
+- Config smoke: `PASS`, route `nanbeige`, 22 layers, 48 query heads, 8 KV
+  heads, profile `JANG_4M`.
+- Template smoke: `PASS`, xml-function tools render, qwen3 thinking template
+  renders.
+- Thinking-on prompt: `PASS`, 248 generated tokens, 44.7 tok/s, closed
+  `</think>`, `finish = stop`, visible content coherent.
+- Thinking-off prompt: `PASS`, no reasoning chars, `finish = stop`, visible
+  content coherent.
+- Tool-call probe: `PASS`, parsed structured
+  `get_weather({"location":"Tokyo"})`, no tool markers leaked to content.
+- Disk L2 growing-cache probe: `PASS`, cache topology `layers=44,kvLayers=44`,
+  prompt-boundary disk hit restored 533 tokens, post-answer disk hit restored
+  540 tokens, turn-2 prompt time ratio 0.18, TurboQuant compressions 0.
+
+### JANG_6M
+
+- Config smoke: `PASS`, profile `JANG_6M`.
+- Template smoke: `PASS`.
+- Thinking-off prompt: `PASS`, no reasoning chars, `finish = stop`, visible
+  content coherent.
+- Disk L2 growing-cache probe: `PASS`, cache topology `layers=44,kvLayers=44`,
+  disk hit restored 348 tokens, turn-2 prompt time ratio 0.49, TurboQuant
+  compressions 0.
+
+### MXFP8
+
+- Config smoke: `PASS`, profile `MXFP8`.
+- Template smoke: `PASS`.
+- Thinking-off prompt: `PASS`, no reasoning chars, `finish = stop`, visible
+  content coherent.
+- Disk L2 growing-cache probe: `PASS`, cache topology `layers=44,kvLayers=44`,
+  disk hit restored 348 tokens, turn-2 prompt time ratio 0.53, TurboQuant
+  compressions 0.
+
+## Still missing before user-facing compatibility
+
+- Isolated Release Osaurus app build pinned to this vMLX source.
+- Live UI load proof for each available Nanbeige bundle.
+- Visible reasoning UI proof with thinking enabled and disabled.
+- Live interleaved reasoning -> tool -> reasoning -> final answer proof.
+- Stop-button/input-unlock/follow-up-turn proof.
+- Osaurus Server/Cache UI counters for disk L2 reuse from the live app.
+- App-level settings proof that bundle generation defaults are used unless
+  overridden by visible user settings.
+
+Until those rows are complete, this runtime is not release-verified for
+Osaurus.


### PR DESCRIPTION
## Summary

Adds the Nanbeige 4.2 looped-transformer runtime for local bundles with `model_type = nanbeige`.

Key source behavior:
- one physical stack of 22 Llama-shaped layers is executed for `num_loops = 2`;
- KV cache topology uses 44 independent loop-layer slots;
- cache index is `layerIndex + loopIndex * layers.count`;
- `jang_runtime.cache_slots` and `cache_slot_formula` are validated when present;
- explicit `head_dim` / `kv_channels` is required;
- unsupported future Nanbeige flags reject instead of silently routing through the 4.2 path;
- registry route added for `nanbeige`.

## Proof

Source tests:
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --no-parallel --filter NanbeigeRuntimeTests`
- Result: PASS, 6 tests / 1 suite.

Runtime probes run locally with `/Users/eric/models/JANGQ-AI/Nanbeige4.2-3B-*`:
- JANG_4M config smoke: PASS, route `nanbeige`, 22 physical layers, 44 cache slots by runtime topology.
- JANG_4M template smoke: PASS, qwen3 reasoning parser stamp, xml_function tool parser stamp.
- JANG_4M thinking-on probe: PASS, closed `</think>`, `finish = stop`, coherent answer, 44.7 tok/s.
- JANG_4M thinking-off probe: PASS, no reasoning chars, `finish = stop`, coherent answer.
- JANG_4M xml tool-call probe: PASS, structured `get_weather({"location":"Tokyo"})`, no raw tool markers leaked.
- JANG_4M disk L2 growing-cache probe: PASS, `layers=44,kvLayers=44`, disk restored 533/540-token blocks, turn-2 prompt-time ratio 0.18, TurboQuant compressions 0.
- JANG_6M and MXFP8 config/template/no-thinking/disk-L2 probes: PASS, 44-slot cache topology preserved.

Text-only evidence note added at:
- `docs/internal/live-gates/20260727_nanbeige42_runtime/README.md`

## Not claimed

This PR is not Osaurus release verification. Osaurus live UI proof is still required after the app pins this commit:
- isolated Release Osaurus app build;
- visible reasoning UI on/off;
- interleaved reasoning/tool/final lifecycle;
- Stop/input unlock/follow-up turn;
- live Server/Cache UI counters for disk L2 reuse.
