### PR TITLE
Expose atomic BatchEngine capacity snapshots

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -1144,6 +1144,7 @@ public actor BatchEngine {
         soloFastPathID = fastPathID
         soloFastPathTask = generationTask
         soloFastPathHadMedia = hasMediaContent
+        activeCountHighWatermark = max(activeCountHighWatermark, 1)
 
         continuation.onTermination = { @Sendable _ in
             generationTask.cancel()
@@ -1312,6 +1313,26 @@ public actor BatchEngine {
 
     /// Maximum active-slot count observed since engine creation.
     public var activeCountHighWatermarkForDiagnostics: Int { activeCountHighWatermark }
+
+    /// Actor-consistent admission and capacity diagnostics.
+    ///
+    /// This is a point-in-time observation, not a slot reservation. Consumers
+    /// must still submit through this engine and let its scheduler own
+    /// admission. `nominalAvailableCount` reports configured headroom only;
+    /// per-request cache topology can impose a narrower effective batch.
+    public var capacitySnapshot: BatchEngineCapacitySnapshot {
+        let active = activeCount
+        let accepting = !isShutdown
+        return BatchEngineCapacitySnapshot(
+            configuredMaximum: maxBatchSize,
+            activeCount: active,
+            pendingCount: waitQueue.count,
+            nominalAvailableCount: accepting ? max(0, maxBatchSize - active) : 0,
+            isAcceptingRequests: accepting,
+            isShutdown: isShutdown,
+            activeCountHighWatermark: activeCountHighWatermark
+        )
+    }
 
     /// Number of decode compatibility splits observed since engine creation.
     public var decodeCompatibilitySplitCountForDiagnostics: Int {

--- a/Libraries/MLXLMCommon/BatchEngine/BatchTypes.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchTypes.swift
@@ -20,6 +20,58 @@ public struct BatchRequestID: Hashable, Sendable, CustomStringConvertible {
     public var description: String { value.uuidString.prefix(8).lowercased() }
 }
 
+/// One actor-consistent view of a ``BatchEngine``'s admission capacity.
+///
+/// Read this through ``BatchEngine/capacitySnapshot`` when a serving layer
+/// needs active, queued, and configured-capacity values from the same actor
+/// turn. Reading the engine's individual diagnostic properties separately can
+/// observe different scheduling turns.
+///
+/// `nominalAvailableCount` is configured sequence headroom, not a reservation.
+/// Architecture-specific admission rules can still serialize work (for
+/// example, hybrid-pool cache requests), and another request can consume the
+/// headroom immediately after the snapshot is returned.
+public struct BatchEngineCapacitySnapshot: Sendable, Equatable {
+    /// Configured maximum number of simultaneously active sequences.
+    public let configuredMaximum: Int
+
+    /// Currently active sequences, including the direct B=1 solo path.
+    public let activeCount: Int
+
+    /// Requests waiting for engine admission.
+    public let pendingCount: Int
+
+    /// Configured headroom at this instant, or zero after shutdown.
+    public let nominalAvailableCount: Int
+
+    /// Whether the engine accepts new requests.
+    public let isAcceptingRequests: Bool
+
+    /// Whether terminal engine shutdown has begun.
+    public let isShutdown: Bool
+
+    /// Maximum concurrent active sequence count observed since engine creation.
+    public let activeCountHighWatermark: Int
+
+    public init(
+        configuredMaximum: Int,
+        activeCount: Int,
+        pendingCount: Int,
+        nominalAvailableCount: Int,
+        isAcceptingRequests: Bool,
+        isShutdown: Bool,
+        activeCountHighWatermark: Int
+    ) {
+        self.configuredMaximum = configuredMaximum
+        self.activeCount = activeCount
+        self.pendingCount = pendingCount
+        self.nominalAvailableCount = nominalAvailableCount
+        self.isAcceptingRequests = isAcceptingRequests
+        self.isShutdown = isShutdown
+        self.activeCountHighWatermark = activeCountHighWatermark
+    }
+}
+
 /// A token-level event yielded by ``BatchEngine`` for each active request.
 ///
 /// Consumers iterate an `AsyncStream<BatchGeneration>` to receive tokens

--- a/Tests/MLXLMTests/BatchEngineTests.swift
+++ b/Tests/MLXLMTests/BatchEngineTests.swift
@@ -644,6 +644,74 @@ class BatchEngineIntegrationTests: XCTestCase {
         XCTAssertEqual(completedCount, 4, "All 4 requests should complete")
     }
 
+    /// The capacity snapshot must capture configured, active, and queued work
+    /// from one actor turn. A third request cannot become active while B=2.
+    func testCapacitySnapshotTracksTwoActiveAndThirdPending() async {
+        let engine = makeSlowPrefillEngine(
+            prefillDelayMicroseconds: 100_000,
+            maxBatchSize: 2)
+        let params = GenerateParameters(maxTokens: 1_000, temperature: 0)
+
+        var streams = [AsyncStream<BatchGeneration>]()
+        for _ in 0 ..< 3 {
+            let (_, stream) = await engine.submit(
+                input: LMInput(tokens: MLXArray(Int32(1) ..< Int32(8))),
+                parameters: params)
+            streams.append(stream)
+        }
+
+        let snapshot = await waitForCapacitySnapshot(engine) {
+            $0.activeCount == 2 && $0.pendingCount == 1
+        }
+        XCTAssertEqual(snapshot.configuredMaximum, 2)
+        XCTAssertEqual(snapshot.activeCount, 2)
+        XCTAssertEqual(snapshot.pendingCount, 1)
+        XCTAssertEqual(snapshot.nominalAvailableCount, 0)
+        XCTAssertTrue(snapshot.isAcceptingRequests)
+        XCTAssertFalse(snapshot.isShutdown)
+        XCTAssertEqual(snapshot.activeCountHighWatermark, 2)
+        assertCapacitySnapshotInvariants(snapshot)
+
+        await engine.shutdown()
+        _ = streams
+    }
+
+    /// Cancelling a queued request must be visible in the next atomic snapshot
+    /// without disturbing the active request.
+    func testCapacitySnapshotReflectsPendingCancellation() async {
+        let engine = makeSlowPrefillEngine(
+            prefillDelayMicroseconds: 100_000,
+            maxBatchSize: 1)
+        let params = GenerateParameters(maxTokens: 1_000, temperature: 0)
+
+        let (_, activeStream) = await engine.submit(
+            input: LMInput(tokens: MLXArray(Int32(1) ..< Int32(8))),
+            parameters: params)
+        let (pendingID, pendingStream) = await engine.submit(
+            input: LMInput(tokens: MLXArray(Int32(10) ..< Int32(18))),
+            parameters: params)
+
+        let queued = await waitForCapacitySnapshot(engine) {
+            $0.activeCount == 1 && $0.pendingCount == 1
+        }
+        XCTAssertEqual(queued.configuredMaximum, 1)
+        XCTAssertEqual(queued.nominalAvailableCount, 0)
+
+        await engine.cancel(pendingID)
+        let cancelled = await engine.capacitySnapshot
+        XCTAssertEqual(cancelled.activeCount, 1)
+        XCTAssertEqual(cancelled.pendingCount, 0)
+        XCTAssertEqual(cancelled.nominalAvailableCount, 0)
+        XCTAssertEqual(cancelled.activeCountHighWatermark, 1)
+        assertCapacitySnapshotInvariants(cancelled)
+
+        let pendingResult = await collectTokens(from: pendingStream)
+        XCTAssertEqual(pendingResult.info?.stopReason, .cancelled)
+
+        await engine.shutdown()
+        _ = activeStream
+    }
+
     /// Test: runtime maxBatchSize updates immediately admit queued work.
     func testUpdateMaxBatchSizeAdmitsQueuedRequests() async throws {
         let engine = makeEngine(maxBatchSize: 1)
@@ -672,6 +740,41 @@ class BatchEngineIntegrationTests: XCTestCase {
             let result = await collectTokens(from: stream)
             XCTAssertNotNil(result.info, "Resized engine should finish every stream")
         }
+    }
+
+    /// A capacity increase and the resulting queue admission happen on the
+    /// engine actor, so the first post-resize snapshot is internally coherent.
+    func testCapacitySnapshotReflectsAtomicResizeAdmission() async throws {
+        let engine = makeSlowPrefillEngine(
+            prefillDelayMicroseconds: 100_000,
+            maxBatchSize: 1)
+        let params = GenerateParameters(maxTokens: 1_000, temperature: 0)
+
+        var streams = [AsyncStream<BatchGeneration>]()
+        for _ in 0 ..< 3 {
+            let (_, stream) = await engine.submit(
+                input: LMInput(tokens: MLXArray(Int32(1) ..< Int32(8))),
+                parameters: params)
+            streams.append(stream)
+        }
+
+        let before = await waitForCapacitySnapshot(engine) {
+            $0.activeCount == 1 && $0.pendingCount == 2
+        }
+        XCTAssertEqual(before.configuredMaximum, 1)
+        XCTAssertEqual(before.nominalAvailableCount, 0)
+
+        try await engine.updateMaxBatchSize(3)
+        let after = await engine.capacitySnapshot
+        XCTAssertEqual(after.configuredMaximum, 3)
+        XCTAssertEqual(after.activeCount, 3)
+        XCTAssertEqual(after.pendingCount, 0)
+        XCTAssertEqual(after.nominalAvailableCount, 0)
+        XCTAssertEqual(after.activeCountHighWatermark, 3)
+        assertCapacitySnapshotInvariants(after)
+
+        await engine.shutdown()
+        _ = streams
     }
 
     /// Test: invalid runtime maxBatchSize updates fail without mutating state.
@@ -831,6 +934,32 @@ class BatchEngineIntegrationTests: XCTestCase {
         let activeCount = await engine.activeCount
         XCTAssertTrue(soloActive, "Idle B=1 generate() should use the direct solo fast path")
         XCTAssertEqual(activeCount, 1, "solo fast path should count as active work")
+
+        await engine.shutdown()
+        let result = await collectGenerations(from: stream)
+        XCTAssertEqual(result.info?.stopReason, .cancelled)
+    }
+
+    /// The direct B=1 path is real engine occupancy even though it does not use
+    /// `activeSlots`; both current activity and the high-water mark must count it.
+    func testCapacitySnapshotCountsSoloFastPath() async {
+        let engine = makeSlowPrefillEngine(
+            prefillDelayMicroseconds: 100_000,
+            maxBatchSize: 1)
+        let stream = await engine.generate(
+            input: LMInput(tokens: MLXArray(Int32(1) ..< Int32(8))),
+            parameters: GenerateParameters(maxTokens: 1_000, temperature: 0)
+        )
+
+        let active = await engine.capacitySnapshot
+        XCTAssertEqual(active.configuredMaximum, 1)
+        XCTAssertEqual(active.activeCount, 1)
+        XCTAssertEqual(active.pendingCount, 0)
+        XCTAssertEqual(active.nominalAvailableCount, 0)
+        XCTAssertEqual(active.activeCountHighWatermark, 1)
+        XCTAssertTrue(active.isAcceptingRequests)
+        XCTAssertFalse(active.isShutdown)
+        assertCapacitySnapshotInvariants(active)
 
         await engine.shutdown()
         let result = await collectGenerations(from: stream)
@@ -1140,6 +1269,72 @@ class BatchEngineIntegrationTests: XCTestCase {
         XCTAssertFalse(isRunning)
     }
 
+    /// Shutdown is terminal and must zero nominal availability even though the
+    /// configured maximum remains available for diagnostics.
+    func testCapacitySnapshotAfterShutdownIsNotAccepting() async {
+        let engine = makeEngine(maxBatchSize: 2)
+        let before = await engine.capacitySnapshot
+        XCTAssertEqual(before.configuredMaximum, 2)
+        XCTAssertEqual(before.activeCount, 0)
+        XCTAssertEqual(before.pendingCount, 0)
+        XCTAssertEqual(before.nominalAvailableCount, 2)
+        XCTAssertTrue(before.isAcceptingRequests)
+        XCTAssertFalse(before.isShutdown)
+
+        await engine.shutdown()
+
+        let after = await engine.capacitySnapshot
+        XCTAssertEqual(after.configuredMaximum, 2)
+        XCTAssertEqual(after.activeCount, 0)
+        XCTAssertEqual(after.pendingCount, 0)
+        XCTAssertEqual(after.nominalAvailableCount, 0)
+        XCTAssertFalse(after.isAcceptingRequests)
+        XCTAssertTrue(after.isShutdown)
+        XCTAssertEqual(after.activeCountHighWatermark, 0)
+        assertCapacitySnapshotInvariants(after)
+    }
+
+    /// Under a stable configured limit, repeated concurrent submissions may
+    /// queue but can never make the actor report more active work than capacity.
+    func testCapacitySnapshotNeverExceedsStableConfiguredMaximum() async {
+        let engine = makeSlowPrefillEngine(
+            prefillDelayMicroseconds: 50_000,
+            maxBatchSize: 2)
+        let params = GenerateParameters(maxTokens: 1_000, temperature: 0)
+
+        var streams = [AsyncStream<BatchGeneration>]()
+        for _ in 0 ..< 8 {
+            let (_, stream) = await engine.submit(
+                input: LMInput(tokens: MLXArray(Int32(1) ..< Int32(8))),
+                parameters: params)
+            streams.append(stream)
+
+            let snapshot = await engine.capacitySnapshot
+            XCTAssertLessThanOrEqual(snapshot.activeCount, snapshot.configuredMaximum)
+            assertCapacitySnapshotInvariants(snapshot)
+        }
+
+        let saturated = await waitForCapacitySnapshot(engine) {
+            $0.activeCount == 2 && $0.pendingCount > 0
+        }
+        XCTAssertEqual(saturated.configuredMaximum, 2)
+        XCTAssertLessThanOrEqual(saturated.activeCount, saturated.configuredMaximum)
+        XCTAssertLessThanOrEqual(
+            saturated.activeCountHighWatermark,
+            saturated.configuredMaximum)
+        assertCapacitySnapshotInvariants(saturated)
+
+        await engine.shutdown()
+        let finished = await engine.capacitySnapshot
+        XCTAssertEqual(finished.activeCount, 0)
+        XCTAssertEqual(finished.pendingCount, 0)
+        XCTAssertLessThanOrEqual(
+            finished.activeCountHighWatermark,
+            finished.configuredMaximum)
+        assertCapacitySnapshotInvariants(finished)
+        _ = streams
+    }
+
     /// Test: high-level text generate() also rejects stale post-shutdown handles.
     func testGenerateAfterShutdownRejectsWithoutRestartingEngine() async throws {
         let engine = makeEngine(maxBatchSize: 2)
@@ -1165,6 +1360,53 @@ class BatchEngineIntegrationTests: XCTestCase {
     }
 
     // MARK: - Helpers
+
+    private func waitForCapacitySnapshot(
+        _ engine: BatchEngine,
+        attempts: Int = 200,
+        matching predicate: (BatchEngineCapacitySnapshot) -> Bool
+    ) async -> BatchEngineCapacitySnapshot {
+        for _ in 0 ..< attempts {
+            let snapshot = await engine.capacitySnapshot
+            if predicate(snapshot) {
+                return snapshot
+            }
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+        let snapshot = await engine.capacitySnapshot
+        XCTFail(
+            "Timed out waiting for BatchEngine capacity state; "
+                + "configured=\(snapshot.configuredMaximum), "
+                + "active=\(snapshot.activeCount), pending=\(snapshot.pendingCount)")
+        return snapshot
+    }
+
+    private func assertCapacitySnapshotInvariants(
+        _ snapshot: BatchEngineCapacitySnapshot,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertGreaterThan(snapshot.configuredMaximum, 0, file: file, line: line)
+        XCTAssertGreaterThanOrEqual(snapshot.activeCount, 0, file: file, line: line)
+        XCTAssertGreaterThanOrEqual(snapshot.pendingCount, 0, file: file, line: line)
+        XCTAssertGreaterThanOrEqual(
+            snapshot.activeCountHighWatermark,
+            snapshot.activeCount,
+            file: file,
+            line: line)
+        XCTAssertEqual(
+            snapshot.isAcceptingRequests,
+            !snapshot.isShutdown,
+            file: file,
+            line: line)
+        XCTAssertEqual(
+            snapshot.nominalAvailableCount,
+            snapshot.isAcceptingRequests
+                ? max(0, snapshot.configuredMaximum - snapshot.activeCount)
+                : 0,
+            file: file,
+            line: line)
+    }
 
     private func collectTokens(from stream: AsyncStream<BatchGeneration>)
         async -> (tokens: [Int], info: GenerateCompletionInfo?)


### PR DESCRIPTION
## Proposed changes

Expose one actor-consistent `BatchEngineCapacitySnapshot` containing configured capacity, active and pending request counts, nominal headroom, accepting/shutdown state, and active high-watermark.

This lets serving layers make conservative admission decisions without combining diagnostic values observed on different actor turns. The snapshot is explicitly observational, not a reservation, and documents that architecture-specific cache topology can reduce effective batching.

The change also counts the direct B=1 solo path in the active high-watermark.

## Verification

- `env DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --filter BatchEngineIntegrationTests`
- 28/28 passed locally on exact source `d7483a88668bb3ec70e0ea7f8423a5f684084c28`
- Covered two-active/third-pending, pending cancellation, atomic hot resize, solo fast path, shutdown, stable-capacity invariants, queueing, cancellation, cache storage, and throughput.
- Throughput row: serial 46.8 tok/s; batched 289.3 tok/s; 6.19x.
- `git diff --check 002e658e..d7483a88`
- The fork's four GitHub Actions jobs are skipped by their repository-identity condition; they did not execute and are not represented as passing CI.
- `xcrun swift-format lint` is available, but linting the complete changed files reports existing repository-wide style debt; no broad formatter rewrite is included in this focused PR. `pre-commit` is not installed on this host.

## Checklist

- [x] I have read the CONTRIBUTING document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes (not installed; exact focused tests and diff checks are recorded above)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the necessary documentation (public API documentation is included inline)
