### PR TITLE
Fix hybrid cache precision and linked disk quota eviction

### DIFF
--- a/Libraries/MLXLLM/Models/GatedDelta.swift
+++ b/Libraries/MLXLLM/Models/GatedDelta.swift
@@ -25,7 +25,7 @@ import MLXNN
 private let _compiledComputeG: @Sendable (MLXArray, MLXArray, MLXArray) -> MLXArray =
     compile(shapeless: true) { (aLog: MLXArray, a: MLXArray, dtBias: MLXArray) -> MLXArray in
         let decay = exp(-exp(aLog.asType(.float32)) * softplus(a + dtBias))
-        return decay.asType(a.dtype)
+        return decay
     }
 
 func computeGatedDeltaG(_ aLog: MLXArray, _ a: MLXArray, _ dtBias: MLXArray) -> MLXArray {
@@ -102,6 +102,8 @@ private func makeGatedDeltaKernel(
                   y[dv_idx] = static_cast<InT>(out);
                 }
         \(stepRoundSource)
+              } else {
+                y[dv_idx] = static_cast<InT>(0);
               }
               // Increment data pointers to next time step
               q_ += Hk * Dk;
@@ -113,7 +115,7 @@ private func makeGatedDeltaKernel(
             }
             for (int i = 0; i < n_per_t; ++i) {
               auto s_idx = n_per_t * dk_idx + i;
-              o_state[s_idx] = static_cast<InT>(state[i]);
+              o_state[s_idx] = static_cast<StT>(state[i]);
             }
         """
 
@@ -176,6 +178,7 @@ func gatedDeltaKernel(
     let Hv = v.dim(2)
     let Dv = v.dim(3)
     let inputType = q.dtype
+    let stateType = state.dtype
 
     let selectedKernel: MLXFast.MLXFastKernel?
     var inputs: [MLXArray] = [q, k, v, g, beta, state, MLXArray(T)]
@@ -198,6 +201,7 @@ func gatedDeltaKernel(
         inputs,
         template: [
             ("InT", inputType),
+            ("StT", stateType),
             ("Dk", Dk),
             ("Dv", Dv),
             ("Hk", Hk),
@@ -206,7 +210,7 @@ func gatedDeltaKernel(
         grid: (32, Dv, B * Hv),
         threadGroup: (32, 4, 1),
         outputShapes: [[B, T, Hv, Dv], state.shape],
-        outputDTypes: [inputType, inputType]
+        outputDTypes: [inputType, stateType]
     )
 
     return (outputs[0], outputs[1])
@@ -270,12 +274,12 @@ private func gatedDeltaStepOps(
         } else {
             fatalError("Unsupported mask shape \(mask.shape)")
         }
-        return (y, MLX.where(expandedMask, newState, oldState))
+        return (y.asType(q.dtype), MLX.where(expandedMask, newState, oldState))
     }
 
     // Decode path — compiled, fuses ~10 ops into 1 Metal dispatch
     let result = _compiledStepOps([q, k, v, g, beta, state])
-    return (result[0], result[1])
+    return (result[0].asType(q.dtype), result[1])
 }
 
 func gatedDeltaOps(
@@ -304,7 +308,7 @@ func gatedDeltaOps(
         k = repeated(k, count: repeatFactor, axis: -2)
     }
 
-    var state = state ?? MLXArray.zeros([B, Hv, Dv, Dk], dtype: q.dtype)
+    var state = state ?? MLXArray.zeros([B, Hv, Dv, Dk], dtype: .float32)
 
     var ys = [MLXArray]()
     ys.reserveCapacity(T)
@@ -327,7 +331,9 @@ func gatedDeltaOps(
             mask: maskT
         )
         ys.append(y)
-        state = roundStateEachStep ? newState.asType(q.dtype) : newState
+        state = roundStateEachStep
+            ? newState.asType(q.dtype).asType(.float32)
+            : newState
     }
 
     let y = MLX.stacked(ys, axis: 1)
@@ -348,7 +354,7 @@ func gatedDeltaUpdate(
     mask: MLXArray? = nil,
     roundStateEachStep: Bool = false
 ) -> (MLXArray, MLXArray) {
-    let beta = sigmoid(b)
+    let beta = sigmoid(b).asType(.float32)
     let g = computeGatedDeltaG(aLog, a, dtBias)
 
     let B = q.dim(0)
@@ -356,7 +362,13 @@ func gatedDeltaUpdate(
     let Hv = v.dim(2)
     let Dv = v.dim(3)
 
-    let state = state ?? MLXArray.zeros([B, Hv, Dv, Dk], dtype: q.dtype)
+    // Keep recurrent state in float32 so a cached-prefix boundary does not
+    // introduce a BF16 rounding point that a cold full prefill never saw.
+    // This matches upstream mlx-lm / mlx-swift-lm GatedDelta semantics.
+    var state = state ?? MLXArray.zeros([B, Hv, Dv, Dk], dtype: .float32)
+    if state.dtype != .float32 {
+        state = state.asType(.float32)
+    }
 
     // Mirror `MLXVLM/Models/Qwen35.swift` `gatedDeltaUpdate`:
     // (1) select the masked vs unmasked kernel by `mask` presence so a

--- a/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
@@ -653,12 +653,11 @@ public final class CacheCoordinator: @unchecked Sendable {
         guard let folded = TQDiskSerializer.ssmStates(from: diskArrays) else {
             return nil
         }
-        ssmStateCache.store(
-            ssmStates: folded,
+        storePersistentBoundary(
             tokens: tokens,
-            boundary: boundary,
+            diskArrays: nil,
+            ssmStates: folded,
             mediaSalt: mediaSalt)
-        enforceCombinedDiskQuota()
         return folded
     }
 
@@ -870,7 +869,7 @@ public final class CacheCoordinator: @unchecked Sendable {
                 mediaSalt: mediaSalt)
         }
 
-        // Store in disk cache.
+        // Build the disk payload before entering the linked-store transaction.
         //
         // SLIDING-1: when the raw cache is available, use the v2
         // `TQDiskSerializer.serialize(cache:)` path unconditionally. The
@@ -883,14 +882,14 @@ public final class CacheCoordinator: @unchecked Sendable {
         // disk persistence for sliding-window models (Gemma3/Gemma4
         // SWA layers, Mistral4 with maxKVSize, MiMoV2Flash, BaichuanM1,
         // Qwen3.5-VL inherited sliding layers).
-        if let diskCache {
+        var diskArrays: [String: MLXArray]?
+        if diskCache != nil {
             if let cache {
                 let arrays = TQDiskSerializer.serialize(
                     cache: cache,
                     ssmStates: isHybrid ? ssmStates : nil)
                 if !arrays.isEmpty {
-                    diskCache.store(
-                        tokens: promptTokens, arrays: arrays, mediaSalt: mediaSalt)
+                    diskArrays = arrays
                 }
             } else {
                 // Legacy fallback when the caller didn't pass the raw cache:
@@ -906,24 +905,66 @@ public final class CacheCoordinator: @unchecked Sendable {
                     }
                 }
                 if !arrays.isEmpty {
-                    diskCache.store(
-                        tokens: promptTokens, arrays: arrays, mediaSalt: mediaSalt)
+                    diskArrays = arrays
                 }
             }
         }
 
-        // Store SSM companion states for hybrid models
-        if isHybrid, let ssmStates, !ssmStates.isEmpty {
-            let boundary = totalTokens
-            ssmStateCache.store(
-                ssmStates: ssmStates,
-                tokens: promptTokens,
-                boundary: boundary,
-                mediaSalt: mediaSalt
-            )
+        storePersistentBoundary(
+            tokens: promptTokens,
+            diskArrays: diskArrays,
+            ssmStates: isHybrid ? ssmStates : nil,
+            mediaSalt: mediaSalt)
+    }
+
+    /// Persist one reusable prompt boundary as a linked transaction.
+    ///
+    /// `DiskCache` and `SSMCompanionDiskStore` remain independently usable,
+    /// but applying each store's full quota while a hybrid boundary is only
+    /// half-written can evict an older usable prefix, admit a newer KV/SSM
+    /// half, then have the combined pass evict that oversized new pair too.
+    /// Holding the cross-store lock and deferring both standalone quota passes
+    /// ensures the final eviction decision sees complete linked groups.
+    func storePersistentBoundary(
+        tokens: [Int],
+        diskArrays: [String: MLXArray]?,
+        ssmStates: [MLXArray]?,
+        mediaSalt: String? = nil
+    ) {
+        let usesCombinedQuota = config.enableDiskCache
+            && diskCache != nil
+            && ssmStateCache.diskStore != nil
+        if usesCombinedQuota {
+            CombinedDiskCacheQuotaLock.shared.lock()
+        }
+        defer {
+            if usesCombinedQuota {
+                CombinedDiskCacheQuotaLock.shared.unlock()
+            }
         }
 
-        enforceCombinedDiskQuota()
+        if let diskArrays, !diskArrays.isEmpty {
+            diskCache?.store(
+                tokens: tokens,
+                arrays: diskArrays,
+                mediaSalt: mediaSalt,
+                enforceQuota: !usesCombinedQuota)
+        }
+
+        if isHybrid, let ssmStates, !ssmStates.isEmpty {
+            ssmStateCache.store(
+                ssmStates: ssmStates,
+                tokens: tokens,
+                boundary: tokens.count,
+                mediaSalt: mediaSalt,
+                enforceDiskQuota: !usesCombinedQuota)
+        }
+
+        if usesCombinedQuota {
+            enforceCombinedDiskQuotaLocked()
+        } else {
+            enforceCombinedDiskQuota()
+        }
     }
 
     /// Enforce `diskCacheMaxGB` across the whole persistent cache root, not
@@ -936,13 +977,24 @@ public final class CacheCoordinator: @unchecked Sendable {
     /// recorded KV payload is already gone are removed immediately.
     func enforceCombinedDiskQuota() {
         guard config.enableDiskCache,
+              diskCache != nil,
+              ssmStateCache.diskStore != nil
+        else { return }
+
+        CombinedDiskCacheQuotaLock.shared.lock()
+        defer { CombinedDiskCacheQuotaLock.shared.unlock() }
+        enforceCombinedDiskQuotaLocked()
+    }
+
+    /// Reconcile the linked KV + recurrent quota. Caller must hold
+    /// ``CombinedDiskCacheQuotaLock``.
+    private func enforceCombinedDiskQuotaLocked() {
+        guard config.enableDiskCache,
               let diskCache,
               let companionStore = ssmStateCache.diskStore
         else { return }
 
         let maxBytes = Int64(max(1, Int(config.diskCacheMaxGB * 1_073_741_824)))
-        CombinedDiskCacheQuotaLock.shared.lock()
-        defer { CombinedDiskCacheQuotaLock.shared.unlock() }
 
         let kvEntries = diskCache.quotaEntries()
         let kvHashes = Set(kvEntries.map(\.hash))
@@ -1008,11 +1060,25 @@ public final class CacheCoordinator: @unchecked Sendable {
         var remaining = totalBefore
         var evictKV = Set<String>()
         var evictCompanion = Set<String>()
+
+        // Reject any group that can never fit before applying LRU. Stable
+        // boundaries are normally written shortest-to-longest; evicting the
+        // older fitting boundary first and only then discovering that the
+        // newest group is individually oversized leaves the cache empty.
+        // Pre-eviction preserves the best prior prefix that actually fits.
+        let oversized = groups.filter { $0.bytes > maxBytes }
+        for group in oversized {
+            evictKV.formUnion(group.kvHashes)
+            evictCompanion.formUnion(group.companionHashes)
+            remaining -= group.bytes
+        }
+        let oversizedKeys = Set(oversized.map(\.sortKey))
+
         for group in groups.sorted(by: {
             if $0.priority != $1.priority { return $0.priority < $1.priority }
             if $0.createdAt == $1.createdAt { return $0.sortKey < $1.sortKey }
             return $0.createdAt < $1.createdAt
-        }) where remaining > maxBytes {
+        }) where remaining > maxBytes && !oversizedKeys.contains(group.sortKey) {
             evictKV.formUnion(group.kvHashes)
             evictCompanion.formUnion(group.companionHashes)
             remaining -= group.bytes

--- a/Libraries/MLXLMCommon/Cache/DiskCache.swift
+++ b/Libraries/MLXLMCommon/Cache/DiskCache.swift
@@ -176,6 +176,23 @@ public final class DiskCache: @unchecked Sendable {
     ///   - tokens: Token IDs used to compute the cache key hash.
     ///   - arrays: Dictionary of named MLX arrays to persist.
     public func store(tokens: [Int], arrays: [String: MLXArray], mediaSalt: String? = nil) {
+        store(
+            tokens: tokens,
+            arrays: arrays,
+            mediaSalt: mediaSalt,
+            enforceQuota: true)
+    }
+
+    /// Coordinator-only transactional store. The unified coordinator writes
+    /// KV and recurrent companion payloads under one combined quota lock, so
+    /// it defers this cache's standalone quota pass until the linked group is
+    /// complete. Direct callers retain the historical per-cache quota above.
+    func store(
+        tokens: [Int],
+        arrays: [String: MLXArray],
+        mediaSalt: String? = nil,
+        enforceQuota: Bool
+    ) {
         let hash = DiskCache.hashTokens(tokens, modelKey: modelKey, mediaSalt: mediaSalt)
         let url = safetensorsURL(for: hash)
         let tokenCount = tokens.count
@@ -274,7 +291,9 @@ public final class DiskCache: @unchecked Sendable {
             } else {
                 validatedFiles.removeValue(forKey: hash)
             }
-            _evictIfNeededLocked()
+            if enforceQuota {
+                _evictIfNeededLocked()
+            }
         } catch {
             // Best-effort: swallow so a write failure doesn't fail
             // the caller's request — the model output is already

--- a/Libraries/MLXLMCommon/Cache/SSMCompanionDiskStore.swift
+++ b/Libraries/MLXLMCommon/Cache/SSMCompanionDiskStore.swift
@@ -158,6 +158,25 @@ public final class SSMCompanionDiskStore: @unchecked Sendable {
         mediaSalt: String? = nil,
         isComplete: Bool = true
     ) throws {
+        try store(
+            ssmStates: ssmStates,
+            tokens: tokens,
+            boundary: boundary,
+            mediaSalt: mediaSalt,
+            isComplete: isComplete,
+            enforceQuota: true)
+    }
+
+    /// Coordinator-only transactional store. See ``DiskCache/store``: linked
+    /// KV + recurrent state must be admitted or evicted as one group.
+    func store(
+        ssmStates: [MLXArray],
+        tokens: [Int],
+        boundary: Int,
+        mediaSalt: String? = nil,
+        isComplete: Bool = true,
+        enforceQuota: Bool
+    ) throws {
         guard !ssmStates.isEmpty, boundary > 0, boundary <= tokens.count else { return }
         let key = Self.keyFor(
             tokens: tokens, boundary: boundary,
@@ -260,7 +279,9 @@ public final class SSMCompanionDiskStore: @unchecked Sendable {
             validatedEntries.removeValue(forKey: key)
         }
 
-        evictIfNeededLocked()
+        if enforceQuota {
+            evictIfNeededLocked()
+        }
     }
 
     /// Look up SSM layer states for a given token prefix + boundary.

--- a/Libraries/MLXLMCommon/Cache/SSMStateCache.swift
+++ b/Libraries/MLXLMCommon/Cache/SSMStateCache.swift
@@ -127,7 +127,8 @@ public final class SSMStateCache: @unchecked Sendable {
         boundary: Int,
         mediaSalt: String? = nil,
         isComplete: Bool = true,
-        persistToDisk: Bool = true
+        persistToDisk: Bool = true,
+        enforceDiskQuota: Bool = true
     ) {
         let key = Self.makeKey(tokens: tokens, boundary: boundary, mediaSalt: mediaSalt, modelKey: modelKey)
 
@@ -190,7 +191,8 @@ public final class SSMStateCache: @unchecked Sendable {
                 tokens: tokens,
                 boundary: boundary,
                 mediaSalt: mediaSalt,
-                isComplete: isComplete)
+                isComplete: isComplete,
+                enforceQuota: enforceDiskQuota)
         }
     }
 

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -39,7 +39,7 @@ private enum Qwen35VLError: Error {
 private let _vlmCompiledComputeG: @Sendable (MLXArray, MLXArray, MLXArray) -> MLXArray = {
     let body: @Sendable (MLXArray, MLXArray, MLXArray) -> MLXArray = { (aLog: MLXArray, a: MLXArray, dtBias: MLXArray) -> MLXArray in
         let decay = exp(-exp(aLog.asType(.float32)) * softplus(a + dtBias))
-        return decay.asType(a.dtype)
+        return decay
     }
     return HardwareInfo.isCompiledDecodeSupported ? compile(shapeless: true, body) : body
 }()
@@ -127,11 +127,11 @@ private func gatedDeltaStepOps(
         } else {
             fatalError("Unsupported mask shape \(mask.shape)")
         }
-        return (y, MLX.where(expandedMask, newState, oldState))
+        return (y.asType(q.dtype), MLX.where(expandedMask, newState, oldState))
     }
 
     let result = _vlmCompiledStepOps([q, k, v, g, beta, state])
-    return (result[0], result[1])
+    return (result[0].asType(q.dtype), result[1])
 }
 
 private func gatedDeltaOps(
@@ -160,7 +160,7 @@ private func gatedDeltaOps(
         k = repeated(k, count: repeatFactor, axis: -2)
     }
 
-    var state = state ?? MLXArray.zeros([B, Hv, Dv, Dk], dtype: q.dtype)
+    var state = state ?? MLXArray.zeros([B, Hv, Dv, Dk], dtype: .float32)
 
     var ys = [MLXArray]()
     ys.reserveCapacity(T)
@@ -183,7 +183,9 @@ private func gatedDeltaOps(
             mask: maskT
         )
         ys.append(y)
-        state = roundStateEachStep ? newState.asType(q.dtype) : newState
+        state = roundStateEachStep
+            ? newState.asType(q.dtype).asType(.float32)
+            : newState
     }
 
     let y = MLX.stacked(ys, axis: 1)
@@ -260,6 +262,8 @@ private func makeVLMGatedDeltaKernel(
                   y[dv_idx] = static_cast<InT>(out);
                 }
         \(stepRoundSource)
+              } else {
+                y[dv_idx] = static_cast<InT>(0);
               }
               q_ += Hk * Dk;
               k_ += Hk * Dk;
@@ -270,7 +274,7 @@ private func makeVLMGatedDeltaKernel(
             }
             for (int i = 0; i < n_per_t; ++i) {
               auto s_idx = n_per_t * dk_idx + i;
-              o_state[s_idx] = static_cast<InT>(state[i]);
+              o_state[s_idx] = static_cast<StT>(state[i]);
             }
         """
     var inputNames = ["q", "k", "v", "g", "beta", "state_in", "T"]
@@ -320,6 +324,7 @@ private func vlmGatedDeltaKernel(
     let Hv = v.dim(2)
     let Dv = v.dim(3)
     let inputType = q.dtype
+    let stateType = state.dtype
 
     let selectedKernel: MLXFast.MLXFastKernel?
     var inputs: [MLXArray] = [q, k, v, g, beta, state, MLXArray(T)]
@@ -340,6 +345,7 @@ private func vlmGatedDeltaKernel(
         inputs,
         template: [
             ("InT", inputType),
+            ("StT", stateType),
             ("Dk", Dk),
             ("Dv", Dv),
             ("Hk", Hk),
@@ -348,7 +354,7 @@ private func vlmGatedDeltaKernel(
         grid: (32, Dv, B * Hv),
         threadGroup: (32, 4, 1),
         outputShapes: [[B, T, Hv, Dv], state.shape],
-        outputDTypes: [inputType, inputType]
+        outputDTypes: [inputType, stateType]
     )
     return (outputs[0], outputs[1])
 }
@@ -365,7 +371,7 @@ private func gatedDeltaUpdate(
     mask: MLXArray? = nil,
     roundStateEachStep: Bool = false
 ) -> (MLXArray, MLXArray) {
-    let beta = sigmoid(b)
+    let beta = sigmoid(b).asType(.float32)
     let g = computeGatedDeltaG(aLog, a, dtBias)
 
     let B = q.dim(0)
@@ -373,7 +379,13 @@ private func gatedDeltaUpdate(
     let Hv = v.dim(2)
     let Dv = v.dim(3)
 
-    let state = state ?? MLXArray.zeros([B, Hv, Dv, Dk], dtype: q.dtype)
+    // Keep recurrent state in float32 so cached and cold prefill partitions
+    // preserve the same GatedDelta recurrence. This mirrors the text path and
+    // upstream mlx-lm / mlx-swift-lm.
+    var state = state ?? MLXArray.zeros([B, Hv, Dv, Dk], dtype: .float32)
+    if state.dtype != .float32 {
+        state = state.asType(.float32)
+    }
 
     // Prefer fused Metal kernel (Python parity, ~210 fewer dispatches per token).
     // The kernel tiles Dk in 32-wide SIMD chunks; unsupported head widths must

--- a/RunBench/Bench.swift
+++ b/RunBench/Bench.swift
@@ -381,6 +381,18 @@ struct Bench {
                 modelPath: modelPath, maxNew: maxNew)
             return
         }
+
+        // BENCH_ORNITH_REPORTED_REPLAY=1: synthetic but structurally exact
+        // replay of the reported Ornith JANG_4M failure: long Swift file
+        // result, failed discovery calls, repeated DB calls, a long plan,
+        // then the same file result again before continuation. Two bounded
+        // precursor generations populate the production disk-prefix path so
+        // the final row also exercises hybrid companion restore/extension.
+        if (env["BENCH_ORNITH_REPORTED_REPLAY"] ?? "0") == "1" {
+            try await runOrnithReportedReplay(
+                modelPath: modelPath, maxNew: maxNew)
+            return
+        }
         // BENCH_OMNI=1 (2026-04-28): full multi-turn matrix for
         // Nemotron-3-Nano-Omni bundles. Tests text-only single, text
         // multi-turn, image single, image multi-turn, video, audio
@@ -7685,6 +7697,345 @@ func runQwenMultiturnToolCheck(modelPath: String, maxNew: Int) async throws {
     print("PASS: no non-tool reasoning-only empty-visible turns")
     print("PASS: all tool-required turns emitted structured .toolCall events")
     print("=== BENCH_QWEN_MULTITURN_TOOL: passed ===")
+}
+
+// MARK: - Ornith reported long tool-history replay
+
+/// Replays the structure and approximate payload sizes of the July 28 Ornith
+/// incident where a second `file_read` continuation emitted an unbounded run
+/// of exclamation marks. This is deliberately not a sampler workaround: it
+/// uses the bundle's generation defaults and fails on punctuation looping,
+/// parser debris, empty terminal output, or missing completion telemetry.
+func runOrnithReportedReplay(modelPath: String, maxNew: Int) async throws {
+    let modelDir = URL(fileURLWithPath: modelPath)
+    let env = ProcessInfo.processInfo.environment
+    let thinking = (env["BENCH_ORNITH_THINKING"] ?? "0") == "1"
+    let cacheDir = URL(fileURLWithPath:
+        env["BENCH_ORNITH_CACHE_DIR"]
+            ?? "/tmp/vmlx-ornith-reported-replay/\(modelDir.lastPathComponent)")
+    try? FileManager.default.removeItem(at: cacheDir)
+
+    print("\n=== BENCH_ORNITH_REPORTED_REPLAY: long tool-history continuation ===")
+    let loadStart = CFAbsoluteTimeGetCurrent()
+    let context = try await MLXLMCommon.loadModel(
+        from: modelDir, using: #huggingFaceTokenizerLoader())
+    print(String(format: "Load: %.2fs", CFAbsoluteTimeGetCurrent() - loadStart))
+    print("Model: \(type(of: context.model))")
+    print("Reasoning stamp: \(context.configuration.reasoningParserName ?? "nil")")
+    print("Tool format: \(context.configuration.toolCallFormat.map { "\($0)" } ?? "nil")")
+
+    nonisolated(unsafe) let ctx = context
+    var cacheConfig = CacheCoordinatorConfig()
+    cacheConfig.usePagedCache = false
+    cacheConfig.enableDiskCache = (env["BENCH_ORNITH_CACHE"] ?? "1") != "0"
+    cacheConfig.diskCacheDir = cacheDir
+    cacheConfig.diskCacheMaxGB = 1
+    cacheConfig.modelKey = "\(modelDir.lastPathComponent)|ornith-reported-replay"
+    let coordinator = CacheCoordinator(config: cacheConfig)
+    let engine = BatchEngine(
+        context: ctx, maxBatchSize: 1, cacheCoordinator: coordinator)
+    defer { Task { await engine.shutdown() } }
+
+    let objectParameters: [String: any Sendable] = [
+        "type": "object",
+        "additionalProperties": true,
+    ]
+    func tool(_ name: String, _ description: String) -> ToolSpec {
+        [
+            "type": "function",
+            "function": [
+                "name": name,
+                "description": description,
+                "parameters": objectParameters,
+            ] as [String: any Sendable],
+        ]
+    }
+    let tools: [ToolSpec] = [
+        tool("file_read", "Read a UTF-8 file with numbered lines."),
+        tool("file_write", "Write an updated UTF-8 file."),
+        tool("capabilities_discover", "Discover an available capability."),
+        tool("db_query", "Run a read-only SQL query."),
+    ]
+
+    func assistantToolCall(
+        _ name: String,
+        id: String,
+        arguments: [String: any Sendable]
+    ) -> Chat.Message {
+        .assistant(
+            "",
+            toolCalls: [
+                ToolCall(
+                    function: .init(name: name, arguments: arguments),
+                    id: id)
+            ])
+    }
+
+    var swiftSource = """
+    import Foundation
+
+    final class NetworkManager: Sendable {
+        static let shared = NetworkManager()
+        static let serverURLKey = "osaurus_server_url"
+        static let apiKeyKey = "osaurus_api_key"
+
+        func fetchAvailableAgents() async throws -> [AgentModel] {
+            let endpoints = ["/v1/models", "/v1/agents", "/agents"]
+            for path in endpoints {
+                // request and decode each supported server response shape
+                struct ModelsResponse: Decodable {
+                    let data: [AgentModel]?
+                    let models: [AgentModel]?
+                    var availableModels: [AgentModel] { data ?? models ?? [] }
+                }
+            }
+            return []
+        }
+
+        func sendChatMessage(prompt: String, agentId: String? = nil) async throws -> String {
+            let selectedModel = agentId ?? "legacy-hardcoded-model"
+            return selectedModel + prompt
+        }
+    }
+    """
+    var fillerLine = 1
+    while swiftSource.utf8.count < 9_523 {
+        swiftSource += "\n// \(fillerLine)| networking fixture line: URLSession decoding, error handling, and model selection."
+        fillerLine += 1
+    }
+    if swiftSource.utf8.count > 9_523 {
+        swiftSource = String(swiftSource.prefix(9_523))
+    }
+    let fileResult = """
+    {"ok":true,"result":{"bytes_read":9523,"file_size":9523,"path":"/workspace/project/NetworkManager.swift","start_line":1,"end_line":228,"text":
+    \(swiftSource)
+    }}
+    """
+    let noCapability = """
+    {"ok":true,"result":{"text":"No capabilities found matching 'swift best practices coding'. Build it from sandbox primitives."}}
+    """
+    let dbRows = """
+    {"ok":true,"result":{"columns":["category","topic","content"],"rows":[["Swift 6.4 Updates","Asynchronous defer statements","Asynchronous cleanup is supported."],["Swift 6.4 Updates","Foundation Performance","URL parsing performance improved."]],"truncated":false}}
+    """
+
+    var history: [Chat.Message] = [
+        .system("You are a careful local coding agent. Inspect files, use tools, and make only approved changes."),
+        .user("Review the attached Swift implementation plan against best practices. Do not edit until I approve a step."),
+        assistantToolCall(
+            "file_read",
+            id: "call_file_1",
+            arguments: ["path": "/workspace/project/NetworkManager.swift"]),
+        .tool(fileResult, toolCallId: "call_file_1"),
+        assistantToolCall(
+            "capabilities_discover",
+            id: "call_cap_1",
+            arguments: ["query": "swift best practices coding"]),
+        .tool(noCapability, toolCallId: "call_cap_1"),
+        assistantToolCall(
+            "capabilities_discover",
+            id: "call_cap_2",
+            arguments: ["query": "swift coding best practices"]),
+        .tool(noCapability, toolCallId: "call_cap_2"),
+    ]
+
+    func parameters(maxTokens: Int) -> GenerateParameters {
+        let fallback = GenerateParameters(maxTokens: maxTokens, prefillStepSize: 512)
+        var result = GenerateParameters(
+            generationConfig: context.configuration.generationDefaults,
+            fallback: fallback)
+        result.maxTokens = maxTokens
+        result.prefillStepSize = 512
+        result.randomSeed = env["BENCH_ORNITH_SEED"].flatMap(UInt64.init)
+        return result
+    }
+
+    func run(
+        label: String,
+        history: [Chat.Message],
+        maxTokens: Int
+    ) async throws -> (
+        text: String,
+        reasoning: String,
+        toolCalls: Int,
+        info: GenerateCompletionInfo?,
+        promptTokens: Int,
+        wall: Double
+    ) {
+        let prepared = try await context.processor.prepare(input: UserInput(
+            chat: history,
+            tools: tools,
+            additionalContext: ["enable_thinking": thinking]))
+        let input = prepared.withToolSchemas(tools)
+        let promptTokens = input.text.tokenIds?.count ?? input.text.tokens.size
+        nonisolated(unsafe) let sendable = input
+        var text = ""
+        var reasoning = ""
+        var toolCallCount = 0
+        var info: GenerateCompletionInfo?
+        let start = CFAbsoluteTimeGetCurrent()
+        for await event in await engine.generate(
+            input: sendable,
+            parameters: parameters(maxTokens: maxTokens)
+        ) {
+            switch event {
+            case .chunk(let chunk): text += chunk
+            case .reasoning(let chunk): reasoning += chunk
+            case .toolCall: toolCallCount += 1
+            case .info(let completion): info = completion
+            case .toolCallProgress, .prefillProgress: break
+            }
+        }
+        let wall = CFAbsoluteTimeGetCurrent() - start
+        print(String(format:
+            "  %@ prompt=%d promptTime=%.3fs gen=%d wall=%.2fs tokps=%.2f textChars=%d reasoningChars=%d tools=%d stop=%@",
+            label,
+            promptTokens,
+            info?.promptTime ?? -1,
+            info?.generationTokenCount ?? 0,
+            wall,
+            Double(info?.generationTokenCount ?? 0) / max(wall, 0.001),
+            text.count,
+            reasoning.count,
+            toolCallCount,
+            info.map { "\($0.stopReason)" } ?? "missing"))
+        return (text, reasoning, toolCallCount, info, promptTokens, wall)
+    }
+
+    // Populate the same stable prompt-boundary path used by Osaurus's
+    // one-token hidden warm-up. The generated token is deliberately ignored;
+    // subsequent history is the recorded transcript, just like the report.
+    _ = try await run(label: "stage1-file-and-discovery", history: history, maxTokens: 1)
+
+    for index in 1 ... 8 {
+        let id = "call_db_\(index)"
+        history.append(assistantToolCall(
+            "db_query",
+            id: id,
+            arguments: [
+                "sql": "SELECT topic, content FROM swift_knowledge_base WHERE category = 'Swift 6.4 Updates' LIMIT \(index + 1)"
+            ]))
+        history.append(.tool(dbRows, toolCallId: id))
+    }
+    history.append(.assistant("""
+        The plan correctly targets the rigid model-list decoder and hardcoded fallback. Keep the flexible wrapper, accept raw arrays, log endpoint failures, avoid a guessed default model, and move any embedded credential to secure storage. For the first approved step I will only simplify availableModels to data ?? models ?? [] and preserve both response shapes.
+        """))
+    history.append(.user("Those suggestions are good. Execute only your proposed step 1."))
+    _ = try await run(label: "stage2-db-plan-user", history: history, maxTokens: 1)
+
+    history.append(.assistant("I will re-read the current file before applying the approved Step 1 change."))
+    history.append(assistantToolCall(
+        "file_read",
+        id: "call_file_2",
+        arguments: ["path": "/workspace/project/NetworkManager.swift"]))
+    history.append(.tool(fileResult, toolCallId: "call_file_2"))
+
+    let result = try await run(
+        label: "final-second-file-continuation",
+        history: history,
+        maxTokens: max(256, maxNew))
+    let visible = result.text.trimmingCharacters(in: .whitespacesAndNewlines)
+    let protocolMarkers = [
+        "<think>", "</think>", "<tool_call>", "</tool_call>",
+        "<|channel>", "\u{FFFE}",
+    ]
+    let leakedMarker = protocolMarkers.first { result.text.contains($0) }
+
+    var longestBangRun = 0
+    var currentBangRun = 0
+    for character in result.text {
+        if character == "!" {
+            currentBangRun += 1
+            longestBangRun = max(longestBangRun, currentBangRun)
+        } else {
+            currentBangRun = 0
+        }
+    }
+
+    print("  final sample: \(String(result.text.prefix(400)).debugDescription)")
+    print("  longestBangRun=\(longestBangRun)")
+    let snapshot = coordinator.snapshotStats()
+    if let disk = snapshot.diskStats {
+        print(
+            "  diskCache hits=\(disk.hits) misses=\(disk.misses) stores=\(disk.stores) skips=\(disk.storeSkips) maxBytes=\(disk.maxSizeBytes)"
+        )
+    }
+    print(
+        "  ssmCache hybrid=\(snapshot.isHybrid) hits=\(snapshot.ssmStats.hits) misses=\(snapshot.ssmStats.misses) reDerives=\(snapshot.ssmStats.reDerives)"
+    )
+
+    if (env["BENCH_ORNITH_RAW_DIAGNOSTIC"] ?? "0") == "1" {
+        let prepared = try await context.processor.prepare(input: UserInput(
+            chat: history,
+            tools: tools,
+            additionalContext: ["enable_thinking": thinking]))
+        let rawInput = prepared.withToolSchemas(tools)
+        nonisolated(unsafe) let rawSendable = rawInput
+        let rawBudget = min(max(256, maxNew), 512)
+        let (_, rawStream) = await engine.submit(
+            input: rawSendable,
+            parameters: parameters(maxTokens: rawBudget))
+        var tokenIDs: [Int] = []
+        var rawInfo: GenerateCompletionInfo?
+        for await event in rawStream {
+            switch event {
+            case .token(let id): tokenIDs.append(id)
+            case .info(let info): rawInfo = info
+            case .prefillProgress: break
+            }
+        }
+        let frequencies = Dictionary(grouping: tokenIDs, by: { $0 })
+            .map { (id: $0.key, count: $0.value.count) }
+            .sorted {
+                if $0.count == $1.count { return $0.id < $1.id }
+                return $0.count > $1.count
+            }
+        print(
+            "  RAW_DIAGNOSTIC tokens=\(tokenIDs.count) stop=\(rawInfo.map { "\($0.stopReason)" } ?? "missing") top=\(frequencies.prefix(12).map { "\($0.id):\($0.count)" }.joined(separator: ","))"
+        )
+        for frequency in frequencies.prefix(8) {
+            let decoded = context.tokenizer.decode(
+                tokenIds: [frequency.id], skipSpecialTokens: false)
+            print(
+                "  RAW_TOKEN id=\(frequency.id) count=\(frequency.count) decoded=\(decoded.debugDescription)"
+            )
+        }
+        let rawText = context.tokenizer.decode(
+            tokenIds: tokenIDs, skipSpecialTokens: false)
+        print("  RAW_TEXT_PREFIX \(String(rawText.prefix(600)).debugDescription)")
+        print("  RAW_TEXT_SUFFIX \(String(rawText.suffix(600)).debugDescription)")
+    }
+
+    guard result.info != nil else {
+        throw NSError(
+            domain: "BENCH_ORNITH_REPORTED_REPLAY", code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "final stream emitted no completion info"])
+    }
+    guard longestBangRun < 32 else {
+        throw NSError(
+            domain: "BENCH_ORNITH_REPORTED_REPLAY", code: 2,
+            userInfo: [NSLocalizedDescriptionKey: "reproduced punctuation loop: \(longestBangRun) consecutive exclamation marks"])
+    }
+    guard leakedMarker == nil else {
+        throw NSError(
+            domain: "BENCH_ORNITH_REPORTED_REPLAY", code: 3,
+            userInfo: [NSLocalizedDescriptionKey: "visible content leaked parser marker \(leakedMarker!)"])
+    }
+    guard !visible.isEmpty || result.toolCalls > 0 else {
+        throw NSError(
+            domain: "BENCH_ORNITH_REPORTED_REPLAY", code: 4,
+            userInfo: [NSLocalizedDescriptionKey: "final continuation was empty and emitted no structured tool call"])
+    }
+    guard result.info?.stopReason != .length else {
+        throw NSError(
+            domain: "BENCH_ORNITH_REPORTED_REPLAY", code: 5,
+            userInfo: [
+                NSLocalizedDescriptionKey:
+                    "final continuation exhausted \(result.info?.generationTokenCount ?? 0) tokens after only \(result.text.count) visible characters"
+            ])
+    }
+
+    await engine.shutdown()
+    print("=== BENCH_ORNITH_REPORTED_REPLAY: PASS ===")
 }
 
 // MARK: - Perf micro-bench (BENCH_PERF=1)

--- a/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
@@ -1084,7 +1084,16 @@ struct MTPRuntimeFocusedTests {
             #expect(source.contains("_strict"))
             #expect(source.contains("_fast"))
             #expect(source.contains("state[i] = static_cast<float>(static_cast<InT>(state[i]));"))
-            #expect(source.contains("roundStateEachStep ? newState.asType(q.dtype) : newState"))
+            #expect(source.contains("newState.asType(q.dtype).asType(.float32)"))
+            #expect(source.contains("dtype: .float32"))
+            #expect(source.contains("sigmoid(b).asType(.float32)"))
+            #expect(source.contains("return decay"))
+            #expect(!source.contains("return decay.asType(a.dtype)"))
+            #expect(source.contains("if state.dtype != .float32"))
+            #expect(source.contains("(\"StT\", stateType)"))
+            #expect(source.contains("outputDTypes: [inputType, stateType]"))
+            #expect(source.contains("o_state[s_idx] = static_cast<StT>(state[i]);"))
+            #expect(!source.contains("o_state[s_idx] = static_cast<InT>(state[i]);"))
         }
 
         let textQwen = try Self.source("Libraries/MLXLLM/Models/Qwen35.swift")

--- a/Tests/MLXLMTests/DiskCacheTests.swift
+++ b/Tests/MLXLMTests/DiskCacheTests.swift
@@ -771,6 +771,105 @@ import Testing
     }
 }
 
+@Test func combinedQuotaRejectsOversizedNewestBoundaryButPreservesPriorFittingPrefix() async throws {
+    try await MLXMetalTestLock.withLock {
+        let sizingRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vmlx-linked-quota-sizing-\(UUID().uuidString)")
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vmlx-linked-quota-fitting-\(UUID().uuidString)")
+        defer {
+            try? FileManager.default.removeItem(at: sizingRoot)
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        let modelKey = "linked-quota-fitting-model"
+        let oldTokens = [1, 2, 3, 4]
+        let newTokens = [1, 2, 3, 4, 5, 6, 7, 8]
+        let oldKV = ["data": MLXArray.ones([16_384])]
+        let newKV = ["data": MLXArray.ones([65_536])]
+        let oldSSM = [MLXArray.ones([16_384])]
+        let newSSM = [MLXArray.ones([65_536])]
+
+        // Measure the exact safetensors + sidecar sizes first, then select a
+        // cap where the prior linked group fits, each half of the new group
+        // fits independently, but the new linked group does not. This is the
+        // geometry that previously let each standalone store evict the old
+        // prefix before combined quota also evicted the new one.
+        let sizingDisk = DiskCache(
+            cacheDir: sizingRoot, maxSizeGB: 1, modelKey: modelKey)
+        let sizingCompanion = try SSMCompanionDiskStore(
+            cacheDir: sizingRoot.appendingPathComponent("ssm_companion"),
+            modelKey: modelKey,
+            maxBytes: 1_073_741_824)
+        sizingDisk.store(tokens: oldTokens, arrays: oldKV)
+        try sizingCompanion.store(
+            ssmStates: oldSSM, tokens: oldTokens, boundary: oldTokens.count)
+        sizingDisk.store(tokens: newTokens, arrays: newKV)
+        try sizingCompanion.store(
+            ssmStates: newSSM, tokens: newTokens, boundary: newTokens.count)
+
+        let oldKVHash = DiskCache.hashTokens(oldTokens, modelKey: modelKey)
+        let newKVHash = DiskCache.hashTokens(newTokens, modelKey: modelKey)
+        let oldSSMHash = SSMCompanionDiskStore.keyFor(
+            tokens: oldTokens, boundary: oldTokens.count, modelKey: modelKey)
+        let newSSMHash = SSMCompanionDiskStore.keyFor(
+            tokens: newTokens, boundary: newTokens.count, modelKey: modelKey)
+        let oldKVBytes = try #require(
+            sizingDisk.quotaEntries().first { $0.hash == oldKVHash }).bytes
+        let newKVBytes = try #require(
+            sizingDisk.quotaEntries().first { $0.hash == newKVHash }).bytes
+        let oldSSMBytes = try #require(
+            sizingCompanion.quotaEntries().first { $0.hash == oldSSMHash }).bytes
+        let newSSMBytes = try #require(
+            sizingCompanion.quotaEntries().first { $0.hash == newSSMHash }).bytes
+
+        let lowerBound = max(
+            oldKVBytes + oldSSMBytes,
+            max(newKVBytes, newSSMBytes))
+        let upperBound = min(
+            newKVBytes + newSSMBytes,
+            min(oldKVBytes + newKVBytes, oldSSMBytes + newSSMBytes))
+        #expect(lowerBound < upperBound)
+        let capBytes = lowerBound + (upperBound - lowerBound) / 2
+
+        let coordinator = CacheCoordinator(config: CacheCoordinatorConfig(
+            usePagedCache: false,
+            enableDiskCache: true,
+            diskCacheMaxGB: Float(capBytes) / 1_073_741_824,
+            diskCacheDir: root,
+            modelKey: modelKey))
+        coordinator.setHybrid(true, requiresRecurrentSSMCompanion: true)
+
+        coordinator.storePersistentBoundary(
+            tokens: oldTokens,
+            diskArrays: oldKV,
+            ssmStates: oldSSM)
+        #expect(coordinator.diskCache?.fetch(tokens: oldTokens) != nil)
+        #expect(
+            coordinator.ssmStateCache.diskStore?.fetch(
+                tokens: oldTokens, boundary: oldTokens.count) != nil)
+
+        coordinator.storePersistentBoundary(
+            tokens: newTokens,
+            diskArrays: newKV,
+            ssmStates: newSSM)
+
+        let remainingKV = Set(coordinator.diskCache?.quotaEntries().map(\.hash) ?? [])
+        let remainingSSM = Set(
+            coordinator.ssmStateCache.diskStore?.quotaEntries().map(\.hash) ?? [])
+        #expect(remainingKV == Set([oldKVHash]))
+        #expect(remainingSSM == Set([oldSSMHash]))
+        #expect(coordinator.diskCache?.fetch(tokens: oldTokens) != nil)
+        #expect(coordinator.diskCache?.fetch(tokens: newTokens) == nil)
+        #expect(
+            coordinator.ssmStateCache.diskStore?.fetch(
+                tokens: oldTokens, boundary: oldTokens.count) != nil)
+        #expect(
+            coordinator.ssmStateCache.diskStore?.fetch(
+                tokens: newTokens, boundary: newTokens.count) == nil)
+    }
+}
+
 @Test func combinedQuotaRetiresUnlinkedLegacyCompanionBeforeIndexedKV() async throws {
     try await MLXMetalTestLock.withLock {
         let root = FileManager.default.temporaryDirectory

--- a/Tests/MLXLMTests/Qwen35VLMGatedDeltaTests.swift
+++ b/Tests/MLXLMTests/Qwen35VLMGatedDeltaTests.swift
@@ -66,6 +66,8 @@ struct Qwen35VLMGatedDeltaTests {
             #expect(cache.count == 4)
             #expect(cache.first is MambaCache)
             #expect(cache.first?.offset == 3)
+            let mambaCache = try #require(cache.first as? MambaCache)
+            #expect(mambaCache[1]?.dtype == .float32)
         }
     }
 }

--- a/docs/internal/live-gates/20260729_ornith_cache_quota_followup/README.md
+++ b/docs/internal/live-gates/20260729_ornith_cache_quota_followup/README.md
@@ -1,0 +1,71 @@
+# Ornith recurrent-state and linked disk-quota follow-up
+
+Date: 2026-07-29
+
+Status: `PARTIAL`. Focused source, cache, tiny-forward, and local-model replay
+rows pass as recorded below. The coordinated Osaurus pin and real-app UI
+lifecycle are separate downstream gates.
+
+## Source and model identity
+
+- vMLX baseline: `439f53694f3d630663e97612c264ae73e499121a`
+- tested vMLX head: `68935c5c46e89e79827ea504cea7ac56b7527f20`
+- model bundle:
+  `/Users/eric/models/JANGQ-AI/Ornith-1.0-9B-JANG_4M`
+- `config.json` SHA-256:
+  `2f4828bffc846f5f8e300284addfdebef8ef7a1f9583636a982c0c137449cc63`
+- `generation_config.json` SHA-256:
+  `12a900f4edc6e82f7b03c94b1abaf8763b7fdec971c6e1440809461e21e8eae3`
+- `tokenizer_config.json` SHA-256:
+  `792fa3f0cb88b111e54ef3134c873531008c4df471d108da17903426e308aa7b`
+- generation configuration contains no temperature, top-p, top-k, min-p,
+  repetition-penalty, or sampling override. The replay uses bundle defaults,
+  a 512-token prefill step, a named random seed, and the stated diagnostic
+  output cap. Paged RAM is disabled.
+
+## Focused automated results
+
+| Lane | Result |
+| --- | ---: |
+| GatedDelta full-precision source contract | 1/1 passed |
+| Qwen 3.5 VLM tiny forward and recurrent cache dtype | 1/1 passed |
+| linked oversized-boundary quota regression | 1/1 passed |
+| complete `DiskCache` focused lane | 18/18 passed |
+
+The initial tiny VLM test launch failed because the ad-hoc local test bundle
+lacked its packaged MLX metallib. Copying the already-built package metallibs
+into that test bundle fixed the packaging-only failure; the unchanged test then
+passed. No model/runtime assertion failed.
+
+## Exact reported-history replay
+
+The `BENCH_ORNITH_REPORTED_REPLAY=1` RunBench lane constructs the reported
+sequence: a 9,523-byte Swift file result, failed capability discoveries,
+repeated database tool calls, plan/review turns, and a second file result. Two
+one-token precursor requests populate the same persistent boundary path before
+the final continuation.
+
+| Seed | Disk cache | Final observation |
+| ---: | :---: | --- |
+| 1 | on | `stop`; 272 generated tokens; 98 visible characters; one tool call; disk hits 2; SSM hits 2; zero exclamation run |
+| 1 | off | `stop`; 267 generated tokens; 72 visible characters; one tool call; zero exclamation run |
+| 2 | on/off | raw tokens matched; coherent open full-file `file_write` call reached the 512-token diagnostic cap |
+| 2 | on | the same large envelope reached the 4,096-token diagnostic cap |
+| 3 | on | valid tool call and `stop`; zero exclamation run |
+| 4 | on | valid tool call and `stop`; zero exclamation run |
+| 5 | on | coherent large full-file write envelope reached the 512-token diagnostic cap; zero exclamation run |
+
+Seed 1 is the reported cache-dependent corruption row and passes with and
+without disk cache after the fix. Seeds 2 and 5 are retained as failed terminal
+lifecycle rows under their diagnostic output caps; they are coherent oversized
+tool envelopes, not punctuation degeneration, and are not hidden with sampler,
+prompt, parser, or forced-stop behavior.
+
+## Proof boundary
+
+- The replay is a non-UI runtime harness. It does not prove Osaurus tool-card,
+  Stop-control, input-unlock, or follow-up-turn lifecycle.
+- The downstream Osaurus PR must pin this exact vMLX revision (or its merged
+  descendant), rebuild, and rerun affected focused/CI gates.
+- Computer Use was explicitly stopped, so no real-app lifecycle claim is made
+  here.


### PR DESCRIPTION
# Ornith recurrent-state and linked disk-quota follow-up

Date: 2026-07-29

Status: `PARTIAL`. Focused source, cache, tiny-forward, and local-model replay
rows pass as recorded below. The coordinated Osaurus pin and real-app UI
lifecycle are separate downstream gates.

## Source and model identity

- vMLX baseline: `439f53694f3d630663e97612c264ae73e499121a`
- tested vMLX head: `68935c5c46e89e79827ea504cea7ac56b7527f20`
- model bundle:
  `/Users/eric/models/JANGQ-AI/Ornith-1.0-9B-JANG_4M`
- `config.json` SHA-256:
  `2f4828bffc846f5f8e300284addfdebef8ef7a1f9583636a982c0c137449cc63`
- `generation_config.json` SHA-256:
  `12a900f4edc6e82f7b03c94b1abaf8763b7fdec971c6e1440809461e21e8eae3`
- `tokenizer_config.json` SHA-256:
  `792fa3f0cb88b111e54ef3134c873531008c4df471d108da17903426e308aa7b`
- generation configuration contains no temperature, top-p, top-k, min-p,
  repetition-penalty, or sampling override. The replay uses bundle defaults,
  a 512-token prefill step, a named random seed, and the stated diagnostic
  output cap. Paged RAM is disabled.

## Focused automated results

| Lane | Result |
| --- | ---: |
| GatedDelta full-precision source contract | 1/1 passed |
| Qwen 3.5 VLM tiny forward and recurrent cache dtype | 1/1 passed |
| linked oversized-boundary quota regression | 1/1 passed |
| complete `DiskCache` focused lane | 18/18 passed |

The initial tiny VLM test launch failed because the ad-hoc local test bundle
lacked its packaged MLX metallib. Copying the already-built package metallibs
into that test bundle fixed the packaging-only failure; the unchanged test then
passed. No model/runtime assertion failed.

## Exact reported-history replay

The `BENCH_ORNITH_REPORTED_REPLAY=1` RunBench lane constructs the reported
sequence: a 9,523-byte Swift file result, failed capability discoveries,
repeated database tool calls, plan/review turns, and a second file result. Two
one-token precursor requests populate the same persistent boundary path before
the final continuation.

| Seed | Disk cache | Final observation |
| ---: | :---: | --- |
| 1 | on | `stop`; 272 generated tokens; 98 visible characters; one tool call; disk hits 2; SSM hits 2; zero exclamation run |
| 1 | off | `stop`; 267 generated tokens; 72 visible characters; one tool call; zero exclamation run |
| 2 | on/off | raw tokens matched; coherent open full-file `file_write` call reached the 512-token diagnostic cap |
| 2 | on | the same large envelope reached the 4,096-token diagnostic cap |
| 3 | on | valid tool call and `stop`; zero exclamation run |
| 4 | on | valid tool call and `stop`; zero exclamation run |
| 5 | on | coherent large full-file write envelope reached the 512-token diagnostic cap; zero exclamation run |

Seed 1 is the reported cache-dependent corruption row and passes with and
without disk cache after the fix. Seeds 2 and 5 are retained as failed terminal
lifecycle rows under their diagnostic output caps; they are coherent oversized
tool envelopes, not punctuation degeneration, and are not hidden with sampler,
prompt, parser, or forced-stop behavior.

## Proof boundary

- The replay is a non-UI runtime harness. It does not prove Osaurus tool-card,
  Stop-control, input-unlock, or follow-up-turn lifecycle.
- The downstream Osaurus PR must pin this exact vMLX revision (or its merged
  descendant), rebuild, and rerun affected focused/CI gates.
- Computer Use was explicitly stopped, so no real-app lifecycle claim is made
  here.
