### PR TITLE
Fix reusable-prefix warmups and mixed quantization overrides

### DIFF
--- a/Libraries/MLXLMCommon/BaseConfiguration.swift
+++ b/Libraries/MLXLMCommon/BaseConfiguration.swift
@@ -83,9 +83,25 @@ public struct BaseConfiguration: Codable, Sendable {
             self.perLayerQuantization = perLayerQuantization
         }
 
+        /// Return an explicit layer override without falling back to the
+        /// top-level quantization default.
+        ///
+        /// Checkpoint metadata conventionally prefixes text-model paths with
+        /// `model.`, while Swift module trees expose the same paths without
+        /// that wrapper. Keep the stored metadata unchanged for round trips,
+        /// but normalize both spellings at the lookup boundary.
+        func explicitQuantizationOption(layer: String) -> QuantizationOption? {
+            for candidate in Self.layerPathCandidates(layer) {
+                if let option = perLayerQuantization[candidate] {
+                    return option
+                }
+            }
+            return nil
+        }
+
         /// The quantization to apply for the given layer name or nil for no quantization.
         public func quantization(layer: String) -> Quantization? {
-            if let perLayer = perLayerQuantization[layer] {
+            if let perLayer = explicitQuantizationOption(layer: layer) {
                 switch perLayer {
                 case .skip:
                     return nil
@@ -95,6 +111,50 @@ public struct BaseConfiguration: Codable, Sendable {
             } else {
                 return quantization
             }
+        }
+
+        private static func layerPathCandidates(_ layer: String) -> [String] {
+            var seen = Set<String>()
+            var candidates = [String]()
+
+            func add(_ value: String) {
+                guard seen.insert(value).inserted else { return }
+                candidates.append(value)
+            }
+
+            func addWithAttentionAlias(_ value: String) {
+                add(value)
+                if value.contains(".attn.") {
+                    add(value.replacingOccurrences(of: ".attn.", with: ".self_attn."))
+                } else if value.hasSuffix(".attn") {
+                    add(String(value.dropLast(".attn".count)) + ".self_attn")
+                }
+            }
+
+            addWithAttentionAlias(layer)
+            if layer.hasPrefix("language_model.model.") {
+                let modelPath = String(layer.dropFirst("language_model.".count))
+                addWithAttentionAlias(modelPath)
+                addWithAttentionAlias(String(modelPath.dropFirst("model.".count)))
+            } else if layer.hasPrefix("language_model.") {
+                let innerPath = String(layer.dropFirst("language_model.".count))
+                addWithAttentionAlias(innerPath)
+                if innerPath.hasPrefix("model.") {
+                    addWithAttentionAlias(String(innerPath.dropFirst("model.".count)))
+                } else {
+                    addWithAttentionAlias("model.\(innerPath)")
+                }
+            } else if layer.hasPrefix("model.") {
+                let barePath = String(layer.dropFirst("model.".count))
+                addWithAttentionAlias(barePath)
+                addWithAttentionAlias("language_model.\(layer)")
+                addWithAttentionAlias("language_model.\(barePath)")
+            } else {
+                addWithAttentionAlias("model.\(layer)")
+                addWithAttentionAlias("language_model.\(layer)")
+                addWithAttentionAlias("language_model.model.\(layer)")
+            }
+            return candidates
         }
     }
 

--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -937,7 +937,10 @@ public actor BatchEngine {
     }
 
     private func shouldSkipDiskBackedToolPromptSeedBoundary(for slot: BatchSlot) -> Bool {
-        shouldSkipDiskBackedToolPromptSeedBoundary(
+        if slot.originalInput.cacheRestorePolicy == .freshRequiredToolSelection {
+            return true
+        }
+        return shouldSkipDiskBackedToolPromptSeedBoundary(
             toolSchemas: slot.originalInput.toolSchemas,
             disablesGeneratedCacheBoundary: slot.disablesGeneratedCacheBoundary)
     }
@@ -986,9 +989,13 @@ public actor BatchEngine {
         let promptTokenCount = input.text.tokens.size
         let hasMediaContent = input.hasMediaContent
         let toolSchemas = input.toolSchemas
-        let skipDiskBackedToolPromptSeedBoundary = shouldSkipDiskBackedToolPromptSeedBoundary(
-            toolSchemas: toolSchemas,
-            disablesGeneratedCacheBoundary: false)
+        let requiresFreshToolSelection =
+            input.cacheRestorePolicy == .freshRequiredToolSelection
+        let skipDiskBackedToolPromptSeedBoundary =
+            requiresFreshToolSelection
+            || shouldSkipDiskBackedToolPromptSeedBoundary(
+                toolSchemas: toolSchemas,
+                disablesGeneratedCacheBoundary: false)
         let fastPathID = UUID()
         var soloParameters = parameters
         soloParameters.extraStopStrings = mergeStopStrings(
@@ -1098,6 +1105,7 @@ public actor BatchEngine {
                 // when progress frames reach the consumer changes.
                 let promptTokenIdsForTail = input.text.tokens.reshaped(-1).asArray(Int.self)
                 let deferredParameters = soloParameters
+                let deferredDisableRestore = requiresFreshToolSelection
                 let deferredSkipSeedBoundary = skipDiskBackedToolPromptSeedBoundary
                 let deferredInputs = SendableBox(
                     (input, context.model, cacheCoordinator))
@@ -1111,6 +1119,7 @@ public actor BatchEngine {
                         cache: nil,
                         parameters: deferredParameters,
                         cacheCoordinator: deferredCoordinator,
+                        disableDiskBackedRequiredToolRestore: deferredDisableRestore,
                         skipDiskBackedToolPromptSeedBoundary: deferredSkipSeedBoundary,
                         prefillProgressHandler: { progress in
                             deferredContinuation.yield(.prefillProgress(prefillGate.clamp(progress)))
@@ -1675,10 +1684,17 @@ public actor BatchEngine {
                 return stepPrefillAfterCacheLookup(slotIndex: slotIndex, inputForPrepare: inputForPrepare)
             }
             let requiresDiskBackedRestore = cacheRequiresDiskBackedCoordinatorRestore(slot.cache)
-            // Scope the fetch result to this coordinator branch. Disk-backed
-            // topologies must all attempt restore; safety is decided by the
-            // topology-aware restore path below, not a model-name denylist.
-            do {
+            // Scope the fetch result to this coordinator branch. Ordinary
+            // requests keep longest-prefix reuse. A caller that is forcing a
+            // fresh tool selection may bypass only an unproven disk-backed
+            // topology; paged/full-KV restores remain eligible.
+            if requiresDiskBackedRestore,
+               slot.originalInput.cacheRestorePolicy == .freshRequiredToolSelection
+            {
+                Self.logger.info(
+                    "Slot \(slot.id.description, privacy: .public): skipped disk-backed required-tool cache restore; caller requested fresh tool selection"
+                )
+            } else {
                 let result = coordinator.fetch(
                     tokens: tokenIds,
                     mediaSalt: slot.mediaSalt,

--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -2760,6 +2760,10 @@ public actor BatchEngine {
                 coordinator.isHybrid && sharedPromptStripBoundary != nil
             let isReusablePrefixWarmup =
                 slot.originalInput.cachePromptIntent == .reusablePrefixWarmup
+            let shouldPersistExactWarmupPrompt = shouldPersistExactPromptBoundary(
+                cachePromptIntent: slot.originalInput.cachePromptIntent,
+                requiresRecurrentSSMCompanion:
+                    coordinator.requiresRecurrentSSMCompanion)
 
             func storeCacheEntry(tokens: [Int], snapshot: [KVCache], label: String) {
                 guard !tokens.isEmpty else { return }
@@ -2936,11 +2940,15 @@ public actor BatchEngine {
                 }
             }
 
-            if !usesCanonicalHybridBoundary {
+            if !usesCanonicalHybridBoundary, shouldPersistExactWarmupPrompt {
                 storeCacheEntry(
                     tokens: promptTokens,
                     snapshot: promptCacheSnapshot,
                     label: "prompt-boundary")
+            } else if isReusablePrefixWarmup, !shouldPersistExactWarmupPrompt {
+                Self.logger.info(
+                    "Skipped exact recurrent warmup boundary for slot \(slot.id.description, privacy: .public); retaining processor-proven safe prefix seeds only"
+                )
             }
 
             if !slot.cachePromptUsesPostPrepareKey {

--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -2742,6 +2742,8 @@ public actor BatchEngine {
             // existing prompt/post-answer policy.
             let usesCanonicalHybridBoundary =
                 coordinator.isHybrid && sharedPromptStripBoundary != nil
+            let isReusablePrefixWarmup =
+                slot.originalInput.cachePromptIntent == .reusablePrefixWarmup
 
             func storeCacheEntry(tokens: [Int], snapshot: [KVCache], label: String) {
                 guard !tokens.isEmpty else { return }
@@ -2929,6 +2931,7 @@ public actor BatchEngine {
                 let requiresDiskBackedRestore =
                     cacheRequiresDiskBackedCoordinatorRestore(promptCacheSnapshot)
                 if !usesCanonicalHybridBoundary,
+                   !isReusablePrefixWarmup,
                    requiresDiskBackedRestore,
                    !shouldSkipDiskBackedToolPromptSeedBoundary(for: slot),
                    promptTokens.count > 1,
@@ -3061,6 +3064,7 @@ public actor BatchEngine {
             // it covers prompt + generated tokens exactly enough to resume.
             let generatedBoundaryTokens = promptTokens + slot.generatedTokenIds
             if !usesCanonicalHybridBoundary,
+               !isReusablePrefixWarmup,
                reason == .stop,
                !slot.disablesGeneratedCacheBoundary,
                !containsUnprovenZayaTurboQuantDiskState(slot.cache),

--- a/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
@@ -153,6 +153,22 @@ public func cacheRequiresDiskBackedCoordinatorRestore(_ cache: [any KVCache]) ->
     }
 }
 
+/// Whether the complete prompt boundary from a reusable-prefix warmup is safe
+/// to publish for later coordinator restores.
+///
+/// Recurrent hybrid caches remain path-dependent even when their token key is
+/// an exact prefix. A live Ornith reasoning Off -> On warmup restored such a
+/// checkpoint and replayed the prior tool command. The processor-proven stable
+/// seed remains reusable, but the complete warmup boundary must not become the
+/// longest candidate until that topology has byte-parity proof.
+func shouldPersistExactPromptBoundary(
+    cachePromptIntent: LMInput.CachePromptIntent,
+    requiresRecurrentSSMCompanion: Bool
+) -> Bool {
+    cachePromptIntent != .reusablePrefixWarmup
+        || !requiresRecurrentSSMCompanion
+}
+
 /// Whether paged KV blocks can safely serve this mixed rotating topology when
 /// the exact leaf also carries a typed rotating-boundary companion.
 ///

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1330,8 +1330,12 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.model = model
         self.y = input.text
         self.cacheCoordinator = cacheCoordinator
-        self.disableDiskBackedRequiredToolRestore = disableDiskBackedRequiredToolRestore
-        self.skipDiskBackedToolPromptSeedBoundary = skipDiskBackedToolPromptSeedBoundary
+        let requiresFreshToolSelection =
+            input.cacheRestorePolicy == .freshRequiredToolSelection
+        self.disableDiskBackedRequiredToolRestore =
+            disableDiskBackedRequiredToolRestore || requiresFreshToolSelection
+        self.skipDiskBackedToolPromptSeedBoundary =
+            skipDiskBackedToolPromptSeedBoundary || requiresFreshToolSelection
         let promptTokenCount = input.text.tokens.size
         var effectiveParameters = parameters
         if let coordinator = cacheCoordinator {
@@ -1450,7 +1454,7 @@ public struct TokenIterator: TokenIteratorProtocol {
                 }
             }
             let requiresDiskBackedRestore = cacheRequiresDiskBackedCoordinatorRestore(self.cache)
-            if requiresDiskBackedRestore && disableDiskBackedRequiredToolRestore {
+            if requiresDiskBackedRestore && self.disableDiskBackedRequiredToolRestore {
                 Self.logger.info(
                     "TokenIterator: skipped disk-backed required-tool cache restore; warm restore is not proven safe for this topology"
                 )

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1845,6 +1845,7 @@ public struct TokenIterator: TokenIteratorProtocol {
         guard let coordinator,
             coordinator.canPersistBoundaries,
             !skipBoundary,
+            input.cachePromptIntent != .reusablePrefixWarmup,
             promptTokenIds.count > 1,
             !input.hasMediaContent,
             !input.requiresPostPrepareCacheKey,
@@ -1906,6 +1907,7 @@ public struct TokenIterator: TokenIteratorProtocol {
                 audio: input.audio,
                 mediaTokenIds: input.mediaTokenIds,
                 cacheScopeSalt: input.cacheScopeSalt,
+                cachePromptIntent: input.cachePromptIntent,
                 toolSchemas: input.toolSchemas)
             : nil
         let tail = LMInput(
@@ -1914,6 +1916,7 @@ public struct TokenIterator: TokenIteratorProtocol {
                 mask: flatMask.map { slice($0[split...]) },
                 tokenIds: tailTokenIds),
             cacheScopeSalt: input.cacheScopeSalt,
+            cachePromptIntent: input.cachePromptIntent,
             toolSchemas: input.toolSchemas)
         return (head, tail)
     }
@@ -2238,6 +2241,8 @@ public struct TokenIterator: TokenIteratorProtocol {
         // processor-proven boundary keep the existing storage policy.
         let usesCanonicalHybridBoundary =
             coordinator.isHybrid && hybridStripBoundary != nil
+        let isReusablePrefixWarmup =
+            originalInput.cachePromptIntent == .reusablePrefixWarmup
 
         func store(
             tokens: [Int],
@@ -2349,6 +2354,7 @@ public struct TokenIterator: TokenIteratorProtocol {
                 let requiresDiskBackedRestore =
                     cacheRequiresDiskBackedCoordinatorRestore(promptCacheSnapshot)
                 if !usesCanonicalHybridBoundary,
+                   !isReusablePrefixWarmup,
                    requiresDiskBackedRestore,
                    !skipDiskBackedToolPromptSeedBoundary,
                    promptTokenIds.count > 1
@@ -2472,6 +2478,7 @@ public struct TokenIterator: TokenIteratorProtocol {
         }
 
         guard !usesCanonicalHybridBoundary,
+            !isReusablePrefixWarmup,
             includeGeneratedBoundary, !generatedTokenIds.isEmpty
         else { return }
         guard !needsCacheQuantization else { return }

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -2247,6 +2247,10 @@ public struct TokenIterator: TokenIteratorProtocol {
             coordinator.isHybrid && hybridStripBoundary != nil
         let isReusablePrefixWarmup =
             originalInput.cachePromptIntent == .reusablePrefixWarmup
+        let shouldPersistExactWarmupPrompt = shouldPersistExactPromptBoundary(
+            cachePromptIntent: originalInput.cachePromptIntent,
+            requiresRecurrentSSMCompanion:
+                coordinator.requiresRecurrentSSMCompanion)
 
         func store(
             tokens: [Int],
@@ -2346,12 +2350,16 @@ public struct TokenIterator: TokenIteratorProtocol {
             let promptDiskKVMode = selectivePromptBoundaryDiskKVMode(
                 cache: promptCacheSnapshot,
                 requested: kvMode)
-            if !usesCanonicalHybridBoundary {
+            if !usesCanonicalHybridBoundary, shouldPersistExactWarmupPrompt {
                 store(
                     tokens: promptTokenIds,
                     cache: promptCacheSnapshot,
                     kvBits: nil,
                     kvMode: promptDiskKVMode)
+            } else if isReusablePrefixWarmup, !shouldPersistExactWarmupPrompt {
+                Self.logger.info(
+                    "TokenIterator: skipped exact recurrent warmup boundary; retaining processor-proven safe prefix seeds only"
+                )
             }
 
             if !originalInput.requiresPostPrepareCacheKey {

--- a/Libraries/MLXLMCommon/JangLoader.swift
+++ b/Libraries/MLXLMCommon/JangLoader.swift
@@ -2194,36 +2194,14 @@ public struct JangLoader: Sendable {
         }
 
         func declaredQuantization(for basePath: String) -> BaseConfiguration.Quantization? {
-            func variants(_ key: String) -> [String] {
-                var out = [key]
-                if key.contains(".attn.") || key.hasSuffix(".attn") {
-                    out.append(key.replacingOccurrences(of: ".attn.", with: ".self_attn."))
-                    if key.hasSuffix(".attn") {
-                        out.append(String(key.dropLast(".attn".count)) + ".self_attn")
-                    }
-                }
-                if key.hasPrefix("language_model.model.") {
-                    out.append(String(key.dropFirst("language_model.".count)))
-                } else if key.hasPrefix("language_model.") {
-                    out.append(String(key.dropFirst("language_model.".count)))
-                } else {
-                    out.append("model.\(key)")
-                    out.append("language_model.\(key)")
-                    out.append("language_model.model.\(key)")
-                }
-                return Array(Set(out))
-            }
-
-            if let declaredPerLayerQuantization {
-                for key in variants(basePath) {
-                    if let declared = declaredPerLayerQuantization.perLayerQuantization[key] {
-                        switch declared {
-                        case .quantize(let quantization):
-                            return quantization
-                        case .skip:
-                            return nil
-                        }
-                    }
+            if let declared = declaredPerLayerQuantization?
+                .explicitQuantizationOption(layer: basePath)
+            {
+                switch declared {
+                case .quantize(let quantization):
+                    return quantization
+                case .skip:
+                    return nil
                 }
             }
             if let roleBits = declaredMXTQRoleBits(for: basePath) {
@@ -2282,6 +2260,18 @@ public struct JangLoader: Sendable {
             let packedDim = weightArray.shape.last ?? 0
             let numGroups = scalesArray.shape.last ?? 1
             let (bits, inferredGroupSize): (Int, Int)
+            let declaredForLayer = declaredQuantization(for: basePath)
+            let explicitForLayer: BaseConfiguration.Quantization? = {
+                guard let explicit = declaredPerLayerQuantization?
+                    .explicitQuantizationOption(layer: basePath)
+                else { return nil }
+                guard case .quantize(let quantization) = explicit else { return nil }
+                return quantization
+            }()
+            // A real per-module group size is authoritative for the packed
+            // width calculation. The top-level default is not: architecture
+            // dimension hints must still be able to correct stale defaults.
+            let moduleGroupSize = explicitForLayer?.groupSize ?? groupSize
 
             let isHiddenAnchor =
                 basePath.hasSuffix("embed_tokens")
@@ -2368,7 +2358,7 @@ public struct JangLoader: Sendable {
             // fails this check, and still falls through to the shape walk.
             if let manifest = manifestQuantization(for: basePath) {
                 (bits, inferredGroupSize) = (manifest.bits, manifest.groupSize)
-            } else if let dq = declaredQuantization(for: basePath),
+            } else if let dq = explicitForLayer,
                dq.bits > 0, numGroups > 0, (packedDim * 32) % dq.bits == 0,
                case let declaredInputDim = (packedDim * 32) / dq.bits,
                declaredInputDim % numGroups == 0,
@@ -2382,7 +2372,7 @@ public struct JangLoader: Sendable {
                 (bits, inferredGroupSize) = inferBitWidthAndGroupSize(
                     packedDim: packedDim,
                     numGroups: numGroups,
-                    knownGroupSize: groupSize,
+                    knownGroupSize: moduleGroupSize,
                     bitWidthsUsed: bitWidthsUsed,
                     expectedInDim: hiddenSize)
             } else if isMTPFusionFC,
@@ -2391,7 +2381,7 @@ public struct JangLoader: Sendable {
                 (bits, inferredGroupSize) = inferBitWidthAndGroupSize(
                     packedDim: packedDim,
                     numGroups: numGroups,
-                    knownGroupSize: groupSize,
+                    knownGroupSize: moduleGroupSize,
                     bitWidthsUsed: bitWidthsUsed,
                     expectedInDim: hiddenSize * 2)
             } else if isLinearAttnOutputProjection,
@@ -2400,7 +2390,7 @@ public struct JangLoader: Sendable {
                 (bits, inferredGroupSize) = inferBitWidthAndGroupSize(
                     packedDim: packedDim,
                     numGroups: numGroups,
-                    knownGroupSize: groupSize,
+                    knownGroupSize: moduleGroupSize,
                     bitWidthsUsed: bitWidthsUsed,
                     expectedInDim: valueDim)
             } else if isAttentionOutputProjection,
@@ -2412,7 +2402,7 @@ public struct JangLoader: Sendable {
                     let inferred = inferBitWidthAndGroupSize(
                         packedDim: packedDim,
                         numGroups: numGroups,
-                        knownGroupSize: groupSize,
+                        knownGroupSize: moduleGroupSize,
                         bitWidthsUsed: bitWidthsUsed,
                         expectedInDim: dim)
                     let inputDim = (packedDim * 32) / inferred.bits
@@ -2427,7 +2417,7 @@ public struct JangLoader: Sendable {
                     (bits, inferredGroupSize) = inferBitWidthAndGroupSize(
                         weight: weightArray,
                         scales: scalesArray,
-                        knownGroupSize: groupSize,
+                        knownGroupSize: moduleGroupSize,
                         bitWidthsUsed: bitWidthsUsed)
                 }
             } else if isZayaCCAOutputProjection,
@@ -2442,7 +2432,7 @@ public struct JangLoader: Sendable {
                 (bits, inferredGroupSize) = inferBitWidthAndGroupSize(
                     packedDim: packedDim,
                     numGroups: numGroups,
-                    knownGroupSize: groupSize,
+                    knownGroupSize: moduleGroupSize,
                     bitWidthsUsed: bitWidthsUsed,
                     expectedInDim: ccaOutputDim)
             } else if isPerLayerProjection,
@@ -2452,7 +2442,7 @@ public struct JangLoader: Sendable {
                 (bits, inferredGroupSize) = inferBitWidthAndGroupSize(
                     packedDim: packedDim,
                     numGroups: numGroups,
-                    knownGroupSize: groupSize,
+                    knownGroupSize: moduleGroupSize,
                     bitWidthsUsed: bitWidthsUsed,
                     expectedInDim: perLayerInputDim)
             } else if isPerLayerModelProjection,
@@ -2461,7 +2451,7 @@ public struct JangLoader: Sendable {
                 (bits, inferredGroupSize) = inferBitWidthAndGroupSize(
                     packedDim: packedDim,
                     numGroups: numGroups,
-                    knownGroupSize: groupSize,
+                    knownGroupSize: moduleGroupSize,
                     bitWidthsUsed: bitWidthsUsed,
                     expectedInDim: hiddenSize)
             } else if isExpertDownProjection,
@@ -2471,7 +2461,7 @@ public struct JangLoader: Sendable {
                 (bits, inferredGroupSize) = inferBitWidthAndGroupSize(
                     packedDim: packedDim,
                     numGroups: numGroups,
-                    knownGroupSize: groupSize,
+                    knownGroupSize: moduleGroupSize,
                     bitWidthsUsed: bitWidthsUsed,
                     expectedInDim: expertIntermediateSize)
             } else if let picked = inferFromUniqueValidInDim() {
@@ -2504,19 +2494,18 @@ public struct JangLoader: Sendable {
                     (bits, inferredGroupSize) = inferBitWidthAndGroupSize(
                         weight: weightArray,
                         scales: scalesArray,
-                        knownGroupSize: groupSize,
+                        knownGroupSize: moduleGroupSize,
                         bitWidthsUsed: bitWidthsUsed)
                 }
             } else {
                 (bits, inferredGroupSize) = inferBitWidthAndGroupSize(
                     weight: weightArray,
                     scales: scalesArray,
-                    knownGroupSize: groupSize,
+                    knownGroupSize: moduleGroupSize,
                     bitWidthsUsed: bitWidthsUsed)
             }
 
             let mode = weights[basePath + ".biases"] == nil ? defaultMode : .affine
-            let declaredForLayer = declaredQuantization(for: basePath)
             let declaredMatches =
                 declaredForLayer?.bits == bits
                 && declaredForLayer?.groupSize == inferredGroupSize

--- a/Libraries/MLXLMCommon/LanguageModel.swift
+++ b/Libraries/MLXLMCommon/LanguageModel.swift
@@ -33,6 +33,20 @@ public struct THW: Sendable {
 /// The ``ModelContext`` holds the ``UserInputProcessor`` associated with a
 /// ``LanguageModel``.
 public struct LMInput {
+    /// How the prepared prompt participates in prefix-cache persistence.
+    ///
+    /// Ordinary generation requests may derive template-specific history
+    /// boundaries and may persist a post-generation boundary. A
+    /// ``reusablePrefixWarmup`` is different: its complete token stream has
+    /// already been proven by the caller to be an exact prefix of a future
+    /// request. The runtime must persist that prompt boundary verbatim, must
+    /// not strip another generation scaffold from it, and must not cache the
+    /// warmup's throwaway decoded tokens.
+    public enum CachePromptIntent: Sendable, Equatable {
+        case generation
+        case reusablePrefixWarmup
+    }
+
     public let text: Text
     public let image: ProcessedImage?
     public let video: ProcessedVideo?
@@ -78,6 +92,9 @@ public struct LMInput {
     /// deliberately persisted for reuse by unrelated new chat sessions and may
     /// require an architecture-native rederive when a cache cannot be trimmed.
     public let cacheStablePrefixTokenCounts: [Int]
+
+    /// Typed cache-persistence contract for this prepared prompt.
+    public let cachePromptIntent: CachePromptIntent
 
     /// Representation of tokenized input text.
     public struct Text {
@@ -187,6 +204,7 @@ public struct LMInput {
         cacheScopeSalt: String? = nil,
         cachePrefixTokenCounts: [Int] = [],
         cacheStablePrefixTokenCounts: [Int] = [],
+        cachePromptIntent: CachePromptIntent = .generation,
         toolSchemas: [ToolSpec]? = nil
     ) {
         self.init(
@@ -194,6 +212,7 @@ public struct LMInput {
             cacheScopeSalt: cacheScopeSalt,
             cachePrefixTokenCounts: cachePrefixTokenCounts,
             cacheStablePrefixTokenCounts: cacheStablePrefixTokenCounts,
+            cachePromptIntent: cachePromptIntent,
             toolSchemas: toolSchemas)
     }
 
@@ -205,6 +224,7 @@ public struct LMInput {
         cacheScopeSalt: String? = nil,
         cachePrefixTokenCounts: [Int] = [],
         cacheStablePrefixTokenCounts: [Int] = [],
+        cachePromptIntent: CachePromptIntent = .generation,
         toolSchemas: [ToolSpec]? = nil
     ) {
         self.text = text
@@ -215,6 +235,7 @@ public struct LMInput {
         self.cacheScopeSalt = cacheScopeSalt
         self.cachePrefixTokenCounts = cachePrefixTokenCounts
         self.cacheStablePrefixTokenCounts = cacheStablePrefixTokenCounts
+        self.cachePromptIntent = cachePromptIntent
         self.toolSchemas = toolSchemas
     }
 
@@ -228,6 +249,7 @@ public struct LMInput {
             cacheScopeSalt: cacheScopeSalt,
             cachePrefixTokenCounts: cachePrefixTokenCounts,
             cacheStablePrefixTokenCounts: cacheStablePrefixTokenCounts,
+            cachePromptIntent: cachePromptIntent,
             toolSchemas: schemas)
     }
 }
@@ -256,6 +278,7 @@ public extension LMInput {
         promptTokenIds: [Int],
         boundary: Int
     ) -> Bool {
+        guard cachePromptIntent != .reusablePrefixWarmup else { return false }
         guard hasMediaContent else { return true }
         guard !requiresPostPrepareCacheKey,
               boundary > 0,

--- a/Libraries/MLXLMCommon/LanguageModel.swift
+++ b/Libraries/MLXLMCommon/LanguageModel.swift
@@ -47,6 +47,18 @@ public struct LMInput {
         case reusablePrefixWarmup
     }
 
+    /// Correctness policy for restoring a persisted prompt prefix.
+    ///
+    /// Ordinary requests use the longest validated prefix. A caller that is
+    /// about to force a tool selection can require a fresh selection for
+    /// disk-backed cache topologies whose recurrent/path-dependent state has
+    /// not been proven safe for that boundary. Paged/full-KV restores and
+    /// ordinary continuation turns keep their normal reuse policy.
+    public enum CacheRestorePolicy: Sendable, Equatable {
+        case standard
+        case freshRequiredToolSelection
+    }
+
     public let text: Text
     public let image: ProcessedImage?
     public let video: ProcessedVideo?
@@ -95,6 +107,9 @@ public struct LMInput {
 
     /// Typed cache-persistence contract for this prepared prompt.
     public let cachePromptIntent: CachePromptIntent
+
+    /// Typed cache-restore contract for this prepared prompt.
+    public let cacheRestorePolicy: CacheRestorePolicy
 
     /// Representation of tokenized input text.
     public struct Text {
@@ -205,6 +220,7 @@ public struct LMInput {
         cachePrefixTokenCounts: [Int] = [],
         cacheStablePrefixTokenCounts: [Int] = [],
         cachePromptIntent: CachePromptIntent = .generation,
+        cacheRestorePolicy: CacheRestorePolicy = .standard,
         toolSchemas: [ToolSpec]? = nil
     ) {
         self.init(
@@ -213,6 +229,7 @@ public struct LMInput {
             cachePrefixTokenCounts: cachePrefixTokenCounts,
             cacheStablePrefixTokenCounts: cacheStablePrefixTokenCounts,
             cachePromptIntent: cachePromptIntent,
+            cacheRestorePolicy: cacheRestorePolicy,
             toolSchemas: toolSchemas)
     }
 
@@ -225,6 +242,7 @@ public struct LMInput {
         cachePrefixTokenCounts: [Int] = [],
         cacheStablePrefixTokenCounts: [Int] = [],
         cachePromptIntent: CachePromptIntent = .generation,
+        cacheRestorePolicy: CacheRestorePolicy = .standard,
         toolSchemas: [ToolSpec]? = nil
     ) {
         self.text = text
@@ -236,6 +254,7 @@ public struct LMInput {
         self.cachePrefixTokenCounts = cachePrefixTokenCounts
         self.cacheStablePrefixTokenCounts = cacheStablePrefixTokenCounts
         self.cachePromptIntent = cachePromptIntent
+        self.cacheRestorePolicy = cacheRestorePolicy
         self.toolSchemas = toolSchemas
     }
 
@@ -250,7 +269,24 @@ public struct LMInput {
             cachePrefixTokenCounts: cachePrefixTokenCounts,
             cacheStablePrefixTokenCounts: cacheStablePrefixTokenCounts,
             cachePromptIntent: cachePromptIntent,
+            cacheRestorePolicy: cacheRestorePolicy,
             toolSchemas: schemas)
+    }
+
+    /// Return an otherwise-identical input with an explicit restore policy.
+    public func withCacheRestorePolicy(_ policy: CacheRestorePolicy) -> LMInput {
+        LMInput(
+            text: text,
+            image: image,
+            video: video,
+            audio: audio,
+            mediaTokenIds: mediaTokenIds,
+            cacheScopeSalt: cacheScopeSalt,
+            cachePrefixTokenCounts: cachePrefixTokenCounts,
+            cacheStablePrefixTokenCounts: cacheStablePrefixTokenCounts,
+            cachePromptIntent: cachePromptIntent,
+            cacheRestorePolicy: policy,
+            toolSchemas: toolSchemas)
     }
 }
 

--- a/Libraries/MLXLMCommon/LanguageModel.swift
+++ b/Libraries/MLXLMCommon/LanguageModel.swift
@@ -39,9 +39,12 @@ public struct LMInput {
     /// boundaries and may persist a post-generation boundary. A
     /// ``reusablePrefixWarmup`` is different: its complete token stream has
     /// already been proven by the caller to be an exact prefix of a future
-    /// request. The runtime must persist that prompt boundary verbatim, must
-    /// not strip another generation scaffold from it, and must not cache the
-    /// warmup's throwaway decoded tokens.
+    /// request. Fully restorable cache topologies persist that prompt boundary
+    /// verbatim. Recurrent hybrid topologies instead persist their longest
+    /// processor-proven safe seed: a live Ornith Mamba/GDN row proved that an
+    /// exact warmup checkpoint can replay the previous tool turn after a
+    /// reasoning-mode change even though its token prefix matches. No warmup
+    /// path may cache the throwaway decoded tokens.
     public enum CachePromptIntent: Sendable, Equatable {
         case generation
         case reusablePrefixWarmup

--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -638,18 +638,10 @@ public func loadWeights(
             let biasKey = "\(matchedBase).bias"
             let tup: (groupSize: Int, bits: Int, mode: QuantizationMode)?
             if let effectivePerLayerQuantization {
-                let explicit = baseCandidates.lazy.compactMap { candidate -> BaseConfiguration.Quantization? in
-                    guard let option = effectivePerLayerQuantization.perLayerQuantization[candidate] else {
-                        return nil
-                    }
-                    switch option {
-                    case .skip:
-                        return nil
-                    case .quantize(let quantization):
-                        return quantization
-                    }
-                }.first
-                tup = (explicit ?? effectivePerLayerQuantization.quantization)?.asTuple
+                // Module paths omit the checkpoint's leading `model.` prefix.
+                // Resolve through the canonical per-layer API so the module's
+                // own bits and group size reach the quantization predicate.
+                tup = effectivePerLayerQuantization.quantization(layer: path)?.asTuple
             } else {
                 tup = quantization?.asTuple
             }

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -221,11 +221,21 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                     coordinator.setPagedIncompatible(true)
                 }
             }
-            switch coordinator.fetch(
-                tokens: cacheLookupTokenIds,
-                mediaSalt: mediaSalt,
-                preferredDiskBoundaries: originalInput.cacheStablePrefixTokenCounts
-            ) {
+            let requiresDiskBackedRestore =
+                cacheRequiresDiskBackedCoordinatorRestore(self.cache)
+            let result: CacheFetchResult
+            if requiresDiskBackedRestore,
+               input.cacheRestorePolicy == .freshRequiredToolSelection
+            {
+                result = .miss
+            } else {
+                result = coordinator.fetch(
+                    tokens: cacheLookupTokenIds,
+                    mediaSalt: mediaSalt,
+                    preferredDiskBoundaries: originalInput.cacheStablePrefixTokenCounts
+                )
+            }
+            switch result {
             case .hit(
                 let matchedTokens, let remainingTokens, _, let blocks,
                 let ssmStates, let diskArrays):

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -472,6 +472,10 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             }()
             let isReusablePrefixWarmup =
                 originalInput.cachePromptIntent == .reusablePrefixWarmup
+            let shouldPersistExactWarmupPrompt = shouldPersistExactPromptBoundary(
+                cachePromptIntent: originalInput.cachePromptIntent,
+                requiresRecurrentSSMCompanion:
+                    coordinator.requiresRecurrentSSMCompanion)
             var sharedPromptRederivedStates: [Int: [MLXArray]]?
             let sharedPromptAdditionalBoundaries = Array(Set(
                 cachePrefixTokenCounts + [sharedPromptStripBoundary].compactMap { $0 }
@@ -544,17 +548,23 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                     mediaSalt: mediaSalt)
             }
 
-            store(
-                tokens: promptTokenIds,
-                snapshot: promptCacheSnapshot,
-                label: "prompt-boundary")
+            if shouldPersistExactWarmupPrompt {
+                store(
+                    tokens: promptTokenIds,
+                    snapshot: promptCacheSnapshot,
+                    label: "prompt-boundary")
+            }
 
             if !originalInput.requiresPostPrepareCacheKey {
                 for boundary in Set(cachePrefixTokenCounts).sorted()
                 where boundary > 0 && boundary < promptTokenIds.count {
-                    let boundaryTokens = Array(promptTokenIds.prefix(boundary))
                     let isStableBoundary = originalInput
                         .cacheStablePrefixTokenCounts.contains(boundary)
+                    let storeBoundary = isStableBoundary
+                        && coordinator.requiresRecurrentSSMCompanion && boundary > 1
+                        ? boundary - 1
+                        : boundary
+                    let boundaryTokens = Array(promptTokenIds.prefix(storeBoundary))
                     if isStableBoundary,
                        coordinator.hasValidatedDiskEntry(
                         tokens: boundaryTokens,

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -450,14 +450,18 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             let sharedPromptStripBoundary: Int? = {
                 guard ProcessInfo.processInfo.environment["VMLX_HYBRID_STRIPPED_STORE"] != "0",
                     coordinator.isHybrid,
-                    !originalInput.hasMediaContent,
                     let turnStartToken = coordinator.genPromptSuffixTokens.first,
                     let stripAt = promptTokenIds.lastIndex(of: turnStartToken),
                     stripAt > 0,
-                    stripAt < promptTokenIds.count - 1
+                    stripAt < promptTokenIds.count - 1,
+                    originalInput.canCaptureHybridStripBoundary(
+                        promptTokenIds: promptTokenIds,
+                        boundary: stripAt)
                 else { return nil }
                 return stripAt
             }()
+            let isReusablePrefixWarmup =
+                originalInput.cachePromptIntent == .reusablePrefixWarmup
             var sharedPromptRederivedStates: [Int: [MLXArray]]?
             let sharedPromptAdditionalBoundaries = Array(Set(
                 cachePrefixTokenCounts + [sharedPromptStripBoundary].compactMap { $0 }
@@ -592,7 +596,8 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 }
             }
 
-            if includeGeneratedBoundary,
+            if !isReusablePrefixWarmup,
+               includeGeneratedBoundary,
                !generatedTokenIds.isEmpty,
                !cache.isEmpty
             {

--- a/Package.swift
+++ b/Package.swift
@@ -851,6 +851,7 @@ let package = Package(
                 "NemotronHOmniPreEncodedAudioTests.swift",
                 "NemotronHJANGTQDispatchFocusedTests.swift",
                 "MTPRuntimeFocusedTests.swift",
+                "MixedGroupSizeQuantizationFocusedTests.swift",
                 "MLXPressCLISourceContractsTests.swift",
                 "VMLXServerRuntimeSettingsTests.swift",
                 "VMLXMemorySafetySettingsTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
@@ -1,6 +1,7 @@
 // Copyright © 2026 Osaurus AI. All rights reserved.
 
 import Foundation
+import MLX
 @testable import MLXLMCommon
 import Testing
 
@@ -16,9 +17,26 @@ struct BatchEngineGrowingChatCacheSourceTests {
         #expect(source.contains("case reusablePrefixWarmup"))
         #expect(source.contains("cachePromptIntent: CachePromptIntent = .generation"))
         #expect(source.components(
-            separatedBy: "cachePromptIntent: cachePromptIntent").count - 1 == 2)
+            separatedBy: "cachePromptIntent: cachePromptIntent").count - 1 == 3)
         #expect(source.contains(
             "guard cachePromptIntent != .reusablePrefixWarmup else { return false }"))
+    }
+
+    @Test("fresh required-tool restore policy survives input copies")
+    func freshRequiredToolRestorePolicyIsPreserved() {
+        let tokenArray = MLXArray([Int32(41), Int32(42), Int32(43)])
+            .expandedDimensions(axis: 0)
+        let input = LMInput(
+            text: LMInput.Text(tokens: tokenArray),
+            cacheRestorePolicy: .freshRequiredToolSelection)
+
+        #expect(input.cacheRestorePolicy == .freshRequiredToolSelection)
+        #expect(
+            input.withToolSchemas(nil).cacheRestorePolicy
+                == .freshRequiredToolSelection)
+        #expect(
+            input.withCacheRestorePolicy(.standard).cacheRestorePolicy
+                == .standard)
     }
 
     @Test("all generation paths persist the exact warmup prompt and reject throwaway boundaries")
@@ -160,8 +178,8 @@ struct BatchEngineGrowingChatCacheSourceTests {
             encoding: .utf8)
 
         #expect(source.contains("shouldSkipHistoryBoundaryRederiveAfterTrimMiss(promptSnapshot)"))
-        #expect(source.contains(
-            "a coordinator\n                // miss means this request's token/scope identity did not match"))
+        #expect(source.contains("a coordinator"))
+        #expect(source.contains("miss means this request's token/scope identity did not match"))
         #expect(source.contains("self.cache = model.newCache(parameters: effectiveParameters)"))
         #expect(source.contains("inputForPrepare = input"))
         #expect(source.contains("return nil"))

--- a/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
@@ -39,7 +39,7 @@ struct BatchEngineGrowingChatCacheSourceTests {
                 == .standard)
     }
 
-    @Test("all generation paths persist the exact warmup prompt and reject throwaway boundaries")
+    @Test("all generation paths reject unsafe exact recurrent warmups and throwaway boundaries")
     func cacheWarmupPersistenceContractCoversAllGenerationPaths() throws {
         let evaluate = try String(
             contentsOfFile: "Libraries/MLXLMCommon/Evaluate.swift",
@@ -60,12 +60,30 @@ struct BatchEngineGrowingChatCacheSourceTests {
         #expect(mtp.contains(
             "originalInput.cachePromptIntent == .reusablePrefixWarmup"))
         #expect(mtp.contains("originalInput.canCaptureHybridStripBoundary("))
+        #expect(evaluate.contains("shouldPersistExactPromptBoundary("))
+        #expect(batch.contains("shouldPersistExactPromptBoundary("))
+        #expect(mtp.contains("shouldPersistExactPromptBoundary("))
+        #expect(mtp.contains(
+            "coordinator.requiresRecurrentSSMCompanion && boundary > 1"))
 
         // Solo and batched paths each gate both their N-1/generated stores;
         // native MTP has no N-1 writer and gates its generated store.
         #expect(evaluate.components(separatedBy: "!isReusablePrefixWarmup").count - 1 == 2)
         #expect(batch.components(separatedBy: "!isReusablePrefixWarmup").count - 1 == 2)
         #expect(mtp.components(separatedBy: "!isReusablePrefixWarmup").count - 1 == 1)
+    }
+
+    @Test("exact reusable-prefix warmups remain enabled only for non-recurrent cache topologies")
+    func exactWarmupBoundaryRequiresRestorableTopology() {
+        #expect(shouldPersistExactPromptBoundary(
+            cachePromptIntent: .generation,
+            requiresRecurrentSSMCompanion: true))
+        #expect(shouldPersistExactPromptBoundary(
+            cachePromptIntent: .reusablePrefixWarmup,
+            requiresRecurrentSSMCompanion: false))
+        #expect(!shouldPersistExactPromptBoundary(
+            cachePromptIntent: .reusablePrefixWarmup,
+            requiresRecurrentSSMCompanion: true))
     }
 
     @Test("coordinator miss resets only populated caller-owned caches")

--- a/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
@@ -6,6 +6,50 @@ import Testing
 
 @Suite("BatchEngine growing-chat cache source coverage")
 struct BatchEngineGrowingChatCacheSourceTests {
+    @Test("reusable-prefix warmup intent survives input copies and forbids hybrid stripping")
+    func reusablePrefixWarmupIntentIsPreserved() throws {
+        let source = try String(
+            contentsOfFile: "Libraries/MLXLMCommon/LanguageModel.swift",
+            encoding: .utf8)
+
+        #expect(source.contains("public enum CachePromptIntent: Sendable, Equatable"))
+        #expect(source.contains("case reusablePrefixWarmup"))
+        #expect(source.contains("cachePromptIntent: CachePromptIntent = .generation"))
+        #expect(source.components(
+            separatedBy: "cachePromptIntent: cachePromptIntent").count - 1 == 2)
+        #expect(source.contains(
+            "guard cachePromptIntent != .reusablePrefixWarmup else { return false }"))
+    }
+
+    @Test("all generation paths persist the exact warmup prompt and reject throwaway boundaries")
+    func cacheWarmupPersistenceContractCoversAllGenerationPaths() throws {
+        let evaluate = try String(
+            contentsOfFile: "Libraries/MLXLMCommon/Evaluate.swift",
+            encoding: .utf8)
+        let batch = try String(
+            contentsOfFile: "Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift",
+            encoding: .utf8)
+        let mtp = try String(
+            contentsOfFile: "Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift",
+            encoding: .utf8)
+
+        #expect(evaluate.contains(
+            "input.cachePromptIntent != .reusablePrefixWarmup"))
+        #expect(evaluate.contains(
+            "originalInput.cachePromptIntent == .reusablePrefixWarmup"))
+        #expect(batch.contains(
+            "slot.originalInput.cachePromptIntent == .reusablePrefixWarmup"))
+        #expect(mtp.contains(
+            "originalInput.cachePromptIntent == .reusablePrefixWarmup"))
+        #expect(mtp.contains("originalInput.canCaptureHybridStripBoundary("))
+
+        // Solo and batched paths each gate both their N-1/generated stores;
+        // native MTP has no N-1 writer and gates its generated store.
+        #expect(evaluate.components(separatedBy: "!isReusablePrefixWarmup").count - 1 == 2)
+        #expect(batch.components(separatedBy: "!isReusablePrefixWarmup").count - 1 == 2)
+        #expect(mtp.components(separatedBy: "!isReusablePrefixWarmup").count - 1 == 1)
+    }
+
     @Test("coordinator miss resets only populated caller-owned caches")
     func coordinatorMissResetRequiresPopulatedCache() {
         let empty = KVCacheSimple()

--- a/Tests/MLXLMCommonFocusedTests/CacheCoordinatorTopologyFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/CacheCoordinatorTopologyFocusedTests.swift
@@ -1079,8 +1079,8 @@ struct CacheCoordinatorTopologyFocusedTests {
                 parameters: GenerateParameters()))
     }
 
-    @Test("LFM tool prompts use disk restore while the unproven Gemma MXFP4 seed exception remains")
-    func lfmToolPromptsUseDiskRestore() throws {
+    @Test("caller policy bypasses only disk-backed forced-tool restore")
+    func callerPolicyBypassesOnlyDiskBackedForcedToolRestore() throws {
         let batchSource = try String(
             contentsOfFile: "Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift",
             encoding: .utf8)
@@ -1096,15 +1096,18 @@ struct CacheCoordinatorTopologyFocusedTests {
         #expect(batchSource.contains(#"modelName.contains("mxfp4")"#))
         #expect(batchSource.contains("!shouldSkipDiskBackedToolPromptSeedBoundary(for: slot)"))
         #expect(!batchSource.contains("shouldDisableDiskBackedRequiredToolRestore"))
-        #expect(!batchSource.contains("disableDiskBackedRequiredToolRestore: deferredDisableRestore"))
-        #expect(!batchSource.contains("Skipped disk-backed required-tool cache restore"))
+        #expect(batchSource.contains("disableDiskBackedRequiredToolRestore: deferredDisableRestore"))
+        #expect(batchSource.contains(
+            "slot.originalInput.cacheRestorePolicy == .freshRequiredToolSelection"))
+        #expect(batchSource.contains(
+            "skipped disk-backed required-tool cache restore; caller requested fresh tool selection"))
         #expect(batchSource.contains("Skipped disk-backed tool prompt seed boundary"))
-        // Keep the explicit iterator parameter source-compatible for callers
-        // that have their own measured safety policy. BatchEngine must not set
-        // it from a model-name heuristic.
+        // Keep ordinary tool-schema requests on the normal restore path. The
+        // explicit caller policy, not a model-name heuristic, gates bypass.
         #expect(evaluateSource.contains("disableDiskBackedRequiredToolRestore"))
         #expect(evaluateSource.contains("TokenIterator: skipped disk-backed required-tool cache restore"))
-        #expect(evaluateSource.contains("requiresDiskBackedRestore && disableDiskBackedRequiredToolRestore"))
+        #expect(evaluateSource.contains(
+            "requiresDiskBackedRestore && self.disableDiskBackedRequiredToolRestore"))
     }
 
     @Test("KV policy changes dynamic cache salt")

--- a/Tests/MLXLMCommonFocusedTests/MixedGroupSizeQuantizationFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/MixedGroupSizeQuantizationFocusedTests.swift
@@ -1,0 +1,82 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite("Mixed group-size quantization")
+struct MixedGroupSizeQuantizationFocusedTests {
+    private let bareExpertPath = "layers.1.mlp.switch_mlp.gate_proj"
+
+    @Test("model-prefixed override resolves for a bare module path")
+    func modelPrefixedOverrideResolvesForBareModulePath() throws {
+        let configJSON = """
+            {
+              "model_type": "laguna",
+              "quantization": {
+                "bits": 8,
+                "group_size": 64,
+                "model.layers.1.mlp.switch_mlp.gate_proj": {
+                  "bits": 4,
+                  "group_size": 128,
+                  "mode": "affine"
+                }
+              }
+            }
+            """
+        let config = try JSONDecoder().decode(
+            BaseConfiguration.self,
+            from: Data(configJSON.utf8))
+
+        let bare = config.perLayerQuantization?.quantization(layer: bareExpertPath)
+        let prefixed = config.perLayerQuantization?.quantization(
+            layer: "model.\(bareExpertPath)")
+
+        #expect(bare?.bits == 4)
+        #expect(bare?.groupSize == 128)
+        #expect(prefixed == bare)
+    }
+
+    @Test("Raptor expert shapes use the module group size during inference")
+    func raptorExpertShapesUseModuleGroupSizeDuringInference() {
+        let checkpointPath = "model.\(bareExpertPath)"
+        let declared = BaseConfiguration.PerLayerQuantization(
+            quantization: BaseConfiguration.Quantization(
+                groupSize: 64, bits: 8, mode: .affine),
+            perLayerQuantization: [
+                checkpointPath: .quantize(
+                    BaseConfiguration.Quantization(
+                        groupSize: 128, bits: 4, mode: .affine))
+            ])
+
+        guard let expert = declared.quantization(layer: bareExpertPath) else {
+            Issue.record("Expected the Raptor routed-expert quantization override")
+            return
+        }
+
+        // The real expert tensor is [128, 512, 256] and its scales are
+        // [128, 512, 16]. The resolved module group size must establish
+        // in_features = scales_last * group_size = 16 * 128 = 2048 and
+        // therefore bits = packed_last * 32 / in_features = 4.
+        let inferred = JangLoader.inferBitWidthAndGroupSize(
+            packedDim: 256,
+            numGroups: 16,
+            knownGroupSize: expert.groupSize,
+            bitWidthsUsed: [4, 8])
+
+        #expect(inferred.bits == 4)
+        #expect(inferred.groupSize == 128)
+        #expect(16 * inferred.groupSize == 2048)
+    }
+
+    @Test("model-prefixed skip is not replaced by the global default")
+    func modelPrefixedSkipRemainsSkipped() {
+        let settings = BaseConfiguration.PerLayerQuantization(
+            quantization: BaseConfiguration.Quantization(groupSize: 64, bits: 8),
+            perLayerQuantization: ["model.\(bareExpertPath)": .skip])
+
+        #expect(settings.quantization(layer: bareExpertPath) == nil)
+    }
+}


### PR DESCRIPTION
## Summary

- add typed reusable-prefix warmup intent across solo, batched, and native-MTP generation
- preserve the largest safe warmup boundary without generating throwaway output tokens
- normalize `model.`-prefixed per-module quantization overrides and use each module's effective bits/group size for both shape inference and module construction
- force fresh required-tool selection instead of accepting disk-restored sampled output
- avoid unsafe exact-full-prompt recurrent warmup records while retaining the processor-proven stable N-1 seed

## Root causes fixed

1. Hybrid Ornith/Qwen warmups were treated like ordinary generation, stripped twice, and could persist path-dependent recurrent state at an unsafe boundary.
2. Forced required-tool turns could restore a previously sampled output from disk instead of making a fresh tool selection.
3. Raptor's bundle has a global 8-bit/group-64 default but routed experts are explicitly 4-bit/group-128. Swift module paths omit the serialized leading `model.`, so the override could be missed and a 1024-wide grid constructed for a 2048-wide activation.
4. Exact recurrent warmup records could replay stale output after a setting/tool-state change. Recurrent paths now persist only the stable N-1 seed; non-recurrent paths may retain the exact full prompt.

## Verification

Exact tested vMLX head: `0d54c2517fd39cc5781df6d44942a44b36615c6a`

- 131/131 focused assertions passed across 7 cache, batch, mixed-quantization, and native-MTP suites.
- Raw log: `/private/tmp/osaurus-pr2235-final-evidence/vmlx-focused-0d54c251.log`
- Log SHA-256: `78b7738082b91481193a329434ea24f34c4cad9a68816c4b8b71624c7a9596ac`
- Xcode Swift 6 Release `RunBench` built and loaded the unchanged mixed bundle:
  `/Users/eric/models/OsaurusAI/Raptor-1.0-16B-A3B-qat-JANG_4M-L12c`
- Bundle config SHA-256: `b8fe788ceee47cbe4c4aea7223d3e3136765ae296096b9317144aa3267a52f48`
- Bundle generation config SHA-256: `d79da1da2752e6f5aac8f68346df613532e5989dca3958329cf0bc9446faa517`
- Global quantization is 8-bit/group-64; 439 explicit module overrides include routed 4-bit/group-128 experts; `top_k=20`; no hidden sampler override was applied.

Consuming exact-pin Osaurus proof at `260668294a7c0ab7ca7417940384f57267331e34`:

- 186/186 focused integration assertions passed across 3 suites.
- Production Release build passed.
- Ornith JANG_4M Thinking-off tool turn + follow-up finalized exactly `ORNITH_OFF=71` and `ORNITH_FOLLOW=72`; Thinking-on reasoning/tool continuation finalized coherently with `ORNITH_REASONING=73`, no stale replay, all cards settled, Stop gone, input unlocked.
- Raptor L12c mixed-group tool turn + follow-up finalized exactly `RAPTOR_MIXED=81` and `RAPTOR_FOLLOW=82`; no shape mismatch or unsupported-model error; 87.0/86.7 tok/s; steady physical footprint 8,167,673,168 bytes.
- No screenshots are committed or uploaded. Local evidence paths and hashes are recorded in Osaurus PR #2235.

The broader Ornith model-quality eval scores belong to the consuming Osaurus agent-loop PR and are reported there without being relabeled as vMLX runtime passes.
