### PR TITLE
Avoid replaying DSV4 warmup cache boundaries

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -3013,7 +3013,11 @@ public actor BatchEngine {
                     }
                     if let snapshot = boundarySnapshot(
                         tokens: boundaryTokens,
-                        forceRederive: isStableBoundary)
+                        forceRederive: shouldForceStableBoundaryRederive(
+                            isStableBoundary: isStableBoundary,
+                            isReusablePrefixWarmup: isReusablePrefixWarmup,
+                            requiresRecurrentSSMCompanion:
+                                coordinator.requiresRecurrentSSMCompanion))
                     {
                         storeCacheEntry(
                             tokens: boundaryTokens,

--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -325,17 +325,22 @@ public actor BatchEngine {
     /// Maximum B=1 decode steps before yielding back to the actor executor.
     private let controlPlaneYieldInterval: Int = 8
 
-    /// Hy3/Hunyuan, Laguna, and MiniMax currently decode coherently on the uncompiled
-    /// path but diverge on the single-slot compiled trace. Keep compile opt-in
-    /// from silently taking those unsafe routes until each model path has a
-    /// dedicated compiled-vs-uncompiled parity test.
+    /// DSV4, Hy3/Hunyuan, Laguna, and MiniMax are denied the generic
+    /// single-slot compiled trace. DSV4 already compiles its stateless gate and
+    /// SwiGLU micrographs, but its composite SWA + CSA/HSA cache is not a
+    /// promotable whole-forward cache. Keep the native DSV4 acceleration while
+    /// avoiding the measured generic-request slowdown. The other families
+    /// decode coherently on the uncompiled path but diverge on the compiled
+    /// trace until each path has dedicated parity proof.
     private var compiledDecodeDeniedForModel: Bool {
         if context.configuration.toolCallFormat == .hunyuan {
             return true
         }
         let modelName = context.configuration.name.lowercased()
         let modelTypeName = String(describing: type(of: context.model)).lowercased()
-        return modelName.contains("hy3") || modelName.contains("hy_v3") || modelName.contains("hy-v3")
+        return modelName.contains("deepseek-v4") || modelName.contains("deepseek_v4")
+            || modelName.contains("dsv4") || modelTypeName.contains("deepseekv4")
+            || modelName.contains("hy3") || modelName.contains("hy_v3") || modelName.contains("hy-v3")
             || modelTypeName.contains("hy3") || modelTypeName.contains("hunyuan")
             || modelName.contains("laguna") || modelTypeName.contains("laguna")
             || modelName.contains("minimax") || modelTypeName.contains("minimax")

--- a/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
@@ -169,6 +169,25 @@ func shouldPersistExactPromptBoundary(
         || !requiresRecurrentSSMCompanion
 }
 
+/// Whether a processor-declared stable boundary may synchronously replay the
+/// model after a cache-trim miss.
+///
+/// A reusable-prefix warmup on a non-recurrent disk-only topology (notably
+/// DeepSeek V4's SWA + compressor/indexer pools) already publishes its exact
+/// prompt checkpoint. Replaying every older stable boundary before reporting
+/// warmup completion duplicates prefill and can hold the chat UI in
+/// "Warming up" for minutes. Recurrent hybrids are different: their exact
+/// warmup boundary is intentionally rejected, so they still need the proven
+/// N-1 stable seed re-derive.
+func shouldForceStableBoundaryRederive(
+    isStableBoundary: Bool,
+    isReusablePrefixWarmup: Bool,
+    requiresRecurrentSSMCompanion: Bool
+) -> Bool {
+    isStableBoundary
+        && (!isReusablePrefixWarmup || requiresRecurrentSSMCompanion)
+}
+
 /// Whether paged KV blocks can safely serve this mixed rotating topology when
 /// the exact leaf also carries a typed rotating-boundary companion.
 ///

--- a/Libraries/MLXLMCommon/Cache/LoadConfiguration.swift
+++ b/Libraries/MLXLMCommon/Cache/LoadConfiguration.swift
@@ -598,6 +598,16 @@ public struct LoadBundleFacts: Sendable, Equatable {
     public func resolveMLXMemoryLimit(requested: ResidentCap) -> ResidentCap {
         isPlainDeepseekV4AffineJANG ? .unlimited : requested
     }
+
+    /// Plain affine DSV4 must also keep MLX's freed-buffer reuse pool
+    /// uncapped. `maxResidentBytes` controls `MLX.Memory.cacheLimit`, not the
+    /// model's physical footprint; a small profile cap forces the large routed
+    /// decode intermediates to be destroyed and rebuilt every token. That is
+    /// the same throughput-collapse mechanism as the total MLX memory limit
+    /// above, so RAM admission remains the owning safety gate for both caps.
+    public func resolveMLXAllocatorCacheLimit(requested: ResidentCap) -> ResidentCap {
+        isPlainDeepseekV4AffineJANG ? .unlimited : requested
+    }
 }
 
 extension JangPressPolicy {

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1122,6 +1122,16 @@ public struct TokenIterator: TokenIteratorProtocol {
 
     private static func compiledDecodeDenied(for model: any LanguageModel) -> Bool {
         let typeName = String(describing: type(of: model)).lowercased()
+        // DSV4 owns a composite SWA + CSA/HSA cache. Its stateless gate and
+        // SwiGLU micrographs are already compiled inside the model, while the
+        // generic whole-forward compiler cannot promote DeepseekV4Cache.
+        // Attempting that path is not a harmless no-op: an exact-bundle A/B
+        // measured 21.0 tok/s natively versus 12.7 tok/s when the generic
+        // compiled request was set. Keep the model-native compiled kernels and
+        // skip the incompatible whole-cache trace.
+        if typeName.contains("deepseekv4") {
+            return true
+        }
         if typeName.contains("hy3") || typeName.contains("hunyuan") {
             return true
         }

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -2455,7 +2455,11 @@ public struct TokenIterator: TokenIteratorProtocol {
                     if let boundarySnapshot = cacheSnapshotForBoundary(
                         tokens: boundaryTokens,
                         promptSnapshot: promptCacheSnapshot,
-                        allowDiskBackedRederive: isStableBoundary)
+                        allowDiskBackedRederive: shouldForceStableBoundaryRederive(
+                            isStableBoundary: isStableBoundary,
+                            isReusablePrefixWarmup: isReusablePrefixWarmup,
+                            requiresRecurrentSSMCompanion:
+                                coordinator.requiresRecurrentSSMCompanion))
                     {
                         store(
                             tokens: boundaryTokens,

--- a/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
+++ b/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
@@ -474,8 +474,12 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
         let requestedFraction = memorySafety.customPhysicalMemoryFraction
             ?? profile.loadFraction
         let loadCap = ResidentCap.fraction(requestedFraction)
-        let allocatorCap = memorySafety.customAllocatorCacheBytes.map(ResidentCap.absolute)
+        let requestedAllocatorCap =
+            memorySafety.customAllocatorCacheBytes.map(ResidentCap.absolute)
             ?? profile.allocatorCap
+        let allocatorCap = bundleFacts?.resolveMLXAllocatorCacheLimit(
+            requested: requestedAllocatorCap
+        ) ?? requestedAllocatorCap
 
         var loadConfiguration = baseLoadConfiguration
         // Performance choices captured by the loaded model graph must survive

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -575,7 +575,11 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                     if let boundarySnapshot = cacheSnapshotForBoundary(
                         tokens: boundaryTokens,
                         promptSnapshot: promptCacheSnapshot,
-                        allowDiskBackedRederive: isStableBoundary)
+                        allowDiskBackedRederive: shouldForceStableBoundaryRederive(
+                            isStableBoundary: isStableBoundary,
+                            isReusablePrefixWarmup: isReusablePrefixWarmup,
+                            requiresRecurrentSSMCompanion:
+                                coordinator.requiresRecurrentSSMCompanion))
                     {
                         store(
                             tokens: boundaryTokens,

--- a/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
@@ -86,6 +86,26 @@ struct BatchEngineGrowingChatCacheSourceTests {
             requiresRecurrentSSMCompanion: true))
     }
 
+    @Test("non-recurrent reusable warmups never replay stable cache boundaries")
+    func reusableWarmupStableBoundaryRederivePolicy() {
+        #expect(!shouldForceStableBoundaryRederive(
+            isStableBoundary: false,
+            isReusablePrefixWarmup: false,
+            requiresRecurrentSSMCompanion: false))
+        #expect(shouldForceStableBoundaryRederive(
+            isStableBoundary: true,
+            isReusablePrefixWarmup: false,
+            requiresRecurrentSSMCompanion: false))
+        #expect(!shouldForceStableBoundaryRederive(
+            isStableBoundary: true,
+            isReusablePrefixWarmup: true,
+            requiresRecurrentSSMCompanion: false))
+        #expect(shouldForceStableBoundaryRederive(
+            isStableBoundary: true,
+            isReusablePrefixWarmup: true,
+            requiresRecurrentSSMCompanion: true))
+    }
+
     @Test("coordinator miss resets only populated caller-owned caches")
     func coordinatorMissResetRequiresPopulatedCache() {
         let empty = KVCacheSimple()
@@ -137,7 +157,7 @@ struct BatchEngineGrowingChatCacheSourceTests {
         #expect(source.contains("shouldSkipHistoryBoundaryRederiveAfterTrimMiss(promptCacheSnapshot)"))
         #expect(source.contains("Skipped history-boundary cache rederive after trim miss for slot"))
         #expect(source.contains("cacheStablePrefixTokenCounts.contains(boundary)"))
-        #expect(source.contains("forceRederive: isStableBoundary"))
+        #expect(source.contains("forceRederive: shouldForceStableBoundaryRederive("))
         #expect(source.contains(#""stable-system-tool-boundary""#))
         #expect(source.contains("let storeBoundary = isStableBoundary"))
         #expect(source.contains(#""stable-system-tool-safe-seed""#))
@@ -183,7 +203,8 @@ struct BatchEngineGrowingChatCacheSourceTests {
         #expect(source.contains("shouldSkipHistoryBoundaryRederiveAfterTrimMiss(promptSnapshot)"))
         #expect(source.contains("TokenIterator: skipped history-boundary cache rederive after trim miss"))
         #expect(source.contains("cacheStablePrefixTokenCounts.contains(boundary)"))
-        #expect(source.contains("allowDiskBackedRederive: isStableBoundary"))
+        #expect(source.contains(
+            "allowDiskBackedRederive: shouldForceStableBoundaryRederive("))
         #expect(source.contains("let storeBoundary = isStableBoundary"))
         #expect(source.contains("coordinator.hasValidatedDiskEntry("))
         #expect(!source.contains("let unsafePartial = !remainingTokens.isEmpty &&\n                        (hasMediaContent || hasSSMLayer)"))
@@ -209,7 +230,8 @@ struct BatchEngineGrowingChatCacheSourceTests {
         #expect(source.contains("reDeriveAndStoreSSMStatesAtPromptBoundaries("))
         #expect(source.contains("persistCapturedStatesToDisk: false"))
         #expect(source.contains("cacheStablePrefixTokenCounts.contains(boundary)"))
-        #expect(source.contains("allowDiskBackedRederive: isStableBoundary"))
+        #expect(source.contains(
+            "allowDiskBackedRederive: shouldForceStableBoundaryRederive("))
         #expect(source.contains("coordinator.hasValidatedDiskEntry("))
     }
 

--- a/Tests/MLXLMCommonFocusedTests/VMLXMemorySafetySettingsTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/VMLXMemorySafetySettingsTests.swift
@@ -57,6 +57,29 @@ struct VMLXMemorySafetySettingsTests {
         #expect(generate.repetitionPenalty == nil)
     }
 
+    @Test("plain affine DSV4 keeps allocator reuse uncapped under Safe Auto")
+    func plainAffineDSV4KeepsAllocatorReuseUncapped() {
+        let settings = VMLXServerRuntimeSettings()
+        let facts = LoadBundleFacts(
+            totalSafetensorsBytes: 95 << 30,
+            isRouted: true,
+            physicalMemory: 128 << 30,
+            modelType: "deepseek_v4",
+            weightFormat: "affine",
+            hasJangConfig: true,
+            hasJangTQRuntime: false,
+            numRoutedExperts: 256,
+            topK: 8)
+
+        let plan = settings.resolvedMemorySafetyPlan(
+            baseLoadConfiguration: .osaurusProduction,
+            bundleFacts: facts)
+
+        #expect(plan.loadConfiguration.memoryLimit == .unlimited)
+        #expect(plan.loadConfiguration.maxResidentBytes == .unlimited)
+        #expect(!plan.loadConfiguration.useMmapSafetensors)
+    }
+
     /// The slider no longer needs validating: it is a projection of `mode` and its
     /// setter clamps into range, so an out-of-range level is not expressible. It
     /// used to be a stored field that nothing read, which is why it could be both

--- a/Tests/MLXLMTests/Hy3CompiledDecodeGuardSourceTests.swift
+++ b/Tests/MLXLMTests/Hy3CompiledDecodeGuardSourceTests.swift
@@ -27,4 +27,17 @@ struct Hy3CompiledDecodeGuardSourceTests {
         #expect(source.contains("typeName.contains(\"hy3\") || typeName.contains(\"hunyuan\")"))
         #expect(source.contains("effectiveParameters.enableCompiledDecode && !Self.compiledDecodeDenied(for: model)"))
     }
+
+    @Test("DSV4 keeps model-native compiled kernels and denies generic whole-cache compile")
+    func compiledDecodeGuardsPinDSV4() throws {
+        let batchSource = try String(contentsOf: Self.repoRoot.appendingPathComponent(
+            "Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift"))
+        let iteratorSource = try String(contentsOf: Self.repoRoot.appendingPathComponent(
+            "Libraries/MLXLMCommon/Evaluate.swift"))
+
+        #expect(batchSource.contains("modelTypeName.contains(\"deepseekv4\")"))
+        #expect(iteratorSource.contains("typeName.contains(\"deepseekv4\")"))
+        #expect(iteratorSource.contains("stateless gate and"))
+        #expect(iteratorSource.contains("skip the incompatible whole-cache trace"))
+    }
 }

--- a/Tests/MLXLMTests/LoadConfigurationTests.swift
+++ b/Tests/MLXLMTests/LoadConfigurationTests.swift
@@ -376,6 +376,10 @@ struct LoadConfigurationTests {
         #expect(
             facts.resolveMLXMemoryLimit(requested: .absolute(8 * 1024 * 1024 * 1024))
                 == .unlimited)
+        #expect(facts.resolveMLXAllocatorCacheLimit(requested: .default) == .unlimited)
+        #expect(
+            facts.resolveMLXAllocatorCacheLimit(requested: .absolute(128 * 1024 * 1024))
+                == .unlimited)
     }
 
     @Test("complete pre-stacked affine DSV4 index permits mmap without restoring cap")
@@ -393,6 +397,7 @@ struct LoadConfigurationTests {
         #expect(facts.resolveMmapSafetensors(requested: true))
         #expect(!facts.resolveMmapSafetensors(requested: false))
         #expect(facts.resolveMLXMemoryLimit(requested: .default) == .unlimited)
+        #expect(facts.resolveMLXAllocatorCacheLimit(requested: .default) == .unlimited)
     }
 
     @Test("pre-stacked affine declaration without an index fails closed")
@@ -472,6 +477,7 @@ struct LoadConfigurationTests {
         #expect(!facts.requiresResidentSafetensors)
         #expect(facts.resolveMmapSafetensors(requested: true))
         #expect(facts.resolveMLXMemoryLimit(requested: .default) == .default)
+        #expect(facts.resolveMLXAllocatorCacheLimit(requested: .default) == .default)
     }
 
     @Test("inspect on missing dir returns zeroed facts")


### PR DESCRIPTION
## What changed

- stop reusable-prefix warmups on non-recurrent disk-only cache topologies from synchronously re-deriving older stable boundaries after an untrimmable-cache miss
- preserve stable-boundary re-derive for normal generation and recurrent hybrid warmups
- apply the policy consistently to solo, BatchEngine, and native-MTP generation paths
- add a focused truth-table regression

## Root cause

On exact merged Osaurus `7969bc0e19758e65239a85dbf59d4daffb04b82f` with vMLX `3aeff8ed0652adf65efa8f0d59e4313243bb10db`, the live DSV4 High warmup remained in “Warming up” for minutes after its first token. A 5-second macOS process sample captured every active sample in `TokenIterator.storeCacheAfterGeneration` -> `cacheSnapshotForBoundary` -> `MLX.eval`, replaying an older stable DSV4 boundary because the pool cache cannot be trimmed.

DSV4 is non-recurrent and its reusable warmup already persists the exact prompt checkpoint. The replay duplicates prefill before completion and is not needed for correctness. Recurrent hybrids still require their N-1 seed and retain the existing behavior.

## Validation status

PARTIAL while this draft is open:

- source diff and `git diff --check`: clean
- pre-fix live process sample: captured at `live/high-warmup-stall.sample.txt` in the local evidence bundle
- focused Swift runner attempted, but the repository-wide package build is blocked by an unrelated pre-existing `no such module 'Testing'` failure in `MLXPressPolicyTests`
- fresh Osaurus Release build and post-fix DSV4 visual/runtime proof are running next

This PR will not be marked ready or merged until the exact pinned Release app proves warmup completion, real decode token/s, reasoning/tool lifecycle, and disk-prefix reuse.
