### PR TITLE
Capture safe DSV4 disk prefix seeds during prefill

### DIFF
--- a/Libraries/MLXLLM/Models/DeepseekV4Compressor.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV4Compressor.swift
@@ -515,7 +515,12 @@ public final class DeepseekV4Cache: QuantizedHybridPoolCache, CacheRetainedByteC
             poolQuantizationEnabled: hybridPoolQuantizationEnabled)
         let localState = local.state
         if !localState.isEmpty {
-            dup.local.state = localState.map { $0[.ellipsis] }
+            // RotatingKVCache writes decode tokens into its ring in place.
+            // An ellipsis slice is only a view, so the retained prompt-minus-one
+            // checkpoint would otherwise be overwritten before the synchronous
+            // disk store at terminal state. Create independent buffers; the
+            // snapshot caller batches their materialization in one MLX.eval.
+            dup.local.state = localState.map { $0 * 1 }
         }
         dup.local.metaState = local.metaState
         dup.compPool = compPool.copy()

--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -2060,7 +2060,10 @@ public actor BatchEngine {
     /// the cache-copy high-water mark. A restored N-1 request does not retain
     /// that duplicate and is consequently much faster. The seed is already a
     /// complete, immutable prompt boundary here, so write it synchronously and
-    /// release it before the final prompt token and sampled decode run.
+    /// release it before the final prompt token and sampled decode run. This is
+    /// also the boundary a reusable-prefix warmup must publish: DSV4 deliberately
+    /// rejects an exact post-prefill restore, so excluding warmups here causes the
+    /// immediately following visible request to prefill the same prefix again.
     private func storePrefillCapturedDiskSeed(
         _ snapshot: [KVCache],
         for slot: BatchSlot
@@ -2126,7 +2129,6 @@ public actor BatchEngine {
                     cacheCoordinator?.canPersistBoundaries == true
                     && slot.diskSeedSnapshot == nil
                     && cacheRequiresPrefillCapturedDiskSeed(slot.cache)
-                    && slot.originalInput.cachePromptIntent != .reusablePrefixWarmup
                     && !slot.originalInput.hasMediaContent
                     && !slot.originalInput.requiresPostPrepareCacheKey
                     && !shouldSkipDiskBackedToolPromptSeedBoundary(for: slot)

--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -1259,7 +1259,7 @@ public actor BatchEngine {
         // Check active slots
         if let idx = activeSlots.firstIndex(where: { $0.id == id }) {
             var slot = activeSlots[idx]
-            finishSlot(slot, reason: .cancelled)
+            finishSlot(&slot, reason: .cancelled)
             slot.isFinished = true
             activeSlots[idx] = slot
         }
@@ -1307,8 +1307,8 @@ public actor BatchEngine {
         waitQueue.removeAll()
 
         // Finish all active slots
-        for slot in activeSlots {
-            finishSlot(slot, reason: .cancelled)
+        for var slot in activeSlots {
+            finishSlot(&slot, reason: .cancelled)
         }
         activeSlots.removeAll()
 
@@ -2001,6 +2001,58 @@ public actor BatchEngine {
         stepPrefillAfterCacheLookup(slotIndex: slotIndex, inputForPrepare: inputForPrepare, slot: slot)
     }
 
+    /// Split the still-unprocessed prompt immediately before its final token.
+    /// The head retains request metadata for the first prepare call; the tail
+    /// is text-only because callers admit this path only for non-media inputs.
+    private func splitPrefillInputBeforeFinalToken(
+        _ input: LMInput
+    ) -> (head: LMInput?, tail: LMInput)? {
+        let size = input.text.tokens.size
+        guard size > 0 else { return nil }
+        let split = size - 1
+
+        var flatMask: MLXArray? = nil
+        if let mask = input.text.mask {
+            guard mask.size == size else { return nil }
+            flatMask = mask.reshaped([-1])
+        }
+        let maskIsBatched = (input.text.mask?.ndim ?? 1) >= 2
+        func maskSlice(_ range: MLXArray) -> MLXArray {
+            maskIsBatched ? range[.newAxis, 0...] : range
+        }
+
+        let flat = input.text.tokens.reshaped([-1])
+        let headTokenIds = input.text.tokenIds.map { Array($0[..<split]) }
+        let tailTokenIds = input.text.tokenIds.map { Array($0[split...]) }
+        let head = split > 0
+            ? LMInput(
+                text: LMInput.Text(
+                    tokens: flat[..<split][.newAxis, 0...],
+                    mask: flatMask.map { maskSlice($0[..<split]) },
+                    tokenIds: headTokenIds),
+                image: input.image,
+                video: input.video,
+                audio: input.audio,
+                mediaTokenIds: input.mediaTokenIds,
+                cacheScopeSalt: input.cacheScopeSalt,
+                cachePrefixTokenCounts: input.cachePrefixTokenCounts,
+                cacheStablePrefixTokenCounts: input.cacheStablePrefixTokenCounts,
+                cachePromptIntent: input.cachePromptIntent,
+                cacheRestorePolicy: input.cacheRestorePolicy,
+                toolSchemas: input.toolSchemas)
+            : nil
+        let tail = LMInput(
+            text: LMInput.Text(
+                tokens: flat[split...][.newAxis, 0...],
+                mask: flatMask.map { maskSlice($0[split...]) },
+                tokenIds: tailTokenIds),
+            cacheScopeSalt: input.cacheScopeSalt,
+            cachePromptIntent: input.cachePromptIntent,
+            cacheRestorePolicy: input.cacheRestorePolicy,
+            toolSchemas: input.toolSchemas)
+        return (head, tail)
+    }
+
     private func stepPrefillAfterCacheLookup(
         slotIndex: Int,
         inputForPrepare: LMInput,
@@ -2027,14 +2079,58 @@ public actor BatchEngine {
             prepareResult = try PrefillProgressReporter.withHandler({
                 progressAccumulator.report(completedInPrepare: $0)
             }) {
-                try context.model.prepare(
+                // DSV4's typed disk cache contains every SWA/CSA/HSA state,
+                // but after its 128-token local ring wraps it cannot produce a
+                // lossless N-1 checkpoint by trimming the completed prompt.
+                // Consume all remaining prompt tokens except the final one,
+                // snapshot that exact state, then run the final token through
+                // the ordinary prepare path. A later exact replay restores the
+                // N-1 disk entry and performs only this one-token prefill.
+                let shouldCaptureDiskSeed =
+                    cacheCoordinator?.canPersistBoundaries == true
+                    && slot.diskSeedSnapshot == nil
+                    && cacheRequiresPrefillCapturedDiskSeed(slot.cache)
+                    && slot.originalInput.cachePromptIntent != .reusablePrefixWarmup
+                    && !slot.originalInput.hasMediaContent
+                    && !slot.originalInput.requiresPostPrepareCacheKey
+                    && !shouldSkipDiskBackedToolPromptSeedBoundary(for: slot)
+                    && totalPromptUnits > 1
+                    && remainingPromptUnits > 1
+
+                if shouldCaptureDiskSeed,
+                   let split = splitPrefillInputBeforeFinalToken(inputForPrepare)
+                {
+                    if let head = split.head {
+                        let headResult = try context.model.prepare(
+                            head,
+                            cache: slot.cache,
+                            windowSize: slot.prefillStepSize)
+                        if case .tokens(let remainingHead) = headResult {
+                            _ = context.model(
+                                remainingHead[text: .newAxis],
+                                cache: slot.cache,
+                                state: nil)
+                        }
+                    }
+                    MLX.eval(slot.cache)
+                    slot.diskSeedSnapshot = makePromptBoundaryCacheSnapshot(
+                        from: slot.cache)
+                    progressAccumulator.report(
+                        completedInPrepare: remainingPromptUnits - 1)
+                    return try context.model.prepare(
+                        split.tail,
+                        cache: slot.cache,
+                        windowSize: slot.prefillStepSize)
+                }
+
+                return try context.model.prepare(
                     inputForPrepare,
                     cache: slot.cache,
                     windowSize: slot.prefillStepSize)
             }
         } catch {
             // Prefill failed (e.g., invalid input) — finish with cancellation
-            finishSlot(slot, reason: .cancelled)
+            finishSlot(&slot, reason: .cancelled)
             slot.isFinished = true
             activeSlots[slotIndex] = slot
             return
@@ -2089,7 +2185,10 @@ public actor BatchEngine {
         // Capture the cache exactly at the prompt boundary. The first sampled
         // token has not been fed back into the model yet, so this snapshot is
         // safe for paged and L2 disk storage under the prompt-token key.
-        slot.promptCacheSnapshot = makePromptBoundaryCacheSnapshot(from: slot.cache)
+        // The captured DSV4 N-1 seed replaces the unusable exact-prompt
+        // snapshot. Retain one cache copy through decode, not two.
+        slot.promptCacheSnapshot = makeRetainedExactPromptSnapshot(
+            from: slot.cache)
 
         let tokenID = firstToken.item(Int.self)
 
@@ -2099,7 +2198,7 @@ public actor BatchEngine {
 
         // Check EOS on first generated token before yielding
         if stopTokenIDs.contains(tokenID) {
-            finishSlot(slot, reason: .stop)
+            finishSlot(&slot, reason: .stop)
             slot.isFinished = true
         } else {
             slot.continuation.yield(.token(tokenID))
@@ -2108,7 +2207,7 @@ public actor BatchEngine {
             slot.nextToken = firstToken
 
             if let maxTokens = slot.maxTokens, slot.generatedTokenCount >= maxTokens {
-                finishSlot(slot, reason: .length)
+                finishSlot(&slot, reason: .length)
                 slot.isFinished = true
             }
         }
@@ -2220,7 +2319,7 @@ public actor BatchEngine {
 
         // Stop conditions (same rules as uncompiled path).
         if stopTokenIDs.contains(tokenID) {
-            finishSlot(slot, reason: .stop)
+            finishSlot(&slot, reason: .stop)
             slot.isFinished = true
         } else {
             slot.continuation.yield(.token(tokenID))
@@ -2229,7 +2328,7 @@ public actor BatchEngine {
             slot.nextToken = token
 
             if let maxTokens = slot.maxTokens, slot.generatedTokenCount >= maxTokens {
-                finishSlot(slot, reason: .length)
+                finishSlot(&slot, reason: .length)
                 slot.isFinished = true
             }
         }
@@ -2605,7 +2704,7 @@ public actor BatchEngine {
             // Check stop conditions BEFORE yielding — don't emit EOS tokens to callers.
             // This matches TokenIterator behavior where the stop token is never surfaced.
             if stopTokenIDs.contains(tokenID) {
-                finishSlot(slot, reason: .stop)
+                finishSlot(&slot, reason: .stop)
                 slot.isFinished = true
             } else {
                 slot.continuation.yield(.token(tokenID))
@@ -2614,7 +2713,7 @@ public actor BatchEngine {
                 slot.nextToken = token
 
                 if let maxTokens = slot.maxTokens, slot.generatedTokenCount >= maxTokens {
-                    finishSlot(slot, reason: .length)
+                    finishSlot(&slot, reason: .length)
                     slot.isFinished = true
                 }
             }
@@ -2694,7 +2793,15 @@ public actor BatchEngine {
     /// When a cache coordinator is present and the slot completed normally
     /// (not cancelled), stores prompt and safe post-answer boundaries for
     /// future cache reuse.
-    private func finishSlot(_ slot: BatchSlot, reason: GenerateStopReason) {
+    private func finishSlot(_ liveSlot: inout BatchSlot, reason: GenerateStopReason) {
+        let slot = liveSlot
+        defer {
+            // Cache stores are synchronous. Drop the sole retained prompt/seed
+            // snapshot as soon as they finish instead of holding it until the
+            // scheduler's next completed-slot cleanup pass.
+            liveSlot.promptCacheSnapshot = nil
+            liveSlot.diskSeedSnapshot = nil
+        }
         let now = Date()
         let prefillTime = (slot.decodeStartTime ?? now).timeIntervalSince(slot.prefillStartTime)
         let decodeTime = slot.decodeStartTime.map { now.timeIntervalSince($0) } ?? 0
@@ -2723,15 +2830,13 @@ public actor BatchEngine {
         if reason != .cancelled, let coordinator = cacheCoordinator {
             let promptTokens = slot.cachePromptTokenIds
             let hasHybridPool = slot.cache.contains { $0 is HybridPoolCache }
-            guard let promptCacheSnapshot = slot.promptCacheSnapshot
+            let promptCacheSnapshot = slot.promptCacheSnapshot
                 ?? (hasHybridPool ? nil : makePromptBoundaryCacheSnapshot(from: slot.cache))
-            else {
-                Self.logger.error(
-                    "Slot \(slot.id.description, privacy: .public): skipped cache store because no prompt-boundary snapshot exists for hybrid-pool cache"
-                )
-                slot.continuation.finish()
-                return
-            }
+            let capturedDiskSeed = slot.diskSeedSnapshot
+            if let storageTopologySnapshot = promptCacheSnapshot ?? capturedDiskSeed {
+                let storageSnapshotTokenCount = promptCacheSnapshot == nil
+                    ? max(0, promptTokens.count - 1)
+                    : promptTokens.count
 
             func cacheCovers(_ tokenCount: Int, cache: [KVCache]) -> Bool {
                 cache.map(\.offset).max() ?? 0 >= tokenCount
@@ -2867,11 +2972,17 @@ public actor BatchEngine {
             }
 
             func boundarySnapshot(tokens: [Int], forceRederive: Bool = false) -> [KVCache]? {
-                guard !tokens.isEmpty, tokens.count < promptTokens.count else {
+                guard !tokens.isEmpty,
+                    tokens.count <= storageSnapshotTokenCount,
+                    storageSnapshotTokenCount <= promptTokens.count
+                else {
                     return nil
                 }
-                let trimCount = promptTokens.count - tokens.count
-                let trimmed = promptCacheSnapshot.map { $0.copy() }
+                if tokens.count == storageSnapshotTokenCount {
+                    return storageTopologySnapshot.map { $0.copy() }
+                }
+                let trimCount = storageSnapshotTokenCount - tokens.count
+                let trimmed = storageTopologySnapshot.map { $0.copy() }
                 if canTrimPromptCache(trimmed),
                    trimPromptCache(trimmed, numTokens: trimCount) == trimCount
                 {
@@ -2891,7 +3002,7 @@ public actor BatchEngine {
                 // boundary would never be stored and growing hybrid turns could
                 // never reuse prefill.
                 if !forceRederive,
-                   shouldSkipHistoryBoundaryRederiveAfterTrimMiss(promptCacheSnapshot) {
+                   shouldSkipHistoryBoundaryRederiveAfterTrimMiss(storageTopologySnapshot) {
                     Self.logger.debug(
                         "Skipped history-boundary cache rederive after trim miss for slot \(slot.id.description, privacy: .public): disk-backed cache topology"
                     )
@@ -2947,34 +3058,36 @@ public actor BatchEngine {
                 }
             }
 
-            if !usesCanonicalHybridBoundary, shouldPersistExactWarmupPrompt {
-                storeCacheEntry(
-                    tokens: promptTokens,
-                    snapshot: promptCacheSnapshot,
-                    label: "prompt-boundary")
-            } else if isReusablePrefixWarmup, !shouldPersistExactWarmupPrompt {
-                Self.logger.info(
-                    "Skipped exact recurrent warmup boundary for slot \(slot.id.description, privacy: .public); retaining processor-proven safe prefix seeds only"
-                )
+            if let promptCacheSnapshot {
+                if !usesCanonicalHybridBoundary, shouldPersistExactWarmupPrompt {
+                    storeCacheEntry(
+                        tokens: promptTokens,
+                        snapshot: promptCacheSnapshot,
+                        label: "prompt-boundary")
+                } else if isReusablePrefixWarmup, !shouldPersistExactWarmupPrompt {
+                    Self.logger.info(
+                        "Skipped exact recurrent warmup boundary for slot \(slot.id.description, privacy: .public); retaining processor-proven safe prefix seeds only"
+                    )
+                }
             }
 
             if !slot.cachePromptUsesPostPrepareKey {
                 let requiresDiskBackedRestore =
-                    cacheRequiresDiskBackedCoordinatorRestore(promptCacheSnapshot)
+                    cacheRequiresDiskBackedCoordinatorRestore(storageTopologySnapshot)
                 if !usesCanonicalHybridBoundary,
                    !isReusablePrefixWarmup,
                    requiresDiskBackedRestore,
                    !shouldSkipDiskBackedToolPromptSeedBoundary(for: slot),
                    promptTokens.count > 1,
-                   let snapshot = boundarySnapshot(
-                    tokens: Array(promptTokens.dropLast()),
-                    // Direct full-KV + rotating-SWA stacks are fully typed on
-                    // disk but stop being trimmable once the ring wraps. Their
-                    // exact N-1 seed is still safe to rebuild synchronously;
-                    // persisting it lets a fresh process re-feed only the final
-                    // prompt token instead of cold-prefilling the whole chat.
-                    forceRederive: cacheCanUsePagedWithRotatingCompanion(
-                        promptCacheSnapshot))
+                   let snapshot = capturedDiskSeed ?? boundarySnapshot(
+                        tokens: Array(promptTokens.dropLast()),
+                        // Direct full-KV + rotating-SWA stacks are fully typed on
+                        // disk but stop being trimmable once the ring wraps. Their
+                        // exact N-1 seed is still safe to rebuild synchronously;
+                        // persisting it lets a fresh process re-feed only the final
+                        // prompt token instead of cold-prefilling the whole chat.
+                        forceRederive: cacheCanUsePagedWithRotatingCompanion(
+                            storageTopologySnapshot))
                 {
                     storeCacheEntry(
                         tokens: Array(promptTokens.dropLast()),
@@ -3113,6 +3226,11 @@ public actor BatchEngine {
             } else if !slot.generatedTokenIds.isEmpty {
                 Self.logger.debug(
                     "Skipped post-answer cache entry for slot \(slot.id.description, privacy: .public): reason=\(String(describing: reason), privacy: .public) generated=\(slot.generatedTokenIds.count) cacheOffset=\((slot.cache.map(\.offset).max() ?? 0), privacy: .public)"
+                )
+            }
+            } else {
+                Self.logger.debug(
+                    "Slot \(slot.id.description, privacy: .public): skipped cache store because no new prompt-boundary snapshot was retained"
                 )
             }
         }

--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -2053,6 +2053,42 @@ public actor BatchEngine {
         return (head, tail)
     }
 
+    /// Persist DSV4's exact N-1 disk seed before decode starts.
+    ///
+    /// Keeping the fully materialized SWA + compressor/indexer pool duplicate
+    /// alive for the whole response makes an uncached DSV4 request decode from
+    /// the cache-copy high-water mark. A restored N-1 request does not retain
+    /// that duplicate and is consequently much faster. The seed is already a
+    /// complete, immutable prompt boundary here, so write it synchronously and
+    /// release it before the final prompt token and sampled decode run.
+    private func storePrefillCapturedDiskSeed(
+        _ snapshot: [KVCache],
+        for slot: BatchSlot
+    ) {
+        guard let coordinator = cacheCoordinator,
+            slot.cachePromptTokenIds.count > 1,
+            CacheStoreBudget.canStore(snapshot)
+        else { return }
+
+        let tokens = Array(slot.cachePromptTokenIds.dropLast())
+        let diskStoreCache = makeDiskStoreCache(
+            fromPromptBoundary: snapshot,
+            kvBits: slot.parameters.kvBits,
+            kvGroupSize: slot.parameters.kvGroupSize,
+            quantizedKVStart: slot.parameters.quantizedKVStart,
+            kvMode: slot.parameters.kvMode)
+        coordinator.storeAfterGeneration(
+            promptTokens: tokens,
+            perLayerData: [],
+            ssmStates: nil,
+            cache: diskStoreCache,
+            mediaSalt: slot.mediaSalt)
+        if ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1" {
+            FileHandle.standardError.write(Data(
+                "[vmlx][cache/store] label=disk-backed-safe-prompt-boundary-prefill count=\(tokens.count)\n".utf8))
+        }
+    }
+
     private func stepPrefillAfterCacheLookup(
         slotIndex: Int,
         inputForPrepare: LMInput,
@@ -2113,8 +2149,12 @@ public actor BatchEngine {
                         }
                     }
                     MLX.eval(slot.cache)
-                    slot.diskSeedSnapshot = makePromptBoundaryCacheSnapshot(
+                    let diskSeedSnapshot = makePromptBoundaryCacheSnapshot(
                         from: slot.cache)
+                    storePrefillCapturedDiskSeed(diskSeedSnapshot, for: slot)
+                    // The synchronous store above owns the N-1 boundary now.
+                    // Do not keep the duplicate SWA/pool state through decode.
+                    slot.diskSeedSnapshot = nil
                     progressAccumulator.report(
                         completedInPrepare: remainingPromptUnits - 1)
                     return try context.model.prepare(

--- a/Libraries/MLXLMCommon/BatchEngine/BatchScheduler.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchScheduler.swift
@@ -63,6 +63,11 @@ struct BatchSlot {
     /// not the live decode cache, because coordinator keys are prompt-only.
     var promptCacheSnapshot: [KVCache]?
 
+    /// Exact prompt-minus-one cache state captured during prefill for typed
+    /// disk-only topologies (currently DSV4 SWA + compressor/indexer pools)
+    /// that cannot be losslessly trimmed after their rotating window wraps.
+    var diskSeedSnapshot: [KVCache]?
+
     /// Token IDs that describe the cache snapshot at the prompt boundary.
     ///
     /// Usually this is the same as `originalInput.text.tokens`. Some models
@@ -187,6 +192,7 @@ extension BatchSlot {
         self.maxTokens = request.parameters.maxTokens
         self.cache = cache
         self.promptCacheSnapshot = nil
+        self.diskSeedSnapshot = nil
         self.cachePromptTokenIds = request.input.text.tokens.reshaped(-1).asArray(Int.self)
         self.cachePromptUsesPostPrepareKey = false
         self.originalInput = request.input

--- a/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
@@ -215,11 +215,11 @@ func shouldPersistExactPromptBoundary(
 ///
 /// A reusable-prefix warmup on a non-recurrent disk-only topology (notably
 /// DeepSeek V4's SWA + compressor/indexer pools) already publishes its exact
-/// prompt checkpoint. Replaying every older stable boundary before reporting
-/// warmup completion duplicates prefill and can hold the chat UI in
-/// "Warming up" for minutes. Recurrent hybrids are different: their exact
-/// warmup boundary is intentionally rejected, so they still need the proven
-/// N-1 stable seed re-derive.
+/// prompt-minus-one checkpoint captured during prefill. Replaying every older
+/// stable boundary before reporting warmup completion duplicates prefill and
+/// can hold the chat UI in "Warming up" for minutes. Recurrent hybrids are
+/// different: their exact warmup boundary is intentionally rejected, so they
+/// still need the proven N-1 stable seed re-derive.
 func shouldForceStableBoundaryRederive(
     isStableBoundary: Bool,
     isReusablePrefixWarmup: Bool,

--- a/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
@@ -27,6 +27,22 @@ func makePromptBoundaryCacheSnapshot(from cache: [any KVCache]) -> [any KVCache]
     return snapshot
 }
 
+/// Retain the exact prompt snapshot unless the cache uses DSV4's typed pool
+/// topology, whose coordinator boundary must always be prompt-minus-one.
+///
+/// DeepSeek V4 deliberately restores N-1 and re-feeds the final prompt token.
+/// Its exact prompt snapshot is not a usable coordinator boundary. Suppress it
+/// even on a warm N-1 restore where no new seed is captured; otherwise an exact
+/// cache copy is retained through decode only to be discarded at store time.
+/// Standalone rotating/SWA caches retain their existing exact snapshot because
+/// their prompt/stable-boundary storage policy still consumes it.
+func makeRetainedExactPromptSnapshot(
+    from cache: [any KVCache]
+) -> [any KVCache]? {
+    guard !cacheRequiresPrefillCapturedDiskSeed(cache) else { return nil }
+    return makePromptBoundaryCacheSnapshot(from: cache)
+}
+
 /// Build the cache object list passed to ``TQDiskSerializer`` from a clean
 /// prompt-boundary snapshot.
 ///
@@ -151,6 +167,31 @@ public func cacheRequiresDiskBackedCoordinatorRestore(_ cache: [any KVCache]) ->
             layer is TurboQuantKVCache ||
             layer is QuantizedKVCache
     }
+}
+
+/// True when a disk-backed prompt must publish an exact prompt-minus-one
+/// checkpoint captured while prefill crosses that boundary.
+///
+/// DeepSeek V4's typed cache is fully serialized (local SWA plus compressor
+/// and indexer pools), but its 128-token rotating window cannot be trimmed
+/// after it wraps. Exact prompt checkpoints are deliberately not consumed by
+/// the coordinator because generation needs logits from the final prompt
+/// token. Capturing N-1 before that token is evaluated gives a later request a
+/// lossless disk seed that can restore the longest valid prefix and re-feed
+/// only the final token. Recurrent Mamba/Arrays/CCA topologies keep their
+/// separate companion-state policy.
+func cacheRequiresPrefillCapturedDiskSeed(_ cache: [any KVCache]) -> Bool {
+    cache.contains { layer in
+        if layer is HybridPoolCache { return true }
+        if let cacheList = layer as? CacheList {
+            for index in 0..<cacheList.count {
+                if cacheRequiresPrefillCapturedDiskSeed([cacheList[index]]) {
+                    return true
+                }
+            }
+        }
+        return false
+    } && !cacheContainsPathDependentState(cache)
 }
 
 /// Whether the complete prompt boundary from a reusable-prefix warmup is safe

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1739,7 +1739,11 @@ public struct TokenIterator: TokenIteratorProtocol {
             completedUnitCount: promptTokenCount,
             totalUnitCount: promptTokenCount,
             detail: "decode_ready"))
-        self.promptCacheSnapshot = makePromptBoundaryCacheSnapshot(from: self.cache)
+        // The prefill-captured N-1 state is the only prompt checkpoint an
+        // exact DSV4 replay can consume safely. Keep one retained snapshot,
+        // not both N-1 and the deliberately skipped exact prompt boundary.
+        self.promptCacheSnapshot = makeRetainedExactPromptSnapshot(
+            from: self.cache)
 
         if effectiveParameters.enableCompiledDecode && !Self.compiledDecodeDenied(for: model) {
             try setupCompiledDecode(
@@ -1827,7 +1831,7 @@ public struct TokenIterator: TokenIteratorProtocol {
     }
 
     /// The prompt-minus-one seed used to make an exact disk restore safe for a
-    /// standalone rotating/SWA cache.
+    /// standalone rotating/SWA cache or a typed DSV4 hybrid-pool cache.
     static func diskSeedBoundaryIndex(
         coordinator: CacheCoordinator?,
         promptTokenIds: [Int],
@@ -1842,7 +1846,8 @@ public struct TokenIterator: TokenIteratorProtocol {
             promptTokenIds.count > 1,
             !input.hasMediaContent,
             !input.requiresPostPrepareCacheKey,
-            cacheHasStandaloneRotatingWindowState(cache)
+            (cacheHasStandaloneRotatingWindowState(cache)
+                || cacheRequiresPrefillCapturedDiskSeed(cache))
         else { return nil }
         return promptTokenIds.count - 1
     }
@@ -1861,13 +1866,15 @@ public struct TokenIterator: TokenIteratorProtocol {
     /// already restored.
     private func boundarySplit(
         of input: LMInput,
-        at boundary: Int
+        at boundary: Int,
+        allowHybridPool: Bool = false
     ) -> (head: LMInput?, tail: LMInput)? {
         guard !input.requiresPostPrepareCacheKey,
-            // Capturing/trimming a boundary snapshot across DSV4 compressor
-            // and indexer pool state remains a separate unproven operation.
-            // Normal model prefill may still chunk at the requested window.
-            !cache.contains(where: { $0 is HybridPoolCache })
+            // A DSV4 prompt-minus-one seed must be captured before the final
+            // token because its rotating cache cannot be trimmed after the
+            // 128-token window wraps. Other structural-boundary captures keep
+            // the conservative hybrid-pool exclusion.
+            (allowHybridPool || !cache.contains(where: { $0 is HybridPoolCache }))
         else { return nil }
 
         let size = input.text.tokens.size
@@ -1926,7 +1933,11 @@ public struct TokenIterator: TokenIteratorProtocol {
         }
         if let boundary = diskSeedBoundary,
            diskSeedSnapshot == nil,
-           let split = boundarySplit(of: input, at: boundary)
+           let split = boundarySplit(
+                of: input,
+                at: boundary,
+                allowHybridPool: cacheRequiresPrefillCapturedDiskSeed(cache)),
+           split.head != nil
         {
             return (.diskSeed, split.head, split.tail)
         }
@@ -2327,6 +2338,17 @@ public struct TokenIterator: TokenIteratorProtocol {
             )
         }
 
+        // Keep the sole retained prompt checkpoint available to every store
+        // decision below. For DSV4 this is the N-1 snapshot, not an unusable
+        // exact-prompt duplicate. Stores are synchronous, so release it as soon
+        // as this method returns.
+        let capturedDiskSeed = diskSeedSnapshot
+        let storageTopologySnapshot = promptCacheSnapshot ?? capturedDiskSeed
+        let storageSnapshotTokenCount = promptCacheSnapshot == nil
+            ? diskSeedBoundary ?? promptTokenIds.count
+            : promptTokenIds.count
+        defer { diskSeedSnapshot = nil }
+
         if let promptCacheSnapshot {
             // Prompt-boundary disk entries must remain raw KV even when the
             // live decode path uses TurboQuant/affine KV. Cold decode delays
@@ -2351,10 +2373,13 @@ public struct TokenIterator: TokenIteratorProtocol {
                     "TokenIterator: skipped exact recurrent warmup boundary; retaining processor-proven safe prefix seeds only"
                 )
             }
+        }
 
-            if !originalInput.requiresPostPrepareCacheKey {
+        if let storageTopologySnapshot,
+           !originalInput.requiresPostPrepareCacheKey
+        {
                 let requiresDiskBackedRestore =
-                    cacheRequiresDiskBackedCoordinatorRestore(promptCacheSnapshot)
+                    cacheRequiresDiskBackedCoordinatorRestore(storageTopologySnapshot)
                 if !usesCanonicalHybridBoundary,
                    !isReusablePrefixWarmup,
                    requiresDiskBackedRestore,
@@ -2364,11 +2389,12 @@ public struct TokenIterator: TokenIteratorProtocol {
                     let seedTokens = Array(promptTokenIds.dropLast())
                     var seedSnapshot: [KVCache]?
                     if diskSeedBoundary == seedTokens.count {
-                        seedSnapshot = diskSeedSnapshot
+                        seedSnapshot = capturedDiskSeed
                     } else {
                         seedSnapshot = cacheSnapshotForBoundary(
                             tokens: seedTokens,
-                            promptSnapshot: promptCacheSnapshot)
+                            storageSnapshot: storageTopologySnapshot,
+                            storageSnapshotTokenCount: storageSnapshotTokenCount)
                     }
                     if let seedSnapshot {
                         store(
@@ -2380,7 +2406,6 @@ public struct TokenIterator: TokenIteratorProtocol {
                                 requested: kvMode))
                     }
                 }
-                diskSeedSnapshot = nil
                 // Cross-turn reuse boundary for hybrid-SSM models (qwen3.5 /
                 // ornith GatedDeltaNet, Nemotron-H Mamba-2, LFM2, ZAYA CCA, …):
                 // store the generation-prompt-STRIPPED prompt, ending just before
@@ -2464,7 +2489,8 @@ public struct TokenIterator: TokenIteratorProtocol {
                     }
                     if let boundarySnapshot = cacheSnapshotForBoundary(
                         tokens: boundaryTokens,
-                        promptSnapshot: promptCacheSnapshot,
+                        storageSnapshot: storageTopologySnapshot,
+                        storageSnapshotTokenCount: storageSnapshotTokenCount,
                         allowDiskBackedRederive: shouldForceStableBoundaryRederive(
                             isStableBoundary: isStableBoundary,
                             isReusablePrefixWarmup: isReusablePrefixWarmup,
@@ -2480,7 +2506,6 @@ public struct TokenIterator: TokenIteratorProtocol {
                                 requested: kvMode))
                     }
                 }
-            }
         }
 
         guard !usesCanonicalHybridBoundary,
@@ -2497,14 +2522,21 @@ public struct TokenIterator: TokenIteratorProtocol {
 
     private func cacheSnapshotForBoundary(
         tokens: [Int],
-        promptSnapshot: [KVCache],
+        storageSnapshot: [KVCache],
+        storageSnapshotTokenCount: Int,
         allowDiskBackedRederive: Bool = false
     ) -> [KVCache]? {
-        guard !tokens.isEmpty, tokens.count < promptTokenIds.count else {
+        guard !tokens.isEmpty,
+            tokens.count <= storageSnapshotTokenCount,
+            storageSnapshotTokenCount <= promptTokenIds.count
+        else {
             return nil
         }
-        let trimCount = promptTokenIds.count - tokens.count
-        let trimmed = promptSnapshot.map { $0.copy() }
+        if tokens.count == storageSnapshotTokenCount {
+            return storageSnapshot.map { $0.copy() }
+        }
+        let trimCount = storageSnapshotTokenCount - tokens.count
+        let trimmed = storageSnapshot.map { $0.copy() }
         if canTrimPromptCache(trimmed),
            trimPromptCache(trimmed, numTokens: trimCount) == trimCount
         {
@@ -2513,7 +2545,7 @@ public struct TokenIterator: TokenIteratorProtocol {
         }
 
         if !allowDiskBackedRederive,
-           shouldSkipHistoryBoundaryRederiveAfterTrimMiss(promptSnapshot) {
+           shouldSkipHistoryBoundaryRederiveAfterTrimMiss(storageSnapshot) {
             Self.logger.debug(
                 "TokenIterator: skipped history-boundary cache rederive after trim miss for disk-backed cache topology"
             )

--- a/Libraries/MLXLMCommon/ModelFactory.swift
+++ b/Libraries/MLXLMCommon/ModelFactory.swift
@@ -604,6 +604,8 @@ public func loadModel(
         requested: loadConfiguration.useMmapSafetensors)
     let memoryLimit = facts.resolveMLXMemoryLimit(
         requested: loadConfiguration.memoryLimit)
+    let dsv4NativeAllocatorCeiling =
+        applyPlainDeepseekV4ProcessMemoryLimitsIfNeeded(facts: facts)
     if loadConfiguration.useMmapSafetensors && !useMmapSafetensors {
         FileHandle.standardError.write(Data(
             "[Load] DeepSeek V4 affine JANG selected resident safetensors for production decode\n"
@@ -624,7 +626,12 @@ public func loadModel(
     //    Skipped when `.unlimited` so existing iter-25 in-loader cap
     //    (1 GB during sanitize) is not overridden.
     let priorCap: Int?
-    if let cap = loadConfiguration.maxResidentBytes
+    if dsv4NativeAllocatorCeiling != nil {
+        // DSV4 needs the native freed-buffer reuse pool for decode. Keep the
+        // restored ceiling after load instead of putting a stale model-specific
+        // cap back in the defer below.
+        priorCap = nil
+    } else if let cap = loadConfiguration.maxResidentBytes
         .applyAsCacheLimitInt(physicalMemory: facts.physicalMemory)
     {
         priorCap = MLX.Memory.cacheLimit
@@ -649,7 +656,8 @@ public func loadModel(
     //     so we never trip Apple's "limit larger than max working set
     //     size" rejection (the original 847a8c7 crash condition). See
     //     docs/WIRED-LIMIT-INVESTIGATION-2026-05-03.md.
-    if let rawCap = memoryLimit
+    if dsv4NativeAllocatorCeiling == nil,
+        let rawCap = memoryLimit
         .applyAsCacheLimitInt(physicalMemory: facts.physicalMemory)
     {
         let workingSetCap = MLX.GPU.maxRecommendedWorkingSetBytes() ?? Int.max
@@ -725,6 +733,36 @@ public func loadModel(
     }
     context.jangPressRuntime = runtime
     return (context, runtime)
+}
+
+/// Restore MLX's native process ceilings for plain affine DSV4.
+///
+/// `MLX.Memory.memoryLimit` is process-global and intentionally persists after
+/// a model load. A preceding Safe Auto model therefore leaves a 70%-of-RAM
+/// limit behind. DSV4 resolves its requested limit to `.unlimited`, but that
+/// produces no integer assignment and used to leave the stale cap active,
+/// collapsing decode throughput. The allocator cache has the same process-wide
+/// hazard. Reset both to MLX's native ceiling before loading DSV4; Osaurus keeps
+/// ownership of RAM admission before this point.
+@discardableResult
+func applyPlainDeepseekV4ProcessMemoryLimitsIfNeeded(
+    facts: LoadBundleFacts,
+    recommendedWorkingSetBytes: Int? = MLX.GPU.maxRecommendedWorkingSetBytes()
+) -> Int? {
+    guard facts.isPlainDeepseekV4AffineJANG else { return nil }
+
+    let physical = Int(clamping: facts.physicalMemory)
+    let physical95 = (physical / 20) * 19 + ((physical % 20) * 19) / 20
+    let recommended150: Int = {
+        guard let recommendedWorkingSetBytes else { return Int.max }
+        let half = recommendedWorkingSetBytes / 2
+        guard recommendedWorkingSetBytes <= Int.max - half else { return Int.max }
+        return recommendedWorkingSetBytes + half
+    }()
+    let nativeCeiling = max(1 << 30, min(physical95, recommended150))
+    MLX.Memory.memoryLimit = nativeCeiling
+    MLX.Memory.cacheLimit = nativeCeiling
+    return nativeCeiling
 }
 
 private func load<R>(loader: (ModelFactory) async throws -> sending R) async throws -> sending R {

--- a/Package.swift
+++ b/Package.swift
@@ -826,6 +826,7 @@ let package = Package(
                 "DeepseekV4Step37RuntimeContractsTests.swift",
                 "DSMLInlineJSONToolFallbackFocusedTests.swift",
                 "DSMLToolCallParserFocusedTests.swift",
+                "DeepseekV4ToolHistoryPrefixBoundaryTests.swift",
                 "ToolCallProgressRoutingTests.swift",
                 "FocusedMLXTestSupport.swift",
                 "CanonicalChatCacheBoundariesTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
@@ -312,7 +312,10 @@ struct BatchEngineGrowingChatCacheSourceTests {
         #expect(batch.contains("splitPrefillInputBeforeFinalToken("))
         #expect(batch.contains("cacheRequiresPrefillCapturedDiskSeed(slot.cache)"))
         #expect(batch.contains("remainingPromptUnits > 1"))
-        #expect(batch.contains("slot.diskSeedSnapshot = makePromptBoundaryCacheSnapshot("))
+        #expect(batch.contains("let diskSeedSnapshot = makePromptBoundaryCacheSnapshot("))
+        #expect(batch.contains(
+            "storePrefillCapturedDiskSeed(diskSeedSnapshot, for: slot)"))
+        #expect(batch.contains("slot.diskSeedSnapshot = nil"))
         #expect(batch.contains("let capturedDiskSeed = slot.diskSeedSnapshot"))
         #expect(batch.contains("capturedDiskSeed ?? boundarySnapshot("))
         #expect(batch.contains("slot.promptCacheSnapshot = makeRetainedExactPromptSnapshot("))
@@ -397,6 +400,29 @@ struct BatchEngineGrowingChatCacheSourceTests {
 
         #expect(makeRetainedExactPromptSnapshot(from: [dsv4]) == nil)
         #expect(makeRetainedExactPromptSnapshot(from: [KVCacheSimple()]) != nil)
+    }
+
+    @Test("batch DSV4 persists its N-1 seed before decode and releases the duplicate")
+    func dsv4DiskSeedDoesNotRemainResidentThroughDecode() throws {
+        let source = try String(
+            contentsOfFile: "Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift",
+            encoding: .utf8)
+
+        #expect(source.contains("private func storePrefillCapturedDiskSeed("))
+        #expect(source.contains(
+            "storePrefillCapturedDiskSeed(diskSeedSnapshot, for: slot)"))
+        #expect(source.contains(
+            "label=disk-backed-safe-prompt-boundary-prefill"))
+        let immediateStore = try #require(source.range(of:
+            "storePrefillCapturedDiskSeed(diskSeedSnapshot, for: slot)"))
+        let release = try #require(source.range(
+            of: "slot.diskSeedSnapshot = nil",
+            range: immediateStore.lowerBound..<source.endIndex))
+        let tailPrefill = try #require(source.range(
+            of: "return try context.model.prepare(\n                        split.tail",
+            range: release.lowerBound..<source.endIndex))
+        #expect(immediateStore.lowerBound < release.lowerBound)
+        #expect(release.lowerBound < tailPrefill.lowerBound)
     }
 
     @Test("history-boundary rederive skips disk-backed cache topologies after trim miss")

--- a/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
@@ -311,6 +311,10 @@ struct BatchEngineGrowingChatCacheSourceTests {
         #expect(source.contains("seedSnapshot = capturedDiskSeed"))
         #expect(batch.contains("splitPrefillInputBeforeFinalToken("))
         #expect(batch.contains("cacheRequiresPrefillCapturedDiskSeed(slot.cache)"))
+        #expect(!batch.contains(
+            "slot.originalInput.cachePromptIntent != .reusablePrefixWarmup"))
+        #expect(batch.contains(
+            "excluding warmups here causes the"))
         #expect(batch.contains("remainingPromptUnits > 1"))
         #expect(batch.contains("let diskSeedSnapshot = makePromptBoundaryCacheSnapshot("))
         #expect(batch.contains(

--- a/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
@@ -2,6 +2,7 @@
 
 import Foundation
 import MLX
+import MLXLLM
 @testable import MLXLMCommon
 import Testing
 
@@ -154,7 +155,7 @@ struct BatchEngineGrowingChatCacheSourceTests {
         #expect(!source.contains("disk-backed full cache hit: re-feeding last token can corrupt path-dependent or rotating state"))
         #expect(source.contains("!slot.originalInput.requiresPostPrepareCacheKey"))
         #expect(!source.contains("let hasPathDependentLayer = slot.cache.contains"))
-        #expect(source.contains("shouldSkipHistoryBoundaryRederiveAfterTrimMiss(promptCacheSnapshot)"))
+        #expect(source.contains("shouldSkipHistoryBoundaryRederiveAfterTrimMiss(storageTopologySnapshot)"))
         #expect(source.contains("Skipped history-boundary cache rederive after trim miss for slot"))
         #expect(source.contains("cacheStablePrefixTokenCounts.contains(boundary)"))
         #expect(source.contains("forceRederive: shouldForceStableBoundaryRederive("))
@@ -200,7 +201,7 @@ struct BatchEngineGrowingChatCacheSourceTests {
         #expect(!source.contains("Populated-cache miss: full prefix matches cache"))
         #expect(!source.contains("Populated-cache miss: trimmed"))
         #expect(!source.contains("let hasPathDependentLayer = self.cache.contains"))
-        #expect(source.contains("shouldSkipHistoryBoundaryRederiveAfterTrimMiss(promptSnapshot)"))
+        #expect(source.contains("shouldSkipHistoryBoundaryRederiveAfterTrimMiss(storageSnapshot)"))
         #expect(source.contains("TokenIterator: skipped history-boundary cache rederive after trim miss"))
         #expect(source.contains("cacheStablePrefixTokenCounts.contains(boundary)"))
         #expect(source.contains(
@@ -288,24 +289,114 @@ struct BatchEngineGrowingChatCacheSourceTests {
         #expect(source.contains("Cache \\(detail.rawValue) hit: restored \\(diskRestored) tokens from disk"))
     }
 
-    @Test("solo rotating cache captures the prompt-minus-one disk seed during prefill")
-    func tokenIteratorCapturesRotatingDiskSeedDuringPrefill() throws {
+    @Test("solo and batched DSV4 paths capture prompt-minus-one disk seeds during prefill")
+    func generationPathsCaptureTypedDiskSeedDuringPrefill() throws {
         let source = try String(
             contentsOfFile: "Libraries/MLXLMCommon/Evaluate.swift",
+            encoding: .utf8)
+        let batch = try String(
+            contentsOfFile: "Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift",
+            encoding: .utf8)
+        let scheduler = try String(
+            contentsOfFile: "Libraries/MLXLMCommon/BatchEngine/BatchScheduler.swift",
             encoding: .utf8)
 
         #expect(source.contains("static func diskSeedBoundaryIndex("))
         #expect(source.contains("cacheHasStandaloneRotatingWindowState(cache)"))
+        #expect(source.contains("cacheRequiresPrefillCapturedDiskSeed(cache)"))
         #expect(source.contains("case diskSeed"))
         #expect(source.contains("diskSeedSnapshot = snapshot"))
+        #expect(source.contains("split.head != nil"))
         #expect(source.contains("if diskSeedBoundary == seedTokens.count"))
-        #expect(source.contains("seedSnapshot = diskSeedSnapshot"))
+        #expect(source.contains("seedSnapshot = capturedDiskSeed"))
+        #expect(batch.contains("splitPrefillInputBeforeFinalToken("))
+        #expect(batch.contains("cacheRequiresPrefillCapturedDiskSeed(slot.cache)"))
+        #expect(batch.contains("remainingPromptUnits > 1"))
+        #expect(batch.contains("slot.diskSeedSnapshot = makePromptBoundaryCacheSnapshot("))
+        #expect(batch.contains("let capturedDiskSeed = slot.diskSeedSnapshot"))
+        #expect(batch.contains("capturedDiskSeed ?? boundarySnapshot("))
+        #expect(batch.contains("slot.promptCacheSnapshot = makeRetainedExactPromptSnapshot("))
+        #expect(batch.contains("let storageSnapshotTokenCount = promptCacheSnapshot == nil"))
+        #expect(batch.contains("tokens.count <= storageSnapshotTokenCount"))
+        #expect(batch.contains("shouldSkipHistoryBoundaryRederiveAfterTrimMiss(storageTopologySnapshot)"))
+        #expect(batch.contains("liveSlot.diskSeedSnapshot = nil"))
+        #expect(batch.contains("liveSlot.promptCacheSnapshot = nil"))
+        #expect(source.contains("self.promptCacheSnapshot = makeRetainedExactPromptSnapshot("))
+        #expect(source.contains("diskSeedSnapshot = nil"))
+        #expect(scheduler.contains("var diskSeedSnapshot: [KVCache]?"))
 
         let prepare = try #require(source.range(of: "if let capture = prefillBoundaryCapture(of: input)"))
         let capture = try #require(source.range(of: "diskSeedSnapshot = snapshot"))
-        let store = try #require(source.range(of: "seedSnapshot = diskSeedSnapshot"))
+        let store = try #require(source.range(of: "seedSnapshot = capturedDiskSeed"))
         #expect(prepare.lowerBound < capture.lowerBound)
         #expect(capture.lowerBound < store.lowerBound)
+
+        // Scope the one-snapshot assertion to the real coordinator initializer:
+        // seed selection must precede the retained exact-snapshot decision.
+        let seedSelection = try #require(source.range(
+            of: "self.diskSeedBoundary = Self.diskSeedBoundaryIndex("))
+        let retainedSnapshot = try #require(source.range(
+            of: "self.promptCacheSnapshot = makeRetainedExactPromptSnapshot(",
+            range: seedSelection.lowerBound..<source.endIndex))
+        let compiledDecode = try #require(source.range(
+            of: "if effectiveParameters.enableCompiledDecode",
+            range: retainedSnapshot.lowerBound..<source.endIndex))
+        #expect(seedSelection.lowerBound < retainedSnapshot.lowerBound)
+        #expect(retainedSnapshot.lowerBound < compiledDecode.lowerBound)
+
+        // A seed-only DSV4 store must still reach stable system/tool prefix
+        // handling. The stable loop is a sibling of, not nested inside, the
+        // optional exact-prompt store and consumes the topology snapshot.
+        let topology = try #require(source.range(
+            of: "let storageTopologySnapshot = promptCacheSnapshot ?? capturedDiskSeed"))
+        let stableLoop = try #require(source.range(
+            of: "for boundary in Set(cachePrefixTokenCounts).sorted()",
+            range: topology.lowerBound..<source.endIndex))
+        let generatedBoundary = try #require(source.range(
+            of: "guard !usesCanonicalHybridBoundary",
+            range: stableLoop.lowerBound..<source.endIndex))
+        let storageBody = source[topology.lowerBound..<generatedBoundary.lowerBound]
+        #expect(storageBody.contains("if let storageTopologySnapshot,"))
+        #expect(storageBody.contains("storageSnapshot: storageTopologySnapshot"))
+        #expect(topology.lowerBound < stableLoop.lowerBound)
+    }
+
+    @Test("batch warm DSV4 replay skips storage without bypassing terminal drain")
+    func batchWarmDSV4ReplayPreservesTerminalDrain() throws {
+        let source = try String(
+            contentsOfFile: "Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift",
+            encoding: .utf8)
+        let finishStart = try #require(source.range(of: "private func finishSlot("))
+        let finishEnd = try #require(source.range(
+            of: "\n}\n\n// BatchEngine uses the shared",
+            range: finishStart.lowerBound..<source.endIndex))
+        let finishBody = String(source[finishStart.lowerBound..<finishEnd.lowerBound])
+
+        #expect(finishBody.contains(
+            "if let storageTopologySnapshot = promptCacheSnapshot ?? capturedDiskSeed"))
+        #expect(!finishBody.contains(
+            "guard let storageTopologySnapshot = promptCacheSnapshot ?? capturedDiskSeed"))
+        #expect(finishBody.contains(
+            "skipped cache store because no new prompt-boundary snapshot was retained"))
+        #expect(finishBody.components(separatedBy: "slot.continuation.finish()").count - 1 == 1)
+
+        let skip = try #require(finishBody.range(of:
+            "skipped cache store because no new prompt-boundary snapshot was retained"))
+        let drain = try #require(finishBody.range(of: "Stream().synchronize()"))
+        let finish = try #require(finishBody.range(of: "slot.continuation.finish()"))
+        #expect(skip.lowerBound < drain.lowerBound)
+        #expect(drain.lowerBound < finish.lowerBound)
+    }
+
+    @Test("only non-recurrent typed hybrid pools require prefill-captured disk seeds")
+    func dsv4DiskSeedCapturePolicyIsTopologySpecific() {
+        let dsv4 = DeepseekV4Cache(slidingWindow: 16, compressRatio: 4)
+        #expect(cacheRequiresPrefillCapturedDiskSeed([dsv4]))
+        #expect(!cacheRequiresPrefillCapturedDiskSeed([KVCacheSimple()]))
+        #expect(!cacheRequiresPrefillCapturedDiskSeed([MambaCache()]))
+
+        #expect(makeRetainedExactPromptSnapshot(from: [dsv4]) == nil)
+        #expect(makeRetainedExactPromptSnapshot(from: [KVCacheSimple()]) != nil)
     }
 
     @Test("history-boundary rederive skips disk-backed cache topologies after trim miss")

--- a/Tests/MLXLMCommonFocusedTests/DeepseekV4IndexerCausalTopKTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/DeepseekV4IndexerCausalTopKTests.swift
@@ -3,10 +3,73 @@
 
 import MLX
 @testable import MLXLLM
+import MLXLMCommon
 import Testing
 
 @Suite("DSV4 indexer causal top-k", .serialized)
 struct DeepseekV4IndexerCausalTopKTests {
+
+    @Test("prompt-minus-one typed disk seed matches cold DSV4 chunking")
+    func promptMinusOneDiskSeedMatchesColdPrefill() {
+        FocusedMLXTestSupport.withLock {
+            var cfg = DeepseekV4Configuration()
+            cfg.hiddenSize = 8
+            cfg.numAttentionHeads = 2
+            cfg.headDim = 4
+            cfg.qkRopeHeadDim = 2
+            cfg.qLoraRank = 4
+            cfg.oGroups = 2
+            cfg.oLoraRank = 2
+            cfg.indexNHeads = 2
+            cfg.indexHeadDim = 4
+            cfg.indexTopk = 2
+            cfg.slidingWindow = 8
+            cfg.compressRatios = [4]
+
+            let attention = DeepseekV4Attention(config: cfg, layerIdx: 0)
+            let values = (0..<(25 * cfg.hiddenSize)).map {
+                Float(($0 % 29) - 14) / 32
+            }
+            let input = MLXArray(values).asType(.float16)
+                .reshaped(1, 25, cfg.hiddenSize)
+
+            func cache() -> DeepseekV4Cache {
+                DeepseekV4Cache(
+                    slidingWindow: cfg.slidingWindow,
+                    compressRatio: 4,
+                    poolQuantizationEnabled: false)
+            }
+
+            // Existing cold prefill shape for step=16: 16 tokens, then the
+            // final 9-token remainder in one forward.
+            let cold = cache()
+            _ = attention(input[0..., ..<16, 0...], mask: .none, cache: cold)
+            let coldTail = attention(
+                input[0..., 16..., 0...], mask: .none, cache: cold)
+
+            // New capture shape: the same first 16 tokens, then 8 tokens to
+            // snapshot exact N-1 state, followed by the final token.
+            let seed = cache()
+            _ = attention(input[0..., ..<16, 0...], mask: .none, cache: seed)
+            _ = attention(input[0..., 16..<24, 0...], mask: .none, cache: seed)
+            MLX.eval(seed)
+            let encoded = TQDiskSerializer.serialize(cache: [seed])
+
+            var restored: [any KVCache] = [cache()]
+            let restoredTokens = restoreFromDiskArrays(encoded, into: &restored)
+            let restoredSeed = restored[0] as! DeepseekV4Cache
+            let warmTail = attention(
+                input[0..., 24..., 0...], mask: .none, cache: restoredSeed)
+            MLX.eval(coldTail, warmTail)
+
+            let coldLast = coldTail[0, -1, 0...]
+            let warmLast = warmTail[0, -1, 0...]
+            let maxError = (coldLast - warmLast).abs().max().item(Float.self)
+            #expect(restoredTokens == 24)
+            #expect(restoredSeed.offset == 25)
+            #expect(maxError < 2e-3)
+        }
+    }
 
     @Test("ratio-4 attention preserves indexer history across the top-k boundary")
     func attentionAdvancesIndexerHistoryBeforeTopKSelection() {

--- a/Tests/MLXLMCommonFocusedTests/DeepseekV4IndexerCausalTopKTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/DeepseekV4IndexerCausalTopKTests.swift
@@ -9,6 +9,50 @@ import Testing
 @Suite("DSV4 indexer causal top-k", .serialized)
 struct DeepseekV4IndexerCausalTopKTests {
 
+    @Test("prompt snapshot survives source rotating-ring mutation")
+    func promptSnapshotSurvivesSourceRotatingRingMutation() {
+        FocusedMLXTestSupport.withLock {
+            let source = DeepseekV4Cache(
+                slidingWindow: 8,
+                compressRatio: 4,
+                poolQuantizationEnabled: true)
+
+            func row(_ value: Float) -> MLXArray {
+                MLXArray([Float](repeating: value, count: 4))
+                    .reshaped(1, 1, 1, 4)
+            }
+
+            for value in 0..<8 {
+                _ = source.local.update(
+                    keys: row(Float(value)),
+                    values: row(Float(value + 100)))
+            }
+            let snapshot = source.copy() as! DeepseekV4Cache
+            MLX.eval(snapshot)
+            let expectedKeys = snapshot.local.state[0] * 1
+            let expectedValues = snapshot.local.state[1] * 1
+            MLX.eval(expectedKeys, expectedValues)
+
+            // Force a complete source-ring overwrite after capture. The
+            // retained checkpoint must continue to encode the original rows.
+            for value in 8..<16 {
+                _ = source.local.update(
+                    keys: row(Float(value)),
+                    values: row(Float(value + 100)))
+            }
+            MLX.eval(source, snapshot)
+
+            let keyError = (snapshot.local.state[0] - expectedKeys)
+                .abs().max().item(Float.self)
+            let valueError = (snapshot.local.state[1] - expectedValues)
+                .abs().max().item(Float.self)
+            #expect(keyError == 0)
+            #expect(valueError == 0)
+            #expect(source.offset == 16)
+            #expect(snapshot.offset == 8)
+        }
+    }
+
     @Test("prompt-minus-one typed disk seed matches cold DSV4 chunking")
     func promptMinusOneDiskSeedMatchesColdPrefill() {
         FocusedMLXTestSupport.withLock {

--- a/Tests/MLXLMCommonFocusedTests/DeepseekV4ToolHistoryPrefixBoundaryTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/DeepseekV4ToolHistoryPrefixBoundaryTests.swift
@@ -1,0 +1,154 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Live DSV4 agent rows lost prefix-cache reuse the moment a tool call entered
+// the transcript. Captured from a real Osaurus run (minesweeper artifact):
+//
+//   prompt=1458 stable=[72, 1128] all=[72, 1128, 1456]   <- history boundary
+//   prompt=7017 stable=[72, 1128] all=[72, 1128]         <- history boundary GONE
+//   HIT disk boundary=1457 remaining=5560
+//
+// `canonicalChatCacheBoundaries` derives the history boundary by re-rendering
+// the whole message list with `addGenerationPrompt: false` and requiring the
+// result to be an exact TOKEN PREFIX of the real prompt. Once that re-render
+// stops matching, every later agent turn cold-prefills the entire growing
+// transcript, which is what made tool turns appear to hang forever.
+//
+// These tests pin that round-trip for tool histories.
+
+import Foundation
+import MLXLMCommon
+import Testing
+
+@Suite("DSV4 tool-history prefix boundary round-trip")
+struct DeepseekV4ToolHistoryPrefixBoundaryTests {
+
+    /// The exact rail contract the boundary derivation depends on: rendering
+    /// without the generation prompt must be a strict textual prefix of
+    /// rendering with it. Anything else costs the history boundary.
+    private func expectPrefixRoundTrip(
+        _ messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        label: String
+    ) throws {
+        let withRail = try DeepseekV4ChatEncoder.renderOpenAIChat(
+            messages: messages,
+            tools: tools,
+            additionalContext: nil,
+            addGenerationPrompt: true)
+        let withoutRail = try DeepseekV4ChatEncoder.renderOpenAIChat(
+            messages: messages,
+            tools: tools,
+            additionalContext: nil,
+            addGenerationPrompt: false)
+
+        guard withRail.hasPrefix(withoutRail) else {
+            // Surface the exact divergence point — that byte is the bug.
+            let common = zip(withRail, withoutRail).prefix { $0 == $1 }.count
+            let railTail = String(withRail.dropFirst(common).prefix(120))
+            let noRailTail = String(withoutRail.dropFirst(common).prefix(120))
+            Issue.record(
+                """
+                \(label): no-generation-prompt render is NOT a prefix of the real prompt.
+                diverges at char \(common)
+                  withRail   : \(railTail.debugDescription)
+                  withoutRail: \(noRailTail.debugDescription)
+                """)
+            return
+        }
+        #expect(withRail.count > withoutRail.count, "\(label): rail was not appended at all")
+    }
+
+    private func weatherTools() -> [[String: any Sendable]] {
+        [
+            [
+                "type": "function",
+                "function": [
+                    "name": "file_write",
+                    "description": "Write a file",
+                    "parameters": [
+                        "type": "object",
+                        "properties": [
+                            "path": ["type": "string"] as [String: any Sendable],
+                            "content": ["type": "string"] as [String: any Sendable],
+                        ] as [String: any Sendable],
+                        "required": ["path", "content"],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable],
+            ] as [String: any Sendable]
+        ]
+    }
+
+    @Test("plain chat history keeps the exact-prefix round trip")
+    func plainChatHistoryRoundTrips() throws {
+        let messages: [[String: any Sendable]] = [
+            ["role": "system", "content": "You are a coding agent."],
+            ["role": "user", "content": "Hi"],
+            ["role": "assistant", "content": "Hello.", "reasoning_content": "greeting"],
+            ["role": "user", "content": "Build me a minesweeper game"],
+        ]
+        try expectPrefixRoundTrip(messages, tools: weatherTools(), label: "plain chat")
+    }
+
+    @Test("a tool-call turn in history keeps the exact-prefix round trip")
+    func toolCallHistoryRoundTrips() throws {
+        // The shape that killed the boundary live: assistant emits a DSML tool
+        // call carrying a large string payload, the result comes back, and the
+        // next turn must still reuse everything before it.
+        let payload = String(repeating: "<div class=\"cell\"></div>\n", count: 60)
+        let arguments = String(
+            data: try JSONSerialization.data(
+                withJSONObject: ["path": "/tmp/minesweeper.html", "content": payload],
+                options: [.sortedKeys]),
+            encoding: .utf8)!
+
+        let messages: [[String: any Sendable]] = [
+            ["role": "system", "content": "You are a coding agent."],
+            ["role": "user", "content": "Build me a minesweeper game"],
+            [
+                "role": "assistant",
+                "content": "",
+                "reasoning_content": "I'll write the HTML file and share it.",
+                "tool_calls": [
+                    [
+                        "id": "call_1",
+                        "type": "function",
+                        "function": [
+                            "name": "file_write",
+                            "arguments": arguments,
+                        ] as [String: any Sendable],
+                    ] as [String: any Sendable]
+                ] as [any Sendable],
+            ],
+            ["role": "tool", "tool_call_id": "call_1", "content": "{\"ok\":true}"],
+        ]
+        try expectPrefixRoundTrip(messages, tools: weatherTools(), label: "tool-call history")
+    }
+
+    @Test("a completed tool round followed by a new user turn round trips")
+    func toolRoundThenUserTurnRoundTrips() throws {
+        let messages: [[String: any Sendable]] = [
+            ["role": "system", "content": "You are a coding agent."],
+            ["role": "user", "content": "Build me a minesweeper game"],
+            [
+                "role": "assistant",
+                "content": "",
+                "reasoning_content": "writing the file",
+                "tool_calls": [
+                    [
+                        "id": "call_1",
+                        "type": "function",
+                        "function": [
+                            "name": "file_write",
+                            "arguments": "{\"content\":\"<html/>\",\"path\":\"/tmp/m.html\"}",
+                        ] as [String: any Sendable],
+                    ] as [String: any Sendable]
+                ] as [any Sendable],
+            ],
+            ["role": "tool", "tool_call_id": "call_1", "content": "{\"ok\":true}"],
+            ["role": "assistant", "content": "Done.", "reasoning_content": "confirmed"],
+            ["role": "user", "content": "Now add a timer."],
+        ]
+        try expectPrefixRoundTrip(messages, tools: weatherTools(), label: "tool round + user turn")
+    }
+}

--- a/Tests/MLXLMTests/LoadConfigurationTests.swift
+++ b/Tests/MLXLMTests/LoadConfigurationTests.swift
@@ -286,6 +286,64 @@ struct LoadConfigurationTests {
         #expect(s.memoryLimit == target)
     }
 
+    @Test("DSV4 clears stale process-wide MLX limits")
+    func dsv4ClearsStaleProcessLimits() {
+        let priorMemoryLimit = MLX.Memory.memoryLimit
+        let priorCacheLimit = MLX.Memory.cacheLimit
+        defer {
+            MLX.Memory.memoryLimit = priorMemoryLimit
+            MLX.Memory.cacheLimit = priorCacheLimit
+        }
+
+        let gib = UInt64(1 << 30)
+        let facts = LoadBundleFacts(
+            totalSafetensorsBytes: 95 * gib,
+            isRouted: true,
+            physicalMemory: 128 * gib,
+            modelType: "deepseek_v4",
+            weightFormat: "affine",
+            hasJangConfig: true,
+            numRoutedExperts: 256,
+            topK: 8)
+        MLX.Memory.memoryLimit = Int(128 * gib * 7 / 10)
+        MLX.Memory.cacheLimit = 128 << 20
+
+        let restored = applyPlainDeepseekV4ProcessMemoryLimitsIfNeeded(
+            facts: facts,
+            recommendedWorkingSetBytes: Int(80 * gib))
+
+        #expect(restored == Int(120 * gib))
+        #expect(MLX.Memory.memoryLimit == restored)
+        #expect(MLX.Memory.cacheLimit == restored)
+    }
+
+    @Test("non-DSV4 load does not rewrite process-wide MLX limits")
+    func nonDSV4DoesNotRewriteProcessLimits() {
+        let priorMemoryLimit = MLX.Memory.memoryLimit
+        let priorCacheLimit = MLX.Memory.cacheLimit
+        defer {
+            MLX.Memory.memoryLimit = priorMemoryLimit
+            MLX.Memory.cacheLimit = priorCacheLimit
+        }
+
+        let gib = UInt64(1 << 30)
+        let facts = LoadBundleFacts(
+            totalSafetensorsBytes: 8 * gib,
+            isRouted: false,
+            physicalMemory: 128 * gib,
+            modelType: "llama")
+        MLX.Memory.memoryLimit = Int(64 * gib)
+        MLX.Memory.cacheLimit = Int(2 * gib)
+
+        let restored = applyPlainDeepseekV4ProcessMemoryLimitsIfNeeded(
+            facts: facts,
+            recommendedWorkingSetBytes: Int(80 * gib))
+
+        #expect(restored == nil)
+        #expect(MLX.Memory.memoryLimit == Int(64 * gib))
+        #expect(MLX.Memory.cacheLimit == Int(2 * gib))
+    }
+
     // MARK: - LoadBundleFacts.inspect
 
     @Test("inspect counts safetensors byte total")

--- a/docs/DSV4_TOOL_TURN_PREFILL_2026_08_02.md
+++ b/docs/DSV4_TOOL_TURN_PREFILL_2026_08_02.md
@@ -1,0 +1,113 @@
+# DSV4 tool-turn prefill: live findings (2026-08-02)
+
+Live Osaurus Release run, DeepSeek-V4-Flash-0731-JANG, vMLX `9d22ac14`,
+isolated root `osaurus-dsv4-double-prefill-proof-root.CjFIm55GAY`,
+`VMLX_CACHE_FETCH_TRACE=1`.
+
+## 1. Duplicate prefill on the visible send — FIXED, live-proven
+
+Before `9d22ac14` the reusable-prefix warm-up was excluded from the DSV4
+prefill-captured N-1 disk store, so the warm-up prefilled the prefix and the
+visible send then logged `MISS all tiers` and prefilled the same tokens again.
+That is the "prefill runs twice" the UI showed.
+
+Live trace after the fix:
+
+```
+[vmlx][cache/fetch] MISS all tiers tokens=1129            <- warm-up, cold, stores seed
+[vmlx][cache/fetch] HIT disk boundary=1127 remaining=96 tokens=1223   <- visible send
+```
+
+The visible send restores 1127 of 1223 tokens and prefills only the 96-token
+user suffix. Turn finalized: reasoning opened and closed ("Thought for 3.6s"),
+coherent answer, `TTFT 1.73s · 31.3 tok/s · 144 tokens`, Stop cleared, input
+unlocked.
+
+Two `[vmlx][cache/boundaries]` lines per warm-up are **not** a duplicate
+prefill. They are the two probe renders in
+`MLXBatchAdapter.warmupSendInvariantPrefixTokens`, which tokenize twice to find
+the send-invariant prefix. Only `cache/fetch` marks real prefill work. An
+earlier diagnosis mis-read those probe lines as a second prefill.
+
+## 2. Tool turns lose the history cache boundary — OPEN
+
+This is the defect behind "tool calls hang forever". The tool call itself is
+fine: DSML parses, the tool runs, the artifact is written
+(`minesweeper.html`, 7 KB). What fails is prefix reuse afterwards.
+
+`canonicalChatCacheBoundaries` (Tokenizer.swift:62) publishes three kinds of
+boundary. The **history** boundary comes from `exactPrefixBoundary(messages:)`,
+which re-renders the whole message list with `addGenerationPrompt: false` and
+requires the result to be an exact token prefix of the real prompt. Cache
+entries can only be stored at a published boundary.
+
+Observed timeline:
+
+| step | prompt | `all=` boundaries | fetch |
+|---|---|---|---|
+| 1 | 1223 | `[72, 1128, 1221]` | HIT 1127, remaining 96 |
+| 2 | 1378 | `[72, 1128, 1376]` | HIT 1367, remaining 9 |
+| 3 | 1458 | `[72, 1128, 1456]` | HIT 1367, remaining 91 |
+| 4 | **7017** | **`[72, 1128]`** | HIT 1457, **remaining 5560** |
+
+At step 4 — the first prompt containing the completed tool call and its 7 KB
+artifact — the history boundary disappears. Only the static system boundaries
+survive. Two consequences:
+
+1. that turn cold-prefills 5560 tokens; and
+2. because stores happen **at** published boundaries, no history entry can be
+   stored for this prompt either, so the next agent iteration cannot reuse it.
+
+The agent loop therefore re-prefills the whole growing transcript every
+iteration. Osaurus's stream log shows the loop turning over with nothing to
+show for it:
+
+```
+Stream completed: 1 content/reasoning deltas in 46.73s ... toolHints=0
+Starting stream wrapper for model: DeepSeek-V4-Flash-0731-JANG
+```
+
+Visible symptom: "Thinking" stays animating, a "Preparing tool call" card sits
+under it, Stop stays active, the process holds ~130% CPU, and each round is
+slower than the last.
+
+### Ruled out
+
+- **Not a permissions problem.** `config/tools.json` has empty `policy` and
+  `grants`, all 78 tools enabled, and the process had no dialog or sheet
+  pending while stuck.
+- **Not the DSML parser.** First and second tool calls both round-trip
+  correctly over `/v1/chat/completions`, streaming and non-streaming, including
+  a call issued after a tool result is fed back.
+- **Not the generation-prompt rail.** `DeepseekV4ToolHistoryPrefixBoundaryTests`
+  pins that rendering with `addGenerationPrompt: false` stays an exact textual
+  prefix of the real prompt for a plain history, a tool-call history carrying a
+  large string payload, and a completed tool round followed by a new user turn.
+  All three pass, so the rail contract is intact for those shapes.
+
+### Still to isolate
+
+Why `exactPrefixBoundary` returns nil for the real 7017-token tool transcript
+when the same shape round-trips in the focused tests. `promptTokens` and the
+boundary render come from the same encoder and the same message list, so the
+remaining candidates are (a) `renderOpenAIChat` throwing on the real message
+list — `try?` swallows it into a silent nil, which is also why this failed
+invisibly — or (b) the real list differing from the reconstruction (artifact
+card representation, `latest_reminder` insertion, reasoning content).
+
+Next step: log the thrown error instead of discarding it in `exactPrefixBoundary`,
+then replay the persisted 7017-token transcript through the encoder.
+
+## 3. End-of-turn finalization
+
+`BatchEngine.swift:3264-3296` runs the end-of-turn cache store, then
+`Stream().synchronize()`, and only then `slot.continuation.finish()`. Each DSV4
+entry serializes 25-61 MB (measured: 20 entries / 524 MB in one short session),
+so that work sits between the last token and the turn finalizing. The GPU drain
+is deliberate and must stay — it is what closes the Metal
+concurrent-encoder crash class. The disk serialization is CPU/IO only and is a
+candidate to move off the critical path once the store's GPU eval has drained.
+
+Not yet measured in isolation: the plain-chat turn above cleared Stop within
+the 10s poll interval, so this has not been shown to be user-visible on short
+turns.


### PR DESCRIPTION
## What changed

- Capture a typed DeepSeek V4 prompt-minus-one cache seed while prefill crosses that exact boundary, before the final prompt token is evaluated.
- Use the captured seed for solo and batched disk-prefix storage across DSV4 local SWA, compressor/CSA, and indexer/HSA state.
- Retain only the usable N-1 seed for DSV4 instead of also holding an exact-prompt snapshot that the coordinator intentionally cannot restore.
- On an N-1 warm hit, re-feed only the final prompt token without recapturing the seed or retaining another exact snapshot.
- Preserve terminal GPU synchronization, stream completion, and long-context memory purge when a warm hit has no new snapshot to store.

## Root cause

The DSV4 disk coordinator correctly rejects an exact full-prompt restore because generation still needs logits from the final prompt token. It therefore needs a prompt-minus-one seed. After the 128-token local SWA ring wraps, the completed DSV4 hybrid cache cannot be losslessly trimmed back by one token, so the N-1 entry was never published. Exact replay consequently fell back to an older stable 285-token boundary even though a 721-token exact entry existed.

This change captures the complete typed state at N-1 during normal prefill, then evaluates the last token normally. It does not relax token identity or positional validity and does not enable suffix matching.

## Validation

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --skip-build --filter DeepseekV4IndexerCausalTopKTests` — 4/4 passed, including typed N-1 cold-vs-disk-restore equality.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter BatchEngineGrowingChatCacheSourceTests` — 26/26 passed, including solo/batch capture selection, warm no-recapture, one-snapshot retention, and terminal cleanup reachability.
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift build --target MLXLMCommon` — passed.
- `git diff --check` — passed.

## Current proof status

PARTIAL. The source and focused regression gates pass. The exact Osaurus Release CacheProof replay, restart restore counters, coherent follow-up output, cache bytes, terminal UI state, and throughput still need to be rerun against this commit before the PR is merge-ready.
