### PR TITLE
Keep the history cache boundary for an assistant continuation turn

### DIFF
--- a/Libraries/MLXLMCommon/Tokenizer.swift
+++ b/Libraries/MLXLMCommon/Tokenizer.swift
@@ -218,7 +218,35 @@ public func canonicalChatCacheBoundaries(
                 .compactMap { $0 }
         )
     ).sorted()
-    let history = exactPrefixBoundary(messages: messages).map { [$0] } ?? []
+    /// A transcript ending in an assistant turn is a CONTINUATION, and formats
+    /// that model that faithfully append no generation rail for it — DSV4's
+    /// official encoder only emits `<｜Assistant｜>` after a user/developer/
+    /// latest_reminder message. Rendering with and without the generation
+    /// prompt then produces identical tokens, so `exactPrefixBoundary`'s strict
+    /// `tokens.count < promptTokens.count` rejects it and the history boundary
+    /// disappears entirely.
+    ///
+    /// That silently killed prefix reuse for exactly the agent-loop turns that
+    /// need it most. Live DSV4 row: a plain turn published
+    /// `all=[72, 1128, 1456]`, but the first turn carrying a completed tool call
+    /// and its artifact published only `all=[72, 1128]` and cold-prefilled 5560
+    /// tokens — and because entries are stored AT published boundaries, the next
+    /// iteration had nothing to reuse either, so every round re-prefilled the
+    /// whole growing transcript.
+    ///
+    /// Fall back to the transcript without that trailing assistant turn. It is
+    /// strictly shorter, and it is still proven by the same exact-token-prefix
+    /// check — this does not relax token identity or admit suffix matching.
+    func trailingContinuationBoundary() -> Int? {
+        guard messages.count > 1,
+              let last = messages.last,
+              (last["role"] as? String) == "assistant"
+        else { return nil }
+        return exactPrefixBoundary(messages: Array(messages.dropLast()))
+    }
+
+    let history = (exactPrefixBoundary(messages: messages)
+        ?? trailingContinuationBoundary()).map { [$0] } ?? []
     let all = Array(Set(stable + history)).sorted()
     if ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1" {
         FileHandle.standardError.write(Data(

--- a/Tests/MLXLMCommonFocusedTests/CanonicalChatCacheBoundariesTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/CanonicalChatCacheBoundariesTests.swift
@@ -194,6 +194,99 @@ struct CanonicalChatCacheBoundariesTests {
         }
     }
 
+    /// DSV4-shaped: the generation rail is appended only after a
+    /// user/developer turn, so a transcript ending in an assistant turn (an
+    /// agent-loop continuation) renders identically with and without the
+    /// generation prompt.
+    private struct ContinuationRailTokenizer: GenerationPromptControllableTokenizer {
+        var bosToken: String? { nil }
+        var eosToken: String? { nil }
+        var unknownToken: String? { nil }
+
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+        func convertTokenToId(_ token: String) -> Int? { nil }
+        func convertIdToToken(_ id: Int) -> String? { nil }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] {
+            try applyChatTemplate(
+                messages: messages,
+                tools: tools,
+                additionalContext: additionalContext,
+                addGenerationPrompt: true)
+        }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?,
+            addGenerationPrompt: Bool
+        ) throws -> [Int] {
+            var result = [1]
+            for message in messages {
+                switch message["role"] as? String {
+                case "system":
+                    result.append(10)
+                    // Tool schemas render inside the system turn, as they do in
+                    // every real template — keeping them here is what makes an
+                    // earlier message list a true token prefix of a later one.
+                    if tools?.isEmpty == false { result.append(20) }
+                case "user": result.append(30)
+                case "assistant": result.append(40)
+                default: result.append(50)
+                }
+            }
+            // The rail exists only when an assistant turn is being OPENED.
+            if addGenerationPrompt, (messages.last?["role"] as? String) != "assistant" {
+                result.append(99)
+            }
+            return result
+        }
+    }
+
+    @Test("a trailing assistant continuation still publishes a history boundary")
+    func trailingAssistantContinuationPublishesHistoryBoundary() {
+        let tokenizer = ContinuationRailTokenizer()
+        let messages: [[String: any Sendable]] = [
+            ["role": "system", "content": "instructions"],
+            ["role": "user", "content": "build it"],
+            ["role": "assistant", "content": "working"],
+        ]
+        let promptTokens = try! tokenizer.applyChatTemplate(
+            messages: messages, tools: tools, additionalContext: nil,
+            addGenerationPrompt: true)
+
+        let boundaries = canonicalChatCacheBoundaries(
+            tokenizer: tokenizer,
+            messages: messages,
+            tools: tools,
+            additionalContext: nil,
+            promptTokens: promptTokens)
+
+        // Without the continuation fallback the whole-list render equals the
+        // prompt, the strict `<` rejects it, and `all` collapses to the stable
+        // prefix only — which is what made every DSV4 agent-loop turn
+        // cold-prefill the entire growing transcript.
+        let history = boundaries.all.filter { !boundaries.stable.contains($0) }
+        #expect(!history.isEmpty, "history boundary was dropped for a continuation turn")
+
+        // Whatever it published must still be a real, strictly shorter,
+        // exact token prefix of the prompt.
+        for boundary in boundaries.all {
+            #expect(boundary < promptTokens.count)
+            let rendered = try! tokenizer.applyChatTemplate(
+                messages: Array(messages.dropLast()), tools: tools,
+                additionalContext: nil, addGenerationPrompt: false)
+            if boundary == rendered.count {
+                #expect(promptTokens.prefix(boundary).elementsEqual(rendered))
+            }
+        }
+    }
+
     @Test("stable system and tool prefix is distinct from full history")
     func stableSystemToolPrefix() throws {
         let tokenizer = BoundaryTokenizer(breakStablePrefix: false)

--- a/Tests/MLXLMCommonFocusedTests/DeepseekV4ToolHistoryPrefixBoundaryTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/DeepseekV4ToolHistoryPrefixBoundaryTests.swift
@@ -125,6 +125,37 @@ struct DeepseekV4ToolHistoryPrefixBoundaryTests {
         try expectPrefixRoundTrip(messages, tools: weatherTools(), label: "tool-call history")
     }
 
+    @Test("a transcript ending in an assistant turn appends no generation rail")
+    func trailingAssistantTurnAppendsNoRail() throws {
+        // Documents the encoder contract that broke boundary derivation. DSV4's
+        // official Python encoder emits `<｜Assistant｜>` only after a
+        // user/developer/latest_reminder message, so an assistant continuation
+        // renders identically with and without the generation prompt. That is
+        // CORRECT for the format — it is `canonicalChatCacheBoundaries` that
+        // must cope with it (see `trailingContinuationBoundary`).
+        let messages: [[String: any Sendable]] = [
+            ["role": "system", "content": "You are a coding agent."],
+            ["role": "user", "content": "Build me a minesweeper game"],
+            ["role": "assistant", "content": "Working on it.", "reasoning_content": "plan"],
+        ]
+        let withRail = try DeepseekV4ChatEncoder.renderOpenAIChat(
+            messages: messages, tools: weatherTools(),
+            additionalContext: nil, addGenerationPrompt: true)
+        let withoutRail = try DeepseekV4ChatEncoder.renderOpenAIChat(
+            messages: messages, tools: weatherTools(),
+            additionalContext: nil, addGenerationPrompt: false)
+
+        #expect(withRail == withoutRail, "a continuation turn must not gain a rail")
+
+        // And the transcript WITHOUT that trailing assistant turn is the
+        // strictly shorter prefix the boundary fallback relies on.
+        let dropped = try DeepseekV4ChatEncoder.renderOpenAIChat(
+            messages: Array(messages.dropLast()), tools: weatherTools(),
+            additionalContext: nil, addGenerationPrompt: false)
+        #expect(dropped.count < withRail.count)
+        #expect(withRail.hasPrefix(dropped))
+    }
+
     @Test("a completed tool round followed by a new user turn round trips")
     func toolRoundThenUserTurnRoundTrips() throws {
         let messages: [[String: any Sendable]] = [

--- a/docs/DSV4_TOOL_TURN_PREFILL_2026_08_02.md
+++ b/docs/DSV4_TOOL_TURN_PREFILL_2026_08_02.md
@@ -29,7 +29,7 @@ prefill. They are the two probe renders in
 the send-invariant prefix. Only `cache/fetch` marks real prefill work. An
 earlier diagnosis mis-read those probe lines as a second prefill.
 
-## 2. Tool turns lose the history cache boundary — OPEN
+## 2. Tool turns lose the history cache boundary — ROOT-CAUSED AND FIXED
 
 This is the defect behind "tool calls hang forever". The tool call itself is
 fine: DSML parses, the tool runs, the artifact is written
@@ -85,18 +85,51 @@ slower than the last.
   large string payload, and a completed tool round followed by a new user turn.
   All three pass, so the rail contract is intact for those shapes.
 
-### Still to isolate
+### Root cause
 
-Why `exactPrefixBoundary` returns nil for the real 7017-token tool transcript
-when the same shape round-trips in the focused tests. `promptTokens` and the
-boundary render come from the same encoder and the same message list, so the
-remaining candidates are (a) `renderOpenAIChat` throwing on the real message
-list — `try?` swallows it into a silent nil, which is also why this failed
-invisibly — or (b) the real list differing from the reconstruction (artifact
-card representation, `latest_reminder` insertion, reasoning content).
+`exactPrefixBoundary` requires the no-rail render to be **strictly shorter**
+than the real prompt:
 
-Next step: log the thrown error instead of discarding it in `exactPrefixBoundary`,
-then replay the persisted 7017-token transcript through the encoder.
+```swift
+tokens.count < promptTokens.count,
+promptTokens.prefix(tokens.count).elementsEqual(tokens)
+```
+
+DSV4 appends its `<｜Assistant｜>` rail only after a user / developer /
+latest_reminder message — `renderMessage`, mirroring `encoding_dsv4.py`:
+
+```python
+elif messages[index].get("role") in ["user", "developer"]:
+    prompt += ASSISTANT_SP_TOKEN + <think>/</think>
+```
+
+So when the transcript ends in an **assistant continuation** — the shape every
+agent-loop turn takes once the model is mid-turn — rendering with and without
+the generation prompt produces *identical* tokens. Measured on the real
+encoder: `withRail.count → 1283` == `withoutRail.count → 1283`. The strict `<`
+then rejects the boundary and `try?`/`?? []` turns that into a silent nil, so
+the history boundary disappears with no diagnostic.
+
+The encoder is correct here; the boundary derivation was not.
+
+### Fix
+
+`canonicalChatCacheBoundaries` gains `trailingContinuationBoundary()`: when the
+whole-list render yields no boundary and the last message is an assistant turn,
+retry against the transcript **without** that trailing turn. That render is
+strictly shorter and is still proven by the same exact-token-prefix check — no
+relaxation of token identity, no suffix matching.
+
+Regression cover, both sabotage-verified red:
+
+- `CanonicalChatCacheBoundariesTests."a trailing assistant continuation still publishes a history boundary"`
+  — without the fallback the published history set is `[]`.
+- `DeepseekV4ToolHistoryPrefixBoundaryTests."a transcript ending in an assistant turn appends no generation rail"`
+  — pins the encoder contract the fallback exists for.
+
+Full focused target: 22 pre-existing failures in `DeepseekV4ChatTemplateFallbackFocusedTests`
+and `VMLXMemorySafetySettingsTests` both with and without this change — this
+change adds none.
 
 ## 3. End-of-turn finalization
 


### PR DESCRIPTION
## What changed

`canonicalChatCacheBoundaries` gains `trailingContinuationBoundary()`: when the
whole-message-list render yields no history boundary and the last message is an
assistant turn, retry against the transcript **without** that trailing turn.

## Root cause

DSV4 agent-loop turns lost prefix-cache reuse entirely. Live Release trace
(vMLX `9d22ac14`, `~/models/DeepSeek-V4-Flash-0731-JANG`, isolated root, paged
RAM off / disk L2 on, `VMLX_CACHE_FETCH_TRACE=1`):

| prompt | `all=` boundaries | fetch |
|---|---|---|
| 1223 | `[72, 1128, 1221]` | HIT 1127, remaining 96 |
| 1458 | `[72, 1128, 1456]` | HIT 1367, remaining 91 |
| **7017** | **`[72, 1128]`** | HIT 1457, **remaining 5560** |

Row 3 is the first prompt containing a completed tool call and its 7 KB
artifact. The history boundary disappears, so that turn cold-prefills 5560
tokens — and because entries are stored **at** published boundaries, the next
agent iteration has nothing to reuse either. Every round re-prefills the whole
growing transcript. In the live run that prefill had not finished after ~20
minutes at ~180% CPU, with the chat showing "Preparing tool call" and Stop
still active.

`exactPrefixBoundary` requires the no-generation-prompt render to be **strictly
shorter** than the prompt:

```swift
tokens.count < promptTokens.count,
promptTokens.prefix(tokens.count).elementsEqual(tokens)
```

DSV4 appends its `<｜Assistant｜>` rail only after a user / developer /
latest_reminder message, mirroring `encoding_dsv4.py`:

```python
elif messages[index].get("role") in ["user", "developer"]:
    prompt += ASSISTANT_SP_TOKEN + <think>/</think>
```

So a transcript ending in an assistant **continuation** — the shape every
agent-loop turn takes mid-turn — renders identically with and without the
generation prompt. Measured on the real encoder: `withRail.count → 1283` ==
`withoutRail.count → 1283`. The strict `<` rejects it, and `try?` / `?? []`
turn that into a silent nil with no diagnostic.

The encoder is correct per the official contract; the boundary derivation was
not.

## Why this is safe

The fallback only engages when the normal path returns nil **and** the last
message is an assistant turn. The retried render is strictly shorter and is
still proven by the same exact-token-prefix check. Token identity is unchanged
and suffix matching is not admitted.

## Validation

- `CanonicalChatCacheBoundariesTests."a trailing assistant continuation still publishes a history boundary"` — sabotage-verified: without the fallback the published history set is `[]`.
- `DeepseekV4ToolHistoryPrefixBoundaryTests` (4/4) — pins the encoder contract the fallback exists for, plus exact-prefix round-trips for a plain history, a tool-call history with a large string payload, and a completed tool round followed by a user turn.
- `swift test --filter 'CanonicalChatCacheBoundariesTests|DeepseekV4ToolHistoryPrefixBoundaryTests'` → 12/12 passed.
- Full `MLXLMCommonFocusedTests`: 22 failures in `DeepseekV4ChatTemplateFallbackFocusedTests` and `VMLXMemorySafetySettingsTests` **both with and without** this change — pre-existing, none added.

## Proof status

**PARTIAL.** Source and focused regression gates pass and the root cause is
proven from a live Release trace. The live UI re-run on a build carrying THIS
commit — agent turn with a tool call, then a follow-up, showing the history
boundary published and the next iteration restoring instead of cold-prefilling —
has not been done yet. Details in `docs/DSV4_TOOL_TURN_PREFILL_2026_08_02.md`.