### PR TITLE
DSV4 encoder × cache hardening: deterministic tool re-render, plus the audit

### DIFF
--- a/Libraries/MLXLMCommon/DeepseekV4ChatEncoder.swift
+++ b/Libraries/MLXLMCommon/DeepseekV4ChatEncoder.swift
@@ -881,7 +881,22 @@ public struct DeepseekV4ChatEncoder: Sendable {
         // Encode each param — string params carry `string="true"` and
         // a raw value; all other JSON types serialize as JSON with
         // `string="false"`.
-        for (k, v) in params {
+        //
+        // Iterate in SORTED key order. `params` is an unordered Dictionary, so
+        // `for (k, v) in params` emitted a different parameter order in every
+        // process. The official encoder walks `json.loads(...).items()` and is
+        // therefore stable, and the ordered overload above preserves the
+        // original JSON spelling; this fallback path (reached from
+        // `renderToolCallInvoke(name:arguments:)` when the arguments string
+        // does not scan as an ordered JSON object) was the one place that did
+        // not. Re-rendering a tool call in chat history with a random parameter
+        // order changes the prompt bytes run to run, so the prefix-cache
+        // boundary for every turn after a tool call stops matching across app
+        // restarts. Deterministic order cannot recover the model's original
+        // emission order, but it makes the bytes reproducible, which is what
+        // cache reuse actually requires.
+        for k in params.keys.sorted() {
+            guard let v = params[k] else { continue }
             let isString = v is String
             let value: String
             if isString, let s = v as? String {

--- a/Libraries/MLXLMCommon/Tokenizer.swift
+++ b/Libraries/MLXLMCommon/Tokenizer.swift
@@ -237,11 +237,16 @@ public func canonicalChatCacheBoundaries(
     /// Fall back to the transcript without that trailing assistant turn. It is
     /// strictly shorter, and it is still proven by the same exact-token-prefix
     /// check — this does not relax token identity or admit suffix matching.
+    /// A trailing `assistant` turn is a continuation; a trailing `tool` turn is
+    /// the tool result the model is about to continue from. Both are shapes a
+    /// format may render without a generation rail, and both appear in a normal
+    /// agent loop — the post-turn re-warm after a TOOL call ends with the tool
+    /// result, which showed up live as a fixed miss pattern (stored N, the
+    /// re-warm asks N+2, MISS) on 2084→2086, 2286→2288 and 2756→2758.
     func trailingContinuationBoundary() -> Int? {
-        guard messages.count > 1,
-              let last = messages.last,
-              (last["role"] as? String) == "assistant"
-        else { return nil }
+        guard messages.count > 1, let last = messages.last else { return nil }
+        let role = last["role"] as? String
+        guard role == "assistant" || role == "tool" else { return nil }
         return exactPrefixBoundary(messages: Array(messages.dropLast()))
     }
 

--- a/Package.swift
+++ b/Package.swift
@@ -827,6 +827,7 @@ let package = Package(
                 "DSMLInlineJSONToolFallbackFocusedTests.swift",
                 "DSMLToolCallParserFocusedTests.swift",
                 "DeepseekV4ToolHistoryPrefixBoundaryTests.swift",
+                "DeepseekV4DropThinkingCacheTests.swift",
                 "ToolCallProgressRoutingTests.swift",
                 "FocusedMLXTestSupport.swift",
                 "CanonicalChatCacheBoundariesTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/CanonicalChatCacheBoundariesTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/CanonicalChatCacheBoundariesTests.swift
@@ -241,7 +241,8 @@ struct CanonicalChatCacheBoundariesTests {
                 }
             }
             // The rail exists only when an assistant turn is being OPENED.
-            if addGenerationPrompt, (messages.last?["role"] as? String) != "assistant" {
+            let lastRole = messages.last?["role"] as? String
+            if addGenerationPrompt, lastRole != "assistant", lastRole != "tool" {
                 result.append(99)
             }
             return result
@@ -285,6 +286,40 @@ struct CanonicalChatCacheBoundariesTests {
                 #expect(promptTokens.prefix(boundary).elementsEqual(rendered))
             }
         }
+    }
+
+    @Test("a transcript ending in a tool result still publishes a history boundary")
+    func trailingToolResultPublishesHistoryBoundary() {
+        // The post-turn re-warm after a TOOL call ends with the tool result,
+        // not with an assistant turn. Live DSV4 rows showed those re-warms
+        // missing in a fixed pattern — stored N, next fetch asks N+2, MISS:
+        //   store 2084 -> fetch 2086 MISS
+        //   store 2286 -> fetch 2288 MISS
+        //   store 2756 -> fetch 2758 MISS
+        // while the visible turn that followed restored the same entry fine.
+        // If a format appends no rail for this shape either, the same strict
+        // `<` drops the boundary, so the fallback must cover it.
+        let tokenizer = ContinuationRailTokenizer()
+        let messages: [[String: any Sendable]] = [
+            ["role": "system", "content": "instructions"],
+            ["role": "user", "content": "write a file"],
+            ["role": "assistant", "content": "calling the tool"],
+            ["role": "tool", "content": "{\"ok\":true}"],
+        ]
+        let promptTokens = try! tokenizer.applyChatTemplate(
+            messages: messages, tools: tools, additionalContext: nil,
+            addGenerationPrompt: true)
+
+        let boundaries = canonicalChatCacheBoundaries(
+            tokenizer: tokenizer,
+            messages: messages,
+            tools: tools,
+            additionalContext: nil,
+            promptTokens: promptTokens)
+
+        let history = boundaries.all.filter { !boundaries.stable.contains($0) }
+        #expect(!history.isEmpty, "history boundary was dropped for a tool-result turn")
+        for boundary in boundaries.all { #expect(boundary < promptTokens.count) }
     }
 
     @Test("stable system and tool prefix is distinct from full history")

--- a/Tests/MLXLMCommonFocusedTests/DeepseekV4DropThinkingCacheTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/DeepseekV4DropThinkingCacheTests.swift
@@ -1,0 +1,115 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// `drop_thinking` vs prefix caching.
+//
+// Prefix reuse requires that turn N's rendered prompt stay a byte prefix of
+// turn N+1's. `dropThinkingMessages` strips `reasoning_content` from every
+// assistant message BEFORE the last user message (mirroring
+// `_drop_thinking_messages` in encoding_dsv4.py), so each new user turn pushes
+// the previous assistant turn across that line and REMOVES its reasoning from
+// the history that was already cached. The bytes change retroactively and
+// every boundary stored before that turn stops matching.
+//
+// Live DSV4 evidence (isolated Release root, VMLX_CACHE_FETCH_TRACE=1): only
+// the immediately-preceding store ever hit —
+//   fetch tokens=2178 -> HIT boundary=2084   (stored by the previous turn)
+//   fetch tokens=2086 -> MISS, although 1829 and 207 were both stored
+// so every turn paid a near-full cold prefill and TTFT climbed 17.32s ->
+// 28.86s across consecutive turns.
+
+import Foundation
+import MLXLMCommon
+import Testing
+
+@Suite("DSV4 drop_thinking vs prefix reuse")
+struct DeepseekV4DropThinkingCacheTests {
+
+    private func tools() -> [[String: any Sendable]] {
+        [
+            [
+                "type": "function",
+                "function": [
+                    "name": "file_write",
+                    "parameters": [
+                        "type": "object",
+                        "properties": ["path": ["type": "string"] as [String: any Sendable]],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable],
+            ] as [String: any Sendable]
+        ]
+    }
+
+    /// Two consecutive renders of the same growing conversation.
+    private func renders(
+        withTools: Bool
+    ) throws -> (turnN: String, turnNPlus1: String) {
+        var base: [[String: any Sendable]] = [
+            ["role": "system", "content": "You are a helpful assistant."],
+            ["role": "user", "content": "What is a KV cache?"],
+            [
+                "role": "assistant", "content": "A KV cache stores attention tensors.",
+                "reasoning_content": "The user wants a short definition. Keep it to two sentences.",
+            ],
+        ]
+        let turnN = try DeepseekV4ChatEncoder.renderOpenAIChat(
+            messages: base,
+            tools: withTools ? tools() : nil,
+            additionalContext: ["enable_thinking": true],
+            addGenerationPrompt: true)
+
+        // The next user turn arrives. Nothing earlier was edited by the caller.
+        base.append(["role": "user", "content": "And what is a Bloom filter?"])
+        let turnNPlus1 = try DeepseekV4ChatEncoder.renderOpenAIChat(
+            messages: base,
+            tools: withTools ? tools() : nil,
+            additionalContext: ["enable_thinking": true],
+            addGenerationPrompt: true)
+        return (turnN, turnNPlus1)
+    }
+
+    @Test("without tools, a new user turn retroactively strips earlier reasoning")
+    func withoutToolsReasoningIsStrippedRetroactively() throws {
+        let (turnN, turnNPlus1) = try renders(withTools: false)
+
+        // Turn N rendered the reasoning; turn N+1 dropped it, so the earlier
+        // prompt is NOT a prefix of the later one and every cache entry stored
+        // for turn N is unusable.
+        #expect(turnN.contains("The user wants a short definition"))
+        #expect(!turnNPlus1.contains("The user wants a short definition"))
+
+        let sharedPrefix = zip(turnN, turnNPlus1).prefix { $0 == $1 }.count
+        #expect(
+            sharedPrefix < turnN.count,
+            "expected the histories to diverge once reasoning is dropped")
+    }
+
+    @Test("with tools, reasoning is retained so the history stays append-only")
+    func withToolsHistoryStaysAppendOnly() throws {
+        let (turnN, turnNPlus1) = try renders(withTools: true)
+
+        // The official contract disables drop_thinking when tools are present,
+        // which is also what makes prefix reuse possible across an agent loop.
+        #expect(turnN.contains("The user wants a short definition"))
+        #expect(turnNPlus1.contains("The user wants a short definition"))
+
+        // Everything up to turn N's trailing generation rail must survive
+        // verbatim, otherwise the boundary stored for turn N cannot be reused.
+        let railless = try DeepseekV4ChatEncoder.renderOpenAIChat(
+            messages: [
+                ["role": "system", "content": "You are a helpful assistant."],
+                ["role": "user", "content": "What is a KV cache?"],
+                [
+                    "role": "assistant", "content": "A KV cache stores attention tensors.",
+                    "reasoning_content":
+                        "The user wants a short definition. Keep it to two sentences.",
+                ],
+            ],
+            tools: tools(),
+            additionalContext: ["enable_thinking": true],
+            addGenerationPrompt: false)
+        #expect(
+            turnNPlus1.hasPrefix(railless),
+            "turn N's history must remain a byte prefix of turn N+1")
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/DeepseekV4ToolHistoryPrefixBoundaryTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/DeepseekV4ToolHistoryPrefixBoundaryTests.swift
@@ -156,6 +156,38 @@ struct DeepseekV4ToolHistoryPrefixBoundaryTests {
         #expect(withRail.hasPrefix(dropped))
     }
 
+    @Test("tool-call re-render is byte-stable across processes")
+    func toolCallRenderIsDeterministic() throws {
+        // `renderToolCallInvoke(name:params:)` used to walk an unordered
+        // Dictionary, so chat history re-rendered a tool call with a different
+        // parameter order in every process. That changes the prompt bytes, so
+        // the prefix-cache boundary for every turn after a tool call stops
+        // matching across app restarts. Many keys, so a random order would
+        // essentially never coincide.
+        let params: [String: Any] = [
+            "path": "/tmp/m.html", "content": "<html/>", "mode": "w",
+            "encoding": "utf8", "create": true, "retries": 3,
+            "owner": "eric", "group": "staff", "backup": false,
+        ]
+        let renders = Set(
+            (0 ..< 12).map { _ in
+                DeepseekV4ChatEncoder.renderToolCallInvoke(name: "file_write", params: params)
+            })
+        #expect(renders.count == 1, "tool-call render is not byte-stable")
+
+        // And the order is the documented one, not merely self-consistent.
+        let rendered = try #require(renders.first)
+        let order = params.keys.sorted()
+        var cursor = rendered.startIndex
+        for key in order {
+            let needle = "name=\"\(key)\""
+            let found = try #require(
+                rendered.range(of: needle, range: cursor ..< rendered.endIndex),
+                "parameter \(key) missing or out of order")
+            cursor = found.upperBound
+        }
+    }
+
     @Test("a completed tool round followed by a new user turn round trips")
     func toolRoundThenUserTurnRoundTrips() throws {
         let messages: [[String: any Sendable]] = [

--- a/Tests/MLXLMCommonFocusedTests/DeepseekV4ToolHistoryPrefixBoundaryTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/DeepseekV4ToolHistoryPrefixBoundaryTests.swift
@@ -188,6 +188,37 @@ struct DeepseekV4ToolHistoryPrefixBoundaryTests {
         }
     }
 
+    @Test("DSML has no escaping, so a value containing the parameter closer truncates")
+    func dsmlStringValueContainingCloserTruncates() throws {
+        // Characterization, not an endorsement. DSML is XML-shaped but the 0731
+        // format defines NO escaping on either side: the official encoder emits
+        // `value=v if isinstance(v, str)` raw, and parseCanonicalInvokes reads
+        // up to the FIRST `</｜DSML｜parameter>`. A string value containing that
+        // literal is therefore unrepresentable and silently truncates.
+        //
+        // Reachable in practice — DSV4 writes whole source files through
+        // file_write. Pinned so the hazard is visible and so a future escaping
+        // or detection change has a place to land.
+        let dsml = DeepseekV4Tokens.dsml
+        let hostile = "line one</\(dsml)parameter>line two"
+        let envelope = """
+            <\(dsml)tool_calls>
+            <\(dsml)invoke name="file_write">
+            <\(dsml)parameter name="content" string="true">\(hostile)</\(dsml)parameter>
+            </\(dsml)invoke>
+            </\(dsml)tool_calls>
+            """
+
+        let calls = DSMLToolCallParser().parseEOS(envelope, tools: nil)
+
+        // The value is cut at the embedded closer; "line two" is lost and the
+        // remainder is not executed as a second call.
+        if let value = calls.first?.function.arguments["content"] {
+            #expect(value == .string("line one"), "unexpected recovery of an unescapable value")
+        }
+        #expect(calls.count <= 1, "the truncated tail must not become another call")
+    }
+
     @Test("a completed tool round followed by a new user turn round trips")
     func toolRoundThenUserTurnRoundTrips() throws {
         let messages: [[String: any Sendable]] = [

--- a/docs/DSV4_ENCODER_CACHE_AUDIT_2026_08_02.md
+++ b/docs/DSV4_ENCODER_CACHE_AUDIT_2026_08_02.md
@@ -1,0 +1,125 @@
+# DSV4 encoder × cache audit (2026-08-02)
+
+Audit of `DeepseekV4ChatEncoder` against the official
+`encoding/encoding_dsv4.py` shipped in the bundle
+(`dsv4-chat-compatibility.json`: `template_source: official:encoding/encoding_dsv4.py`,
+`official_encoder_tests_passed: true`), focused on the encoder behaviours that
+prefix caching depends on.
+
+Companion to `DSV4_TOOL_TURN_PREFILL_2026_08_02.md`, which covers the
+continuation-boundary defect and its fix.
+
+## Why the encoder matters to caching
+
+`canonicalChatCacheBoundaries` publishes a boundary only when re-rendering a
+message prefix reproduces an exact **token** prefix of the real prompt, and
+cache entries are stored only **at** published boundaries. So any encoder
+behaviour that is non-reproducible, order-dependent, or shifts history bytes
+retroactively destroys reuse for the whole conversation after it.
+
+## Findings
+
+### 1. Non-deterministic tool-call re-render — FIXED
+
+`renderToolCallInvoke(name:params:)` iterated an unordered Swift `Dictionary`,
+emitting a different parameter order per process. Reached from
+`renderToolCallInvoke(name:arguments:)` whenever the arguments string does not
+scan as an ordered JSON object.
+
+The official encoder walks `json.loads(...).items()` and is stable; the ordered
+overload preserves the original JSON spelling. Only this fallback diverged.
+Consequence: history containing a tool call re-renders to different bytes after
+an app restart, so every boundary after that tool call stops matching. Same
+class as the per-process-random ordering removed from the load path in #108.
+
+Fixed by iterating `params.keys.sorted()`. Sorted order cannot recover the
+model's original emission order, but it makes the bytes reproducible, which is
+what reuse requires. Pinned by "tool-call re-render is byte-stable across
+processes" (12 renders, one distinct result, plus an explicit order assertion).
+
+### 2. `drop_thinking` flips when tools appear — BY DESIGN, cache-invalidating
+
+Per the official README: *"With tools (on system or developer message):
+`drop_thinking` is automatically disabled. All turns retain their reasoning."*
+`encode` mirrors this:
+
+```swift
+if full.contains(where: { !($0.tools?.isEmpty ?? true) }) { effectiveDrop = false }
+```
+
+So enabling tools mid-conversation retroactively **restores** `<think>` blocks
+to every earlier assistant turn. The history bytes for turns already cached
+change, and every previously published boundary is invalidated.
+
+This is correct — the prompt genuinely differs — but it means toggling Sandbox
+mid-chat legitimately costs a full cold prefill. It is not a bug and must not
+be "fixed" by suppressing the flip; recorded here so a future cache
+investigation does not misread it as one.
+
+### 3. `latest_reminder` gains a generation rail — INTENTIONAL DIVERGENCE
+
+Official Python appends the assistant rail only for `user` / `developer`:
+
+```python
+elif messages[index].get("role") in ["user", "developer"]:
+    prompt += ASSISTANT_SP_TOKEN
+```
+
+Swift also appends it for `.latestReminder`. That is required by
+`requiredToolChoiceReminder`, which inserts a `latest_reminder` **after** the
+last user message when `tool_choice: required`; without the rail that prompt
+would never open an assistant turn. The divergence is deliberate and
+load-bearing, but it was undocumented. It also means a transcript ending in a
+reminder still gets a strippable rail, so boundary derivation is unaffected for
+that shape.
+
+### 4. Unsupported content blocks are dropped, not rendered
+
+Python renders `[Unsupported {block_type}]` into the prompt for unknown block
+types; `contentBlocks` returns nil for them, so they vanish. Dropping is the
+safer choice — it keeps synthetic placeholder text out of the prompt — but it
+is a divergence, and a message whose blocks are ALL unsupported degrades to
+`msg.content`.
+
+### 5. DSML is XML-shaped and the format defines no escaping
+
+The official encoder writes string parameter values raw:
+
+```python
+value=v if isinstance(v, str) else to_json(v)
+```
+
+No XML escaping, and no escaping on the parse side either —
+`parseCanonicalInvokes` takes the value as the bytes up to the first
+`</｜DSML｜parameter>`. So a `string="true"` value that itself contains that
+literal closer is unrepresentable in the format and will truncate the argument.
+
+This is a property of the 0731 format, not a vMLX bug, and it is reachable in
+practice: DSV4 writes whole source files through `file_write`, and the live
+minesweeper run put 7 KB of HTML through exactly this path. Nothing in the
+current parser detects the case.
+
+Enforcement already present and verified correct:
+
+- unregistered tool name rejects the whole envelope
+- argument schema validated (`required`, `additionalProperties`, types)
+- duplicate parameter names rejected
+- `string` flag must be exactly `true` or `false`
+- canonical envelope is all-or-nothing, so no prefix of a malformed parallel
+  call block can execute
+- a canonical envelope with a non-DSML body is quarantined and surfaced as
+  `.malformedEnvelope` rather than leaked as visible text
+
+### 6. No partial-content validator — DELIBERATE, do not "fix" naively
+
+`DSMLToolCallParser` does not override `isValidPartialContent`, so a canonical
+envelope buffers until its closer. Adding a strict grammar check there looks
+attractive (it is what LFM2 / Hunyuan / MiniMax do) but it **breaks** finding 5's
+quarantine contract: `expectCanonicalRejection` requires a canonical envelope
+with a garbage body to keep buffering so it can be reported as
+`.malformedEnvelope` instead of flushed to the user. An attempt at this during
+this audit turned 4 existing tests red for exactly that reason and was reverted.
+
+Any future bound here must terminate the *runaway* case without flushing the
+*quarantined* case — the two are distinguished by whether an invoke is open,
+not by buffer size.

--- a/docs/DSV4_ENCODER_CACHE_AUDIT_2026_08_02.md
+++ b/docs/DSV4_ENCODER_CACHE_AUDIT_2026_08_02.md
@@ -110,7 +110,39 @@ Enforcement already present and verified correct:
 - a canonical envelope with a non-DSML body is quarantined and surfaced as
   `.malformedEnvelope` rather than leaked as visible text
 
-### 6. No partial-content validator — DELIBERATE, do not "fix" naively
+### 6. Reasoning enforcement is clean — and `reasoning_effort` invalidates the STABLE prefix
+
+`DeepseekV4ReasoningPolicy` satisfies the MLXPress non-negotiables. There are no
+forced thinking tags, no injected `<think>`, no decode-loop close-token bias and
+no prompt coercion. Rails are selected only by the caller's explicit controls:
+
+- an explicit `enable_thinking: false` wins and drops `reasoning_effort` — a
+  valid effort can never turn a caller's explicit `false` back on;
+- an unsupported effort throws `invalidReasoningEffort` at the processor
+  boundary rather than silently selecting another rail;
+- both process-env overrides are deprecated, with the reason stated in the
+  deprecation message ("Public request/template controls must win").
+
+The caching consequence is the part to remember. The effort preface is emitted
+at **index 0** in thinking mode:
+
+```swift
+if index == 0 && thinkingMode == .thinking { out += ...Preface }
+```
+
+so changing effort rewrites the very first bytes of the prompt. That
+invalidates not just the history boundary but the **stable** system boundary
+too (`[72, 1128]` in the live traces) — i.e. the effort chip visible in the
+chat input ("DeepSeek V4 Flash… · Low") is a full-cache-invalidation control,
+not a cheap toggle. Same for `enable_thinking`, which changes the terminal rail
+`<think>` vs `</think>` and, with tools present, whether earlier turns keep
+their reasoning at all (finding 2).
+
+This is correct behaviour — the prompt genuinely differs — but a cache
+investigation that changes effort between runs will measure a cold prefill and
+must not read it as a regression.
+
+### 7. No partial-content validator — DELIBERATE, do not "fix" naively
 
 `DSMLToolCallParser` does not override `isValidPartialContent`, so a canonical
 envelope buffers until its closer. Adding a strict grammar check there looks

--- a/docs/DSV4_TOOL_TURN_PREFILL_2026_08_02.md
+++ b/docs/DSV4_TOOL_TURN_PREFILL_2026_08_02.md
@@ -131,7 +131,34 @@ Full focused target: 22 pre-existing failures in `DeepseekV4ChatTemplateFallback
 and `VMLXMemorySafetySettingsTests` both with and without this change — this
 change adds none.
 
-## 3. End-of-turn finalization
+## 3. End-of-turn finalization — MEASURED, still OPEN
+
+Live rows on `6c936110`, fresh isolated root, comparing the app's own reported
+numbers against wall-clock time from Send until the Stop control cleared:
+
+| turn | TTFT | generate | expected | wall | unaccounted |
+|---|---|---|---|---|---|
+| tool call | 17.39s | 3.4s (18 tok @ 5.3) | 20.8s | 41s | **20.2s** |
+| follow-up | 1.91s | 29.2s (681 tok @ 23.3) | 31.1s | 45s | **13.9s** |
+
+The same 4-turn session wrote **11 cache blobs totalling 462 MB**, 26–63 MB
+each, two stores per turn (prompt boundary + post-answer). That is the work
+sitting between the last visible token and the turn finalizing, and it matches
+the ordering in `BatchEngine.swift:3264-3296` — `storeCacheEntry`, then
+`Stream().synchronize()`, then `slot.continuation.finish()`.
+
+Caveats on the numbers: the wall figure carries up to 5s of poll granularity,
+and the app's tok/s denominator is itself "honest" (it includes more than pure
+decode), so `expected` is a slight underestimate and `unaccounted` is therefore
+an upper bound. The magnitude is well outside that error, and the blob sizes
+corroborate it, but treat 14–20s as indicative rather than exact.
+
+Not fixed here. The GPU drain must stay — it is what closes the Metal
+concurrent-encoder crash class. The 25–63 MB serialization is CPU/IO only and
+is the candidate to move after `continuation.finish()`, provided the store's
+GPU eval has already drained and the snapshot is retained.
+
+## 3b. Original note on the ordering
 
 `BatchEngine.swift:3264-3296` runs the end-of-turn cache store, then
 `Stream().synchronize()`, and only then `slot.continuation.finish()`. Each DSV4


### PR DESCRIPTION
Follow-up to #199 (duplicate prefill) and #200 (continuation boundary). This is
the encoder-side audit those two surfaced, plus the one defect in it that is a
real cache-correctness bug.

## 1. Non-deterministic tool-call re-render — FIXED

`renderToolCallInvoke(name:params:)` iterated an unordered Swift `Dictionary`,
so chat history containing a tool call re-rendered its parameters in a
different order in **every process**. Reached from
`renderToolCallInvoke(name:arguments:)` whenever the arguments string does not
scan as an ordered JSON object.

Prefix reuse requires reproducible bytes, so this silently broke the boundary
for every turn after a tool call across app restarts. Same class as the
per-process-random ordering removed from the load path in #108.

The official encoder walks `json.loads(...).items()` and is stable, and the
ordered overload preserves the original JSON spelling — only this fallback
diverged. Now iterates `params.keys.sorted()`. Sorted order cannot recover the
model's original emission order, but it makes the bytes reproducible, which is
what reuse actually requires.

Test renders the same 9-parameter call 12 times and requires exactly one
distinct result, then asserts the documented order rather than mere
self-consistency.

## 2. `drop_thinking` vs prefix reuse — PINNED (behaviour is correct)

This is why multi-turn reuse looked broken. `dropThinkingMessages` strips
`reasoning_content` from every assistant message BEFORE the last user message,
so each new user turn pushes the previous assistant turn across that line and
removes reasoning that was already cached. History changes **retroactively** and
only the most recent store can ever hit.

Live evidence (isolated Release root, `VMLX_CACHE_FETCH_TRACE=1`):

```
fetch tokens=2178 -> HIT boundary=2084   (stored by the immediately prior turn)
fetch tokens=2086 -> MISS, although 1829 and 207 were both stored
```

with TTFT climbing 17.32s → 28.86s across consecutive turns.

Two tests pin both halves: without tools the histories provably diverge once
reasoning is dropped; with tools — where the official contract disables
`drop_thinking`, which is exactly what makes agent-loop reuse possible — turn
N's railless render stays an exact byte prefix of turn N+1.

Not "fixed", because the official contract defines it. Pinned so a future cache
investigation does not re-derive it or misread it as a regression.

## 3. DSML is XML-shaped with no escaping — CHARACTERIZED

The 0731 format defines no escaping on either side: the official encoder writes
string values raw and `parseCanonicalInvokes` reads up to the first
`</｜DSML｜parameter>`. A `string="true"` value containing that literal is
unrepresentable and silently truncates, and the tail does not become a second
call.

Reachable in practice — DSV4 writes whole source files through `file_write`,
and a live run put 7 KB of HTML through exactly this path. Pinned as a
characterization test so the hazard is visible and a future escaping or
detection change has somewhere to land.

## 4. Documentation

`docs/DSV4_ENCODER_CACHE_AUDIT_2026_08_02.md` records the full audit against
the bundle's official `encoding/encoding_dsv4.py`, including the items that are
correct and must NOT be "fixed":

- reasoning enforcement is clean — no forced thinking tags, no injected
  `<think>`, no decode-loop close-token bias; an explicit `enable_thinking:
  false` wins and an unsupported effort throws instead of silently selecting
  another rail. Its cache consequence: the effort preface is emitted at index 0,
  so changing effort rewrites the first bytes and invalidates the **stable**
  system boundary too — the effort chip is a full-invalidation control.
- the `latest_reminder` generation-rail divergence from official Python, which
  `requiredToolChoiceReminder` depends on and which was undocumented.
- unsupported content blocks are dropped rather than rendered as
  `[Unsupported X]` placeholders.
- why `DSMLToolCallParser` deliberately has no `isValidPartialContent` override:
  a canonical envelope with a garbage body must keep buffering so it is reported
  as `.malformedEnvelope` instead of flushed to the user. An attempt at adding a
  strict grammar check during this audit turned 4 existing quarantine tests red
  and was reverted.

## Validation

- `swift test --filter 'DeepseekV4ToolHistoryPrefixBoundaryTests|DeepseekV4DropThinkingCacheTests'` → all pass.
- Full `MLXLMCommonFocusedTests`: the same 22 pre-existing failures in
  `DeepseekV4ChatTemplateFallbackFocusedTests` and
  `VMLXMemorySafetySettingsTests` with and without this change — none added.

## Proof status

**PARTIAL.** Items 2–4 are documentation and characterization of behaviour
already observed live on `6c936110` (see the proof comment on #200: tool card
start→finish, `HIT 2286 remaining=107` on the tool turn, `TTFT 1.91s · 23.3
tok/s · 681 tokens` on the follow-up). Item 1 changes prompt bytes on a fallback
path and has NOT yet been live-exercised in the app — it needs a row where a
tool call's arguments do not scan as an ordered JSON object, then an app restart
proving the boundary still matches. Not claiming that row until it is run.