### PR TITLE
Add a prefix digest to the cache-boundary trace

### DIFF
--- a/Libraries/MLXLMCommon/Tokenizer.swift
+++ b/Libraries/MLXLMCommon/Tokenizer.swift
@@ -254,8 +254,27 @@ public func canonicalChatCacheBoundaries(
         ?? trailingContinuationBoundary()).map { [$0] } ?? []
     let all = Array(Set(stable + history)).sorted()
     if ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1" {
+        // Token counts alone cannot distinguish two prompts of equal length, so
+        // a boundary that is stored and then immediately missed looks identical
+        // in the trace to one that genuinely diverged. Emit a digest of the
+        // leading tokens as well: comparing `head=` across a store and the
+        // following re-warm shows directly whether the prompt changed in the
+        // system region rather than leaving it to inference.
+        //
+        // Diagnostic only — gated behind the same trace flag, never consulted
+        // by cache logic, and never used as a cache key.
+        func digest(_ ids: ArraySlice<Int>) -> String {
+            var hash: UInt64 = 0xcbf2_9ce4_8422_2325
+            for id in ids {
+                hash = (hash ^ UInt64(bitPattern: Int64(id))) &* 0x1000_0000_01b3
+            }
+            return String(hash & 0xffff_ffff, radix: 16)
+        }
+        let headDigest = digest(promptTokens.prefix(256))
+        let stableDigest = stable.first.map { digest(promptTokens.prefix($0)) } ?? "-"
         FileHandle.standardError.write(Data(
-            "[vmlx][cache/boundaries] prompt=\(promptTokens.count) stable=\(stable) all=\(all)\n".utf8
+            ("[vmlx][cache/boundaries] prompt=\(promptTokens.count) stable=\(stable) all=\(all)"
+                + " head=\(headDigest) stable0=\(stableDigest)\n").utf8
         ))
     }
     return CanonicalChatCacheBoundaries(all: all, stable: stable)


### PR DESCRIPTION
Diagnostic only. Unblocks the `stored+2` re-warm miss whose cause #203 recorded
as unresolved.

## Why

The boundary trace prints token counts and nothing else, so a boundary that is
stored and then immediately missed looks identical in the log to one that
genuinely diverged. Two prompts of equal length cannot be told apart, which is
exactly the ambiguity that made me record a wrong root cause in #202 and correct
it in #203.

## What

`[vmlx][cache/boundaries]` now also emits:

- `head=` — digest of the leading 256 tokens
- `stable0=` — digest of the prompt up to the first stable boundary

Comparing these across a store and the following re-warm shows directly whether
the prompt changed in the system region, which is the leading hypothesis: the
todo tool was observed moving `stable[1]` from 1160 to 1128 between consecutive
boundary computations inside one session, while the static boundary 72 held.

Gated behind the existing `VMLX_CACHE_FETCH_TRACE` flag, never consulted by
cache logic, never used as a cache key. FNV-1a truncated to 32 bits purely for
log legibility.

## Validation

`swift test --filter 'CanonicalChatCacheBoundariesTests|DeepseekV4ToolHistoryPrefixBoundaryTests|DeepseekV4DropThinkingCacheTests'` → 17/17 passed.
`swift build --target MLXLMCommon` → clean.

## Proof status

Diagnostic instrumentation behind an off-by-default trace flag, so there is no
runtime behaviour to prove live. The live run that *uses* it — capturing
`head=`/`stable0=` across a store and its following re-warm to settle the cause —
is the next step and will be reported separately.