### PR TITLE
Add a history-boundary digest to the cache-boundary trace

### DIFF
--- a/Libraries/MLXLMCommon/Tokenizer.swift
+++ b/Libraries/MLXLMCommon/Tokenizer.swift
@@ -272,9 +272,16 @@ public func canonicalChatCacheBoundaries(
         }
         let headDigest = digest(promptTokens.prefix(256))
         let stableDigest = stable.first.map { digest(promptTokens.prefix($0)) } ?? "-"
+        // `head`/`stable0` both sit inside the system prefix, so when they match
+        // across a store and a failing re-warm they only prove the system region
+        // is stable — the first live capture showed exactly that, and the
+        // divergence has to be further in. `hist` covers the conversation span
+        // up to the history boundary, which is where the remaining `stored+2`
+        // miss must originate.
+        let historyDigest = all.last.map { digest(promptTokens.prefix($0)) } ?? "-"
         FileHandle.standardError.write(Data(
             ("[vmlx][cache/boundaries] prompt=\(promptTokens.count) stable=\(stable) all=\(all)"
-                + " head=\(headDigest) stable0=\(stableDigest)\n").utf8
+                + " head=\(headDigest) stable0=\(stableDigest) hist=\(historyDigest)\n").utf8
         ))
     }
     return CanonicalChatCacheBoundaries(all: all, stable: stable)


### PR DESCRIPTION
Diagnostic only, follow-up to #204. Same contract: gated behind
`VMLX_CACHE_FETCH_TRACE`, never consulted by cache logic, never a cache key.

## Why

#204's first live capture came back with `head=` and `stable0=` **identical on
every boundary line, including the re-warm that missed**:

```
prompt=1141 all=[72,1128,1139] head=22bca74a stable0=e7fcebd8   HIT 1127 remaining=12
prompt=1221 all=[72,1128,1219] head=22bca74a stable0=e7fcebd8   HIT 1127 remaining=94
disk-store count=1333
prompt=1338 all=[72,1128,1336] head=22bca74a stable0=e7fcebd8   MISS tokens=1335
```

That proves the system region is byte-stable and falsifies the
mutable-system-section hypothesis from #203 — the second wrong root cause for
this symptom.

Both existing digests sit inside the system prefix (first 256 and first 72
tokens), so neither can see where the divergence must actually be: the span
between the stable prefix and the stored boundary. The store was
`1220 + 113 generated = 1333`; the re-warm's usable boundary was
`1338 - 3 = 1335`.

## What

`hist=` — digest of the prompt up to the history boundary (`all.last`).

Comparing `hist=` across a store and its following re-warm localizes the change
to the conversation span rather than leaving it to inference for a third time.

## Validation

`swift test --filter 'CanonicalChatCacheBoundariesTests|DeepseekV4ToolHistoryPrefixBoundaryTests|DeepseekV4DropThinkingCacheTests'` → 17/17 passed.
`swift build --target MLXLMCommon` → clean.

## Proof status

No runtime behaviour to prove live — it only adds a field to an off-by-default
trace. The capture that *uses* it will be reported on the tracking issue for the
`stored+2` miss.