### PR TITLE
Refuse disk-cache stores whose cache offset disagrees with the boundary key

### DIFF
--- a/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
@@ -861,6 +861,36 @@ public final class CacheCoordinator: @unchecked Sendable {
         let traceCacheStore =
             ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1"
 
+        // A boundary entry asserts "this cache covers exactly these tokens".
+        // The paged tier already enforces that for its rotating companion —
+        // `serializePagedRotatingCompanion(expectedOffset:)` returns nil on a
+        // mismatch, observed live as `companion=false rotatingOffsets=[1832]`
+        // under `tokens=1831`. The disk tier had no equivalent guard, so the
+        // very same poisoned snapshot was persisted to SSD.
+        //
+        // A later fetch content-matches the key, restores one more token of
+        // state than the key claims, and the engine re-feeds the boundary
+        // token the cache already contains. Every subsequent position shifts
+        // by one, attention is silently wrong for the whole continuation, and
+        // each following turn stores a new seed derived FROM that corrupted
+        // state — compounding per turn. Live signature: fluent DSV4 agent
+        // turns degenerating into non-converging loops, only with disk L2
+        // enabled.
+        //
+        // Refuse the whole store instead: a skipped entry costs one prefill,
+        // a poisoned entry costs correctness for every later turn.
+        if let cache {
+            let offsets = Set(cache.map(\.offset))
+            if offsets.contains(where: { $0 != totalTokens }) {
+                if traceCacheStore {
+                    FileHandle.standardError.write(Data(
+                        ("[vmlx][cache/store] REFUSED offset/key mismatch"
+                            + " tokens=\(totalTokens) offsets=\(offsets.sorted())\n").utf8))
+                }
+                return
+            }
+        }
+
         // Older generation call sites intentionally supplied an empty paged
         // payload for every cache that also needed typed disk persistence.
         // That was correct for rotating/CCA/pool layouts, but it silently

--- a/Package.swift
+++ b/Package.swift
@@ -834,6 +834,7 @@ let package = Package(
                 "CanonicalChatCacheBoundariesTests.swift",
                 "BatchEngineGrowingChatCacheSourceTests.swift",
                 "CacheCoordinatorTopologyFocusedTests.swift",
+                "DiskStoreOffsetConsistencyFocusedTests.swift",
                 "VMLXUmbrellaProductTests.swift",
                 "ZayaConfigDecodeFocusedTests.swift",
                 "VLShapeGuardFocusedTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/DiskStoreOffsetConsistencyFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/DiskStoreOffsetConsistencyFocusedTests.swift
@@ -1,0 +1,128 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// The disk tier must refuse a snapshot whose rotating offset does not match
+// the boundary token count it is being stored under.
+//
+// Observed live (2026-08-02, VMLX_CACHE_FETCH_TRACE=1):
+//
+//   [vmlx][cache/paged-store] tokens=1831 requiredCompanion=true
+//       effectiveKVLayers=0 blocks=0 payload=false companion=false
+//       rotatingOffsets=[1832]
+//
+// A snapshot keyed at 1831 tokens carried a rotating cache at offset 1832.
+// The PAGED tier caught it — `serializePagedRotatingCompanion(expectedOffset:)`
+// returned nil, so `companion=false` and the paged store was refused. The DISK
+// tier had no equivalent guard: `TQDiskSerializer.serialize(cache:)` ran
+// unconditionally and the poisoned entry was persisted to SSD.
+//
+// What a later fetch does with it: content-addressing matches the 1831-token
+// key, restore reinstates offset 1832, the engine believes 1831 tokens are
+// covered and re-feeds token index 1831 — which the cache already contains.
+// One duplicated position shifts every subsequent token's position by one, so
+// attention is subtly wrong for the whole continuation while generation stays
+// fluent. Each following turn captures its N-1 seed FROM that corrupted state
+// and stores it, compounding per turn.
+//
+// This is the DSV4 agent-loop degeneration: it appears only with disk L2
+// enabled (RAM prefix reuse shares the live object and never round-trips), it
+// worsens across tool rounds, and DSV4 is hit hardest because it is
+// paged-incompatible, so the disk tier is its only reuse path — every turn
+// round-trips through exactly this seam.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import Testing
+
+@Suite("Disk store offset consistency", .serialized)
+struct DiskStoreOffsetConsistencyFocusedTests {
+
+    private func makeCoordinator(diskDir: URL) -> CacheCoordinator {
+        CacheCoordinator(config: CacheCoordinatorConfig(
+            usePagedCache: false,
+            enableDiskCache: true,
+            pagedBlockSize: 4,
+            maxCacheBlocks: 16,
+            diskCacheMaxGB: 1.0,
+            diskCacheDir: diskDir,
+            modelKey: "disk-offset-consistency"))
+    }
+
+    private func rotatingCache(fedTokens: Int, window: Int = 8) -> RotatingKVCache {
+        let rot = RotatingKVCache(maxSize: window, keep: 0)
+        for position in 0 ..< fedTokens {
+            _ = rot.update(
+                keys: MLXArray.ones([1, 1, 1, 4]) * Float(position + 1),
+                values: MLXArray.ones([1, 1, 1, 4]) * Float(-(position + 1)))
+        }
+        MLX.eval(rot)
+        return rot
+    }
+
+    private func tempDir() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("disk-offset-consistency-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    @Test("a snapshot whose offset exceeds the boundary must not reach disk")
+    func inconsistentSnapshotIsRefused() throws {
+        let dir = try tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let coordinator = makeCoordinator(diskDir: dir)
+
+        // The live shape: keyed at N tokens, cache actually fed N+1.
+        let tokens = Array(0 ..< 11)
+        let cache = rotatingCache(fedTokens: 12)
+        #expect(cache.offset == 12)
+
+        coordinator.storeAfterGeneration(
+            promptTokens: tokens,
+            perLayerData: [],
+            ssmStates: nil,
+            cache: [cache])
+
+        // A fetch at the same key must MISS: restoring this entry would hand
+        // back one more token of state than the engine believes is covered,
+        // duplicating the boundary token on re-feed.
+        let result = coordinator.fetch(tokens: tokens)
+        guard case .miss = result else {
+            Issue.record(
+                """
+                poisoned entry was stored and served: keyed=\(tokens.count) offset=12 — \
+                the boundary token will be fed twice and every later position shifts
+                """)
+            return
+        }
+    }
+
+    @Test("a consistent snapshot still stores and hits")
+    func consistentSnapshotStillStores() throws {
+        let dir = try tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let coordinator = makeCoordinator(diskDir: dir)
+
+        let tokens = Array(0 ..< 12)
+        let cache = rotatingCache(fedTokens: 12)
+        #expect(cache.offset == 12)
+
+        coordinator.storeAfterGeneration(
+            promptTokens: tokens,
+            perLayerData: [],
+            ssmStates: nil,
+            cache: [cache])
+
+        // Guard must not be over-broad: the healthy path keeps working. The
+        // exact boundary is skippable by policy, so probe via a longer prompt
+        // that can reuse this entry as a prefix.
+        let longer = tokens + [12, 13]
+        let result = coordinator.fetch(tokens: longer)
+        guard case .hit(let matched, _, _, _, _, _) = result else {
+            Issue.record("consistent entry did not round-trip — guard is over-broad")
+            return
+        }
+        #expect(matched == 12)
+    }
+}

--- a/Tests/MLXLMTests/DeepseekV4PartialRestoreContinuationTests.swift
+++ b/Tests/MLXLMTests/DeepseekV4PartialRestoreContinuationTests.swift
@@ -1,0 +1,167 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// DSV4 PARTIAL disk restore, then continue.
+//
+// `DeepseekV4CacheDiskRoundTripTests` proves serialize -> deserialize is
+// lossless for a cache that is then left alone. That is not what the engine
+// does. Live DSV4 (2026-08-02) restores an EARLIER boundary and keeps feeding:
+//
+//   [vmlx][cache/fetch] HIT disk boundary=8092  remaining=2004
+//   [vmlx][cache/fetch] HIT disk boundary=10095 remaining=2498
+//
+// DSV4's per-layer cache is `RotatingKVCache(maxSize: slidingWindow, keep: 0)`
+// for cr=0 layers, i.e. a ring. `CacheHelpers` already warns that once that
+// ring wraps, the cache "cannot produce a lossless N-1 checkpoint by trimming
+// the completed prompt". A restore at an arbitrary earlier boundary followed
+// by thousands more tokens is that hazard in its worst form.
+//
+// The invariant the prefix cache depends on is stronger than round-tripping:
+//
+//     restore(B) + feed(N-B)   ==   feed(N)
+//
+// If it does not hold, attention reads a subtly wrong window and the model
+// stays fluent while losing the plot — which is exactly the symptom that
+// appeared the day disk L2 started working on this machine (a coherent
+// reasoning loop repeating verbatim at ~12.5k tokens, at temperature 1.0 /
+// top_p 0.95, where sampling cannot explain verbatim repetition).
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import Testing
+
+@Suite("DSV4 partial disk restore then continue", .serialized)
+struct DeepseekV4PartialRestoreContinuationTests {
+
+    /// One decode step of deterministic, position-dependent content, so a
+    /// misaligned ring shows up as a value mismatch rather than coincidentally
+    /// matching uniform data.
+    private static func step(
+        _ cache: any KVCache, position: Int, B: Int = 1, H: Int = 1, headDim: Int = 8
+    ) {
+        let keys = MLXArray.ones([B, H, 1, headDim]) * Float(position + 1)
+        let values = MLXArray.ones([B, H, 1, headDim]) * Float(-(position + 1))
+        _ = cache.update(keys: keys, values: values)
+    }
+
+    private static func feed(_ cache: any KVCache, from: Int, to: Int) {
+        for position in from ..< to { step(cache, position: position) }
+    }
+
+    private static func assertSameState(
+        _ warm: any KVCache, _ cold: any KVCache, label: String
+    ) {
+        #expect(warm.offset == cold.offset, "\(label): offset diverged")
+        let warmState = warm.state
+        let coldState = cold.state
+        guard warmState.count == coldState.count else {
+            Issue.record("\(label): state tensor count \(warmState.count) vs \(coldState.count)")
+            return
+        }
+        for (index, pair) in zip(warmState, coldState).enumerated() {
+            let (w, c) = pair
+            guard w.shape == c.shape else {
+                Issue.record("\(label): tensor \(index) shape \(w.shape) vs \(c.shape)")
+                continue
+            }
+            let equal = MLX.allClose(w, c).item(Bool.self)
+            #expect(equal, "\(label): tensor \(index) differs after restore+continue")
+        }
+    }
+
+    /// The ring has wrapped several times before the boundary, and thousands
+    /// more tokens arrive after it — the live shape, scaled down.
+    @Test("RotatingKVCache: restore(B) + feed(N-B) == feed(N) after the ring wraps")
+    func rotatingPartialRestoreMatchesColdPrefill() {
+        let window = 16
+        let boundary = 40   // ring already wrapped twice
+        let total = 72      // and wraps twice more after the restore
+
+        // Cold: one continuous run.
+        let cold = RotatingKVCache(maxSize: window, keep: 0)
+        Self.feed(cold, from: 0, to: total)
+
+        // Warm: run to the boundary, persist, restore, continue.
+        let source = RotatingKVCache(maxSize: window, keep: 0)
+        Self.feed(source, from: 0, to: boundary)
+        let encoded = TQDiskSerializer.serialize(cache: [source])
+
+        let warm = RotatingKVCache(maxSize: window, keep: 0)
+        var target: [any KVCache] = [warm]
+        _ = restoreFromDiskArrays(encoded, into: &target)
+        #expect(warm.offset == boundary, "restore did not reinstate the boundary offset")
+        Self.feed(warm, from: boundary, to: total)
+
+        Self.assertSameState(warm, cold, label: "rotating restore(\(boundary))+\(total - boundary)")
+    }
+
+    /// Same invariant for the composite type every cr>0 layer uses.
+    @Test("DeepseekV4Cache: restore(B) + feed(N-B) == feed(N) after the ring wraps")
+    func deepseekV4CachePartialRestoreMatchesColdPrefill() {
+        let window = 16
+        let boundary = 40
+        let total = 72
+
+        let cold = DeepseekV4Cache(slidingWindow: window, compressRatio: 4)
+        Self.feed(cold, from: 0, to: total)
+
+        let source = DeepseekV4Cache(slidingWindow: window, compressRatio: 4)
+        Self.feed(source, from: 0, to: boundary)
+        let encoded = TQDiskSerializer.serialize(cache: [source])
+
+        let warm = DeepseekV4Cache(slidingWindow: window, compressRatio: 4)
+        var target: [any KVCache] = [warm]
+        _ = restoreFromDiskArrays(encoded, into: &target)
+        Self.feed(warm, from: boundary, to: total)
+
+        Self.assertSameState(warm, cold, label: "dsv4 restore(\(boundary))+\(total - boundary)")
+    }
+
+    /// Edge case: boundary exactly on a ring wrap. Off-by-one in the rotation
+    /// index is invisible mid-window and maximal here.
+    @Test("restore exactly on a ring-wrap boundary continues correctly")
+    func restoreOnExactWrapBoundary() {
+        let window = 16
+        for boundary in [window, window * 2, window * 3] {
+            let total = boundary + window + 3
+
+            let cold = RotatingKVCache(maxSize: window, keep: 0)
+            Self.feed(cold, from: 0, to: total)
+
+            let source = RotatingKVCache(maxSize: window, keep: 0)
+            Self.feed(source, from: 0, to: boundary)
+            let encoded = TQDiskSerializer.serialize(cache: [source])
+
+            let warm = RotatingKVCache(maxSize: window, keep: 0)
+            var target: [any KVCache] = [warm]
+            _ = restoreFromDiskArrays(encoded, into: &target)
+            Self.feed(warm, from: boundary, to: total)
+
+            Self.assertSameState(warm, cold, label: "wrap-boundary restore(\(boundary))")
+        }
+    }
+
+    /// Edge case: restore, then feed only ONE token — the `skipExactDisk`
+    /// N-1 seed path the engine prefers for path-dependent topologies.
+    @Test("restore(N-1) + one token == feed(N)")
+    func restoreMinusOneSeedMatches() {
+        let window = 16
+        let total = 51
+
+        let cold = RotatingKVCache(maxSize: window, keep: 0)
+        Self.feed(cold, from: 0, to: total)
+
+        let source = RotatingKVCache(maxSize: window, keep: 0)
+        Self.feed(source, from: 0, to: total - 1)
+        let encoded = TQDiskSerializer.serialize(cache: [source])
+
+        let warm = RotatingKVCache(maxSize: window, keep: 0)
+        var target: [any KVCache] = [warm]
+        _ = restoreFromDiskArrays(encoded, into: &target)
+        Self.feed(warm, from: total - 1, to: total)
+
+        Self.assertSameState(warm, cold, label: "N-1 seed restore")
+    }
+}

--- a/Tests/MLXLMTests/DeepseekV4PoolBufferRestoreTests.swift
+++ b/Tests/MLXLMTests/DeepseekV4PoolBufferRestoreTests.swift
@@ -1,0 +1,162 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// DSV4 compressor/indexer POOL + BUFFER survival across a partial disk restore.
+//
+// `DeepseekV4PartialRestoreContinuationTests` drives the cache through
+// `update(keys:values:)`, which only forwards to the inner rotating window:
+//
+//     public func update(keys:values:) -> (MLXArray, MLXArray) {
+//         local.update(keys: keys, values: values)
+//     }
+//
+// The compressor/indexer pool is fed by the attention module through a separate
+// API (`appendPooled` / `setBuffers`). So that suite left both pools nil in the
+// cold AND warm caches and compared empty to empty — it never proved the pool
+// survives a restore. The pool is the whole-history-dependent state, so that is
+// precisely where a "fluent but cannot converge" failure would originate.
+//
+// `DeepseekV4Cache` documents the design assumption on its buffer accessors:
+//
+//     "verify the ephemeral buffers are cleared on restore
+//      (they recompute from prompt tokens on the next prefill)"
+//
+// That holds for a FULL re-prefill. The engine does partial restores —
+// `HIT disk boundary=8092 remaining=2004` — where only tokens B..N are fed
+// afterwards, so anything the buffers held from tokens 0..B is never
+// reconstructed. These tests pin what actually survives, so the assumption is
+// checked rather than assumed.
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import Testing
+
+@Suite("DSV4 pool/buffer survival across disk restore", .serialized)
+struct DeepseekV4PoolBufferRestoreTests {
+
+    private static func pooledRow(_ value: Float, dim: Int = 4) -> MLXArray {
+        MLXArray.ones([1, 1, dim]) * value
+    }
+
+    /// Populate the branch the way the attention module does: several pooled
+    /// rows, plus a partial-window buffer that has not been flushed into the
+    /// pool yet.
+    private static func fillBranch(
+        _ cache: DeepseekV4Cache, _ key: DeepseekV4Cache.BranchKey, base: Float
+    ) {
+        for index in 0 ..< 3 {
+            _ = cache.appendPooled(key, value: pooledRow(base + Float(index)))
+        }
+        cache.setBuffers(
+            key,
+            kv: MLXArray.ones([1, 2, 4]) * (base + 100),
+            gate: MLXArray.ones([1, 2, 4]) * (base + 200))
+    }
+
+    @Test("pooled rows survive a disk round trip")
+    func pooledRowsSurviveDiskRoundTrip() throws {
+        let source = DeepseekV4Cache(slidingWindow: 16, compressRatio: 4)
+        Self.fillBranch(source, .compressor, base: 1)
+        Self.fillBranch(source, .indexer, base: 10)
+
+        let sourceComp = try #require(
+            source.getPooled(.compressor), "compressor pool was not populated by the test")
+        let sourceIdx = try #require(source.getPooled(.indexer))
+
+        let encoded = TQDiskSerializer.serialize(cache: [source])
+        let target = DeepseekV4Cache(slidingWindow: 16, compressRatio: 4)
+        var restoreTarget: [any KVCache] = [target]
+        _ = restoreFromDiskArrays(encoded, into: &restoreTarget)
+
+        let restoredComp = try #require(
+            target.getPooled(.compressor),
+            "compressor POOL did not survive the disk round trip")
+        let restoredIdx = try #require(target.getPooled(.indexer), "indexer pool lost")
+
+        #expect(restoredComp.shape == sourceComp.shape)
+        #expect(MLX.allClose(restoredComp, sourceComp).item(Bool.self))
+        #expect(restoredIdx.shape == sourceIdx.shape)
+        #expect(MLX.allClose(restoredIdx, sourceIdx).item(Bool.self))
+    }
+
+    /// Characterize the documented buffer-clearing behaviour, and state plainly
+    /// what it costs on a PARTIAL restore.
+    ///
+    /// If the buffers come back nil, the contract is "the next prefill rebuilds
+    /// them". A partial restore only feeds tokens B..N, so a buffer holding the
+    /// unflushed window from before B cannot be rebuilt — the pool is then
+    /// missing that fragment for the rest of the conversation.
+    @Test("buffer clearing on restore is only safe if the boundary is pool-aligned")
+    func bufferClearingIsOnlySafeWhenPoolAligned() throws {
+        let source = DeepseekV4Cache(slidingWindow: 16, compressRatio: 4)
+        Self.fillBranch(source, .compressor, base: 1)
+
+        let (sourceKV, sourceGate) = source.getBuffers(.compressor)
+        #expect(sourceKV != nil, "test did not populate the compressor buffer")
+        #expect(sourceGate != nil)
+
+        let encoded = TQDiskSerializer.serialize(cache: [source])
+        let target = DeepseekV4Cache(slidingWindow: 16, compressRatio: 4)
+        var restoreTarget: [any KVCache] = [target]
+        _ = restoreFromDiskArrays(encoded, into: &restoreTarget)
+
+        let (restoredKV, restoredGate) = target.getBuffers(.compressor)
+
+        // Whichever way this lands, record it explicitly — the engine's partial
+        // restore depends on the answer, and it was previously untested.
+        if restoredKV == nil || restoredGate == nil {
+            Issue.record(
+                """
+                DSV4 compressor buffers are DROPPED by the disk round trip \
+                (kv=\(restoredKV == nil ? "nil" : "present"), \
+                gate=\(restoredGate == nil ? "nil" : "present")).
+
+                That is safe only when the restored boundary is aligned to \
+                compressRatio. The engine restores arbitrary boundaries — live: \
+                `HIT disk boundary=8092 remaining=2004` — and then feeds only the \
+                suffix, so an unflushed window from before the boundary is never \
+                rebuilt. The pool is permanently missing that fragment, which \
+                degrades attention over long context while leaving generation \
+                fluent.
+                """)
+        } else {
+            #expect(MLX.allClose(restoredKV!, sourceKV!).item(Bool.self))
+            #expect(MLX.allClose(restoredGate!, sourceGate!).item(Bool.self))
+        }
+    }
+
+    /// The pool must also survive when the cache is restored and then KEEPS
+    /// receiving tokens, which is what a partial restore actually does.
+    @Test("pool is intact after restore + continued decoding")
+    func poolIntactAfterRestoreAndContinue() throws {
+        let source = DeepseekV4Cache(slidingWindow: 16, compressRatio: 4)
+        Self.fillBranch(source, .compressor, base: 1)
+        for position in 0 ..< 20 {
+            _ = source.update(
+                keys: MLXArray.ones([1, 1, 1, 8]) * Float(position + 1),
+                values: MLXArray.ones([1, 1, 1, 8]) * Float(-(position + 1)))
+        }
+        let expectedRows = try #require(source.getPooled(.compressor)).dim(1)
+
+        let encoded = TQDiskSerializer.serialize(cache: [source])
+        let target = DeepseekV4Cache(slidingWindow: 16, compressRatio: 4)
+        var restoreTarget: [any KVCache] = [target]
+        _ = restoreFromDiskArrays(encoded, into: &restoreTarget)
+
+        // Continue decoding, as the engine does after `remaining=N`.
+        for position in 20 ..< 30 {
+            _ = target.update(
+                keys: MLXArray.ones([1, 1, 1, 8]) * Float(position + 1),
+                values: MLXArray.ones([1, 1, 1, 8]) * Float(-(position + 1)))
+        }
+
+        let after = try #require(
+            target.getPooled(.compressor),
+            "compressor pool was LOST once decoding continued after a restore")
+        #expect(
+            after.dim(1) >= expectedRows,
+            "pool shrank across restore+continue: \(after.dim(1)) < \(expectedRows)")
+    }
+}


### PR DESCRIPTION
## The DSV4 agent-loop degeneration, root-caused

Long DSV4 tool chains degenerated into fluent, non-converging reasoning loops
at ~12.5k tokens. Live A/B on the affected machine, run twice: prefix-RAM-only
never loops; disk L2 on loops; everything off never loops.

## The smoking gun was already in the trace

```
[vmlx][cache/paged-store] tokens=1831 requiredCompanion=true
    effectiveKVLayers=0 blocks=0 payload=false companion=false rotatingOffsets=[1832]
```

A snapshot keyed at **1831 tokens** carrying a rotating cache at **offset
1832**. The paged tier refused it — `serializePagedRotatingCompanion(expectedOffset:)`
returns nil on mismatch, hence `companion=false`. The disk tier has no
equivalent guard (`expectedOffset` appears only in the paged path), so the same
poisoned snapshot went to SSD.

## Why that produces loops instead of a crash

A later fetch content-matches the key, restore reinstates offset 1832, the
engine believes 1831 tokens are covered and re-feeds the boundary token the
cache already contains. One duplicated position shifts every subsequent
position by one — attention is silently wrong for the entire continuation
while generation stays fluent. Each following turn then captures its N-1 seed
FROM that corrupted state and stores it, so the corruption compounds per tool
round.

DSV4 is hit hardest because it marks itself paged-incompatible: the disk tier
is its only reuse path, so **every** turn crosses this seam.

## What was ruled out first, by test

- raw KV round-trip and partial restore (`restore(B)+feed(N-B) == feed(N)`,
  incl. exact ring-wrap boundaries and the N-1 seed) — #207, passes
- DSV4 pool/buffer survival under realistic state — passes
- sampler (agent `temperature: 0` was real, fixed, loop persisted) — osaurus#2274
- DSML parser — tool chains executed correctly before degradation

## The fix

`storeAfterGeneration` refuses the entire store when any layer's `offset`
disagrees with the boundary token count, with a `VMLX_CACHE_FETCH_TRACE` line
naming both. A skipped entry costs one prefill; a poisoned entry costs
correctness for every later turn.

## Validation

- New unit test reproduces the poison without a model: RotatingKVCache fed 12
  tokens stored under an 11-token key → previously **HIT with one extra token
  of state**, now MISS. Healthy path (offset == key) still stores and serves.
- **123 tests / 12 suites** pass with the guard: hybrid topologies
  (Nemotron-Omni Mamba layouts), DSV4 + Zaya disk round trips, TQ serializer,
  boundary derivation, growing-chat sources.

## Deployment note

Machines that ran disk L2 before this fix may hold poisoned entries — clear
the cache directory once after upgrading. Live proof on the affected machine
follows in a comment before merge.