### PR TITLE
Round-trip LFM2 short-conv prefix-cache state through disk and paged restore

### DIFF
--- a/Libraries/MLXLLM/Models/LFM2.swift
+++ b/Libraries/MLXLLM/Models/LFM2.swift
@@ -26,7 +26,10 @@ public struct LFM2Configuration: Codable, Sendable {
     private let _blockDim: Int?
     var blockDim: Int { _blockDim ?? hiddenSize }
     private let _blockFFDim: Int?
-    var blockFFDim: Int { _blockFFDim ?? hiddenSize }
+    private let _intermediateSize: Int?
+    // Stock LiquidAI / transformers-5 LFM2.5 configs carry only
+    // `intermediate_size`; `block_ff_dim` is the legacy LFM2 spelling.
+    var blockFFDim: Int { _blockFFDim ?? _intermediateSize ?? hiddenSize }
     let blockMultipleOf: Int
     let blockFFNDimMultiplier: Float
     let blockAutoAdjustFFDim: Bool
@@ -62,6 +65,7 @@ public struct LFM2Configuration: Codable, Sendable {
         case convLCache = "conv_L_cache"
         case _blockDim = "block_dim"
         case _blockFFDim = "block_ff_dim"
+        case _intermediateSize = "intermediate_size"
         case blockMultipleOf = "block_multiple_of"
         case blockFFNDimMultiplier = "block_ffn_dim_multiplier"
         case blockAutoAdjustFFDim = "block_auto_adjust_ff_dim"
@@ -88,6 +92,8 @@ public struct LFM2Configuration: Codable, Sendable {
         self.convLCache = try container.decodeIfPresent(Int.self, forKey: .convLCache) ?? 3
         self._blockDim = try container.decodeIfPresent(Int.self, forKey: ._blockDim)
         self._blockFFDim = try container.decodeIfPresent(Int.self, forKey: ._blockFFDim)
+        self._intermediateSize = try container.decodeIfPresent(
+            Int.self, forKey: ._intermediateSize)
         self.blockMultipleOf =
             try container.decodeIfPresent(Int.self, forKey: .blockMultipleOf) ?? 256
         self.blockFFNDimMultiplier =

--- a/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
@@ -591,24 +591,61 @@ public func restoreSSMStates(
     into cache: [any KVCache],
     boundary: Int? = nil
 ) {
+    // `extractSSMStates` emits each MambaCache's OCCUPIED slots: full Mamba
+    // layers (Nemotron-H, Jamba) contribute 2 arrays, LFM2/LFM2.5 short-conv
+    // layers contribute exactly 1 (slot 1 is never written). A fresh restore
+    // target has empty state, so the per-layer arity must be recovered from
+    // the list itself: every mamba layer in one companion list shares one
+    // arity, so the total length disambiguates. A list matching neither
+    // layout is refused outright — consuming a best-effort prefix cross-wired
+    // layer N with layer N+1's state and left the tail layers empty.
+    var totalWithTwoSlotMamba = 0
+    var totalWithOneSlotMamba = 0
+    for layer in cache {
+        if layer is MambaCache {
+            totalWithTwoSlotMamba += 2
+            totalWithOneSlotMamba += 1
+        } else if let arrays = layer as? ArraysCache {
+            totalWithTwoSlotMamba += arrays.slotCount
+            totalWithOneSlotMamba += arrays.slotCount
+        } else if let cacheList = layer as? CacheList {
+            for i in 0..<cacheList.count {
+                if cacheList[i] is MambaCache {
+                    totalWithTwoSlotMamba += 2
+                    totalWithOneSlotMamba += 1
+                } else if let arrays = cacheList[i] as? ArraysCache {
+                    totalWithTwoSlotMamba += arrays.slotCount
+                    totalWithOneSlotMamba += arrays.slotCount
+                }
+            }
+        }
+    }
+    let mambaArity: Int
+    if states.count == totalWithTwoSlotMamba {
+        mambaArity = 2
+    } else if states.count == totalWithOneSlotMamba {
+        mambaArity = 1
+    } else {
+        // Unknown companion layout (e.g. a stale entry from a run whose
+        // model layout has drifted). Restoring nothing is safe — the caller
+        // re-prefills; restoring a misaligned prefix is silent corruption.
+        return
+    }
+
     var stateIdx = 0
     for layer in cache {
         if let mamba = layer as? MambaCache {
-            let existingCount = mamba.state.count
-            if existingCount == 0 {
-                // Fresh cache — MambaCache always has 2 slots (conv + hidden)
-                let slotCount = 2
-                if stateIdx + slotCount <= states.count {
-                    mamba.state = Array(states[stateIdx..<(stateIdx + slotCount)])
+            if stateIdx + mambaArity <= states.count {
+                if mambaArity == 2 {
+                    mamba.state = Array(states[stateIdx..<(stateIdx + 2)])
                         .map { $0[.ellipsis] }
-                    if let boundary { mamba.offset = boundary }
-                    stateIdx += slotCount
+                } else {
+                    // Single-slot short-conv layout: keep the 2-slot
+                    // container geometry, occupy only slot 0.
+                    mamba[0] = states[stateIdx][.ellipsis]
                 }
-            } else if stateIdx + existingCount <= states.count {
-                mamba.state = Array(states[stateIdx..<(stateIdx + existingCount)])
-                    .map { $0[.ellipsis] }
                 if let boundary { mamba.offset = boundary }
-                stateIdx += existingCount
+                stateIdx += mambaArity
             }
         } else if let arrays = layer as? ArraysCache {
             // ArraysCache (GatedDeltaNet / linear-attention recurrence, e.g.
@@ -637,12 +674,15 @@ public func restoreSSMStates(
         } else if let cacheList = layer as? CacheList {
             for i in 0..<cacheList.count {
                 if let mamba = cacheList[i] as? MambaCache {
-                    let slotCount = 2
-                    if stateIdx + slotCount <= states.count {
-                        mamba.state = Array(states[stateIdx..<(stateIdx + slotCount)])
-                            .map { $0[.ellipsis] }
+                    if stateIdx + mambaArity <= states.count {
+                        if mambaArity == 2 {
+                            mamba.state = Array(states[stateIdx..<(stateIdx + 2)])
+                                .map { $0[.ellipsis] }
+                        } else {
+                            mamba[0] = states[stateIdx][.ellipsis]
+                        }
                         if let boundary { mamba.offset = boundary }
-                        stateIdx += slotCount
+                        stateIdx += mambaArity
                     }
                 } else if let arrays = cacheList[i] as? ArraysCache {
                     let slotCount = arrays.slotCount
@@ -1400,16 +1440,25 @@ private func restoreMambaLayer(
     _ comp: TQDiskSerializer.MambaLayerComponents,
     into layer: any KVCache
 ) {
-    if let mamba = layer as? MambaCache {
-        mamba.state = [comp.state0, comp.state1]
+    func apply(_ mamba: MambaCache) {
+        if let state1 = comp.state1 {
+            mamba.state = [comp.state0, state1]
+        } else {
+            // Single-slot layout (LFM2/LFM2.5 short-conv): restore into
+            // slot 0 via the subscript so the 2-slot container geometry is
+            // preserved and slot 1 stays genuinely empty.
+            mamba[0] = comp.state0
+        }
         mamba.offset = comp.offset
+    }
+    if let mamba = layer as? MambaCache {
+        apply(mamba)
         return
     }
     if let cacheList = layer as? CacheList {
         for i in 0..<cacheList.count {
             if let mamba = cacheList[i] as? MambaCache {
-                mamba.state = [comp.state0, comp.state1]
-                mamba.offset = comp.offset
+                apply(mamba)
                 return
             }
         }

--- a/Libraries/MLXLMCommon/Cache/TQDiskSerializer.swift
+++ b/Libraries/MLXLMCommon/Cache/TQDiskSerializer.swift
@@ -419,19 +419,27 @@ public enum TQDiskSerializer {
         }
     }
 
-    /// Serialize a single MambaCache layer's state (conv state + ssm state).
+    /// Serialize a single MambaCache layer's state. Full Mamba layers carry
+    /// two slots (conv state + hidden state); LFM2/LFM2.5 short-conv layers
+    /// occupy only slot 0, and dropping that single slot here (the old
+    /// `count >= 2` guard) meant every disk restore handed the model 22
+    /// zeroed conv windows while still reporting a KV hit.
     private static func serializeMambaLayer(
         _ mamba: MambaCache,
         index i: Int,
         into result: inout [String: MLXArray]
     ) {
         let state = mamba.state
-        guard state.count >= 2 else {
-            // Mamba layer with incomplete state — nothing to persist.
+        guard state.count >= 1 else {
+            // Pre-prefill layer with no state at all — nothing to persist.
+            // Deserialization treats a tagged mamba layer without state as
+            // an atomic required miss.
             return
         }
         result["mamba_\(i)_state0"] = state[0]
-        result["mamba_\(i)_state1"] = state[1]
+        if state.count >= 2 {
+            result["mamba_\(i)_state1"] = state[1]
+        }
         result["__mamba_\(i)_offset__"] = metaInt32(Int32(mamba.offset))
     }
 
@@ -516,9 +524,11 @@ public enum TQDiskSerializer {
 
             if let mamba = sub as? MambaCache {
                 let state = mamba.state
-                if state.count >= 2 {
+                if state.count >= 1 {
                     result["mamba_\(i)_sub_\(j)_state0"] = state[0]
-                    result["mamba_\(i)_sub_\(j)_state1"] = state[1]
+                    if state.count >= 2 {
+                        result["mamba_\(i)_sub_\(j)_state1"] = state[1]
+                    }
                     result["__mamba_\(i)_sub_\(j)_offset__"] =
                         metaInt32(Int32(mamba.offset))
                     result[subKindKey(layer: i, sub: j)] = kindArray(.mamba)
@@ -804,10 +814,14 @@ public enum TQDiskSerializer {
         public let values: MLXArray
     }
 
-    /// Mamba SSM state for a single hybrid layer.
+    /// Mamba SSM state for a single hybrid layer. `state1` is nil for
+    /// single-slot layouts: LFM2/LFM2.5 short-conv layers only ever occupy
+    /// slot 0 of their 2-slot `MambaCache` container
+    /// (`jang_runtime.cache.conv: "arrays_state_size_1"`), while full Mamba
+    /// layers (Nemotron-H, Jamba) persist both conv and hidden state.
     public struct MambaLayerComponents {
         public let state0: MLXArray
-        public let state1: MLXArray
+        public let state1: MLXArray?
         public let offset: Int
     }
 
@@ -1011,9 +1025,9 @@ public enum TQDiskSerializer {
                     out.append(IndexedLayerData(index: i, data: .skip))
                 }
             case .mamba:
-                if let s0 = arrays["mamba_\(i)_state0"],
-                   let s1 = arrays["mamba_\(i)_state1"]
-                {
+                if let s0 = arrays["mamba_\(i)_state0"] {
+                    // `state1` is optional: short-conv (LFM2/LFM2.5) layers
+                    // persist a single slot, full Mamba layers persist two.
                     let offset: Int
                     if let offArr = arrays["__mamba_\(i)_offset__"] {
                         offset = Int(readMetaInt32(offArr))
@@ -1026,14 +1040,19 @@ public enum TQDiskSerializer {
                             data: .mamba(
                                 MambaLayerComponents(
                                     state0: s0,
-                                    state1: s1,
+                                    state1: arrays["mamba_\(i)_state1"],
                                     offset: offset
                                 )
                             )
                         )
                     )
                 } else {
-                    out.append(IndexedLayerData(index: i, data: .skip))
+                    // A tagged mamba layer without persisted state cannot
+                    // degrade to a KV-only hit: recurrent prefix state is
+                    // required, so the whole entry is an atomic miss (this
+                    // also retires pre-fix entries that skipped short-conv
+                    // state while stamping the mamba kind tag).
+                    out.append(IndexedLayerData(index: i, data: .requiredMiss))
                 }
             case .qkv:
                 if let comp = deserializeQKVLayer(index: i, from: arrays) {
@@ -1323,9 +1342,7 @@ public enum TQDiskSerializer {
                     subs.append(.skip)
                 }
             case .mamba:
-                if let s0 = arrays["mamba_\(i)_sub_\(j)_state0"],
-                   let s1 = arrays["mamba_\(i)_sub_\(j)_state1"]
-                {
+                if let s0 = arrays["mamba_\(i)_sub_\(j)_state0"] {
                     let off: Int
                     if let oa = arrays["__mamba_\(i)_sub_\(j)_offset__"] {
                         off = Int(readMetaInt32(oa))
@@ -1333,7 +1350,11 @@ public enum TQDiskSerializer {
                         off = 0
                     }
                     subs.append(
-                        .mamba(MambaLayerComponents(state0: s0, state1: s1, offset: off)))
+                        .mamba(
+                            MambaLayerComponents(
+                                state0: s0,
+                                state1: arrays["mamba_\(i)_sub_\(j)_state1"],
+                                offset: off)))
                 } else {
                     subs.append(.skip)
                 }

--- a/Package.swift
+++ b/Package.swift
@@ -862,6 +862,8 @@ let package = Package(
                 "DSV4AgenticToolSourceTests.swift",
                 "NoHiddenReasoningCloseBiasFocusedTests.swift",
                 "TokenizerAddedTokenRegexFocusedTests.swift",
+                "LFM2ShortConvCacheRestoreFocusedTests.swift",
+                "LFM25ChatTemplateRenderFocusedTests.swift",
             ]
         ),
         .testTarget(

--- a/Tests/MLXLMCommonFocusedTests/LFM25ChatTemplateRenderFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/LFM25ChatTemplateRenderFocusedTests.swift
@@ -1,0 +1,252 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import MLXLMCommon
+import Testing
+import VMLXJinja
+
+/// Renders the exact LFM2.5-2.6B bundle chat template (identical bytes in
+/// the JANG_6M and MXFP8 bundles, and in upstream LiquidAI's release) and
+/// pins the constructs the runtime depends on:
+///
+/// - `add_generation_prompt` ALWAYS ends the prompt inside an open
+///   `<think>` block — this model has no `enable_thinking` knob, so the
+///   reasoning parser must start in-reasoning from the prompt tail;
+/// - assistant tool calls render as the Pythonic
+///   `<|tool_call_start|>[fn(a='x')]<|tool_call_end|>` envelope that
+///   `LFM2ToolCallParser` parses back;
+/// - prior-turn `<think>` bodies are stripped from history before the last
+///   user turn (`preserve_thinking` defaults false via `| default(false)`);
+/// - the `{% generation %}`/`{% endgeneration %}` tags, `.get()`,
+///   `.endswith()`, `.split()[-1]`, and slice constructs all execute.
+@Suite("LFM2.5-2.6B chat template render")
+struct LFM25ChatTemplateRenderFocusedTests {
+
+    static let lfm25Template = #"""
+        {{- bos_token -}}
+        {%- set preserve_thinking = preserve_thinking | default(false) -%}
+
+        {%- macro format_arg_value(arg_value) -%}
+            {%- if arg_value is string -%}
+                {{- "'" + (arg_value | replace("\\", "\\\\") | replace("'", "\\'") | replace("\n", "\\n") | replace("\r", "\\r")) + "'" -}}
+            {%- elif arg_value is mapping or arg_value is iterable -%}
+                {{- arg_value | tojson -}}
+            {%- else -%}
+                {{- arg_value | string -}}
+            {%- endif -%}
+        {%- endmacro -%}
+
+        {%- macro parse_content(content) -%}
+            {%- if content is string -%}
+                {{- content -}}
+            {%- elif content is mapping -%}
+                {{- content | tojson -}}
+            {%- elif content is iterable -%}
+                {%- set _ns = namespace(result="") -%}
+                {%- for item in content -%}
+                    {%- if item is string -%}
+                        {%- set _ns.result = _ns.result + item -%}
+                    {%- elif item is mapping and item.get("type") == "image" -%}
+                        {%- set _ns.result = _ns.result + "<image>" -%}
+                    {%- elif item is mapping and item.get("type") == "text" -%}
+                        {%- set _ns.result = _ns.result + ((item.get("text") or "") | string) -%}
+                    {%- else -%}
+                        {%- set _ns.result = _ns.result + (item | tojson) -%}
+                    {%- endif -%}
+                {%- endfor -%}
+                {{- _ns.result -}}
+            {%- endif -%}
+        {%- endmacro -%}
+
+        {%- macro render_tool_calls(tool_calls) -%}
+            {%- set tool_calls_ns = namespace(tool_calls=[]) -%}
+            {%- for tool_call in tool_calls -%}
+                {%- set func = tool_call["function"] if "function" in tool_call else tool_call -%}
+                {%- set func_name = func["name"] -%}
+                {%- set func_args = func.get("arguments") -%}
+                {%- set args_ns = namespace(arg_strings=[]) -%}
+                {%- if func_args is mapping -%}
+                    {%- for arg_name, arg_value in func_args.items() -%}
+                        {%- set args_ns.arg_strings = args_ns.arg_strings + [arg_name + "=" + format_arg_value(arg_value)] -%}
+                    {%- endfor -%}
+                {%- elif func_args is string and (func_args | trim) not in ["", "{}", "null"] -%}
+                    {{- raise_exception("Tool call arguments must be a mapping, got a JSON-encoded string: parse arguments with json.loads() before applying the chat template") -}}
+                {%- endif -%}
+                {%- set tool_calls_ns.tool_calls = tool_calls_ns.tool_calls + [func_name + "(" + (args_ns.arg_strings | join(", ")) + ")"] -%}
+            {%- endfor -%}
+            {{- "<|tool_call_start|>[" + (tool_calls_ns.tool_calls | join(", ")) + "]<|tool_call_end|>" -}}
+        {%- endmacro -%}
+
+        {%- set ns = namespace(system_prompt="", last_user_index=-1) -%}
+        {%- if messages and messages[0]["role"] == "system" -%}
+            {%- if messages[0].get("content") -%}
+                {%- set ns.system_prompt = parse_content(messages[0]["content"]) -%}
+            {%- endif -%}
+            {%- set messages = messages[1:] -%}
+        {%- endif -%}
+        {%- if tools -%}
+            {%- set ns.system_prompt = ns.system_prompt + ("\n" if ns.system_prompt else "") + "List of tools: [" -%}
+            {%- for tool in tools -%}
+                {%- if tool is not string -%}
+                    {%- set tool = tool | tojson -%}
+                {%- endif -%}
+                {%- set ns.system_prompt = ns.system_prompt + tool -%}
+                {%- if not loop.last -%}
+                    {%- set ns.system_prompt = ns.system_prompt + ", " -%}
+                {%- endif -%}
+            {%- endfor -%}
+            {%- set ns.system_prompt = ns.system_prompt + "]" -%}
+        {%- endif -%}
+        {%- if ns.system_prompt -%}
+            {{- "<|im_start|>system\n" + ns.system_prompt + "<|im_end|>\n" -}}
+        {%- endif -%}
+        {%- for message in messages -%}
+            {%- if message["role"] == "user" -%}
+                {%- set ns.last_user_index = loop.index0 -%}
+            {%- endif -%}
+        {%- endfor -%}
+        {%- for message in messages -%}
+            {{- "<|im_start|>" + message.role + "\n" -}}
+            {%- if message.role == "assistant" -%}
+                {%- generation -%}
+                {%- set keep_thinking = preserve_thinking or loop.index0 > ns.last_user_index -%}
+                {%- set thinking = message.thinking or message.reasoning or message.reasoning_content -%}
+                {%- set thinking = thinking if thinking is string else "" -%}
+                {%- if thinking and keep_thinking -%}
+                    {{- "<think>" + thinking + "</think>" -}}
+                {%- endif -%}
+                {%- set _cfm_tag = "CONTINUE_FINAL_MESSAGE_TAG " -%}
+                {%- set _has_cfm = false -%}
+                {%- set content = "" -%}
+                {%- if message.get("content") -%}
+                    {%- set content = parse_content(message.content) -%}
+                {%- endif -%}
+                {%- if not keep_thinking and "</think>" in content -%}
+                    {%- set content = content.split("</think>")[-1] | trim -%}
+                {%- endif -%}
+                {%- if content.endswith(_cfm_tag) -%}
+                    {%- set _has_cfm = true -%}
+                    {%- set _trunc_len = (content | length) - (_cfm_tag | length) -%}
+                    {%- set content = content[:_trunc_len] -%}
+                {%- endif -%}
+                {{- content -}}
+                {%- if message.tool_calls -%}
+                    {{- render_tool_calls(message.tool_calls) -}}
+                {%- endif -%}
+                {%- if _has_cfm -%}
+                    {{- _cfm_tag -}}
+                {%- endif -%}
+                {{- "<|im_end|>\n" -}}
+                {%- endgeneration -%}
+            {%- else %}
+                {%- if message.get("content") -%}
+                    {{- parse_content(message["content"]) -}}
+                {%- endif -%}
+                {{- "<|im_end|>\n" -}}
+            {%- endif %}
+        {%- endfor -%}
+        {%- if add_generation_prompt -%}
+            {{- "<|im_start|>assistant\n<think>" -}}
+        {%- endif -%}
+        """#
+
+    private func render(_ context: [String: any Sendable]) throws -> String {
+        let template = try Template(Self.lfm25Template)
+        var values: [String: Value] = [:]
+        for (key, value) in context {
+            values[key] = try Value(any: value)
+        }
+        if values["bos_token"] == nil {
+            values["bos_token"] = try Value(any: "<|startoftext|>")
+        }
+        return try template.render(values)
+    }
+
+    @Test("generation prompt always ends inside an open think block")
+    func generationPromptOpensThink() throws {
+        let out = try render([
+            "messages": [
+                ["role": "system", "content": "You are helpful."],
+                ["role": "user", "content": "Hi"],
+            ],
+            "add_generation_prompt": true,
+        ])
+        #expect(out.hasPrefix("<|startoftext|><|im_start|>system\nYou are helpful.<|im_end|>\n"))
+        #expect(out.hasSuffix("<|im_start|>user\nHi<|im_end|>\n<|im_start|>assistant\n<think>"))
+    }
+
+    @Test("tools land in the system prompt as a JSON tool list")
+    func toolsRenderIntoSystemPrompt() throws {
+        let out = try render([
+            "messages": [["role": "user", "content": "What time is it?"]],
+            "tools": [
+                [
+                    "type": "function",
+                    "function": [
+                        "name": "get_current_time",
+                        "parameters": ["type": "object", "properties": [String: any Sendable]()]
+                            as [String: any Sendable],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable]
+            ],
+            "add_generation_prompt": true,
+        ])
+        #expect(out.contains("<|im_start|>system\nList of tools: ["))
+        #expect(out.contains("get_current_time"))
+        #expect(out.hasSuffix("<|im_start|>assistant\n<think>"))
+    }
+
+    @Test("assistant tool calls round-trip through the Pythonic envelope")
+    func assistantToolCallsRenderPythonic() throws {
+        let out = try render([
+            "messages": [
+                ["role": "user", "content": "Weather in Paris then Tokyo"],
+                [
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        [
+                            "function": [
+                                "name": "get_weather",
+                                "arguments": ["city": "Paris"],
+                            ] as [String: any Sendable]
+                        ] as [String: any Sendable]
+                    ],
+                ] as [String: any Sendable],
+                ["role": "tool", "content": "18C sunny"],
+                ["role": "user", "content": "And Tokyo?"],
+            ],
+            "add_generation_prompt": true,
+        ])
+        #expect(out.contains("<|tool_call_start|>[get_weather(city='Paris')]<|tool_call_end|>"))
+        #expect(out.hasSuffix("<|im_start|>assistant\n<think>"))
+
+        // The rendered envelope must be exactly what LFM2ToolCallParser
+        // accepts back — the round-trip contract for multiturn tool history.
+        let parser = LFM2ToolCallParser()
+        let calls = parser.parseEOS(
+            "<|tool_call_start|>[get_weather(city='Paris')]<|tool_call_end|>",
+            tools: nil)
+        #expect(calls.count == 1)
+        #expect(calls.first?.function.name == "get_weather")
+    }
+
+    @Test("history thinking is stripped before the last user turn by default")
+    func historyThinkingStripped() throws {
+        let out = try render([
+            "messages": [
+                ["role": "user", "content": "First question"],
+                [
+                    "role": "assistant",
+                    "content": "secret deliberation</think>The answer is 4.",
+                ],
+                ["role": "user", "content": "Second question"],
+            ],
+            "add_generation_prompt": true,
+        ])
+        #expect(!out.contains("secret deliberation"))
+        #expect(out.contains("<|im_start|>assistant\nThe answer is 4.<|im_end|>\n"))
+        #expect(out.hasSuffix("<|im_start|>user\nSecond question<|im_end|>\n<|im_start|>assistant\n<think>"))
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/LFM2ShortConvCacheRestoreFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/LFM2ShortConvCacheRestoreFocusedTests.swift
@@ -1,0 +1,258 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import MLX
+@testable import MLXLLM
+@testable import MLXLMCommon
+import Testing
+
+/// LFM2 / LFM2.5 short-conv layers use `MambaCache` (a fixed 2-slot
+/// `ArraysCache`) but only ever write slot 0 — `state.count == 1` after
+/// prefill (`jang_runtime.cache.conv: "arrays_state_size_1"`). Both cache
+/// persistence rails must round-trip that single-slot state exactly:
+///
+/// - the v2 disk payload (`TQDiskSerializer`) must persist and restore the
+///   one conv slot instead of silently skipping the layer, and an entry
+///   whose mamba layer has no state must be an atomic required miss rather
+///   than a KV-only "hit" that hands the model 22 empty conv windows;
+/// - the paged/L1 companion rail (`restoreSSMStates`) must consume ONE
+///   array per short-conv layer for a 1-per-layer companion list instead
+///   of assuming the full-Mamba 2-slot layout, which cross-wired layer N
+///   with layer N+1's state and left the tail layers empty.
+@Suite("LFM2 short-conv cache restore", .serialized)
+struct LFM2ShortConvCacheRestoreFocusedTests {
+
+    /// Build an LFM2-style short-conv cache: 2-slot MambaCache with only
+    /// slot 0 occupied (the conv window), never slot 1.
+    private func shortConvCache(fill: Float, offset: Int) -> MambaCache {
+        let mamba = MambaCache()
+        mamba[0] = MLXArray.full([1, 2, 8], values: MLXArray(fill))
+        mamba.offset = offset
+        return mamba
+    }
+
+    private func prefilledKV(tokens: Int) -> KVCacheSimple {
+        let kv = KVCacheSimple()
+        let keys = MLXArray.full([1, 2, tokens, 4], values: MLXArray(Float(0.5)))
+        let values = MLXArray.full([1, 2, tokens, 4], values: MLXArray(Float(0.25)))
+        _ = kv.update(keys: keys, values: values)
+        return kv
+    }
+
+    @Test("v2 disk payload round-trips a single-slot short-conv layer")
+    func diskRoundTripSingleSlotConv() {
+        FocusedMLXTestSupport.withLock {
+            let source: [any KVCache] = [
+                prefilledKV(tokens: 6),
+                shortConvCache(fill: 3.5, offset: 6),
+            ]
+            let arrays = TQDiskSerializer.serialize(cache: source)
+
+            var target: [any KVCache] = [KVCacheSimple(), MambaCache()]
+            let restored = restoreFromDiskArrays(arrays, into: &target)
+
+            #expect(restored == 6)
+            guard let mamba = target[1] as? MambaCache else {
+                Issue.record("restore target lost its MambaCache layer")
+                return
+            }
+            #expect(mamba.offset == 6)
+            #expect(mamba.state.count == 1)
+            if let conv = mamba[0] {
+                #expect(conv.shape == [1, 2, 8])
+                #expect(abs(conv.mean().item(Float.self) - 3.5) < 1e-6)
+            } else {
+                Issue.record("conv slot 0 was not restored from the v2 payload")
+            }
+            // Slot 1 is genuinely absent for short-conv layers and must
+            // stay empty rather than aliasing another layer's tensor.
+            #expect(mamba[1] == nil)
+        }
+    }
+
+    @Test("v2 disk payload still round-trips the full two-slot Mamba layout")
+    func diskRoundTripTwoSlotMamba() {
+        FocusedMLXTestSupport.withLock {
+            let full = MambaCache()
+            full[0] = MLXArray.full([1, 2, 8], values: MLXArray(Float(1.5)))
+            full[1] = MLXArray.full([1, 4, 4], values: MLXArray(Float(2.5)))
+            full.offset = 9
+            let source: [any KVCache] = [prefilledKV(tokens: 9), full]
+            let arrays = TQDiskSerializer.serialize(cache: source)
+
+            var target: [any KVCache] = [KVCacheSimple(), MambaCache()]
+            let restored = restoreFromDiskArrays(arrays, into: &target)
+
+            #expect(restored == 9)
+            guard let mamba = target[1] as? MambaCache else {
+                Issue.record("restore target lost its MambaCache layer")
+                return
+            }
+            #expect(mamba.offset == 9)
+            #expect(mamba.state.count == 2)
+            if mamba.state.count == 2 {
+                #expect(abs(mamba.state[0].mean().item(Float.self) - 1.5) < 1e-6)
+                #expect(abs(mamba.state[1].mean().item(Float.self) - 2.5) < 1e-6)
+            }
+        }
+    }
+
+    @Test("mamba layer with no persisted state is an atomic required miss")
+    func statelessMambaLayerIsRequiredMiss() {
+        FocusedMLXTestSupport.withLock {
+            // Reproduce a pre-fix stored entry: the serializer stamped the
+            // .mamba kind tag but persisted no state for the layer. Restoring
+            // such an entry as a KV-only hit hands the model empty conv
+            // windows for the restored prefix — it must be a full miss.
+            let source: [any KVCache] = [
+                prefilledKV(tokens: 6),
+                shortConvCache(fill: 3.5, offset: 6),
+            ]
+            var arrays = TQDiskSerializer.serialize(cache: source)
+            for key in Array(arrays.keys)
+            where key.contains("mamba_1_state") || key.contains("__mamba_1_offset__") {
+                arrays.removeValue(forKey: key)
+            }
+
+            var target: [any KVCache] = [KVCacheSimple(), MambaCache()]
+            let restored = restoreFromDiskArrays(arrays, into: &target)
+
+            #expect(restored == 0)
+            if let mamba = target[1] as? MambaCache {
+                #expect(mamba.state.isEmpty)
+            }
+        }
+    }
+
+    @Test("companion restore consumes one array per short-conv layer")
+    func companionRestoreSingleSlotAlignment() {
+        FocusedMLXTestSupport.withLock {
+            // Two LFM2-style layers, each contributing exactly one conv
+            // state to the companion list (extractSSMStates order).
+            let sourceA = shortConvCache(fill: 10, offset: 5)
+            let sourceB = shortConvCache(fill: 20, offset: 5)
+            let states = extractSSMStates(from: [sourceA, sourceB])
+            #expect(states.count == 2)
+
+            let freshA = MambaCache()
+            let freshB = MambaCache()
+            restoreSSMStates(states, into: [freshA, freshB], boundary: 5)
+
+            #expect(freshA.offset == 5)
+            #expect(freshB.offset == 5)
+            if let a = freshA[0], let b = freshB[0] {
+                #expect(abs(a.mean().item(Float.self) - 10) < 1e-6)
+                #expect(abs(b.mean().item(Float.self) - 20) < 1e-6)
+            } else {
+                Issue.record("companion restore left short-conv slot 0 empty")
+            }
+            #expect(freshA[1] == nil)
+            #expect(freshB[1] == nil)
+        }
+    }
+
+    @Test("companion restore keeps the full-Mamba two-slot layout")
+    func companionRestoreTwoSlotAlignment() {
+        FocusedMLXTestSupport.withLock {
+            let full = MambaCache()
+            full[0] = MLXArray.full([1, 2, 8], values: MLXArray(Float(1)))
+            full[1] = MLXArray.full([1, 4, 4], values: MLXArray(Float(2)))
+            full.offset = 7
+            let second = MambaCache()
+            second[0] = MLXArray.full([1, 2, 8], values: MLXArray(Float(3)))
+            second[1] = MLXArray.full([1, 4, 4], values: MLXArray(Float(4)))
+            second.offset = 7
+            let states = extractSSMStates(from: [full, second])
+            #expect(states.count == 4)
+
+            let freshA = MambaCache()
+            let freshB = MambaCache()
+            restoreSSMStates(states, into: [freshA, freshB], boundary: 7)
+
+            #expect(freshA.state.count == 2)
+            #expect(freshB.state.count == 2)
+            if freshA.state.count == 2, freshB.state.count == 2 {
+                #expect(abs(freshA.state[0].mean().item(Float.self) - 1) < 1e-6)
+                #expect(abs(freshA.state[1].mean().item(Float.self) - 2) < 1e-6)
+                #expect(abs(freshB.state[0].mean().item(Float.self) - 3) < 1e-6)
+                #expect(abs(freshB.state[1].mean().item(Float.self) - 4) < 1e-6)
+            }
+        }
+    }
+
+    @Test("companion restore refuses a companion list with unknown arity")
+    func companionRestoreRefusesMismatchedTotals() {
+        FocusedMLXTestSupport.withLock {
+            // 3 arrays for 2 mamba layers matches neither 1-per-layer nor
+            // 2-per-layer. Restoring a best-effort prefix would cross-wire
+            // layers; the whole list must be refused (caller re-prefills).
+            let states = [
+                MLXArray.full([1, 2, 8], values: MLXArray(Float(1))),
+                MLXArray.full([1, 2, 8], values: MLXArray(Float(2))),
+                MLXArray.full([1, 2, 8], values: MLXArray(Float(3))),
+            ]
+            let freshA = MambaCache()
+            let freshB = MambaCache()
+            restoreSSMStates(states, into: [freshA, freshB], boundary: 4)
+
+            #expect(freshA.state.isEmpty)
+            #expect(freshB.state.isEmpty)
+            #expect(freshA.offset == 0)
+            #expect(freshB.offset == 0)
+        }
+    }
+
+    @Test("mixed KV + GatedDeltaNet companion restore is unchanged")
+    func companionRestoreArraysCacheUnchanged() {
+        FocusedMLXTestSupport.withLock {
+            // qwen3.5/ornith-style layer list: attention + ArraysCache with
+            // every slot occupied. The slotCount-driven consumption must not
+            // regress while the mamba arity logic changes around it.
+            let gdn = ArraysCache(size: 2)
+            gdn[0] = MLXArray.full([1, 2, 4], values: MLXArray(Float(6)))
+            gdn[1] = MLXArray.full([1, 3, 3], values: MLXArray(Float(7)))
+            gdn.offset = 11
+            let states = extractSSMStates(from: [KVCacheSimple(), gdn])
+            #expect(states.count == 2)
+
+            let fresh = ArraysCache(size: 2)
+            restoreSSMStates(states, into: [KVCacheSimple(), fresh], boundary: 11)
+
+            #expect(fresh.state.count == 2)
+            if fresh.state.count == 2 {
+                #expect(abs(fresh.state[0].mean().item(Float.self) - 6) < 1e-6)
+                #expect(abs(fresh.state[1].mean().item(Float.self) - 7) < 1e-6)
+            }
+            #expect(fresh.offset == 11)
+        }
+    }
+
+    @Test("LFM2 configuration honors intermediate_size without block_ff_dim")
+    func lfm2ConfigIntermediateSizeFallback() {
+        // Stock LiquidAI / transformers-5 LFM2.5 configs carry only
+        // `intermediate_size`; the JANG converter injects `block_ff_dim`.
+        // Both spellings must produce the same FFN width.
+        let json = """
+            {
+              "hidden_size": 2048,
+              "num_hidden_layers": 2,
+              "num_attention_heads": 32,
+              "num_key_value_heads": 8,
+              "intermediate_size": 10752,
+              "vocab_size": 128000,
+              "layer_types": ["conv", "full_attention"],
+              "conv_L_cache": 3,
+              "block_auto_adjust_ff_dim": false,
+              "norm_eps": 1e-5,
+              "rope_theta": 10000000.0
+            }
+            """.data(using: .utf8)!
+        do {
+            let config = try JSONDecoder().decode(LFM2Configuration.self, from: json)
+            #expect(config.blockFFDim == 10752)
+        } catch {
+            Issue.record("LFM2Configuration failed to decode: \(error)")
+        }
+    }
+}

--- a/Tests/MLXLMTests/ReasoningStampFromModelTypeTests.swift
+++ b/Tests/MLXLMTests/ReasoningStampFromModelTypeTests.swift
@@ -264,4 +264,50 @@ final class ReasoningStampFromModelTypeTests: XCTestCase {
         XCTAssertNil(parser,
             "LFM2 must get a nil reasoning parser — any parser that starts in reasoning mode would leak chunks")
     }
+
+    // MARK: - LFM2.5-2.6B (always-thinking dense lfm2 bundle)
+
+    /// LFM2.5-2.6B ships `model_type: "lfm2"` with a JANG capabilities
+    /// stamp of `reasoning_parser: "qwen3"`, `tool_parser: "lfm2"`, and
+    /// `think_in_template: true` — its template unconditionally ends the
+    /// generation prompt with `<|im_start|>assistant\n<think>`. The stamp
+    /// must be honored (NOT demoted the way a `think_in_template: false`
+    /// lfm2 stamp is), the prompt-tail resolution must start the parser
+    /// inside the template-opened think block, and the tool stamp must
+    /// route to the Pythonic LFM2 envelope parser.
+    func testLFM25DenseAlwaysThinkingStampIsHonored() throws {
+        let capabilities = JangCapabilities(
+            reasoningParser: "qwen3",
+            toolParser: "lfm2",
+            thinkInTemplate: true,
+            supportsTools: true,
+            supportsThinking: true,
+            family: "lfm2",
+            cacheType: "hybrid")
+
+        XCTAssertFalse(
+            ParserResolution.shouldIgnoreReasoningStamp(
+                capabilities: capabilities,
+                modelType: "lfm2"),
+            "think_in_template=true must keep the qwen3 reasoning stamp for dense lfm2")
+
+        let resolved = ParserResolution.reasoning(
+            capabilities: capabilities,
+            modelType: "lfm2",
+            chatTemplate: nil)
+        XCTAssertNotNil(resolved.parser)
+        XCTAssertEqual(resolved.source, .jangStamped)
+
+        // The template opens the think block itself; generation starts
+        // INSIDE reasoning with no opening tag in the stream.
+        var parser = try XCTUnwrap(
+            ReasoningParser.forPrompt(
+                stampName: "qwen3",
+                promptTail: "<|im_start|>user\nHi<|im_end|>\n<|im_start|>assistant\n<think>"))
+        let segments = parser.feed("planning the reply</think>Hello!") + parser.flush()
+        XCTAssertEqual(collect(segments).reasoning, "planning the reply")
+        XCTAssertEqual(collect(segments).content, "Hello!")
+
+        XCTAssertEqual(ToolCallFormat.fromCapabilityName("lfm2"), .lfm2)
+    }
 }


### PR DESCRIPTION
LFM2/LFM2.5 short-conv layers keep their conv window in slot 0 of a 2-slot `MambaCache` and never write slot 1 (`jang_runtime.cache.conv: "arrays_state_size_1"`). Both prefix-cache rails mishandled that layout, which matters now that LFM2.5-2.6B (JANG_6M / MXFP8) is a first-class hybrid bundle:

## Disk-L2 (v2 payload)
- `TQDiskSerializer.serializeMambaLayer` dropped any `MambaCache` with `state.count < 2` while still stamping the `.mamba` kind tag. Every disk restore of an LFM2.5 chat therefore reported a KV hit with all 22 short-conv windows zeroed — the first decode steps after a warm restore ran on wrong recurrent state in 22 of 30 layers.
- Now the single occupied slot is persisted (`state1` optional; full 2-slot Mamba unchanged), and a tagged mamba layer with **no** persisted state deserializes as an atomic `requiredMiss` — KV-only pseudo-hits (including entries stored before this fix) become honest misses that re-prefill and re-store in the fixed format.
- The CacheList sub-layer path gets the same single-slot round-trip.

## Paged/L1 companion rail
- `restoreSSMStates` hard-coded 2 consumed arrays per fresh `MambaCache`, but `extractSSMStates` emits **occupied** slots — 1 per short-conv layer. A paged warm restore cross-wired layer N with layer N+1's state and left the tail layers empty (reproduced verbatim in the new tests: layer B's state landed in layer A's slot 1).
- The per-layer arity is now recovered from the companion list total (uniform 1-slot vs 2-slot layouts disambiguate by length), single-slot layers restore into slot 0 of the preserved 2-slot container, and a list matching neither layout is refused outright (fail-closed re-prefill instead of silent corruption). GatedDeltaNet (`ArraysCache`) and full-Mamba (Nemotron-H/Jamba) consumption is unchanged and covered by regression tests.

## Config
- `LFM2Configuration` falls back to `intermediate_size` when `block_ff_dim` is absent. Stock LiquidAI / transformers-5 LFM2.5 configs ship only `intermediate_size`; without the JANG converter's injected `block_ff_dim` the FFN silently built at `hidden_size`.

## Pinned contracts (new tests)
- `LFM2ShortConvCacheRestoreFocusedTests` — all six cache behaviors above, red before the fix, green after.
- `LFM25ChatTemplateRenderFocusedTests` — renders the exact LFM2.5-2.6B bundle template (`{% generation %}`, `.get`/`.endswith`/`.split[-1]`/slicing, macros, namespace) byte-correct: unconditional `<|im_start|>assistant\n<think>` generation prompt, Pythonic `<|tool_call_start|>[fn(a='x')]<|tool_call_end|>` envelope that round-trips through `LFM2ToolCallParser`, history-thinking stripping before the last user turn.
- `ReasoningStampFromModelTypeTests.testLFM25DenseAlwaysThinkingStampIsHonored` — the dense-lfm2 `think_in_template: true` stamp keeps the qwen3 reasoning parser (not demoted like the `false` case), `forPrompt` starts inside the template-opened think block, and `tool_parser: "lfm2"` routes to the Pythonic envelope parser.

## Verification
- New suites red on main (5 failing tests reproducing all three bugs, including the literal cross-layer scramble), green after the fix.
- Regression sweep green: CacheCoordinatorTopologyFocusedTests, DiskStoreOffsetConsistencyFocusedTests, CanonicalChatCacheBoundariesTests, BatchEngineGrowingChatCacheSourceTests, MambaCacheCompileProbeTests, MultiTurnFamilyMatrixTests, ToolCallProcessorFuzzTests, LFM2MoESanitizeTests, ReasoningStampFromModelTypeTests — 118 tests, 0 failures.