### PR TITLE
Honor DSV4's thinking default, publish warmup disk seeds, align boundary keys

### DIFF
--- a/Libraries/MLXLLM/Models/DeepseekV4Compressor.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV4Compressor.swift
@@ -285,6 +285,12 @@ private final class DeepseekV4PoolStorage {
 // entirely (Python mirror: `if v4_cache is None and L < compress_ratio
 // → skip`).
 public final class DeepseekV4Cache: QuantizedHybridPoolCache, CacheRetainedByteCountProviding {
+    /// Bit width the pool storage encodes with. The disk serializer's
+    /// quantized-pool schema accepts exactly this width — pinned by
+    /// `DeepseekV4CacheDiskRoundTripTests.serializerBitsMatchPoolStorage`
+    /// so neither constant can drift alone.
+    public static var poolQuantizationBits: Int { DeepseekV4PoolStorage.bits }
+
     /// Expose the inner rotating cache so `TQDiskSerializer` and
     /// `restoreRotatingLayer` can round-trip the sliding-window state.
     /// Compressor/Indexer pool tensors and their incomplete-window

--- a/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
@@ -758,9 +758,18 @@ private func restoreFromV2Arrays(
             if case .deepseekV4 = entry.data { return 0 }
             if case .zayaCCA = entry.data { return 0 }
             if case .zayaCCATQ = entry.data { return 0 }
+            if case .qkv = entry.data { return 0 }
             continue
         }
         switch entry.data {
+        case .qkv(let comp):
+            // Quantized-KV layers share the atomic contract: a record whose
+            // group size / bit width no longer matches the runtime cache (or
+            // whose layer class drifted) must refuse BEFORE any live layer is
+            // seated. The apply loop below seeds `totalTokens` from sibling
+            // layers, so skipping just this layer would report a "hit" that
+            // leaves it empty.
+            guard canRestoreQKVLayer(comp, into: cache[entry.index]) else { return 0 }
         case .deepseekV4(let comp):
             let staged = cache[entry.index].copy()
             guard canRestoreDeepseekV4Layer(comp, into: staged),
@@ -856,7 +865,14 @@ private func restoreFromV2Arrays(
             // shapes won't line up). A fresh request starts from
             // KVCacheSimple, so materialize the quantized layer from the
             // disk payload before reporting a hit.
-            guard restoreQKVLayer(comp, into: &cache[i]) else { continue }
+            //
+            // A failed seat (group-size/bits mismatch or drifted layer
+            // class) must refuse the WHOLE record: `totalTokens` is seeded
+            // from sibling layers, so skipping just this layer reported a
+            // "hit" that left it empty — silent attention corruption for
+            // the restored prefix. Same atomic contract as .deepseekV4 /
+            // .zayaCCA below.
+            guard restoreQKVLayer(comp, into: &cache[i]) else { return 0 }
             if totalTokens == 0 {
                 totalTokens = comp.offset
             }
@@ -1133,6 +1149,28 @@ private func restoreKVLayer(
 /// touching state — a mismatch means the model was reconfigured since the
 /// disk entry was written and the qweight shapes will not align, so the
 /// only safe behavior is to no-op and let the caller re-prefill.
+/// Non-mutating twin of `restoreQKVLayer` used by the atomic pre-validation
+/// pass: mirrors exactly the conditions under which the restore would fail,
+/// without seating any state.
+private func canRestoreQKVLayer(
+    _ comp: TQDiskSerializer.QKVLayerComponents,
+    into layer: any KVCache
+) -> Bool {
+    if let qkv = layer as? QuantizedKVCache {
+        return qkv.groupSize == comp.groupSize && qkv.bits == comp.bits
+    }
+    if layer is KVCacheSimple { return true }
+    if let cacheList = layer as? CacheList {
+        for i in 0..<cacheList.count {
+            if let qkv = cacheList[i] as? QuantizedKVCache {
+                return qkv.groupSize == comp.groupSize && qkv.bits == comp.bits
+            }
+            if cacheList[i] is KVCacheSimple { return true }
+        }
+    }
+    return false
+}
+
 private func restoreQKVLayer(
     _ comp: TQDiskSerializer.QKVLayerComponents,
     into layer: inout any KVCache

--- a/Libraries/MLXLMCommon/Cache/TQDiskSerializer.swift
+++ b/Libraries/MLXLMCommon/Cache/TQDiskSerializer.swift
@@ -658,6 +658,19 @@ public enum TQDiskSerializer {
             }
         }
 
+        // A pool with zero rows is the legitimate "no compressed windows
+        // yet" state (prompt shorter than one compress window). Its
+        // canonical on-disk form is ABSENCE — the restore validator
+        // accepts a nil pool and leaves the branch empty. Writing the
+        // zero-row tensor instead produced a record the validator could
+        // never accept, so every short-prompt DSV4 checkpoint stored a
+        // permanently unrestorable entry (observed as the same prompt
+        // cold-prefilling again next session).
+        func normalizedPool(_ pool: MLXArray?) -> MLXArray? {
+            guard let pool, pool.ndim == 3, pool.dim(1) > 0 else { return nil }
+            return pool
+        }
+
         func putQuantizedPool(
             _ stem: String,
             _ segments: [HybridPoolQuantizedSegment]
@@ -682,16 +695,28 @@ public enum TQDiskSerializer {
             return true
         }
 
+        // On a quantized-pool serialization failure (unsupported bit width
+        // or malformed segment), the layer must poison the record as an
+        // atomic miss — stamping `.skip` let sibling .deepseekV4 layers
+        // restore while this one stayed empty (the all-or-nothing
+        // validation only covers layers tagged .deepseekV4). A tagged
+        // DSV4 layer without its keys deserializes as `.requiredMiss`.
+        func poisonAsRequiredMiss() {
+            result.removeValue(forKey: "dsv4_\(i)_keys")
+            result.removeValue(forKey: "dsv4_\(i)_values")
+            result[kindKey(for: i)] = kindArray(.deepseekV4)
+        }
+
         if let quantized = dsv4 as? QuantizedHybridPoolCache,
            let segments = quantized.hybridPoolQuantizedSegments(branch: .compressor)
         {
             putOptional("dsv4_\(i)_pool_comp", nil)
             guard putQuantizedPool("dsv4_\(i)_pool_comp", segments) else {
-                result[kindKey(for: i)] = kindArray(.skip)
+                poisonAsRequiredMiss()
                 return
             }
         } else {
-            putOptional("dsv4_\(i)_pool_comp", dsv4.hybridPool(branch: .compressor))
+            putOptional("dsv4_\(i)_pool_comp", normalizedPool(dsv4.hybridPool(branch: .compressor)))
         }
 
         if let quantized = dsv4 as? QuantizedHybridPoolCache,
@@ -699,11 +724,11 @@ public enum TQDiskSerializer {
         {
             putOptional("dsv4_\(i)_pool_idx", nil)
             guard putQuantizedPool("dsv4_\(i)_pool_idx", segments) else {
-                result[kindKey(for: i)] = kindArray(.skip)
+                poisonAsRequiredMiss()
                 return
             }
         } else {
-            putOptional("dsv4_\(i)_pool_idx", dsv4.hybridPool(branch: .indexer))
+            putOptional("dsv4_\(i)_pool_idx", normalizedPool(dsv4.hybridPool(branch: .indexer)))
         }
         let compBuf = dsv4.hybridBuffers(branch: .compressor)
         putOptional("dsv4_\(i)_buf_comp_kv", compBuf.kv)

--- a/Libraries/MLXLMCommon/DeepseekV4ChatEncoder.swift
+++ b/Libraries/MLXLMCommon/DeepseekV4ChatEncoder.swift
@@ -221,14 +221,15 @@ public struct DeepseekV4ChatEncoder: Sendable {
 
         let effort = Self.reasoningEffort(from: additionalContext)
         let explicitlyEnabled = additionalContext?["enable_thinking"] as? Bool
-        let thinkingMode: DeepseekV4ThinkingMode
-        if explicitlyEnabled == false {
-            thinkingMode = .chat
-        } else if explicitlyEnabled == true || effort != nil {
-            thinkingMode = .thinking
-        } else {
-            thinkingMode = .chat
-        }
+        // DSV4's bundle contract (jang_config chat.reasoning) declares
+        // default_mode="thinking" with default_effort="low", and "low" adds
+        // no preface. Absent controls therefore mean the thinking rail —
+        // the same default `encode(thinkingMode:)` uses. Only an explicit
+        // enable_thinking=false selects the chat rail; defaulting the
+        // absent case to chat rendered a closed </think> tail while the
+        // UI reported the "Low" thinking default.
+        let thinkingMode: DeepseekV4ThinkingMode =
+            explicitlyEnabled == false ? .chat : .thinking
         let dropEarlierReasoning =
             (additionalContext?["drop_earlier_reasoning"] as? Bool) ?? true
         let (toolChoiceRequired, toolChoiceName) = Self.toolChoice(

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1842,13 +1842,19 @@ public struct TokenIterator: TokenIteratorProtocol {
         guard let coordinator,
             coordinator.canPersistBoundaries,
             !skipBoundary,
-            input.cachePromptIntent != .reusablePrefixWarmup,
             promptTokenIds.count > 1,
             !input.hasMediaContent,
             !input.requiresPostPrepareCacheKey,
             (cacheHasStandaloneRotatingWindowState(cache)
                 || cacheRequiresPrefillCapturedDiskSeed(cache))
         else { return nil }
+        // Reusable-prefix warmups MUST publish this seed — same contract as
+        // the batched path. Disk-backed topologies (DSV4) deliberately
+        // reject an exact post-prefill restore, so a warmup that skips the
+        // N-1 capture publishes nothing at all and the immediately following
+        // visible request prefills the identical prefix again from scratch.
+        // Observed live: two warmup prefills plus the real send each ran the
+        // full ~3.5k-token prompt on a cold DSV4 first message.
         return promptTokenIds.count - 1
     }
 
@@ -2381,16 +2387,24 @@ public struct TokenIterator: TokenIteratorProtocol {
                 let requiresDiskBackedRestore =
                     cacheRequiresDiskBackedCoordinatorRestore(storageTopologySnapshot)
                 if !usesCanonicalHybridBoundary,
-                   !isReusablePrefixWarmup,
                    requiresDiskBackedRestore,
                    !skipDiskBackedToolPromptSeedBoundary,
                    promptTokenIds.count > 1
                 {
+                    // Reusable-prefix warmups publish this N-1 seed too —
+                    // for a warmup prompt (send-invariant prefix + rail) it
+                    // IS the stable system/tool boundary, and without it a
+                    // disk-backed topology's warmup publishes nothing and
+                    // the visible send re-prefills the identical prefix.
+                    // Warmups only use the seed captured during their own
+                    // prefill: the re-derive fallback costs a full extra
+                    // prefill, which would recreate the very waste the
+                    // warmup exists to remove.
                     let seedTokens = Array(promptTokenIds.dropLast())
                     var seedSnapshot: [KVCache]?
                     if diskSeedBoundary == seedTokens.count {
                         seedSnapshot = capturedDiskSeed
-                    } else {
+                    } else if !isReusablePrefixWarmup {
                         seedSnapshot = cacheSnapshotForBoundary(
                             tokens: seedTokens,
                             storageSnapshot: storageTopologySnapshot,
@@ -2514,10 +2528,45 @@ public struct TokenIterator: TokenIteratorProtocol {
         else { return }
         guard !needsCacheQuantization else { return }
         guard !containsUnprovenZayaTurboQuantDiskState(cache) else { return }
-        let generatedBoundaryTokens = promptTokenIds + generatedTokenIds
-        guard (cache.map(\.offset).max() ?? 0) >= generatedBoundaryTokens.count
-        else { return }
+        // The async decode pipeline forwards the consumed stop token while
+        // computing the never-consumed next step, so at store time every
+        // cache layer can legitimately sit ONE token past
+        // `prompt + generated`. That state is not poison — the next turn's
+        // templated history includes the stop token — but keying it as
+        // `prompt + generated` desynchronizes key and cache and the disk
+        // boundary-offset guard (correctly) refuses the store, silently
+        // costing the post-answer boundary every turn (observed live:
+        // "REFUSED offset/key mismatch tokens=3627 offsets=[3628]").
+        // Extend the key by the pending drained token instead.
+        let generatedBoundaryTokens = Self.generatedBoundaryTokensAligned(
+            promptTokenIds: promptTokenIds,
+            generatedTokenIds: generatedTokenIds,
+            cacheOffsets: cache.map(\.offset),
+            pendingDrainedTokenId: y.tokens.size == 1
+                ? y.tokens.item(Int.self) : nil)
+        guard let generatedBoundaryTokens else { return }
         store(tokens: generatedBoundaryTokens, cache: cache, kvBits: kvBits, kvMode: kvMode)
+    }
+
+    /// Align the post-answer boundary key with what the cache actually
+    /// contains. Returns nil when no consistent key exists (fail-closed —
+    /// the caller skips the store rather than persisting a poisoned entry).
+    static func generatedBoundaryTokensAligned(
+        promptTokenIds: [Int],
+        generatedTokenIds: [Int],
+        cacheOffsets: [Int],
+        pendingDrainedTokenId: Int?
+    ) -> [Int]? {
+        let base = promptTokenIds + generatedTokenIds
+        let uniqueOffsets = Set(cacheOffsets)
+        guard let maxOffset = cacheOffsets.max() else { return nil }
+        if maxOffset == base.count { return base }
+        // Exactly one extra forwarded token, uniform across layers, and the
+        // iterator still holds it: that is the consumed stop token.
+        if uniqueOffsets == Set([base.count + 1]), let pendingDrainedTokenId {
+            return base + [pendingDrainedTokenId]
+        }
+        return maxOffset > base.count ? base : nil
     }
 
     private func cacheSnapshotForBoundary(

--- a/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
@@ -52,8 +52,14 @@ struct BatchEngineGrowingChatCacheSourceTests {
             contentsOfFile: "Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift",
             encoding: .utf8)
 
-        #expect(evaluate.contains(
+        // The solo N-1 disk-seed boundary is published for reusable-prefix
+        // warmups too (same contract as the batched path): a disk-backed
+        // topology's warmup that skips the seed publishes nothing, and the
+        // visible send re-prefills the identical prefix from scratch.
+        #expect(!evaluate.contains(
             "input.cachePromptIntent != .reusablePrefixWarmup"))
+        #expect(evaluate.contains(
+            "Reusable-prefix warmups MUST publish this seed"))
         #expect(evaluate.contains(
             "originalInput.cachePromptIntent == .reusablePrefixWarmup"))
         #expect(batch.contains(
@@ -177,7 +183,13 @@ struct BatchEngineGrowingChatCacheSourceTests {
         #expect(source.contains("promptTokenIds = effectivePromptTokens"))
         #expect(source.contains("!input.requiresPostPrepareCacheKey"))
         #expect(source.contains("!originalInput.requiresPostPrepareCacheKey"))
-        #expect(source.contains("let generatedBoundaryTokens = promptTokenIds + generatedTokenIds"))
+        // The post-answer boundary key is aligned with what the cache
+        // actually contains: the async decode pipeline forwards the consumed
+        // stop token, so the aligned key may extend by that one drained
+        // token instead of desynchronizing and losing the store to the
+        // boundary-offset guard.
+        #expect(source.contains("Self.generatedBoundaryTokensAligned("))
+        #expect(source.contains("pendingDrainedTokenId:"))
         #expect(source.contains("&& !handler.emittedToolCall"))
         #expect(source.contains("input.cacheHitSuffixContainsMediaPlaceholder(remainingTokens)"))
         #expect(source.contains("let requiresDiskBackedRestore ="))

--- a/Tests/MLXLMCommonFocusedTests/DeepseekV4ReasoningPolicyTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/DeepseekV4ReasoningPolicyTests.swift
@@ -108,6 +108,40 @@ struct DeepseekV4ReasoningPolicyTests {
         #expect(prompt.hasSuffix(DeepseekV4Tokens.assistant + DeepseekV4Tokens.thinkStart))
     }
 
+    @Test("absent thinking controls default to the bundle's thinking mode")
+    func absentThinkingControlsDefaultToThinking() throws {
+        // DSV4's jang_config declares default_mode="thinking" with
+        // default_effort="low" (which adds no preface). A request that
+        // carries NO enable_thinking and NO reasoning_effort must render
+        // the thinking rail — an open <think> tail — not silently fall to
+        // chat mode while the UI reports the "Low" default. Explicit
+        // enable_thinking=false remains the only path to the chat rail.
+        let prompt = try DeepseekV4ChatEncoder.renderOpenAIChat(
+            messages: [["role": "user", "content": "hi"]],
+            tools: nil,
+            additionalContext: nil,
+            addGenerationPrompt: true
+        )
+        #expect(!prompt.contains("Reasoning Effort:"))
+        #expect(prompt.hasSuffix(DeepseekV4Tokens.assistant + DeepseekV4Tokens.thinkStart))
+
+        let emptyContext = try DeepseekV4ChatEncoder.renderOpenAIChat(
+            messages: [["role": "user", "content": "hi"]],
+            tools: nil,
+            additionalContext: [:],
+            addGenerationPrompt: true
+        )
+        #expect(emptyContext.hasSuffix(DeepseekV4Tokens.assistant + DeepseekV4Tokens.thinkStart))
+
+        let explicitOff = try DeepseekV4ChatEncoder.renderOpenAIChat(
+            messages: [["role": "user", "content": "hi"]],
+            tools: nil,
+            additionalContext: ["enable_thinking": false],
+            addGenerationPrompt: true
+        )
+        #expect(explicitOff.hasSuffix(DeepseekV4Tokens.assistant + DeepseekV4Tokens.thinkEnd))
+    }
+
     @Test("force direct environment does not override explicit reasoning request")
     func forceDirectRailEnvironmentDoesNotOverrideRequest() throws {
         let context = try DeepseekV4ReasoningPolicy.normalizedAdditionalContext(

--- a/Tests/MLXLMCommonFocusedTests/DiskStoreOffsetConsistencyFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/DiskStoreOffsetConsistencyFocusedTests.swift
@@ -32,7 +32,7 @@
 
 import Foundation
 import MLX
-import MLXLMCommon
+@testable import MLXLMCommon
 import Testing
 
 @Suite("Disk store offset consistency", .serialized)
@@ -124,5 +124,57 @@ struct DiskStoreOffsetConsistencyFocusedTests {
             return
         }
         #expect(matched == 12)
+    }
+
+    // MARK: - Post-answer boundary key alignment (consumed stop token)
+
+    /// The async decode pipeline forwards the consumed stop token while
+    /// computing the never-consumed next step, so at store time every cache
+    /// layer sits ONE token past `prompt + generated`. Keying the store at
+    /// `prompt + generated` desynchronizes key and cache, and the boundary
+    /// guard above (correctly) refuses it — observed live as
+    /// `REFUSED offset/key mismatch tokens=3627 offsets=[3628]`, silently
+    /// costing the post-answer boundary every DSV4 turn. The aligned key
+    /// extends by the pending drained token exactly when the cache is
+    /// uniformly one ahead and the iterator still holds that token.
+    @Test("post-answer boundary key extends by the consumed stop token")
+    func generatedBoundaryKeyExtendsByConsumedStop() {
+        // Exact match: key unchanged.
+        #expect(
+            TokenIterator.generatedBoundaryTokensAligned(
+                promptTokenIds: [1, 2, 3],
+                generatedTokenIds: [4, 5],
+                cacheOffsets: [5, 5],
+                pendingDrainedTokenId: 99) == [1, 2, 3, 4, 5])
+        // Uniformly one ahead with the drained stop token available:
+        // key extends.
+        #expect(
+            TokenIterator.generatedBoundaryTokensAligned(
+                promptTokenIds: [1, 2, 3],
+                generatedTokenIds: [4, 5],
+                cacheOffsets: [6, 6],
+                pendingDrainedTokenId: 99) == [1, 2, 3, 4, 5, 99])
+        // One ahead but the drained token is unavailable: fall back to the
+        // base key so the store guard decides (fail-closed).
+        #expect(
+            TokenIterator.generatedBoundaryTokensAligned(
+                promptTokenIds: [1, 2, 3],
+                generatedTokenIds: [4, 5],
+                cacheOffsets: [6, 6],
+                pendingDrainedTokenId: nil) == [1, 2, 3, 4, 5])
+        // Mixed offsets: no consistent extension; base key for the guard.
+        #expect(
+            TokenIterator.generatedBoundaryTokensAligned(
+                promptTokenIds: [1, 2, 3],
+                generatedTokenIds: [4, 5],
+                cacheOffsets: [5, 6],
+                pendingDrainedTokenId: 99) == [1, 2, 3, 4, 5])
+        // Cache BEHIND the key: no valid store exists.
+        #expect(
+            TokenIterator.generatedBoundaryTokensAligned(
+                promptTokenIds: [1, 2, 3],
+                generatedTokenIds: [4, 5],
+                cacheOffsets: [4, 4],
+                pendingDrainedTokenId: 99) == nil)
     }
 }

--- a/Tests/MLXLMTests/DeepseekV4CacheDiskRoundTripTests.swift
+++ b/Tests/MLXLMTests/DeepseekV4CacheDiskRoundTripTests.swift
@@ -187,6 +187,97 @@ struct DeepseekV4CacheDiskRoundTripTests {
         #expect(restoredSink.metaState == sink.metaState)
     }
 
+    @Test("short-prompt DSV4 cache with an empty pool round-trips restorably")
+    func emptyPoolRoundTripsRestorably() {
+        // A prompt shorter than one compress window leaves the pool with
+        // zero rows. That checkpoint must round-trip: the canonical
+        // on-disk form of an empty pool is absence, and the restore
+        // validator accepts a nil pool. Writing the zero-row tensor made
+        // every short-prompt DSV4 checkpoint permanently unrestorable.
+        let v4 = DeepseekV4Cache(slidingWindow: 16, compressRatio: 4)
+        Self.fillRotating(v4.local)
+        v4.setPooled(.compressor, value: MLXArray.zeros([1, 0, 8]))
+        let originalOffset = v4.offset
+
+        let encoded = TQDiskSerializer.serialize(cache: [v4])
+        let target = DeepseekV4Cache(slidingWindow: 16, compressRatio: 4)
+        var restoreTarget: [any KVCache] = [target]
+        let restored = restoreFromDiskArrays(encoded, into: &restoreTarget)
+
+        #expect(restored > 0, "empty-pool DSV4 record must restore, not miss")
+        #expect(target.offset == originalOffset)
+    }
+
+    @Test("qkv group-size mismatch refuses the whole record atomically")
+    func qkvMismatchRefusesWholeRecord() {
+        // A quantized-KV layer whose stored group size / bit width no
+        // longer matches the runtime cache must refuse the entire record
+        // BEFORE any sibling layer is seated: `totalTokens` seeds from
+        // sibling layers, so a per-layer skip reported a "hit" with this
+        // layer left empty.
+        let plain = KVCacheSimple()
+        let keys = MLXArray.ones([1, 1, 6, 64])
+        let values = MLXArray.ones([1, 1, 6, 64]) * 2.0
+        _ = plain.update(keys: keys, values: values)
+        let qkv = QuantizedKVCache(groupSize: 64, bits: 8)
+        _ = qkv.updateQuantized(keys: keys, values: values)
+
+        let encoded = TQDiskSerializer.serialize(cache: [plain, qkv])
+
+        let targetPlain = KVCacheSimple()
+        let targetQKV = QuantizedKVCache(groupSize: 32, bits: 8)
+        var restoreTarget: [any KVCache] = [targetPlain, targetQKV]
+        let restored = restoreFromDiskArrays(encoded, into: &restoreTarget)
+
+        #expect(restored == 0, "mismatched qkv layer must be an atomic whole-record miss")
+        #expect(targetPlain.offset == 0, "no sibling layer may be seated before the refusal")
+
+        // Control: a matching target restores normally.
+        let okPlain = KVCacheSimple()
+        let okQKV = QuantizedKVCache(groupSize: 64, bits: 8)
+        var okTarget: [any KVCache] = [okPlain, okQKV]
+        let okRestored = restoreFromDiskArrays(encoded, into: &okTarget)
+        #expect(okRestored == 6)
+        #expect(okQKV.offset == 6)
+    }
+
+    @Test("non-q8 quantized pool segment poisons the record as an atomic miss")
+    func nonQ8QuantizedPoolPoisonsRecord() {
+        // The disk schema for quantized pools is defined for 8-bit affine
+        // segments. Any other width must not degrade to a silently
+        // skipped layer (sibling .deepseekV4 layers would restore while
+        // this one stayed empty) — the record poisons to a required miss.
+        let v4 = DeepseekV4Cache(slidingWindow: 16, compressRatio: 4)
+        Self.fillRotating(v4.local)
+        let bogus = HybridPoolQuantizedSegment(
+            codes: MLXArray.zeros([1, 64, 8], dtype: .uint32),
+            scales: MLXArray.zeros([1, 64, 2]),
+            biases: MLXArray.zeros([1, 64, 2]),
+            originalShape: [1, 64, 8],
+            groupSize: 32,
+            bits: 4,
+            originalDType: .float16)
+        v4.setHybridPoolQuantizedSegments(branch: .compressor, segments: [bogus])
+
+        let encoded = TQDiskSerializer.serialize(cache: [v4])
+        #expect(encoded["dsv4_0_keys"] == nil,
+            "poisoned record must not carry restorable keys")
+
+        let target = DeepseekV4Cache(slidingWindow: 16, compressRatio: 4)
+        var restoreTarget: [any KVCache] = [target]
+        let restored = restoreFromDiskArrays(encoded, into: &restoreTarget)
+        #expect(restored == 0, "non-q8 pool record must be an atomic miss")
+        #expect(target.offset == 0)
+    }
+
+    @Test("serializer q8 contract matches DeepseekV4PoolStorage bits")
+    func serializerBitsMatchPoolStorage() {
+        // The serializer accepts exactly 8-bit pool segments; the pool
+        // storage produces exactly 8-bit segments. Tie the two constants
+        // so one cannot drift without this test going red.
+        #expect(DeepseekV4Cache.poolQuantizationBits == 8)
+    }
+
     private func assertStateEqual(
         _ actual: [MLXArray],
         _ expected: [MLXArray],


### PR DESCRIPTION
Four DSV4-Flash runtime fixes, each reproduced live on the dev osaurus app (self-driven GUI + `VMLX_CACHE_FETCH_TRACE`) before fixing:

## 1. Absent thinking controls rendered the chat rail
`DeepseekV4ChatEncoder.renderOpenAIChat` defaulted an **absent** `enable_thinking` to `.chat`, contradicting the bundle contract (`jang_config.chat.reasoning.default_mode = "thinking"`, `default_effort = "low"` — and low adds no preface) and the typed encoder's own `encode(thinkingMode: .thinking)` default. A request with no thinking controls — exactly what a UI sends when the user never touches the effort segments — got a closed `</think>` tail and zero reasoning while the display default said "Low". Reproduced live: cold DSV4 first message with the chip showing "· Low" streamed a direct answer with no thinking region. Absent now means thinking; only an explicit `false` selects chat. Pinned in `DeepseekV4ReasoningPolicyTests` (absent/`[:]`/explicit-false rows).

## 2. Warmups published no disk seed (the triple-prefill amplifier)
The solo TokenIterator excluded `.reusablePrefixWarmup` prompts from the N-1 disk-seed capture/store — the exact exclusion the batched path documents as causing "the immediately following visible request to prefill the same prefix again". A DSV4 warmup's N-1 seed **is** the stable system+tools boundary, so the warmup published nothing: observed live as two full 3479-token warmup prefills plus a full 3489-token real send back to back (~54 s of duplicated prefill on a cold first message; trace showed `MISS all tiers` on all three with zero stores between them). Warmups now publish the seed captured during their own prefill; the re-derive fallback stays non-warmup-only so a warmup can never pay an extra prefill. Source-pin updated in `BatchEngineGrowingChatCacheSourceTests` to the new contract.

## 3. Post-answer boundary key desynchronized by the consumed stop token
The async decode pipeline forwards the consumed stop token while computing the never-consumed next step, so at store time every cache layer sits one token past `prompt + generated`. Keying the store at `prompt + generated` made the #208 boundary-offset guard (correctly) refuse it — observed live as `REFUSED offset/key mismatch tokens=3627 offsets=[3628]` — silently costing the post-answer boundary every DSV4 turn. `generatedBoundaryTokensAligned` extends the key by the pending drained token exactly when offsets are uniformly one ahead and the iterator still holds it; every other shape stays fail-closed. Unit-pinned in `DiskStoreOffsetConsistencyFocusedTests` (exact / one-ahead / unavailable / mixed / behind rows).

## 4. SSD q8 pool-block hardening
- A zero-row pool (prompt shorter than one compress window) serialized as a real tensor the restore validator can never accept → every short-prompt DSV4 checkpoint was permanently unrestorable. Canonical on-disk form of an empty pool is now absence; round-trip pinned.
- A non-8-bit quantized pool segment now poisons the record as an atomic required miss instead of a silently skipped layer beside restorable siblings; the 8-bit contract is tied to `DeepseekV4PoolStorage` via `DeepseekV4Cache.poolQuantizationBits` and pinned.
- A `.qkv` (quantized-KV) layer whose stored group size / bit width no longer matches the runtime cache now pre-validates and refuses the whole record **before** any live layer is seated — it previously `continue`d, producing a reported "hit" with that layer left empty.

## Verification
- New/updated pins: `DeepseekV4ReasoningPolicyTests`, `DeepseekV4CacheDiskRoundTripTests` (+4 tests), `DiskStoreOffsetConsistencyFocusedTests` (+1), `BatchEngineGrowingChatCacheSourceTests` (contract update).
- Suites green: all DeepseekV4 suites, CacheCoordinatorTopologyFocusedTests, CanonicalChatCacheBoundariesTests, LFM2ShortConvCacheRestoreFocusedTests — the only failures in the wider filter are the pre-existing `DeepseekV4ChatTemplateFallbackFocusedTests` LFM2/Gemma4 fallback rows, which fail identically on unmodified main.
- Live re-proof on the rebuilt dev app follows in the osaurus PR (single warmup prefill, reasoning visible at default Low, seed/boundary stores in the trace).