### PR TITLE
DSV4 cache-boundary ladder, concurrency hardening, MTP policy parity, and cache/trace instrumentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,7 @@ iOSInjectionProject/
 
 # VS Code
 .vscode/
+
+# Internal engineering notes — root-cause writeups, live-proof logs, campaign
+# state. Local only; never published.
+Docs/Internal/

--- a/Libraries/MLXLLM/Models/DSV4-FINDINGS-AND-CROSSFAMILY-BACKLOG-2026-08-09.md
+++ b/Libraries/MLXLLM/Models/DSV4-FINDINGS-AND-CROSSFAMILY-BACKLOG-2026-08-09.md
@@ -44,7 +44,7 @@ Gemma 4). Companion docs: `DSV4-PORT-STATUS.md`, `DSV4-SPEED-CAMPAIGN.md`,
   chat prompts the one canonical reusable boundary is the prompt with the
   trailing generation scaffold removed.
 
-## 3. The multi-turn prefill tax (root cause, unfixed — top backlog item)
+## 3. The multi-turn prefill tax (partial mitigation post-merge — full fix in follow-up PR)
 
 Live trace on DSV4: `HIT disk boundary=3464 remaining=1367` and
 `MISS all tiers tokens=2644`. The stored post-answer snapshot (count=4830) can
@@ -54,9 +54,49 @@ previous prompt's history. Consequence: **every multi-turn send re-prefills
 the entire previous assistant reply** (~1367 tok ≈ 3.4 s at 400 pp/s), and the
 tax grows with conversation length.
 
-Candidate fix (follow-up PR): **speculative next-turn cache warming** — after
-the response is delivered, background-prefill the re-rendered (think-stripped)
-assistant reply so the next turn's prompt hits at its true boundary.
+### Partial fix already in place (osaurus post-response warmup)
+
+`ChatSession.handleWarmupAfterRunCompleted` schedules a `warmupPrefill=true`
+generation with the freshly committed transcript. Debug log confirms it fires
+for DSV4 with wall times 49s (cold post-load) → 12s → 6s → 4s → 2s (hot
+prefix-reuse). Because the warmup renders the SAME re-rendered transcript the
+next send will render, the boundary it stores is a true prefix of turn N+1's
+prompt, so turn N+1 pays only the delta prefill (usually one short user turn).
+
+Bug found 2026-08-09 (this PR): `handleWarmupAfterRunCompleted` scanned
+**every historical turn** for tool activity and cancelled warmup if any was
+found. So one tool call at turn 5 permanently disabled post-response warmup
+for every send from turn 6 onward, leaving those chats paying the full tax.
+Fix: scope the tool-activity check to the CURRENT run (from the last user
+turn forward). Turns before the current run are frozen history — safe to
+warmup against no matter what happened earlier.
+
+### Remaining tax (follow-up PR)
+
+Two paths still pay the tax:
+1. **The current run itself had tool activity** — warmup is still cancelled
+   for that specific turn transition, but the next tool-free run's warmup
+   reheats the prefix. Real fix: prove warming a stable post-tool transcript
+   is byte-safe (tool_call rendering, tool_result rendering) and drop the
+   gate here too.
+2. **Warmup was scheduled but the user's next send raced the 500 ms
+   `scheduleDebounce`.** Rapid-fire testing masks the fix. Real users
+   pause ≥1 s between turns, so this is a harness artifact, not a product
+   bug — but the debounce should be adaptive (skip if a send is imminent).
+
+### Deeper follow-up
+
+The strip-store store (`gen-suffix-stripped` boundary — end of last real user
+turn) is currently hybrid-only in the batched path. Widening to DSV4
+HybridPool / Gemma-4 Rotating / Qwen-base TurboQuant / legacy Quantized KV
+requires **prefill-time capture** at the strip boundary (mirroring the
+existing N-1 disk-seed capture). `boundarySnapshot(forceRederive: true)`
+would work but adds a full model.prepare on the stripped tokens post-
+generation (~7-8 s for a 3000-token DSV4 prompt — worse than the tax it
+saves for typical chats). Prefill-time capture makes it near-free. This
+change is the general mechanism; post-response warmup covers most of the
+same benefit today because it re-renders the whole transcript through the
+model anyway. Kept as task #28 phase 1b for cross-family coverage.
 
 ## 4. Live measurements at merge time (dev osaurus GUI, M5 Max)
 

--- a/Libraries/MLXLLM/Models/DeepseekV4.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV4.swift
@@ -135,6 +135,11 @@ class DeepseekV4RoPE: Module {
         let angles = positions.expandedDimensions(axis: -1) * invFreq.expandedDimensions(axis: 0)
         let c = cos(angles)
         let s = sin(angles)
+        // Materialize before publishing. A pending graph node handed to two
+        // requests lets both drive `eval` on one array_desc, and a half-written
+        // position table destroys the model's positional geometry rather than
+        // crashing (Osaurus dispatches chat warmup alongside the visible turn).
+        MLX.eval(c, s)
         tables[key] = (offset, length, c, s)
         return (c, s)
     }
@@ -154,6 +159,7 @@ class DeepseekV4RoPE: Module {
         let angles = positions.expandedDimensions(axis: -1) * invFreq.expandedDimensions(axis: 0)
         let c = cos(angles)
         let s = sin(angles)
+        MLX.eval(c, s)
         stridedTables[sKey] = (base, count, c, s)
         return (c, s)
     }

--- a/Libraries/MLXLLM/Models/DeepseekV4.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV4.swift
@@ -818,10 +818,6 @@ class DeepseekV4MoE: Module, UnaryLayer {
     @ModuleInfo(key: "switch_mlp") var switchMLP: SwitchGLU
     var gate: DeepseekV4MoEGate
     @ModuleInfo(key: "shared_experts") var sharedExperts: DeepseekV4MLP
-    /// Hack to thread the input token ids down into the gate when this
-    /// layer is hash-routed. Set by the outer model before each layer
-    /// call when hash routing applies.
-    var currentInputIds: MLXArray? = nil
     /// Python `_decode_moe_region` parity: one compiled region per layer
     /// covering gate → routed experts → shared expert → fp32 accumulate,
     /// with weights riding as trace constants. Returns `[y, indices]` so
@@ -873,13 +869,22 @@ class DeepseekV4MoE: Module, UnaryLayer {
         return (y, indices)
     }
 
+    // `UnaryLayer` conformance. Hash layers need the token ids, so anything
+    // routed through this shim gets the non-hash gate.
     func callAsFunction(_ x: MLXArray) -> MLXArray {
+        callAsFunction(x, inputIds: nil)
+    }
+
+    // `inputIds` is request-scoped and MUST stay an argument: this module is
+    // shared across every concurrent request through the model, so parking the
+    // ids on `self` lets one request route another's tokens.
+    func callAsFunction(_ x: MLXArray, inputIds: MLXArray?) -> MLXArray {
         let profileStages = deepseekV4StageProfileEnabled && x.dim(1) == 1
 
         // Decode (L==1) routes through the per-layer compiled MoE region.
         // Hash layers without threaded ids fall back to eager (mirrors the
         // Python guard) so the trace never bakes the wrong gate variant.
-        let ids = gate.isHashLayer ? currentInputIds : nil
+        let ids = gate.isHashLayer ? inputIds : nil
         if DeepseekV4Math.compileRegionsEnabled, !profileStages,
             x.dim(1) == 1, moeRegionWarm, !(gate.isHashLayer && ids == nil)
         {
@@ -919,7 +924,7 @@ class DeepseekV4MoE: Module, UnaryLayer {
             stageStart = now
         }
 
-        let (indices, scores) = gate(x, inputIds: currentInputIds)
+        let (indices, scores) = gate(x, inputIds: ids)
         finishStage("gate", [indices, scores])
         JangPressCanonicalExpertAdvisor.shared.observe(layer: layerIdx, indices: indices)
         let routed = switchMLP(x, indices, preDownScores: scores)
@@ -1228,9 +1233,7 @@ class DeepseekV4DecoderLayer: Module {
         finishStage("ffn_hc_pre", [xF, postF, combF])
         let normedF = postAttentionLayerNorm(xF)
         finishStage("ffn_norm", [normedF])
-        mlp.currentInputIds = inputIds
-        let ffnOut = mlp(normedF)
-        mlp.currentInputIds = nil
+        let ffnOut = mlp(normedF, inputIds: inputIds)
         finishStage("moe", [ffnOut])
         let hF = ffnHC.expand(
             blockOut: ffnOut, residual: residualF, post: postF, comb: combF)

--- a/Libraries/MLXLLM/Models/DeepseekV4.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV4.swift
@@ -1115,7 +1115,8 @@ class DeepseekV4DecoderLayer: Module {
         _ h: MLXArray,
         mask: MLXFast.ScaledDotProductAttentionMaskMode,
         cache: KVCache?,
-        inputIds: MLXArray?
+        inputIds: MLXArray?,
+        statsSink: ((String, MLXArray)) -> Void = { _ in }
     ) -> MLXArray {
         // Explicit Release diagnostic only. Splitting the lazy graph at each
         // block boundary perturbs total throughput, but attributes the
@@ -1166,6 +1167,12 @@ class DeepseekV4DecoderLayer: Module {
             attnOut = selfAttn(normedA, mask: mask, cache: cache)
         }
         finishStage("attention", [attnOut])
+        // Sub-block stats split the layer-output trace into "attention block"
+        // vs "MoE block" so a magnitude injection names its half. Raw path
+        // only — the compiled decode region fuses past these seams, but the
+        // corruption under study already shows in the first prefill chunk,
+        // which always takes the raw path.
+        DeepseekV4Math.layerStat("layer\(layerIdx).attn", attnOut).map(statsSink)
 
         // Decode tail region (Python `_decode_tail_region`): everything after
         // SDPA fuses into one compiled dispatch per layer. Gated on the MoE
@@ -1222,6 +1229,7 @@ class DeepseekV4DecoderLayer: Module {
         finishStage("ffn_norm", [normedF])
         let ffnOut = mlp(normedF, inputIds: inputIds)
         finishStage("moe", [ffnOut])
+        DeepseekV4Math.layerStat("layer\(layerIdx).moe", ffnOut).map(statsSink)
         let hF = ffnHC.expand(
             blockOut: ffnOut, residual: residualF, post: postF, comb: combF)
         finishStage("ffn_hc_post", [hF])
@@ -1280,7 +1288,8 @@ public class DeepseekV4ModelInner: Module {
                 h,
                 mask: mask,
                 cache: cache?[i],
-                inputIds: inputs)
+                inputIds: inputs,
+                statsSink: { layerStats.append($0) })
             if layerwisePrefill {
                 MLX.eval(h)
             }
@@ -1294,6 +1303,28 @@ public class DeepseekV4ModelInner: Module {
         out = norm(out)
         layerStats.append(contentsOf: DeepseekV4Math.layerStat("norm", out).map { [$0] } ?? [])
         DeepseekV4Math.flushLayerStats(layerStats, length: out.dim(1))
+        // Weight checksums AFTER the first forward on purpose: forcing every
+        // layer-15 weight to materialize BEFORE the racy first-touch window
+        // would serialize the load and could suppress the very corruption
+        // being fingerprinted. Post-forward, the boot's fate is already
+        // decided; the checksum then separates "weights corrupted at load"
+        // from "weights fine, compute path corrupted".
+        if DeepseekV4Math.weightChecksumEnabled {
+            DeepseekV4Math.runWeightChecksumOnce {
+                for i in [14, 15, 16] where i < layers.count {
+                    let flat = layers[i].parameters().flattened()
+                    let stats = flat.map {
+                        ($0.0, MLX.abs($0.1.asType(.float32)).mean())
+                    }
+                    MLX.eval(stats.map(\.1))
+                    for (name, v) in stats {
+                        print(
+                            "[vmlx][dsv4/wsum] layer\(i).\(name) absmean=\(v.item(Float.self))"
+                        )
+                    }
+                }
+            }
+        }
         return out
     }
 }

--- a/Libraries/MLXLLM/Models/DeepseekV4.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV4.swift
@@ -1273,7 +1273,8 @@ public class DeepseekV4ModelInner: Module {
                 chunkTokens: chunkTokens,
                 finalContextTokens: (firstCache?.offset ?? 0) + chunkTokens)
 
-        DeepseekV4Math.traceLayer("embed", h)
+        var layerStats: [(String, MLXArray)] = []
+        layerStats.append(contentsOf: DeepseekV4Math.layerStat("embed", h).map { [$0] } ?? [])
         for (i, layer) in layers.enumerated() {
             h = layer(
                 h,
@@ -1283,14 +1284,16 @@ public class DeepseekV4ModelInner: Module {
             if layerwisePrefill {
                 MLX.eval(h)
             }
-            DeepseekV4Math.traceLayer("layer\(i)", h)
+            layerStats.append(
+                contentsOf: DeepseekV4Math.layerStat("layer\(i)", h).map { [$0] } ?? [])
         }
 
         // HyperHead reduce: (B, L, hcMult, H) → (B, L, H)
         var out = hcHead.reduce(h)
-        DeepseekV4Math.traceLayer("hcReduce", out)
+        layerStats.append(contentsOf: DeepseekV4Math.layerStat("hcReduce", out).map { [$0] } ?? [])
         out = norm(out)
-        DeepseekV4Math.traceLayer("norm", out)
+        layerStats.append(contentsOf: DeepseekV4Math.layerStat("norm", out).map { [$0] } ?? [])
+        DeepseekV4Math.flushLayerStats(layerStats, length: out.dim(1))
         return out
     }
 }
@@ -1381,7 +1384,14 @@ public class DeepseekV4Model: Module, LLMModel, KVCacheDimensionProvider, LoRAMo
 
     public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]? = nil) -> MLXArray {
         let h = model(inputs, cache: cache)
-        return DeepseekV4Math.lmHeadFp32(h, lmHead: lmHead)
+        let logits = DeepseekV4Math.lmHeadFp32(h, lmHead: lmHead)
+        // Separated from the hidden-state stats on purpose: a normal `norm`
+        // followed by an abnormal `logits` isolates the fused quantized head
+        // (VMLX_DSV4_LM_HEAD_MODE) rather than the transformer stack.
+        DeepseekV4Math.flushLayerStats(
+            [DeepseekV4Math.layerStat("logits", logits)].compactMap { $0 },
+            length: logits.dim(1))
+        return logits
     }
 
     /// DSV4 prefill has opposed optima (Python `_dsv4_attn_subchunk_tokens`):

--- a/Libraries/MLXLLM/Models/DeepseekV4.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV4.swift
@@ -202,8 +202,9 @@ class DeepseekV4Attention: Module {
     /// compiled regions for the decode projections (3 qmm + norms + RoPE +
     /// KV QAT kernel in one dispatch) and the decode output path (inverse
     /// RoPE + grouped o-proj + wo_b). Weights are trace constants.
-    private var preDecodeRegion: (@Sendable ([MLXArray]) -> [MLXArray])? = nil
-    private var outDecodeRegion: (@Sendable ([MLXArray]) -> [MLXArray])? = nil
+    private let regionLock = NSLock()
+    private var preDecodeRegion: DeepseekV4CompiledRegion? = nil
+    private var outDecodeRegion: DeepseekV4CompiledRegion? = nil
 
     // Compressor + Indexer (instantiated only when compressRatio > 0).
     // Swift can't have conditionally-present @ModuleInfo properties
@@ -350,17 +351,13 @@ class DeepseekV4Attention: Module {
         var q: MLXArray
         var kv: MLXArray
         if useRegions {
-            let region: @Sendable ([MLXArray]) -> [MLXArray]
-            if let cached = preDecodeRegion {
-                region = cached
-            } else {
-                region = vmlxTrustedCompile { [unowned self] (args: [MLXArray]) -> [MLXArray] in
+            let region = deepseekV4CachedRegion(regionLock, &preDecodeRegion) {
+                vmlxTrustedCompile { [unowned self] (args: [MLXArray]) -> [MLXArray] in
                     CompiledDecodeTrace.withActive {
                         let out = self.preMath(args[0], cosT: args[1], sinT: args[2])
                         return [out.qResidual, out.q, out.kv]
                     }
                 }
-                preDecodeRegion = region
             }
             let outs = region([x, cosT, sinT])
             if outs.count == 3 {
@@ -582,16 +579,12 @@ class DeepseekV4Attention: Module {
         // sdpaOut shape: (B, numHeads, L, headDim)
 
         if useRegions {
-            let region: @Sendable ([MLXArray]) -> [MLXArray]
-            if let cached = outDecodeRegion {
-                region = cached
-            } else {
-                region = vmlxTrustedCompile { [unowned self] (args: [MLXArray]) -> [MLXArray] in
+            let region = deepseekV4CachedRegion(regionLock, &outDecodeRegion) {
+                vmlxTrustedCompile { [unowned self] (args: [MLXArray]) -> [MLXArray] in
                     CompiledDecodeTrace.withActive {
                         [self.outMath(args[0], cosT: args[1], sinT: args[2])]
                     }
                 }
-                outDecodeRegion = region
             }
             if let out = region([sdpaOut, cosT, sinT]).first {
                 return out
@@ -825,7 +818,8 @@ class DeepseekV4MoE: Module, UnaryLayer {
     /// the trace. The first forward stays eager (`moeRegionWarm`) so
     /// SwitchGLU's fused gate+up cache — which evals — materializes
     /// before any trace records.
-    private var moeDecodeRegion: (@Sendable ([MLXArray]) -> [MLXArray])? = nil
+    private let regionLock = NSLock()
+    private var moeDecodeRegion: DeepseekV4CompiledRegion? = nil
     fileprivate var moeRegionWarm = false
     init(config: DeepseekV4Configuration, layerIdx: Int) {
         self.config = config
@@ -888,11 +882,8 @@ class DeepseekV4MoE: Module, UnaryLayer {
         if DeepseekV4Math.compileRegionsEnabled, !profileStages,
             x.dim(1) == 1, moeRegionWarm, !(gate.isHashLayer && ids == nil)
         {
-            let region: @Sendable ([MLXArray]) -> [MLXArray]
-            if let cached = moeDecodeRegion {
-                region = cached
-            } else {
-                region = vmlxTrustedCompile { [unowned self] (args: [MLXArray]) -> [MLXArray] in
+            let region = deepseekV4CachedRegion(regionLock, &moeDecodeRegion) {
+                vmlxTrustedCompile { [unowned self] (args: [MLXArray]) -> [MLXArray] in
                     // Nested-compile guard: inner compiled microfunctions
                     // (selector, SwiGLU) inline their raw bodies while this
                     // region traces — and on every retrace.
@@ -902,7 +893,6 @@ class DeepseekV4MoE: Module, UnaryLayer {
                         return [out.y, out.indices]
                     }
                 }
-                moeDecodeRegion = region
             }
             let outs = ids.map { region([x, $0]) } ?? region([x])
             if outs.count == 2 {
@@ -1105,7 +1095,8 @@ class DeepseekV4DecoderLayer: Module {
     /// projection stays outside (Swift attention does not defer it).
     /// Returns `[hF, indices]` so expert-advisor observation runs on real
     /// arrays outside the trace.
-    private var tailDecodeRegion: (@Sendable ([MLXArray]) -> [MLXArray])? = nil
+    private let regionLock = NSLock()
+    private var tailDecodeRegion: DeepseekV4CompiledRegion? = nil
 
     init(config: DeepseekV4Configuration, layerIdx: Int) {
         self.layerIdx = layerIdx
@@ -1185,11 +1176,8 @@ class DeepseekV4DecoderLayer: Module {
             h.dim(1) == 1, mlp.moeRegionWarm,
             !(mlp.gate.isHashLayer && ids == nil)
         {
-            let region: @Sendable ([MLXArray]) -> [MLXArray]
-            if let cached = tailDecodeRegion {
-                region = cached
-            } else {
-                region = vmlxTrustedCompile { [unowned self] (args: [MLXArray]) -> [MLXArray] in
+            let region = deepseekV4CachedRegion(regionLock, &tailDecodeRegion) {
+                vmlxTrustedCompile { [unowned self] (args: [MLXArray]) -> [MLXArray] in
                     // Nested-compile guard: inner compiled microfunctions
                     // (hcPre region, selector, SwiGLU) inline raw bodies
                     // while this region traces — and on every retrace.
@@ -1211,7 +1199,6 @@ class DeepseekV4DecoderLayer: Module {
                         return [hF, out.indices]
                     }
                 }
-                tailDecodeRegion = region
             }
             let regionArgs = [attnOut, residualA, postA, combA] + (ids.map { [$0] } ?? [])
             let outs = region(regionArgs)
@@ -1286,6 +1273,7 @@ public class DeepseekV4ModelInner: Module {
                 chunkTokens: chunkTokens,
                 finalContextTokens: (firstCache?.offset ?? 0) + chunkTokens)
 
+        DeepseekV4Math.traceLayer("embed", h)
         for (i, layer) in layers.enumerated() {
             h = layer(
                 h,
@@ -1295,11 +1283,14 @@ public class DeepseekV4ModelInner: Module {
             if layerwisePrefill {
                 MLX.eval(h)
             }
+            DeepseekV4Math.traceLayer("layer\(i)", h)
         }
 
         // HyperHead reduce: (B, L, hcMult, H) → (B, L, H)
         var out = hcHead.reduce(h)
+        DeepseekV4Math.traceLayer("hcReduce", out)
         out = norm(out)
+        DeepseekV4Math.traceLayer("norm", out)
         return out
     }
 }

--- a/Libraries/MLXLLM/Models/DeepseekV4Compressor.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV4Compressor.swift
@@ -1282,8 +1282,9 @@ public final class DeepseekV4Compressor: Module {
 
     @ModuleInfo(key: "wkv") var wkv: Linear
     @ModuleInfo(key: "wgate") var wgate: Linear
-    private var frontOverlapRegion: (@Sendable ([MLXArray]) -> [MLXArray])? = nil
-    private var frontRegion: (@Sendable ([MLXArray]) -> [MLXArray])? = nil
+    private let regionLock = NSLock()
+    private var frontOverlapRegion: DeepseekV4CompiledRegion? = nil
+    private var frontRegion: DeepseekV4CompiledRegion? = nil
     /// APE: (compress_ratio, out_dim) learned positional bias inside
     /// each pool window.
     @ParameterInfo(key: "ape") var ape: MLXArray
@@ -1397,12 +1398,9 @@ public final class DeepseekV4Compressor: Module {
         var gate: MLXArray
         var apeFolded = false
         if useCompiledFront, overlap {
-            let region: @Sendable ([MLXArray]) -> [MLXArray]
-            if let cached = frontOverlapRegion {
-                region = cached
-            } else {
-                let ratio = Int32(compressRatio)
-                region = vmlxTrustedCompile { [unowned self] (args: [MLXArray]) -> [MLXArray] in
+            let ratio = Int32(compressRatio)
+            let region = deepseekV4CachedRegion(regionLock, &frontOverlapRegion) {
+                vmlxTrustedCompile { [unowned self] (args: [MLXArray]) -> [MLXArray] in
                     CompiledDecodeTrace.withActive {
                         // Official 0731 stages the compressor projections in
                         // fp32 — the cast must precede the linears.
@@ -1413,7 +1411,6 @@ public final class DeepseekV4Compressor: Module {
                         return [kvOut, gateOut + apeRows.expandedDimensions(axis: 0)]
                     }
                 }
-                frontOverlapRegion = region
             }
             let pos = MLXArray(Int32(startPos)..<Int32(startPos + L))
             let outs = region([x, pos])
@@ -1427,17 +1424,13 @@ public final class DeepseekV4Compressor: Module {
                 gate = wgate(projectionInput)
             }
         } else if useCompiledFront {
-            let region: @Sendable ([MLXArray]) -> [MLXArray]
-            if let cached = frontRegion {
-                region = cached
-            } else {
-                region = vmlxTrustedCompile { [unowned self] (args: [MLXArray]) -> [MLXArray] in
+            let region = deepseekV4CachedRegion(regionLock, &frontRegion) {
+                vmlxTrustedCompile { [unowned self] (args: [MLXArray]) -> [MLXArray] in
                     CompiledDecodeTrace.withActive {
                         let x32 = args[0].asType(.float32)
                         return [self.wkv(x32), self.wgate(x32)]
                     }
                 }
-                frontRegion = region
             }
             let outs = region([x])
             if outs.count == 2 {

--- a/Libraries/MLXLLM/Models/DeepseekV4JANGTQ.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV4JANGTQ.swift
@@ -38,7 +38,6 @@ final class DeepseekV4MoEJANGTQ: Module, UnaryLayer {
     @ModuleInfo(key: "switch_mlp") var switchMLP: TurboQuantSwitchGLU
     var gate: DeepseekV4MoEGate
     @ModuleInfo(key: "shared_experts") var sharedExperts: DeepseekV4MLP
-    var currentInputIds: MLXArray? = nil
 
     init(config: DeepseekV4Configuration, layerIdx: Int, mxtqBits: Int, mxtqSeed: Int) {
         self.config = config
@@ -76,7 +75,12 @@ final class DeepseekV4MoEJANGTQ: Module, UnaryLayer {
     }
 
     func callAsFunction(_ x: MLXArray) -> MLXArray {
-        let (indices, scores) = gate(x, inputIds: currentInputIds)
+        callAsFunction(x, inputIds: nil)
+    }
+
+    // See `DeepseekV4MoE`: request-scoped, must not be parked on `self`.
+    func callAsFunction(_ x: MLXArray, inputIds: MLXArray?) -> MLXArray {
+        let (indices, scores) = gate(x, inputIds: gate.isHashLayer ? inputIds : nil)
         JangPressCanonicalExpertAdvisor.shared.observe(layer: layerIdx, indices: indices)
         var y: MLXArray
         if let streaming = switchMLP as? StreamingTurboQuantSwitchGLU {
@@ -124,9 +128,7 @@ final class DeepseekV4DecoderLayerJANGTQ: Module {
         let hA = attnHC.expand(blockOut: attnOut, residual: residualA, post: postA, comb: combA)
         let residualF = hA
         let (xF, postF, combF) = ffnHC.collapse(hA)
-        mlp.currentInputIds = inputIds
-        let ffnOut = mlp(postAttentionLayerNorm(xF))
-        mlp.currentInputIds = nil
+        let ffnOut = mlp(postAttentionLayerNorm(xF), inputIds: inputIds)
         return ffnHC.expand(blockOut: ffnOut, residual: residualF, post: postF, comb: combF)
     }
 }

--- a/Libraries/MLXLLM/Models/DeepseekV4MathHelpers.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV4MathHelpers.swift
@@ -81,6 +81,31 @@ private let _compiledDeepseekV4ScoredSwiGLUClamped =
 private let _compiledDeepseekV4ScoredSwiGLUUnclamped =
     vmlxTrustedCompile(_deepseekV4ScoredSwiGLUUnclampedArrayBody)
 
+typealias DeepseekV4CompiledRegion = @Sendable ([MLXArray]) -> [MLXArray]
+
+/// Resolve a per-instance compiled decode region, building it once.
+///
+/// The modules holding these caches live on the shared model object, so two
+/// concurrent requests reach the same uninitialised slot together. Without the
+/// lock both threads write the property at once; a closure is a (function,
+/// context) pair, and a torn read pairs one thread's function with the other's
+/// context. The lock is held across the build so the region is compiled once —
+/// that happens on the first decode step of a layer and never again, while the
+/// *call* stays outside the lock so decode is never serialised.
+@inline(__always)
+func deepseekV4CachedRegion(
+    _ lock: NSLock,
+    _ storage: inout DeepseekV4CompiledRegion?,
+    build: () -> DeepseekV4CompiledRegion
+) -> DeepseekV4CompiledRegion {
+    lock.lock()
+    defer { lock.unlock() }
+    if let cached = storage { return cached }
+    let built = build()
+    storage = built
+    return built
+}
+
 public enum DeepseekV4Math {
 
     private static let e4m3KVActivationRoundTripKernel = MLXFast.metalKernel(
@@ -351,6 +376,25 @@ public enum DeepseekV4Math {
             .lowercased()
         return raw != "0" && raw != "false" && raw != "off" && raw != "no"
     }()
+
+    /// `VMLX_DSV4_LAYER_TRACE=1` prints the last position's magnitude after
+    /// every decoder layer. Diagnostic only: it forces a per-layer eval, which
+    /// serialises the lazy graph and costs most of prefill throughput.
+    public static let layerTraceEnabled: Bool = {
+        ProcessInfo.processInfo.environment["VMLX_DSV4_LAYER_TRACE"] == "1"
+    }()
+
+    /// Print `absmax`/`absmean` of the final position of `h`. Both statistics
+    /// are needed: a NaN/Inf blowup moves `absmax` alone, while a routing or
+    /// weight fault that keeps the state finite but wrong moves `absmean`.
+    public static func traceLayer(_ tag: String, _ h: MLXArray) {
+        guard layerTraceEnabled, h.ndim >= 2 else { return }
+        let last = MLX.take(h, MLXArray([Int32(h.dim(1) - 1)]), axis: 1)
+        let a = MLX.abs(last.asType(.float32))
+        print(
+            "[vmlx][dsv4/layer] \(tag) L=\(h.dim(1)) "
+                + "absmax=\(a.max().item(Float.self)) absmean=\(a.mean().item(Float.self))")
+    }
 
     /// Python `_dsv4_attn_subchunk_tokens` parity: attention sub-chunk length
     /// for wide-chunk prefill. SWA/CSA attention cost grows super-linearly

--- a/Libraries/MLXLLM/Models/DeepseekV4MathHelpers.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV4MathHelpers.swift
@@ -408,6 +408,24 @@ public enum DeepseekV4Math {
         }
     }
 
+    /// `VMLX_DSV4_WEIGHT_CHECKSUM=1` fingerprints layers 14-16 weight tensors
+    /// once per process, after the first forward. Separates "weights corrupted
+    /// at load" from "weights fine, compute path corrupted" on a souped boot.
+    public static let weightChecksumEnabled: Bool = {
+        ProcessInfo.processInfo.environment["VMLX_DSV4_WEIGHT_CHECKSUM"] == "1"
+    }()
+
+    private static let weightChecksumOnceLock = NSLock()
+    nonisolated(unsafe) private static var weightChecksumDone = false
+
+    public static func runWeightChecksumOnce(_ body: () -> Void) {
+        weightChecksumOnceLock.lock()
+        let shouldRun = !weightChecksumDone
+        weightChecksumDone = true
+        weightChecksumOnceLock.unlock()
+        if shouldRun { body() }
+    }
+
     /// Python `_dsv4_attn_subchunk_tokens` parity: attention sub-chunk length
     /// for wide-chunk prefill. SWA/CSA attention cost grows super-linearly
     /// with chunk width while MoE gather_qmm throughput grows with batch, so

--- a/Libraries/MLXLLM/Models/DeepseekV4MathHelpers.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV4MathHelpers.swift
@@ -611,6 +611,9 @@ public enum DeepseekV4Math {
         qNormOnesLock.lock(); defer { qNormOnesLock.unlock() }
         if let w = qNormOnesCache[key] { return w }
         let w = MLXArray.ones([headDim], dtype: dtype)
+        // `ones` is a pending `full` node; publishing it unevaluated would let
+        // two concurrent requests drive `eval` on the same array_desc.
+        w.eval()
         qNormOnesCache[key] = w
         return w
     }

--- a/Libraries/MLXLLM/Models/DeepseekV4MathHelpers.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV4MathHelpers.swift
@@ -377,23 +377,35 @@ public enum DeepseekV4Math {
         return raw != "0" && raw != "false" && raw != "off" && raw != "no"
     }()
 
-    /// `VMLX_DSV4_LAYER_TRACE=1` prints the last position's magnitude after
-    /// every decoder layer. Diagnostic only: it forces a per-layer eval, which
-    /// serialises the lazy graph and costs most of prefill throughput.
+    /// `VMLX_DSV4_LAYER_TRACE=1` reports the last position's magnitude after
+    /// every decoder layer. Diagnostic only.
     public static let layerTraceEnabled: Bool = {
         ProcessInfo.processInfo.environment["VMLX_DSV4_LAYER_TRACE"] == "1"
     }()
 
-    /// Print `absmax`/`absmean` of the final position of `h`. Both statistics
-    /// are needed: a NaN/Inf blowup moves `absmax` alone, while a routing or
-    /// weight fault that keeps the state finite but wrong moves `absmean`.
-    public static func traceLayer(_ tag: String, _ h: MLXArray) {
-        guard layerTraceEnabled, h.ndim >= 2 else { return }
+    /// `absmax`/`absmean` of the final position of `h`, as an *unevaluated*
+    /// scalar pair. Both statistics are needed: a NaN/Inf blowup moves `absmax`
+    /// alone, while a routing or weight fault that keeps the state finite but
+    /// wrong moves `absmean`.
+    ///
+    /// Deliberately lazy. Reading these per layer would insert a barrier into
+    /// exactly the lazy cross-layer graph under suspicion, so a laziness or
+    /// concurrency fault could vanish under its own instrumentation. Collect
+    /// here; evaluate once at the end of the forward pass.
+    public static func layerStat(_ tag: String, _ h: MLXArray) -> (String, MLXArray)? {
+        guard layerTraceEnabled, h.ndim >= 2 else { return nil }
         let last = MLX.take(h, MLXArray([Int32(h.dim(1) - 1)]), axis: 1)
         let a = MLX.abs(last.asType(.float32))
-        print(
-            "[vmlx][dsv4/layer] \(tag) L=\(h.dim(1)) "
-                + "absmax=\(a.max().item(Float.self)) absmean=\(a.mean().item(Float.self))")
+        return (tag, MLX.stacked([a.max(), a.mean()]))
+    }
+
+    public static func flushLayerStats(_ stats: [(String, MLXArray)], length: Int) {
+        guard layerTraceEnabled, !stats.isEmpty else { return }
+        MLX.eval(stats.map(\.1))
+        for (tag, stat) in stats {
+            let v = stat.asArray(Float.self)
+            print("[vmlx][dsv4/layer] \(tag) L=\(length) absmax=\(v[0]) absmean=\(v[1])")
+        }
     }
 
     /// Python `_dsv4_attn_subchunk_tokens` parity: attention sub-chunk length

--- a/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
@@ -566,6 +566,13 @@ public final class CacheCoordinator: @unchecked Sendable {
                     touchRecency: false,
                     countHit: false
                 ) else {
+                    // A miss here means the content-addressed key over this
+                    // prefix found no row; a rejection below means the row
+                    // existed but its companion state was refused. Only the
+                    // aggregate "MISS all tiers" was ever traced, which cannot
+                    // tell those apart — and a silent companion veto has
+                    // already cost a whole family (LFM2.5) its cache once.
+                    ftrace("probe boundary=\(boundary) noRow")
                     return nil
                 }
                 let ssmStates = resolveSSMStates(
@@ -588,6 +595,9 @@ public final class CacheCoordinator: @unchecked Sendable {
                         diskArrays: arrays
                     )
                 }
+                ftrace(
+                    "probe boundary=\(boundary) rowFound but companion REJECTED "
+                        + "ssm=\(ssmStates?.count ?? -1)")
                 return nil
             }
 

--- a/Libraries/MLXLMCommon/Cache/DiskCache.swift
+++ b/Libraries/MLXLMCommon/Cache/DiskCache.swift
@@ -231,7 +231,9 @@ public final class DiskCache: @unchecked Sendable {
         let tokenCount = tokens.count
         if ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1" {
             FileHandle.standardError.write(Data(
-                "[vmlx][cache/disk-store] count=\(tokenCount) keys=\(arrays.keys.sorted().prefix(6))\n".utf8))
+                ("[vmlx][cache/disk-store] count=\(tokenCount) hash=\(hash.prefix(12)) "
+                    + "modelKey=\(modelKey ?? "nil") salt=\(mediaSalt.map { String($0.prefix(12)) } ?? "nil") "
+                    + "keys=\(arrays.keys.sorted().prefix(6))\n").utf8))
         }
 
         // Iter 61: the full write path (realize + save + SQLite insert)
@@ -368,6 +370,15 @@ public final class DiskCache: @unchecked Sendable {
         guard FileManager.default.fileExists(atPath: url.path) else {
             validatedFiles.removeValue(forKey: hash)
             misses += 1
+            if ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1" {
+                // A miss with a row/file present under a DIFFERENT hash is a
+                // key-input mismatch (modelKey or salt), invisible without
+                // printing what this lookup actually hashed.
+                FileHandle.standardError.write(Data(
+                    ("[vmlx][cache/disk-fetch] noFile count=\(tokens.count) "
+                        + "hash=\(hash.prefix(12)) modelKey=\(modelKey ?? "nil") "
+                        + "salt=\(mediaSalt.map { String($0.prefix(12)) } ?? "nil")\n").utf8))
+            }
             return nil
         }
 

--- a/Libraries/MLXLMCommon/Cache/MediaSalt.swift
+++ b/Libraries/MLXLMCommon/Cache/MediaSalt.swift
@@ -197,7 +197,21 @@ public func computeCacheSalt(for input: LMInput, parameters: GenerateParameters)
     hasher.update(data: Data("policy:".utf8))
     hasher.update(data: Data(policy.utf8))
     let digest = hasher.finalize()
-    return digest.map { String(format: "%02x", $0) }.joined()
+    let salt = digest.map { String(format: "%02x", $0) }.joined()
+    if ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1" {
+        // The salt is a component of the disk-cache content hash. A warmup
+        // that stores under one salt and a send that fetches under another
+        // can never hit, with identical token bytes — and the aggregate
+        // trace shows only "noRow". Printing the raw pre-hash components
+        // names the differing field directly instead of leaving two opaque
+        // digests to stare at.
+        let scopeDesc = input.cacheScopeSalt ?? "nil"
+        let mediaDesc = computeMediaSalt(for: input).map { String($0.prefix(12)) } ?? "nil"
+        FileHandle.standardError.write(Data(
+            ("[vmlx][cache/salt] salt=\(salt.prefix(12)) policy={\(policy)} "
+                + "scope=\(scopeDesc) media=\(mediaDesc)\n").utf8))
+    }
+    return salt
 }
 
 private func cachePolicySalt(for parameters: GenerateParameters) -> String {

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -4070,14 +4070,29 @@ private func generateLoopTask<Handler: TokenLoopHandler>(
             // drain. Local chat/tool consumers may start a post-tool decode as
             // soon as `.info` closes the stream, so `.info` must not be visible
             // while this generation task can still touch MLX command encoders.
+            // The three phases below run on the request path, so the stream
+            // does not finish until they do. Timed to split "GPU drain" from
+            // "disk store" for the post-output hang: the fix differs by an
+            // order of magnitude depending on which phase owns the wall time.
+            let genTailTrace =
+                ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1"
+            let tailT0 = Date()
             Stream().synchronize()
+            let tailT1 = Date()
             iterator.storeCacheAfterGeneration(
                 generatedTokenIds: generatedTokenIds,
                 includeGeneratedBoundary: stopReason == .stop
                     && !handler.stopSequenceHit
                     && !handler.emittedToolCall)
-
+            let tailT2 = Date()
             Stream().synchronize()
+            if genTailTrace {
+                let tailT3 = Date()
+                print(
+                    "[vmlx][gen/tail] drain1=\(tailT1.timeIntervalSince(tailT0))s"
+                        + " store=\(tailT2.timeIntervalSince(tailT1))s"
+                        + " drain2=\(tailT3.timeIntervalSince(tailT2))s")
+            }
 
             // Router-advice readback runs on its own Dispatch queue. Drain it
             // after MLX synchronization so short-lived CLI runs and app unload

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -928,7 +928,18 @@ public struct SuppressTokensProcessor: LogitProcessor {
 /// capped thinking by forcing the close after a budget): a leading-window
 /// mask can only DELAY a token. It never forces, biases toward, or injects
 /// one — see `NoHiddenReasoningCloseBiasFocusedTests`.
+///
+/// Logit processors run before the sampler's `top_p`, so banning a token that
+/// holds nearly all the probability mass renormalizes a nearly flat residual
+/// and nucleus sampling then admits the whole vocabulary tail — live DSV4 runs
+/// turned into token soup from the first reasoning token. The window therefore
+/// also drops survivors that fall below ``survivorRelativeFloor`` of the best
+/// remaining token, which keeps the nucleus as narrow as it was before the ban.
 public struct InitialSuppressTokensProcessor: LogitProcessor {
+    /// Minimum probability a survivor may hold relative to the best remaining
+    /// token while the ban is active. Standard `min_p` territory.
+    static let survivorRelativeFloor: Float = 0.05
+
     private let tokens: [Int]
     private var remaining: Int
     private let negInf = MLXArray(-Float.infinity)
@@ -958,7 +969,9 @@ public struct InitialSuppressTokensProcessor: LogitProcessor {
             FileHandle.standardError.write(Data(line.utf8))
         }
         logits[0..., MLXArray(valid.map(Int32.init)).asType(.uint32)] = negInf
-        return logits
+        let bestSurvivor = MLX.max(logits, axis: -1, keepDims: true)
+        let cutoff = bestSurvivor + Float(log(Self.survivorRelativeFloor))
+        return MLX.where(logits .< cutoff, negInf, logits)
     }
 
     mutating public func didSample(token: MLXArray) {

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -932,6 +932,8 @@ public struct InitialSuppressTokensProcessor: LogitProcessor {
     private let tokens: [Int]
     private var remaining: Int
     private let negInf = MLXArray(-Float.infinity)
+    private let trace = ProcessInfo.processInfo.environment[
+        "VMLX_REASONING_FLOOR_TRACE"] == "1"
 
     public init(tokens: [Int], count: Int) {
         self.tokens = Array(Set(tokens)).sorted()
@@ -945,12 +947,28 @@ public struct InitialSuppressTokensProcessor: LogitProcessor {
         let vocabSize = logits.dim(-1)
         let valid = tokens.filter { $0 >= 0 && $0 < vocabSize }
         guard !valid.isEmpty else { return logits }
+        if trace {
+            let flat = logits.reshaped(-1)
+            let top = argMax(flat).item(Int.self)
+            let probs = softmax(flat.asType(.float32), axis: -1)
+            let bannedMass = valid.map { probs[$0].item(Float.self) }.reduce(0, +)
+            let line =
+                "[vmlx][reasoning-floor] step remaining=\(remaining) preMaskTop=\(top) "
+                + "bannedMass=\(bannedMass) topMass=\(probs[top].item(Float.self))\n"
+            FileHandle.standardError.write(Data(line.utf8))
+        }
         logits[0..., MLXArray(valid.map(Int32.init)).asType(.uint32)] = negInf
         return logits
     }
 
     mutating public func didSample(token: MLXArray) {
-        if remaining > 0 { remaining -= 1 }
+        guard remaining > 0 else { return }
+        if trace {
+            let line =
+                "[vmlx][reasoning-floor] sampled=\(token.reshaped(-1)[0].item(Int.self))\n"
+            FileHandle.standardError.write(Data(line.utf8))
+        }
+        remaining -= 1
     }
 }
 

--- a/Libraries/MLXLMCommon/MinimumReasoningFloor.swift
+++ b/Libraries/MLXLMCommon/MinimumReasoningFloor.swift
@@ -39,8 +39,21 @@ enum MinimumReasoningFloor {
         let tokenCount: Int
     }
 
+    static let defaultTokenCount = 16
+
     /// Leading sampled-token window during which `</think>` stays masked.
-    static let tokenCount = 16
+    ///
+    /// `VMLX_DSV4_REASONING_FLOOR` overrides the window (`0` disables the
+    /// floor entirely) so a build can be A/B'd against an unfloored run
+    /// without a rebuild.
+    static var tokenCount: Int {
+        guard
+            let raw = ProcessInfo.processInfo.environment[
+                "VMLX_DSV4_REASONING_FLOOR"],
+            let parsed = Int(raw.trimmingCharacters(in: .whitespaces))
+        else { return defaultTokenCount }
+        return max(0, parsed)
+    }
 
     /// First lines of the enforced-effort prefaces — the arming markers.
     /// Derived from the encoder constants so a preface reword can never
@@ -77,6 +90,8 @@ enum MinimumReasoningFloor {
         guard let closeID = tokenizer.convertTokenToId("</think>"),
             tokenizer.convertIdToToken(closeID) == "</think>"
         else { return nil }
-        return Armed(closeTokenID: closeID, tokenCount: Self.tokenCount)
+        let window = Self.tokenCount
+        guard window > 0 else { return nil }
+        return Armed(closeTokenID: closeID, tokenCount: window)
     }
 }

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -45,6 +45,43 @@ private struct NativeMTPCacheCheckpoint {
     }
 }
 
+/// Process-wide memo of the hybrid safety-warmup verdict, keyed by model
+/// instance. The 16-cycle probe otherwise re-runs on every request even
+/// though its outcome is a property of the model, not the prompt — census
+/// showed 84% of requests burning the probe just to land in AR fallback
+/// again. Only the *warmup* verdict is memoized; adaptive acceptance-ratio
+/// fallbacks stay per-request because they are content-dependent.
+enum NativeMTPHybridWarmupMemo {
+    private struct Entry {
+        weak var model: AnyObject?
+        let passed: Bool
+    }
+
+    private static let lock = NSLock()
+    private static var entries: [ObjectIdentifier: Entry] = [:]
+
+    static func verdict(for model: AnyObject) -> Bool? {
+        lock.lock()
+        defer { lock.unlock() }
+        let key = ObjectIdentifier(model)
+        guard let entry = entries[key] else { return nil }
+        // A deallocated model can hand its address to a new instance; the
+        // weak reference detects that and drops the stale verdict rather
+        // than skipping a safety probe the new model never ran.
+        guard entry.model === model else {
+            entries[key] = nil
+            return nil
+        }
+        return entry.passed
+    }
+
+    static func record(_ passed: Bool, for model: AnyObject) {
+        lock.lock()
+        defer { lock.unlock() }
+        entries[ObjectIdentifier(model)] = Entry(model: model, passed: passed)
+    }
+}
+
 struct NativeMTPTokenIterator: TokenIteratorProtocol {
     let model: any NativeMTPModel
     var cache: [KVCache]
@@ -168,8 +205,15 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         self.sampler = effectiveParameters.sampler()
         self.speculativeSampler = SpeculativeSamplingController(parameters: effectiveParameters)
         self.maxTokens = effectiveParameters.maxTokens
-        self.depth = requestedDepth
-        self.currentDepth = requestedDepth
+        // Python-vmlx policy parity: depths > 1 only ever won on a
+        // deterministic counting prompt (the 1.83x artifact); on real prose
+        // depth-3 measured 14% slower than AR. Cap at 1 unless a benchmark
+        // explicitly raises it via VMLX_MTP_DEPTH_CAP.
+        let depthCap =
+            ProcessInfo.processInfo.environment["VMLX_MTP_DEPTH_CAP"]
+            .flatMap(Int.init).map { Swift.max($0, 1) } ?? 1
+        self.depth = Swift.min(requestedDepth, depthCap)
+        self.currentDepth = Swift.min(requestedDepth, depthCap)
         self.verifierModeSetting = effectiveParameters.draftStrategy?.nativeMTPVerifierMode
         let promptTokenStart = Date.timeIntervalSinceReferenceDate
         let promptTokenIds = input.text.tokens.reshaped(-1).asArray(Int.self)
@@ -180,6 +224,17 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         self.cacheInitParameters = effectiveParameters
         self.mediaSalt = computeCacheSalt(for: input, parameters: effectiveParameters)
         self.materializeSyncTime += promptTokenElapsed
+
+        if usesHybridMambaCache,
+            let remembered = NativeMTPHybridWarmupMemo.verdict(for: model)
+        {
+            if remembered {
+                hybridSafetyWarmupComplete = true
+            } else {
+                forceAutoregressiveFallback = true
+                adaptiveFallbackReason = "hybrid_warmup_memo"
+            }
+        }
 
         let requestsAffineKV: Bool = {
             if effectiveParameters.kvBits != nil { return true }
@@ -1135,7 +1190,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             let averageAccepted = Double(acceptedTokens) / Double(Swift.max(verifyCalls, 1))
             if averageAccepted >= Self.hybridWarmupMinimumAverageAccepted {
                 hybridSafetyWarmupComplete = true
+                NativeMTPHybridWarmupMemo.record(true, for: model)
             } else {
+                NativeMTPHybridWarmupMemo.record(false, for: model)
                 enableAutoregressiveFallback(
                     reason: String(
                         format: "hybrid_warmup_avg_accept=%.2f",

--- a/Libraries/MLXLMCommon/Tokenizer.swift
+++ b/Libraries/MLXLMCommon/Tokenizer.swift
@@ -315,6 +315,14 @@ public func canonicalChatCacheBoundaries(
         }
         let headDigest = digest(promptTokens.prefix(256))
         let stableDigest = stable.first.map { digest(promptTokens.prefix($0)) } ?? "-"
+        // Only the *first* stable boundary was digested, but the boundary that
+        // actually gets stored is the last one. A divergence between the two —
+        // an injected reasoning preface, a reordered tool block, a date — moves
+        // the stored key while leaving `head`/`stable0` identical, which reads
+        // in the trace as a cache bug rather than a changed prompt.
+        let stableDigests = stable
+            .map { "\($0):\(digest(promptTokens.prefix($0)))" }
+            .joined(separator: ",")
         // `head`/`stable0` both sit inside the system prefix, so when they match
         // across a store and a failing re-warm they only prove the system region
         // is stable — the first live capture showed exactly that, and the
@@ -324,7 +332,8 @@ public func canonicalChatCacheBoundaries(
         let historyDigest = all.last.map { digest(promptTokens.prefix($0)) } ?? "-"
         FileHandle.standardError.write(Data(
             ("[vmlx][cache/boundaries] prompt=\(promptTokens.count) stable=\(stable) all=\(all)"
-                + " head=\(headDigest) stable0=\(stableDigest) hist=\(historyDigest)\n").utf8
+                + " head=\(headDigest) stable0=\(stableDigest) hist=\(historyDigest)"
+                + " stableDigests=[\(stableDigests)]\n").utf8
         ))
     }
     return CanonicalChatCacheBoundaries(all: all, stable: stable)

--- a/Libraries/MLXLMCommon/Tokenizer.swift
+++ b/Libraries/MLXLMCommon/Tokenizer.swift
@@ -250,8 +250,51 @@ public func canonicalChatCacheBoundaries(
         return exactPrefixBoundary(messages: Array(messages.dropLast()))
     }
 
-    let history = (exactPrefixBoundary(messages: messages)
-        ?? trailingContinuationBoundary()).map { [$0] } ?? []
+    /// Intermediate turn-aligned rungs between the stable prefix and the
+    /// newest history boundary.
+    ///
+    /// Only ONE history boundary used to be published, so the entire span
+    /// between the frozen system/tool prefix and the newest turn held no
+    /// stored entry. Because entries are stored AT published boundaries, any
+    /// divergence in that span dropped reuse all the way back to the system
+    /// prefix. Live DSV4 row: `all=[1114, 2643, 5434]`, and two sends in that
+    /// same session fell back to 2643 and re-prefilled 1948 and 2044 tokens
+    /// that were still byte-identical prefixes.
+    ///
+    /// Exactness is unchanged: a rung is admitted only by `exactPrefixBoundary`,
+    /// which requires the rendered message prefix to equal the real prompt
+    /// token-for-token. Rungs are cut at message boundaries so they re-render
+    /// identically on later turns, and spaced by `minimumGap` so the extra
+    /// disk stores each buy a worthwhile amount of skipped prefill.
+    func historyLadder(below top: Int) -> [Int] {
+        guard ProcessInfo.processInfo.environment["VMLX_CACHE_BOUNDARY_LADDER"] != "0"
+        else { return [] }
+        let maximumRungs = 3
+        let minimumGap = 512
+        let floor = stable.last ?? 0
+        guard top - floor >= minimumGap * 2 else { return [] }
+
+        var rungs: [Int] = []
+        var nextHigher = top
+        // Exponential backoff from the tail: recent turns are re-rendered most
+        // often, so granularity is worth more there than deep in the history.
+        for drop in [1, 2, 4, 8, 16] {
+            if rungs.count == maximumRungs { break }
+            guard messages.count - drop > stableMessages.count else { break }
+            guard let rung = exactPrefixBoundary(
+                messages: Array(messages.dropLast(drop))),
+                rung - floor >= minimumGap,
+                nextHigher - rung >= minimumGap
+            else { continue }
+            rungs.append(rung)
+            nextHigher = rung
+        }
+        return rungs
+    }
+
+    let historyTop = exactPrefixBoundary(messages: messages)
+        ?? trailingContinuationBoundary()
+    let history = historyTop.map { [$0] + historyLadder(below: $0) } ?? []
     let all = Array(Set(stable + history)).sorted()
     if ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1" {
         // Token counts alone cannot distinguish two prompts of equal length, so

--- a/RunBench/Bench.swift
+++ b/RunBench/Bench.swift
@@ -606,6 +606,19 @@ struct Bench {
             return
         }
 
+        // BENCH_SOLO_LONGFORM=1: single long-form generation through
+        // `BatchEngine.generate` (solo path) with the real chat template.
+        // For block-diffusion models the [BlockDiffusion] stderr line
+        // reports canvases / denoising forwards / tokens-per-forward —
+        // the honest long-form throughput metric. BENCH_PROMPT overrides
+        // the default essay prompt. Runs before the multi-turn load below:
+        // it loads its own context, and a 100GB-class bundle cannot be
+        // resident twice.
+        if (env["BENCH_SOLO_LONGFORM"] ?? "0") == "1" {
+            try await runSoloLongform(modelPath: modelPath, maxNew: maxNew)
+            return
+        }
+
         print("=== vmlx-swift-lm — \(modelDir.lastPathComponent) MULTI-TURN ===")
         print("Tokens: \(tokensPath)")
         print("Loading...")
@@ -716,16 +729,6 @@ struct Bench {
             return
         }
 
-        // BENCH_SOLO_LONGFORM=1: single long-form generation through
-        // `BatchEngine.generate` (solo path) with the real chat template.
-        // For block-diffusion models the [BlockDiffusion] stderr line
-        // reports canvases / denoising forwards / tokens-per-forward —
-        // the honest long-form throughput metric. BENCH_PROMPT overrides
-        // the default essay prompt.
-        if (env["BENCH_SOLO_LONGFORM"] ?? "0") == "1" {
-            try await runSoloLongform(modelPath: modelPath, maxNew: maxNew)
-            return
-        }
         if (env["BENCH_GROWING_CHAT_CACHE"] ?? "0") == "1" {
             do {
                 try await runGrowingChatCacheReuse(modelPath: modelPath, maxNew: maxNew)
@@ -2372,10 +2375,66 @@ func runSoloLongform(modelPath: String, maxNew: Int) async throws {
     let input = try await context.processor.prepare(input: UserInput(prompt: prompt))
     let promptTokens = input.text.tokens.size
     nonisolated(unsafe) let ctx = context
-    let engine = BatchEngine(context: ctx, maxBatchSize: 1)
+    // BENCH_SOLO_COORDINATOR=1 reproduces the shipping Osaurus cache config
+    // (paged OFF, SSD L2 ON). It is the only way this bench reaches the
+    // prompt-minus-one disk-seed prefill split, which a coordinator-less run
+    // never takes.
+    var coordinator: CacheCoordinator? = nil
+    if (ProcessInfo.processInfo.environment["BENCH_SOLO_COORDINATOR"] ?? "0") == "1" {
+        var cfg = CacheCoordinatorConfig()
+        cfg.usePagedCache = false
+        cfg.enableDiskCache = true
+        cfg.diskCacheDir = URL(fileURLWithPath:
+            ProcessInfo.processInfo.environment["BENCH_SOLO_DISK_DIR"]
+                ?? "/tmp/bench_solo_disk_cache")
+        cfg.modelKey = modelDir.lastPathComponent
+        coordinator = CacheCoordinator(config: cfg)
+        print("  [Coord] paged=false disk=true dir=\(cfg.diskCacheDir?.path ?? "-")")
+    }
+    let engine = BatchEngine(
+        context: ctx, maxBatchSize: 1, cacheCoordinator: coordinator)
     nonisolated(unsafe) let sendable = input
+    var warmupTask: Task<Void, Never>? = nil
+
+    // BENCH_SOLO_WARMUP=1 sends a throwaway request through the same engine
+    // first, the way Osaurus's chat warmup does. A slot's DSV4 pool state that
+    // survives request teardown would only ever be visible in this ordering.
+    if (ProcessInfo.processInfo.environment["BENCH_SOLO_WARMUP"] ?? "0") == "1" {
+        let warmText = ProcessInfo.processInfo.environment["BENCH_SOLO_WARMUP_PROMPT"]
+            ?? "Say OK."
+        let warmInput = try await context.processor.prepare(
+            input: UserInput(prompt: warmText))
+        nonisolated(unsafe) let warmSendable = warmInput
+        var warmParams = GenerateParameters(
+            maxTokens: Int(
+                ProcessInfo.processInfo.environment["BENCH_SOLO_WARMUP_TOKENS"] ?? "1") ?? 1,
+            temperature: 0, prefillStepSize: 512)
+        warmParams.extraStopStrings = []
+        // BENCH_SOLO_WARMUP_CONCURRENT=1 lets the warmup prefill overlap the
+        // visible request instead of completing first. That overlap is what
+        // Osaurus actually does, and it is the only ordering under which two
+        // requests share process-wide model memos mid-forward.
+        let overlap =
+            (ProcessInfo.processInfo.environment["BENCH_SOLO_WARMUP_CONCURRENT"] ?? "0") == "1"
+        let warm = Task {
+            let warmStream = await engine.generate(
+                input: warmSendable, parameters: warmParams)
+            var warmTokens = 0
+            for await event in warmStream {
+                if case .info(let info) = event { warmTokens = info.generationTokenCount }
+            }
+            print("  [Warmup] prompt=\(warmInput.text.tokens.size) genTokens=\(warmTokens)")
+        }
+        if overlap {
+            warmupTask = warm
+            print("  [Warmup] overlapping the visible request")
+        } else {
+            await warm.value
+        }
+    }
 
     var text = ""
+    var reasoning = ""
     var generationTokens = 0
     var firstChunkAt: Double? = nil
     let t0 = CFAbsoluteTimeGetCurrent()
@@ -2385,6 +2444,9 @@ func runSoloLongform(modelPath: String, maxNew: Int) async throws {
         case .chunk(let chunk):
             if firstChunkAt == nil { firstChunkAt = CFAbsoluteTimeGetCurrent() - t0 }
             text += chunk
+        case .reasoning(let chunk):
+            if firstChunkAt == nil { firstChunkAt = CFAbsoluteTimeGetCurrent() - t0 }
+            reasoning += chunk
         case .info(let info):
             generationTokens = info.generationTokenCount
         default:
@@ -2392,15 +2454,21 @@ func runSoloLongform(modelPath: String, maxNew: Int) async throws {
         }
     }
     let wall = CFAbsoluteTimeGetCurrent() - t0
+    await warmupTask?.value
     await engine.shutdown()
 
     let charCount = text.count
     print(String(format:
-        "  prompt=%d genTokens=%d wall=%.2fs TTFT=%.2fs wallTokPerSec=%.1f chars=%d",
+        "  prompt=%d genTokens=%d wall=%.2fs TTFT=%.2fs wallTokPerSec=%.1f chars=%d reasoningChars=%d",
         promptTokens, generationTokens, wall, firstChunkAt ?? 0,
-        Double(generationTokens) / max(wall, 0.001), charCount))
+        Double(generationTokens) / max(wall, 0.001), charCount, reasoning.count))
     let preview = text.count > 700 ? String(text.prefix(700)) + "…" : text
     print("  TEXT:\n\(preview)")
+    if !reasoning.isEmpty {
+        let rPreview =
+            reasoning.count > 700 ? String(reasoning.prefix(700)) + "…" : reasoning
+        print("  REASONING:\n\(rPreview)")
+    }
     print("\n=== Solo long-form done ===")
 }
 

--- a/Tests/MLXLMCommonFocusedTests/CanonicalChatCacheBoundariesTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/CanonicalChatCacheBoundariesTests.swift
@@ -488,4 +488,117 @@ struct CanonicalChatCacheBoundariesTests {
         #expect(Array(enabledPrompt.prefix(enabledBoundary))
             != Array(disabledPrompt.prefix(disabledBoundary)))
     }
+
+    /// Builds a long alternating transcript: one 600-scalar system message
+    /// plus `turns` further 600-scalar messages. `ContentBoundaryTokenizer`
+    /// emits one token per scalar, so each message is ~601 tokens — wide
+    /// enough to clear the ladder's 512-token minimum gap.
+    private func longTranscript(turns: Int) -> [[String: any Sendable]] {
+        var messages: [[String: any Sendable]] = [
+            ["role": "system", "content": String(repeating: "s", count: 600)]
+        ]
+        for index in 0..<turns {
+            messages.append([
+                "role": index.isMultiple(of: 2) ? "user" : "assistant",
+                "content": String(repeating: index.isMultiple(of: 2) ? "u" : "a", count: 600)
+                    + String(index),
+            ])
+        }
+        return messages
+    }
+
+    /// Every published boundary must be reproducible as the exact token
+    /// render of some message prefix. This is the invariant the ladder must
+    /// not weaken: more rungs, but never a rung that isn't byte-identical.
+    private func assertEveryBoundaryIsAnExactMessagePrefix(
+        _ boundaries: CanonicalChatCacheBoundaries,
+        tokenizer: some GenerationPromptControllableTokenizer,
+        messages: [[String: any Sendable]],
+        promptTokens: [Int]
+    ) {
+        for boundary in boundaries.all {
+            #expect(boundary > 0)
+            #expect(boundary < promptTokens.count)
+            let matchesSomeMessagePrefix = (0...messages.count).contains { count in
+                guard let rendered = try? tokenizer.applyChatTemplate(
+                    messages: Array(messages.prefix(count)), tools: nil,
+                    additionalContext: nil, addGenerationPrompt: false),
+                    rendered.count == boundary
+                else { return false }
+                return promptTokens.prefix(boundary).elementsEqual(rendered)
+            }
+            #expect(
+                matchesSomeMessagePrefix,
+                "a published boundary is not an exact render of any message prefix")
+        }
+    }
+
+    @Test("intermediate history rungs are published between the stable prefix and the newest turn")
+    func historyLadderFillsTheGapAboveTheStablePrefix() throws {
+        // Live DSV4 published all=[1114, 2643, 5434] for a 5436-token prompt:
+        // a 2.8k-token span with no stored entry. Two sends in that session
+        // fell back to the frozen 2643 stable prefix and re-prefilled 1948 and
+        // 2044 tokens that were still valid prefixes.
+        let tokenizer = ContentBoundaryTokenizer()
+        let messages = longTranscript(turns: 10)
+        let promptTokens = try tokenizer.applyChatTemplate(
+            messages: messages, tools: nil, additionalContext: nil,
+            addGenerationPrompt: true)
+
+        let boundaries = canonicalChatCacheBoundaries(
+            tokenizer: tokenizer,
+            messages: messages,
+            tools: nil,
+            additionalContext: nil,
+            promptTokens: promptTokens)
+
+        let stableFloor = try #require(boundaries.stable.last)
+        let history = boundaries.all.filter { !boundaries.stable.contains($0) }
+        let historyTop = try #require(history.max())
+
+        // The regression: a single history boundary leaves the whole span
+        // between the stable floor and the newest turn uncovered.
+        #expect(
+            history.count > 1,
+            "only one history boundary published; a mid-transcript divergence still falls back to the stable prefix")
+
+        let rungs = history.filter { $0 != historyTop }.sorted()
+        #expect(rungs.count <= 3, "ladder must stay bounded: extra rungs cost a disk store each")
+        for (index, rung) in rungs.enumerated() {
+            #expect(rung - stableFloor >= 512)
+            let nextHigher = index + 1 < rungs.count ? rungs[index + 1] : historyTop
+            #expect(nextHigher - rung >= 512, "rungs must be spaced to be worth their store")
+        }
+
+        assertEveryBoundaryIsAnExactMessagePrefix(
+            boundaries, tokenizer: tokenizer, messages: messages,
+            promptTokens: promptTokens)
+    }
+
+    @Test("a short transcript publishes no extra rungs")
+    func historyLadderStaysOffWhenTheGapIsSmall() throws {
+        // The rungs are only worth their disk store when they skip real
+        // prefill; a two-turn chat must keep the old single-boundary shape.
+        let tokenizer = ContentBoundaryTokenizer()
+        let messages: [[String: any Sendable]] = [
+            ["role": "system", "content": "instructions"],
+            ["role": "user", "content": "hello"],
+        ]
+        let promptTokens = try tokenizer.applyChatTemplate(
+            messages: messages, tools: nil, additionalContext: nil,
+            addGenerationPrompt: true)
+
+        let boundaries = canonicalChatCacheBoundaries(
+            tokenizer: tokenizer,
+            messages: messages,
+            tools: nil,
+            additionalContext: nil,
+            promptTokens: promptTokens)
+
+        let history = boundaries.all.filter { !boundaries.stable.contains($0) }
+        #expect(history.count <= 1)
+        assertEveryBoundaryIsAnExactMessagePrefix(
+            boundaries, tokenizer: tokenizer, messages: messages,
+            promptTokens: promptTokens)
+    }
 }

--- a/Tests/MLXLMCommonFocusedTests/MinimumReasoningFloorFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/MinimumReasoningFloorFocusedTests.swift
@@ -44,11 +44,16 @@ struct MinimumReasoningFloorFocusedTests {
     @Test("masking a near-certain token must not open the nucleus to the vocab tail")
     func maskedWindowKeepsNucleusClosed() throws {
         try FocusedMLXTestSupport.withLock {
-            // Reproduces the live DSV4 token soup: on the enforced-low rail the
-            // model puts ~97% of its mass on `</think>`. Logit processors run
-            // BEFORE the sampler's top_p, so banning that token renormalizes a
-            // nearly flat residual and nucleus sampling then admits thousands of
-            // junk tokens. Unmasked, top_p would have kept the close token alone.
+            // Logit processors run BEFORE the sampler's top_p, so banning a token
+            // that holds most of the mass renormalizes a nearly flat residual and
+            // nucleus sampling then admits thousands of junk tokens. Unmasked,
+            // top_p would have kept the close token alone.
+            //
+            // This is a property of the processor, not an explanation of the live
+            // DSV4 token soup — that reproduces at temperature 0, where this whole
+            // path is argmax and the min_p floor cannot matter. The commit that
+            // added this test claimed otherwise; see
+            // Docs/Internal/DSV4-TOKEN-SOUP-ROOT-CAUSE-2026-08-09.md.
             let vocab = 4000
             let banned = 7
             let plausible: Set<Int> = [1, 2, 3]

--- a/Tests/MLXLMCommonFocusedTests/MinimumReasoningFloorFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/MinimumReasoningFloorFocusedTests.swift
@@ -41,6 +41,43 @@ struct MinimumReasoningFloorFocusedTests {
         }
     }
 
+    @Test("masking a near-certain token must not open the nucleus to the vocab tail")
+    func maskedWindowKeepsNucleusClosed() throws {
+        try FocusedMLXTestSupport.withLock {
+            // Reproduces the live DSV4 token soup: on the enforced-low rail the
+            // model puts ~97% of its mass on `</think>`. Logit processors run
+            // BEFORE the sampler's top_p, so banning that token renormalizes a
+            // nearly flat residual and nucleus sampling then admits thousands of
+            // junk tokens. Unmasked, top_p would have kept the close token alone.
+            let vocab = 4000
+            let banned = 7
+            let plausible: Set<Int> = [1, 2, 3]
+            var values = [Float](repeating: 0, count: vocab)
+            values[banned] = 12
+            values[1] = 5.0
+            values[2] = 4.7
+            values[3] = 4.5
+            let logits = MLXArray(values).reshaped(1, vocab)
+
+            var processor = InitialSuppressTokensProcessor(
+                tokens: [banned], count: 512)
+            let sampler = TopPSampler(temperature: 0.6, topP: 0.95, randomSeed: 42)
+
+            var junk = 0
+            let draws = 200
+            for _ in 0..<draws {
+                let token = sampler.sample(logits: processor.process(logits: logits))
+                let id = token.reshaped(-1)[0].item(Int.self)
+                #expect(id != banned, "the ban itself must hold")
+                if !plausible.contains(id) { junk += 1 }
+                processor.didSample(token: token)
+            }
+
+            let summary = "masked window leaked \(junk)/\(draws) samples into the tail"
+            #expect(junk == 0, "\(summary) — the floor must not widen the nucleus")
+        }
+    }
+
     @Test("floor arms on every enforced-effort thinking rail and nowhere else")
     func railMatchingIsExact() {
         let lowHead = DeepseekV4ChatEncoder.reasoningEffortLowPreface + "You are helpful."

--- a/Tests/MLXLMTests/DeepseekV4MoERequestScopedIdsTests.swift
+++ b/Tests/MLXLMTests/DeepseekV4MoERequestScopedIdsTests.swift
@@ -1,0 +1,231 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import MLX
+import MLXNN
+import MLXRandom
+import Testing
+
+@testable import MLXLLM
+
+/// The MoE modules live on the shared model object — one weight set serves every
+/// concurrent request — so a mutable field on one of them is as shared as a
+/// global. `DeepseekV4MoE` used to park the current request's token ids in a
+/// `currentInputIds` field that the decoder layer set immediately before the
+/// call and cleared immediately after. On a hash-routed layer the gate ignores
+/// the hidden states and picks experts purely by token id, so a concurrent write
+/// routed one request's activations through another request's experts — finite,
+/// in-range, and silently wrong. `num_hash_layers = 3` puts that in layers 0-2,
+/// from where it propagates through all 43.
+@Suite("DSV4 MoE token ids stay request-scoped", .serialized)
+struct DeepseekV4MoERequestScopedIdsTests {
+
+    /// Small enough to build in milliseconds, still hash-routed at layer 0.
+    private static func tinyConfig() -> DeepseekV4Configuration {
+        var c = DeepseekV4Configuration()
+        c.vocabSize = 32
+        c.hiddenSize = 8
+        c.numHiddenLayers = 2
+        c.nRoutedExperts = 8
+        c.numExpertsPerTok = 2
+        c.moeIntermediateSize = 8
+        c.numHashLayers = 1
+        return c
+    }
+
+    /// Every token id must land on a distinct expert pair, otherwise a swapped
+    /// id would be indistinguishable from the right one and the test could not
+    /// see the bug it exists to catch.
+    private static func makeHashGate(_ c: DeepseekV4Configuration) -> DeepseekV4MoEGate {
+        let gate = DeepseekV4MoEGate(config: c, layerIdx: 0)
+        #expect(gate.isHashLayer, "layer 0 must be hash-routed for this test to mean anything")
+        let table = (0..<c.vocabSize).flatMap { t in
+            [Int32(t % c.nRoutedExperts), Int32((t * 3 + 1) % c.nRoutedExperts)]
+        }
+        gate.update(parameters: ModuleParameters.unflattened([
+            "tid2eid": MLXArray(table, [c.vocabSize, c.numExpertsPerTok]),
+            "weight": MLXRandom.normal([c.nRoutedExperts, c.hiddenSize], key: MLXRandom.key(7)),
+        ]))
+        return gate
+    }
+
+    private static func ints(_ a: MLXArray) -> [Int32] {
+        a.asType(.int32).asArray(Int32.self)
+    }
+
+    private static func floats(_ a: MLXArray) -> [Float] {
+        a.asType(.float32).asArray(Float.self)
+    }
+
+    @Test("hash routing is decided by the ids passed to the call, not by module state")
+    func hashRoutingFollowsTheArgument() {
+        let c = Self.tinyConfig()
+        let gate = Self.makeHashGate(c)
+        let x = MLXRandom.normal([1, 3, c.hiddenSize], key: MLXRandom.key(11))
+
+        let idsA = MLXArray([Int32(0), 1, 2], [1, 3])
+        let idsB = MLXArray([Int32(17), 23, 29], [1, 3])
+
+        let (indA, _) = gate(x, inputIds: idsA)
+        let (indB, _) = gate(x, inputIds: idsB)
+
+        // Same activations, different ids -> different experts. This is what
+        // makes a cross-request clobber corrupting rather than harmless.
+        #expect(
+            Self.ints(indA) != Self.ints(indB),
+            "hash routing ignored the ids; the rest of this suite proves nothing")
+
+        // A third party's call in between must not disturb the first caller.
+        let (indNil, _) = gate(x, inputIds: nil)
+        let (indAAgain, _) = gate(x, inputIds: idsA)
+        #expect(Self.ints(indA) == Self.ints(indAAgain))
+
+        // nil takes the non-hash softmax gate — the exact wrong-expert set a
+        // premature clear used to produce.
+        #expect(Self.ints(indNil) != Self.ints(indA))
+    }
+
+    @Test("MoE forward is a pure function of (x, inputIds) across interleaved calls")
+    func moeForwardCarriesNoStateBetweenCalls() {
+        let c = Self.tinyConfig()
+        let moe = DeepseekV4MoE(config: c, layerIdx: 0)
+        let table = (0..<c.vocabSize).flatMap { t in
+            [Int32(t % c.nRoutedExperts), Int32((t * 3 + 1) % c.nRoutedExperts)]
+        }
+        moe.gate.update(parameters: ModuleParameters.unflattened([
+            "tid2eid": MLXArray(table, [c.vocabSize, c.numExpertsPerTok])
+        ]))
+
+        // L > 1 keeps this on the eager path, which is where the field lived.
+        let x = MLXRandom.normal([1, 3, c.hiddenSize], key: MLXRandom.key(13))
+        let idsA = MLXArray([Int32(0), 1, 2], [1, 3])
+        let idsB = MLXArray([Int32(17), 23, 29], [1, 3])
+
+        let first = Self.floats(moe(x, inputIds: idsA))
+        _ = moe(x, inputIds: idsB)
+        _ = moe(x, inputIds: nil)
+        _ = moe(x)
+        let second = Self.floats(moe(x, inputIds: idsA))
+
+        #expect(first == second)
+
+        // The `UnaryLayer` shim must mean "no ids", i.e. the non-hash gate —
+        // never "whatever ids were last seen".
+        #expect(Self.floats(moe(x)) == Self.floats(moe(x, inputIds: nil)))
+    }
+
+    @Test("concurrent callers with different ids do not see each other's routing")
+    func concurrentCallersAreIsolated() {
+        let c = Self.tinyConfig()
+        let gate = Self.makeHashGate(c)
+        let x = MLXRandom.normal([1, 3, c.hiddenSize], key: MLXRandom.key(17))
+
+        let lanes: [MLXArray] = (0..<8).map { (lane: Int) -> MLXArray in
+            let ids: [Int32] = [Int32(lane), Int32(lane + 8), Int32(lane + 16)]
+            return MLXArray(ids, [1, 3])
+        }
+        let reference = lanes.map { Self.ints(gate(x, inputIds: $0).0) }
+
+        let lock = NSLock()
+        nonisolated(unsafe) var mismatches = 0
+        DispatchQueue.concurrentPerform(iterations: lanes.count * 8) { i in
+            let lane = i % lanes.count
+            let got = Self.ints(gate(x, inputIds: lanes[lane]).0)
+            if got != reference[lane] {
+                lock.lock()
+                mismatches += 1
+                lock.unlock()
+            }
+        }
+        #expect(mismatches == 0)
+    }
+
+    // MARK: - Source invariants
+    //
+    // The behavioural tests above go red only when a race actually lands, and a
+    // race that lands 20% of the time in production lands ~never in a unit test.
+    // These pin the shape of the fix directly so reintroducing the pattern is a
+    // deterministic failure.
+
+    private static func source(_ relativePath: String) throws -> String {
+        let repo = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        return try String(contentsOf: repo.appendingPathComponent(relativePath), encoding: .utf8)
+    }
+
+    /// Lines of a top-level `class`/`final class` body, each paired with the
+    /// brace depth it sits at relative to the class. Depth 1 is a stored
+    /// property; anything deeper is a local inside a member and irrelevant here.
+    private static func classMembers(_ src: String, _ name: String) -> [(String, Int)] {
+        let lines = src.components(separatedBy: "\n")
+        // The delimiter matters: a bare prefix match on "DeepseekV4MoE" lands on
+        // `DeepseekV4MoEGate`, which declares its weights via `@ParameterInfo`
+        // on the same line and so passes this guard vacuously.
+        func declares(_ line: String) -> Bool {
+            for prefix in ["class \(name)", "final class \(name)"] {
+                guard line.hasPrefix(prefix) else { continue }
+                let rest = line.dropFirst(prefix.count).first
+                if rest == nil || rest == ":" || rest == " " || rest == "<" { return true }
+            }
+            return false
+        }
+        guard let start = lines.firstIndex(where: declares) else {
+            Issue.record("class \(name) not found — this guard is scanning nothing")
+            return []
+        }
+        // Depth recorded is the depth *before* the line's own braces, so the
+        // `class …  {` header itself is depth 0 and its properties depth 1.
+        var members: [(String, Int)] = []
+        var depth = 0
+        for line in lines[start...] {
+            let opens = line.filter { $0 == "{" }.count
+            let closes = line.filter { $0 == "}" }.count
+            members.append((line, depth))
+            depth += opens - closes
+            if depth == 0 && members.count > 1 { break }
+        }
+        return members
+    }
+
+    @Test("neither MoE module stores request-scoped MLXArray state")
+    func moeModulesHoldNoMutableArrayState() throws {
+        for (path, name) in [
+            ("Libraries/MLXLLM/Models/DeepseekV4.swift", "DeepseekV4MoE"),
+            ("Libraries/MLXLLM/Models/DeepseekV4JANGTQ.swift", "DeepseekV4MoEJANGTQ"),
+        ] {
+            let members = Self.classMembers(try Self.source(path), name)
+            #expect(members.count > 10, "\(name) body did not parse")
+            let body = members.map(\.0).joined(separator: "\n")
+            let offenders = members.filter { line, depth in
+                guard depth == 1 else { return false }
+                let t = line.trimmingCharacters(in: .whitespaces)
+                guard t.hasPrefix("var ") else { return false }
+                return t.contains(": MLXArray") || t.contains(": MLX.MLXArray")
+            }.map(\.0)
+            #expect(
+                offenders.isEmpty,
+                """
+                \(name) declares mutable MLXArray state: \(offenders).
+                This module is shared by every concurrent request; request-scoped
+                values must be call arguments. See the `currentInputIds` soup bug.
+                """)
+            #expect(body.contains("currentInputIds") == false)
+        }
+    }
+
+    @Test("token ids reach both MoE modules as a call argument")
+    func decoderLayersThreadIdsAsArguments() throws {
+        let dsv4 = try Self.source("Libraries/MLXLLM/Models/DeepseekV4.swift")
+        let jangtq = try Self.source("Libraries/MLXLLM/Models/DeepseekV4JANGTQ.swift")
+
+        for src in [dsv4, jangtq] {
+            #expect(src.contains("func callAsFunction(_ x: MLXArray, inputIds: MLXArray?)"))
+            // The decoder layer must pass them down, not assign them onto `mlp`.
+            #expect(src.contains("mlp(") && src.contains("inputIds: inputIds"))
+            #expect(src.range(of: #"mlp\.\w+\s*=\s*inputIds"#, options: .regularExpression) == nil)
+        }
+    }
+}

--- a/Tests/MLXLMTests/DeepseekV4PoolQuantizationTests.swift
+++ b/Tests/MLXLMTests/DeepseekV4PoolQuantizationTests.swift
@@ -455,6 +455,110 @@ struct DeepseekV4PoolQuantizationTests {
         }
     }
 
+    @Test("heads16 matches reference at cold-prefill production shape")
+    func heads16ColdPrefillProductionShapeParity() {
+        let mlxLock = lockSerializedMLXTest()
+        defer { mlxLock.unlock() }
+
+        // The other heads16 cases all run offset > 0 with a pool that is
+        // almost entirely causally visible, and shapes (seq <= 24, window
+        // <= 32) far below anything DSV4-Flash decodes. A cold prefill is
+        // the opposite regime: offset == 0, window 128 from the bundle, and
+        // early queries where EVERY selected pool row is causally invisible
+        // so the kernel's threadgroup-uniform `continue` carries the result.
+        let seqLen = 512
+        let rows = 512
+        let poolRows = 128
+        let k = 96
+        let window = 128
+        let ratio = 4
+        let scale = Float(pow(Double(512), -0.5))
+        var topkValues = [Int32]()
+        for t in 0..<seqLen {
+            for i in 0..<k {
+                topkValues.append(Int32((t * 13 + i * 11) % poolRows))
+            }
+        }
+        let topk2d = MLXArray(topkValues).reshaped(seqLen, k)
+        let sinks32 = Self.heads16Values(64, frequency: 0.61, phase: 0.3)
+        for offset in [0, 2048] {
+            let q = Self.heads16Values(
+                64 * seqLen * 512, frequency: 0.29, phase: 0.7
+            ).reshaped(1, 64, seqLen, 512).asType(.bfloat16)
+            let kv2d = Self.heads16Values(
+                rows * 512, frequency: 0.47, phase: 1.3
+            ).reshaped(rows, 512).asType(.bfloat16)
+            let pool2d = Self.heads16Values(
+                poolRows * 512, frequency: 0.73, phase: 2.1
+            ).reshaped(poolRows, 512).asType(.bfloat16)
+            let got = DeepseekV4Math.heads16RunKernel(
+                q: q, kv2d: kv2d, pool2d: pool2d, topk2d: topk2d,
+                sinks32: sinks32,
+                offset: offset, window: window, ratio: ratio, scale: scale
+            ).asType(.float32)
+            let ref = DeepseekV4Math.heads16Reference(
+                q: q, kv2d: kv2d, pool2d: pool2d, topk2d: topk2d,
+                sinks32: sinks32,
+                offset: offset, window: window, ratio: ratio, scale: scale
+            ).asType(.float32)
+            MLX.eval(got, ref)
+            let denom = max(MLX.abs(ref).max().item(Float.self), Float(1e-6))
+            let rel = MLX.abs(got - ref).max().item(Float.self) / denom
+            #expect(rel.isFinite && rel <= 2.5e-2, "rel \(rel) offset \(offset)")
+        }
+    }
+
+    @Test("heads16 is bit-stable across repeated runs at production shape")
+    func heads16RepeatedRunsAreStable() {
+        let mlxLock = lockSerializedMLXTest()
+        defer { mlxLock.unlock() }
+
+        // Live DSV4 produced token soup on one cold prefill and clean prose
+        // on the next with an identical prompt and build. MLX ops are
+        // deterministic, so a run-to-run difference here would localize that
+        // to the kernel's threadgroup staging rather than to sampling.
+        let seqLen = 512
+        let rows = 512
+        let poolRows = 128
+        let k = 96
+        var topkValues = [Int32]()
+        for t in 0..<seqLen {
+            for i in 0..<k {
+                topkValues.append(Int32((t * 13 + i * 11) % poolRows))
+            }
+        }
+        let topk2d = MLXArray(topkValues).reshaped(seqLen, k)
+        let sinks32 = Self.heads16Values(64, frequency: 0.61, phase: 0.3)
+        let q = Self.heads16Values(
+            64 * seqLen * 512, frequency: 0.29, phase: 0.7
+        ).reshaped(1, 64, seqLen, 512).asType(.bfloat16)
+        let kv2d = Self.heads16Values(
+            rows * 512, frequency: 0.47, phase: 1.3
+        ).reshaped(rows, 512).asType(.bfloat16)
+        let pool2d = Self.heads16Values(
+            poolRows * 512, frequency: 0.73, phase: 2.1
+        ).reshaped(poolRows, 512).asType(.bfloat16)
+
+        func run() -> MLXArray {
+            DeepseekV4Math.heads16RunKernel(
+                q: q, kv2d: kv2d, pool2d: pool2d, topk2d: topk2d,
+                sinks32: sinks32,
+                offset: 0, window: 128, ratio: 4,
+                scale: Float(pow(Double(512), -0.5)))
+        }
+        let baseline = run()
+        MLX.eval(baseline)
+        for attempt in 1...8 {
+            let again = run()
+            MLX.eval(again)
+            let identical = MLX.all(again .== baseline)
+            MLX.eval(identical)
+            #expect(
+                identical.item(Bool.self),
+                "attempt \(attempt) diverged from the first run")
+        }
+    }
+
     @Test("heads16 entry path reshapes/casts correctly and matches reference")
     func heads16EntryMatchesReference() {
         let mlxLock = lockSerializedMLXTest()

--- a/Tests/MLXLMTests/DeepseekV4RoPETableConcurrencyTests.swift
+++ b/Tests/MLXLMTests/DeepseekV4RoPETableConcurrencyTests.swift
@@ -1,0 +1,123 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import MLX
+import MLXLMCommon
+import Testing
+
+@testable import MLXLLM
+
+/// The shared RoPE cos/sin memos are process-wide statics. Two concurrent
+/// requests (Osaurus dispatches chat warmup alongside the visible turn) reach
+/// them at the same time, so whatever they hand out is used from two threads
+/// against two different MLX graphs.
+@Suite("DSV4 shared RoPE tables are concurrency-safe", .serialized)
+struct DeepseekV4RoPETableConcurrencyTests {
+
+    private static func makeRoPE() -> DeepseekV4RoPE {
+        DeepseekV4RoPE(dim: 64, base: 10000, factor: 1.0, origMaxPos: 65536)
+    }
+
+    private static func checksum(_ cos: MLXArray, _ sin: MLXArray) -> Float {
+        let value = cos.asType(.float32).sum() * 3.0 + sin.asType(.float32).sum() * 7.0
+        value.eval()
+        return value.item(Float.self)
+    }
+
+    private static let lanes = 8
+    private static let iterations = 40
+
+    private static func countMismatches(
+        reference: [Float], _ sample: @escaping (Int, Int) -> Float
+    ) -> Int {
+        let tally = NSLock()
+        nonisolated(unsafe) var mismatches = 0
+        DispatchQueue.concurrentPerform(iterations: lanes) { lane in
+            var bad = 0
+            for iteration in 0 ..< iterations {
+                let slot = (lane + iteration) % reference.count
+                if sample(lane, iteration) != reference[slot] { bad += 1 }
+            }
+            tally.lock()
+            mismatches += bad
+            tally.unlock()
+        }
+        return mismatches
+    }
+
+    /// Each entry is stored while still an unevaluated graph node. Handing the
+    /// same node to another thread lets both threads drive `eval` on one
+    /// `array_desc`, so the table can be read half-written.
+    @Test("contended cos/sin windows stay bit-exact against a serial reference")
+    func concurrentCosSinMatchesSerialReference() {
+        nonisolated(unsafe) let rope = Self.makeRoPE()
+        let windows: [(offset: Int, length: Int)] = [
+            (0, 512), (512, 512), (2048, 724), (0, 1), (2772, 1),
+        ]
+
+        var reference: [Float] = []
+        for w in windows {
+            let (c, s) = rope.cosSin(offset: w.offset, length: w.length)
+            reference.append(Self.checksum(c, s))
+        }
+
+        let mismatches = Self.countMismatches(reference: reference) { lane, iteration in
+            let w = windows[(lane + iteration) % windows.count]
+            let (c, s) = rope.cosSin(offset: w.offset, length: w.length)
+            return Self.checksum(c, s)
+        }
+        #expect(mismatches == 0)
+    }
+
+    @Test("contended strided pool windows stay bit-exact against a serial reference")
+    func concurrentStridedCosSinMatchesSerialReference() {
+        nonisolated(unsafe) let rope = Self.makeRoPE()
+        let windows: [(base: Int, count: Int, stride: Int)] = [
+            (0, 512, 4), (0, 16, 128), (2048, 181, 4), (2048, 5, 128), (512, 128, 4),
+        ]
+
+        var reference: [Float] = []
+        for w in windows {
+            let (c, s) = rope.cosSin(base: w.base, count: w.count, stride: w.stride)
+            reference.append(Self.checksum(c, s))
+        }
+
+        let mismatches = Self.countMismatches(reference: reference) { lane, iteration in
+            let w = windows[(lane + iteration) % windows.count]
+            let (c, s) = rope.cosSin(base: w.base, count: w.count, stride: w.stride)
+            return Self.checksum(c, s)
+        }
+        #expect(mismatches == 0)
+    }
+
+    /// The structural invariant behind the fix: nothing may leave the memo
+    /// while it is still a pending graph node, because a pending node is what
+    /// two threads can race. MLX Swift exposes no `isAvailable`, so this pins
+    /// the source instead — drop either `eval` and it goes red deterministically
+    /// rather than waiting for the scheduler to lose the race.
+    @Test("memoized tables are materialized before they are shared")
+    func memoizedTablesAreEvaluatedBeforeSharing() throws {
+        let source = try String(
+            contentsOf: URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent()  // MLXLMTests
+                .deletingLastPathComponent()  // Tests
+                .deletingLastPathComponent()  // package root
+                .appendingPathComponent("Libraries/MLXLLM/Models/DeepseekV4.swift"),
+            encoding: .utf8)
+
+        let memos = [
+            ("sharedCosSin", "tables[key] = (offset, length, c, s)"),
+            ("sharedStridedCosSin", "stridedTables[sKey] = (base, count, c, s)"),
+        ]
+        for (memo, storeStatement) in memos {
+            let start = try #require(source.range(of: "private static func \(memo)("))
+            let body = String(source[start.lowerBound...].prefix(1400))
+            let store = try #require(body.range(of: storeStatement)?.lowerBound)
+            let materialize = try #require(body.range(of: "MLX.eval(c, s)")?.lowerBound)
+            #expect(
+                materialize < store,
+                "\(memo) must eval the table before publishing it to other threads")
+        }
+    }
+}


### PR DESCRIPTION
Post-#215 fixes and instrumentation from the DSV4-Flash speed campaign.

## Fixes

- **Boundary ladder** (`77cdeb68`): publish up to 3 turn-aligned intermediate history boundaries (>=512 tokens apart, exponential backoff from the tail) so mid-transcript divergence keeps its longest prefix instead of falling back to the system prefix. Exactness unchanged — the `exactPrefixBoundary` gate still content-verifies every candidate. `VMLX_CACHE_BOUNDARY_LADDER=0` disables. Hybrid-SSM stacks skip the extra rungs.
- **Reasoning-floor nucleus fix** (`67171d05` + `075a7e84`): the floor ban no longer widens the sampling nucleus; kill switch `VMLX_DSV4_REASONING_FLOOR=0` + pre-mask trace for diagnosis.
- **Shared-memo materialization** (`e04be0b7`): DSV4 shared RoPE/qNorm memos are evaluated before publication — a pending graph node handed to two concurrent requests let both drive eval on one array_desc. Source-ordering guard is test-pinned.
- **MoE routing ids off the shared module** (`7cfa55d8` + `ff976088`): token ids for hash-layer routing are threaded as a call argument instead of parked on the (process-shared) module; 5 guards, sabotage-verified.
- **Compiled decode regions built once under a lock** (`d5769615`): region construction no longer races under concurrent requests (6 sites via `deepseekV4CachedRegion`).
- **Native MTP policy parity** (`81d5ee62`): depth capped at 1 (`VMLX_MTP_DEPTH_CAP` raises it for benchmarks) — depth>1 only ever won on a deterministic counting prompt and measures slower on prose; the 16-cycle hybrid safety-warmup verdict is memoized per model instance (weak-ref-validated) instead of re-probing on every request. temp>0 skip was already enforced by the greedy-only guard.

## Instrumentation (all env-gated, off by default)

- `stableDigests` for EVERY stable boundary (`39a950ab`) — previously only the first was fingerprinted while the LAST is what gets stored; this blind spot cost a full day of cache-miss misattribution.
- Disk-cache probe traces (`d5769615`): `noRow` vs `companion REJECTED` per boundary, ending the silent-veto ambiguity that once cost LFM2.5 its cache.
- Cache-salt component traces (`81d5ee62`): raw policy string + reasoning scope + content hash on store/fetch. This trace found the warmup-vs-send scope-salt mismatch behind the first-turn double-prefill (fix lands osaurus-side).
- Lazy per-layer stats + per-block attn/moe split + once-per-process weight checksums (`6a739950`, `81d5ee62`): localized the DSV4 cold-boot token-soup to nondeterministically mis-materialized layer-15/16 quantized tensors at load (clean boots read scales/biases as 0.0 where soup boots read nonzero). Collection is laziness-preserving so the instrumentation cannot mask the fault it hunts; weight checksums run only after the first forward for the same reason.
- Generation-tail phase timing (`81d5ee62`) to split the post-output hang between GPU drain and the synchronous disk store.

## Validation

- 22 instrumented cold-boot live trials (10 + 12) across two builds: cache traces confirmed store row + file present with digest-identical probes (the salt mismatch), layer traces bit-identical across independent recomputes on souped boots (per-boot determinism), weight checksums separated load-corruption from compute-path.
- `swift build` clean on MLXLMCommon + MLXLLM; existing sabotage-verified guards (`ff976088`, `e04be0b7`) stay red without their fixes.