### PR TITLE
Refuse to load truncated safetensors shards (root cause of the DSV4-Flash token soup)

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -855,6 +855,8 @@ public actor BatchEngine {
 
             var sawTerminalInfo = false
             var generatedTokenCount = 0
+            var lastTokenAt: Date?
+            var lastPumpAt: Date?
             let streamStartedAt = Date()
 
             for await event in tokenStream {
@@ -863,9 +865,11 @@ public actor BatchEngine {
                     continuation.yield(.prefillProgress(progress))
                 case .token(let id):
                     generatedTokenCount += 1
+                    lastTokenAt = Date()
                     detokenizer.append(token: id)
                     if let text = detokenizer.next() {
                         pump(text)
+                        lastPumpAt = Date()
                     }
                     if stopMatched {
                         // Tell the BatchEngine actor to halt this slot
@@ -912,6 +916,21 @@ public actor BatchEngine {
                         unclosedReasoning: unclosed,
                         toolCallProtocolFailure: toolCallProcessor?.toolCallProtocolFailure)
                     terminationState.markCompleted()
+                    if ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1" {
+                        // Hosts report the visible answer finishing seconds
+                        // before the turn finalizes. Deltas and `.info` are
+                        // both produced here, so timing the gap between the
+                        // last token, the last emitted text, and `.info`
+                        // separates "still decoding invisible tokens" from
+                        // "decode done, terminal event delayed".
+                        let now = Date()
+                        let sinceToken = lastTokenAt.map { now.timeIntervalSince($0) } ?? -1
+                        let sincePump = lastPumpAt.map { now.timeIntervalSince($0) } ?? -1
+                        FileHandle.standardError.write(Data(
+                            ("[vmlx][gen/info-gap] sinceLastToken=\(sinceToken)s "
+                                + "sinceLastEmittedText=\(sincePump)s "
+                                + "tokens=\(generatedTokenCount)\n").utf8))
+                    }
                     continuation.yield(.info(finalInfo))
                     // Publish the terminal event before hopping back to the
                     // engine actor for diagnostics. If finishSlot is still

--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -422,6 +422,38 @@ public func loadWeights(
             FileHandle.standardError.write(
                 Data("[Load] JANG shape walk produced \(inferred.perLayerQuantization.count) per-layer quant override(s) over default (bits=\(b), gs=\(g))\n".utf8))
         }
+        if ProcessInfo.processInfo.environment["VMLX_LOAD_QUANT_TRACE"] == "1" {
+            // DSV4-Flash boots read `layers.15.ffn.shared_experts.*` and
+            // `layers.16.attn.indexer.wq_b.*` as all-zero (~80% of boots) or
+            // garbage (~20%) in module space, while the bundle holds sane
+            // values — so either the resolved (bits, gs) for exactly these
+            // tensors is wrong, or their load is dropped. Print what THIS
+            // boot resolved and what the source tensors look like, per
+            // suspect path, so one boot names the failing step.
+            for probe in [
+                "layers.14.ffn.shared_experts.w1", "layers.15.ffn.shared_experts.w1",
+                "layers.15.ffn.shared_experts.w2", "layers.16.attn.indexer.wq_b",
+                "layers.14.attn.indexer.wq_b",
+            ] {
+                let scales = weights[probe + ".scales"]
+                let weightArr = weights[probe + ".weight"]
+                let override = inferred.perLayerQuantization[probe]
+                let desc: String
+                if let scales, let weightArr {
+                    let s = MLX.abs(scales.asType(.float32)).mean()
+                    MLX.eval(s)
+                    desc =
+                        "present wShape=\(weightArr.shape) sShape=\(scales.shape) "
+                        + "sAbsmean=\(s.item(Float.self)) override=\(String(describing: override))"
+                } else {
+                    desc =
+                        "MISSING (weight=\(weightArr != nil) scales=\(scales != nil)) "
+                        + "override=\(String(describing: override))"
+                }
+                FileHandle.standardError.write(
+                    Data("[Load][quant-trace] \(probe): \(desc)\n".utf8))
+            }
+        }
         func variants(_ key: String) -> [String] {
             var seen = Set<String>()
             var out: [String] = []

--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -35,6 +35,62 @@ private func loadSafetensorsHeaderNamesForBaseLoad(_ url: URL) throws -> [String
     return header.keys.filter { $0 != "__metadata__" }
 }
 
+/// A bundle whose shard files are shorter than their headers declare.
+public struct TruncatedSafetensorsError: LocalizedError {
+    public let description: String
+    public var errorDescription: String? { description }
+}
+
+/// Bytes a safetensors file is short of what its own header declares, or nil
+/// when the file is complete (or its header cannot be parsed).
+///
+/// Weights are memory-mapped, so a shard truncated by an interrupted download
+/// does NOT fail to load: the tensors whose data falls past end-of-file map to
+/// pages that read as zeros on most boots and as leftover garbage on some, with
+/// the outcome fixed for the lifetime of the mapping. A model in that state
+/// produces subtly degraded output most of the time and complete token soup the
+/// rest, deterministically per launch — which reads exactly like a
+/// nondeterministic runtime/concurrency bug and is nearly impossible to
+/// attribute from the output alone. Concrete case: a DeepSeek-V4-Flash bundle
+/// with 8 of 102 shards short by ~301 MB total spent days looking like a race
+/// in the MoE routing path; ~20% of launches produced gibberish from the first
+/// sampled token, and the other 80% silently dropped a shared-expert
+/// contribution. Checking the length is cheap and turns that whole class into
+/// one obvious message at load.
+func safetensorsMissingByteCount(_ url: URL) -> Int64? {
+    guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+    defer { try? handle.close() }
+    guard let lengthData = try? handle.read(upToCount: 8), lengthData.count == 8
+    else { return nil }
+    var headerLength: UInt64 = 0
+    for (index, byte) in lengthData.enumerated() {
+        headerLength |= UInt64(byte) << UInt64(index * 8)
+    }
+    guard headerLength > 0, headerLength <= 64 * 1024 * 1024,
+        let headerData = try? handle.read(upToCount: Int(headerLength)),
+        headerData.count == Int(headerLength),
+        let header = try? JSONSerialization.jsonObject(with: headerData) as? [String: Any]
+    else { return nil }
+
+    var maxEnd: UInt64 = 0
+    for (name, value) in header where name != "__metadata__" {
+        guard let entry = value as? [String: Any],
+            let offsets = entry["data_offsets"] as? [Any],
+            offsets.count == 2,
+            let end = (offsets[1] as? NSNumber)?.uint64Value
+        else { continue }
+        maxEnd = max(maxEnd, end)
+    }
+    guard maxEnd > 0 else { return nil }
+
+    let declared = Int64(8 + headerLength + maxEnd)
+    guard let size = (try? FileManager.default.attributesOfItem(atPath: url.path))?[.size]
+        as? NSNumber
+    else { return nil }
+    let actual = size.int64Value
+    return actual < declared ? declared - actual : nil
+}
+
 private func modelIndexContainsPreservedMTPWeight(at modelDirectory: URL) -> Bool? {
     let indexURL = modelDirectory.appendingPathComponent("model.safetensors.index.json")
     guard let data = try? Data(contentsOf: indexURL),
@@ -209,6 +265,41 @@ public func loadWeights(
                     "-of-\(String(format: "%05d", completeTotal)).safetensors")
             }
         }
+        // Fail loudly on a truncated bundle BEFORE mapping any of it. See
+        // `safetensorsMissingByteCount` — mapping past end-of-file is silent,
+        // so without this the only symptom is degraded or garbage output that
+        // looks like a runtime bug. `VMLX_ALLOW_TRUNCATED_SHARDS=1` downgrades
+        // this to a warning for deliberate partial-bundle experiments.
+        var truncatedShards: [(String, Int64)] = []
+        for url in allShardURLs {
+            if let missing = safetensorsMissingByteCount(url) {
+                truncatedShards.append((url.lastPathComponent, missing))
+            }
+        }
+        if !truncatedShards.isEmpty {
+            let total = truncatedShards.reduce(Int64(0)) { $0 + $1.1 }
+            let detail = truncatedShards
+                .sorted { $0.0 < $1.0 }
+                .map { "  \($0.0): missing \($0.1) bytes" }
+                .joined(separator: "\n")
+            let message =
+                "\(truncatedShards.count) of \(allShardURLs.count) safetensors "
+                + "shard(s) in \(modelDirectory.path) are shorter than their own "
+                + "header declares (\(total) bytes missing in total) — the download "
+                + "is incomplete or the files were truncated. Weights are "
+                + "memory-mapped, so loading anyway yields zeros or uninitialized "
+                + "memory for the affected tensors and produces degraded or "
+                + "garbage output that varies per launch. Re-download the bundle.\n"
+                + detail
+            if ProcessInfo.processInfo.environment["VMLX_ALLOW_TRUNCATED_SHARDS"] == "1" {
+                FileHandle.standardError.write(Data(
+                    "[loadWeights] WARNING (VMLX_ALLOW_TRUNCATED_SHARDS=1): \(message)\n".utf8))
+            } else {
+                FileHandle.standardError.write(Data("[loadWeights] \(message)\n".utf8))
+                throw TruncatedSafetensorsError(description: message)
+            }
+        }
+
         // Canonical loader entry. On patched osaurus mlx-swift pins,
         // `loadArraysAndMetadata(url:)` honors the safetensors mmap
         // environment set by `ModelFactory.withMmapSafetensorsEnv`,

--- a/Tests/MLXLMTests/TruncatedSafetensorsTests.swift
+++ b/Tests/MLXLMTests/TruncatedSafetensorsTests.swift
@@ -1,0 +1,100 @@
+// A safetensors shard that is shorter than its own header declares does not
+// fail to load — the weights are memory-mapped, so the tensors whose data falls
+// past end-of-file read as zeros on most launches and as leftover garbage on
+// some, with the outcome fixed for the life of the mapping.
+//
+// Observed: a DeepSeek-V4-Flash bundle with 8 of 102 shards short by ~301 MB in
+// total. About one launch in five produced gibberish from the very first sampled
+// token; the rest silently dropped a shared-expert contribution and looked fine.
+// Because the outcome was decided at load and then held for the whole process,
+// it presented as a nondeterministic concurrency bug in the MoE routing path and
+// survived five A/B legs that each changed a suspected racing component and
+// moved the failure rate not at all.
+//
+// The file length is knowable before a single byte is mapped, so these tests pin
+// that we look.
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+struct TruncatedSafetensorsTests {
+
+    /// Build a safetensors file whose header declares `declaredBytes` of tensor
+    /// data while only `actualBytes` are written.
+    private func makeShard(
+        at url: URL, declaredBytes: Int, actualBytes: Int
+    ) throws {
+        let header: [String: Any] = [
+            "weight": [
+                "dtype": "F16",
+                "shape": [declaredBytes / 2],
+                "data_offsets": [0, declaredBytes],
+            ]
+        ]
+        let headerData = try JSONSerialization.data(withJSONObject: header)
+        var out = Data()
+        var length = UInt64(headerData.count)
+        withUnsafeBytes(of: &length) { out.append(contentsOf: $0) }
+        out.append(headerData)
+        out.append(Data(repeating: 0, count: actualBytes))
+        try out.write(to: url)
+    }
+
+    @Test("A shard shorter than its header reports exactly the missing bytes")
+    func truncatedShardIsDetected() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vmlx-trunc-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let url = dir.appendingPathComponent("model-00001-of-00001.safetensors")
+        try makeShard(at: url, declaredBytes: 4096, actualBytes: 1024)
+
+        #expect(safetensorsMissingByteCount(url) == 3072)
+    }
+
+    @Test("A complete shard reports no missing bytes")
+    func completeShardIsAccepted() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vmlx-trunc-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let url = dir.appendingPathComponent("model-00001-of-00001.safetensors")
+        try makeShard(at: url, declaredBytes: 4096, actualBytes: 4096)
+
+        #expect(safetensorsMissingByteCount(url) == nil)
+    }
+
+    /// A file longer than its header declares is NOT truncation — some writers
+    /// pad. Flagging it would turn a working bundle into a hard load failure.
+    @Test("A shard longer than its header declares is not treated as truncated")
+    func paddedShardIsAccepted() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vmlx-trunc-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let url = dir.appendingPathComponent("model-00001-of-00001.safetensors")
+        try makeShard(at: url, declaredBytes: 4096, actualBytes: 8192)
+
+        #expect(safetensorsMissingByteCount(url) == nil)
+    }
+
+    /// Non-safetensors and unparseable files must stay silent — this check is a
+    /// guard against a specific corruption, not a general file validator.
+    @Test("An unparseable file is ignored rather than reported as truncated")
+    func unparseableFileIsIgnored() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vmlx-trunc-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let url = dir.appendingPathComponent("garbage.safetensors")
+        try Data(repeating: 0xAB, count: 32).write(to: url)
+
+        #expect(safetensorsMissingByteCount(url) == nil)
+    }
+}


### PR DESCRIPTION
## The bug

A safetensors shard that is shorter than its own header declares does **not** fail to load. Weights are memory-mapped, so tensors whose data falls past end-of-file map to pages that read as **zeros on most launches** and as **leftover garbage on some**, with the outcome fixed for the life of the mapping.

`dealign.ai/DeepSeek-V4-Flash-0731-JANG-CRACK` has **8 of its 102 shards (33–40) short by ~301 MB in total**:

```
model-00033-of-00102.safetensors  missing 24,786,776 bytes
model-00034-of-00102.safetensors  missing 26,453,040
model-00035-of-00102.safetensors  missing 32,208,456
model-00036-of-00102.safetensors  missing 27,945,168
model-00037-of-00102.safetensors  missing 38,640,104
model-00038-of-00102.safetensors  missing 68,548,320
model-00039-of-00102.safetensors  missing 39,094,808
model-00040-of-00102.safetensors  missing 44,029,944
```

`layers.15.ffn.shared_experts.*.scales` begins at byte 1,027,757,536 of shard 38, which is 961,851,392 bytes long — the tensor starts ~66 MB past EOF. Same for `layers.16.attn.indexer.wq_b.scales`.

## Why it took so long to find

The symptom was ~20% of cold launches producing gibberish from the first sampled token, deterministic within a launch. That reads exactly like a concurrency bug, and it was hunted as one. Five A/B legs each disabled a suspected racing component — the reasoning floor, the shared RoPE/qNorm memos, the compiled decode regions, the MoE expert-routing input ids, the heads-16 prefill kernel — and **none moved the failure rate**, because none touched the cause.

What finally localized it:
1. Lazy per-layer magnitude traces put the blow-up at **layer 15** (absmax 1.6 → 34k–123k), present from the warm-up's first prefill chunk and **bit-identical** across the send's independent recompute — so per-boot deterministic, not per-request.
2. A once-per-process weight checksum showed a clean and a souped boot differing on **exactly** `layers.15.mlp.shared_experts.*.{scales,biases}` and `layers.16.self_attn.indexer.wq_b.*` and nothing else.
3. Reading the bundle's own headers showed those tensors start past end-of-file.

The 80% of launches that read zeros were not "clean" either — they silently dropped the layer-15 shared-expert contribution.

## The fix

Check every shard's length against its header's maximum `data_offsets[1]` **before** mapping anything, and throw with each short shard named and its missing byte count. Cheap (header parse + `stat`), and it converts a whole class of silent corruption into one obvious message.

- `VMLX_ALLOW_TRUNCATED_SHARDS=1` downgrades it to a warning for deliberate partial-bundle experiments.
- A file **longer** than its header declares is left alone — some writers pad, and rejecting that would break working bundles.

## Tests

`TruncatedSafetensorsTests` — 4 tests, all passing: exact missing-byte count on a short shard, no report on a complete shard, no report on a padded shard, and silence on an unparseable file.

## Also in this PR

Two env-gated diagnostics (off by default), which is how the above was found:
- `VMLX_LOAD_QUANT_TRACE=1` — per-path source shapes, scales magnitude, and the resolved per-layer quant override.
- `VMLX_CACHE_FETCH_TRACE=1` now also reports the gap between the last generated token, the last emitted text, and the terminal `.info` event. Live measurement: **~4 s on Gemma-4-12B, ~49 s on Bonsai-27B** between the last visible token and stream completion, with the UI finishing 0.12 s after the engine — so the long-reported "output hangs before showing stats" is engine-side, not the renderer. That investigation continues separately.