### PR TITLE
Cut the post-answer stall: stop re-storing already-durable cache boundaries

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -1208,6 +1208,15 @@ public actor BatchEngine {
             generationTask.cancel()
         }
         Task {
+            // Hosts report the visible answer finishing seconds before the turn
+            // finalizes, and `maxBatchSize == 1` means every real request takes
+            // THIS path — the batched loop's probe never fires. Time the gap
+            // between the last text event and the terminal `.info` here, where
+            // it can actually be observed.
+            let gapTrace =
+                ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1"
+            var lastTextAt: Date?
+            var textEvents = 0
             for await generation in sourceStream {
                 if case .info(let info) = generation, info.turboQuantCompressions > 0 {
                     turboQuantCompressionCount += info.turboQuantCompressions
@@ -1216,6 +1225,20 @@ public actor BatchEngine {
                    let transition = info.turboQuantCacheTransition
                 {
                     lastTurboQuantCacheTransition = transition
+                }
+                switch generation {
+                case .chunk, .reasoning:
+                    lastTextAt = Date()
+                    textEvents += 1
+                case .info:
+                    if gapTrace {
+                        let gap = lastTextAt.map { Date().timeIntervalSince($0) } ?? -1
+                        FileHandle.standardError.write(Data(
+                            ("[vmlx][solo/info-gap] sinceLastText=\(gap)s "
+                                + "textEvents=\(textEvents)\n").utf8))
+                    }
+                default:
+                    break
                 }
                 continuation.yield(generation)
             }

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -2588,13 +2588,22 @@ public struct TokenIterator: TokenIteratorProtocol {
                         ? boundary - 1
                         : boundary
                     let boundaryTokens = Array(promptTokenIds.prefix(storeBoundary))
-                    if isStableBoundary,
-                       coordinator.hasValidatedDiskEntry(
+                    // Applies to EVERY boundary, not just the stable ones. The
+                    // ladder republishes the same rungs each turn, so a chat
+                    // rewrote the identical seeds turn after turn — and this
+                    // work is on the request path: the whole post-answer stall
+                    // is this loop (measured 12.4 s for one DSV4-Flash turn
+                    // writing five boundaries, against a 1.2 ms GPU drain).
+                    // `hasValidatedDiskEntry` is content-addressed over exactly
+                    // these tokens, so when it says yes the write it replaces
+                    // is byte-for-byte the same entry — skipping is free
+                    // correctness-wise and removes the repeat cost outright.
+                    if coordinator.hasValidatedDiskEntry(
                         tokens: boundaryTokens,
                         mediaSalt: mediaSalt)
                     {
                         Self.logger.debug(
-                            "TokenIterator: skipped already-validated stable system/tool cache boundary at \(boundary, privacy: .public) tokens"
+                            "TokenIterator: skipped already-durable cache boundary at \(boundary, privacy: .public) tokens (stable=\(isStableBoundary, privacy: .public))"
                         )
                         continue
                     }


### PR DESCRIPTION
## The stall, measured

Every turn ended with the answer fully visible but the turn not finalized — spinner up, no stats — for seconds. Two probes added here agree to the millisecond on a DeepSeek-V4-Flash turn:

```
[vmlx][solo/info-gap] sinceLastText=12.3767s  textEvents=1027
[vmlx][gen/tail]      drain1=0.0012s  store=12.3754s  drain2=0.00003s
```

The stall **is** the synchronous cache store. Not the GPU drain (1.2 ms), and not the UI — the host's renderer finished 0.12 s after the engine.

Worth recording how the earlier measurement misled: `gen/tail` existed before this PR but only ever fired for **warm-ups** (`max_tokens: 1`), which store ~20 ms. That number was used to rule the store out. The real per-turn store is three orders larger. The second probe here (`solo/info-gap`) exists because the batched loop's instrumentation never fired at all: hosts run `maxBatchSize == 1`, so every request returns early through `startSoloFastPath`.

## What one turn was writing

```
count=2643   count=2773   count=1113   count=2642   count=3807   count=3807
```

Five boundaries per turn, each a full-KV `MLX.eval` + GPU sync + safetensors write + sqlite. The already-durable skip existed but was gated to *stable* boundaries, so the ladder's other rungs were rewritten every single turn.

## The change

Widen that skip to every boundary. `hasValidatedDiskEntry` is content-addressed over exactly the tokens being stored, so when it reports the entry durable the write being skipped is byte-for-byte identical — a later fetch cannot tell the difference.

## Result (live, DSV4-Flash, two-turn chat)

| | before | after |
|---|---|---|
| turn 1 (cold cache) | 10.2 s | 10.2 s — correct, all five writes genuinely new |
| **turn 2 (warm)** | ~10 s | **0.374 s** |
| warm-ups | 20 ms | 20–26 ms |

Turn 1 is untouched by design: on a cold cache nothing is durable, so nothing is skippable. Taking turn 1's cost off the request path needs the store moved behind `.info`, which the current code deliberately avoids so a new request's GPU work cannot race the store's `MLX.eval` — that is a separate, riskier change and is not attempted here.

## Cache behavior re-verified after the change

- Same conversation, extension: `HIT disk boundary=2643 remaining=131` — 95% of a 2,774-token prompt restored.
- **Different conversation, shared system+tools prefix, warm cache**: `HIT disk boundary=2643 remaining=1` on warm-up and `remaining=107` on the send — the shared prefix is reused across conversations, not just extensions.
- Cross-family: Ornith-9B turn-2 TTFT 0.61 s at 3,651 tokens; Gemma-4-12B turn-2 TTFT 0.66 s at 3,233 tokens, one disk miss across an entire two-turn session.
- DSV4-Flash cold-boot batch after the bundle repair: 8/8 clean, no token soup.

Both probes are gated behind `VMLX_CACHE_FETCH_TRACE=1` and off by default.