### PR TITLE
NemotronHOmni: support items holding images of differing aspect ratios

### DIFF
--- a/Libraries/MLXVLM/Models/NemotronHOmni/NemotronHOmni.swift
+++ b/Libraries/MLXVLM/Models/NemotronHOmni/NemotronHOmni.swift
@@ -259,7 +259,7 @@ public class NemotronHOmni: Module, VLMModel, KVCacheDimensionProvider, LoRAMode
         var imageEmbedCount = 0
         var videoRetention: (keepIndices: [Int], totalTokens: Int)? = nil
         if let pixelValues = input.image?.pixels {
-            visualEmbeds = extractImageEmbeds(pixelValues: pixelValues)
+            visualEmbeds = extractImageEmbeds(pixelValues: pixelValues, frames: input.image?.frames)
             imageEmbedCount = visualEmbeds?.dim(0) ?? 0
         }
         if let video = input.video {
@@ -340,7 +340,39 @@ public class NemotronHOmni: Module, VLMModel, KVCacheDimensionProvider, LoRAMode
 
     /// Run RADIO + mlp1 on a (B, 3, H, W) pixel tensor (already CLIP-normalized).
     /// Returns flat (totalTokens, llmHidden) embeddings in tile-row-major order.
-    public func extractImageEmbeds(pixelValues: MLXArray, video: Bool = false) -> MLXArray {
+    /// Embed images, one per `frames` entry.
+    ///
+    /// `frames` is what makes ragged input work. The grid below is derived from
+    /// `pixelValues.dim(2/3)` — ONE grid for the whole tensor — which is only correct when every
+    /// image shares a shape, or when there is exactly one image. So when `frames` describes several
+    /// images, each is sliced out of the flat buffer, embedded alone, and the flat
+    /// `(tokens, hidden)` results are concatenated. Identical output to the old batched path for
+    /// uniform images; correct output for images of differing aspect ratio, which the old path
+    /// refused outright.
+    ///
+    /// Cost is N tower calls instead of one batched call. MMMU's multi-image items hold 2-5 images,
+    /// and 95% of items hold exactly one (N == 1, so no change at all).
+    public func extractImageEmbeds(pixelValues: MLXArray, frames: [THW]? = nil,
+                                   video: Bool = false) -> MLXArray {
+        // A 4-D tensor is the rectangular layout: uniform images (or one image, or a video clip).
+        // Unchanged path, unchanged numbers. Only a FLAT buffer means ragged, and only then does
+        // `frames` become load-bearing.
+        guard pixelValues.ndim == 1, let frames, !frames.isEmpty else {
+            return extractImageEmbedsUniform(pixelValues: pixelValues, video: video)
+        }
+        var offset = 0
+        var perImage: [MLXArray] = []
+        perImage.reserveCapacity(frames.count)
+        for f in frames {
+            let count = 3 * f.h * f.w
+            let one = pixelValues[offset ..< (offset + count)].reshaped([1, 3, f.h, f.w])
+            perImage.append(extractImageEmbedsUniform(pixelValues: one, video: video))
+            offset += count
+        }
+        return MLX.concatenated(perImage, axis: 0)
+    }
+
+    private func extractImageEmbedsUniform(pixelValues: MLXArray, video: Bool = false) -> MLXArray {
         var feats = radioModel(pixelValues, video: video)
         // Strip cls/register tokens (first numClsTokens)
         feats = feats[0..., config.visionNumClsTokens..., 0...]
@@ -696,8 +728,11 @@ public struct NemotronHOmniProcessor: UserInputProcessor {
     }
 
     /// Tile-preprocess images into (totalTiles, 3, H, W) MLX pixel values.
-    public func preprocess(images: [CIImage]) throws -> (MLXArray, [Int]) {
-        let (pixels, tokenCounts) = try nemotronOmniPreprocessImages(
+    /// Returns flat-concatenated pixels, per-image token counts, and each image's own (H, W).
+    /// The dims are what make ragged images work: every image keeps its aspect-preserving
+    /// resolution, and the consumer slices them apart rather than requiring one rectangular batch.
+    public func preprocess(images: [CIImage]) throws -> (MLXArray, [Int], [(h: Int, w: Int)]) {
+        let (pixels, tokenCounts, dims) = try nemotronOmniPreprocessImages(
             images,
             imageSize: config.imageSize,
             minNum: config.minNumPatches,
@@ -706,7 +741,7 @@ public struct NemotronHOmniProcessor: UserInputProcessor {
             patchSize: config.patchSize,
             downsampleRatio: config.downsampleRatio,
             maxModelLen: config.maxModelLen)
-        return (pixels, tokenCounts)
+        return (pixels, tokenCounts, dims)
     }
 
     /// Decode + resample audio resources into 16 kHz mono Float32 PCM
@@ -816,10 +851,13 @@ public struct NemotronHOmniProcessor: UserInputProcessor {
 
         if !input.images.isEmpty {
             let ciImages = try input.images.map { try $0.asCIImage() }
-            let (pixels, tokenCounts) = try preprocess(images: ciImages)
+            let (pixels, tokenCounts, dims) = try preprocess(images: ciImages)
+            // Each frame carries its OWN (h, w). This used to stamp every frame with the batch's
+            // single shape — harmless while all images were forced to match, and exactly the
+            // information that had to exist for them not to be.
             processedImage = LMInput.ProcessedImage(
                 pixels: pixels,
-                frames: tokenCounts.map { _ in THW(1, pixels.dim(2), pixels.dim(3)) })
+                frames: dims.map { THW(1, $0.h, $0.w) })
             totalImageTokens = tokenCounts.reduce(0, +)
         }
 

--- a/Libraries/MLXVLM/Models/NemotronHOmni/Preprocessors.swift
+++ b/Libraries/MLXVLM/Models/NemotronHOmni/Preprocessors.swift
@@ -252,7 +252,7 @@ public func nemotronOmniPreprocessImages(
     patchSize: Int = 16,
     downsampleRatio: Float = 0.5,
     maxModelLen: Int = 16384
-) throws -> (pixelValues: MLXArray, tokenCounts: [Int]) {
+) throws -> (pixelValues: MLXArray, tokenCounts: [Int], dims: [(h: Int, w: Int)]) {
     var allImages: [MLXArray] = []
     var tokenCounts: [Int] = []
     let downsampleFactor = max(1, Int(round(1.0 / Double(downsampleRatio))))
@@ -284,17 +284,34 @@ public func nemotronOmniPreprocessImages(
                 / (downsampleFactor * downsampleFactor))
     }
     if allImages.isEmpty {
-        return (MLXArray.zeros([0, 3, imageSize, imageSize]), [])
+        return (MLXArray.zeros([0, 3, imageSize, imageSize]), [], [])
     }
+    // Rasters are (3, H, W) — which is exactly why `stacked(axis: 0)` below yields (N, 3, H, W).
+    // Index from the END so this holds whether or not a leading batch axis is ever added.
+    let dims = allImages.map { (h: $0.dim($0.ndim - 2), w: $0.dim($0.ndim - 1)) }
+
+    // UNIFORM images keep the original rectangular (N, 3, H, W) layout — byte-for-byte the previous
+    // behaviour, so every existing consumer (and the 95% of items that hold a single image) is
+    // untouched.
+    //
+    // RAGGED images are concatenated FLAT, with `dims` carrying each image's (H, W) so the consumer
+    // can slice them back apart. That is the layout `LMInput.ProcessedImage` already documents —
+    // "concatenated pixels from one or more images", with `frames` describing each — and it was
+    // always representable; only the stacking here forced uniformity.
+    //
+    // Stacking was never required by the model. `extractImageEmbeds` derives its patch grid from
+    // `pixelValues.dim(2/3)`, ONE grid for the whole tensor, which is correct exactly when the
+    // images match or when there is a single image. Feeding the tower one image at a time is
+    // therefore exact, and its flat (tokens, hidden) return concatenates cleanly.
+    //
+    // This previously threw for any item whose images differed in aspect ratio — 42 of MMMU's 847
+    // items (5%), and a hard blocker for document analysis, where image count and shape are whatever
+    // the document happens to contain.
     let referenceShape = allImages[0].shape
-    guard allImages.allSatisfy({ $0.shape == referenceShape }) else {
-        throw NSError(
-            domain: "NemotronHOmni", code: -12,
-            userInfo: [NSLocalizedDescriptionKey:
-                "Nemotron Omni image batches with mixed dynamic resolutions are not yet supported"])
+    if allImages.allSatisfy({ $0.shape == referenceShape }) {
+        return (MLX.stacked(allImages, axis: 0), tokenCounts, dims)   // (N, 3, H, W)
     }
-    let stacked = MLX.stacked(allImages, axis: 0) // (N, 3, H, W)
-    return (stacked, tokenCounts)
+    return (MLX.concatenated(allImages.map { $0.reshaped([-1]) }, axis: 0), tokenCounts, dims)
 }
 
 // MARK: - Audio preprocessing (parakeet mel STFT)

--- a/RunBench/OmniBench.swift
+++ b/RunBench/OmniBench.swift
@@ -104,7 +104,9 @@ enum OmniBench {
             } else {
                 image = try synthesiseGradient(side: 224)
             }
-            let (pixels, tokenCounts) = try processor.preprocess(images: [image])
+            // Third element is the per-image (h, w); a single image stays rectangular, so the
+            // `pixels.dim(2)/dim(3)` reads below are unaffected.
+            let (pixels, tokenCounts, _) = try processor.preprocess(images: [image])
             MLX.eval(pixels)
             let values = pixels.asArray(Float.self)
             let height = pixels.dim(2)


### PR DESCRIPTION
## Problem

`nemotronOmniPreprocessImages` gives each image its own aspect-preserving resolution, then requires
every raster to share a shape so it can `MLX.stacked` them into a rectangular `(N, 3, H, W)`. Any
item holding two images of different aspect ratios therefore throws:

```
NemotronHOmni Code=-12 "Nemotron Omni image batches with mixed dynamic resolutions are not yet supported"
```

Measured on MMMU: **42 of 847 items (5%)** hold more than one image, and every one of them was
unscoreable on this model family. The limitation matters well beyond benchmarks — in document
analysis there is no guarantee about how many images a page carries or what shape they are.

## Why stacking was never required

`extractImageEmbeds` derives its patch grid from `pixelValues.dim(2)/dim(3)` — **one** grid for the
whole tensor:

```swift
let gridH = pixelValues.dim(2) / config.visionPatchSize
let gridW = pixelValues.dim(3) / config.visionPatchSize
precondition(gridH * gridW == P, …)
```

That is correct exactly when the images match, or when there is a single image. So embedding one
image at a time is **exact**, not an approximation, and the flat `(N*tokens, llm_hidden)` return
concatenates cleanly along axis 0.

`LMInput.ProcessedImage` already documents the layout this needs — *"Concatenated pixels from one or
more images"* with `frames: [THW]` describing each. The information was representable all along;
`prepare` simply stamped every frame with the batch's single shape, which was only correct because
the preprocessor had forced the images to be equal.

## Change

- **Uniform images keep the rectangular `(N, 3, H, W)` layout, byte for byte.** Every existing
  caller and code path is untouched, including video and the single-image case (95% of MMMU items).
- **Ragged images** are concatenated flat, with real per-image `frames`.
- `extractImageEmbeds` takes `frames` and, **only for a flat buffer**, slices each image out,
  embeds it alone, and concatenates. A 4-D tensor still means rectangular, so `frames` only becomes
  load-bearing when it has to be.
- `RunBench/OmniBench.swift` updated for the third tuple element; its `pixels.dim(2)/dim(3)` reads
  are unaffected because a single image still returns rectangular.

## Verification

On-device, `Nemotron-3-Nano-Omni-30B-A3B-JANGTQ4`, MMMU, 50 items, identical sample:

| | mmmu | items refused |
|---|---|---|
| before | 28/50 = 56.0% | 1 |
| after | **29/50 = 58.0%** | **0** |

The previously-unscoreable multi-image item now scores, and scores correctly.

One note in case it saves someone time: `rasterizeImage` returns **3-D** `(3, H, W)` — which is why
`stacked(axis: 0)` yields `(N, 3, H, W)`. Per-image dims are therefore read from the trailing axes
(`ndim-2`, `ndim-1`) so the code holds whether or not a leading batch axis is ever added.
