### PR TITLE
Capture cache boundaries during prefill instead of replaying the prefix afterwards

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1324,6 +1324,22 @@ public struct TokenIterator: TokenIteratorProtocol {
     /// a second full prefill. Released once stored.
     var hybridStripSnapshot: [KVCache]?
 
+    /// Cache state at each processor-declared stable boundary, captured during
+    /// prefill, keyed by the token count actually stored.
+    ///
+    /// Without this the post-generation store loop has to reconstruct those
+    /// boundaries. Trimming serves topologies that can trim; everything else
+    /// falls through to `cacheSnapshotForBoundary`, which replays the prefix
+    /// through the model — a whole extra prefill per boundary, on the request
+    /// path, after the user's answer is already on screen. Measured on a
+    /// DeepSeek-V4-Flash turn writing five boundaries: 12.4 s of store against
+    /// a 1.2 ms GPU drain, which is the stall hosts report as the answer
+    /// finishing and the turn refusing to end.
+    ///
+    /// Prefill already passes through every one of these boundaries, so the
+    /// state is free at that moment; keeping a copy costs one cache copy.
+    var stableBoundarySnapshots: [Int: [KVCache]] = [:]
+
     /// Absolute `promptTokenIds.count - 1` boundary for text-only
     /// standalone rotating/SWA cache topologies.
     ///
@@ -2075,6 +2091,15 @@ public struct TokenIterator: TokenIteratorProtocol {
             case .diskSeed:
                 diskSeedSnapshot = snapshot
             }
+            // The head we just prefilled ends exactly at a boundary the store
+            // loop will ask for later. Keep it so that loop can use it instead
+            // of replaying the prefix through the model.
+            if let head = capture.head {
+                let headCount = head.text.tokenIds?.count ?? head.text.tokens.size
+                if headCount > 0 {
+                    stableBoundarySnapshots[headCount] = snapshot
+                }
+            }
             try prepareRemainder(
                 input: capture.tail, windowSize: windowSize,
                 promptTokensForProcessor: input.text.tokens)
@@ -2612,11 +2637,20 @@ public struct TokenIterator: TokenIteratorProtocol {
                         isReusablePrefixWarmup: isReusablePrefixWarmup,
                         requiresRecurrentSSMCompanion:
                             coordinator.requiresRecurrentSSMCompanion)
-                    let boundarySnapshotOrNil = cacheSnapshotForBoundary(
-                        tokens: boundaryTokens,
-                        storageSnapshot: storageTopologySnapshot,
-                        storageSnapshotTokenCount: storageSnapshotTokenCount,
-                        allowDiskBackedRederive: allowRederive)
+                    // Prefer a snapshot taken while prefill was passing through
+                    // this boundary. `cacheSnapshotForBoundary` otherwise
+                    // replays the prefix through the model for any topology it
+                    // cannot trim, which is a whole extra prefill per boundary
+                    // and runs after the answer is already visible.
+                    let boundarySnapshotOrNil =
+                        stableBoundarySnapshots[storeBoundary].map { captured in
+                            captured.map { $0.copy() }
+                        }
+                        ?? cacheSnapshotForBoundary(
+                            tokens: boundaryTokens,
+                            storageSnapshot: storageTopologySnapshot,
+                            storageSnapshotTokenCount: storageSnapshotTokenCount,
+                            allowDiskBackedRederive: allowRederive)
                     if ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1" {
                         // Hybrid-SSM models never store the seed their own
                         // fetch probes for, so a second conversation re-prefills

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -2105,9 +2105,75 @@ public struct TokenIterator: TokenIteratorProtocol {
                 promptTokensForProcessor: input.text.tokens)
             return
         }
+        if try prepareCapturingStableBoundaries(input: input, windowSize: windowSize) {
+            return
+        }
         try prepareRemainder(
             input: input, windowSize: windowSize,
             promptTokensForProcessor: input.text.tokens)
+    }
+
+    /// Prefill in segments that end on each processor-declared stable boundary,
+    /// keeping the cache state at every one.
+    ///
+    /// The store loop needs exactly these snapshots after generation. Without
+    /// them it reconstructs each boundary: topologies that can be trimmed take
+    /// the cheap path, and everything else replays the prefix through the model
+    /// — an extra prefill per boundary, on the request path, after the answer is
+    /// already on screen. That reconstruction is also cancellable, and on a slow
+    /// enough model it loses the race: Bonsai-27B produced
+    /// `rederive-failed tokens=2986 error=CancellationError()` and therefore
+    /// never wrote its stable seed at all, so every later conversation
+    /// cold-prefilled the whole shared prefix.
+    ///
+    /// Prefill already crosses these boundaries, so the state is free at that
+    /// moment and only the cache copy is paid for. Segments run through the
+    /// model's real prepare/forward path in order, exactly as the single-split
+    /// capture above does, so sampling and template behaviour are unchanged.
+    /// Returns false when there is nothing worth splitting, leaving the caller
+    /// on the untouched single-prefill path.
+    private mutating func prepareCapturingStableBoundaries(
+        input: LMInput, windowSize: Int?
+    ) throws -> Bool {
+        let promptCount = input.text.tokenIds?.count ?? input.text.tokens.size
+        // Store shifts stable boundaries one token short for disk-backed
+        // restores, so capture N-1 as well and let the loop find either.
+        let wanted = Set(
+            input.cacheStablePrefixTokenCounts
+                .filter { $0 > 0 && $0 < promptCount }
+                .flatMap { [$0, $0 - 1] }
+        ).filter { $0 > 0 }.sorted()
+        guard !wanted.isEmpty else { return false }
+
+        var consumed = 0
+        var remaining = input
+        for boundary in wanted {
+            guard boundary > consumed,
+                let split = boundarySplit(of: remaining, at: boundary - consumed),
+                let head = split.head
+            else { continue }
+            let prepared = try MLXPressGenerationProfile.time("prompt.model_prepare") {
+                try model.prepare(head, cache: cache, windowSize: windowSize)
+            }
+            switch prepared {
+            case .tokens(let leftover):
+                _ = model(
+                    leftover[text: .newAxis],
+                    cache: cache.isEmpty ? nil : cache,
+                    state: nil)
+            case .logits:
+                break
+            }
+            MLX.eval(cache)
+            stableBoundarySnapshots[boundary] = makePromptBoundaryCacheSnapshot(from: cache)
+            remaining = split.tail
+            consumed = boundary
+        }
+        guard consumed > 0 else { return false }
+        try prepareRemainder(
+            input: remaining, windowSize: windowSize,
+            promptTokensForProcessor: input.text.tokens)
+        return true
     }
 
     /// Prefill `input` and prime `y` with the first sampled token.

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -2607,16 +2607,32 @@ public struct TokenIterator: TokenIteratorProtocol {
                         )
                         continue
                     }
-                    if let boundarySnapshot = cacheSnapshotForBoundary(
+                    let allowRederive = shouldForceStableBoundaryRederive(
+                        isStableBoundary: isStableBoundary,
+                        isReusablePrefixWarmup: isReusablePrefixWarmup,
+                        requiresRecurrentSSMCompanion:
+                            coordinator.requiresRecurrentSSMCompanion)
+                    let boundarySnapshotOrNil = cacheSnapshotForBoundary(
                         tokens: boundaryTokens,
                         storageSnapshot: storageTopologySnapshot,
                         storageSnapshotTokenCount: storageSnapshotTokenCount,
-                        allowDiskBackedRederive: shouldForceStableBoundaryRederive(
-                            isStableBoundary: isStableBoundary,
-                            isReusablePrefixWarmup: isReusablePrefixWarmup,
-                            requiresRecurrentSSMCompanion:
-                                coordinator.requiresRecurrentSSMCompanion))
-                    {
+                        allowDiskBackedRederive: allowRederive)
+                    if ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1" {
+                        // Hybrid-SSM models never store the seed their own
+                        // fetch probes for, so a second conversation re-prefills
+                        // the whole system/tool prefix. The decision that drops
+                        // it is several guards deep and only logs at debug
+                        // level, which is not persisted — so report the inputs
+                        // and the outcome for each boundary considered.
+                        FileHandle.standardError.write(Data(
+                            ("[vmlx][cache/store-boundary] boundary=\(boundary)"
+                                + " store=\(storeBoundary) stable=\(isStableBoundary)"
+                                + " allowRederive=\(allowRederive)"
+                                + " snapshotTokens=\(storageSnapshotTokenCount)"
+                                + " snapshot=\(boundarySnapshotOrNil == nil ? "nil" : "ok")\n")
+                                .utf8))
+                    }
+                    if let boundarySnapshot = boundarySnapshotOrNil {
                         store(
                             tokens: boundaryTokens,
                             cache: boundarySnapshot,

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -2765,6 +2765,14 @@ public struct TokenIterator: TokenIteratorProtocol {
             Self.logger.debug(
                 "TokenIterator: skipped history-boundary cache rederive: \(String(describing: error), privacy: .public)"
             )
+            if ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1" {
+                // This catch silently costs hybrid-SSM models every
+                // cross-conversation prefix hit (vmlx#219). At debug level the
+                // reason is unobservable on a real run, so surface it.
+                FileHandle.standardError.write(Data(
+                    ("[vmlx][cache/rederive-failed] tokens=\(tokens.count) "
+                        + "error=\(String(describing: error))\n").utf8))
+            }
             return nil
         }
     }


### PR DESCRIPTION
## The problem

After generation, the store loop needs the cache state at each boundary it writes. Topologies that can be trimmed get a cheap trim. Everything else falls through to `cacheSnapshotForBoundary`, which **replays the prefix through the model** — a whole extra prefill per boundary, on the request path, after the user's answer is already on screen.

Two symptoms, one cause.

**1. The post-answer stall.** Measured on a DeepSeek-V4-Flash turn writing five boundaries:

```
[vmlx][solo/info-gap] sinceLastText=12.3767s  textEvents=1027
[vmlx][gen/tail]      drain1=0.0012s  store=12.3754s  drain2=0.00003s
```

Not the GPU drain (1.2 ms), not the renderer (the host UI finished 0.12 s after the engine), not the disk write. The reconstruction.

**2. A cache that could never populate.** The reconstruction is cancellable, and on a slow enough model it loses the race:

```
[vmlx][cache/store-boundary] boundary=2987 store=2986 stable=true allowRederive=true snapshotTokens=3114 snapshot=nil
[vmlx][cache/rederive-failed] tokens=2986 error=CancellationError()
```

Bonsai-27B therefore **never wrote its stable seed at all**, so every later conversation cold-prefilled the entire shared system+tools prefix. Ornith-9B re-derived fast enough to finish, which is why the same topology hit on one model and missed on the other — it looked like a hybrid-SSM defect and is really a speed-dependent one. (I filed and then retracted vmlx#219 on that mistaken reading; the retraction has the details.)

## The change

Prefill already crosses every one of these boundaries, so the state is free at that moment. `prefillBoundaryCapture` already exploited this for the hybrid-strip and disk-seed cases, explicitly "to avoid a second full prefill after generation" — this generalises it to each declared stable boundary (and its N−1 form, since disk-backed restores store one token short) and lets the store loop use what prefill kept.

Segments run through the model's real prepare/forward path in order, exactly as the existing single split does, so sampling and template behaviour are unchanged. When there is nothing worth splitting the caller stays on the untouched single-prefill path.

## Result — Bonsai-27B, two conversations sharing only the system+tools prefix

| | before | after |
|---|---|---|
| run-2 warm-up | `MISS all tiers tokens=2987` | **`HIT disk boundary=2986 remaining=1 ssm=96`** |
| run-2 send | `MISS all tiers tokens=3113` | **`HIT disk boundary=2986 remaining=126 ssm=96`** |
| `rederive-failed` | `CancellationError()` | none |

`ssm=96` is the recurrent companion state for all 48 mamba layers restored alongside the KV.

## Honest note on scope

An earlier commit in this branch (`af839954`) taught the store loop to consume a prefill snapshot but did not make prefill capture the stable boundaries, so the lookup missed and it changed nothing measurable — Bonsai's store was still 25.2 s and the seed still unwritten. `51b2ec30` is the commit that does the work. Bonsai's cold-turn store cost is still ~25 s in this run and is **not** claimed as fixed here; the cold path writes genuinely new boundaries and reducing that further is separate work.

## Also in this branch

Diagnostics that made the above visible, all gated behind `VMLX_CACHE_FETCH_TRACE=1` and off by default: per-boundary store decisions (`cache/store-boundary`), the re-derive failure reason (`cache/rederive-failed`, previously debug-only and therefore unobservable on a real run), and the terminal-info gap on the single-model path hosts actually take (`solo/info-gap` — the batched loop's probe never fired because `maxBatchSize == 1` returns early through `startSoloFastPath`).