### PR TITLE
SpecDec: mark the MTP warmup memo nonisolated(unsafe)

### DIFF
--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -58,7 +58,10 @@ enum NativeMTPHybridWarmupMemo {
     }
 
     private static let lock = NSLock()
-    private static var entries: [ObjectIdentifier: Entry] = [:]
+    // `nonisolated(unsafe)` because the invariant is MANUAL, not static: every read and write below
+    // is bracketed by `lock`. Swift 6 strict concurrency cannot see an NSLock discipline, so without
+    // the annotation this is an error rather than the correctly-synchronised code it is.
+    nonisolated(unsafe) private static var entries: [ObjectIdentifier: Entry] = [:]
 
     static func verdict(for model: AnyObject) -> Bool? {
         lock.lock()


### PR DESCRIPTION
## Problem

Building `MLXLMCommon` in Swift 6 language mode (Swift 6.4, macOS 27) fails:

```
Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift:61:24: error: static property
'entries' is not concurrency-safe because it is nonisolated global shared mutable state
```

## Why the annotation is the right fix

`NativeMTPHybridWarmupMemo.entries` is **already correctly synchronised** — every read and
write is bracketed by the `NSLock` declared immediately above it:

```swift
private static let lock = NSLock()
private static var entries: [ObjectIdentifier: Entry] = [:]

static func verdict(for model: AnyObject) -> Bool? {
    lock.lock()
    defer { lock.unlock() }
    …
}
```

Swift 6 cannot see an `NSLock` discipline, so it reports correctly-locked storage as unsafe.
`nonisolated(unsafe)` states the invariant the code already keeps, rather than changing the
synchronisation.

An alternative would be `Mutex<[ObjectIdentifier: Entry]>` from `Synchronization`, which the
compiler *can* verify — but that is a behavioural refactor of a hot-path memo, so I kept this
minimal. Happy to switch if you'd prefer the checked form.

## Scope

One line plus a comment. No behaviour change; the lock discipline is untouched.

Surfaced while building against `main` at `19814d47` with Swift 6.4
(`swiftlang-6.4.0.30.4`), target `arm64-apple-macosx27.0.0`.
