### PR TITLE
Parse GLM/DeepSeek tool calls that take no arguments

### DIFF
--- a/Libraries/MLXLMCommon/Tool/Parsers/GLM4ToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/GLM4ToolCallParser.swift
@@ -21,12 +21,31 @@ public struct GLM4ToolCallParser: ToolCallParser, Sendable {
         }
         text = text.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        // Extract function name (everything before first <arg_key>)
-        guard let argKeyStart = text.range(of: "<arg_key>") else { return nil }
-        let funcName = String(text[..<argKeyStart.lowerBound]).trimmingCharacters(
-            in: .whitespacesAndNewlines)
+        // Extract function name (everything before first <arg_key>).
+        //
+        // A tool that declares no parameters is invoked with the bare name —
+        // `<tool_call>list_mailboxes</tool_call>` — so a missing `<arg_key>`
+        // is a zero-argument call, not a malformed one. Treating it as a
+        // parse failure dropped the call silently: the surface saw a turn with
+        // no text and no tool work, nudged the model, got the same correct
+        // call again, and after the retry budget told the user the model had
+        // "returned empty output after tool execution".
+        //
+        // With no `<arg_key>` to bound it, the name is the entire body, so it
+        // has to earn acceptance: prose wrapped in `<tool_call>` would
+        // otherwise be promoted to a call named after the prose. Calls that do
+        // carry arguments keep the original, laxer rule — their name is
+        // already delimited, and tightening it here would reject spellings
+        // that parse today.
+        let nameEnd = text.range(of: "<arg_key>")?.lowerBound
+        let funcName = String(text[..<(nameEnd ?? text.endIndex)])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
 
-        guard !funcName.isEmpty else { return nil }
+        if nameEnd == nil {
+            guard Self.isFunctionNameShaped(funcName) else { return nil }
+        } else {
+            guard !funcName.isEmpty else { return nil }
+        }
 
         var arguments: [String: any Sendable] = [:]
 
@@ -68,5 +87,17 @@ public struct GLM4ToolCallParser: ToolCallParser, Sendable {
         }
 
         return ToolCall(function: .init(name: funcName, arguments: arguments))
+    }
+
+    /// Whether a bare `<tool_call>` body reads as a function identifier
+    /// rather than as text the model happened to wrap in the envelope.
+    /// Deliberately narrow: OpenAI-compatible tool names are
+    /// `[A-Za-z0-9_.-]{1,64}`, and every name reaching this parser came from
+    /// a schema that had to satisfy that.
+    static func isFunctionNameShaped(_ name: String) -> Bool {
+        guard (1 ... 64).contains(name.count) else { return false }
+        return name.allSatisfy {
+            $0.isASCII && ($0.isLetter || $0.isNumber || $0 == "_" || $0 == "." || $0 == "-")
+        }
     }
 }

--- a/Tests/MLXLMTests/RaptorToolContinuationTests.swift
+++ b/Tests/MLXLMTests/RaptorToolContinuationTests.swift
@@ -1,0 +1,211 @@
+import Foundation
+import MLX
+import MLXLMCommon
+import Testing
+@preconcurrency import VMLXTokenizers
+
+@testable import MLXHuggingFace
+@testable import MLXLLM
+
+/// Raptor 1.0 16B (laguna) answers the first turn by calling a capability
+/// tool, then produces **nothing** on the continuation turn — three times in a
+/// row, so the agent loop's nudge-and-retry is exhausted and the user sees
+/// "The model returned empty output after tool execution."
+///
+/// The app cannot tell "the model emitted EOS immediately" from "the model
+/// emitted text that the serving stack dropped". This runs the same
+/// conversation straight through the engine — no agent loop, no UI, no
+/// history compaction — and prints every channel the stream produces, so the
+/// two are distinguishable.
+///
+/// Enable with `RAPTOR_LIVE=1`. The tool result is the real Osaurus Mail skill
+/// document (`~/.osaurus/PluginSpecs/central/plugins/osaurus.mail.json`)
+/// wrapped in the envelope `capabilities_load` returns.
+@Suite("Raptor tool continuation", .serialized)
+struct RaptorToolContinuationTests {
+
+    static let bundle = URL(fileURLWithPath: NSHomeDirectory())
+        .appendingPathComponent("models/OsaurusAI/Raptor-1.0-16B-A3B-qat-JANG_4M")
+
+    static var enabled: Bool {
+        ProcessInfo.processInfo.environment["RAPTOR_LIVE"] == "1"
+            && FileManager.default.fileExists(
+                atPath: bundle.appendingPathComponent("config.json").path)
+    }
+
+    /// The `capabilities_load` result the app fed back, verbatim in shape:
+    /// `{"ok":true,"result":{"text":"## Skill: Osaurus Mail…"}}`.
+    static func mailToolResult() throws -> String {
+        let path = ProcessInfo.processInfo.environment["RAPTOR_TOOL_RESULT"]
+            ?? "/private/tmp/claude-501/-Users-eric-vmlx-swift/cf33ccb8-c141-4823-ac15-d7bb83cca83d/scratchpad/mail_tool_result.json"
+        return try String(contentsOf: URL(fileURLWithPath: path), encoding: .utf8)
+    }
+
+    static func toolSpec(_ name: String, _ description: String) -> ToolSpec {
+        [
+            "type": "function",
+            "function": [
+                "name": name,
+                "description": description,
+                "parameters": [
+                    "type": "object",
+                    "properties": [String: any Sendable](),
+                    "required": [String](),
+                ] as [String: any Sendable],
+            ] as [String: any Sendable],
+        ]
+    }
+
+    static let capabilityTools: [ToolSpec] = [
+        toolSpec(
+            "capabilities_discover",
+            "Search installed capabilities by keyword when the Enabled list does not already name one."),
+        toolSpec(
+            "capabilities_load",
+            "Load capabilities into the current session by ID. IDs come from the Enabled capabilities list or from `capabilities_discover` results — do not invent IDs."),
+    ]
+
+    struct Collected {
+        var content = ""
+        var reasoning = ""
+        var toolCalls: [String] = []
+        var progress = 0
+        var tokens = 0
+        var infoLine = ""
+    }
+
+    static func collect(_ stream: AsyncStream<Generation>) async -> Collected {
+        var out = Collected()
+        for await event in stream {
+            switch event {
+            case .chunk(let text):
+                out.content += text
+                out.tokens += 1
+            case .reasoning(let text):
+                out.reasoning += text
+            case .toolCall(let call):
+                out.toolCalls.append(call.function.name)
+            case .info(let info):
+                let pp = info.promptTime > 0
+                    ? Double(info.promptTokenCount) / info.promptTime : 0
+                let tg = info.generateTime > 0
+                    ? Double(info.generationTokenCount) / info.generateTime : 0
+                out.infoLine =
+                    "prompt=\(info.promptTokenCount) gen=\(info.generationTokenCount)"
+                    + " stop=\(info.stopReason)"
+                    + " pp=\(String(format: "%.1f", pp))/s"
+                    + " tg=\(String(format: "%.1f", tg))/s"
+            default:
+                out.progress += 1
+            }
+        }
+        return out
+    }
+
+    static func report(_ label: String, _ c: Collected) {
+        print("[raptor] ── \(label) ──")
+        print("[raptor] \(c.infoLine)")
+        print("[raptor] content chars=\(c.content.count) reasoning chars=\(c.reasoning.count) toolCalls=\(c.toolCalls) other-events=\(c.progress)")
+        if !c.reasoning.isEmpty {
+            print("[raptor] reasoning: \(c.reasoning.prefix(600))")
+        }
+        print("[raptor] content: \(c.content.isEmpty ? "<EMPTY>" : String(c.content.prefix(600)))")
+    }
+
+    /// Run one prompt through the engine and report every channel.
+    static func run(
+        label: String, chat: [Chat.Message], tools: [ToolSpec]?, maxTokens: Int = 320
+    ) async throws -> Collected {
+        let context = try await MLXLMCommon.loadModel(
+            from: bundle, using: #huggingFaceTokenizerLoader())
+        let input = try await context.processor.prepare(
+            input: UserInput(chat: chat, tools: tools))
+
+        let tokens = input.text.tokens.reshaped(-1).asArray(Int.self)
+        let rendered = context.tokenizer.decode(tokenIds: tokens, skipSpecialTokens: false)
+        print("[raptor] \(label): prompt tokens=\(tokens.count)")
+        print("[raptor] \(label): prompt tail ⟦\(rendered.suffix(220))⟧")
+
+        let params = GenerateParameters(maxTokens: maxTokens, temperature: 0)
+
+        // Raw pass first: the serving stack peels reasoning off, swallows tool
+        // envelopes and applies stop strings, so "empty" there is ambiguous.
+        // Decoding the token ids directly shows exactly what the model emitted.
+        var iterator = try TokenIterator(
+            input: input, model: context.model, parameters: params)
+        var raw: [Int] = []
+        for _ in 0 ..< maxTokens {
+            guard let id = iterator.next() else { break }
+            raw.append(id)
+            if id == context.tokenizer.eosTokenId { break }
+        }
+        let rawText = context.tokenizer.decode(tokenIds: raw, skipSpecialTokens: false)
+        print("[raptor] \(label): RAW \(raw.count) tokens ids=\(raw.suffix(8))")
+        print("[raptor] \(label): RAW ⟦\(rawText)⟧")
+
+        nonisolated(unsafe) let send = input
+        nonisolated(unsafe) let ctx = context
+        let stream = try MLXLMCommon.generate(input: send, parameters: params, context: ctx)
+        let collected = await collect(stream)
+        report(label, collected)
+        return collected
+    }
+
+    static let userQuestion = "how many unread emails do I have in my mailbox"
+
+    static func conversation(toolResult: String) throws -> [Chat.Message] {
+        [
+            .user(userQuestion),
+            .assistant(
+                "",
+                toolCalls: [
+                    ToolCall(
+                        id: "call_0_capabilities_load",
+                        function: .init(
+                            name: "capabilities_load",
+                            arguments: ["ids": ["plugin/osaurus.mail"]]))
+                ]),
+            .tool(toolResult, toolCallId: "call_0_capabilities_load"),
+        ]
+    }
+
+    // MARK: - Control: does the model answer at all?
+
+    @Test("control — plain question, no tools", .enabled(if: enabled))
+    func plainAnswer() async throws {
+        let c = try await Self.run(
+            label: "no-tools",
+            chat: [.user("Name the capital of France in one short sentence.")],
+            tools: nil)
+        #expect(!c.content.isEmpty, "the model produced no content on a plain question")
+    }
+
+    // MARK: - Control: continuation after a *small* tool result
+
+    @Test("continuation after a small tool result", .enabled(if: enabled))
+    func smallToolResult() async throws {
+        let c = try await Self.run(
+            label: "small-tool-result",
+            chat: try Self.conversation(
+                toolResult: #"{"ok":true,"result":{"text":"Mail tools loaded: list_mailboxes, list_messages."}}"#),
+            tools: Self.capabilityTools)
+        #expect(
+            !c.content.isEmpty || !c.toolCalls.isEmpty,
+            "empty continuation even on a small tool result")
+    }
+
+    // MARK: - The reported failure
+
+    @Test("continuation after the real Mail capability load", .enabled(if: enabled))
+    func largeToolResult() async throws {
+        let payload = try Self.mailToolResult()
+        print("[raptor] tool result chars=\(payload.count)")
+        let c = try await Self.run(
+            label: "mail-capability-load",
+            chat: try Self.conversation(toolResult: payload),
+            tools: Self.capabilityTools)
+        #expect(
+            !c.content.isEmpty || !c.toolCalls.isEmpty,
+            "the model returned empty output after tool execution — reproduces the report")
+    }
+}

--- a/Tests/MLXLMTests/ZeroArgumentToolCallTests.swift
+++ b/Tests/MLXLMTests/ZeroArgumentToolCallTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+/// A tool that declares no parameters is a normal thing to ship — Osaurus
+/// alone exposes `list_mailboxes`, `capabilities_discover`, `todo_read` and
+/// others. Every wire format can express calling one, and every parser has to
+/// accept it, because the failure is invisible: the parser returns nil, the
+/// envelope is discarded as non-content, and the surface sees a turn with no
+/// text and no tool work. That reaches the user as "the model returned empty
+/// output after tool execution" while the model in fact emitted a correct
+/// call. (`RaptorToolContinuationTests` shows it end to end on real weights.)
+///
+/// One row per format, using that format's own spelling of "call this tool
+/// with no arguments".
+@Suite("Zero-argument tool calls")
+struct ZeroArgumentToolCallTests {
+
+    static let toolName = "list_mailboxes"
+
+    /// Schema for a tool that takes nothing, in the shape parsers receive.
+    static let noParameterTool: [String: any Sendable] = [
+        "type": "function",
+        "function": [
+            "name": toolName,
+            "description": "List all mailboxes in Apple Mail.",
+            "parameters": [
+                "type": "object",
+                "properties": [String: any Sendable](),
+                "required": [String](),
+            ] as [String: any Sendable],
+        ] as [String: any Sendable],
+    ]
+
+    static let dsml = DeepseekV4Tokens.dsml
+
+    /// `(format, wire text)` — the text a model emits to call
+    /// `list_mailboxes` with no arguments, per format.
+    static let samples: [(ToolCallFormat, String)] = [
+        (.json, #"<tool_call>{"name": "list_mailboxes", "arguments": {}}</tool_call>"#),
+        (.xmlFunction, "<tool_call><function=list_mailboxes></function></tool_call>"),
+        (.glm4, "<tool_call>list_mailboxes</tool_call>"),
+        (.hunyuan, "<tool_calls><tool_call>list_mailboxes<tool_sep></tool_call></tool_calls>"),
+        (.minimaxM2, #"<invoke name="list_mailboxes"></invoke>"#),
+        (.atem, """
+            <atem:function_calls>
+            <atem:invoke name="list_mailboxes">
+            </atem:invoke>
+            </atem:function_calls>
+            """),
+        (.dsml, """
+            <\(dsml)tool_calls>
+            <\(dsml)invoke name="list_mailboxes">
+            </\(dsml)invoke>
+            </\(dsml)tool_calls>
+            """),
+        (.zayaXml, "<zyphra_tool_call><function=list_mailboxes></function></zyphra_tool_call>"),
+        (.kimiK2, "functions.list_mailboxes:0<|tool_call_argument_begin|>{}"),
+        (.llama3, #"{"name": "list_mailboxes", "parameters": {}}"#),
+        (.mistral, #"[TOOL_CALLS]list_mailboxes[ARGS]{}"#),
+        (.lfm2, "<|tool_call_start|>[list_mailboxes()]<|tool_call_end|>"),
+        (.gemma, "call:list_mailboxes{}"),
+        (.gemma4, "<|tool_call>call:list_mailboxes{}<tool_call|>"),
+        (.step, "<tool_call><function=list_mailboxes></function></tool_call>"),
+        (.nemotron, "<tool_call><function=list_mailboxes></function></tool_call>"),
+    ]
+
+    /// A format added without a sample here would silently skip the check.
+    @Test func everyFormatHasASample() {
+        let covered = Set(Self.samples.map(\.0))
+        let missing = ToolCallFormat.allCases.filter { !covered.contains($0) }
+        #expect(missing.isEmpty, "no zero-argument sample for: \(missing.map(\.rawValue))")
+    }
+
+    @Test("every format parses a call with no arguments", arguments: samples)
+    func zeroArgumentCallSurvives(_ sample: (format: ToolCallFormat, wire: String)) {
+        let parser = sample.format.createParser()
+        let tools = [Self.noParameterTool]
+
+        // `parse` is the streaming path; `parseEOS` is the end-of-generation
+        // path. A format only works if the call survives whichever one its
+        // transport uses, so accept either.
+        let single = parser.parse(content: sample.wire, tools: tools)
+        let batch = parser.parseEOS(sample.wire, tools: tools)
+        let resolved = single ?? batch.first
+
+        #expect(
+            resolved != nil,
+            "\(sample.format.rawValue) discarded a zero-argument call — the model's tool call vanishes and the turn looks empty")
+        #expect(
+            resolved?.function.name == Self.toolName,
+            "\(sample.format.rawValue) parsed the wrong function name: \(resolved?.function.name ?? "<nil>")")
+        #expect(
+            resolved?.function.arguments.isEmpty == true,
+            "\(sample.format.rawValue) invented arguments for a no-parameter tool: \(resolved?.function.arguments ?? [:])")
+    }
+
+    // MARK: - The bare-name branch must not promote prose
+
+    /// With no `<arg_key>` to bound it, a GLM-family function name is the whole
+    /// envelope body, so the acceptance rule is all that separates a real call
+    /// from text the model wrapped in `<tool_call>`.
+    @Test(arguments: [
+        "I should call list_mailboxes now",
+        "list_mailboxes(folder=INBOX)",
+        "",
+        "   ",
+        "{\"name\": \"list_mailboxes\"}",
+        String(repeating: "a", count: 65),
+    ])
+    func glm4RejectsNonIdentifierBodies(_ body: String) {
+        let parser = GLM4ToolCallParser()
+        let call = parser.parse(content: "<tool_call>\(body)</tool_call>", tools: nil)
+        #expect(call == nil, "GLM4 promoted non-identifier text to a tool call: \(body)")
+    }
+
+    @Test(arguments: ["list_mailboxes", "get.time", "todo-read", "a", "tool_9"])
+    func glm4AcceptsIdentifierBodies(_ name: String) {
+        let parser = GLM4ToolCallParser()
+        let call = parser.parse(content: "<tool_call>\(name)</tool_call>", tools: nil)
+        #expect(call?.function.name == name)
+        #expect(call?.function.arguments.isEmpty == true)
+    }
+
+    /// Calls that DO carry arguments must be untouched by the bare-name rule.
+    @Test func glm4ArgumentCallsUnchanged() {
+        let parser = GLM4ToolCallParser()
+        let call = parser.parse(
+            content:
+                "<tool_call>list_messages<arg_key>mailbox_path</arg_key><arg_value>you@x.com/INBOX</arg_value></tool_call>",
+            tools: nil)
+        #expect(call?.function.name == "list_messages")
+        #expect(call?.function.arguments["mailbox_path"] == .string("you@x.com/INBOX"))
+    }
+}


### PR DESCRIPTION
## The bug

`GLM4ToolCallParser` found the function name as "everything before the first `<arg_key>`" and returned `nil` when there was no `<arg_key>`:

```swift
guard let argKeyStart = text.range(of: "<arg_key>") else { return nil }
```

A tool that declares no parameters is invoked with the bare name — `<tool_call>list_mailboxes</tool_call>` — so **every zero-argument call was discarded**.

Nothing downstream can distinguish that from a model that said nothing. The envelope is consumed as non-content, the turn carries no text and no tool work, the agent loop nudges and retries, the model emits the same correct call again, and after the retry budget the user gets:

> The model returned empty output after tool execution. The agent task may be incomplete; retry with less context or continue from the latest tool result.

## Reproduction on real weights

`Raptor-1.0-16B-A3B-qat-JANG_4M` (laguna → `.glm4`), asked *"how many unread emails do I have in my mailbox"* with the Osaurus Mail capability loaded (the real 13,136-char `capabilities_load` result). Raw token stream vs. what the serving stack emitted:

| case | prompt | raw model output | parsed |
|---|---|---|---|
| plain question | 51 | `…</think>The capital of France is Paris.` | content ✅ |
| small tool result | 258 | `…</think><tool_call>list_mailboxes<arg_key>folder</arg_key><arg_value>INBOX</arg_value></tool_call>` | `list_mailboxes` ✅ |
| **real Mail load** | 3476 | `…</think><tool_call>list_mailboxes</tool_call>` | **`[]` ❌ dropped** |

`list_mailboxes` takes no parameters, so the third call is exactly right. With a *short* tool result the model had not been told that and guessed a `folder` argument — which parsed. That is why this survived testing.

After the fix the same run yields `toolCalls=["list_mailboxes"]`, prefill 981 pp/s, decode 19.2 tok/s, `stop=stop`.

## Blast radius

Everything routed to `.glm4`: **GLM-4.x / GLM-5, DeepSeek V3 aliases, Laguna/Raptor, Poolside, Ling/Bailing.**

## The fix

The name is taken from the whole envelope body when no `<arg_key>` bounds it. That branch requires an identifier-shaped name (`[A-Za-z0-9_.-]{1,64}`) because without a delimiter, prose wrapped in `<tool_call>` would otherwise be promoted to a call. Calls that *do* carry arguments keep the original rule byte-for-byte.

## Tests

- **`ZeroArgumentToolCallTests`** — runs the no-argument case through **all 16 `ToolCallFormat` cases**. Verified against the pre-fix tree: `glm4` was the **only** format that dropped it. Also fails if a format is added without a sample, and covers the bare-name branch rejecting prose/empty/over-long bodies while accepting identifiers.
- **`RaptorToolContinuationTests`** (`RAPTOR_LIVE=1`) — drives the real bundle end to end and prints the raw token stream beside the parsed channels, so "the model said nothing" and "we ate it" stay distinguishable.