### PR TITLE
Stop generation when the output collapses into a verbatim cycle

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -4731,9 +4731,16 @@ struct TextToolTokenLoopHandler: TokenLoopHandler, @unchecked Sendable {
     /// `onToken` returns false to halt the loop; the `.info` event
     /// reports `stopReason = .stop`.
     var stopStringMatcher: StopStringMatcher
+    /// Degenerate-repetition guard. Sees the same visible text as the stop
+    /// matcher and halts the loop when the tail collapses into a verbatim
+    /// cycle, so a model stuck repeating itself cannot spend the whole token
+    /// budget and finish with no stop reason at all.
+    var repetitionDetector: RepetitionCycleDetector = .fromEnvironment()
     /// Flipped by `dispatch` when the stop matcher fires, so the loop
     /// task can signal `.stop` in its terminal `.info` event.
     private(set) var stopSequenceHit: Bool = false
+    /// The cycle that halted generation, when the repetition guard fired.
+    private(set) var repetitionCycle: RepetitionCycleDetector.Cycle?
     private(set) var emittedToolCall: Bool = false
 
     init(
@@ -4975,18 +4982,33 @@ struct TextToolTokenLoopHandler: TokenLoopHandler, @unchecked Sendable {
         emit: (sending Generation) -> AsyncStream<Generation>.Continuation.YieldResult
     ) -> AsyncStream<Generation>.Continuation.YieldResult {
         guard stopStringMatcher.isEnabled else {
-            return emit(.chunk(text))
+            let result = emit(.chunk(text))
+            return haltingOnRepetition(text, otherwise: result)
         }
         switch stopStringMatcher.feed(text) {
         case .streaming(let out):
             if out.isEmpty { return .enqueued(remaining: 0) }
-            return emit(.chunk(out))
+            let result = emit(.chunk(out))
+            return haltingOnRepetition(out, otherwise: result)
         case .stopped(let out):
             stopSequenceHit = true
             if out.isEmpty { return .terminated }
             _ = emit(.chunk(out))
             return .terminated
         }
+    }
+
+    /// Feed already-emitted visible text to the repetition guard and convert a
+    /// detected cycle into loop termination. Text is emitted first and never
+    /// withheld: the guard bounds how much more arrives, it does not edit what
+    /// already did.
+    private mutating func haltingOnRepetition(
+        _ emitted: String,
+        otherwise result: AsyncStream<Generation>.Continuation.YieldResult
+    ) -> AsyncStream<Generation>.Continuation.YieldResult {
+        guard let cycle = repetitionDetector.feed(emitted) else { return result }
+        repetitionCycle = cycle
+        return .terminated
     }
 
     func infoEvent(_ info: GenerateCompletionInfo) -> Generation {

--- a/Libraries/MLXLMCommon/RepetitionCycleDetector.swift
+++ b/Libraries/MLXLMCommon/RepetitionCycleDetector.swift
@@ -1,0 +1,161 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+
+/// Streaming detector for degenerate repetition — the state where a model
+/// emits one unit of text over and over, verbatim, until something else stops
+/// it.
+///
+/// ## Why this exists
+///
+/// Observed on Raptor 1.0 16B after two consecutive `invalid_args` tool
+/// rejections:
+///
+/// ```
+/// The answer is AppleScript; it begins with `use AppleScript version`.
+/// I do not generate or repeat the request.   (× N, to the token cap)
+/// ```
+///
+/// Nothing downstream caught it. The turn spent its entire token budget, the
+/// host recorded no terminal stop reason at all, and the user was handed
+/// thousands of characters of the same two sentences. A repetition penalty
+/// would make the state less likely but cannot bound it, and not every bundle
+/// ships one — the observed model declares none.
+///
+/// ## What counts as degenerate
+///
+/// A unit `U` repeated back to back at the tail, at least `minimumRepeats`
+/// times, where `U` is at least `minimumUnitLength` characters AND primitive
+/// at that scale — no shorter string repeats to build it. So the trigger is
+/// ≥128 characters of *exact* consecutive repetition of something that is not
+/// itself a repetition.
+///
+/// The primitivity rule is what separates a collapsed model from ordinary
+/// punctuation: a run of `---`, `. . .` or `| | |` also repeats at period 32,
+/// and a length floor alone would fire on all of them. Their real period is 1
+/// to 6, so they are rejected; the observed loop's period is a whole sentence
+/// pair, so it is not.
+///
+/// The shortest qualifying unit wins, so `ABABAB…` reports `AB` rather than
+/// `ABAB`.
+///
+/// ## Scope
+///
+/// Fed the same user-visible `.chunk` text as ``StopStringMatcher``, after
+/// reasoning and tool-call bytes have been scoped out. It never withholds or
+/// rewrites text: detection only reports that the loop should stop, and
+/// everything already emitted stays emitted.
+public struct RepetitionCycleDetector: Sendable {
+
+    /// Shortest repeating unit treated as degenerate. Below this, repetition
+    /// is ordinary punctuation and formatting.
+    public static let minimumUnitLength = 32
+
+    /// Longest unit considered. A cycle longer than this is cheaper to let
+    /// the token cap handle than to scan for on every chunk.
+    public static let maximumUnitLength = 512
+
+    /// Consecutive repeats required. With the unit floor this means ≥128
+    /// characters of exact repetition before anything fires.
+    public static let minimumRepeats = 4
+
+    /// Output below this length is never examined, so a short answer that
+    /// happens to echo itself is left alone.
+    public static let minimumOutputLength = 128
+
+    /// Rolling tail. Only the end of the stream can carry a cycle that is
+    /// still running, and bounding this keeps `feed` O(1) in stream length.
+    private static let tailCapacity = maximumUnitLength * (minimumRepeats + 1)
+
+    /// `false` disables detection entirely — the generation loop then behaves
+    /// exactly as it did before this type existed.
+    public let isEnabled: Bool
+
+    private var tail: [Character] = []
+    private var total = 0
+
+    public init(isEnabled: Bool = true) {
+        self.isEnabled = isEnabled
+    }
+
+    /// Environment opt-out: `VMLX_REPETITION_STOP=0`.
+    public static func fromEnvironment(
+        _ environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> RepetitionCycleDetector {
+        RepetitionCycleDetector(isEnabled: environment["VMLX_REPETITION_STOP"] != "0")
+    }
+
+    /// The repeating unit, when the tail has collapsed into a cycle.
+    public struct Cycle: Sendable, Equatable {
+        public let unit: String
+        public let repeats: Int
+    }
+
+    /// Append visible text and report a cycle if the tail is now degenerate.
+    public mutating func feed(_ text: String) -> Cycle? {
+        guard isEnabled, !text.isEmpty else { return nil }
+        tail.append(contentsOf: text)
+        total += text.count
+        if tail.count > Self.tailCapacity {
+            tail.removeFirst(tail.count - Self.tailCapacity)
+        }
+        guard total >= Self.minimumOutputLength else { return nil }
+        return Self.cycle(in: tail)
+    }
+
+    /// Shortest unit whose back-to-back repetition ends the buffer.
+    ///
+    /// Exposed for testing and for callers that already hold a full
+    /// transcript; `feed` is the streaming entry point.
+    public static func cycle(in buffer: [Character]) -> Cycle? {
+        let n = buffer.count
+        guard n >= minimumUnitLength * minimumRepeats else { return nil }
+        let longestUnit = min(maximumUnitLength, n / minimumRepeats)
+        guard longestUnit >= minimumUnitLength else { return nil }
+
+        for unit in minimumUnitLength ... longestUnit {
+            // Count how many times the final `unit` characters repeat
+            // immediately before themselves.
+            var repeats = 1
+            while (repeats + 1) * unit <= n {
+                let a = buffer[(n - unit * repeats) ..< (n - unit * (repeats - 1))]
+                let b = buffer[(n - unit * (repeats + 1)) ..< (n - unit * repeats)]
+                if !a.elementsEqual(b) { break }
+                repeats += 1
+            }
+            guard repeats >= minimumRepeats else { continue }
+            // A run of filler — `----`, `. . .`, `| | |\n` — also repeats at
+            // period 32, so unit length alone cannot separate a collapsed
+            // model from ordinary punctuation. Require the unit to be
+            // primitive at this scale: if it is itself a repetition of
+            // something shorter than the floor, the real period is that
+            // shorter thing and this is filler.
+            let candidate = Array(buffer[(n - unit) ..< n])
+            guard minimalPeriod(of: candidate) >= minimumUnitLength else { continue }
+            return Cycle(unit: String(candidate), repeats: repeats)
+        }
+        return nil
+    }
+
+
+    /// Length of the shortest string whose repetition builds `unit` exactly.
+    /// Returns `unit.count` when the unit is primitive.
+    static func minimalPeriod(of unit: [Character]) -> Int {
+        let n = unit.count
+        guard n > 0 else { return 0 }
+        for period in 1 ..< n where n % period == 0 {
+            var matches = true
+            for i in period ..< n where unit[i] != unit[i - period] {
+                matches = false
+                break
+            }
+            if matches { return period }
+        }
+        return n
+    }
+
+    public static func cycle(in text: String) -> Cycle? {
+        cycle(in: Array(text))
+    }
+}

--- a/Tests/MLXLMTests/RepetitionCycleDetectorTests.swift
+++ b/Tests/MLXLMTests/RepetitionCycleDetectorTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+/// The guard has to fire on the observed collapse and stay silent on every
+/// ordinary shape that happens to repeat. False positives here truncate real
+/// answers, so the negative cases matter more than the positive one.
+@Suite("Degenerate repetition detector")
+struct RepetitionCycleDetectorTests {
+
+    /// Verbatim from the live Raptor turn that spent its whole token budget.
+    static let observedUnit =
+        "The answer is AppleScript; it begins with `use AppleScript version`. "
+        + "I do not generate or repeat the request. "
+
+    @Test("fires on the observed collapse")
+    func detectsObservedLoop() throws {
+        let text = String(repeating: Self.observedUnit, count: 6)
+        let cycle = try #require(RepetitionCycleDetector.cycle(in: text))
+        #expect(cycle.unit == Self.observedUnit)
+        #expect(cycle.repeats >= RepetitionCycleDetector.minimumRepeats)
+    }
+
+    @Test("reports the shortest primitive unit, not a multiple of it")
+    func reportsShortestUnit() throws {
+        // Primitive: no shorter string repeats to build it.
+        let unit = "the same sentence again and again, ok? "  // 39 chars
+        let cycle = try #require(RepetitionCycleDetector.cycle(in: String(repeating: unit, count: 8)))
+        #expect(cycle.unit == unit, "reported \(cycle.unit.count)-char unit: \(cycle.unit.debugDescription)")
+    }
+
+    /// A unit that is itself built from a shorter period is filler, however
+    /// long it looks — `"abcdefgh" x 4` is a 32-character unit with period 8.
+    @Test("a non-primitive unit is treated as filler")
+    func nonPrimitiveUnitIsFiller() {
+        let unit = String(repeating: "abcdefgh", count: 4)
+        #expect(RepetitionCycleDetector.cycle(in: String(repeating: unit, count: 8)) == nil)
+        #expect(RepetitionCycleDetector.minimalPeriod(of: Array(unit)) == 8)
+    }
+
+    @Test("streams to the same verdict as the whole-string form")
+    func streamingMatchesWholeString() throws {
+        var detector = RepetitionCycleDetector()
+        var fired: RepetitionCycleDetector.Cycle?
+        for _ in 0 ..< 8 {
+            // Arrive in small pieces, the way detokenized chunks do.
+            for piece in Self.observedUnit.chunked(into: 7) where fired == nil {
+                fired = detector.feed(piece)
+            }
+        }
+        let cycle = try #require(fired)
+        #expect(cycle.unit == Self.observedUnit)
+    }
+
+    // MARK: - Must NOT fire
+
+    @Test("three repeats are not enough")
+    func threeRepeatsAreBelowThreshold() {
+        #expect(RepetitionCycleDetector.cycle(in: String(repeating: Self.observedUnit, count: 3)) == nil)
+    }
+
+    @Test(
+        "short repeating filler never qualifies",
+        arguments: [
+            String(repeating: "-", count: 400),
+            String(repeating: "= ", count: 200),
+            String(repeating: "...", count: 140),
+            String(repeating: "| | |\n", count: 80),
+            String(repeating: "\n", count: 500),
+        ])
+    func shortFillerIsIgnored(_ text: String) {
+        #expect(
+            RepetitionCycleDetector.cycle(in: text) == nil,
+            "fired on filler: \(text.prefix(12).debugDescription)")
+    }
+
+    @Test("ordinary prose does not fire")
+    func proseIsIgnored() {
+        let prose = """
+            A Merkle proof lets a verifier confirm that one leaf belongs to a tree \
+            without downloading the whole tree. The prover supplies the audit path: \
+            the sibling hash at each level between the leaf and the root. The verifier \
+            hashes upward and compares the result against the known root. If they \
+            match, the leaf is in the tree; if not, it is not. The cost is logarithmic \
+            in the number of leaves rather than linear, which is what makes the scheme \
+            practical for large datasets and for clients that cannot store them.
+            """
+        #expect(RepetitionCycleDetector.cycle(in: prose) == nil)
+    }
+
+    /// Repeated *structure* with differing content is the shape most at risk of
+    /// a false positive, and it must survive.
+    @Test("a table with distinct rows does not fire")
+    func tableWithDistinctRowsIsIgnored() {
+        var table = "| name | size | kind |\n| --- | --- | --- |\n"
+        for i in 0 ..< 40 {
+            table += "| entry_\(i) | \(i * 137) bytes | file |\n"
+        }
+        #expect(RepetitionCycleDetector.cycle(in: table) == nil)
+    }
+
+    @Test("repeated code blocks with differing bodies do not fire")
+    func codeWithDifferingBodiesIsIgnored() {
+        var code = ""
+        for i in 0 ..< 30 {
+            code += "func step\(i)() -> Int {\n    return \(i) * 3 + 1\n}\n\n"
+        }
+        #expect(RepetitionCycleDetector.cycle(in: code) == nil)
+    }
+
+    @Test("short output is never examined")
+    func shortOutputIsIgnored() {
+        var detector = RepetitionCycleDetector()
+        #expect(detector.feed(String(repeating: "xy", count: 20)) == nil)
+    }
+
+    @Test("disabled detector never fires")
+    func disabledNeverFires() {
+        var detector = RepetitionCycleDetector(isEnabled: false)
+        #expect(detector.feed(String(repeating: Self.observedUnit, count: 10)) == nil)
+    }
+
+    @Test("VMLX_REPETITION_STOP=0 disables it")
+    func environmentOptOut() {
+        #expect(!RepetitionCycleDetector.fromEnvironment(["VMLX_REPETITION_STOP": "0"]).isEnabled)
+        #expect(RepetitionCycleDetector.fromEnvironment([:]).isEnabled)
+    }
+}
+
+extension String {
+    fileprivate func chunked(into size: Int) -> [String] {
+        var out: [String] = []
+        var index = startIndex
+        while index < endIndex {
+            let next = self.index(index, offsetBy: size, limitedBy: endIndex) ?? endIndex
+            out.append(String(self[index ..< next]))
+            index = next
+        }
+        return out
+    }
+}


### PR DESCRIPTION
## What happens today

Observed live on `Raptor 1.0 16B A3B qat JANG_4M` after two consecutive `invalid_args` tool rejections:

> The answer is AppleScript; it begins with `use AppleScript version`. I do not generate or repeat the request. *(× N, to the token cap)*

Nothing bounded it. From the host's history database that turn recorded **`terminal_stop_reason = NULL`, `generation_token_count = NULL`, 3801 characters** — it spent the entire budget and exited through no classified path at all. A repetition penalty makes the state less likely but cannot bound it, and the observed bundle declares none (`temperature 1.0, top_p 1.0, top_k 20`, no penalty).

## The guard

`RepetitionCycleDetector` sits beside `StopStringMatcher` in the generation loop, sees the same user-visible `.chunk` text (reasoning and tool-call bytes already scoped out), and halts the loop when the tail has collapsed. It never withholds or rewrites text — chunks are emitted first, and detection only bounds how much *more* arrives.

Firing requires a unit repeated back to back **≥4 times**, **≥32 characters**, **and primitive at that scale** — no shorter string repeats to build it.

Primitivity is what does the real work. A run of `---`, `. . .` or `| | |` also repeats at period 32, so a length floor alone fires on all of them; my first cut did exactly that and the negative tests caught it. Their true period is 1–6, so they are rejected. The observed loop's period is a whole sentence pair, so it is not.

`VMLX_REPETITION_STOP=0` disables the guard entirely.

## Tests — the negative cases are the point

12 cases. Beyond firing on the observed collapse and reporting the shortest primitive unit, the suite pins everything that must **not** fire:

- filler runs: `-`×400, `= `×200, `...`×140, `\| \| \|\n`×80, `\n`×500
- ordinary prose
- a 40-row markdown table with distinct rows
- 30 repeated code blocks with differing bodies
- three repeats (below threshold), short output, a non-primitive 32-char unit

Neighbouring stream suites re-run unchanged: **97 tests in 10 suites passed** (`StopStringMatcher`, `ReasoningParser`, `ToolCallProcessor`).

## Scope

This bounds the blast radius; it does not remove the cause. The provocation behind the observed loop — the AppleScript tools' `invalid_args` contract — is fixed separately in osaurus-ai/osaurus#2351 and #2352, both merged and GUI-proven.