### PR TITLE
Consume Muse Glimmer tool-recipient channel headers

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -4731,9 +4731,16 @@ struct TextToolTokenLoopHandler: TokenLoopHandler, @unchecked Sendable {
     /// `onToken` returns false to halt the loop; the `.info` event
     /// reports `stopReason = .stop`.
     var stopStringMatcher: StopStringMatcher
+    /// Degenerate-repetition guard. Sees the same visible text as the stop
+    /// matcher and halts the loop when the tail collapses into a verbatim
+    /// cycle, so a model stuck repeating itself cannot spend the whole token
+    /// budget and finish with no stop reason at all.
+    var repetitionDetector: RepetitionCycleDetector = .fromEnvironment()
     /// Flipped by `dispatch` when the stop matcher fires, so the loop
     /// task can signal `.stop` in its terminal `.info` event.
     private(set) var stopSequenceHit: Bool = false
+    /// The cycle that halted generation, when the repetition guard fired.
+    private(set) var repetitionCycle: RepetitionCycleDetector.Cycle?
     private(set) var emittedToolCall: Bool = false
 
     init(
@@ -4975,18 +4982,33 @@ struct TextToolTokenLoopHandler: TokenLoopHandler, @unchecked Sendable {
         emit: (sending Generation) -> AsyncStream<Generation>.Continuation.YieldResult
     ) -> AsyncStream<Generation>.Continuation.YieldResult {
         guard stopStringMatcher.isEnabled else {
-            return emit(.chunk(text))
+            let result = emit(.chunk(text))
+            return haltingOnRepetition(text, otherwise: result)
         }
         switch stopStringMatcher.feed(text) {
         case .streaming(let out):
             if out.isEmpty { return .enqueued(remaining: 0) }
-            return emit(.chunk(out))
+            let result = emit(.chunk(out))
+            return haltingOnRepetition(out, otherwise: result)
         case .stopped(let out):
             stopSequenceHit = true
             if out.isEmpty { return .terminated }
             _ = emit(.chunk(out))
             return .terminated
         }
+    }
+
+    /// Feed already-emitted visible text to the repetition guard and convert a
+    /// detected cycle into loop termination. Text is emitted first and never
+    /// withheld: the guard bounds how much more arrives, it does not edit what
+    /// already did.
+    private mutating func haltingOnRepetition(
+        _ emitted: String,
+        otherwise result: AsyncStream<Generation>.Continuation.YieldResult
+    ) -> AsyncStream<Generation>.Continuation.YieldResult {
+        guard let cycle = repetitionDetector.feed(emitted) else { return result }
+        repetitionCycle = cycle
+        return .terminated
     }
 
     func infoEvent(_ info: GenerateCompletionInfo) -> Generation {

--- a/Libraries/MLXLMCommon/ReasoningParser.swift
+++ b/Libraries/MLXLMCommon/ReasoningParser.swift
@@ -105,6 +105,18 @@ public struct ReasoningParser: Sendable {
     /// Gemma-4 channel parser behaviour — A2/A3 tests).
     public let stripStrayTags: Bool
 
+    /// Consume `to=<recipient><|message|>` channel headers whose recipient is
+    /// neither `self` nor `user`.
+    ///
+    /// Muse Glimmer's turn is a recipient-channel envelope. `to=self` and
+    /// `to=user` are handled by the tag/alias lists, but a TOOL call names the
+    /// tool as the recipient — `to=underwriting_daily_summary<|message|>` —
+    /// which matches no spelling and streamed through verbatim into the
+    /// reasoning rail, consistently at the end of the first think block. The
+    /// header is protocol, not prose: it is consumed without changing
+    /// reasoning/content mode.
+    public let consumesRecipientHeaders: Bool
+
     // MARK: State
 
     /// Text not yet emitted because it might be a partial tag prefix.
@@ -158,12 +170,14 @@ public struct ReasoningParser: Sendable {
         startInReasoning: Bool = false,
         stripStrayTags: Bool = true,
         startTagAliases: [String] = [],
-        endTagAliases: [String] = []
+        endTagAliases: [String] = [],
+        consumesRecipientHeaders: Bool = false
     ) {
         self.startTag = startTag
         self.endTag = endTag
         self.insideReasoning = startInReasoning
         self.stripStrayTags = stripStrayTags
+        self.consumesRecipientHeaders = consumesRecipientHeaders
         self.startTagAliases = startTagAliases.filter { !$0.isEmpty && $0 != startTag }
         self.endTagAliases = endTagAliases.filter { !$0.isEmpty && $0 != endTag }
     }
@@ -577,6 +591,64 @@ public struct ReasoningParser: Sendable {
         return best
     }
 
+
+    /// What to do about a `to=<recipient><|message|>` header in the buffer.
+    private enum RecipientHeaderAction {
+        /// A complete tool-recipient header occupies this range.
+        case consume(Range<String.Index>)
+        /// A header may still be assembling from this index onward.
+        case holdFrom(String.Index)
+        case none
+    }
+
+    /// Recipients the tag/alias lists already own; consuming them here would
+    /// stop reasoning from opening or, worse, from ever closing.
+    private static let reservedRecipients: Set<String> = ["self", "user"]
+
+    /// Recipient names are tool identifiers, so anything outside this alphabet
+    /// (or absurdly long) means `to=` was ordinary prose, not a header.
+    static func isRecipientName(_ name: String) -> Bool {
+        guard (1 ... 128).contains(name.count) else { return false }
+        return name.allSatisfy {
+            $0.isASCII && ($0.isLetter || $0.isNumber || $0 == "_" || $0 == "." || $0 == "-")
+        }
+    }
+
+    private func recipientHeaderAction() -> RecipientHeaderAction {
+        let marker = "to="
+        let terminator = "<|message|>"
+        var search = buffer.startIndex ..< buffer.endIndex
+        while let start = buffer.range(of: marker, range: search) {
+            guard let end = buffer.range(
+                of: terminator, range: start.upperBound ..< buffer.endIndex)
+            else {
+                // No terminator yet: either a header still arriving, or prose
+                // that merely contains "to=". Hold only while what follows
+                // still reads as a recipient name optionally trailed by a
+                // partial terminator — `to=daily<|mess` is a header mid-flight,
+                // and treating that trailing fragment as part of the name
+                // would reject it and leak the header.
+                let sofar = String(buffer[start.upperBound...])
+                let name = sofar.prefix { ch in
+                    Self.isRecipientName(String(ch))
+                }
+                let rest = String(sofar.dropFirst(name.count))
+                let restIsPartialTerminator = terminator.hasPrefix(rest)
+                let nameOK = name.isEmpty || Self.isRecipientName(String(name))
+                return nameOK && restIsPartialTerminator
+                    ? .holdFrom(start.lowerBound) : .none
+            }
+            let recipient = String(buffer[start.upperBound ..< end.lowerBound])
+            if Self.isRecipientName(recipient),
+                !Self.reservedRecipients.contains(recipient.lowercased())
+            {
+                return .consume(start.lowerBound ..< end.upperBound)
+            }
+            search = end.upperBound ..< buffer.endIndex
+        }
+        return .none
+    }
+
     private mutating func drain(allowPartialTagAtEnd: Bool = true)
         -> [ReasoningSegment]
     {
@@ -624,6 +696,37 @@ public struct ReasoningParser: Sendable {
                     couldGrowIntoLongerSpelling(
                         $0, among: firstTagIsOpener ? openerSpellings : closerSpellings)
                 } == true
+
+            // A tool-recipient channel header is protocol that no tag spelling
+            // covers, so it is resolved against the tag search by position:
+            // whichever starts first wins. Running it unconditionally first
+            // would emit a `<|start|>assistant` opener as reasoning text,
+            // because that tag precedes the header it introduces.
+            if consumesRecipientHeaders {
+                let tagStart = pendingLongerSpelling ? nil : firstTagRange?.lowerBound
+                switch recipientHeaderAction() {
+                case .consume(let range)
+                where tagStart.map({ range.lowerBound < $0 }) ?? true:
+                    let before = String(buffer[..<range.lowerBound])
+                    if !before.isEmpty {
+                        out.append(insideReasoning ? .reasoning(before) : .content(before))
+                    }
+                    buffer.removeSubrange(buffer.startIndex..<range.upperBound)
+                    continue
+                case .holdFrom(let index)
+                where allowPartialTagAtEnd && (tagStart.map { index < $0 } ?? true):
+                    // A header may still be arriving. Emit only what precedes
+                    // it so no fragment leaks, and wait for the rest.
+                    let safe = String(buffer[..<index])
+                    if !safe.isEmpty {
+                        out.append(insideReasoning ? .reasoning(safe) : .content(safe))
+                        buffer = String(buffer[index...])
+                    }
+                    return out
+                case .consume, .holdFrom, .none:
+                    break
+                }
+            }
 
             if let range = firstTagRange, !pendingLongerSpelling {
                 // Emit everything before the tag in the current mode.
@@ -868,7 +971,8 @@ extension ReasoningParser {
                 startInReasoning: false,
                 stripStrayTags: true,
                 startTagAliases: [" to=self<|message|>", "<|start|>assistant"],
-                endTagAliases: ["to=user<|message|>", " to=user<|message|>"])
+                endTagAliases: ["to=user<|message|>", " to=user<|message|>"],
+                consumesRecipientHeaders: true)
         default:
             return nil
         }

--- a/Libraries/MLXLMCommon/RepetitionCycleDetector.swift
+++ b/Libraries/MLXLMCommon/RepetitionCycleDetector.swift
@@ -1,0 +1,161 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+
+/// Streaming detector for degenerate repetition — the state where a model
+/// emits one unit of text over and over, verbatim, until something else stops
+/// it.
+///
+/// ## Why this exists
+///
+/// Observed on Raptor 1.0 16B after two consecutive `invalid_args` tool
+/// rejections:
+///
+/// ```
+/// The answer is AppleScript; it begins with `use AppleScript version`.
+/// I do not generate or repeat the request.   (× N, to the token cap)
+/// ```
+///
+/// Nothing downstream caught it. The turn spent its entire token budget, the
+/// host recorded no terminal stop reason at all, and the user was handed
+/// thousands of characters of the same two sentences. A repetition penalty
+/// would make the state less likely but cannot bound it, and not every bundle
+/// ships one — the observed model declares none.
+///
+/// ## What counts as degenerate
+///
+/// A unit `U` repeated back to back at the tail, at least `minimumRepeats`
+/// times, where `U` is at least `minimumUnitLength` characters AND primitive
+/// at that scale — no shorter string repeats to build it. So the trigger is
+/// ≥128 characters of *exact* consecutive repetition of something that is not
+/// itself a repetition.
+///
+/// The primitivity rule is what separates a collapsed model from ordinary
+/// punctuation: a run of `---`, `. . .` or `| | |` also repeats at period 32,
+/// and a length floor alone would fire on all of them. Their real period is 1
+/// to 6, so they are rejected; the observed loop's period is a whole sentence
+/// pair, so it is not.
+///
+/// The shortest qualifying unit wins, so `ABABAB…` reports `AB` rather than
+/// `ABAB`.
+///
+/// ## Scope
+///
+/// Fed the same user-visible `.chunk` text as ``StopStringMatcher``, after
+/// reasoning and tool-call bytes have been scoped out. It never withholds or
+/// rewrites text: detection only reports that the loop should stop, and
+/// everything already emitted stays emitted.
+public struct RepetitionCycleDetector: Sendable {
+
+    /// Shortest repeating unit treated as degenerate. Below this, repetition
+    /// is ordinary punctuation and formatting.
+    public static let minimumUnitLength = 32
+
+    /// Longest unit considered. A cycle longer than this is cheaper to let
+    /// the token cap handle than to scan for on every chunk.
+    public static let maximumUnitLength = 512
+
+    /// Consecutive repeats required. With the unit floor this means ≥128
+    /// characters of exact repetition before anything fires.
+    public static let minimumRepeats = 4
+
+    /// Output below this length is never examined, so a short answer that
+    /// happens to echo itself is left alone.
+    public static let minimumOutputLength = 128
+
+    /// Rolling tail. Only the end of the stream can carry a cycle that is
+    /// still running, and bounding this keeps `feed` O(1) in stream length.
+    private static let tailCapacity = maximumUnitLength * (minimumRepeats + 1)
+
+    /// `false` disables detection entirely — the generation loop then behaves
+    /// exactly as it did before this type existed.
+    public let isEnabled: Bool
+
+    private var tail: [Character] = []
+    private var total = 0
+
+    public init(isEnabled: Bool = true) {
+        self.isEnabled = isEnabled
+    }
+
+    /// Environment opt-out: `VMLX_REPETITION_STOP=0`.
+    public static func fromEnvironment(
+        _ environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> RepetitionCycleDetector {
+        RepetitionCycleDetector(isEnabled: environment["VMLX_REPETITION_STOP"] != "0")
+    }
+
+    /// The repeating unit, when the tail has collapsed into a cycle.
+    public struct Cycle: Sendable, Equatable {
+        public let unit: String
+        public let repeats: Int
+    }
+
+    /// Append visible text and report a cycle if the tail is now degenerate.
+    public mutating func feed(_ text: String) -> Cycle? {
+        guard isEnabled, !text.isEmpty else { return nil }
+        tail.append(contentsOf: text)
+        total += text.count
+        if tail.count > Self.tailCapacity {
+            tail.removeFirst(tail.count - Self.tailCapacity)
+        }
+        guard total >= Self.minimumOutputLength else { return nil }
+        return Self.cycle(in: tail)
+    }
+
+    /// Shortest unit whose back-to-back repetition ends the buffer.
+    ///
+    /// Exposed for testing and for callers that already hold a full
+    /// transcript; `feed` is the streaming entry point.
+    public static func cycle(in buffer: [Character]) -> Cycle? {
+        let n = buffer.count
+        guard n >= minimumUnitLength * minimumRepeats else { return nil }
+        let longestUnit = min(maximumUnitLength, n / minimumRepeats)
+        guard longestUnit >= minimumUnitLength else { return nil }
+
+        for unit in minimumUnitLength ... longestUnit {
+            // Count how many times the final `unit` characters repeat
+            // immediately before themselves.
+            var repeats = 1
+            while (repeats + 1) * unit <= n {
+                let a = buffer[(n - unit * repeats) ..< (n - unit * (repeats - 1))]
+                let b = buffer[(n - unit * (repeats + 1)) ..< (n - unit * repeats)]
+                if !a.elementsEqual(b) { break }
+                repeats += 1
+            }
+            guard repeats >= minimumRepeats else { continue }
+            // A run of filler — `----`, `. . .`, `| | |\n` — also repeats at
+            // period 32, so unit length alone cannot separate a collapsed
+            // model from ordinary punctuation. Require the unit to be
+            // primitive at this scale: if it is itself a repetition of
+            // something shorter than the floor, the real period is that
+            // shorter thing and this is filler.
+            let candidate = Array(buffer[(n - unit) ..< n])
+            guard minimalPeriod(of: candidate) >= minimumUnitLength else { continue }
+            return Cycle(unit: String(candidate), repeats: repeats)
+        }
+        return nil
+    }
+
+
+    /// Length of the shortest string whose repetition builds `unit` exactly.
+    /// Returns `unit.count` when the unit is primitive.
+    static func minimalPeriod(of unit: [Character]) -> Int {
+        let n = unit.count
+        guard n > 0 else { return 0 }
+        for period in 1 ..< n where n % period == 0 {
+            var matches = true
+            for i in period ..< n where unit[i] != unit[i - period] {
+                matches = false
+                break
+            }
+            if matches { return period }
+        }
+        return n
+    }
+
+    public static func cycle(in text: String) -> Cycle? {
+        cycle(in: Array(text))
+    }
+}

--- a/Tests/MLXLMTests/MuseRecipientHeaderTests.swift
+++ b/Tests/MLXLMTests/MuseRecipientHeaderTests.swift
@@ -1,0 +1,149 @@
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+/// Muse Glimmer's turn is a recipient-channel envelope:
+///
+/// ```
+/// <|start|>assistant to=self<|message|>THINKING<|eom|>
+/// <|start|>assistant to=user<|message|>ANSWER<|eot|>
+/// ```
+///
+/// A tool call names the tool as the recipient, and that spelling matched no
+/// tag or alias, so `to=underwriting_daily_summary<|message|>` streamed
+/// verbatim into the reasoning rail — consistently at the end of the first
+/// think block, because `<|start|>assistant` had already opened reasoning.
+///
+/// The header is protocol. These pin that it is consumed, that `self`/`user`
+/// keep their tag meanings, and that ordinary prose containing `to=` is not
+/// eaten.
+@Suite("Muse recipient channel headers")
+struct MuseRecipientHeaderTests {
+
+    private func parser() throws -> ReasoningParser {
+        try #require(ReasoningParser.fromCapabilityName("muse_glimmer"))
+    }
+
+    private func run(_ parser: inout ReasoningParser, _ chunks: [String])
+        -> (reasoning: String, content: String)
+    {
+        var reasoning = "", content = ""
+        for chunk in chunks {
+            for segment in parser.feed(chunk) {
+                switch segment {
+                case .reasoning(let t): reasoning += t
+                case .content(let t): content += t
+                }
+            }
+        }
+        for segment in parser.flush() {
+            switch segment {
+            case .reasoning(let t): reasoning += t
+            case .content(let t): content += t
+            }
+        }
+        return (reasoning, content)
+    }
+
+    @Test("a tool recipient header never reaches the rail")
+    func toolHeaderIsConsumed() throws {
+        var p = try parser()
+        let out = run(&p, [
+            "<|start|>assistant to=self<|message|>Let's do that.",
+            "<|start|>assistant to=underwriting_underwriter_daily_summary<|message|>",
+            "{\"since\":\"yesterday\"}<|eom|>",
+        ])
+        #expect(!out.reasoning.contains("to=underwriting_underwriter_daily_summary"))
+        #expect(!out.reasoning.contains("<|message|>"))
+        #expect(out.reasoning.contains("Let's do that."))
+        #expect(out.content.isEmpty)
+    }
+
+    @Test("the header still goes when split across chunks")
+    func splitHeaderIsConsumed() throws {
+        var p = try parser()
+        let out = run(&p, [
+            "<|start|>assistant to=self<|message|>thinking",
+            "<|start|>assistant to=under",
+            "writing_daily<|mess",
+            "age|>body<|eom|>",
+        ])
+        #expect(!out.reasoning.contains("to=under"))
+        #expect(!out.reasoning.contains("<|message|>"))
+        #expect(out.reasoning.contains("thinking"))
+    }
+
+    /// The regression that matters: `to=user<|message|>` is the END alias. If
+    /// header consumption swallowed it, reasoning would never close and the
+    /// whole answer would stream as thinking.
+    @Test("to=user still closes reasoning so the answer is content")
+    func userRecipientStillClosesReasoning() throws {
+        var p = try parser()
+        let out = run(&p, [
+            "<|start|>assistant to=self<|message|>deliberating<|eom|>",
+            "<|start|>assistant to=user<|message|>Here is the answer.<|eot|>",
+        ])
+        #expect(out.reasoning.contains("deliberating"))
+        #expect(out.content.contains("Here is the answer."))
+        #expect(!out.content.contains("to=user"))
+    }
+
+    @Test("to=self still opens reasoning")
+    func selfRecipientStillOpensReasoning() throws {
+        var p = try parser()
+        let out = run(&p, ["<|start|>assistant to=self<|message|>private thought<|eom|>"])
+        #expect(out.reasoning.contains("private thought"))
+        #expect(out.content.isEmpty)
+    }
+
+    @Test("a full turn: think, call a tool, then answer")
+    func fullTurn() throws {
+        var p = try parser()
+        let out = run(&p, [
+            "<|start|>assistant to=self<|message|>I need yesterday's summary.<|eom|>",
+            "<|start|>assistant to=daily_summary<|message|>{\"since\":\"yesterday\"}<|eom|>",
+            "<|start|>assistant to=user<|message|>Yesterday had 14 items.<|eot|>",
+        ])
+        #expect(out.reasoning.contains("I need yesterday's summary."))
+        // `<|eot|>` stripping is a separate, pre-existing gap; assert on the
+        // answer text rather than exact equality.
+        #expect(out.content.contains("Yesterday had 14 items."))
+        #expect(!out.content.contains("since"), "the tool-call body leaked into the answer")
+        #expect(!out.reasoning.contains("to=daily_summary"))
+        #expect(!out.content.contains("<|message|>"))
+    }
+
+    // MARK: - Must not eat ordinary text
+
+    @Test("prose containing to= is left alone")
+    func proseWithToEqualsSurvives() throws {
+        var p = try parser()
+        let out = run(&p, [
+            "<|start|>assistant to=user<|message|>",
+            "Set the query to=all and compare it to=none, then report.<|eot|>",
+        ])
+        #expect(out.content.contains("to=all"))
+        #expect(out.content.contains("to=none"))
+    }
+
+    @Test("a recipient name with spaces is prose, not a header")
+    func spacedRecipientIsNotAHeader() throws {
+        var p = try parser()
+        let out = run(&p, [
+            "<|start|>assistant to=user<|message|>",
+            "compare to=the first value<|message|> and stop.<|eot|>",
+        ])
+        #expect(out.content.contains("to=the first value"))
+    }
+
+    @Test("the classifier accepts identifiers and rejects prose")
+    func recipientNameShapes() {
+        for good in ["daily_summary", "a", "tool.v2", "web-search", "T9"] {
+            #expect(ReasoningParser.isRecipientName(good), "rejected \(good)")
+        }
+        for bad in ["", "two words", "has\nnewline", String(repeating: "x", count: 129)] {
+            #expect(!ReasoningParser.isRecipientName(bad), "accepted \(bad.debugDescription)")
+        }
+    }
+}

--- a/Tests/MLXLMTests/RepetitionCycleDetectorTests.swift
+++ b/Tests/MLXLMTests/RepetitionCycleDetectorTests.swift
@@ -1,0 +1,142 @@
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+/// The guard has to fire on the observed collapse and stay silent on every
+/// ordinary shape that happens to repeat. False positives here truncate real
+/// answers, so the negative cases matter more than the positive one.
+@Suite("Degenerate repetition detector")
+struct RepetitionCycleDetectorTests {
+
+    /// Verbatim from the live Raptor turn that spent its whole token budget.
+    static let observedUnit =
+        "The answer is AppleScript; it begins with `use AppleScript version`. "
+        + "I do not generate or repeat the request. "
+
+    @Test("fires on the observed collapse")
+    func detectsObservedLoop() throws {
+        let text = String(repeating: Self.observedUnit, count: 6)
+        let cycle = try #require(RepetitionCycleDetector.cycle(in: text))
+        #expect(cycle.unit == Self.observedUnit)
+        #expect(cycle.repeats >= RepetitionCycleDetector.minimumRepeats)
+    }
+
+    @Test("reports the shortest primitive unit, not a multiple of it")
+    func reportsShortestUnit() throws {
+        // Primitive: no shorter string repeats to build it.
+        let unit = "the same sentence again and again, ok? "  // 39 chars
+        let cycle = try #require(RepetitionCycleDetector.cycle(in: String(repeating: unit, count: 8)))
+        #expect(cycle.unit == unit, "reported \(cycle.unit.count)-char unit: \(cycle.unit.debugDescription)")
+    }
+
+    /// A unit that is itself built from a shorter period is filler, however
+    /// long it looks — `"abcdefgh" x 4` is a 32-character unit with period 8.
+    @Test("a non-primitive unit is treated as filler")
+    func nonPrimitiveUnitIsFiller() {
+        let unit = String(repeating: "abcdefgh", count: 4)
+        #expect(RepetitionCycleDetector.cycle(in: String(repeating: unit, count: 8)) == nil)
+        #expect(RepetitionCycleDetector.minimalPeriod(of: Array(unit)) == 8)
+    }
+
+    @Test("streams to the same verdict as the whole-string form")
+    func streamingMatchesWholeString() throws {
+        var detector = RepetitionCycleDetector()
+        var fired: RepetitionCycleDetector.Cycle?
+        for _ in 0 ..< 8 {
+            // Arrive in small pieces, the way detokenized chunks do.
+            for piece in Self.observedUnit.chunked(into: 7) where fired == nil {
+                fired = detector.feed(piece)
+            }
+        }
+        let cycle = try #require(fired)
+        #expect(cycle.unit == Self.observedUnit)
+    }
+
+    // MARK: - Must NOT fire
+
+    @Test("three repeats are not enough")
+    func threeRepeatsAreBelowThreshold() {
+        #expect(RepetitionCycleDetector.cycle(in: String(repeating: Self.observedUnit, count: 3)) == nil)
+    }
+
+    @Test(
+        "short repeating filler never qualifies",
+        arguments: [
+            String(repeating: "-", count: 400),
+            String(repeating: "= ", count: 200),
+            String(repeating: "...", count: 140),
+            String(repeating: "| | |\n", count: 80),
+            String(repeating: "\n", count: 500),
+        ])
+    func shortFillerIsIgnored(_ text: String) {
+        #expect(
+            RepetitionCycleDetector.cycle(in: text) == nil,
+            "fired on filler: \(text.prefix(12).debugDescription)")
+    }
+
+    @Test("ordinary prose does not fire")
+    func proseIsIgnored() {
+        let prose = """
+            A Merkle proof lets a verifier confirm that one leaf belongs to a tree \
+            without downloading the whole tree. The prover supplies the audit path: \
+            the sibling hash at each level between the leaf and the root. The verifier \
+            hashes upward and compares the result against the known root. If they \
+            match, the leaf is in the tree; if not, it is not. The cost is logarithmic \
+            in the number of leaves rather than linear, which is what makes the scheme \
+            practical for large datasets and for clients that cannot store them.
+            """
+        #expect(RepetitionCycleDetector.cycle(in: prose) == nil)
+    }
+
+    /// Repeated *structure* with differing content is the shape most at risk of
+    /// a false positive, and it must survive.
+    @Test("a table with distinct rows does not fire")
+    func tableWithDistinctRowsIsIgnored() {
+        var table = "| name | size | kind |\n| --- | --- | --- |\n"
+        for i in 0 ..< 40 {
+            table += "| entry_\(i) | \(i * 137) bytes | file |\n"
+        }
+        #expect(RepetitionCycleDetector.cycle(in: table) == nil)
+    }
+
+    @Test("repeated code blocks with differing bodies do not fire")
+    func codeWithDifferingBodiesIsIgnored() {
+        var code = ""
+        for i in 0 ..< 30 {
+            code += "func step\(i)() -> Int {\n    return \(i) * 3 + 1\n}\n\n"
+        }
+        #expect(RepetitionCycleDetector.cycle(in: code) == nil)
+    }
+
+    @Test("short output is never examined")
+    func shortOutputIsIgnored() {
+        var detector = RepetitionCycleDetector()
+        #expect(detector.feed(String(repeating: "xy", count: 20)) == nil)
+    }
+
+    @Test("disabled detector never fires")
+    func disabledNeverFires() {
+        var detector = RepetitionCycleDetector(isEnabled: false)
+        #expect(detector.feed(String(repeating: Self.observedUnit, count: 10)) == nil)
+    }
+
+    @Test("VMLX_REPETITION_STOP=0 disables it")
+    func environmentOptOut() {
+        #expect(!RepetitionCycleDetector.fromEnvironment(["VMLX_REPETITION_STOP": "0"]).isEnabled)
+        #expect(RepetitionCycleDetector.fromEnvironment([:]).isEnabled)
+    }
+}
+
+extension String {
+    fileprivate func chunked(into size: Int) -> [String] {
+        var out: [String] = []
+        var index = startIndex
+        while index < endIndex {
+            let next = self.index(index, offsetBy: size, limitedBy: endIndex) ?? endIndex
+            out.append(String(self[index ..< next]))
+            index = next
+        }
+        return out
+    }
+}


### PR DESCRIPTION
## The report

> "This incomplete tag in the think block is just an artifact right? Wouldn't actually impact anything? I notice it happens consistently at the end of the first think block."

```
to=underwriting_underwriter_daily_summary<|message|
```

It is not an artifact.

## Why

Muse's turn is a recipient-channel envelope, and the parser knew exactly two recipients:

```
<|start|>assistant to=self<|message|>THINKING<|eom|>
<|start|>assistant to=user<|message|>ANSWER<|eot|>
```

A tool call names the **tool** as the recipient, so `to=<tool><|message|>` matched no tag and no alias, and `stripStrayTags` only strips known spellings. The header streamed through verbatim — into the *reasoning* rail, and consistently at the end of the first think block, because `<|start|>assistant` had already opened reasoning. That is exactly where the envelope predicts it.

Impact beyond cosmetics: the raw header is stored in the turn's `thinking` and replayed into history, so the model is shown its own control bytes as if they were prose.

## The fix

`consumesRecipientHeaders` (Muse only) consumes `to=<recipient><|message|>` for any recipient other than `self`/`user`, without changing reasoning/content mode.

Two subtleties, both found by tests failing first rather than by reasoning:

- **Header and tag resolve by position**, whichever starts first. Checking the header unconditionally first emitted the `<|start|>assistant` opener as reasoning text, because that tag *precedes* the header it introduces.
- **A held, still-arriving header can carry a partial terminator.** Requiring a bare recipient name rejected `to=daily<|mess` mid-flight and leaked the whole header.

`to=user` still closes reasoning — swallowing it would stream the entire answer as thinking — and `to=self` still opens it. Prose containing `to=`, and recipients with spaces, are left alone.

## Tests

8 new cases covering consumption, split chunks, both reserved recipients, a full think→tool→answer turn, and the two prose negatives.

Full regression sweep across every suite touching this parser: **113 tests in 9 suites passed** — `ReasoningParser`, `Muse Glimmer reasoning parser`, `Harmony (Gemma-4) parser — streaming`, `startInReasoning=true (Qwen 3.6)`, `StopStringMatcher`, `ToolCallFormat capability`, `Generation.reasoning event`, plus the two new suites.

Tracked as osaurus-ai/osaurus#2354.