### PR TITLE
Match the Muse header terminator as it actually arrives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,7 @@ iOSInjectionProject/
 # Internal engineering notes — root-cause writeups, live-proof logs, campaign
 # state. Local only; never published.
 Docs/Internal/
+
+# session-local scratch build paths
+.build-rep/
+.build-rp2/

--- a/Libraries/MLXLMCommon/ReasoningParser.swift
+++ b/Libraries/MLXLMCommon/ReasoningParser.swift
@@ -614,9 +614,19 @@ public struct ReasoningParser: Sendable {
         }
     }
 
+    /// The header terminator as it actually arrives.
+    ///
+    /// Live Muse output ends the header at `<|message|` — the closing `>` is
+    /// not part of what reaches this parser, because the tool-call envelope
+    /// that follows is consumed downstream. Requiring the full `<|message|>`
+    /// meant the header never matched and leaked verbatim, which is exactly
+    /// what shipped and had to be re-fixed. Match the open form and swallow a
+    /// trailing `>` when it is there.
+    private static let recipientHeaderTerminator = "<|message|"
+
     private func recipientHeaderAction() -> RecipientHeaderAction {
         let marker = "to="
-        let terminator = "<|message|>"
+        let terminator = Self.recipientHeaderTerminator
         var search = buffer.startIndex ..< buffer.endIndex
         while let start = buffer.range(of: marker, range: search) {
             guard let end = buffer.range(
@@ -642,7 +652,12 @@ public struct ReasoningParser: Sendable {
             if Self.isRecipientName(recipient),
                 !Self.reservedRecipients.contains(recipient.lowercased())
             {
-                return .consume(start.lowerBound ..< end.upperBound)
+                // Swallow the closing `>` when the full spelling did arrive.
+                var stop = end.upperBound
+                if stop < buffer.endIndex, buffer[stop] == ">" {
+                    stop = buffer.index(after: stop)
+                }
+                return .consume(start.lowerBound ..< stop)
             }
             search = end.upperBound ..< buffer.endIndex
         }
@@ -714,13 +729,23 @@ public struct ReasoningParser: Sendable {
                     buffer.removeSubrange(buffer.startIndex..<range.upperBound)
                     continue
                 case .holdFrom(let index)
-                where allowPartialTagAtEnd && (tagStart.map { index < $0 } ?? true):
-                    // A header may still be arriving. Emit only what precedes
-                    // it so no fragment leaks, and wait for the rest.
+                where tagStart.map({ index < $0 }) ?? true:
                     let safe = String(buffer[..<index])
                     if !safe.isEmpty {
                         out.append(insideReasoning ? .reasoning(safe) : .content(safe))
+                    }
+                    if allowPartialTagAtEnd {
+                        // A header may still be arriving. Emit only what
+                        // precedes it so no fragment leaks, and wait.
                         buffer = String(buffer[index...])
+                    } else {
+                        // End of stream: no more tokens are coming, so the
+                        // held text will never complete. It is a header either
+                        // way — DROP it rather than flushing it as reasoning.
+                        // A turn that ends on its tool-call header does exactly
+                        // this, and emitting here is what leaked
+                        // `to=get_current_time<|message|` into the rail.
+                        buffer.removeAll(keepingCapacity: false)
                     }
                     return out
                 case .consume, .holdFrom, .none:

--- a/Tests/MLXLMTests/MuseRecipientHeaderTests.swift
+++ b/Tests/MLXLMTests/MuseRecipientHeaderTests.swift
@@ -146,4 +146,47 @@ struct MuseRecipientHeaderTests {
             #expect(!ReasoningParser.isRecipientName(bad), "accepted \(bad.debugDescription)")
         }
     }
+
+    // MARK: - The shapes that actually ship
+
+    /// Live Muse output ends the header at `<|message|` with no closing `>`,
+    /// because the tool-call envelope after it is consumed downstream.
+    /// Requiring the full spelling meant the header never matched — this is
+    /// the exact text that leaked in production.
+    @Test("the open `<|message|` terminator is enough")
+    func openTerminatorIsConsumed() throws {
+        var p = try parser()
+        let out = run(&p, [
+            "<|start|>assistant to=self<|message|>Let's call it. ",
+            "to=get_current_time<|message|",
+        ])
+        #expect(!out.reasoning.contains("to=get_current_time"))
+        #expect(!out.reasoning.contains("<|message|"))
+        #expect(out.reasoning.contains("Let's call it."))
+    }
+
+    /// And when the turn simply ends on the header, flush must DROP it rather
+    /// than emit what it was holding.
+    @Test("a header held at end-of-stream is dropped, not flushed")
+    func heldHeaderIsDroppedOnFlush() throws {
+        var p = try parser()
+        let out = run(&p, [
+            "<|start|>assistant to=self<|message|>thinking about it. ",
+            "to=some_tool",
+        ])
+        #expect(!out.reasoning.contains("to=some_tool"))
+        #expect(out.reasoning.contains("thinking about it."))
+        #expect(out.content.isEmpty)
+    }
+
+    @Test("the closing `>` is swallowed when it does arrive")
+    func closingBracketIsSwallowed() throws {
+        var p = try parser()
+        let out = run(&p, [
+            "<|start|>assistant to=self<|message|>a. ",
+            "to=tool_x<|message|>body<|eom|>",
+        ])
+        #expect(!out.reasoning.contains(">body"), "leaked the closing bracket")
+        #expect(out.reasoning.contains("body"))
+    }
 }


### PR DESCRIPTION
Follow-up to #230, found by driving the running app after it shipped.

## What #230 missed

It required the full `<|message|>`. Live Muse output ends the header at `<|message|` — no closing `>`, because the tool-call envelope after it is consumed downstream. So the header never matched and leaked exactly as before. From the app's stored `thinking` on the post-#230 build:

```
Let's call it. to=get_current_time<|message|
```

Two gaps, both reachable only by the shape that actually ships:

1. **The terminator is matched in its open form**, with a trailing `>` swallowed when it does arrive.
2. **A header held at end-of-stream is dropped, not flushed.** `flush` drains with `allowPartialTagAtEnd: false`, which skipped the hold branch entirely and emitted the held bytes as reasoning — so a turn that *ends* on its tool-call header leaked the whole thing.

This is a second pass on one defect. The first was locally correct and never reached production shapes, which is why the new tests are built from the exact leaked text rather than from my model of the format.

## Tests

Three added: the open terminator, a header held at end-of-stream, and the closing bracket being swallowed when present. Full sweep: **116 tests in 9 suites passed** — `ReasoningParser`, `Muse Glimmer reasoning parser`, `Harmony (Gemma-4) — streaming`, `startInReasoning=true (Qwen 3.6)`, `StopStringMatcher`, `ToolCallFormat capability`, `Generation.reasoning event`, `Degenerate repetition detector`, `Muse recipient channel headers`.

Also adds the session-local scratch build paths to `.gitignore`.