### PR TITLE
Select the Muse parser for Muse bundles

### DIFF
--- a/Libraries/MLXLMCommon/ReasoningParser.swift
+++ b/Libraries/MLXLMCommon/ReasoningParser.swift
@@ -1219,6 +1219,17 @@ public func reasoningStampFromModelType(_ modelType: String?) -> String {
         return "hy_v3"
     }
 
+    // Muse Glimmer's recipient-channel envelope
+    // (`<|start|>assistant to=self<|message|>…<|eom|>`). Without this entry
+    // `muse_glimmer` fell through to the final "none", so the parser that
+    // understands `to=self` / `to=user` — and consumes tool-recipient headers
+    // — was never selected for the bundle that needs it, and
+    // `to=<tool><|message|` leaked into the rail on every tool call. The
+    // parser was fixed twice before anyone checked it was being reached.
+    if compact.hasPrefix("museglimmer") || compact == "muse" || compact == "atem" {
+        return "muse_glimmer"
+    }
+
     // Gemma-4 harmony channel envelope: `<|channel>thought\n…<channel|>`.
     // Distinct from `<think>` XML.
     if compact.hasPrefix("gemma4") {

--- a/Tests/MLXLMTests/MuseRecipientHeaderTests.swift
+++ b/Tests/MLXLMTests/MuseRecipientHeaderTests.swift
@@ -190,3 +190,32 @@ struct MuseRecipientHeaderTests {
         #expect(out.reasoning.contains("body"))
     }
 }
+
+/// The parser above is only useful if the Muse bundle actually selects it.
+/// `muse_glimmer` had no entry in `reasoningStampFromModelType`, so it fell
+/// through to "none" and the recipient-channel parser was never reached — the
+/// header kept leaking through two rounds of parser fixes.
+@Suite("Muse reasoning stamp resolution")
+struct MuseReasoningStampTests {
+
+    @Test(arguments: ["muse_glimmer", "muse-glimmer", "MUSE_GLIMMER", "muse_glimmer_vl"])
+    func museResolvesToItsOwnParser(_ modelType: String) {
+        #expect(reasoningStampFromModelType(modelType) == "muse_glimmer",
+            "\(modelType) resolved to \(reasoningStampFromModelType(modelType))")
+    }
+
+    @Test("the resolved stamp builds the recipient-channel parser")
+    func stampBuildsTheRightParser() throws {
+        let stamp = reasoningStampFromModelType("muse_glimmer")
+        let parser = try #require(ReasoningParser.fromCapabilityName(stamp))
+        #expect(parser.consumesRecipientHeaders)
+    }
+
+    /// Neighbouring families must be untouched.
+    @Test func otherFamiliesUnchanged() {
+        #expect(reasoningStampFromModelType("gemma4") == "harmony")
+        #expect(reasoningStampFromModelType("qwen3") == "think_xml")
+        #expect(reasoningStampFromModelType("deepseek_v4") == "think_xml")
+        #expect(reasoningStampFromModelType("llama") == "none")
+    }
+}


### PR DESCRIPTION
## Why the header kept leaking

`muse_glimmer` had **no entry** in `reasoningStampFromModelType`, so it fell through to the final `"none"` and the parser that understands `to=self` / `to=user` was never selected for the bundle that needs it.

That is why the tool-recipient header survived two rounds of parser work. #230 taught the parser to consume `to=<tool><|message|>`. #231 fixed the terminator to its real open form and made a held header drop on flush. Both were correct. Neither was reachable. Driving the running app after each one showed the stored `thinking` still ending with:

```
to=get_current_time<|message|
```

Nothing in the bundle can override it either — `config.json` carries only `model_type: muse_glimmer`, `jang_config.json` declares no `reasoningParser`, and the chat template contains `<|start|>` / `<|message|>` / `to=self` but no `<think>`. The family stamp is the only thing that can pick the parser.

## The change

`muse_glimmer` (and `muse` / `atem`) resolve to the `"muse_glimmer"` stamp.

## Tests

The resolution is asserted **and** so is the consequence — the resolved stamp must build a parser with `consumesRecipientHeaders` — so a rename cannot silently unhook it again. Neighbouring families are pinned unchanged (`gemma4` → harmony, `qwen3` / `deepseek_v4` → think_xml, `llama` → none).

**88 tests in 8 suites passed.**

## Note for review

This is the third pass on one defect and the same root mistake each time: I verified the code was correct without verifying it was *reached*. The stamp test exists specifically so the reachability, not just the behaviour, is pinned.