### PR TITLE
Carry recipient-header consumption through forPrompt

### DIFF
--- a/Libraries/MLXLMCommon/ReasoningParser.swift
+++ b/Libraries/MLXLMCommon/ReasoningParser.swift
@@ -1123,7 +1123,15 @@ extension ReasoningParser {
             // would give prompt-resolved Hunyuan parsers a narrower tag set
             // than stamp-resolved ones.
             startTagAliases: base.startTagAliases,
-            endTagAliases: base.endTagAliases)
+            endTagAliases: base.endTagAliases,
+            // And the recipient-header policy. This rebuild is field-by-field,
+            // so every capability the family configured has to be carried
+            // explicitly — a default here silently downgrades the live parser
+            // relative to the stamp-resolved one. Muse lost header consumption
+            // exactly this way: the flag was set by `fromCapabilityName`,
+            // dropped here, and the generation loop only ever uses this path,
+            // so three correct parser fixes changed nothing on the app.
+            consumesRecipientHeaders: base.consumesRecipientHeaders)
         if startInReasoning && parser.isHarmonyChannelParser {
             parser.insideHarmonyChannel = true
             parser.harmonyChannelIsReasoning = true

--- a/Tests/MLXLMTests/MuseRecipientHeaderTests.swift
+++ b/Tests/MLXLMTests/MuseRecipientHeaderTests.swift
@@ -219,3 +219,53 @@ struct MuseReasoningStampTests {
         #expect(reasoningStampFromModelType("llama") == "none")
     }
 }
+
+/// `forPrompt` is the only constructor the generation loop uses, and it
+/// rebuilds the parser field by field. Anything the family configured that is
+/// not carried across is silently lost at runtime while every stamp-resolved
+/// unit test still passes — which is exactly how the Muse header leak survived
+/// three correct parser fixes.
+@Suite("forPrompt preserves family capabilities")
+struct ForPromptCarryOverTests {
+
+    @Test("recipient-header consumption survives the rebuild")
+    func carriesRecipientHeaderFlag() throws {
+        let base = try #require(ReasoningParser.fromCapabilityName("muse_glimmer"))
+        #expect(base.consumesRecipientHeaders)
+
+        for tail in ["", "<|start|>assistant to=self<|message|>", "some prompt tail"] {
+            let live = try #require(
+                ReasoningParser.forPrompt(stampName: "muse_glimmer", promptTail: tail))
+            #expect(live.consumesRecipientHeaders,
+                "lost the flag for promptTail: \(tail.debugDescription)")
+        }
+    }
+
+    /// The behaviour, not just the flag: a parser built the way the loop
+    /// builds it must actually swallow the header.
+    @Test("a prompt-resolved parser consumes the header")
+    func promptResolvedParserConsumesHeader() throws {
+        var p = try #require(
+            ReasoningParser.forPrompt(
+                stampName: "muse_glimmer",
+                promptTail: "<|start|>assistant to=self<|message|>"))
+        var reasoning = ""
+        for segment in p.feed("thinking. to=get_current_time<|message|") + p.flush() {
+            if case .reasoning(let t) = segment { reasoning += t }
+        }
+        #expect(!reasoning.contains("to=get_current_time"), "leaked: \(reasoning)")
+        #expect(!reasoning.contains("<|message|"))
+        #expect(reasoning.contains("thinking."))
+    }
+
+    /// The other carried fields stay carried.
+    @Test("stray-tag policy and aliases still survive")
+    func carriesExistingFields() throws {
+        let base = try #require(ReasoningParser.fromCapabilityName("muse_glimmer"))
+        let live = try #require(
+            ReasoningParser.forPrompt(stampName: "muse_glimmer", promptTail: "x"))
+        #expect(live.stripStrayTags == base.stripStrayTags)
+        #expect(live.startTagAliases == base.startTagAliases)
+        #expect(live.endTagAliases == base.endTagAliases)
+    }
+}


### PR DESCRIPTION
## This is the one that actually fixes it

`forPrompt` is the **only** constructor the generation loop uses, and it rebuilds the parser field by field. It carried `stripStrayTags` and both alias lists — but not `consumesRecipientHeaders`, which therefore defaulted to `false` on every live parser.

That is why the Muse tool-recipient header survived three correct fixes:

- **#230** taught the parser to consume `to=<recipient><|message|>`
- **#231** matched the terminator in its real open form and dropped held headers on flush
- **#232** made `muse_glimmer` resolve to that parser at all

Every stamp-resolved unit test passed each time, and the app kept leaking `to=get_current_time<|message|` — because the object the loop actually ran never had the flag. Same root mistake three times: verifying the code was correct without verifying the code that runs is the code I fixed.

## Tests

Two levels, because the flag alone is not the point:

- the flag survives the rebuild across several prompt tails
- a **prompt-resolved** parser — built the way the loop builds it — actually swallows the header

The previously-carried fields (`stripStrayTags`, both alias lists) are pinned too, so the next capability added to this family fails loudly here rather than silently downgrading at runtime.

**91 tests in 9 suites passed.**