### PR TITLE
Stop the Nemotron fallback template from eating its newlines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ Docs/Internal/
 # session-local scratch build paths
 .build-rep/
 .build-rp2/
+.build-tmpl/

--- a/Libraries/MLXLMCommon/ChatTemplates/ChatTemplateFallbacks.swift
+++ b/Libraries/MLXLMCommon/ChatTemplates/ChatTemplateFallbacks.swift
@@ -454,53 +454,47 @@ value_1
 <|im_end|>
 {% for message in loop_messages -%}
 {%- if message['role'] == 'user' -%}
-<|im_start|>user
-{{ message['content'] }}
-{%- if required_tool_choice and loop.last %}
-
-{{ render_required_tool_choice_instruction(message['content']) }}
-{%- endif %}
-<|im_end|>
-{%- elif message['role'] == 'assistant' -%}
-<|im_start|>assistant
-{%- if message['content'] -%}
-{{ message['content'] }}
-{%- endif %}
-{%- if message['tool_calls'] is defined and message['tool_calls'] %}
-{%- for tc in message['tool_calls'] %}
-<tool_call>
-<function={{ tc['function']['name'] }}>
-{%- if tc['function']['arguments'] is mapping %}
-{%- for k, v in tc['function']['arguments'] | dictsort %}
-<parameter={{ k }}>
-{{ v }}
-</parameter>
-{%- endfor %}
-{%- elif tc['function']['arguments'] is string -%}
-{{ tc['function']['arguments'] }}
-{%- endif %}
-</function>
-</tool_call>
-{%- endfor %}
-{%- endif %}
-<|im_end|>
-{%- elif message['role'] == 'tool' -%}
-<|im_start|>user
-<tool_response>
-{{ message['content'] }}
-</tool_response>
-<|im_end|>
+{{- '<|im_start|>user\n' -}}
+{{- message['content'] -}}
+{%- if required_tool_choice and loop.last -%}
+{{- '\n\n' -}}
+{{- render_required_tool_choice_instruction(message['content']) -}}
 {%- endif -%}
-
+{{- '<|im_end|>\n' -}}
+{%- elif message['role'] == 'assistant' -%}
+{{- '<|im_start|>assistant\n' -}}
+{%- if message['content'] -%}
+{{- message['content'] -}}
+{%- endif -%}
+{%- if message['tool_calls'] is defined and message['tool_calls'] -%}
+{%- for tc in message['tool_calls'] -%}
+{{- '\n<tool_call>\n<function=' + tc['function']['name'] + '>\n' -}}
+{%- if tc['function']['arguments'] is mapping -%}
+{%- for k, v in tc['function']['arguments'] | dictsort -%}
+{{- '<parameter=' + k + '>\n' -}}
+{{- v -}}
+{{- '\n</parameter>\n' -}}
+{%- endfor -%}
+{%- elif tc['function']['arguments'] is string -%}
+{{- tc['function']['arguments'] -}}
+{%- endif -%}
+{{- '</function>\n</tool_call>' -}}
+{%- endfor -%}
+{%- endif -%}
+{{- '<|im_end|>\n' -}}
+{%- elif message['role'] == 'tool' -%}
+{{- '<|im_start|>user\n<tool_response>\n' -}}
+{{- message['content'] -}}
+{{- '\n</tool_response>\n<|im_end|>\n' -}}
+{%- endif -%}
 {% endfor -%}
-{%- if add_generation_prompt %}
-<|im_start|>assistant
-{%- if enable_thinking %}
-<think>
-{%- else %}
-<think></think>
-{%- endif %}
-{%- endif %}
+{%- if add_generation_prompt -%}
+{%- if enable_thinking -%}
+{{- '<|im_start|>assistant\n<think>\n' -}}
+{%- else -%}
+{{- '<|im_start|>assistant\n<think></think>' -}}
+{%- endif -%}
+{%- endif -%}
 """#
 
     /// DeepSeek-V4 minimal template. DSV4-Flash bundles ship NO

--- a/Tests/MLXLMTests/NemotronChatTemplateFallbackTests.swift
+++ b/Tests/MLXLMTests/NemotronChatTemplateFallbackTests.swift
@@ -1,0 +1,170 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import VMLXJinja
+import MLXLMCommon
+import XCTest
+
+/// Nemotron 3.5 Lightning ships its chat template as a standalone
+/// `chat_template.jinja` and carries no `chat_template` in
+/// `tokenizer_config.json`, so `NemotronMinimal` is what actually renders every
+/// tool-enabled turn. Its wire format therefore has to match the bundle's
+/// template byte for byte.
+///
+/// It did not. The generation prompt was written as
+///
+///     <|im_start|>assistant
+///     {%- if enable_thinking %}
+///     <think>
+///
+/// and each `{%-` strips the newline in front of it, so the rendered tail
+/// collapsed to `<|im_start|>assistant<think>` where the bundle emits
+/// `<|im_start|>assistant\n<think>\n`. The model never saw that spelling in
+/// training, so it closed the block on its first token: reasoning was enabled,
+/// the block was open, and the turn still produced zero thinking. Measured live
+/// before the fix — 637 generated tokens, 0 characters of reasoning, on a
+/// prompt that explicitly asked for step-by-step work.
+///
+/// These pin the exact separators, because the failure was invisible at the
+/// "does it contain `<think>`" level of detail.
+final class NemotronChatTemplateFallbackTests: XCTestCase {
+
+    private func render(_ context: [String: Any]) throws -> String {
+        let template = try Template(ChatTemplateFallbacks.nemotronMinimal)
+        var values: [String: Value] = [:]
+        for (key, value) in context {
+            values[key] = try Value(any: value)
+        }
+        return try template.render(values)
+    }
+
+    private let oneUser: [[String: Any]] = [["role": "user", "content": "hi"]]
+
+    // MARK: - The generation prompt (the reasoning bug)
+
+    func testThinkingOnOpensTheBlockWithTheTrainedSpelling() throws {
+        let rendered = try render([
+            "messages": oneUser,
+            "add_generation_prompt": true,
+            "enable_thinking": true,
+        ])
+        XCTAssertTrue(
+            rendered.hasSuffix("<|im_start|>assistant\n<think>\n"),
+            rendered.debugDescription)
+        // The exact regression: newlines eaten by whitespace control.
+        XCTAssertFalse(rendered.contains("assistant<think>"), rendered.debugDescription)
+    }
+
+    func testThinkingOffPreClosesTheBlock() throws {
+        let rendered = try render([
+            "messages": oneUser,
+            "add_generation_prompt": true,
+            "enable_thinking": false,
+        ])
+        XCTAssertTrue(
+            rendered.hasSuffix("<|im_start|>assistant\n<think></think>"),
+            rendered.debugDescription)
+        XCTAssertFalse(rendered.contains("assistant<think>"), rendered.debugDescription)
+    }
+
+    /// On and off must differ only in the block, never in the header.
+    func testBothRailsShareTheSameAssistantHeader() throws {
+        for thinking in [true, false] {
+            let rendered = try render([
+                "messages": oneUser,
+                "add_generation_prompt": true,
+                "enable_thinking": thinking,
+            ])
+            XCTAssertTrue(
+                rendered.contains("<|im_start|>assistant\n<think>"),
+                "thinking=\(thinking): \(rendered.debugDescription)")
+        }
+    }
+
+    // MARK: - Message separators
+
+    /// The bundle emits `<|im_start|>user\n{content}<|im_end|>\n`. The fallback
+    /// used to put a newline *before* `<|im_end|>` and drop the one after it.
+    func testUserMessageMatchesBundleSeparators() throws {
+        let rendered = try render([
+            "messages": oneUser,
+            "add_generation_prompt": true,
+            "enable_thinking": true,
+        ])
+        XCTAssertTrue(rendered.contains("<|im_start|>user\nhi<|im_end|>\n"), rendered.debugDescription)
+        XCTAssertFalse(rendered.contains("hi\n<|im_end|>"), rendered.debugDescription)
+    }
+
+    func testAssistantMessageMatchesBundleSeparators() throws {
+        let rendered = try render([
+            "messages": [
+                ["role": "user", "content": "hi"],
+                ["role": "assistant", "content": "hello"],
+                ["role": "user", "content": "again"],
+            ],
+            "add_generation_prompt": true,
+            "enable_thinking": true,
+        ])
+        XCTAssertTrue(
+            rendered.contains("<|im_start|>assistant\nhello<|im_end|>\n"),
+            rendered.debugDescription)
+    }
+
+    func testToolResponseMatchesBundleSeparators() throws {
+        let rendered = try render([
+            "messages": [
+                ["role": "user", "content": "hi"],
+                ["role": "tool", "content": "42"],
+            ],
+            "add_generation_prompt": true,
+            "enable_thinking": true,
+        ])
+        XCTAssertTrue(
+            rendered.contains("<|im_start|>user\n<tool_response>\n42\n</tool_response>\n<|im_end|>\n"),
+            rendered.debugDescription)
+    }
+
+    /// Two `<|im_start|>` markers must never end up glued to the previous
+    /// turn's `<|im_end|>` — that was the same stripped-newline defect showing
+    /// up between every pair of messages.
+    func testNoGluedTurnBoundaries() throws {
+        let rendered = try render([
+            "messages": [
+                ["role": "user", "content": "one"],
+                ["role": "assistant", "content": "two"],
+                ["role": "user", "content": "three"],
+            ],
+            "add_generation_prompt": true,
+            "enable_thinking": true,
+        ])
+        XCTAssertFalse(rendered.contains("<|im_end|><|im_start|>"), rendered.debugDescription)
+    }
+
+    // MARK: - Tool calls still render
+
+    func testAssistantToolCallRendersFunctionBlock() throws {
+        let rendered = try render([
+            "messages": [
+                ["role": "user", "content": "weather?"],
+                [
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        [
+                            "function": [
+                                "name": "get_weather",
+                                "arguments": ["city": "Paris"],
+                            ]
+                        ]
+                    ],
+                ],
+            ],
+            "add_generation_prompt": true,
+            "enable_thinking": true,
+        ])
+        XCTAssertTrue(
+            rendered.contains("<tool_call>\n<function=get_weather>\n<parameter=city>\nParis\n</parameter>\n</function>\n</tool_call>"),
+            rendered.debugDescription)
+        XCTAssertTrue(rendered.contains("</tool_call><|im_end|>\n"), rendered.debugDescription)
+    }
+}

--- a/Tests/MLXLMTests/NemotronLightningMTPTests.swift
+++ b/Tests/MLXLMTests/NemotronLightningMTPTests.swift
@@ -305,7 +305,10 @@ struct NemotronLightningMTPBenchTests {
                         if let mamba = c as? MambaCache {
                             _ = mamba.commitRecordedPrefix(length: 1)
                         } else {
-                            c.offset -= 1
+                            // `offset` is get-only on the protocol; `trim` is
+                            // the supported rewind and reports what it could
+                            // actually drop.
+                            _ = c.trim(1)
                         }
                     }
                     pending = v0


### PR DESCRIPTION
Nemotron 3.5 Lightning ships its chat template as a standalone `chat_template.jinja` and carries no `chat_template` in `tokenizer_config.json`; the tools branch engages `NemotronMinimal` for every tool-enabled turn. So this fallback — not the bundle file — renders the prompt in practice.

## The defect

```jinja
<|im_start|>assistant
{%- if enable_thinking %}
<think>
```

Each `{%-` strips the newline in front of it, so the tail rendered as `<|im_start|>assistant<think>` where the bundle emits `<|im_start|>assistant\n<think>\n`. The model was never trained on that spelling and closed the block on its first token — reasoning enabled, block open, and still no thinking.

## Evidence

Captured from the running app with `VMLINUX_REASONING_PROMPT_DUMP_DIR`:

```
...much does the ball cost? Reason it through carefully.<|im_end|><|im_start|>assistant<think>
```

The newline after `<|im_end|>` was gone too, so every turn boundary was glued. That same turn generated **637 tokens and stored 0 characters of reasoning** on a prompt that explicitly asked for step-by-step work, while `disableThinking: false` was persisted for the model.

## The fix

Emit every separator explicitly instead of relying on whitespace control, matching the bundle template exactly.

## Tests

`NemotronChatTemplateFallbackTests` pins the separators byte for byte, including the two shapes that were wrong (`assistant<think>`, `<|im_end|><|im_start|>`). A containment check for `<think>` passed throughout the bug. 8/8 pass.

Also repairs a compile error in the MTP test added earlier: `offset` is get-only on `KVCache`, so the speculation rewind uses `trim`.