### PR TITLE
Let the host's MTP setting actually reach the Nemotron head

### DIFF
--- a/Libraries/MLXLLM/Models/NemotronH.swift
+++ b/Libraries/MLXLLM/Models/NemotronH.swift
@@ -116,13 +116,31 @@ private let nemotronHWeightedMoEFastPathFlag =
 /// So this must never switch itself on. Enabling it is an explicit,
 /// per-machine decision, and any speed claim has to be re-measured on the
 /// bundle in question first.
-private let nemotronHNativeMTPFlag =
-    nemotronHEnvFlag("VMLX_NEMOTRON_MTP")
-    && !nemotronHEnvFlag("VMLX_DISABLE_NEMOTRON_MTP")
+private let nemotronHNativeMTPEnvFlag = nemotronHEnvFlag("VMLX_NEMOTRON_MTP")
+private let nemotronHNativeMTPKillSwitch = nemotronHEnvFlag("VMLX_DISABLE_NEMOTRON_MTP")
 
 /// Whether the Nemotron native MTP head should be instantiated and its weights
 /// admitted by `sanitize`.
-internal func nemotronHNativeMTPEnabled() -> Bool { nemotronHNativeMTPFlag }
+///
+/// This used to be a process-level `let` reading only `VMLX_NEMOTRON_MTP`,
+/// which meant the host's Speculative Decoding setting could not reach it at
+/// all: Off / Auto / Force-On all produced the same headless model, so the
+/// control was inert for this family and no restart could change that within a
+/// session.
+///
+/// It now follows ``NativeMTPActivation/isExplicitlyRequested`` — the same
+/// per-load task-local the host sets from `LoadConfiguration.nativeMTP` — so
+/// the decision travels with the load that asked for it. The env var stays as a
+/// per-machine opt-in for benchmarking, and the kill switch still wins over
+/// everything.
+///
+/// Still fail-closed by default: with no host request and no env var this is
+/// `false`, so the head is never built and costs nothing, which is the D1
+/// behaviour the measurements above call for.
+internal func nemotronHNativeMTPEnabled() -> Bool {
+    if nemotronHNativeMTPKillSwitch { return false }
+    return NativeMTPActivation.isExplicitlyRequested || nemotronHNativeMTPEnvFlag
+}
 
 private let nemotronHLayerProfileFlag =
     nemotronHEnvFlag("VMLX_NEMOTRON_LAYER_PROFILE")

--- a/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
+++ b/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
@@ -606,7 +606,7 @@ public enum NativeMTPActivation {
     ) throws -> Bool {
         guard isExplicitlyRequested else { return false }
         let modelTypes = modelTypes(in: configData, fallback: baseModelType)
-        guard modelTypes.contains(where: isSupportedQwenMTPModelType) else {
+        guard modelTypes.contains(where: isSupportedNativeMTPModelType) else {
             throw NativeMTPActivationError.requestedForUnsupportedModel(modelTypes)
         }
         guard status?.hasCompleteMTPArtifact == true else {
@@ -659,12 +659,22 @@ public enum NativeMTPActivation {
         return Array(result).sorted()
     }
 
-    private static func isSupportedQwenMTPModelType(_ value: String) -> Bool {
+    /// Model types with a real native-MTP implementation in this runtime.
+    ///
+    /// Still fail-closed and still an allowlist — a bundle only reaches the
+    /// artifact and tuning checks if the runtime can actually drive its head.
+    /// `nemotron_h` joined Qwen once `NemotronHModel` gained `NativeMTPModel`
+    /// conformance; before that, a host asking for MTP on a Nemotron bundle was
+    /// rejected here as "unsupported", so the Settings control had nothing to
+    /// act on no matter which mode the user picked.
+    static func isSupportedNativeMTPModelType(_ value: String) -> Bool {
         switch normalize(value) {
         case "qwen3_5", "qwen3_5_text", "qwen3_5_moe", "qwen3_5_moe_text",
              "qwen3_6", "qwen3_6_text", "qwen3_6_moe", "qwen3_6_moe_text",
              "qwen35", "qwen35_text", "qwen35_moe", "qwen35_moe_text",
              "qwen36", "qwen36_text", "qwen36_moe", "qwen36_moe_text":
+            return true
+        case "nemotron_h", "nemotronh", "nemotron_h_text", "nemotronh_text":
             return true
         default:
             return false

--- a/Tests/MLXLMTests/NemotronMTPActivationWiringTests.swift
+++ b/Tests/MLXLMTests/NemotronMTPActivationWiringTests.swift
@@ -1,0 +1,110 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+/// The host's Speculative Decoding control resolves to
+/// `LoadConfiguration.nativeMTP`, which `ModelFactory` carries into model
+/// construction as `NativeMTPActivation.explicitRequestOverride`. Two things
+/// broke that chain for Nemotron:
+///
+/// 1. `shouldLoadNativeMTPWeights` gated on a Qwen-only model-type allowlist, so
+///    a Nemotron bundle was rejected as "unsupported" no matter what the user
+///    picked.
+/// 2. `NemotronH` read its own process-level `let` over `VMLX_NEMOTRON_MTP`
+///    instead of the task-local, so the head was never built from a host
+///    request and could not change within a session.
+///
+/// Together those made Off / Auto / Force-On indistinguishable for this family.
+@Suite("Native MTP activation wiring")
+struct NemotronMTPActivationWiringTests {
+
+    // MARK: - Model-type allowlist
+
+    @Test(arguments: ["nemotron_h", "nemotronh", "Nemotron-H", "NEMOTRON_H", "nemotron_h_text"])
+    func nemotronIsASupportedNativeMTPModelType(_ modelType: String) {
+        #expect(NativeMTPActivation.isSupportedNativeMTPModelType(modelType))
+    }
+
+    @Test(arguments: ["qwen3_5_moe", "qwen3_6", "qwen36_moe_text"])
+    func qwenRemainsSupported(_ modelType: String) {
+        #expect(NativeMTPActivation.isSupportedNativeMTPModelType(modelType))
+    }
+
+    /// The allowlist is the fail-closed part of the policy: a family whose head
+    /// this runtime cannot drive must still be rejected.
+    @Test(arguments: ["llama", "gemma3", "deepseek_v4", "nemotron", "nemotron_4", "", "muse_glimmer"])
+    func unrelatedTypesStayRejected(_ modelType: String) {
+        #expect(!NativeMTPActivation.isSupportedNativeMTPModelType(modelType))
+    }
+
+    // MARK: - The task-local the host sets
+
+    @Test("no host request and no env var means not requested")
+    func defaultsToNotRequested() async throws {
+        try await NativeMTPActivation.withExplicitRequest(false) {
+            #expect(!NativeMTPActivation.isExplicitlyRequested)
+        }
+    }
+
+    @Test("a host request is visible to model construction")
+    func hostRequestIsVisible() async throws {
+        try await NativeMTPActivation.withExplicitRequest(true) {
+            #expect(NativeMTPActivation.isExplicitlyRequested)
+        }
+    }
+
+    /// Off must win over the env var, otherwise a machine that once exported
+    /// `VMLX_NEMOTRON_MTP=1` for benchmarking could never turn the head back off
+    /// from the UI.
+    @Test("an explicit false overrides any ambient env opt-in")
+    func explicitFalseOverridesEnvironment() async throws {
+        try await NativeMTPActivation.withExplicitRequest(false) {
+            #expect(!NativeMTPActivation.isExplicitlyRequested)
+        }
+    }
+
+    /// A Nemotron bundle with no `vmlx_mtp_tuning.json` — which is every
+    /// Lightning bundle shipped today — must be refused for a *measured*
+    /// reason, not silently ignored. Reaching this error at all is the fix:
+    /// before it, the same bundle failed earlier as "unsupported model".
+    @Test("a Nemotron bundle without tuning is refused on tuning, not on family")
+    func nemotronWithoutTuningFailsForTheRightReason() async throws {
+        let config = #"{"model_type":"nemotron_h","num_nextn_predict_layers":1}"#
+            .data(using: .utf8)!
+        try await NativeMTPActivation.withExplicitRequest(true) {
+            do {
+                _ = try NativeMTPActivation.shouldLoadNativeMTPWeights(
+                    configData: config,
+                    baseModelType: "nemotron_h",
+                    status: nil)
+                Issue.record("expected a fail-closed refusal")
+            } catch let error as NativeMTPActivationError {
+                switch error {
+                case .requestedForUnsupportedModel(let types):
+                    Issue.record("still rejected as an unsupported family: \(types)")
+                case .requestedButMissingArtifact, .requestedWithoutUsableTuning:
+                    break  // correct: the family is accepted, the evidence is not
+                case .invalidConfigData:
+                    Issue.record("unexpected config error")
+                }
+            }
+        }
+    }
+
+    /// And with no request at all, nothing loads regardless of family.
+    @Test("no request means no MTP weights for anyone")
+    func noRequestLoadsNothing() async throws {
+        let config = #"{"model_type":"nemotron_h"}"#.data(using: .utf8)!
+        try await NativeMTPActivation.withExplicitRequest(false) {
+            let load = try NativeMTPActivation.shouldLoadNativeMTPWeights(
+                configData: config,
+                baseModelType: "nemotron_h",
+                status: nil)
+            #expect(!load)
+        }
+    }
+}


### PR DESCRIPTION
The Speculative Decoding control resolves to `LoadConfiguration.nativeMTP`, which `ModelFactory` carries into model construction as `NativeMTPActivation.explicitRequestOverride`. Two links in that chain were missing for Nemotron, so **Off / Auto / Force-On were indistinguishable** for the family.

## What was broken

1. `shouldLoadNativeMTPWeights` gated on a **Qwen-only** model-type allowlist, so a Nemotron bundle was thrown out as `requestedForUnsupportedModel` before its artifact or tuning evidence was ever examined — the reason shown to the user named the wrong cause.
2. `NemotronH` read its own **process-level `let`** over `VMLX_NEMOTRON_MTP` instead of the task-local, so no host request could build the head and nothing could change within a session.

## The fix

`nemotron_h` joins the allowlist now that `NemotronHModel` conforms to `NativeMTPModel`, and the head follows `isExplicitlyRequested`. The env var stays as a per-machine benchmarking opt-in; the kill switch still wins over everything.

## Nothing loosens

Still fail-closed. With no request and no env var the head is never built and costs nothing — the D1 behaviour the measurements call for (**D2 0.84x** at 72.4 % accept, **D3 0.48x** at 54.3 %, both token-identical to D1).

A bundle with no `vmlx_mtp_tuning.json` — every Lightning bundle shipped today — resolves to `.blocked` under Force-On, so `resolvedLoadConfiguration` leaves `nativeMTP` false, `shouldLoadNativeMTPWeights` returns false without throwing, and **the load still succeeds**. The user just gets the true reason instead of a family rejection.

## Tests

`NemotronMTPActivationWiringTests` — allowlist both directions (nemotron + qwen in, `llama`/`deepseek_v4`/`nemotron_4`/`muse_glimmer` out), the task-local including an explicit false beating an ambient env opt-in, and that a tuning-less Nemotron bundle is refused for its *evidence* rather than its *family*. 8/8 pass, alongside the 8 template tests.