### PR TITLE
Load the Nemotron-H Audex text tower instead of refusing the bundle

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -226,6 +226,16 @@ public enum LLMTypeRegistry {
             "step3p7": dispatchStep3p5,
             "nanochat": create(NanoChatConfiguration.self, NanoChatModel.init),
             "nemotron_h": dispatchNemotronH,
+            // Audex is a Nemotron-H text tower with an audio encoder bolted on:
+            // same 52 layers, hidden 2688, 32 heads / 2 KV heads, intermediate
+            // 1856, n_groups 8, ssm_state 128, 64 mamba heads at head_dim 64 —
+            // identical to Lightning apart from a larger vocab for the sound
+            // tokens. Without this entry the bundle failed to load at all
+            // ("Unsupported model type: nemotron_h_audex"), which left the text
+            // tower unreachable even though this runtime can drive it. `sanitize`
+            // drops `audio_encoder.*` / `audio_projector.*`, so it loads
+            // text-only; audio input is not claimed or supported.
+            "nemotron_h_audex": dispatchNemotronH,
             "afmoe": create(AfMoEConfiguration.self, AfMoEModel.init),
             "jamba_3b": create(JambaConfiguration.self, JambaModel.init),
             "mistral3": dispatchMistral3LLM,

--- a/Libraries/MLXLLM/Models/NemotronH.swift
+++ b/Libraries/MLXLLM/Models/NemotronH.swift
@@ -1512,6 +1512,13 @@ public class NemotronHModel: Module, LLMModel, KVCacheDimensionProvider, LoRAMod
             if key.hasPrefix("vision_model.")
                 || key.hasPrefix("sound_encoder.")
                 || key.hasPrefix("sound_projection.")
+                // Audex bundles name their audio tower `audio_encoder.*` /
+                // `audio_projector.*` rather than the `sound_*` spelling above.
+                // Its 487 encoder tensors and 3 projector tensors have no
+                // module to bind to in this text runtime, so drop them the same
+                // way and keep the `backbone.*` / `lm_head.*` text tower.
+                || key.hasPrefix("audio_encoder.")
+                || key.hasPrefix("audio_projector.")
                 || key.hasPrefix("mlp1.")
             {
                 continue

--- a/Tests/MLXLMTests/NemotronAudexDispatchTests.swift
+++ b/Tests/MLXLMTests/NemotronAudexDispatchTests.swift
@@ -1,0 +1,215 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import MLX
+import Testing
+
+@testable import MLXLLM
+@testable import MLXLMCommon
+
+/// `Nemotron-Labs-Audex-30B-A3B-*` declares `model_type = "nemotron_h_audex"`,
+/// which no dispatch entry claimed, so selecting it in the app failed outright
+/// with `Unsupported model type: nemotron_h_audex` — the text tower was
+/// unreachable even though this runtime can drive it.
+///
+/// Its text tower is byte-for-byte the Nemotron-H shape Lightning uses: 52
+/// layers, hidden 2688, 32 heads / 2 KV heads, intermediate 1856, n_groups 8,
+/// ssm_state 128, 64 mamba heads at head_dim 64. Only the vocab differs (larger,
+/// for the sound tokens) plus an `audio_encoder` / `audio_projector` tower that
+/// this runtime has no module for.
+@Suite("Nemotron Audex dispatch")
+struct NemotronAudexDispatchTests {
+
+    /// The real 30B-A3B Audex text-tower shape, with the audio keys present.
+    private var audexConfig: Data {
+        #"""
+        {
+          "architectures": [
+            "NemotronHAudexForConditionalGeneration"
+          ],
+          "attention_bias": false,
+          "attention_dropout": 0.0,
+          "audio_encoder_hidden_size": 1280,
+          "audio_model_type": "NV-Whisper",
+          "audio_projector_activation": "relu2",
+          "audio_projector_intermediate_size": 4096,
+          "audio_projector_norm_eps": 1e-05,
+          "bos_token_id": 1,
+          "chunk_size": 128,
+          "conv_kernel": 4,
+          "dtype": "bfloat16",
+          "eos_token_id": 11,
+          "expand": 2,
+          "head_dim": 128,
+          "hidden_dropout": 0.0,
+          "hidden_size": 2688,
+          "hybrid_override_pattern": "MEMEM*EMEMEM",
+          "initializer_range": 0.02,
+          "intermediate_size": 1856,
+          "layer_norm_epsilon": 1e-05,
+          "mamba_head_dim": 64,
+          "mamba_hidden_act": "silu",
+          "mamba_num_heads": 64,
+          "mamba_proj_bias": false,
+          "max_position_embeddings": 262144,
+          "mlp_bias": false,
+          "mlp_hidden_act": "relu2",
+          "model_type": "nemotron_h_audex",
+          "moe_intermediate_size": 1856,
+          "moe_shared_expert_intermediate_size": 3712,
+          "n_group": 1,
+          "n_groups": 8,
+          "n_routed_experts": 128,
+          "n_shared_experts": 1,
+          "norm_eps": 1e-05,
+          "norm_topk_prob": true,
+          "num_attention_heads": 32,
+          "num_experts_per_tok": 6,
+          "num_hidden_layers": 12,
+          "num_key_value_heads": 2,
+          "num_logits_to_keep": 1,
+          "pad_token_id": 0,
+          "partial_rotary_factor": 1.0,
+          "rescale_prenorm_residual": true,
+          "residual_in_fp32": false,
+          "rope_theta": 10000,
+          "routed_scaling_factor": 2.5,
+          "sliding_window": null,
+          "sound_clip_duration": 30.0,
+          "sound_embedding_size": 750,
+          "sound_end_token": "<so_end>",
+          "sound_end_token_id": 31,
+          "sound_model_type": "hf:///nv-whisper",
+          "sound_start_token": "<so_start>",
+          "sound_start_token_id": 30,
+          "sound_target_rate": 16000,
+          "sound_token": "<so_embedding>",
+          "sound_token_id": 29,
+          "ssm_state_size": 128,
+          "tie_word_embeddings": false,
+          "time_step_floor": 0.0001,
+          "time_step_max": 0.1,
+          "time_step_min": 0.001,
+          "topk_group": 1,
+          "use_bias": false,
+          "use_cache": true,
+          "use_conv_bias": true,
+          "use_mamba_kernels": true,
+          "vocab_size": 205312
+        }
+        """#.data(using: .utf8)!
+    }
+
+    @Test("a nemotron_h_audex bundle resolves to a model instead of throwing")
+    func audexDispatches() async throws {
+        let model = try await LLMTypeRegistry.shared.createModel(configuration: audexConfig, modelType: "nemotron_h_audex")
+        #expect(model is NemotronHModel, "expected the Nemotron-H text tower")
+    }
+
+    /// The audio tower has no module to bind to, so those weights must be
+    /// dropped rather than failing `verify`. The prefixes are
+    /// `audio_encoder.` / `audio_projector.` — NOT the `sound_*` spelling the
+    /// scrub list already had, which is why they needed adding.
+    @Test("the audio tower is dropped and the text tower survives")
+    func audioWeightsAreScrubbed() async throws {
+        let model = try await LLMTypeRegistry.shared.createModel(configuration: audexConfig, modelType: "nemotron_h_audex")
+        let nemotron = try #require(model as? NemotronHModel)
+
+        let weights: [String: MLXArray] = [
+            "backbone.embeddings.weight": MLXArray.zeros([8, 4]),
+            "lm_head.weight": MLXArray.zeros([8, 4]),
+            "audio_encoder.layers.0.self_attn.q_proj.weight": MLXArray.zeros([4, 4]),
+            "audio_encoder.conv1.weight": MLXArray.zeros([4, 4]),
+            "audio_projector.linear_1.weight": MLXArray.zeros([4, 4]),
+        ]
+        let sanitized = nemotron.sanitize(weights: weights)
+
+        #expect(sanitized.keys.contains { $0.hasPrefix("backbone.") })
+        #expect(!sanitized.keys.contains { $0.hasPrefix("audio_encoder.") })
+        #expect(!sanitized.keys.contains { $0.hasPrefix("audio_projector.") })
+    }
+
+    /// The plain `nemotron_h` route must keep working unchanged.
+    @Test("nemotron_h still dispatches")
+    func nemotronHStillDispatches() async throws {
+        let config = #"""
+            {
+              "architectures": [
+                "NemotronHForCausalLM"
+              ],
+              "attention_bias": false,
+              "attention_dropout": 0.0,
+              "bos_token_id": 1,
+              "chunk_size": 128,
+              "conv_kernel": 4,
+              "dtype": "bfloat16",
+              "eos_token_id": 11,
+              "expand": 2,
+              "head_dim": 128,
+              "hidden_dropout": 0.0,
+              "hidden_size": 2688,
+              "hybrid_override_pattern": "MEMEM*EMEMEM",
+              "initializer_range": 0.02,
+              "intermediate_size": 1856,
+              "layer_norm_epsilon": 1e-05,
+              "mamba_head_dim": 64,
+              "mamba_hidden_act": "silu",
+              "mamba_num_heads": 64,
+              "mamba_proj_bias": false,
+              "max_position_embeddings": 262144,
+              "mlp_bias": false,
+              "mlp_hidden_act": "relu2",
+              "model_type": "nemotron_h",
+              "moe_intermediate_size": 1856,
+              "moe_shared_expert_intermediate_size": 3712,
+              "n_group": 1,
+              "n_groups": 8,
+              "n_routed_experts": 128,
+              "n_shared_experts": 1,
+              "norm_eps": 1e-05,
+              "norm_topk_prob": true,
+              "num_attention_heads": 32,
+              "num_experts_per_tok": 6,
+              "num_hidden_layers": 12,
+              "num_key_value_heads": 2,
+              "num_logits_to_keep": 1,
+              "pad_token_id": 0,
+              "partial_rotary_factor": 1.0,
+              "rescale_prenorm_residual": true,
+              "residual_in_fp32": false,
+              "rope_theta": 10000,
+              "routed_scaling_factor": 2.5,
+              "sliding_window": null,
+              "ssm_state_size": 128,
+              "tie_word_embeddings": false,
+              "time_step_floor": 0.0001,
+              "time_step_max": 0.1,
+              "time_step_min": 0.001,
+              "topk_group": 1,
+              "use_bias": false,
+              "use_cache": true,
+              "use_conv_bias": true,
+              "use_mamba_kernels": true,
+              "vocab_size": 131072
+            }
+            """#.data(using: .utf8)!
+        let m = try await LLMTypeRegistry.shared.createModel(configuration: config, modelType: "nemotron_h")
+        #expect(m is NemotronHModel)
+    }
+
+    /// The 2B Audex bundles are `nemotron_dense_audex` — a DENSE architecture
+    /// with no hybrid pattern and no mamba parameters. It is deliberately NOT
+    /// routed here; claiming it would load a mismatched model rather than fail
+    /// honestly.
+    @Test("the dense Audex variant is still refused")
+    func denseAudexStaysUnsupported() async {
+        let config = #"""
+            {"model_type": "nemotron_dense_audex", "num_hidden_layers": 28, "hidden_size": 2048}
+            """#.data(using: .utf8)!
+        await #expect(throws: (any Error).self) {
+            _ = try await LLMTypeRegistry.shared.createModel(
+                configuration: config, modelType: "nemotron_dense_audex")
+        }
+    }
+}


### PR DESCRIPTION
`Nemotron-Labs-Audex-30B-A3B-*` declares `model_type = nemotron_h_audex`, which no dispatch entry claimed. Selecting it in the app failed outright:

```
Error: Unsupported model type: nemotron_h_audex
```

## Why it is safe to route to Nemotron-H

Its text tower is the shape this runtime already drives — identical to Lightning apart from a larger vocab for the sound tokens:

| | Audex 30B-A3B | Lightning 30B-A3B |
|---|---|---|
| layers | 52 | 52 |
| hidden | 2688 | 2688 |
| heads / KV heads | 32 / 2 | 32 / 2 |
| intermediate | 1856 | 1856 |
| n_groups / ssm_state | 8 / 128 | 8 / 128 |
| mamba heads × head_dim | 64 × 64 | 64 × 64 |
| vocab | 205312 | 131072 |

Weights are 726 `backbone.*` + `lm_head.*`, alongside 487 `audio_encoder.*` and 3 `audio_projector.*`.

## The scrub gap

`sanitize` already dropped `sound_encoder.` / `sound_projection.`, but Audex uses the **`audio_*`** spelling, so those two prefixes are added. The model loads **text-only** — audio input is neither claimed nor supported.

## Deliberately still refused

The 2B bundles are `nemotron_dense_audex`: a dense architecture, no hybrid pattern, no mamba parameters. Routing it here would load a mismatched model, so it keeps failing honestly.

## Tests

`NemotronAudexDispatchTests` builds its configs from the **real bundle's own config.json** (shrunk to 12 layers) rather than a hand-written stub — a missing required key fails the test instead of passing. Covers dispatch, audio-tower scrubbing with the text tower surviving, `nemotron_h` unchanged, and the dense refusal. 4/4 pass.