### PR TITLE
Make the repetition guard reach the path hosts actually generate on

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -698,15 +698,38 @@ public actor BatchEngine {
                 promptTail: promptTail)
             var stopMatcher = StopStringMatcher(stopStrings: extraStopStrings)
             var stopMatched = false
+            // Degenerate-repetition guard, mirroring `TextToolTokenLoopHandler`.
+            // The solo path has had this since the Raptor collapse; batch is a
+            // parallel implementation of the same pipeline, so without its own
+            // copy the guard simply never ran for hosts that generate through
+            // `BatchEngine` — which is the path the chat app uses. Same
+            // `.fromEnvironment()` construction, so `VMLX_REPETITION_STOP=0`
+            // disables both consistently.
+            var repetitionDetector = RepetitionCycleDetector.fromEnvironment()
+            var repetitionCycle: RepetitionCycleDetector.Cycle?
+
+            /// Feed already-emitted visible text to the repetition guard.
+            /// Text is emitted first and never withheld: the guard bounds how
+            /// much MORE arrives, it does not edit what already went out.
+            func noteForRepetition(_ emitted: String) {
+                guard repetitionCycle == nil, !emitted.isEmpty else { return }
+                if let cycle = repetitionDetector.feed(emitted) {
+                    repetitionCycle = cycle
+                }
+            }
 
             func emitChunkThroughStop(_ text: String) {
                 guard stopMatcher.isEnabled else {
                     continuation.yield(.chunk(text))
+                    noteForRepetition(text)
                     return
                 }
                 switch stopMatcher.feed(text) {
                 case .streaming(let out):
-                    if !out.isEmpty { continuation.yield(.chunk(out)) }
+                    if !out.isEmpty {
+                        continuation.yield(.chunk(out))
+                        noteForRepetition(out)
+                    }
                 case .stopped(let out):
                     if !out.isEmpty { continuation.yield(.chunk(out)) }
                     stopMatched = true
@@ -871,7 +894,7 @@ public actor BatchEngine {
                         pump(text)
                         lastPumpAt = Date()
                     }
-                    if stopMatched {
+                    if stopMatched || repetitionCycle != nil {
                         // Tell the BatchEngine actor to halt this slot
                         // on its next scheduling tick. The actor's
                         // `cancel(id:)` flips `isFinished` and emits
@@ -900,7 +923,12 @@ public actor BatchEngine {
                     // .chunk, show "answer trapped in thinking" banner,
                     // etc.) without instrumenting the parser themselves.
                     let finalStop: GenerateStopReason
-                    if stopMatched {
+                    if stopMatched || repetitionCycle != nil {
+                        // A repetition halt is a deliberate stop, not a
+                        // cancellation and not exhaustion. Reporting `.stop`
+                        // is what lets a host classify the turn at all: the
+                        // collapse this guards against previously ran to the
+                        // token cap and recorded no stop reason whatsoever.
                         finalStop = .stop
                     } else {
                         finalStop = info.stopReason
@@ -952,12 +980,20 @@ public actor BatchEngine {
                     terminalInsideReasoning ?? (reasoningParser?.isInsideReasoning ?? false)
                 detokenizer.startNewSegment()
                 let elapsed = Date().timeIntervalSince(streamStartedAt)
+                // A stop string or repetition halt cancels the slot deliberately,
+                // and cancelling is exactly what can close the token stream before
+                // it emits its own `.info` — so this repair path, not the branch
+                // above, is where those turns usually land. Reporting `.cancelled`
+                // here would erase the classification and leave the collapse
+                // indistinguishable from a user abort.
+                let repairedStop: GenerateStopReason =
+                    (stopMatched || repetitionCycle != nil) ? .stop : .cancelled
                 let finalInfo = GenerateCompletionInfo(
                     promptTokenCount: promptTokenCount,
                     generationTokenCount: generatedTokenCount,
                     promptTime: 0,
                     generationTime: elapsed,
-                    stopReason: .cancelled,
+                    stopReason: repairedStop,
                     unclosedReasoning: unclosed,
                     toolCallProtocolFailure: toolCallProcessor?.toolCallProtocolFailure)
                 continuation.yield(.info(finalInfo))

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -4200,7 +4200,9 @@ private func generateLoopTask<Handler: TokenLoopHandler>(
                     // stream" from "library-internal stop-sequence
                     // match" — the latter should report `stopReason =
                     // .stop`, not `.cancelled`.
-                    stopReason = handler.stopSequenceHit ? .stop : .cancelled
+                    stopReason =
+                        (handler.stopSequenceHit || handler.haltedOnRepetition)
+                        ? .stop : .cancelled
                     break
                 }
                 generatedTokenIds.append(token)
@@ -4684,6 +4686,15 @@ private protocol TokenLoopHandler: Sendable {
     /// text (e.g., the raw-token handler).
     var stopSequenceHit: Bool { get }
 
+    /// True when the last `onToken` returned false because the degenerate-
+    /// repetition guard fired. Reported like a stop sequence — `.stop`, not
+    /// `.cancelled` — because it is a deliberate library-internal halt, not a
+    /// consumer abort. Without this the collapse the guard exists to bound
+    /// still ends the turn, but arrives indistinguishable from the user
+    /// pressing stop, which is precisely the "no usable stop reason" symptom
+    /// that motivated the guard.
+    var haltedOnRepetition: Bool { get }
+
     /// True when the handler is still inside a reasoning envelope before
     /// terminal flush. Must be snapshotted before `onGenerationEnd`, because
     /// flushing drains and closes parser state.
@@ -4702,6 +4713,7 @@ private protocol TokenLoopHandler: Sendable {
 
 extension TokenLoopHandler {
     var stopSequenceHit: Bool { false }
+    var haltedOnRepetition: Bool { false }
     var unclosedReasoning: Bool { false }
     var emittedToolCall: Bool { false }
     var toolCallProtocolFailure: ToolCallProtocolFailure? { nil }
@@ -4751,6 +4763,7 @@ struct TextToolTokenLoopHandler: TokenLoopHandler, @unchecked Sendable {
     private(set) var stopSequenceHit: Bool = false
     /// The cycle that halted generation, when the repetition guard fired.
     private(set) var repetitionCycle: RepetitionCycleDetector.Cycle?
+    var haltedOnRepetition: Bool { repetitionCycle != nil }
     private(set) var emittedToolCall: Bool = false
 
     init(

--- a/Tests/MLXLMTests/BatchEngineRepetitionGuardTests.swift
+++ b/Tests/MLXLMTests/BatchEngineRepetitionGuardTests.swift
@@ -1,0 +1,172 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+@preconcurrency import VMLXTokenizers
+import XCTest
+
+/// The degenerate-repetition guard lives in two places because the streaming
+/// pipeline exists in two places: `TextToolTokenLoopHandler` (solo
+/// `Evaluate.generate`) and the inner `Task.detached` bridge in
+/// `BatchEngine.generate`. The batch copy is not a refactor of the solo one —
+/// it is a parallel implementation, so a guard added to one is simply absent
+/// from the other.
+///
+/// That is not hypothetical. The guard shipped in the solo handler while every
+/// host that generates through `BatchEngine` — which is the path the chat app
+/// uses — kept running unguarded. The collapse it was written for (a model
+/// repeating two sentences until the token cap, finishing with no stop reason
+/// at all) was still reachable in the product after the fix was merged.
+///
+/// So this test drives `BatchEngine.generate` end to end rather than unit-testing
+/// the detector: a model that emits one token forever, and a tokenizer that
+/// decodes it to a long primitive sentence. Without the wiring the run reaches
+/// `maxTokens`; with it, the guard cuts the turn early and classifies it.
+final class BatchEngineRepetitionGuardTests: XCTestCase {
+
+    /// Emits the same token id forever, so the visible text is a pure cycle.
+    private final class OneTokenModel: Module, LanguageModel, @unchecked Sendable {
+        let vocabularySize: Int
+        let tokenID: Int
+
+        init(vocabularySize: Int, tokenID: Int) {
+            self.vocabularySize = vocabularySize
+            self.tokenID = tokenID
+            super.init()
+        }
+
+        private func peakedLogits(count: Int) -> MLXArray {
+            var row = [Float](repeating: -30, count: vocabularySize)
+            row[tokenID] = 30
+            let flat = MLXArray(Array(repeating: row, count: count).flatMap { $0 })
+            return flat.reshaped([1, count, vocabularySize])
+        }
+
+        func callAsFunction(
+            _ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?
+        ) -> LMOutput {
+            LMOutput(logits: peakedLogits(count: input.tokens.dim(-1)))
+        }
+
+        func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+            peakedLogits(count: inputs.dim(-1))
+        }
+
+        func newCache(parameters: GenerateParameters?) -> [KVCache] {
+            [KVCacheSimple()]
+        }
+
+        func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult
+        {
+            .tokens(input.text)
+        }
+    }
+
+    /// Decodes every id to the same sentence, so the visible stream is a pure
+    /// verbatim cycle. 43 characters and primitive, clearing the detector's
+    /// minimum-unit and primitivity rules — it deliberately ignores short
+    /// filler like `---` or `| | |`.
+    private struct RepeatingTokenizer: MLXLMCommon.Tokenizer {
+        static let unit = "The answer is AppleScript; I do not repeat. "
+
+        let _eosTokenId = 1_000_001
+        let _unknownTokenId = 1_000_002
+
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] { [1, 2, 3] }
+
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+            String(repeating: Self.unit, count: tokenIds.count)
+        }
+
+        /// Must return nil for unknown strings. BatchEngine widens its stop set
+        /// by resolving candidate stop-token spellings through this method, so a
+        /// tokenizer that answers with a real id for everything registers the
+        /// model's only token as EOS — the run then ends at zero tokens and the
+        /// halt assertions below pass without generating anything.
+        func convertTokenToId(_ token: String) -> Int? { token == "EOS" ? _eosTokenId : nil }
+        func convertIdToToken(_ id: Int) -> String? {
+            id == _eosTokenId ? "EOS" : Self.unit
+        }
+
+        var bosToken: String? = nil
+        var eosToken: String? = nil
+        var eosTokenId: Int? { _eosTokenId }
+        var unknownToken: String? = nil
+        var unknownTokenId: Int? { _unknownTokenId }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] {
+            encode(text: "", addSpecialTokens: false)
+        }
+    }
+
+    private func makeEngine() -> BatchEngine {
+        let vocabSize = 64
+        let model = OneTokenModel(vocabularySize: vocabSize, tokenID: 7)
+        MLX.eval(model)
+
+        var modelConfig = ModelConfiguration(id: "test-repetition")
+        modelConfig.eosTokenIds = []
+
+        let tokenizer = RepeatingTokenizer()
+        let processor = TestInputProcessor(
+            tokenizer: tokenizer,
+            configuration: modelConfig,
+            messageGenerator: DefaultMessageGenerator()
+        )
+        nonisolated(unsafe) let context = ModelContext(
+            configuration: modelConfig,
+            model: model,
+            processor: processor,
+            tokenizer: tokenizer
+        )
+        return BatchEngine(context: context, maxBatchSize: 1)
+    }
+
+    /// The turn must end well before the cap, and must carry a stop reason —
+    /// the reported collapse ran to the cap and recorded none.
+    func testRepetitionHaltsTheBatchStreamAndClassifiesIt() async throws {
+        let engine = makeEngine()
+        let maxTokens = 400
+
+        let stream = await engine.generate(
+            input: LMInput(tokens: MLXArray(Int32(1) ..< Int32(4))),
+            parameters: GenerateParameters(maxTokens: maxTokens, temperature: 0)
+        )
+
+        var text = ""
+        var info: GenerateCompletionInfo?
+        for await event in stream {
+            switch event {
+            case .chunk(let c): text += c
+            case .info(let i): info = i
+            case .reasoning, .toolCall, .toolCallProgress, .prefillProgress: break
+            }
+        }
+
+        let completion = try XCTUnwrap(info, "no terminal .info event")
+        XCTAssertEqual(
+            completion.stopReason, .stop,
+            "a repetition halt must be classified, not left as exhaustion")
+        XCTAssertLessThan(
+            completion.generationTokenCount, maxTokens,
+            "the guard must cut the turn before the token cap; got \(completion.generationTokenCount)")
+        XCTAssertTrue(
+            text.contains(RepeatingTokenizer.unit),
+            "text emitted before the halt must still reach the consumer")
+    }
+
+    /// `VMLX_REPETITION_STOP=0` must disable the batch copy too, or the two
+    /// pipelines disagree about an escape hatch users are told is global.
+    func testEnvironmentOptOutIsHonoredByTheSameConstruction() {
+        XCTAssertFalse(
+            RepetitionCycleDetector.fromEnvironment(["VMLX_REPETITION_STOP": "0"]).isEnabled)
+        XCTAssertTrue(RepetitionCycleDetector.fromEnvironment([:]).isEnabled)
+    }
+}


### PR DESCRIPTION
Closes the remaining runtime half of osaurus#2350. The degenerate-repetition guard shipped, but two things kept it from doing its job in a product.

## 1. It halted without saying so

`Evaluate`'s loop reported:

```swift
stopReason = handler.stopSequenceHit ? .stop : .cancelled
```

so a repetition halt arrived as **`.cancelled`** — indistinguishable from the user pressing stop. #2350 asked for the turn to be cut *and classified*; only the cut landed. Adds `TokenLoopHandler.haltedOnRepetition` (defaulting false, so other handlers are unaffected) and reports `.stop` for it, exactly as a stop string already is.

## 2. `BatchEngine` never had the guard at all

Its inner streaming pipeline is a **parallel implementation** of `TextToolTokenLoopHandler`, not a reuse — the comment at the top of that bridge says as much — so the guard was simply absent for every host that generates through the batch entry point.

It now feeds the same detector from the same `.fromEnvironment()` construction (so `VMLX_REPETITION_STOP=0` disables both consistently) and reports `.stop` from **both** terminal-info sites: the engine's own `.info`, and the "stream closed early" repair path below it. The repair path matters more than it looks — cancelling the slot is precisely what can close the token stream before it emits its own info, so that is where these turns usually land.

## Test

Drives `BatchEngine.generate` end to end — a model that emits one token forever, a tokenizer that decodes it to a long primitive sentence — rather than unit-testing the detector, because the defect was never that the detector was wrong. It was that nothing called it.

Measured on the fix: the turn ends after **5 tokens / 202 characters with `stopReason == .stop`**, instead of running to the 400-token cap.

Two traps hit while writing it, both left as comments so the next person doesn't repeat them:

- a test tokenizer that answers `convertTokenToId` for unknown strings gets the model's only token registered as EOS by the engine's stop-set widening — the run then ends at **zero tokens** and every halt assertion passes trivially;
- asserting only "stopped early" without also asserting emitted text hides exactly that.