### PR TITLE
ChatSession: honor GenerateParameters.draftStrategy (native MTP was silently ignored on the chat path)

### DIFF
--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -453,6 +453,30 @@ public final class ChatSession {
                                 iterator: iterator,
                                 toolSchemas: input.toolSchemas
                             )
+                        } else if let strategy = generateParameters.draftStrategy,
+                            case .nativeMTP(depth: let depth, verifierMode: _) = strategy,
+                            generateParameters.canUseNativeMTP(for: input)
+                        {
+                            // Native model-owned MTP speculative decode. `generate(...)` and
+                            // `generateTokensTask(...)` already dispatch on `draftStrategy`, but
+                            // `ChatSession` did not — so a caller using the high-level chat API got
+                            // plain autoregressive decode no matter what it set, with no error and
+                            // no log line to say so. Eligibility is `canUseNativeMTP` (greedy-only,
+                            // no media, unbounded KV), so this cannot change what text is produced.
+                            guard let nativeModel = model as? any NativeMTPModel else {
+                                throw NativeMTPRuntimeError.modelDoesNotExposeNativeMTP
+                            }
+                            let iterator = try NativeMTPTokenIterator(
+                                input: input, model: nativeModel, cache: kvCache,
+                                parameters: generateParameters, depth: depth,
+                                cacheCoordinator: cacheCoordinator)
+                            (stream, task) = MLXLMCommon.generateTask(
+                                promptTokenCount: input.text.tokens.size,
+                                modelConfiguration: modelConfiguration,
+                                tokenizer: tokenizer,
+                                iterator: iterator,
+                                toolSchemas: input.toolSchemas
+                            )
                         } else {
                             let iterator = try TokenIterator(
                                 input: input, model: model, cache: kvCache,

--- a/Tests/MLXLMTests/ChatSessionRuntimeWiringSourceCoverageTests.swift
+++ b/Tests/MLXLMTests/ChatSessionRuntimeWiringSourceCoverageTests.swift
@@ -21,6 +21,31 @@ struct ChatSessionRuntimeWiringSourceCoverageTests {
         #expect(source.contains("let iterator = try TokenIterator("))
     }
 
+    /// The branch this pins is the one the bug was: `ChatSession` never consulted
+    /// `draftStrategy`, so a caller that set it got plain autoregressive decode with no error and
+    /// no log line. Deleting the `else if` restores that silence — and nothing else in-tree would
+    /// fail — so this test exists to make the branch's absence loud.
+    ///
+    /// Source-level rather than behavioural because exercising the dispatch needs a real bundle
+    /// with MTP tensors; this pins the wiring, and the guard below pins the safety condition.
+    @Test("streamMap dispatches native MTP when draftStrategy requests it")
+    func streamMapDispatchesNativeMTPForDraftStrategy() throws {
+        let source = try Self.source("Libraries/MLXLMCommon/ChatSession.swift")
+        #expect(source.contains("generateParameters.draftStrategy"))
+        #expect(source.contains("case .nativeMTP(depth: let depth, verifierMode: _)"))
+        #expect(source.contains("let iterator = try NativeMTPTokenIterator("))
+    }
+
+    /// Speculation must stay gated on `canUseNativeMTP(for:)` — greedy-only, no media content,
+    /// unbounded KV. That predicate is what makes "this cannot change what text is produced" true;
+    /// dispatching without it would turn a performance path into a correctness change.
+    @Test("native MTP dispatch stays gated on canUseNativeMTP")
+    func nativeMTPDispatchIsGated() throws {
+        let source = try Self.source("Libraries/MLXLMCommon/ChatSession.swift")
+        #expect(source.contains("generateParameters.canUseNativeMTP(for: input)"))
+        #expect(source.contains("NativeMTPRuntimeError.modelDoesNotExposeNativeMTP"))
+    }
+
     @Test("streamMap consumer termination cancels the producer task")
     func streamMapTerminationCancelsProducerTask() throws {
         let source = try Self.source("Libraries/MLXLMCommon/ChatSession.swift")


### PR DESCRIPTION
### What

`ChatSession` never consulted `GenerateParameters.draftStrategy`. Its non-diffusion branch
always constructed a plain `TokenIterator`, so a caller using the high-level chat API got
autoregressive decode regardless of what it set — no error, no warning.

`generate(...)` and `generateTokensTask(...)` both already dispatch on `draftStrategy` and build a
`NativeMTPTokenIterator` for `.nativeMTP`. This adds the same dispatch to `ChatSession`.

### How it showed up

The failure is silent, which is what makes it worth fixing rather than documenting. Loading a
bundle with `LoadConfiguration.nativeMTP = true` succeeds, the model reports
`nativeMTPAvailable`, `draftStrategy` is accepted, and throughput is simply unchanged. We found
it by A/B-ing a bundle that ships `vmlx_mtp_tuning.json` with speculation on and off and getting
identical tok/s — the flag was being dropped on the only path our harness uses.

### Safety

Guarded by the same `parameters.canUseNativeMTP(for: input)` predicate the other two entry points
use — greedy-only, no media content, unbounded KV window — so it cannot change generated text,
only whether speculation is used. A model that is not a `NativeMTPModel` throws
`NativeMTPRuntimeError.modelDoesNotExposeNativeMTP`, matching `generate(...)` rather than
silently falling back, so a mis-set strategy stays visible.

Callers using `.none` / `nil` are unaffected — they fall through to the existing path unchanged.

### Testing

Built and run on device against `Qwen3.6-27B-MXFP4-MTP` (native MTP, depth 2 from its tuning
row). Before: on and off measure identically. After: the drafter demonstrably engages and the two
arms diverge.

### One finding this unblocked, in case it's useful

With the dispatch in place we could finally A/B native MTP end to end. On an M4 Max against
`Qwen3.6-27B-MXFP4-MTP` at its tuning row's `best_depth=2`, counterbalanced ON/OFF/OFF/ON, 256
tokens, idle machine:

| prompt | MTP off | MTP on |
|---|---|---|
| open-ended | 27.6, 27.5 tok/s | 23.8, 23.5 tok/s |
| `deterministic_count_96` (the tuning row's own class) | 27.4, 27.2 | 23.8, 23.1 |

~14% slower both ways, including on the prompt class where `vmlx_mtp_tuning.json` records
24.655 → 45.712 (1.854x). Prompt predictability was the obvious explanation and the second row
falsifies it.

**Correction — I profiled it, and my guess above was wrong.** Running with
`VMLX_NATIVE_MTP_TRACE=1` on the same setup, over 256 tokens:

| counter | value |
|---|---|
| `iteratorWallSec` | 11.448 |
| `verifyMainSec` | **10.777 (94%)** — real target-model forwards |
| `materializeSyncSec` | 0.162 (1.4%) |
| `cacheCommitSec` / `cacheStateSec` | 0.000 / 0.000 |
| `mtpDraftSec` | 0.041 |

I had speculated that the speculative iterators bypassing `CompiledDecodeTrace` /
`CompilableKVCache` was the cause. Device syncs and cache bookkeeping are 1.4% and 0% — that theory
is dead, and compiling the speculative path would attack almost nothing. Please disregard it.

What the trace actually shows is that speculation is barely running:

| counter | value |
|---|---|
| `outputTokens` | 256 |
| `targetForwards` | **254** — ~one target forward per token, i.e. no speculative saving at all |
| `arFallbackTokens` | **223 of 256 (87%)** — most tokens came from autoregressive fallback |
| `verifyCalls` | 16, `avgCommittedPerVerify` 2.06 → only ~33 tokens came from speculation |
| `depth` / `activeDepth` | **1 / 1**, though the bundle's tuning row says `best_depth=2` |
| `verifierMode` | **`sequential_repair`**, though `chunk_lazy_repair` was requested |
| acceptance | `acceptedByDepth=0:1,1:15`, `hybrid_warmup_avg_accept=`**`0.94`** |

The 14% is the MTP machinery being paid for while doing one target forward per token. The puzzling
part is that acceptance is 0.94 — drafts are accepted 15 times in 16, which ought to encourage more
speculation, not 87% fallback. Three things I can't explain from outside the subsystem:

1. depth downshifted 2 → 1 with `adaptiveDownshifts=0`, so seemingly not the adaptive policy;
2. `verifierMode` resolved to `sequential_repair` despite `chunk_lazy_repair` being requested;
3. 87% AR fallback despite 94% acceptance.

If those are expected behaviour on this bundle, ignore the noise. If not, the arithmetic changes
completely: depth 2 at 0.94 acceptance should roughly halve target forwards, which is about where
the tuning row's 1.854x would come from — so the vendor number may be perfectly reproducible on a
path that currently isn't being taken.

None of this affects the patch itself, which is a one-branch dispatch fix for a parameter that is
otherwise silently ignored.
