### PR TITLE
DFlashDrafterLoader: support quantized drafters (4-bit/8-bit bundles fail .noUnusedKeys on scales/biases)

### DIFF
--- a/Libraries/MLXLMCommon/SpecDec/DFlashDrafterLoader.swift
+++ b/Libraries/MLXLMCommon/SpecDec/DFlashDrafterLoader.swift
@@ -67,6 +67,30 @@ public enum DFlashDrafterLoader {
 
         // 3. Instantiate + apply weights
         let model = DFlashDraftModel(config)
+
+        // Published DFlash drafters are frequently QUANTIZED — the community MLX conversions of
+        // z-lab's bf16 release ship 4-bit and 8-bit variants. Those safetensors carry `.scales` and
+        // `.biases` beside each packed `.weight`, and an unquantized `Linear` has no parameter slots
+        // for them, so the strict `.noUnusedKeys` verify below rejects the whole bundle with
+        // `unhandledKeys(keys: ["biases", "scales"])`. Converting the modules to their quantized
+        // form first is what makes those bundles loadable at all.
+        //
+        // The filter is driven by which paths ACTUALLY carry scales in the file rather than by
+        // assuming every `Linear` is quantized: real bundles leave selected layers in full
+        // precision, and blanket-quantizing those would fail the same verify from the other side
+        // (a quantized module whose weights arrive unpacked).
+        if let root = try? JSONSerialization.jsonObject(with: configData) as? [String: Any],
+            let q = root["quantization"] as? [String: Any],
+            let groupSize = q["group_size"] as? Int,
+            let bits = q["bits"] as? Int
+        {
+            let mode = (q["mode"] as? String)
+                .flatMap(QuantizationMode.init(rawValue:)) ?? .affine
+            quantize(
+                model: model, groupSize: groupSize, bits: bits, mode: mode,
+                filter: { path, _ in weights["\(path).scales"] != nil })
+        }
+
         do {
             let parameters = ModuleParameters.unflattened(weights)
             try model.update(parameters: parameters, verify: [.noUnusedKeys])


### PR DESCRIPTION
### What

`DFlashDrafterLoader.load(from:)` cannot load a quantized DFlash drafter. It builds a plain
`DFlashDraftModel(config)` and calls `update(parameters:verify:[.noUnusedKeys])` with no
quantization step, so the `.scales`/`.biases` that accompany every packed `.weight` have no
parameter slot and the strict verify rejects the bundle:

```
4-bit: weightUpdateFailed(unhandledKeys(path: ["fc"],                           keys: ["biases","scales"]))
8-bit: weightUpdateFailed(unhandledKeys(path: ["layers","0","mlp","gate_proj"], keys: ["biases","scales"]))
```

### Why it matters

This is the common case locally rather than an edge case. z-lab publishes the drafters in bf16
(~2B params); the MLX conversions people actually run on an Apple-silicon box are the 4-bit and
8-bit ones. Both fail, so in practice DFlash is unreachable from a local MLX setup.

### How

Quantize the matching modules before applying weights, reading `group_size`, `bits` and `mode`
from the drafter's own `config.json`.

The filter keys on which paths actually carry `.scales` in the loaded weight map, rather than
assuming every `Linear` is quantized. Bundles routinely leave selected layers in full precision,
and blanket quantization fails the same verify from the opposite direction — a quantized module
whose weights arrive unpacked.

Unquantized drafters are unaffected: absent a `quantization` block in `config.json`, the new
branch does not run.

### Testing

Verified on device against both community conversions of `z-lab/Qwen3.6-27B-DFlash`
(`anthonyya/Qwen3.6-27B-DFlash-4bit` and `-8bit`). Both fail to load before the change with the
errors above, and both load after it. Covered by a regression test that skips when the drafters
are not present on the machine.
