### PR TITLE
Guard the stop set for bundles that under-declare their eos

### DIFF
--- a/Tests/MLXLMTests/UnderDeclaredEOSStopTests.swift
+++ b/Tests/MLXLMTests/UnderDeclaredEOSStopTests.swift
@@ -1,0 +1,115 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+/// Pins the stop set for bundles whose `generation_config.json` **under-declares** its eos —
+/// it names one end token while the model's own chat template ends turns with a different one.
+///
+/// This shape is not hypothetical. Scanning the local model library (78 bundles shipping a
+/// `generation_config.json` with `eos_token_id`, resolving each `commonEndTokenStrings` entry to
+/// its id and checking membership) found three:
+///
+/// | bundle | declared eos | template emits |
+/// |---|---|---|
+/// | `OsaurusAI/VibeThinker-3B-MXFP8`   | `151643` (`<\|endoftext\|>`) | `<\|im_end\|>` (`151645`) |
+/// | `OsaurusAI/VibeThinker-3B-JANG_4M` | `151643`                     | `<\|im_end\|>`            |
+/// | `JANGQ-AI/LFM2.5-230M-MXFP8`       | `124900`                     | `<\|im_end\|>`            |
+///
+/// Today the hard-coded `commonEndTokenStrings` blanket rescues them. That blanket is under
+/// discussion (vmlx-swift#91 proposes skipping it whenever `generation_config.json` declares an
+/// eos, which fixes gpt-oss/harmony halting at `<|end|>`), so this test exists to make the cost of
+/// that trade **executable** rather than a paragraph in a review: if the blanket stops applying to
+/// a declaring-but-incomplete bundle, these turns lose their only turn boundary and run to the
+/// token cap.
+///
+/// `extraEOSTokens` is not a safety net here — it is populated only for registry entries
+/// (`LLMModelFactory` / `VLMModelFactory`), and these bundles are loaded from a local directory,
+/// where it defaults to empty.
+@Suite("Under-declared generation_config eos still stops at the template's turn end")
+struct UnderDeclaredEOSStopTests {
+
+    /// Qwen-style ids, matching the VibeThinker bundles above.
+    private static let endOfText = 151_643
+    private static let imEnd = 151_645
+
+    /// Resolves only the tokens a Qwen2.5-family vocabulary actually carries, so a stop that
+    /// survives here survives because it was resolved — not because the tokenizer said yes to
+    /// everything.
+    private struct QwenishTokenizer: MLXLMCommon.Tokenizer {
+        static let map: [String: Int] = [
+            "<|endoftext|>": endOfText,
+            "<|im_end|>": imEnd,
+        ]
+
+        var bosToken: String? { nil }
+        var eosToken: String? { "<|endoftext|>" }
+        var eosTokenId: Int? { endOfText }
+        var unknownToken: String? { nil }
+        var unknownTokenId: Int? { nil }
+
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+        func convertTokenToId(_ token: String) -> Int? { Self.map[token] }
+        func convertIdToToken(_ id: Int) -> String? {
+            Self.map.first { $0.value == id }?.key
+        }
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] { [] }
+    }
+
+    private func configuration(declaringEOS declared: Int?) -> ModelConfiguration {
+        var configuration = ModelConfiguration(id: "under-declared-eos-fixture")
+        if let declared {
+            configuration.generationDefaults = GenerationConfigFile(
+                eosTokenIds: IntOrIntArray(declared))
+        }
+        return configuration
+    }
+
+    /// The regression this file exists for: a bundle declaring only `<|endoftext|>` must still stop
+    /// at `<|im_end|>`, because that is what its chat template emits at the end of every turn.
+    @Test func underDeclaredEOSStillStopsAtImEnd() {
+        let resolved = resolveStopSequences(
+            modelConfiguration: configuration(declaringEOS: Self.endOfText),
+            tokenizer: QwenishTokenizer())
+
+        #expect(
+            resolved.tokenIDs.contains(Self.imEnd),
+            """
+            a bundle whose generation_config.json names only <|endoftext|> lost <|im_end|>, \
+            the token its chat template actually ends turns with — this turn now runs to the \
+            token cap. Affects VibeThinker-3B (both quants) and LFM2.5-230M in the local library.
+            """)
+        // The declared one obviously has to survive too.
+        #expect(resolved.tokenIDs.contains(Self.endOfText))
+    }
+
+    /// A bundle that declares nothing must be unaffected — that path never depended on the gate,
+    /// so a change to the gate must not disturb it.
+    @Test func undeclaredBundleKeepsBlanketStops() {
+        let resolved = resolveStopSequences(
+            modelConfiguration: configuration(declaringEOS: nil),
+            tokenizer: QwenishTokenizer())
+
+        #expect(resolved.tokenIDs.contains(Self.imEnd))
+        #expect(resolved.tokenIDs.contains(Self.endOfText))
+    }
+
+    /// The tokenizer's own eos is inserted regardless of the blanket, so this stop is the one
+    /// guarantee that holds no matter how the gate is settled.
+    @Test func tokenizerEOSIsAlwaysPresent() {
+        for declared in [Self.endOfText, Self.imEnd, nil] as [Int?] {
+            let resolved = resolveStopSequences(
+                modelConfiguration: configuration(declaringEOS: declared),
+                tokenizer: QwenishTokenizer())
+            #expect(resolved.tokenIDs.contains(Self.endOfText))
+        }
+    }
+}


### PR DESCRIPTION
Context for #91, which proposes trusting `generation_config.json`'s eos and skipping the hard-coded `commonEndTokenStrings` blanket. I think that direction is right — it is the HF contract, and the blanket currently overrides *correct* declarations, which is what makes gpt-oss/harmony halt at the `<|end|>` channel separator.

But the blanket turns out to be load-bearing for a few bundles, and I would rather that be a test than a paragraph in a review.

## How the three were found

Scanned every local bundle shipping `generation_config.json` with an `eos_token_id` (78), resolved each `commonEndTokenStrings` entry to its id via `added_tokens_decoder` / `tokenizer.json`, and checked whether a token the bundle's **own chat template emits** is absent from its declared eos:

```
analyzed=76  safe=73  AT-RISK=3

OsaurusAI/VibeThinker-3B-MXFP8    eos_ids=[151643]  template emits <|im_end|> (151645)
OsaurusAI/VibeThinker-3B-JANG_4M  eos_ids=[151643]  template emits <|im_end|>
JANGQ-AI/LFM2.5-230M-MXFP8        eos_ids=[124900]  template emits <|im_end|>
```

73 of 76 are unaffected, which is the reassuring half. The other three declare `<|endoftext|>` while ending every turn with `<|im_end|>` — the classic Qwen2.5-derived under-declaration.

`extraEOSTokens` does not cover them: it is populated only for **registry** entries (`LLMModelFactory.swift:859+`, `VLMModelFactory.swift:320+`), and these load from a local directory, where it defaults to `[]` (`Downloader.swift:122`).

## What this adds

Three cases against `resolveStopSequences`, using a Qwen-ish tokenizer that carries **only** the two real ids, so a stop that survives does so because it resolved — not because the fixture said yes to everything:

- **`underDeclaredEOSStillStopsAtImEnd`** — the regression itself. Passes on `main` today (the blanket supplies it); **fails under #91**, where the declaration causes the blanket to be skipped and the turn boundary disappears.
- **`undeclaredBundleKeepsBlanketStops`** — a bundle declaring nothing must be untouched; that path never depended on the gate.
- **`tokenizerEOSIsAlwaysPresent`** — the tokenizer's own eos is inserted above the gate, so it is the one stop that survives any resolution of this.

Verified: **3 tests in 1 suite passed**, on current `main`.

## Why it is worth having either way

If #91 lands with the narrower fix I suggested there (keep the blanket, drop only `<|end|>` when a declared eos excludes it), all three stay green and gpt-oss is still fixed. If it lands with the stronger gate, this says exactly which bundles need an `extraEOSTokens` entry first — and keeps saying so when someone adds a fourth.

Independent of #91: nothing currently pins this behaviour at all, so the blanket could be narrowed by accident with no test noticing.