### PR TITLE
Tokenizers: split added tokens with a trie (136k-token omni bundles cost ~28s per special token)

### DIFF
--- a/Tests/MLXLMTests/AddedTokenTrieSourceCoverageTests.swift
+++ b/Tests/MLXLMTests/AddedTokenTrieSourceCoverageTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+
+/// Pins the two properties of `AddedTokenTrie` that a plausible "simplification" would break, and
+/// that no other test in-tree would catch.
+///
+/// Source-level because `AddedTokenTrie` and `String.split(by:)` are both internal to `Tokenizers`,
+/// which has no test target in this tree. The behavioural differential that found the real bug was
+/// run out-of-tree (PR #246); this keeps the fix from silently reverting.
+@Suite("AddedTokenTrie source coverage")
+struct AddedTokenTrieSourceCoverageTests {
+    private static func source(_ relativePath: String) throws -> String {
+        let repoRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        return try String(contentsOf: repoRoot.appending(path: relativePath), encoding: .utf8)
+    }
+
+    /// The walk MUST be over Unicode scalars, not `Character`s.
+    ///
+    /// `Array(text)` yields extended grapheme clusters, so a token's final scalar fuses with a
+    /// following combining mark and the token stops matching entirely — `"<|im_end|>\u{0301}rest"`
+    /// was left unsplit while the regex arm split it correctly. Scalars are also the level the
+    /// regex operates at, which is what makes the two arms identical by construction.
+    @Test("trie walks unicode scalars, not grapheme clusters")
+    func trieWalksUnicodeScalars() throws {
+        let source = try Self.source("Vendors/swift-transformers/Sources/Tokenizers/AddedTokenTrie.swift")
+        #expect(source.contains("[Unicode.Scalar: Node]"))
+        #expect(source.contains("text.unicodeScalars"))
+        #expect(source.contains("for scalar in token.unicodeScalars"))
+        // The exact regression: walking `Character`s.
+        #expect(!source.contains("let characters = Array(text)"))
+        #expect(!source.contains("[Character: Node]"))
+    }
+
+    /// Longest match must win, which requires CONTINUING the walk past a terminal node rather than
+    /// returning at the first one. The regex gets this from longest-first alternation ordering; if
+    /// the trie returned early, `</think>` would split as `<` + `/think>` on any token set where a
+    /// shorter token is a prefix of a longer one.
+    @Test("trie keeps walking past a terminal node so the longest token wins")
+    func triePrefersLongestMatch() throws {
+        let source = try Self.source("Vendors/swift-transformers/Sources/Tokenizers/AddedTokenTrie.swift")
+        #expect(source.contains("if node.isTerminal { longest = index }"))
+    }
+}

--- a/Vendors/swift-transformers/Sources/Tokenizers/AddedTokenTrie.swift
+++ b/Vendors/swift-transformers/Sources/Tokenizers/AddedTokenTrie.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+/// Splits text on a set of literal added-token strings in time independent of how many there are.
+///
+/// The regex path this replaces builds ONE `NSRegularExpression` whose pattern is every added token
+/// joined by `|`, each in its own capture group, and runs it on every `tokenize(text:)` call. That is
+/// O(text x tokenCount) twice over: ICU has no literal-alternation optimisation, and
+/// `String.split(by:)` then walks `(0..<match.numberOfRanges).reversed()` per match doing an
+/// `NSRange` -> `Range<String.Index>` conversion at each step.
+///
+/// With a handful of added tokens that is invisible. Discrete-codebook multimodal models change the
+/// scale: Apertus 1.5 Omni declares 136,366 added tokens (131,072 `<|visual token N|>` plus 4,096
+/// `<|audio token N|>`), and each special token in a prompt then costs ~28 SECONDS — a 76-token
+/// prompt took 218 s to reach first token while decode was a healthy 66 tok/s.
+///
+/// A trie makes the scan O(text) regardless of token count, because shared prefixes (`<|visual token `)
+/// collapse into one path.
+///
+/// **Semantics are matched exactly**, so callers see no behavioural change:
+///   * longest match wins at each position — the regex sorts alternatives longest-first and ICU
+///     alternation is first-match-wins, which is the same rule;
+///   * matched separators are emitted as their own sections, interleaved with the text between them;
+///   * empty sections are omitted.
+///
+/// **Guarded**: only usable when no added token sets `lstrip`/`rstrip`. Those add `\s*` around the
+/// token in the regex, which is not a literal match, so the regex path stays for those bundles.
+final class AddedTokenTrie {
+
+    private final class Node {
+        var children: [Unicode.Scalar: Node] = [:]
+        var isTerminal = false
+    }
+
+    private let root = Node()
+
+    init(tokens: [String]) {
+        for token in tokens where !token.isEmpty {
+            var node = root
+            for scalar in token.unicodeScalars {
+                if let next = node.children[scalar] {
+                    node = next
+                } else {
+                    let next = Node()
+                    node.children[scalar] = next
+                    node = next
+                }
+            }
+            node.isTerminal = true
+        }
+    }
+
+    /// End index of the LONGEST token matching at `start`, or nil when none does.
+    private func longestMatch(_ scalars: [Unicode.Scalar], from start: Int) -> Int? {
+        var node = root
+        var index = start
+        var longest: Int?
+        while index < scalars.count, let next = node.children[scalars[index]] {
+            node = next
+            index += 1
+            if node.isTerminal { longest = index }   // keep going: a longer token may still match
+        }
+        return longest
+    }
+
+    /// Text split into alternating non-token and token sections, empties omitted.
+    ///
+    /// Walks UNICODE SCALARS, not `Character`s. `Array(text)` yields extended grapheme clusters, so
+    /// a token's final scalar can fuse with a following combining mark into one cluster and the walk
+    /// then cannot match the token at all: `"<|im_end|>\u{0301}rest"` left the token unrecognised
+    /// while the regex arm correctly split it out. Scalars are also the level the regex operates at,
+    /// so this keeps the two arms identical by construction rather than by coincidence.
+    /// (Found by a 16-case differential against the regex arm; this was the one divergence.)
+    func split(_ text: String) -> [String] {
+        let scalars = Array(text.unicodeScalars)
+        var sections: [String] = []
+        var pending = String.UnicodeScalarView()
+        var index = 0
+        while index < scalars.count {
+            if let end = longestMatch(scalars, from: index) {
+                if !pending.isEmpty {
+                    sections.append(String(pending))
+                    pending = String.UnicodeScalarView()
+                }
+                sections.append(String(String.UnicodeScalarView(scalars[index ..< end])))
+                index = end
+            } else {
+                pending.append(scalars[index])
+                index += 1
+            }
+        }
+        if !pending.isEmpty { sections.append(String(pending)) }
+        return sections.isEmpty ? [text] : sections
+    }
+}

--- a/Vendors/swift-transformers/Sources/Tokenizers/Tokenizer.swift
+++ b/Vendors/swift-transformers/Sources/Tokenizers/Tokenizer.swift
@@ -496,6 +496,9 @@ public class PreTrainedTokenizer: @unchecked Sendable, Tokenizer {
     let addedTokens: Set<String>
     let specialTokens: [String: Int]
     let addedTokensRegex: NSRegularExpression?
+    /// Fast path for the regex above. Non-nil only when no added token uses lstrip/rstrip, so the
+    /// match is purely literal. See AddedTokenTrie for why this exists.
+    let addedTokensTrie: AddedTokenTrie?
 
     private let preTokenizer: PreTokenizer?
     private let normalizer: Normalizer?
@@ -553,6 +556,17 @@ public class PreTrainedTokenizer: @unchecked Sendable, Tokenizer {
             return "\(prefix)(\(token))\(suffix)"
         }.joined(separator: "|")
         addedTokensRegex = try? NSRegularExpression(pattern: addedTokensRegexString, options: [])
+        // Literal-only bundles get the trie; lstrip/rstrip mean the pattern is not a literal set,
+        // so those keep the regex. Built once, like the regex — the per-request cost is the SCAN.
+        // `SWIFT_TRANSFORMERS_NO_ADDED_TOKEN_TRIE=1` forces the old regex path. This is the CONTROL
+        // ARM: "the trie is N times faster" is only a measurement if the same binary can also run
+        // the other way, and it lets a suspected tokenization difference be bisected in one run.
+        let trieDisabled = ["1", "true", "yes"].contains(
+            (ProcessInfo.processInfo.environment["SWIFT_TRANSFORMERS_NO_ADDED_TOKEN_TRIE"] ?? "")
+                .lowercased())
+        addedTokensTrie = (!trieDisabled && unwrappedAddedTokens.allSatisfy { !$0.prefix && !$0.suffix })
+            ? AddedTokenTrie(tokens: unwrappedAddedTokens.map(\.content))
+            : nil
 
         self.specialTokens = specialTokens
         self.addedTokens = Set(addedTokens.keys)
@@ -662,7 +676,9 @@ public class PreTrainedTokenizer: @unchecked Sendable, Tokenizer {
     public func tokenize(text: String) -> [String] {
         // Take care of special tokens first
         let sections: [String] =
-            if let regex = addedTokensRegex {
+            if let trie = addedTokensTrie {
+                trie.split(text)
+            } else if let regex = addedTokensRegex {
                 text.split(by: regex)
             } else {
                 [text]


### PR DESCRIPTION
### What

Added-token splitting is O(text x tokenCount) per `tokenize(text:)` call. For models with large
added-token tables that makes prompts take minutes.

`PreTrainedTokenizer.init` joins every added token into one `NSRegularExpression` alternation, each
in its own capture group. Two costs then scale with the token count on every match: ICU has no
literal-alternation optimisation, and `String.split(by:)` walks
`(0..<match.numberOfRanges).reversed()` per match with an `NSRange` -> `Range<String.Index>`
conversion at each step — and since tokens are sorted longest-first, the real match sits at a low
index, so that scan traverses nearly the whole capture array.

### Why it shows up now

Discrete-codebook multimodal models. Apertus 1.5 Omni declares **136,366** added tokens — 131,072
`<|visual token N|>` and 4,096 `<|audio token N|>`. That is a correct description of its visual and
audio codebooks, not a malformed bundle, and this shape will become more common.

The cost is ~28 s per special token in the prompt. Measured on an M4 Max, release build:

| | before | after |
|---|---|---|
| TTFT (76-token prompt) | 214,420 ms | **299 ms** |
| load | 86.2 s | **2.3 s** |
| decode | 66.4 tok/s | 64.4 tok/s |

Decode was always healthy — the model was fast and simply unreachable behind tokenization.

The existing `isUnusedPlaceholderAddedToken` filter for `<unusedN>` suggests this shape has been hit
before; it matches none of Apertus's tokens, and widening it would be wrong, since visual tokens are
real tokens the model uses.

### How

A trie: O(text) regardless of token count, because shared prefixes (`<|visual token `) collapse into
one path.

Semantics are preserved exactly — longest match wins at each position (the regex sorts alternatives
longest-first and ICU alternation is first-match-wins, the same rule), matched separators are emitted
as their own sections, empty sections omitted.

**Guarded**: used only when no added token sets `lstrip`/`rstrip`, since those wrap the token in
`\s*` and are not a literal match. Those bundles keep the regex path.
`SWIFT_TRANSFORMERS_NO_ADDED_TOKEN_TRIE=1` forces the regex back, for A/B measurement or for
bisecting a suspected tokenization difference.

### Testing

Correctness is the thing that matters here — a silent tokenization change would corrupt downstream
results while looking like a win. An 8-item arc_challenge cell on `Nemotron-3.5-Lightning-30B-A3B`
scores **6/8 identically on both paths across four counterbalanced runs**.

That same A/B also shows the trie is **not** a general speedup: for a 1,000-added-token model the two
paths are within noise (trie 23 s / 16 s, regex 17 s / 17 s). This fixes pathological bundles and
makes no claim beyond that.
