### PR TITLE
Load: resolve symlinks in the safetensors truncation guard (intact symlinked bundles rejected as truncated)

### DIFF
--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -84,7 +84,13 @@ func safetensorsMissingByteCount(_ url: URL) -> Int64? {
     guard maxEnd > 0 else { return nil }
 
     let declared = Int64(8 + headerLength + maxEnd)
-    guard let size = (try? FileManager.default.attributesOfItem(atPath: url.path))?[.size]
+    // Resolve symlinks before stat-ing. `attributesOfItem(atPath:)` does NOT follow links, so a
+    // symlinked shard reports the length of the TARGET PATH STRING (a few dozen bytes) rather than
+    // the file's real size. The bundle then looks catastrophically truncated and the caller is told
+    // to re-download it — advice that is both wrong and expensive, since symlinking shards is a
+    // normal way to share one set of weights between config variants.
+    guard let size = (try? FileManager.default.attributesOfItem(
+        atPath: url.resolvingSymlinksInPath().path))?[.size]
         as? NSNumber
     else { return nil }
     let actual = size.int64Value


### PR DESCRIPTION
### What

The safetensors truncation guard rejects intact bundles whose shards are symlinks, and tells the
user to re-download them.

`safetensorsMissingByteCount` (`Load.swift:87`) stats each shard with
`FileManager.attributesOfItem(atPath:)`, which does not follow symlinks: for a symlink it reports
the length of the target path string. Every shard therefore appears to be missing essentially all of
its bytes.

Observed on a completely intact 4-shard bundle:

```
4 of 4 safetensors shard(s) … are shorter than their own header declares
(16106726362 bytes missing in total) — the download is incomplete or the files were
truncated … Re-download the bundle.
  model-00001-of-00004.safetensors: missing 5259824638 bytes
  model-00002-of-00004.safetensors: missing 5234712897 bytes
```

### Why it matters

The diagnosis and the remedy are both wrong, and the remedy is a multi-GB download that cannot help.
Symlinking shards is a normal thing to do — it is how you share one copy of the weights across
several config variants without duplicating tens of gigabytes on disk. We hit this building an
A/B where two bundles differed only in `config.json`.

### How

Resolve symlinks before stat-ing. `resolvingSymlinksInPath()` is a no-op for regular files, so
genuinely truncated downloads are still caught — that case is why the guard exists and it is
untouched.

### Testing

Verified on device against the failing layout: a bundle whose four shards are symlinks to an intact
model fails to load before the change with the error above, and loads cleanly after it. The
hard-linked equivalent (which stats correctly either way) was unaffected in both builds, as
expected.
