### PR TITLE
Apertus: strip a stray language_model.lm_head. prefix in sanitize() (bundle fails to load outright)

### DIFF
--- a/Libraries/MLXLLM/Models/Apertus.swift
+++ b/Libraries/MLXLLM/Models/Apertus.swift
@@ -359,10 +359,20 @@ public class ApertusModel: Module, LLMModel, KVCacheDimensionProvider {
     }
 
     public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
-        // Remove unused precomputed rotary frequencies
-        weights.filter {
-            !$0.key.contains("self_attn.rotary_emb.inv_freq")
-        }
+        // Some quantized checkpoints (e.g. mlx-community / vMLX JANG_6M conversions of text-only
+        // Apertus bodies) emit the output projection under a VLM-style `language_model.lm_head.*`
+        // prefix while the body stays at `model.*`. Observed on
+        // mlx-community/Apertus-8B-Instruct-2509-Jang_6M: 775 tensors, of which exactly 3 are
+        // `language_model.lm_head.{weight,scales,biases}` with NO un-prefixed twin — so the head is
+        // unreachable and loading fails outright with
+        // `unhandledKeys(modules: ["ApertusModel"], keys: ["language_model"])`.
+        //
+        // This model binds the head at the top-level `lm_head`, so absorb that stray prefix rather
+        // than refusing the bundle. Scoped to the head: a genuine nested `language_model.*` body is
+        // not ours to rewrite. Identical treatment to Llama, via the same shared helper.
+        Weights.stripLanguageModelPrefix(weights, only: ["lm_head."])
+            // Remove unused precomputed rotary frequencies
+            .filter { !$0.key.contains("self_attn.rotary_emb.inv_freq") }
     }
 
     public func messageGenerator(tokenizer: any Tokenizer) -> any MessageGenerator {

--- a/Tests/MLXLMTests/ApertusSanitizeLMHeadPrefixTests.swift
+++ b/Tests/MLXLMTests/ApertusSanitizeLMHeadPrefixTests.swift
@@ -1,0 +1,105 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import MLX
+import Testing
+
+@testable import MLXLLM
+@testable import MLXLMCommon
+
+/// Covers `ApertusModel.sanitize`'s absorption of a stray `language_model.lm_head.` prefix.
+///
+/// Mirrors `LlamaSanitizeLMHeadPrefixTests` deliberately, case for case. `stripLanguageModelPrefix`
+/// has its own tests, but those pin the HELPER; what a user hits is the CALL SITE, and nothing else
+/// in-tree exercises this wiring — a refactor could drop the call and every other test would still
+/// pass. The `only:` scoping is the part that most needs pinning: widening it to strip a nested
+/// `language_model.*` BODY would silently drop the real weights instead of failing loudly.
+///
+/// Observed on `mlx-community/Apertus-8B-Instruct-2509-Jang_6M`: 775 tensors, of which exactly three
+/// are `language_model.lm_head.{weight,scales,biases}` with no un-prefixed twin, so the head is
+/// unreachable and the bundle fails with `unhandledKeys(modules: ["ApertusModel"], keys:
+/// ["language_model"])`.
+@Suite("ApertusModel.sanitize absorbs a prefixed lm_head")
+struct ApertusSanitizeLMHeadPrefixTests {
+
+    /// Smallest config that constructs; `sanitize` only routes keys, so dims are irrelevant beyond
+    /// being valid.
+    private func makeModel(tieWordEmbeddings: Bool = false) -> ApertusModel {
+        ApertusModel(
+            ApertusConfiguration(
+                hiddenSize: 8,
+                intermediateSize: 16,
+                numHiddenLayers: 1,
+                numAttentionHeads: 2,
+                numKeyValueHeads: 1,
+                rmsNormEps: 1e-5,
+                vocabSize: 32,
+                tieWordEmbeddings: tieWordEmbeddings
+            ))
+    }
+
+    /// Distinct extent per tensor so a mis-bind shows up as the wrong shape rather than passing.
+    private func tagged(_ tag: Int) -> MLXArray { MLXArray.zeros([tag]) }
+
+    @Test("a `language_model.lm_head.*` head lands on the top-level `lm_head.*`")
+    func stripsPrefixedHead() {
+        let sanitized = makeModel().sanitize(weights: [
+            "language_model.lm_head.weight": tagged(7),
+            "model.embed_tokens.weight": tagged(3),
+        ])
+        #expect(sanitized["lm_head.weight"]?.shape == [7])
+        #expect(sanitized["language_model.lm_head.weight"] == nil)
+        #expect(sanitized["model.embed_tokens.weight"]?.shape == [3])
+    }
+
+    /// The quantised bundle that motivated this carries all three keys; dropping the sidecars would
+    /// load a head with no scales and produce garbage rather than an error.
+    @Test("quant sidecars travel with the head")
+    func stripsQuantSidecars() {
+        let sanitized = makeModel().sanitize(weights: [
+            "language_model.lm_head.weight": tagged(1),
+            "language_model.lm_head.scales": tagged(2),
+            "language_model.lm_head.biases": tagged(3),
+        ])
+        #expect(sanitized["lm_head.weight"]?.shape == [1])
+        #expect(sanitized["lm_head.scales"]?.shape == [2])
+        #expect(sanitized["lm_head.biases"]?.shape == [3])
+    }
+
+    /// THE scoping test. A genuine nested body must be left alone: stripping it would rebind real
+    /// weights onto the wrong keys and silently drop them, which is far worse than the load failure
+    /// this patch fixes.
+    @Test("a nested language_model body is left alone")
+    func leavesNestedBodyAlone() {
+        let sanitized = makeModel().sanitize(weights: [
+            "language_model.model.embed_tokens.weight": tagged(5)
+        ])
+        #expect(sanitized["language_model.model.embed_tokens.weight"]?.shape == [5])
+        #expect(sanitized["model.embed_tokens.weight"] == nil)
+    }
+
+    /// The pre-existing behaviour must survive the new strip: precomputed rotary frequencies are
+    /// still dropped, since they are recomputed at load.
+    @Test("precomputed rotary frequencies are still dropped")
+    func stillDropsRotaryInvFreq() {
+        let sanitized = makeModel().sanitize(weights: [
+            "model.layers.0.self_attn.rotary_emb.inv_freq": tagged(9),
+            "model.embed_tokens.weight": tagged(3),
+        ])
+        #expect(sanitized["model.layers.0.self_attn.rotary_emb.inv_freq"] == nil)
+        #expect(sanitized["model.embed_tokens.weight"]?.shape == [3])
+    }
+
+    /// The overwhelmingly common case: an ordinary checkpoint must be returned untouched, so the
+    /// patch cannot change behaviour for any bundle that loads today.
+    @Test("unprefixed weights pass through unchanged")
+    func passesThroughUnprefixed() {
+        let sanitized = makeModel().sanitize(weights: [
+            "lm_head.weight": tagged(4),
+            "model.embed_tokens.weight": tagged(3),
+        ])
+        #expect(sanitized["lm_head.weight"]?.shape == [4])
+        #expect(sanitized["model.embed_tokens.weight"]?.shape == [3])
+    }
+}


### PR DESCRIPTION
### What

Quantized Apertus checkpoints that carry the output projection under a VLM-style
`language_model.lm_head.*` prefix cannot be loaded at all.

`mlx-community/Apertus-8B-Instruct-2509-Jang_6M` ships 775 tensors, of which exactly three are
`language_model.lm_head.{weight,scales,biases}`, with no un-prefixed twin. The body sits at
`model.*` as normal. Loading fails with:

```
unhandledKeys(modules: ["ApertusModel"], keys: ["language_model"])
```

### How

`sanitize()` absorbs that prefix via the existing shared helper,
`Weights.stripLanguageModelPrefix(_:only: ["lm_head."])` — the same one added for the Llama fix in
#95. Scoped to the head only, so a genuine nested `language_model.*` body is untouched.

### Safety

This is the same class of change as #95 and #155: it fires **only** on checkpoints that currently
throw. No bundle that loads today can take a different path, because the path it changes is one that
ends in an error.

### Testing

Verified on device: the bundle above fails to load before the change with the error quoted, and
loads after it.

Worth noting for context, since it may look odd that an "Apertus Omni" bundle is text-only: that
conversion contains **zero** vision or audio tensors (top-level prefixes are just `lm_head` and
`model`), even though its tokenizer still declares the full 136k-entry visual/audio codebook as
added tokens. The vision tower was not converted. That is a bundle-authoring matter, not something
this patch addresses — but it is why the head shows up under a VLM-style prefix on a model that
loads as a plain causal LM.
