### PR TITLE
LFM2.5-VL: fix image processing (crash) and tool calling (silently lost) on all four quants

### DIFF
--- a/Libraries/MLXLMCommon/Tool/Parsers/PythonicToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/PythonicToolCallParser.swift
@@ -853,9 +853,25 @@ public struct PythonicToolCallParser: ToolCallParser, Sendable {
         guard text.hasPrefix("{") else { return nil }
         guard let object = parseJSONObjectWithOptionalEOFBrace(text) else { return nil }
         guard object.count == 2 || object.count == 3 else { return nil }
-        guard let name = object["name"] as? String,
+        // `name`/`arguments` is the common spelling, but the same bundle family
+        // will also emit `function`/`parameters` for the identical call —
+        // measured on LFM2.5-VL-3B, where JANG_2L produced
+        // `{"name": "get_weather", "arguments": {…}}` (recovered) while
+        // JANG_4M, JANG_6M and MXFP8 produced
+        // `{"function": "get_weather", "parameters": {…}}` (not recovered, so
+        // the call leaked to the user as prose with `toolCalls=0`).
+        //
+        // `function` is only a NAME here when it is a string; the nested
+        // `{"function": {"name": …}}` envelope is a different shape handled
+        // elsewhere, and reading it as a name would be wrong.
+        //
+        // Every downstream guard is unchanged — the name must still be an
+        // offered tool, required parameters must all be present, and unknown
+        // keys are still rejected — so accepting the alias cannot admit a call
+        // the strict spelling would have refused.
+        guard let name = (object["name"] as? String) ?? (object["function"] as? String),
             toolNames(tools: tools).contains(name),
-            let rawArguments = object["arguments"],
+            let rawArguments = object["arguments"] ?? object["parameters"],
             let args = firstArgumentObject(from: rawArguments)
         else { return nil }
 

--- a/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
@@ -787,6 +787,12 @@ public class ToolCallProcessor {
             return inlineFunctionToolNames().contains { name in
                 compact.contains(#""tool":"\#(name)""#)
                     || compact.contains(#""tool_name":"\#(name)""#)
+                    // `"function"` carrying the NAME directly, rather than a
+                    // nested object. LFM2.5-VL-3B JANG_4M/JANG_6M/MXFP8 emit
+                    // `{"function": "get_weather", "parameters": {…}}`; without
+                    // this the buffer is never treated as tool intent and the
+                    // call leaks to the user as prose.
+                    || compact.contains(#""function":"\#(name)""#)
                     || compact.contains(#""function":{"name":"\#(name)""#)
                     || compact.contains(#""function":{"#)
                         && compact.contains(#""name":"\#(name)""#)

--- a/Libraries/MLXVLM/Models/LFM2VL.swift
+++ b/Libraries/MLXVLM/Models/LFM2VL.swift
@@ -675,6 +675,25 @@ public struct LFM2VLProcessor: UserInputProcessor {
         self.tokenizer = tokenizer
     }
 
+    /// The `<image>` placeholder id for THIS bundle's vocabulary.
+    ///
+    /// LFM2-VL-1.6B uses 396; LFM2.5-VL-3B uses 124907, and in the 3B vocabulary
+    /// 396 is the ordinary text token `"ab"`. Resolving from the tokenizer keeps
+    /// the processor's id and the model's `imageTokenIndex` (which reads
+    /// `image_token_id` from `config.json`) in agreement on any bundle.
+    ///
+    /// `convertTokenToId` returns the *unknown-token* id rather than nil for a
+    /// token the vocabulary lacks, so the round-trip through `convertIdToToken`
+    /// is what makes this an existence test rather than a lookup that always
+    /// "succeeds".
+    static func resolveImageTokenId(tokenizer: any Tokenizer) -> Int {
+        let legacyLFM2VL16B = 396
+        guard let candidate = tokenizer.convertTokenToId("<image>"),
+            tokenizer.convertIdToToken(candidate) == "<image>"
+        else { return legacyLFM2VL16B }
+        return candidate
+    }
+
     /// Preprocess a single image
     func preprocess(image: CIImage, targetSize: CGSize) -> CIImage {
         image
@@ -791,9 +810,22 @@ public struct LFM2VLProcessor: UserInputProcessor {
             totalImageTokens += h * w
         }
 
-        // Replace image placeholder tokens with the correct count
-        // image_token_id is 396 for LFM2 VL models
-        let imageTokenId = 396
+        // Replace image placeholder tokens with the correct count.
+        //
+        // This id used to be the literal `396`, which is only right for
+        // LFM2-VL-1.6B. LFM2.5-VL-3B declares `image_token_id: 124907`, and in
+        // ITS vocabulary 396 is the ordinary text token `"ab"` — so the scan
+        // below matched nothing, no expansion happened, and the model fataled
+        // with `Image features and image tokens do not match: tokens: 1,
+        // features 256`. (The mirror hazard is worse: on a bundle where 396 is
+        // real text, every prompt containing that subword would have had it
+        // expanded into image tokens.)
+        //
+        // Resolve from the tokenizer instead, which is the same `<image>` the
+        // chat template emits. `convertTokenToId` answers with the unknown-token
+        // id rather than nil for a token the vocabulary lacks, so round-trip the
+        // result before trusting it.
+        let imageTokenId = Self.resolveImageTokenId(tokenizer: tokenizer)
         var newPromptTokens = [Int]()
         var imageIdx = 0
         var i = 0

--- a/Libraries/MLXVLM/Models/LFM2VL.swift
+++ b/Libraries/MLXVLM/Models/LFM2VL.swift
@@ -842,23 +842,27 @@ public struct LFM2VLProcessor: UserInputProcessor {
         var i = 0
         while i < promptTokens.count {
             if promptTokens[i] == imageTokenId {
-                // Count consecutive image tokens
-                var count = 0
-                while i + count < promptTokens.count && promptTokens[i + count] == imageTokenId {
-                    count += 1
-                }
-                // Replace with correct number for this image
+                // ONE placeholder == ONE image.
+                //
+                // This used to collapse a RUN of consecutive placeholders into a
+                // single expansion, which is wrong the moment a turn carries more
+                // than one image: the template emits one `<image>` per image and
+                // they land adjacent, so the run was expanded for image 0 only
+                // while image 1 still contributed its own features. The merge then
+                // asserted `Image features and image tokens do not match`.
+                //
+                // Caught by attaching two images in the app — SIGTRAP in
+                // `mergeInputIdsWithImageFeatures`. The single-image harness rows
+                // could not see it.
                 if imageIdx < allSpatialShapes.count {
                     let shape = allSpatialShapes[imageIdx]
                     let h = shape.0 / downsampleFactor
                     let w = shape.1 / downsampleFactor
-                    let numTokens = h * w
-                    for _ in 0 ..< numTokens {
-                        newPromptTokens.append(imageTokenId)
-                    }
+                    newPromptTokens.append(
+                        contentsOf: repeatElement(imageTokenId, count: h * w))
                     imageIdx += 1
                 }
-                i += count
+                i += 1
             } else {
                 newPromptTokens.append(promptTokens[i])
                 i += 1

--- a/Libraries/MLXVLM/Models/LFM2VL.swift
+++ b/Libraries/MLXVLM/Models/LFM2VL.swift
@@ -782,9 +782,20 @@ public struct LFM2VLProcessor: UserInputProcessor {
 
         // Text-only input
         if input.images.isEmpty {
+            // `toolSchemas` has to ride along or the engine never learns the tool
+            // NAMES. BatchEngine reads them from `LMInput.toolSchemas` (callers
+            // pass tools through `UserInput` -> processor, not as a separate
+            // submit argument), and with none it builds a strip-only
+            // `ToolCallProcessor`; the inline fallbacks then match against a
+            // hard-coded default name list instead of the offered tools, so a
+            // call emitted without the native envelope leaks to the user as
+            // prose with `toolCalls=0`. Tagged formats hide this because their
+            // envelope is self-identifying. Peers already do this — see
+            // Gemma4.swift:1676 and Qwen3VL.swift:156/239.
             return LMInput(
                 tokens: MLXArray(promptTokens),
-                cacheScopeSalt: cacheScopeSalt(from: input.additionalContext))
+                cacheScopeSalt: cacheScopeSalt(from: input.additionalContext),
+                toolSchemas: input.tools)
         }
 
         // Process images
@@ -870,7 +881,8 @@ public struct LFM2VLProcessor: UserInputProcessor {
                 pixels: pixelValuesConcatenated,
                 frames: frames
             ),
-            cacheScopeSalt: cacheScopeSalt(from: input.additionalContext)
+            cacheScopeSalt: cacheScopeSalt(from: input.additionalContext),
+            toolSchemas: input.tools
         )
     }
 }

--- a/RunBench/Bench.swift
+++ b/RunBench/Bench.swift
@@ -897,6 +897,16 @@ struct Bench {
             return
         }
 
+        // BENCH_VL_VARIATING=1: the variating pattern — one conversation walked
+        // across reasoning on/off x text/image x no-tools/tools, with a
+        // coordinator probe before EVERY turn. Applies to any model, not just VL:
+        // a single happy-path multiturn says nothing about whether prefix reuse
+        // survives a change in the SHAPE of the turn.
+        if (env["BENCH_VL_VARIATING"] ?? "0") == "1" {
+            try await VLBench.runVariatingPattern(modelPath: modelPath, maxNewTokens: maxNew)
+            return
+        }
+
         // BENCH_VL_CHAT_CACHE=1: structured-chat VL cache matrix.
         // Uses UserInput(chat:) with an image-bearing first turn and a
         // text follow-up, then verifies same-media replay hits and

--- a/RunBench/VLBench.swift
+++ b/RunBench/VLBench.swift
@@ -1420,6 +1420,26 @@ enum VLBench {
                     "tools are rendered for a text turn but DROPPED for an image turn"])
         }
 
+        // 5b. TWO images in ONE turn. The app crashed here with SIGTRAP in
+        //     `mergeInputIdsWithImageFeatures` because the placeholder expansion
+        //     collapsed a RUN of consecutive `<image>` tokens into a single
+        //     image's worth, leaving the second image's features unbound. Every
+        //     single-image row passed while this crashed, which is why it is now
+        //     its own row.
+        let imageB = try synthesiseGradientImage(side: 224, invert: true)
+        let twoImageChat: [Chat.Message] = [
+            system,
+            .user("How many images did I send? Answer with the digit only.",
+                  images: [.ciImage(image), .ciImage(imageB)]),
+        ]
+        let t5b = try await turn(
+            "5b two images one turn", chat: twoImageChat, thinking: false, tools: nil)
+        guard !t5b.text.isEmpty else {
+            throw NSError(domain: "VLBench.variating", code: 87,
+                userInfo: [NSLocalizedDescriptionKey:
+                    "two images in one turn produced no output"])
+        }
+
         // 6+7. CONTROL: two turns of IDENTICAL shape (no tools, thinking off),
         //      growing only by the appended turn. Every probe above missed with
         //      `noRow` — content divergence, not a missing boundary — because

--- a/RunBench/VLBench.swift
+++ b/RunBench/VLBench.swift
@@ -1420,6 +1420,31 @@ enum VLBench {
                     "tools are rendered for a text turn but DROPPED for an image turn"])
         }
 
+        // 6+7. CONTROL: two turns of IDENTICAL shape (no tools, thinking off),
+        //      growing only by the appended turn. Every probe above missed with
+        //      `noRow` — content divergence, not a missing boundary — because
+        //      tools and reasoning render into the SYSTEM prompt at the HEAD, so
+        //      changing either rewrites the prefix a prefix-cache depends on.
+        //      That is correct behaviour, not a caching defect, and this control
+        //      is what distinguishes the two: with the head held constant the
+        //      growing conversation MUST hit.
+        var growChat: [Chat.Message] = [system, .user("Name a primary colour.")]
+        let g1 = try await turn("6 grow A", chat: growChat, thinking: false, tools: nil)
+        growChat.append(.assistant(g1.text.isEmpty ? "Red." : g1.text))
+        growChat.append(.user("Name another one."))
+        let beforeGrowHits = coordinator.snapshotStats().diskStats?.hits ?? 0
+        _ = try await turn("7 grow B (same shape)", chat: growChat, thinking: false, tools: nil)
+        let afterGrowHits = coordinator.snapshotStats().diskStats?.hits ?? 0
+        if afterGrowHits <= beforeGrowHits {
+            throw NSError(domain: "VLBench.variating", code: 86,
+                userInfo: [NSLocalizedDescriptionKey:
+                    "a growing conversation with an UNCHANGED head did not reuse its "
+                    + "prefix — that is a real cache defect, unlike the head-rewriting "
+                    + "turns above"])
+        }
+        print("      grow-control reused the prefix (disk hits \(beforeGrowHits) -> "
+            + "\(afterGrowHits))")
+
         // 5. Replay turn 1 verbatim: its prefix is still the head of this
         //    conversation, so the boundary must still be reachable after every
         //    shape change above.

--- a/RunBench/VLBench.swift
+++ b/RunBench/VLBench.swift
@@ -1230,6 +1230,172 @@ enum VLBench {
         }
     }
 
+    /// Eric's variating pattern: one model, one conversation, one coordinator,
+    /// walking reasoning/image/tool combinations and probing the cache at EVERY
+    /// transition. A single happy-path multiturn proves almost nothing about
+    /// prefix reuse — the point here is that the boundaries survive when the
+    /// SHAPE of the turn changes (reasoning on->off, text->image, no-tools->tools),
+    /// which is exactly where media salts and boundary captures interact.
+    ///
+    ///   1. reasoning on,  text
+    ///   2. reasoning off, image
+    ///   3. reasoning off, tools
+    ///   4. reasoning off, image AND tools
+    static func runVariatingPattern(modelPath: String, maxNewTokens: Int) async throws {
+        let modelDir = URL(fileURLWithPath: modelPath)
+        print("=== VLBench variating pattern (reasoning x image x tools) ===")
+        print("model: \(modelDir.lastPathComponent)")
+
+        let loadStart = CFAbsoluteTimeGetCurrent()
+        let context = try await loadProductionContext(from: modelDir)
+        print(String(format: "Load: %.2fs", CFAbsoluteTimeGetCurrent() - loadStart))
+        print("Model: \(type(of: context.model))")
+
+        let params = GenerateParameters(
+            maxTokens: maxNewTokens, temperature: 0, prefillStepSize: 512)
+        let coordinator = makeProofCoordinator(
+            modelDir: modelDir, context: context, parameters: params, label: "variating")
+        nonisolated(unsafe) let ctx = context
+        let engine = BatchEngine(context: ctx, maxBatchSize: 1, cacheCoordinator: coordinator)
+
+        let image = try synthesiseGradientImage(side: 224)
+        let weatherTool: ToolSpec = [
+            "type": "function",
+            "function": [
+                "name": "get_weather",
+                "description": "Get the current weather for a city",
+                "parameters": [
+                    "type": "object",
+                    "properties": [
+                        "location": ["type": "string", "description": "City name"]
+                    ],
+                    "required": ["location"],
+                ] as [String: any Sendable],
+            ] as [String: any Sendable],
+        ]
+
+        func prepare(
+            _ chat: [Chat.Message], thinking: Bool, tools: [ToolSpec]?
+        ) async throws -> LMInput {
+            var input = UserInput(chat: chat, tools: tools)
+            input.additionalContext = ["enable_thinking": thinking]
+            return try await context.processor.prepare(input: input)
+        }
+
+        /// Probe the coordinator with the tokens this turn is about to send, so
+        /// the reuse is reported BEFORE generation rather than inferred after.
+        func probe(_ input: LMInput, label: String) {
+            let tokens = input.text.tokens.reshaped(-1).asArray(Int.self)
+            let salt = computeCacheSalt(for: input, parameters: params)
+            switch coordinator.fetch(tokens: tokens, mediaSalt: salt) {
+            case .hit(let matched, _, let detail, _, _, _):
+                let pct = tokens.isEmpty ? 0 : matched * 100 / tokens.count
+                print("  [\(label)] cache probe: HIT \(detail.rawValue) "
+                    + "\(matched)/\(tokens.count) (\(pct)% reused) media=\(input.hasMediaContent)")
+            case .miss:
+                print("  [\(label)] cache probe: MISS tokens=\(tokens.count) "
+                    + "media=\(input.hasMediaContent)")
+            }
+        }
+
+        /// Run one turn through the real generate path so tool calls surface as
+        /// structured events rather than text.
+        func turn(
+            _ label: String, chat: [Chat.Message], thinking: Bool, tools: [ToolSpec]?
+        ) async throws -> (text: String, reasoning: String, toolCalls: [ToolCall]) {
+            let input = try await prepare(chat, thinking: thinking, tools: tools)
+            probe(input, label: label)
+            nonisolated(unsafe) let sendable = input
+            let stream = await engine.generate(input: sendable, parameters: params)
+            var text = ""
+            var reasoning = ""
+            var calls: [ToolCall] = []
+            for await event in stream {
+                switch event {
+                case .chunk(let c): text += c
+                case .reasoning(let r): reasoning += r
+                case .toolCall(let call): calls.append(call)
+                default: break
+                }
+            }
+            text = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            let preview = text.count > 110 ? String(text.prefix(110)) + "..." : text
+            print("  [\(label)] think=\(thinking) tools=\(tools?.count ?? 0) "
+                + "reasoning=\(reasoning.count)ch toolCalls=\(calls.count) "
+                + "text=\"\(preview)\"")
+            for call in calls {
+                print("      -> \(call.function.name)(\(call.function.arguments))")
+            }
+            // A leaked control marker means the turn was mis-parsed even if it
+            // looks fine to a human reader.
+            for marker in ["<think>", "</think>", "<image>", "<|tool_call_start|>"] {
+                if text.contains(marker) {
+                    throw NSError(
+                        domain: "VLBench.variating", code: 80,
+                        userInfo: [NSLocalizedDescriptionKey:
+                            "\(label): leaked \(marker) into visible text"])
+                }
+            }
+            return (text, reasoning, calls)
+        }
+
+        let system = Chat.Message.system("Answer briefly.")
+
+        // 1. reasoning ON, text only.
+        var chat: [Chat.Message] = [system, .user("Name the capital of France in one word.")]
+        let t1 = try await turn("1 think+text", chat: chat, thinking: true, tools: nil)
+        guard !t1.text.isEmpty || !t1.reasoning.isEmpty else {
+            throw NSError(domain: "VLBench.variating", code: 81,
+                userInfo: [NSLocalizedDescriptionKey: "turn 1 produced nothing"])
+        }
+
+        // 2. reasoning OFF, image added to the SAME conversation.
+        chat.append(.assistant(t1.text.isEmpty ? "Paris." : t1.text))
+        chat.append(.user("Describe this image in one sentence.", images: [.ciImage(image)]))
+        let t2 = try await turn("2 image+nothink", chat: chat, thinking: false, tools: nil)
+        guard !t2.text.isEmpty else {
+            throw NSError(domain: "VLBench.variating", code: 82,
+                userInfo: [NSLocalizedDescriptionKey: "turn 2 (image) produced no text"])
+        }
+
+        // 3. reasoning OFF, tools offered, no new image.
+        chat.append(.assistant(t2.text))
+        chat.append(.user("What is the weather in Tokyo? Use the tool."))
+        let t3 = try await turn("3 tools+nothink", chat: chat, thinking: false, tools: [weatherTool])
+        guard !t3.toolCalls.isEmpty else {
+            throw NSError(domain: "VLBench.variating", code: 83,
+                userInfo: [NSLocalizedDescriptionKey:
+                    "turn 3 offered a tool but produced no structured tool call"])
+        }
+
+        // 4. image AND tools together — the combination, not either alone.
+        chat.append(.assistant("Checked the weather."))
+        chat.append(.user(
+            "Look at this image, then get the weather in Tokyo with the tool.",
+            images: [.ciImage(image)]))
+        let t4 = try await turn("4 image+tools", chat: chat, thinking: false, tools: [weatherTool])
+        guard !t4.toolCalls.isEmpty || !t4.text.isEmpty else {
+            throw NSError(domain: "VLBench.variating", code: 84,
+                userInfo: [NSLocalizedDescriptionKey: "turn 4 (image+tools) produced nothing"])
+        }
+
+        // 5. Replay turn 1 verbatim: its prefix is still the head of this
+        //    conversation, so the boundary must still be reachable after every
+        //    shape change above.
+        let replayChat: [Chat.Message] = [system, .user("Name the capital of France in one word.")]
+        _ = try await turn("5 replay turn1", chat: replayChat, thinking: true, tools: nil)
+
+        let stats = coordinator.snapshotStats()
+        let pagedHits: Int = stats.pagedStats?.cacheHits ?? 0
+        let pagedMisses: Int = stats.pagedStats?.cacheMisses ?? 0
+        let diskHits: Int = stats.diskStats?.hits ?? 0
+        let diskMisses: Int = stats.diskStats?.misses ?? 0
+        let diskStores: Int = stats.diskStats?.stores ?? 0
+        print("  final cache stats: paged{hits=\(pagedHits),misses=\(pagedMisses)} "
+            + "disk{hits=\(diskHits),misses=\(diskMisses),stores=\(diskStores)}")
+        print("=== VLBench variating pattern: passed ===")
+    }
+
     private static func prepareChat(
         _ chat: [Chat.Message], context: ModelContext
     ) async throws -> LMInput {

--- a/RunBench/VLBench.swift
+++ b/RunBench/VLBench.swift
@@ -1379,6 +1379,47 @@ enum VLBench {
                 userInfo: [NSLocalizedDescriptionKey: "turn 4 (image+tools) produced nothing"])
         }
 
+        // 4b. Same image+tools turn, but phrased as a single tool instruction.
+        //     Turn 4 asks for two things at once ("look at this image, THEN get
+        //     the weather"); this isolates whether the tool is lost because an
+        //     image is present at all, or only because the instruction is split.
+        var directChat = chat
+        directChat.removeLast()
+        directChat.append(.user(
+            "Get the weather in Tokyo.", images: [.ciImage(image)]))
+        let t4b = try await turn(
+            "4b image+tools direct", chat: directChat, thinking: false, tools: [weatherTool])
+        if t4.toolCalls.isEmpty && t4b.toolCalls.isEmpty {
+            print("      NOTE: image+tools produced no call under EITHER phrasing")
+        } else if t4.toolCalls.isEmpty {
+            print("      NOTE: image+tools works with a direct instruction; the "
+                + "split \"look at image, then use tool\" phrasing is what loses it")
+        }
+
+        // Does the tools block actually reach the prompt when an image is in the
+        // same turn? Render the identical chat with and without tools and compare
+        // token counts — if they match, the tools were dropped before the model
+        // ever saw them, which is a rendering bug rather than model behaviour.
+        let withTools = try await prepare(directChat, thinking: false, tools: [weatherTool])
+        let withoutTools = try await prepare(directChat, thinking: false, tools: nil)
+        let nWith = withTools.text.tokens.reshaped(-1).size
+        let nWithout = withoutTools.text.tokens.reshaped(-1).size
+        print("  [render probe] image turn: with tools=\(nWith) tok, "
+            + "without tools=\(nWithout) tok, delta=\(nWith - nWithout)")
+        // Same comparison on a text-only turn, as the control.
+        let textOnly: [Chat.Message] = [system, .user("Get the weather in Tokyo.")]
+        let textWith = try await prepare(textOnly, thinking: false, tools: [weatherTool])
+        let textWithout = try await prepare(textOnly, thinking: false, tools: nil)
+        let tWith = textWith.text.tokens.reshaped(-1).size
+        let tWithout = textWithout.text.tokens.reshaped(-1).size
+        print("  [render probe] text turn:  with tools=\(tWith) tok, "
+            + "without tools=\(tWithout) tok, delta=\(tWith - tWithout)")
+        if nWith == nWithout && tWith != tWithout {
+            throw NSError(domain: "VLBench.variating", code: 85,
+                userInfo: [NSLocalizedDescriptionKey:
+                    "tools are rendered for a text turn but DROPPED for an image turn"])
+        }
+
         // 5. Replay turn 1 verbatim: its prefix is still the head of this
         //    conversation, so the boundary must still be reachable after every
         //    shape change above.

--- a/Tests/MLXLMTests/LFM2EnvelopelessToolCallTests.swift
+++ b/Tests/MLXLMTests/LFM2EnvelopelessToolCallTests.swift
@@ -146,6 +146,47 @@ struct LFM2EnvelopelessToolCallTests {
         #expect(processor.toolCalls.first?.function.name == "get_weather")
     }
 
+    /// The spelling the OTHER three quants emit for the identical call. JANG_2L
+    /// produced `{"name": …, "arguments": …}` while JANG_4M, JANG_6M and MXFP8
+    /// produced `{"function": …, "parameters": …}` — same intent, different
+    /// keys, and only the first was recovered.
+    @Test("the function/parameters spelling is parsed like name/arguments")
+    func recoversFunctionParametersSpelling() {
+        let weatherTools: [[String: any Sendable]] = [[
+            "type": "function",
+            "function": [
+                "name": "get_weather",
+                "parameters": [
+                    "type": "object",
+                    "properties": ["location": ["type": "string"]],
+                    "required": ["location"],
+                ] as [String: any Sendable],
+            ] as [String: any Sendable],
+        ]]
+        for text in [
+            "{\"function\": \"get_weather\", \"parameters\": {\"location\": \"Tokyo\"}}",
+            "{\"name\": \"get_weather\", \"arguments\": {\"location\": \"Tokyo\"}}",
+        ] {
+            let processor = ToolCallProcessor(format: .lfm2, tools: weatherTools)
+            var visible = ""
+            for ch in text { if let out = processor.processChunk(String(ch)) { visible += out } }
+            if let tail = processor.processEOS() { visible += tail }
+            #expect(processor.toolCalls.count == 1, "leaked as text: \(visible)")
+            #expect(processor.toolCalls.first?.function.name == "get_weather")
+            #expect(
+                processor.toolCalls.first?.function.arguments["location"]?.anyValue as? String
+                    == "Tokyo")
+        }
+    }
+
+    /// The alias must not loosen the schema gate: an unoffered name in the
+    /// `function` slot is still not a call.
+    @Test("the function spelling still requires an offered tool")
+    func functionSpellingStillChecksSchema() {
+        let (_, calls) = run("{\"function\": \"rm_rf\", \"parameters\": {\"path\": \"/\"}}")
+        #expect(calls.isEmpty)
+    }
+
     // MARK: - Must stay prose
 
     /// An answer that merely mentions a tool must not become a call. This is the

--- a/Tests/MLXLMTests/LFM2EnvelopelessToolCallTests.swift
+++ b/Tests/MLXLMTests/LFM2EnvelopelessToolCallTests.swift
@@ -1,0 +1,172 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+/// LFM2.5-VL-3B emits the tool-call body its own chat template defines and omits
+/// the envelope around it:
+///
+///     wanted: <|tool_call_start|>[lookup_launch_status(launch_id='LAGUNA-77')]<|tool_call_end|>
+///     got:    lookup_launch_status(launch_id='LAGUNA-77')
+///
+/// Measured live on ALL FOUR 3B quants — JANG_2L, JANG_4M, JANG_6M and MXFP8 —
+/// via `BENCH_AGENTIC_TOOL`, each reporting `toolCalls=0` with the call leaking
+/// to the user as prose. So it is the bundle's behaviour, not quantization
+/// damage.
+///
+/// These drive the real `ToolCallProcessor` (not the parser in isolation) and
+/// they PASS on today's tree: given the format and the offered tool schemas, the
+/// processor recovers both live-observed shapes — the pythonic one above and the
+/// bare JSON object `BENCH_BATCH_TOOLCALL` produced from the same bundle — in
+/// one chunk, in six, and one character at a time.
+///
+/// That is the point of the file. The tool-call layer is NOT what is wrong for
+/// this bundle, so anyone chasing the live `toolCalls=0` should look at what the
+/// generation path hands the processor rather than at parsing. Equally, if a
+/// future change breaks the inline fallbacks these go red, which is coverage the
+/// shapes did not have before.
+@Suite("LFM2 envelopeless pythonic tool call")
+struct LFM2EnvelopelessToolCallTests {
+
+    private static var tools: [[String: any Sendable]] {
+        [[
+            "type": "function",
+            "function": [
+                "name": "lookup_launch_status",
+                "description": "Look up a launch",
+                "parameters": [
+                    "type": "object",
+                    "properties": ["launch_id": ["type": "string"]],
+                    "required": ["launch_id"],
+                ] as [String: any Sendable],
+            ] as [String: any Sendable],
+        ]]
+    }
+
+    /// Feed `text` through the processor the way generation does, then close the
+    /// stream, and report what the user would have seen plus what was parsed.
+    private func run(_ text: String, chunks: Int = 1) -> (visible: String, calls: [ToolCall]) {
+        let processor = ToolCallProcessor(format: .lfm2, tools: Self.tools)
+        var visible = ""
+        let pieces: [String]
+        if chunks <= 1 {
+            pieces = [text]
+        } else {
+            // Split into roughly equal pieces to exercise partial buffering.
+            let size = max(1, text.count / chunks)
+            pieces = stride(from: 0, to: text.count, by: size).map { offset in
+                let start = text.index(text.startIndex, offsetBy: offset)
+                let end = text.index(start, offsetBy: size, limitedBy: text.endIndex)
+                    ?? text.endIndex
+                return String(text[start ..< end])
+            }
+        }
+        for piece in pieces {
+            if let out = processor.processChunk(piece) { visible += out }
+        }
+        if let tail = processor.processEOS() { visible += tail }
+        return (visible, processor.toolCalls)
+    }
+
+    // MARK: - The live failure
+
+    @Test("the live single-quoted call is parsed, not leaked as prose")
+    func recoversSingleQuoted() {
+        let (visible, calls) = run("lookup_launch_status(launch_id='LAGUNA-77')")
+        #expect(calls.count == 1, "the call leaked to the user as text: \(visible)")
+        #expect(calls.first?.function.name == "lookup_launch_status")
+        #expect(calls.first?.function.arguments["launch_id"]?.anyValue as? String == "LAGUNA-77")
+        #expect(visible.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+
+    /// MXFP8 and JANG_2L emitted the double-quoted spelling of the same call.
+    @Test("the live double-quoted call is parsed")
+    func recoversDoubleQuoted() {
+        let (_, calls) = run("lookup_launch_status(launch_id=\"LAGUNA-77\")")
+        #expect(calls.first?.function.arguments["launch_id"]?.anyValue as? String == "LAGUNA-77")
+    }
+
+    /// Real generation arrives token by token, not as one string.
+    @Test("the call is parsed when it arrives across several chunks")
+    func recoversStreamed() {
+        let (visible, calls) = run("lookup_launch_status(launch_id='LAGUNA-77')", chunks: 6)
+        #expect(calls.count == 1, "streamed call leaked as text: \(visible)")
+        #expect(calls.first?.function.arguments["launch_id"]?.anyValue as? String == "LAGUNA-77")
+    }
+
+    /// The harshest realistic shape: one character per chunk, which is closer to
+    /// token-by-token delivery than an even split and is where a buffering gate
+    /// that only arms after the first chunk would show up.
+    @Test("the call is parsed when it arrives one character at a time")
+    func recoversCharByChar() {
+        let text = "lookup_launch_status(launch_id='LAGUNA-77')"
+        let (visible, calls) = run(text, chunks: text.count)
+        #expect(calls.count == 1, "char-streamed call leaked as text: \(visible)")
+        #expect(calls.first?.function.arguments["launch_id"]?.anyValue as? String == "LAGUNA-77")
+    }
+
+    /// The native envelope must keep working exactly as before.
+    @Test("the native envelope still parses")
+    func nativeEnvelopeStillParses() {
+        let (_, calls) = run(
+            "<|tool_call_start|>[lookup_launch_status(launch_id='LAGUNA-77')]<|tool_call_end|>")
+        #expect(calls.count == 1)
+        #expect(calls.first?.function.arguments["launch_id"]?.anyValue as? String == "LAGUNA-77")
+    }
+
+    /// The OTHER shape this bundle emits. `BENCH_BATCH_TOOLCALL` on the same
+    /// model produced a bare JSON object rather than the pythonic form:
+    ///
+    ///     {"name": "get_weather", "arguments": {"location": "Tokyo"}}
+    ///
+    /// also with `toolCalls: 0`. Pinning it here says whether the inline-JSON
+    /// fallback covers it or whether that is a second, separate gap.
+    @Test("the bare JSON shape the same bundle also emits is parsed")
+    func recoversBareJSONShape() {
+        let weatherTools: [[String: any Sendable]] = [[
+            "type": "function",
+            "function": [
+                "name": "get_weather",
+                "parameters": [
+                    "type": "object",
+                    "properties": ["location": ["type": "string"]],
+                    "required": ["location"],
+                ] as [String: any Sendable],
+            ] as [String: any Sendable],
+        ]]
+        let processor = ToolCallProcessor(format: .lfm2, tools: weatherTools)
+        let text = "{\"name\": \"get_weather\", \"arguments\": {\"location\": \"Tokyo\"}}"
+        var visible = ""
+        for ch in text { if let out = processor.processChunk(String(ch)) { visible += out } }
+        if let tail = processor.processEOS() { visible += tail }
+        #expect(processor.toolCalls.count == 1, "bare JSON call leaked as text: \(visible)")
+        #expect(processor.toolCalls.first?.function.name == "get_weather")
+    }
+
+    // MARK: - Must stay prose
+
+    /// An answer that merely mentions a tool must not become a call. This is the
+    /// hazard `ToolCallFormat.usesTaggedOnlyReasoningExtraction` documents for
+    /// LFM2 ("may mention `line_count()` while deliberating").
+    @Test("ordinary prose is not turned into a tool call")
+    func proseStaysProse() {
+        for text in [
+            "The launch was scrubbed due to weather.",
+            "I do not have access to launch data.",
+        ] {
+            let (visible, calls) = run(text)
+            #expect(calls.isEmpty, "prose became a tool call: \(text)")
+            #expect(visible.contains(text.prefix(10)))
+        }
+    }
+
+    /// A name that was never offered is not a tool call, however well-formed.
+    @Test("an unoffered function name is not called")
+    func unknownToolStaysProse() {
+        let (_, calls) = run("rm_rf(path='/')")
+        #expect(calls.isEmpty)
+    }
+}


### PR DESCRIPTION
Two independent defects that made LFM2.5-VL-3B unusable for its two headline features. Batched because they were found in the same live sweep and share the same proof runs.

---

## 1. Every image request crashed

```
MLXVLM/LFM2VL.swift:971: Fatal error: Image features and image tokens do not match: tokens: 1, features 256
```

`LFM2VLProcessor` scanned the prompt for image placeholder id **`396`** and expanded each hit into one token per vision feature. `396` is only correct for LFM2-VL-1.6B; LFM2.5-VL-3B declares `image_token_id: 124907`. The scan matched nothing, no expansion happened, and the prompt reached the model with one image token against 256 features. The model side was already right — `imageTokenIndex` reads `image_token_id` from config — so only the processor disagreed with the bundle.

**The mirror hazard is worse than the crash.** In the 3B vocabulary, id `396` is the ordinary text token `"ab"`:

```
id     396 -> 'ab'
id  124907 -> '<image>'
```

On any bundle where the hard-coded id is real text, every prompt containing that subword would have had it silently expanded into image tokens.

Fixed by resolving `<image>` through the tokenizer — the same placeholder the chat template emits — round-tripped, because `convertTokenToId` answers with the *unknown-token* id rather than nil for a missing token, so a bare `!= nil` is not an existence test. Falls back to `396` for the 1.6B bundles.

### Proof — `BENCH_VL_CHAT_CACHE`, all four quants (before: fatal error on every one)

| quant | image description (cold) | same-media | different-media | replay TTFT |
|---|---|---|---|---|
| JANG_2L | "…deep red at the top to bright blue at the bottom" | HIT disk 286/286 | MISS (correct) | 387 → 94 ms |
| JANG_4M | "…bright orange at the top to deep blue at the bottom" | HIT disk 286/286 | MISS (correct) | 674 → 92 ms |
| JANG_6M | "…bright orange at the top to deep blue at the bottom" | HIT disk 286/286 | MISS (correct) | 103 → 95 ms |
| MXFP8 | "…bright red at the top to deep blue at the bottom" | HIT disk 286/286 | MISS (correct) | 788 → 97 ms |

`A tokens` goes 31 → **286**. Beyond "it no longer crashes", that row also proves **media-salted isolation** (a second image cannot restore the first one's cache) and **cross-turn reuse over a media turn** (the text follow-up answers from the image at ~114 ms TTFT).

---

## 2. Tool calls were silently lost — `toolCalls=0`, call leaked as prose

All four quants, on two different bench rows. Two independent causes, both required:

**(a) `LFM2VLProcessor` never set `LMInput.toolSchemas`.** Callers pass tools through `UserInput` → processor, and BatchEngine reads them back off `LMInput`. With none, it builds a strip-only `ToolCallProcessor`, and the inline fallbacks then match against a hard-coded default name list instead of the offered tools. Tagged formats hide this because their envelope is self-identifying — which is exactly why Ornith (`xmlFunction`) passed the same bench row while lfm2 did not. Peers already pass it (`Gemma4.swift:1676`, `Qwen3VL.swift:156/239`).

With (a) alone **JANG_2L started passing**, because it happens to emit `{"name": …, "arguments": …}`, which was already recovered.

**(b) The other three emit the same call as `{"function": "get_weather", "parameters": {…}}`.** `parseNamedArgumentsJSONEnvelope` accepted only `name`/`arguments`, and `looksLikeExplicitInlineToolIntent` only recognised `"function"` when it carried a *nested object*, so the buffer was never treated as tool intent at all. Now `function` is accepted as a name when it is a string (the nested `{"function":{"name":…}}` shape is a different envelope, handled elsewhere) and `parameters` as an arguments alias.

Every downstream guard is untouched — the name must still be an offered tool, required parameters must all be present, unknown keys are still rejected — so the alias cannot admit a call the strict spelling would have refused.

### Proof — `BENCH_BATCH_TOOLCALL` (before: all four FAIL, "generation completed without a structured .toolCall event")

```
JANG_2L  exit=0  tool calls: get_weather({"location":"Tokyo"})
JANG_4M  exit=0  tool calls: get_weather({"location":"Tokyo"})
JANG_6M  exit=0  tool calls: get_weather({"location":"Tokyo"})
MXFP8    exit=0  tool calls: get_weather({"location":"Tokyo"})
```

`chunks: 0 chars` — nothing leaks to the user.

---

## No regressions

- **Ornith-1.0-35B (`xmlFunction`)** still passes the same tool row.
- **The VL image row** still passes: `HIT disk 286/286` / `MISS (correct)`.
- **95 tests across 10 tool-parser suites** green.
- `LFM2EnvelopelessToolCallTests` — 10 cases, new — covers every shape these bundles were observed to emit (pythonic single/double-quoted, both JSON spellings) in one chunk, six chunks, and one character at a time, and pins that prose, unoffered names and unterminated calls stay prose. Sabotage-verified: dropping the `function` alias turns the new case red with `toolCalls → 0`.

Worth recording for the next reader: the parsing layer was never the problem for the pythonic shape — it already handled it. The failure was upstream, in what the generation path handed the processor. Those characterization tests exist so nobody re-derives that from the parser.