### PR TITLE
Stop an empty pixel tensor from killing the app in the cache media salt

### DIFF
--- a/Source/MLX/MLXArray+Bytes.swift
+++ b/Source/MLX/MLXArray+Bytes.swift
@@ -177,9 +177,20 @@ extension MLXArray {
 
     /// return a copy of the backing in contiguous layout
     internal func asDataCopy() -> MLXArrayData {
+        // An array with no elements has no backing buffer. `physicalSize` is
+        // derived from the strides and stays non-zero for a shape like
+        // [1, 0, 3, 448], so the null base would pair with a non-zero count —
+        // which `UnsafeRawBufferPointer` traps on.
+        guard let base = mlx_array_data_uint8(self.ctx) else {
+            return MLXArrayData(
+                data: Data(),
+                shape: self.shape, strides: contiguousStrides(shape: self.shape),
+                dType: self.dtype)
+        }
+
         // point into the possibly non-contiguous backing
         let source = UnsafeRawBufferPointer(
-            start: mlx_array_data_uint8(self.ctx), count: physicalSize * itemSize)
+            start: base, count: physicalSize * itemSize)
 
         var data = Data(count: self.nbytes)
         data.withUnsafeMutableBytes { destination in
@@ -217,8 +228,20 @@ extension MLXArray {
         case .noCopyIfContiguous:
             if self.contiguousToDimension() == 0 {
                 // the backing is contiguous, we can provide a wrapper
-                // for the contents without a copy
-                let source = UnsafeMutableRawPointer(mutating: mlx_array_data_uint8(self.ctx))!
+                // for the contents without a copy.
+                //
+                // An array with no elements has no backing buffer, so
+                // `mlx_array_data_uint8` returns null. There are no bytes to
+                // wrap, and `Data(bytesNoCopy:)` may not take a null base, so
+                // hand back empty `Data` rather than trapping. A zero-element
+                // pixel tensor reaches here through `computeMediaSalt`.
+                guard let source = UnsafeMutableRawPointer(mutating: mlx_array_data_uint8(self.ctx))
+                else {
+                    return MLXArrayData(
+                        data: Data(),
+                        shape: self.shape, strides: contiguousStrides(shape: self.shape),
+                        dType: self.dtype)
+                }
                 let data = Data(
                     bytesNoCopy: source, count: size * itemSize,
                     deallocator: .none)
@@ -234,10 +257,14 @@ extension MLXArray {
             }
 
         case .noCopy:
-            let source = UnsafeMutableRawPointer(mutating: mlx_array_data_uint8(self.ctx))!
-            let data = Data(
-                bytesNoCopy: source, count: nbytes,
-                deallocator: .none)
+            // Same null backing as `.noCopyIfContiguous` above: no elements
+            // means no buffer to reference.
+            let data: Data
+            if let source = UnsafeMutableRawPointer(mutating: mlx_array_data_uint8(self.ctx)) {
+                data = Data(bytesNoCopy: source, count: nbytes, deallocator: .none)
+            } else {
+                data = Data()
+            }
 
             let strides: [Int]
             if ndim == 0 {

--- a/Tests/MLXLMTests/CacheCoordinatorMediaSaltTests.swift
+++ b/Tests/MLXLMTests/CacheCoordinatorMediaSaltTests.swift
@@ -207,6 +207,32 @@ final class CacheCoordinatorMediaSaltTests: XCTestCase {
         XCTAssertNotNil(s1)
     }
 
+    /// 2026-08-12: live SIGTRAP. An image turn reached `computeMediaSalt`
+    /// with a zero-element pixel tensor; `asData` force-unwrapped the null
+    /// backing pointer and killed the app mid-conversation. Hashing an empty
+    /// tensor must produce a salt, not a trap.
+    func testComputeMediaSaltOnEmptyPixelsDoesNotTrap() {
+        let empty = MLXArray(Array<Float>(), [1, 0, 3, 448])
+        realize(empty)
+        let input = LMInput(
+            text: .init(tokens: MLXArray([Int32(1)])),
+            image: .init(pixels: empty))
+        let salt = computeMediaSalt(for: input)
+        XCTAssertNotNil(salt, "An image-bearing input must still salt its cache scope.")
+        XCTAssertEqual(salt, computeMediaSalt(for: input), "Salt must stay deterministic.")
+    }
+
+    /// An empty pixel tensor must not collide with a populated one, or a
+    /// blind turn would reuse a sighted turn's KV cache.
+    func testEmptyPixelsSaltDiffersFromPopulatedPixels() {
+        let empty = MLXArray(Array<Float>(), [1, 0, 3, 448])
+        let full = MLXArray((0..<48).map { Float($0) }).reshaped([1, 3, 4, 4])
+        realize(empty, full)
+        let a = LMInput(text: .init(tokens: MLXArray([Int32(1)])), image: .init(pixels: empty))
+        let b = LMInput(text: .init(tokens: MLXArray([Int32(1)])), image: .init(pixels: full))
+        XCTAssertNotEqual(computeMediaSalt(for: a), computeMediaSalt(for: b))
+    }
+
     func testComputeMediaSaltDiffersForDifferentPixels() {
         let p1 = MLXArray((0..<48).map { Float($0) }).reshaped([1, 3, 4, 4])
         let p2 = MLXArray((0..<48).map { Float($0 + 1) }).reshaped([1, 3, 4, 4])

--- a/Tests/MLXTests/EmptyArrayDataTests.swift
+++ b/Tests/MLXTests/EmptyArrayDataTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+import MLX
+import XCTest
+
+/// Reproduces the SIGTRAP seen live in `computeMediaSalt` -> `hashMLXArray`
+/// -> `MLXArray.asData(access:)`: the backing data pointer is null for an
+/// array with no elements, and `asData` force-unwraps it.
+class EmptyArrayDataTests: XCTestCase {
+    func testAsDataOnZeroElementArray() {
+        let empty = MLXArray(Array<Float>(), [0])
+        XCTAssertEqual(empty.size, 0)
+        let d = empty.asData(access: .noCopyIfContiguous)
+        XCTAssertEqual(d.data.count, 0)
+    }
+
+    func testAsDataNoCopyOnZeroElementArray() {
+        let empty = MLXArray(Array<Float>(), [0])
+        let d = empty.asData(access: .noCopy)
+        XCTAssertEqual(d.data.count, 0)
+    }
+
+    func testAsDataStillReturnsBytesForANonEmptyArray() {
+        let a = MLXArray([Float(1), 2, 3], [3])
+        let d = a.asData(access: .noCopyIfContiguous)
+        XCTAssertEqual(d.data.count, 3 * MemoryLayout<Float>.size)
+        XCTAssertEqual(a.asData(access: .copy).data.count, 3 * MemoryLayout<Float>.size)
+    }
+
+    func testAsDataOnZeroElementArrayWithNonZeroRank() {
+        let empty = MLXArray(Array<Float>(), [1, 0, 3, 448])
+        XCTAssertEqual(empty.size, 0)
+        let d = empty.asData(access: .noCopyIfContiguous)
+        XCTAssertEqual(d.data.count, 0)
+        let c = empty.asData(access: .copy)
+        XCTAssertEqual(c.data.count, 0)
+    }
+}


### PR DESCRIPTION
Live SIGTRAP on `LFM2.5-VL-3B-JANG_4M`, second image turn of a conversation in the dev-built app:

```
Swift runtime failure: Unexpectedly found nil while unwrapping an Optional value
MLXArray.asData(access:)
hashMLXArray(_:into:)
computeMediaSalt(for:)
computeCacheSalt(for:parameters:)
TokenIterator.init(...)
closure #2 in BatchEngine.startSoloFastPath(input:parameters:promptTail:)
```

## Cause

An array with no elements has no backing buffer, so `mlx_array_data_uint8`
returns null. All three `asData` access paths assumed a non-null pointer:

- `.noCopyIfContiguous` and `.noCopy` force-unwrapped it (`MLXArray+Bytes.swift:221`, the line in the crash).
- `asDataCopy` passed the null base to `UnsafeRawBufferPointer` along with a
  count derived from the strides. That count stays non-zero for a shape like
  `[1, 0, 3, 448]`, so it trapped separately with
  `UnsafeRawBufferPointer has a nil start and nonzero count`.

Reaching this through a **cache salt** is what makes it fatal rather than
merely wrong: the salt is computed before generation, so an empty pixel tensor
kills the app instead of producing a bad answer.

## Fix

All three paths return empty `Data` — which is what a zero-element array
actually holds. Shape and dtype are still hashed, so an empty pixel tensor
still gets a real salt and **cannot collide with a populated one**; a blind
turn must never reuse a sighted turn's KV cache.

## Tests — 16 pass

Reproduced first, at the exact reported line:

```
MLX/MLXArray+Bytes.swift:221: Fatal error: Unexpectedly found nil while unwrapping an Optional value
```

New `EmptyArrayDataTests` (4): both no-copy paths, the rank-4 copy path that
trapped differently, and a non-empty control proving bytes are still returned.

New in `CacheCoordinatorMediaSaltTests` (2): the exact crashing call
(`computeMediaSalt` over empty pixels) and the no-collision requirement.

Plus the 10 pre-existing media-salt tests, still green.