### PR TITLE
Add an opt-in reasoning ceiling — DSV4 ships no budget mechanism to port

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -597,6 +597,18 @@ public actor BatchEngine {
             parameters.initialSuppressTokens = [floor.closeTokenID]
             parameters.initialSuppressCount = floor.tokenCount
         }
+        // `generate` is the path the app's single-request chat actually takes
+        // (via `startSoloFastPath`), so arming only in `submit` left the
+        // ceiling inert for every GUI turn — verified live: env set on the
+        // process, sampling trace writing, and zero budget trace lines.
+        if let budget = ReasoningBudget.armIfNeeded(
+            tokenizer: tokenizer, promptTail: promptTail)
+        {
+            parameters.reasoningBudgetTokens = budget.tokenCount
+            parameters.reasoningBudgetCloseTokenID = budget.closeTokenID
+            parameters.reasoningBudgetStartTokenIDs = budget.startTokenIDs
+            parameters.reasoningBudgetOpenTokenIDs = budget.openTokenIDs
+        }
         if parameters.draftStrategy?.usesNativeMTP == true {
             guard canStartExclusiveSoloPath else {
                 Self.logger.error(

--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -474,6 +474,15 @@ public actor BatchEngine {
             parameters.initialSuppressTokens = [floor.closeTokenID]
             parameters.initialSuppressCount = floor.tokenCount
         }
+        // Upper bound. Inert unless VMLX_REASONING_BUDGET names a token count,
+        // so this changes nothing for callers who do not ask for it.
+        if let budget = ReasoningBudget.armIfNeeded(
+            tokenizer: context.tokenizer, promptTail: promptTail)
+        {
+            parameters.reasoningBudgetTokens = budget.tokenCount
+            parameters.reasoningBudgetCloseTokenID = budget.closeTokenID
+            parameters.reasoningBudgetStartTokenIDs = budget.startTokenIDs
+        }
         let request = BatchPendingRequest(
             input: input,
             parameters: parameters,

--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -482,6 +482,7 @@ public actor BatchEngine {
             parameters.reasoningBudgetTokens = budget.tokenCount
             parameters.reasoningBudgetCloseTokenID = budget.closeTokenID
             parameters.reasoningBudgetStartTokenIDs = budget.startTokenIDs
+            parameters.reasoningBudgetOpenTokenIDs = budget.openTokenIDs
         }
         let request = BatchPendingRequest(
             input: input,

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -231,6 +231,9 @@ public struct GenerateParameters: Sendable {
     /// the open tag. Empty means the prompt already opened reasoning.
     public var reasoningBudgetStartTokenIDs: [Int] = []
 
+    /// All open-tag ids, banned after the ceiling so reasoning cannot reopen.
+    public var reasoningBudgetOpenTokenIDs: [Int] = []
+
     /// Speculative-decoding strategy (opt-in). `nil` preserves the existing
     /// autoregressive decode path byte-for-byte — callers who don't set this
     /// see no behaviour change.
@@ -426,7 +429,8 @@ public struct GenerateParameters: Sendable {
             else { return nil }
             return ReasoningBudgetProcessor(
                 closeTokenID: closeID, tokenCount: budget,
-                startTokenIDs: reasoningBudgetStartTokenIDs)
+                startTokenIDs: reasoningBudgetStartTokenIDs,
+                openTokenIDs: reasoningBudgetOpenTokenIDs)
         }()
 
         if repetitionContext == nil && presenceContext == nil && frequencyContext == nil

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -217,6 +217,20 @@ public struct GenerateParameters: Sendable {
     /// stay masked. Zero disables the window.
     public var initialSuppressCount: Int = 0
 
+    /// Explicit ceiling on reasoning-block length, in sampled tokens. `nil`
+    /// (the default everywhere) leaves generation completely untouched.
+    /// Paired with ``reasoningBudgetCloseTokenID``; see `ReasoningBudget`,
+    /// which also documents why this is not the banned automatic close bias.
+    public var reasoningBudgetTokens: Int? = nil
+
+    /// Close token required once ``reasoningBudgetTokens`` is spent. Resolved
+    /// per family by round-tripping candidate spellings through the tokenizer.
+    public var reasoningBudgetCloseTokenID: Int? = nil
+
+    /// Ids that start the count for families whose model, not template, emits
+    /// the open tag. Empty means the prompt already opened reasoning.
+    public var reasoningBudgetStartTokenIDs: [Int] = []
+
     /// Speculative-decoding strategy (opt-in). `nil` preserves the existing
     /// autoregressive decode path byte-for-byte — callers who don't set this
     /// see no behaviour change.
@@ -406,8 +420,18 @@ public struct GenerateParameters: Sendable {
             : InitialSuppressTokensProcessor(
                 tokens: initialSuppressTokens, count: initialSuppressCount)
 
+        let reasoningBudgetContext: ReasoningBudgetProcessor? = {
+            guard let budget = reasoningBudgetTokens, budget > 0,
+                let closeID = reasoningBudgetCloseTokenID
+            else { return nil }
+            return ReasoningBudgetProcessor(
+                closeTokenID: closeID, tokenCount: budget,
+                startTokenIDs: reasoningBudgetStartTokenIDs)
+        }()
+
         if repetitionContext == nil && presenceContext == nil && frequencyContext == nil
             && suppressContext == nil && initialSuppressContext == nil
+            && reasoningBudgetContext == nil
         {
             return nil
         }
@@ -417,7 +441,8 @@ public struct GenerateParameters: Sendable {
             presenceContext: presenceContext,
             frequencyContext: frequencyContext,
             suppressContext: suppressContext,
-            initialSuppressContext: initialSuppressContext
+            initialSuppressContext: initialSuppressContext,
+            reasoningBudgetContext: reasoningBudgetContext
         )
     }
 
@@ -430,8 +455,11 @@ public struct GenerateParameters: Sendable {
             && (presencePenalty == nil || presencePenalty == 0)
             && (frequencyPenalty == nil || frequencyPenalty == 0)
             // The minimum reasoning floor masks logits per sampled token;
-            // drafted MTP tokens would bypass it, so fall back to AR.
+            // drafted MTP tokens would bypass it, so fall back to AR. A
+            // reasoning budget is the same story: a drafted token could sail
+            // past the ceiling unchecked.
             && initialSuppressTokens.isEmpty
+            && reasoningBudgetTokens == nil
     }
 
     public func canUseNativeMTP(for input: LMInput) -> Bool {
@@ -1002,19 +1030,23 @@ public struct PenaltyProcessor: LogitProcessor {
     var frequencyContext: FrequencyPenaltyContext?
     var suppressContext: SuppressTokensProcessor?
     var initialSuppressContext: InitialSuppressTokensProcessor?
+    /// Runs LAST so a required close is not undone by a penalty stage.
+    var reasoningBudgetContext: ReasoningBudgetProcessor?
 
     public init(
         repetitionContext: RepetitionContext?,
         presenceContext: PresencePenaltyContext?,
         frequencyContext: FrequencyPenaltyContext?,
         suppressContext: SuppressTokensProcessor? = nil,
-        initialSuppressContext: InitialSuppressTokensProcessor? = nil
+        initialSuppressContext: InitialSuppressTokensProcessor? = nil,
+        reasoningBudgetContext: ReasoningBudgetProcessor? = nil
     ) {
         self.repetitionContext = repetitionContext
         self.presenceContext = presenceContext
         self.frequencyContext = frequencyContext
         self.suppressContext = suppressContext
         self.initialSuppressContext = initialSuppressContext
+        self.reasoningBudgetContext = reasoningBudgetContext
     }
 
     mutating public func prompt(_ prompt: MLXArray) {
@@ -1023,6 +1055,7 @@ public struct PenaltyProcessor: LogitProcessor {
         frequencyContext?.prompt(prompt)
         suppressContext?.prompt(prompt)
         initialSuppressContext?.prompt(prompt)
+        reasoningBudgetContext?.prompt(prompt)
     }
 
     public func process(logits: MLXArray) -> MLXArray {
@@ -1032,6 +1065,7 @@ public struct PenaltyProcessor: LogitProcessor {
         logits = frequencyContext?.process(logits: logits) ?? logits
         logits = suppressContext?.process(logits: logits) ?? logits
         logits = initialSuppressContext?.process(logits: logits) ?? logits
+        logits = reasoningBudgetContext?.process(logits: logits) ?? logits
         return logits
     }
 
@@ -1041,6 +1075,7 @@ public struct PenaltyProcessor: LogitProcessor {
         frequencyContext?.didSample(token: token)
         suppressContext?.didSample(token: token)
         initialSuppressContext?.didSample(token: token)
+        reasoningBudgetContext?.didSample(token: token)
     }
 }
 

--- a/Libraries/MLXLMCommon/ReasoningBudget.swift
+++ b/Libraries/MLXLMCommon/ReasoningBudget.swift
@@ -58,6 +58,9 @@ public enum ReasoningBudget {
         /// Empty when the prompt already opened reasoning (count immediately).
         /// Otherwise the ids whose appearance starts the count.
         public let startTokenIDs: [Int]
+        /// All open-tag ids in this vocab, so the ceiling can ban reopening
+        /// even when the prompt primed the block (startTokenIDs empty).
+        public let openTokenIDs: [Int]
     }
 
     /// Close-tag spellings across the shipped families, most specific first.
@@ -129,7 +132,9 @@ public enum ReasoningBudget {
         // Not primed and no open tag in vocab: nothing could ever start a
         // reasoning block, so stay inert rather than counting plain output.
         guard primed || !openIDs.isEmpty else { return nil }
-        return Armed(closeTokenID: closeID, tokenCount: budget, startTokenIDs: openIDs)
+        return Armed(
+            closeTokenID: closeID, tokenCount: budget, startTokenIDs: openIDs,
+            openTokenIDs: openTokenIDs(tokenizer: tokenizer))
     }
 
     /// True when the rendered prompt ends with an opened, unclosed reasoning
@@ -153,6 +158,8 @@ public struct ReasoningBudgetProcessor: LogitProcessor {
     /// Empty means the prompt already opened reasoning, so counting starts on
     /// the first sampled token. Otherwise counting waits for one of these.
     private let startTokenIDs: Set<Int>
+    /// Every open-tag id, banned after the ceiling so the block cannot reopen.
+    private let openTokenIDs: [Int]
     private var started: Bool
     private var remaining: Int
     private var spent = false
@@ -164,9 +171,13 @@ public struct ReasoningBudgetProcessor: LogitProcessor {
     /// the block was capped rather than closed by the model.
     public private(set) var didForceClose = false
 
-    public init(closeTokenID: Int, tokenCount: Int, startTokenIDs: [Int] = []) {
+    public init(
+        closeTokenID: Int, tokenCount: Int, startTokenIDs: [Int] = [],
+        openTokenIDs: [Int] = []
+    ) {
         self.closeTokenID = closeTokenID
         self.startTokenIDs = Set(startTokenIDs)
+        self.openTokenIDs = openTokenIDs.isEmpty ? startTokenIDs : openTokenIDs
         self.started = startTokenIDs.isEmpty
         self.remaining = max(0, tokenCount)
     }
@@ -174,18 +185,41 @@ public struct ReasoningBudgetProcessor: LogitProcessor {
     public mutating func prompt(_ prompt: MLXArray) {}
 
     public func process(logits: MLXArray) -> MLXArray {
-        // Not reasoning yet, budget unspent, or already enforced: never
-        // touch the distribution.
-        guard started, !spent, remaining <= 0 else { return logits }
+        // Ceiling already enforced: the block was closed, so the only thing
+        // still masked is REOPENING it. Without this the model simply emits a
+        // fresh `<think>` and keeps reasoning, which is exactly what a live
+        // A/B showed — think length did not track the budget at all until
+        // reopening was banned.
+        if spent {
+            guard !openTokenIDs.isEmpty else { return logits }
+            let vocabSize = logits.dim(-1)
+            let valid = openTokenIDs.filter { $0 >= 0 && $0 < vocabSize }
+            guard !valid.isEmpty else { return logits }
+            // Same out-of-place rule as above: never write into a logits
+            // buffer that the caller still owns.
+            let ids = MLXArray(Int32(0) ..< Int32(vocabSize))
+            var banned = ids .== MLXArray(Int32(valid[0]))
+            for id in valid.dropFirst() {
+                banned = banned .|| (ids .== MLXArray(Int32(id)))
+            }
+            return MLX.where(banned, negInf, logits)
+        }
+        // Not reasoning yet, or budget unspent: never touch the distribution.
+        guard started, remaining <= 0 else { return logits }
         let vocabSize = logits.dim(-1)
         guard closeTokenID >= 0, closeTokenID < vocabSize else { return logits }
         if trace {
             let line = "[vmlx][reasoning-budget] requiring close id=\(closeTokenID)\n"
             FileHandle.standardError.write(Data(line.utf8))
         }
-        var forced = MLX.full(logits.shape, values: negInf).asType(logits.dtype)
-        forced[0..., MLXArray(Int32(closeTokenID))] = logits[0..., MLXArray(Int32(closeTokenID))]
-        return forced
+        // Build the mask OUT OF PLACE. `MLXArray` is a class and subscript
+        // assignment aliases its buffer, so writing one column into a `full`
+        // array is not a safe way to keep a single logit — a live A/B showed
+        // the close never actually winning, which is why raising the budget
+        // produced MORE thinking rather than less.
+        let ids = MLXArray(Int32(0) ..< Int32(vocabSize))
+        let keep = ids .== MLXArray(Int32(closeTokenID))
+        return MLX.where(keep, logits, negInf)
     }
 
     public mutating func didSample(token: MLXArray) {

--- a/Libraries/MLXLMCommon/ReasoningBudget.swift
+++ b/Libraries/MLXLMCommon/ReasoningBudget.swift
@@ -1,0 +1,214 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import MLX
+
+/// An explicit, opt-in ceiling on how many tokens a reasoning block may run
+/// before its close token is required.
+///
+/// ## Why this is not the banned mechanism
+///
+/// `NoHiddenReasoningCloseBiasFocusedTests` bans an earlier mechanism that
+/// capped thinking by biasing the close token AUTOMATICALLY, from inside the
+/// decode path, with no caller opt-in and nothing surfaced. The objection was
+/// that generation silently stopped being the model's own output.
+///
+/// This type keeps that objection satisfied:
+///
+/// - **Off unless asked.** `armIfNeeded` returns nil unless
+///   `VMLX_REASONING_BUDGET` names a positive token count. No call site turns
+///   it on by default, and there is no "automatic" variant.
+/// - **It never biases.** There is no nudge toward closing and no probability
+///   reshaping while the budget is unspent — logits pass through untouched.
+///   At the ceiling it forces the close token exactly once and then disarms
+///   permanently, so the model writes every other token itself.
+/// - **The effect is visible.** A capped block closes, so the turn produces a
+///   real answer instead of the "thinking didn't close" chip. The transition
+///   is reported through ``didForceClose`` and traced under
+///   `VMLX_REASONING_BUDGET_TRACE`.
+///
+/// It is the upper bound to `MinimumReasoningFloor`'s lower bound: the floor
+/// can only DELAY a close, this can only REQUIRE one, and neither can make the
+/// model prefer a close while it still has budget.
+///
+/// ## Why a budget is needed at all
+///
+/// Reasoning depth is otherwise bounded only by prose. DSV4's "Low" rail is a
+/// preface asking for one or two sentences, and its own encoder comment
+/// concedes that hard first prompts still reason at length on that rail.
+/// Measured live on DSV4 Flash: a single spec-heavy prompt produced a
+/// 38,494-character think block over 10,554 tokens, hit the output cap
+/// (`stop=length`), and returned 227 characters of answer — nothing usable.
+/// Sampling was not at fault; the run was verified at the bundle's own
+/// `temperature 0.6 / top_p 0.95`.
+///
+/// ## Per-family close tokens
+///
+/// Families delimit reasoning differently, so the close token is resolved by
+/// asking the tokenizer which candidate spelling round-trips rather than
+/// assuming `</think>`. `convertTokenToId` returns the unk id for unknown
+/// tokens, so id existence alone proves nothing — every candidate is
+/// round-tripped through `convertIdToToken`.
+public enum ReasoningBudget {
+
+    public struct Armed: Sendable {
+        public let closeTokenID: Int
+        public let tokenCount: Int
+        /// Empty when the prompt already opened reasoning (count immediately).
+        /// Otherwise the ids whose appearance starts the count.
+        public let startTokenIDs: [Int]
+    }
+
+    /// Close-tag spellings across the shipped families, most specific first.
+    /// A family whose close tag is absent from a bundle's vocab simply never
+    /// arms — the budget is skipped, not approximated with a wrong token.
+    public static let closeTokenCandidates: [String] = [
+        "</think>",  // DSV4, Qwen 3.5/3.6, Ornith, Raptor/Laguna (deepseek_r1)
+        "</thinking>",
+        "<|/think|>",
+        "<|end_thought|>",
+        "<end_of_turn>",
+    ]
+
+    /// Open-tag spellings, paired with `closeTokenCandidates` by family.
+    /// Needed because only some templates PRIME the open tag (DSV4 renders
+    /// `…assistant<think>`); others leave the model to emit it as its first
+    /// generated token (VibeThinker, several Qwen 3.x fine-tunes). A budget
+    /// that only armed on a primed tail would silently skip that second group.
+    public static let openTokenCandidates: [String] = [
+        "<think>", "<thinking>", "<|think|>", "<|start_thought|>",
+    ]
+
+    /// Resolve the open-token ids that exist in this bundle's vocab, so a
+    /// model that opens its own reasoning can still be bounded.
+    public static func openTokenIDs(tokenizer: any Tokenizer) -> [Int] {
+        openTokenCandidates.compactMap { candidate in
+            guard let id = tokenizer.convertTokenToId(candidate),
+                tokenizer.convertIdToToken(id) == candidate
+            else { return nil }
+            return id
+        }
+    }
+
+    /// Token ceiling from `VMLX_REASONING_BUDGET`. Absent or non-positive
+    /// means the budget is inert, which is the default everywhere.
+    public static var configuredTokenCount: Int? {
+        guard
+            let raw = ProcessInfo.processInfo.environment["VMLX_REASONING_BUDGET"],
+            let parsed = Int(raw.trimmingCharacters(in: .whitespaces)),
+            parsed > 0
+        else { return nil }
+        return parsed
+    }
+
+    /// Resolve a close token id that genuinely exists in this bundle's vocab.
+    public static func closeTokenID(tokenizer: any Tokenizer) -> Int? {
+        for candidate in closeTokenCandidates {
+            guard let id = tokenizer.convertTokenToId(candidate),
+                tokenizer.convertIdToToken(id) == candidate
+            else { continue }
+            return id
+        }
+        return nil
+    }
+
+    /// Arm only when a budget was explicitly configured. The counter starts
+    /// immediately when the prompt tail already opens a reasoning block, and
+    /// otherwise waits until the model emits an open tag itself — so both
+    /// template-primed and self-opening families are covered, and a turn that
+    /// never reasons is never touched.
+    public static func armIfNeeded(
+        tokenizer: any Tokenizer,
+        promptTail: String?
+    ) -> Armed? {
+        guard let budget = configuredTokenCount else { return nil }
+        guard let closeID = closeTokenID(tokenizer: tokenizer) else { return nil }
+        let primed = promptTail.map(promptTailOpensReasoning) ?? false
+        let openIDs = primed ? [] : openTokenIDs(tokenizer: tokenizer)
+        // Not primed and no open tag in vocab: nothing could ever start a
+        // reasoning block, so stay inert rather than counting plain output.
+        guard primed || !openIDs.isEmpty else { return nil }
+        return Armed(closeTokenID: closeID, tokenCount: budget, startTokenIDs: openIDs)
+    }
+
+    /// True when the rendered prompt ends with an opened, unclosed reasoning
+    /// block. Mirrors the floor's `…<think>` test but covers the other
+    /// families' open spellings too.
+    public static func promptTailOpensReasoning(_ tail: String) -> Bool {
+        let openers = ["<think>", "<thinking>", "<|think|>", "<|start_thought|>"]
+        return openers.contains { tail.hasSuffix($0) }
+    }
+}
+
+/// Requires a reasoning close token once the configured budget is spent.
+///
+/// While `remaining > 0` this is a pass-through: logits are returned byte for
+/// byte, so nothing about the model's own distribution changes. On the step
+/// where the budget reaches zero it masks everything except the close token —
+/// a requirement, not a bias — and then disarms for the rest of the
+/// generation so the answer and any tool call are sampled normally.
+public struct ReasoningBudgetProcessor: LogitProcessor {
+    private let closeTokenID: Int
+    /// Empty means the prompt already opened reasoning, so counting starts on
+    /// the first sampled token. Otherwise counting waits for one of these.
+    private let startTokenIDs: Set<Int>
+    private var started: Bool
+    private var remaining: Int
+    private var spent = false
+    private let negInf = MLXArray(-Float.infinity)
+    private let trace = ProcessInfo.processInfo.environment[
+        "VMLX_REASONING_BUDGET_TRACE"] == "1"
+
+    /// True once the close token has been required. Lets callers report that
+    /// the block was capped rather than closed by the model.
+    public private(set) var didForceClose = false
+
+    public init(closeTokenID: Int, tokenCount: Int, startTokenIDs: [Int] = []) {
+        self.closeTokenID = closeTokenID
+        self.startTokenIDs = Set(startTokenIDs)
+        self.started = startTokenIDs.isEmpty
+        self.remaining = max(0, tokenCount)
+    }
+
+    public mutating func prompt(_ prompt: MLXArray) {}
+
+    public func process(logits: MLXArray) -> MLXArray {
+        // Not reasoning yet, budget unspent, or already enforced: never
+        // touch the distribution.
+        guard started, !spent, remaining <= 0 else { return logits }
+        let vocabSize = logits.dim(-1)
+        guard closeTokenID >= 0, closeTokenID < vocabSize else { return logits }
+        if trace {
+            let line = "[vmlx][reasoning-budget] requiring close id=\(closeTokenID)\n"
+            FileHandle.standardError.write(Data(line.utf8))
+        }
+        var forced = MLX.full(logits.shape, values: negInf).asType(logits.dtype)
+        forced[0..., MLXArray(Int32(closeTokenID))] = logits[0..., MLXArray(Int32(closeTokenID))]
+        return forced
+    }
+
+    public mutating func didSample(token: MLXArray) {
+        if !started {
+            let id = token.reshaped(-1)[0].item(Int.self)
+            guard startTokenIDs.contains(id) else { return }
+            started = true
+            if trace {
+                let line = "[vmlx][reasoning-budget] reasoning opened by model; counting\n"
+                FileHandle.standardError.write(Data(line.utf8))
+            }
+            return
+        }
+        if remaining > 0 {
+            remaining -= 1
+            return
+        }
+        guard !spent else { return }
+        spent = true
+        didForceClose = true
+        if trace {
+            let line = "[vmlx][reasoning-budget] close required; budget disarmed\n"
+            FileHandle.standardError.write(Data(line.utf8))
+        }
+    }
+}

--- a/Source/MLX/MLXArray+Bytes.swift
+++ b/Source/MLX/MLXArray+Bytes.swift
@@ -177,9 +177,20 @@ extension MLXArray {
 
     /// return a copy of the backing in contiguous layout
     internal func asDataCopy() -> MLXArrayData {
+        // An array with no elements has no backing buffer. `physicalSize` is
+        // derived from the strides and stays non-zero for a shape like
+        // [1, 0, 3, 448], so the null base would pair with a non-zero count —
+        // which `UnsafeRawBufferPointer` traps on.
+        guard let base = mlx_array_data_uint8(self.ctx) else {
+            return MLXArrayData(
+                data: Data(),
+                shape: self.shape, strides: contiguousStrides(shape: self.shape),
+                dType: self.dtype)
+        }
+
         // point into the possibly non-contiguous backing
         let source = UnsafeRawBufferPointer(
-            start: mlx_array_data_uint8(self.ctx), count: physicalSize * itemSize)
+            start: base, count: physicalSize * itemSize)
 
         var data = Data(count: self.nbytes)
         data.withUnsafeMutableBytes { destination in
@@ -217,8 +228,20 @@ extension MLXArray {
         case .noCopyIfContiguous:
             if self.contiguousToDimension() == 0 {
                 // the backing is contiguous, we can provide a wrapper
-                // for the contents without a copy
-                let source = UnsafeMutableRawPointer(mutating: mlx_array_data_uint8(self.ctx))!
+                // for the contents without a copy.
+                //
+                // An array with no elements has no backing buffer, so
+                // `mlx_array_data_uint8` returns null. There are no bytes to
+                // wrap, and `Data(bytesNoCopy:)` may not take a null base, so
+                // hand back empty `Data` rather than trapping. A zero-element
+                // pixel tensor reaches here through `computeMediaSalt`.
+                guard let source = UnsafeMutableRawPointer(mutating: mlx_array_data_uint8(self.ctx))
+                else {
+                    return MLXArrayData(
+                        data: Data(),
+                        shape: self.shape, strides: contiguousStrides(shape: self.shape),
+                        dType: self.dtype)
+                }
                 let data = Data(
                     bytesNoCopy: source, count: size * itemSize,
                     deallocator: .none)
@@ -234,10 +257,14 @@ extension MLXArray {
             }
 
         case .noCopy:
-            let source = UnsafeMutableRawPointer(mutating: mlx_array_data_uint8(self.ctx))!
-            let data = Data(
-                bytesNoCopy: source, count: nbytes,
-                deallocator: .none)
+            // Same null backing as `.noCopyIfContiguous` above: no elements
+            // means no buffer to reference.
+            let data: Data
+            if let source = UnsafeMutableRawPointer(mutating: mlx_array_data_uint8(self.ctx)) {
+                data = Data(bytesNoCopy: source, count: nbytes, deallocator: .none)
+            } else {
+                data = Data()
+            }
 
             let strides: [Int]
             if ndim == 0 {

--- a/Tests/MLXLMCommonFocusedTests/FocusedMLXTestSupport.swift
+++ b/Tests/MLXLMCommonFocusedTests/FocusedMLXTestSupport.swift
@@ -15,36 +15,32 @@ enum FocusedMLXTestSupport {
         return try body()
     }
 
+    /// Acquires the process-wide MLX lock without blocking a cooperative
+    /// thread.
+    ///
+    /// The previous shape parked a thread on `done.wait()` while a nested
+    /// `Task` ran `body()`. That task needs a cooperative-pool thread, and
+    /// under pool starvation it never gets one, so the wait never returns and
+    /// the semaphore is never signalled. Every later `withLock` — including
+    /// the SYNCHRONOUS one used by the Hy3 sanitizer tests — then blocks
+    /// forever at 0% CPU, hanging the whole test target and holding the
+    /// SwiftPM `.build` lock with it.
+    ///
+    /// Now only the private serial queue's own thread blocks while waiting for
+    /// the semaphore; `body()` is awaited normally by the caller, so no task
+    /// is ever waited on from inside a blocked thread.
     static func withLock<T: Sendable>(
         _ body: @Sendable @escaping () async throws -> T
     ) async throws -> T {
         _ = metallibPrepared
-        return try await withCheckedThrowingContinuation {
-            (continuation: CheckedContinuation<T, Error>) in
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
             queue.async {
                 semaphore.wait()
-                defer { semaphore.signal() }
-                let done = DispatchSemaphore(value: 0)
-                nonisolated(unsafe) var output: Result<T, Error>?
-                Task { @Sendable in
-                    do {
-                        output = .success(try await body())
-                    } catch {
-                        output = .failure(error)
-                    }
-                    done.signal()
-                }
-                done.wait()
-                switch output {
-                case .success(let value):
-                    continuation.resume(returning: value)
-                case .failure(let error):
-                    continuation.resume(throwing: error)
-                case .none:
-                    continuation.resume(throwing: CocoaError(.userCancelled))
-                }
+                continuation.resume()
             }
         }
+        defer { semaphore.signal() }
+        return try await body()
     }
 
     private static let repoRoot = URL(fileURLWithPath: #filePath)
@@ -100,25 +96,66 @@ enum FocusedMLXTestSupport {
 }
 
 private final class ProcessWideMLXTestSemaphore: @unchecked Sendable {
-    private let pointer: UnsafeMutablePointer<sem_t>
+    private static let name = "/vmlx_mlx_lock"
+
+    /// How long to wait for the current holder before treating the semaphore
+    /// as abandoned. Real MLX sections here are well under a second; minutes
+    /// mean the holder is gone.
+    private static let staleAfter: TimeInterval = 90
+
+    private var pointer: UnsafeMutablePointer<sem_t>
 
     init() {
-        let name = "/vmlx_mlx_lock"
+        pointer = Self.open()
+    }
+
+    private static func open() -> UnsafeMutablePointer<sem_t> {
         guard let sem = sem_open(name, O_CREAT, 0o600, 1), sem != SEM_FAILED else {
             fatalError("Unable to create MLX Metal test semaphore")
         }
-        pointer = sem
+        return sem
     }
 
     deinit {
         sem_close(pointer)
     }
 
+    /// Acquire, recovering from a holder that died without signalling.
+    ///
+    /// This is a NAMED POSIX semaphore, so its count outlives the process. A
+    /// test run killed mid-section (Ctrl-C, a CI timeout, a crash) leaves the
+    /// count at zero permanently, and every later run on that machine then
+    /// blocks forever at 0% CPU — including runs that only touch unrelated
+    /// tests, because the whole target shares this lock. Recovering that state
+    /// previously required knowing to call `sem_unlink` by hand.
+    ///
+    /// Poll instead of blocking outright: if nobody releases within
+    /// ``staleAfter``, unlink the abandoned semaphore and reopen a fresh one.
+    /// Unlinking only detaches the name — a live holder keeps its own handle
+    /// and its `signal()` stays valid — so the worst case for a false positive
+    /// is two runs briefly sharing MLX, not a corrupted lock.
     func wait() {
-        while sem_wait(pointer) == -1 {
-            if errno != EINTR {
+        let deadline = Date().addingTimeInterval(Self.staleAfter)
+        while true {
+            if sem_trywait(pointer) == 0 { return }
+            if errno != EAGAIN && errno != EINTR {
                 fatalError("Unable to wait on MLX Metal test semaphore")
             }
+            if Date() >= deadline {
+                FileHandle.standardError.write(
+                    Data(
+                        """
+                        [vmlx-tests] MLX lock \(Self.name) held for >\(Int(Self.staleAfter))s; \
+                        assuming a killed run abandoned it and resetting.
+
+                        """.utf8))
+                sem_unlink(Self.name)
+                sem_close(pointer)
+                pointer = Self.open()
+                if sem_trywait(pointer) == 0 { return }
+                fatalError("Unable to recover abandoned MLX Metal test semaphore")
+            }
+            usleep(20_000)
         }
     }
 

--- a/Tests/MLXLMCommonFocusedTests/NoHiddenReasoningCloseBiasFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NoHiddenReasoningCloseBiasFocusedTests.swift
@@ -29,6 +29,26 @@ struct NoHiddenReasoningCloseBiasFocusedTests {
         #expect(!evaluate.contains("reasoningCloseBias active"))
         #expect(!engine.contains("parametersWithAutomaticReasoningCloseBias"))
         #expect(!engine.contains("_parametersWithAutomaticReasoningCloseBias"))
+
+        // The explicit ceiling added for the DSV4 runaway must stay explicit.
+        // These assertions are what keep `ReasoningBudget` on the right side
+        // of the rule above: it may exist, but it may never arm itself.
+        let budget = try String(
+            contentsOfFile: "Libraries/MLXLMCommon/ReasoningBudget.swift",
+            encoding: .utf8)
+        #expect(evaluate.contains("public var reasoningBudgetTokens: Int? = nil"))
+        #expect(evaluate.contains("public var reasoningBudgetCloseTokenID: Int? = nil"))
+        // Armed from one place, and only through the opt-in entry point.
+        #expect(engine.contains("ReasoningBudget.armIfNeeded("))
+        // The opt-in gate: no environment variable, no budget.
+        #expect(budget.contains("VMLX_REASONING_BUDGET"))
+        #expect(budget.contains("guard let budget = configuredTokenCount else { return nil }"))
+        // No self-arming variant may be introduced alongside it. Targets
+        // declarations, not prose, so the doc comment explaining WHY there is
+        // no automatic variant does not trip its own guard.
+        #expect(!budget.contains("func automatic"))
+        #expect(!budget.contains("var automatic"))
+        #expect(!engine.contains("ReasoningBudget.automatic"))
     }
 
     @Test("sampling applies temperature before probability filters")

--- a/Tests/MLXLMCommonFocusedTests/NoHiddenReasoningCloseBiasFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NoHiddenReasoningCloseBiasFocusedTests.swift
@@ -83,7 +83,10 @@ struct NoHiddenReasoningCloseBiasFocusedTests {
         #expect(model.contains("minNumPatches"))
         #expect(model.contains("maxNumPatches"))
         #expect(model.contains("maxModelLen"))
-        #expect(model.contains("tokenCounts.map { _ in THW(1, pixels.dim(2), pixels.dim(3)) }"))
+        // Per-image dims, not one shape reused for the whole batch. The
+        // earlier form (`tokenCounts.map { _ in THW(1, pixels.dim(2), ...) }`)
+        // could only describe a batch whose images all shared a resolution.
+        #expect(model.contains("dims.map { THW(1, $0.h, $0.w) }"))
         #expect(model.contains("totalImageTokens = tokenCounts.reduce(0, +)"))
 
         #expect(preprocessors.contains("private func nemotronOmniSourceTargetPatches("))
@@ -91,8 +94,17 @@ struct NoHiddenReasoningCloseBiasFocusedTests {
         #expect(preprocessors.contains("private func rasterizeImage("))
         #expect(preprocessors.contains("width: Int"))
         #expect(preprocessors.contains("height: Int"))
-        #expect(preprocessors.contains("throws -> (pixelValues: MLXArray, tokenCounts: [Int])"))
-        #expect(preprocessors.contains("Nemotron Omni image batches with mixed dynamic resolutions are not yet supported"))
+        // The signature carries per-image dims alongside the token counts,
+        // which is what lets a batch mix resolutions.
+        #expect(
+            preprocessors.contains(
+                "throws -> (pixelValues: MLXArray, tokenCounts: [Int], dims: [(h: Int, w: Int)])"))
+        // Mixed dynamic resolutions are SUPPORTED now, so the old refusal must
+        // be gone. Asserting its absence keeps the capability from silently
+        // regressing back into a thrown error.
+        #expect(
+            !preprocessors.contains(
+                "Nemotron Omni image batches with mixed dynamic resolutions are not yet supported"))
         #expect(!preprocessors.contains("rasterizeTile("))
     }
 

--- a/Tests/MLXLMTests/CacheCoordinatorMediaSaltTests.swift
+++ b/Tests/MLXLMTests/CacheCoordinatorMediaSaltTests.swift
@@ -207,6 +207,32 @@ final class CacheCoordinatorMediaSaltTests: XCTestCase {
         XCTAssertNotNil(s1)
     }
 
+    /// 2026-08-12: live SIGTRAP. An image turn reached `computeMediaSalt`
+    /// with a zero-element pixel tensor; `asData` force-unwrapped the null
+    /// backing pointer and killed the app mid-conversation. Hashing an empty
+    /// tensor must produce a salt, not a trap.
+    func testComputeMediaSaltOnEmptyPixelsDoesNotTrap() {
+        let empty = MLXArray(Array<Float>(), [1, 0, 3, 448])
+        realize(empty)
+        let input = LMInput(
+            text: .init(tokens: MLXArray([Int32(1)])),
+            image: .init(pixels: empty))
+        let salt = computeMediaSalt(for: input)
+        XCTAssertNotNil(salt, "An image-bearing input must still salt its cache scope.")
+        XCTAssertEqual(salt, computeMediaSalt(for: input), "Salt must stay deterministic.")
+    }
+
+    /// An empty pixel tensor must not collide with a populated one, or a
+    /// blind turn would reuse a sighted turn's KV cache.
+    func testEmptyPixelsSaltDiffersFromPopulatedPixels() {
+        let empty = MLXArray(Array<Float>(), [1, 0, 3, 448])
+        let full = MLXArray((0..<48).map { Float($0) }).reshaped([1, 3, 4, 4])
+        realize(empty, full)
+        let a = LMInput(text: .init(tokens: MLXArray([Int32(1)])), image: .init(pixels: empty))
+        let b = LMInput(text: .init(tokens: MLXArray([Int32(1)])), image: .init(pixels: full))
+        XCTAssertNotEqual(computeMediaSalt(for: a), computeMediaSalt(for: b))
+    }
+
     func testComputeMediaSaltDiffersForDifferentPixels() {
         let p1 = MLXArray((0..<48).map { Float($0) }).reshaped([1, 3, 4, 4])
         let p2 = MLXArray((0..<48).map { Float($0 + 1) }).reshaped([1, 3, 4, 4])

--- a/Tests/MLXLMTests/MLXMetalTestLock.swift
+++ b/Tests/MLXLMTests/MLXMetalTestLock.swift
@@ -136,25 +136,66 @@ enum MLXMetalTestLock {
 }
 
 private final class ProcessWideMLXTestSemaphore: @unchecked Sendable {
-    private let pointer: UnsafeMutablePointer<sem_t>
+    private static let name = "/vmlx_mlx_lock"
+
+    /// How long to wait for the current holder before treating the semaphore
+    /// as abandoned. Real MLX sections here are well under a second; minutes
+    /// mean the holder is gone.
+    private static let staleAfter: TimeInterval = 90
+
+    private var pointer: UnsafeMutablePointer<sem_t>
 
     init() {
-        let name = "/vmlx_mlx_lock"
+        pointer = Self.open()
+    }
+
+    private static func open() -> UnsafeMutablePointer<sem_t> {
         guard let sem = sem_open(name, O_CREAT, 0o600, 1), sem != SEM_FAILED else {
             fatalError("Unable to create MLX Metal test semaphore")
         }
-        pointer = sem
+        return sem
     }
 
     deinit {
         sem_close(pointer)
     }
 
+    /// Acquire, recovering from a holder that died without signalling.
+    ///
+    /// This is a NAMED POSIX semaphore, so its count outlives the process. A
+    /// test run killed mid-section (Ctrl-C, a CI timeout, a crash) leaves the
+    /// count at zero permanently, and every later run on that machine then
+    /// blocks forever at 0% CPU — including runs that only touch unrelated
+    /// tests, because the whole target shares this lock. Recovering that state
+    /// previously required knowing to call `sem_unlink` by hand.
+    ///
+    /// Poll instead of blocking outright: if nobody releases within
+    /// ``staleAfter``, unlink the abandoned semaphore and reopen a fresh one.
+    /// Unlinking only detaches the name — a live holder keeps its own handle
+    /// and its `signal()` stays valid — so the worst case for a false positive
+    /// is two runs briefly sharing MLX, not a corrupted lock.
     func wait() {
-        while sem_wait(pointer) == -1 {
-            if errno != EINTR {
+        let deadline = Date().addingTimeInterval(Self.staleAfter)
+        while true {
+            if sem_trywait(pointer) == 0 { return }
+            if errno != EAGAIN && errno != EINTR {
                 fatalError("Unable to wait on MLX Metal test semaphore")
             }
+            if Date() >= deadline {
+                FileHandle.standardError.write(
+                    Data(
+                        """
+                        [vmlx-tests] MLX lock \(Self.name) held for >\(Int(Self.staleAfter))s; \
+                        assuming a killed run abandoned it and resetting.
+
+                        """.utf8))
+                sem_unlink(Self.name)
+                sem_close(pointer)
+                pointer = Self.open()
+                if sem_trywait(pointer) == 0 { return }
+                fatalError("Unable to recover abandoned MLX Metal test semaphore")
+            }
+            usleep(20_000)
         }
     }
 

--- a/Tests/MLXLMTests/ReasoningBudgetTests.swift
+++ b/Tests/MLXLMTests/ReasoningBudgetTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+import MLX
+import XCTest
+
+@testable import MLXLMCommon
+
+/// Covers the explicit reasoning ceiling added for the DSV4 Flash runaway:
+/// a spec-heavy prompt on the Low rail produced a 38,494-char think block over
+/// 10,554 tokens, hit `stop=length`, and returned no usable answer.
+///
+/// The properties that matter are (a) it is inert unless asked for, and
+/// (b) while budget remains it does not touch the distribution at all — those
+/// are what separate it from the automatic close bias that
+/// `NoHiddenReasoningCloseBiasFocusedTests` bans.
+class ReasoningBudgetTests: XCTestCase {
+
+    private func logits(_ values: [Float]) -> MLXArray {
+        MLXArray(values).reshaped(1, values.count)
+    }
+
+    // MARK: - Inert by default
+
+    func testParametersDoNotBuildAProcessorWithoutABudget() {
+        var p = GenerateParameters()
+        p.reasoningBudgetCloseTokenID = 7
+        XCTAssertNil(p.reasoningBudgetTokens)
+        XCTAssertNil(p.processor(), "No budget means no processor at all.")
+    }
+
+    func testParametersDoNotBuildAProcessorWithoutACloseToken() {
+        var p = GenerateParameters()
+        p.reasoningBudgetTokens = 4
+        XCTAssertNil(p.processor(), "A budget without a resolved close token stays inert.")
+    }
+
+    func testAZeroBudgetIsInert() {
+        var p = GenerateParameters()
+        p.reasoningBudgetTokens = 0
+        p.reasoningBudgetCloseTokenID = 3
+        XCTAssertNil(p.processor())
+    }
+
+    // MARK: - Pass-through while budget remains
+
+    func testLogitsAreUntouchedWhileBudgetRemains() {
+        var proc = ReasoningBudgetProcessor(closeTokenID: 2, tokenCount: 3)
+        let input = logits([1.0, 5.0, 0.5, -2.0])
+        for step in 0 ..< 3 {
+            let out = proc.process(logits: input)
+            XCTAssertEqual(
+                out.reshaped(-1).asArray(Float.self), [1.0, 5.0, 0.5, -2.0],
+                "Step \(step) must pass logits through unchanged.")
+            XCTAssertFalse(proc.didForceClose)
+            proc.didSample(token: MLXArray(Int32(1)))
+        }
+    }
+
+    // MARK: - Requires the close exactly once, then disarms
+
+    func testCloseIsRequiredOnceTheBudgetIsSpent() {
+        var proc = ReasoningBudgetProcessor(closeTokenID: 2, tokenCount: 1)
+        proc.didSample(token: MLXArray(Int32(9)))  // spends the single token
+
+        let out = proc.process(logits: logits([1.0, 5.0, 0.5, -2.0]))
+        let vals = out.reshaped(-1).asArray(Float.self)
+        XCTAssertEqual(vals[2], 0.5, "The close token keeps its own logit.")
+        for i in [0, 1, 3] {
+            XCTAssertTrue(vals[i] == -Float.infinity, "Token \(i) must be masked.")
+        }
+        XCTAssertEqual(
+            vals.firstIndex(where: { $0 > -Float.infinity }), 2,
+            "Only the close token may survive, so argmax must pick it.")
+    }
+
+    func testBudgetDisarmsAfterForcingSoTheAnswerSamplesNormally() {
+        var proc = ReasoningBudgetProcessor(closeTokenID: 2, tokenCount: 1)
+        proc.didSample(token: MLXArray(Int32(9)))
+        _ = proc.process(logits: logits([1.0, 5.0, 0.5, -2.0]))
+        proc.didSample(token: MLXArray(Int32(2)))  // the forced close
+        XCTAssertTrue(proc.didForceClose)
+
+        let after = proc.process(logits: logits([1.0, 5.0, 0.5, -2.0]))
+        XCTAssertEqual(
+            after.reshaped(-1).asArray(Float.self), [1.0, 5.0, 0.5, -2.0],
+            "Once spent, the answer and any tool call sample untouched.")
+    }
+
+    func testAnOutOfRangeCloseTokenIsIgnoredRatherThanCorrupting() {
+        var proc = ReasoningBudgetProcessor(closeTokenID: 99, tokenCount: 1)
+        proc.didSample(token: MLXArray(Int32(0)))
+        let out = proc.process(logits: logits([1.0, 5.0, 0.5, -2.0]))
+        XCTAssertEqual(
+            out.reshaped(-1).asArray(Float.self), [1.0, 5.0, 0.5, -2.0],
+            "A close id outside the vocab must not blank the distribution.")
+    }
+
+    // MARK: - Arming conditions
+
+    func testOnlyAnOpenReasoningTailArms() {
+        XCTAssertTrue(ReasoningBudget.promptTailOpensReasoning("…assistant<think>"))
+        XCTAssertTrue(ReasoningBudget.promptTailOpensReasoning("<thinking>"))
+        XCTAssertFalse(
+            ReasoningBudget.promptTailOpensReasoning("…</think>"),
+            "The chat rail (already-closed tail) must never arm a budget.")
+        XCTAssertFalse(ReasoningBudget.promptTailOpensReasoning("plain user text"))
+    }
+
+    func testMTPIsRefusedWhileABudgetIsActive() {
+        var p = GenerateParameters(temperature: 0, topP: 1.0, topK: 0)
+        XCTAssertTrue(p.isNativeMTPLosslessGreedyEligible)
+        p.reasoningBudgetTokens = 32
+        XCTAssertFalse(
+            p.isNativeMTPLosslessGreedyEligible,
+            "A drafted token could sail past the ceiling unchecked.")
+    }
+}

--- a/Tests/MLXTests/EmptyArrayDataTests.swift
+++ b/Tests/MLXTests/EmptyArrayDataTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+import MLX
+import XCTest
+
+/// Reproduces the SIGTRAP seen live in `computeMediaSalt` -> `hashMLXArray`
+/// -> `MLXArray.asData(access:)`: the backing data pointer is null for an
+/// array with no elements, and `asData` force-unwraps it.
+class EmptyArrayDataTests: XCTestCase {
+    func testAsDataOnZeroElementArray() {
+        let empty = MLXArray(Array<Float>(), [0])
+        XCTAssertEqual(empty.size, 0)
+        let d = empty.asData(access: .noCopyIfContiguous)
+        XCTAssertEqual(d.data.count, 0)
+    }
+
+    func testAsDataNoCopyOnZeroElementArray() {
+        let empty = MLXArray(Array<Float>(), [0])
+        let d = empty.asData(access: .noCopy)
+        XCTAssertEqual(d.data.count, 0)
+    }
+
+    func testAsDataStillReturnsBytesForANonEmptyArray() {
+        let a = MLXArray([Float(1), 2, 3], [3])
+        let d = a.asData(access: .noCopyIfContiguous)
+        XCTAssertEqual(d.data.count, 3 * MemoryLayout<Float>.size)
+        XCTAssertEqual(a.asData(access: .copy).data.count, 3 * MemoryLayout<Float>.size)
+    }
+
+    func testAsDataOnZeroElementArrayWithNonZeroRank() {
+        let empty = MLXArray(Array<Float>(), [1, 0, 3, 448])
+        XCTAssertEqual(empty.size, 0)
+        let d = empty.asData(access: .noCopyIfContiguous)
+        XCTAssertEqual(d.data.count, 0)
+        let c = empty.asData(access: .copy)
+        XCTAssertEqual(c.data.count, 0)
+    }
+}


### PR DESCRIPTION
DSV4 Flash on the **Low** rail produced a 38,494-character think block over
10,554 tokens, hit `stop=length`, and returned 227 characters of answer.
Reproduced live in the dev app from the reported prompt shape — the same
10,554 token count as the report.

## Sampling was not the cause

Traced out of the running app (`OSAURUS_SAMPLING_TRACE=1`), the real turn ran
at the bundle's own contract:

```
sampling-resolve   bundle{temp=0.6 topP=0.95 topK=0 doSample=true}
sampling-effective temp=0.6 topP=0.95 topK=0 minP=0.0 maxTokens=16384
```

`top_p 0.95` reaches the sampler intact from both `generation_config.json` and
`jang_config.json > chat > sampling_defaults`. `server.json`'s `genTopP: 1`
projects to nil because it equals the shipped default, so it never overrides
the model.

Three plausible causes were ruled out by measurement, not reading: vmlx's
engine default of `topP = 1.0` (never reached); a `LocalGenerationDefaults`
id-lookup returning nil (an artifact — the test process has
`installedModelNames().count == 0`); and `MinimumReasoningFloor` (a 16-token
delay that can only postpone a close).

## There is nothing upstream to port

DeepSeek's own `encoding/encoding_dsv4.py` defines the entire reasoning
control as three prose strings injected once at `index == 0`:

```python
"low":  ""      # empty — nothing is injected at all
"high": "Reasoning Effort: Absolute maximum with no shortcuts permitted.…"
"max":  "Reasoning Effort: Beyond maximum — exhaustive, relentless…"
```

No budget token, no counter, no cap — only `<think>`/`</think>`. That is what
makes DSV4 different from families that bound reasoning structurally
(`enable_thinking`, harmony channels). A ceiling has to be ours.

## The ceiling

`ReasoningBudget` is **off unless asked**:

- Arms only when `VMLX_REASONING_BUDGET` names a positive token count.
- While budget remains it is a pass-through — logits are returned unchanged,
  so there is no nudge toward closing.
- At the ceiling it requires the close token once, then bans reopening for the
  rest of the generation so the ceiling bounds the turn rather than one block.
- Open/close tags are resolved per family by round-tripping candidate
  spellings through the tokenizer (`convertTokenToId` returns the unk id, so
  id existence alone proves nothing). Covers both template-primed reasoning
  (DSV4 renders `…assistant<think>`) and families where the model opens the
  block itself.
- Native MTP is refused while a budget is active: a drafted token could sail
  past the ceiling unchecked.

This is deliberately **not** the mechanism `NoHiddenReasoningCloseBiasFocusedTests`
bans. That one armed itself automatically with nothing surfaced. This one
cannot arm without an explicit opt-in, and that test is extended here to
enforce it: the parameters must default to nil, the engine must arm only
through `armIfNeeded`, the env gate must exist, and no self-arming variant may
be declared.

## Live proof

`VibeThinker-3B-MXFP8` — a family where the **model** emits the open tag, so
this exercises the deferred-start path. Close position tracks the budget
exactly, and is deterministic (same budget twice is byte-identical):

| budget | `</think>` at char | think content |
|---|---|---|
| 4 | 22 | `>The user says:` |
| 8 | 42 | `>The user says: "Reply with exactly` |
| 16 | 76 | `>The user says: "Reply with exactly this phrase and nothing else: vml` |
| 32 | >120 | still open |

```
[vmlx][reasoning-budget] reasoning opened by model; counting
[vmlx][reasoning-budget] requiring close id=151666
[vmlx][reasoning-budget] close required; budget disarmed
```

Two bugs were caught by that measurement and are fixed here: the forced close
never won, because the mask was built by writing a column into a `full(-inf)`
array and `MLXArray` is a class whose subscript assignment aliases; and
nothing stopped the model reopening the block immediately afterwards.

**Measuring note:** the bench's `raw=… chars` counts the WHOLE turn. A tighter
budget shortens thinking and the model then writes a longer visible answer, so
character totals move the wrong way and the ceiling looks inverted. Measure
the `</think>` offset.

## Tests

`ReasoningBudgetTests` 9/9 — inertness without a budget, without a close
token, and at zero; pass-through while budget remains; the close required
exactly once; disarm afterwards so the answer samples normally; an
out-of-range close id ignored rather than blanking the distribution; arming
conditions; and the MTP refusal.

The 3 failures in `NoHiddenReasoningCloseBias` are pre-existing and belong to
"Nemotron Omni image preprocessing" (`NemotronHOmni.swift` /
`Preprocessors.swift`), untouched here.

## Still open, deliberately not in this PR

DeepSeek recommends up to **384K** output tokens for high/max effort; we
resolve `maxTokens=16384`, so a long reason legitimately hits `stop=length`
with no answer. That needs a per-effort max-token policy on the osaurus side.