### PR TITLE
Stop treating harmony's <|end|> channel separator as a generation stop

### DIFF
--- a/Libraries/MLXLMCommon/StopStringMatcher.swift
+++ b/Libraries/MLXLMCommon/StopStringMatcher.swift
@@ -170,6 +170,28 @@ let commonEndTokenStrings: [String] = [
     "<|EOT|>",          // Uppercase EOT variants in some shipped templates
 ]
 
+/// The one `commonEndTokenStrings` entry whose meaning is not universal.
+private let harmonyChannelSeparator = "<|end|>"
+
+/// Tokens that, taken together, identify the OpenAI **harmony** channel format
+/// (gpt-oss). No other shipped family carries all three.
+private let harmonyVocabularyMarkers = ["<|channel|>", "<|message|>", "<|return|>"]
+
+/// True when this bundle's vocabulary is harmony-shaped.
+///
+/// Detected from the VOCABULARY rather than `reasoningParserName`, because the
+/// capability stamp is optional: a locally converted gpt-oss bundle that was
+/// never stamped still needs the right stop set. `convertTokenToId` returns the
+/// unk id for unknown tokens, so id existence alone proves nothing — every
+/// marker is checked against unk.
+private func vocabularyIsHarmonyChannelFormat(_ tokenizer: Tokenizer) -> Bool {
+    harmonyVocabularyMarkers.allSatisfy { marker in
+        guard let id = tokenizer.convertTokenToId(marker) else { return false }
+        if let unknownID = tokenizer.unknownTokenId, id == unknownID { return false }
+        return true
+    }
+}
+
 func mergeStopStrings(_ explicit: [String], _ defaults: [String]) -> [String] {
     var seen = Set<String>()
     var merged: [String] = []
@@ -202,7 +224,31 @@ func resolveStopSequences(
             textStopStrings: &textStopStrings,
             allowExactTextFallback: true)
     }
+    // `<|end|>` is carried by `commonEndTokenStrings` for Phi-3/Phi-4, where it genuinely ends
+    // the turn. In the harmony channel format it means the opposite: the model closes its
+    // `analysis` channel with `<|end|>` and then OPENS `final`, so treating it as a stop halts
+    // generation at the end of the reasoning channel and the visible answer is empty. gpt-oss
+    // says so itself — its `generation_config.json` declares `<|return|>` / `<|call|>` /
+    // `<|endoftext|>` as eos and deliberately omits `<|end|>`.
+    //
+    // Suppress it only on TWO pieces of positive evidence: the vocabulary is harmony-shaped, and
+    // the model's own declaration excludes it. Anything less keeps today's behaviour. In
+    // particular the blanket is NOT skipped wholesale for every declaring bundle: bundles that
+    // declare an incomplete eos are common (VibeThinker-3B declares only `<|endoftext|>` while
+    // its template ends turns with `<|im_end|>`), and the blanket is their only turn boundary.
+    // See `UnderDeclaredEOSStopTests`, which fails against that broader gate.
+    let declaredEOS = Set(modelConfiguration.generationDefaults?.eosTokenIds?.values ?? [])
+    let suppressedHarmonyEnd: Int? = {
+        guard !declaredEOS.isEmpty, vocabularyIsHarmonyChannelFormat(tokenizer),
+            let endID = tokenizer.convertTokenToId(harmonyChannelSeparator),
+            tokenizer.unknownTokenId != endID,
+            !declaredEOS.contains(endID)
+        else { return nil }
+        return endID
+    }()
+
     for token in commonEndTokenStrings {
+        if suppressedHarmonyEnd != nil, token == harmonyChannelSeparator { continue }
         resolveStopTokenString(
             token,
             tokenizer: tokenizer,

--- a/Tests/MLXLMTests/HarmonyChannelSeparatorStopTests.swift
+++ b/Tests/MLXLMTests/HarmonyChannelSeparatorStopTests.swift
@@ -1,0 +1,138 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+/// Pins the one narrow exception to the `commonEndTokenStrings` blanket: `<|end|>` is a turn end
+/// for Phi-3/Phi-4 but a CHANNEL SEPARATOR in the OpenAI harmony format (gpt-oss), where the model
+/// closes its `analysis` channel with `<|end|>` and then opens `final`. Stopping there truncates
+/// the turn at the end of reasoning and the visible answer is empty.
+///
+/// Diagnosis from vmlx-swift#91 (rcfa). That PR fixed it by skipping the blanket for ANY bundle
+/// declaring an eos in `generation_config.json`, which is too broad — see
+/// `UnderDeclaredEOSStopTests`, which fails against it because VibeThinker-3B declares only
+/// `<|endoftext|>` while its template ends turns with `<|im_end|>`. The suppression here instead
+/// requires two independent pieces of positive evidence, so exactly one family is affected.
+@Suite("harmony <|end|> is a channel separator, not a stop")
+struct HarmonyChannelSeparatorStopTests {
+
+    private static let endToken = 200_007  // <|end|>  — channel separator
+    private static let returnToken = 200_002  // <|return|> — real stop
+    private static let callToken = 200_012  // <|call|>   — real stop
+    private static let endOfText = 199_999
+    private static let imEnd = 151_645
+
+    /// Resolves exactly the tokens named in `map`, so a stop that survives survives because it
+    /// resolved — not because the tokenizer said yes to everything.
+    private struct MapTokenizer: MLXLMCommon.Tokenizer {
+        let map: [String: Int]
+        let eos: String?
+
+        var bosToken: String? { nil }
+        var eosToken: String? { eos }
+        var unknownToken: String? { nil }
+
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+        func convertTokenToId(_ token: String) -> Int? { map[token] }
+        func convertIdToToken(_ id: Int) -> String? { map.first { $0.value == id }?.key }
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] { [] }
+    }
+
+    /// A harmony vocabulary: carries the three channel markers plus `<|end|>`.
+    private static func harmonyTokenizer() -> MapTokenizer {
+        MapTokenizer(
+            map: [
+                "<|channel|>": 200_005, "<|message|>": 200_008, "<|return|>": returnToken,
+                "<|end|>": endToken, "<|call|>": callToken, "<|endoftext|>": endOfText,
+            ],
+            eos: "<|return|>")
+    }
+
+    /// A Phi-shaped vocabulary: `<|end|>` present, but NO harmony channel markers.
+    private static func phiTokenizer() -> MapTokenizer {
+        MapTokenizer(map: ["<|end|>": endToken, "<|endoftext|>": endOfText], eos: "<|endoftext|>")
+    }
+
+    /// Mirrors the real load path: `ModelTokenConfigurationResolver.resolvedEOSTokenIds` copies a
+    /// declared `generation_config.json` eos into `eosTokenIds`, so a fixture that sets only
+    /// `generationDefaults` would understate the stop set and test a configuration that never ships.
+    private func configuration(declaring declared: [Int]) -> ModelConfiguration {
+        var configuration = ModelConfiguration(id: "stop-set-fixture")
+        if !declared.isEmpty {
+            configuration.generationDefaults = GenerationConfigFile(
+                eosTokenIds: IntOrIntArray(declared))
+            configuration.eosTokenIds = Set(declared)
+        }
+        return configuration
+    }
+
+    /// The reported bug. Harmony vocab + a declaration that omits `<|end|>` → it must not be a stop.
+    @Test func harmonyEndIsNotAStop() {
+        let resolved = resolveStopSequences(
+            modelConfiguration: configuration(declaring: [Self.returnToken, Self.endOfText, Self.callToken]),
+            tokenizer: Self.harmonyTokenizer())
+
+        #expect(
+            !resolved.tokenIDs.contains(Self.endToken),
+            """
+            <|end|> became a stop for a harmony bundle: generation halts at the end of the \
+            analysis channel and the visible answer is empty.
+            """)
+        #expect(!resolved.textStopStrings.contains("<|end|>"))
+        // The model's own declared stops must still be honoured.
+        #expect(resolved.tokenIDs.contains(Self.returnToken))
+        #expect(resolved.tokenIDs.contains(Self.callToken))
+    }
+
+    /// The non-regression #91's blanket gate did not preserve: a Phi-shaped bundle that declares
+    /// an eos must KEEP `<|end|>`, because there it really is the turn end.
+    @Test func phiKeepsEndAsAStopEvenWhenItDeclaresEOS() {
+        let resolved = resolveStopSequences(
+            modelConfiguration: configuration(declaring: [Self.endOfText]),
+            tokenizer: Self.phiTokenizer())
+
+        #expect(
+            resolved.tokenIDs.contains(Self.endToken),
+            "a Phi-style bundle lost <|end|>, the token its template ends turns with")
+    }
+
+    /// Suppression needs the model's own declaration. A harmony-shaped bundle shipping no
+    /// `generation_config.json` eos falls back to today's blanket rather than guessing.
+    @Test func harmonyWithoutDeclarationKeepsBlanket() {
+        let resolved = resolveStopSequences(
+            modelConfiguration: configuration(declaring: []),
+            tokenizer: Self.harmonyTokenizer())
+
+        #expect(resolved.tokenIDs.contains(Self.endToken))
+    }
+
+    /// And if a harmony bundle ever DOES declare `<|end|>` as eos, that declaration wins.
+    @Test func harmonyDeclaringEndKeepsIt() {
+        let resolved = resolveStopSequences(
+            modelConfiguration: configuration(declaring: [Self.returnToken, Self.endToken]),
+            tokenizer: Self.harmonyTokenizer())
+
+        #expect(resolved.tokenIDs.contains(Self.endToken))
+    }
+
+    /// The blast radius, stated as a test: a Qwen-shaped bundle (no harmony markers) that
+    /// under-declares its eos still gets `<|im_end|>` from the blanket. This is the VibeThinker
+    /// shape that the broader gate broke.
+    @Test func qwenUnderDeclarationUnaffected() {
+        let tokenizer = MapTokenizer(
+            map: ["<|endoftext|>": 151_643, "<|im_end|>": Self.imEnd], eos: "<|endoftext|>")
+        let resolved = resolveStopSequences(
+            modelConfiguration: configuration(declaring: [151_643]),
+            tokenizer: tokenizer)
+
+        #expect(resolved.tokenIDs.contains(Self.imEnd))
+    }
+}


### PR DESCRIPTION
## Problem

`resolveStopSequences` augments every model's stop set with `commonEndTokenStrings`. That list
carries `<|end|>` for **Phi-3 / Phi-4**, where it really is the turn end.

In the **OpenAI harmony** format (gpt-oss) `<|end|>` means the opposite: the model closes its
`analysis` channel with `<|end|>` and then **opens `final`**. Treating it as a stop halts
generation at the end of the reasoning channel, so the visible answer is empty.

gpt-oss says so itself — `generation_config.json` declares `eos_token_id: [200002 <|return|>,
199999 <|endoftext|>, 200012 <|call|>]` and deliberately omits `200007 <|end|>`.

Diagnosis is from #91 (@rcfa). This PR takes that diagnosis with a narrower gate — see below.

## Why not #91's gate

#91 skips the blanket for **any** bundle that declares an eos in `generation_config.json`. That
is too broad: declaring-but-incomplete bundles are common, and for them the blanket is the only
turn boundary.

Scanned the local library — 86 bundles with a `tokenizer_config.json`, resolving each
`commonEndTokenStrings` entry against declared eos ∪ tokenizer eos:

| bundle | declares | tokenizer eos | template ends turns with |
|---|---|---|---|
| `VibeThinker-3B-MXFP8` | `<\|endoftext\|>` | `<\|endoftext\|>` | **`<\|im_end\|>`** |
| `VibeThinker-3B-JANG_4M` | `<\|endoftext\|>` | `<\|endoftext\|>` | **`<\|im_end\|>`** |

Under #91 those lose `<|im_end|>` entirely and every turn runs to the token cap. That is not a
review opinion — `UnderDeclaredEOSStopTests` (already on main) fails against #91:

```
✘ underDeclaredEOSStillStopsAtImEnd() — Expectation failed:
  (resolved.tokenIDs → [151643]).contains(Self.imEnd → 151645)
```

A template-terminator probe does not separate the two cases either: harmony renders **historical**
assistant turns ending in `<|end|>` too, and only *generation* ends at `<|return|>`.

## Fix

Suppress `<|end|>` only on **two** independent pieces of positive evidence:

1. the vocabulary is harmony-shaped — carries `<|channel|>`, `<|message|>` **and** `<|return|>`; and
2. the model's own `generation_config.json` declaration excludes `<|end|>`.

Anything less keeps today's behaviour exactly. The format is detected from the **vocabulary**
rather than `reasoningParserName`, because that stamp is optional — a locally converted gpt-oss
bundle that was never stamped still needs the right stop set.

## Blast radius, measured

Across all **86** installed bundles: **0** are harmony-shaped, and **0** carry `<|end|>` at all.
The change is therefore provably inert for the entire local library — confirmed by A/B below.

## Tests

`HarmonyChannelSeparatorStopTests` — 5 tests pinning both sides of the gate:

- harmony vocab + declaration omitting `<|end|>` → not a stop *(the bug)*
- **Phi-shaped vocab + a declared eos → `<|end|>` IS still a stop** *(the non-regression #91 lost)*
- harmony vocab, no declaration → blanket still applies
- harmony vocab that *does* declare `<|end|>` → declaration wins
- Qwen-shaped under-declaration → `<|im_end|>` still resolved

Fixture mirrors the real load path: `ModelTokenConfigurationResolver.resolvedEOSTokenIds` copies a
declared eos into `eosTokenIds`, so a fixture setting only `generationDefaults` would understate
the stop set.

**Sabotage-checked.** Reverting only `StopStringMatcher.swift` and keeping the tests:
```
✘ harmonyEndIsNotAStop() — (resolved.tokenIDs → [200002, 200007, 200012, 199999]).contains(200007)
```
The other four pass on both sides, which is what a correctly-scoped pin should do.

`swift test --filter 'HarmonyChannelSeparatorStopTests|UnderDeclaredEOSStopTests|StopStringMatcherTests|Gemma4StaleEOSTests'` → **30/30 pass**.