### PR TITLE
Fix JANG semantic-width quantization precedence (supersedes #159)

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -1892,10 +1892,10 @@ public final class LLMModelFactory: ModelFactory {
             for: templateResolvedDir)
         async let tokenizerTask = tokenizerLoader.load(from: tokenizerDirectory)
 
-        // When JANG, skip config.json's perLayerQuantization — JANG infers correct
-        // per-layer bits from tensor shapes. This avoids creating QuantizedLinear at
-        // the wrong bit width (which can't be re-quantized later).
-        // BUT: still pass `quantization` (the global config.json group_size /
+        // For JANG, pass config.json's per-layer metadata as declared evidence;
+        // loadWeights validates it against exact manifests, semantic widths, and
+        // tensor geometry before constructing QuantizedLinear modules.
+        // Also pass `quantization` (the global config.json group_size /
         // bits) so JangLoader.inferPerLayerQuantization gets the correct
         // `knownGroupSize` even when jang_config.json doesn't carry quant
         // metadata (e.g. DSV4-Flash bundles ship `weight_format: "bf16"`).
@@ -1903,10 +1903,9 @@ public final class LLMModelFactory: ModelFactory {
             modelDirectory: modelDirectory, model: model,
             quantization: jangConfig != nil ? baseConfig.quantizationContainer?.quantization : nil,
             // 2026-04-28: pass perLayerQuantization through even when JANG;
-            // loadWeights merges config.json's explicit per-layer dict on
-            // top of the shape walk to fix mis-inference of (bits, gs) pairs
-            // that share a packed shape (e.g., (4,64) ≡ (8,32)). Closes
-            // Cascade-2 JANG_4M / Nemotron-Omni MXFP4 first-prefill rmsNorm.
+            // loadWeights treats config.json's explicit per-layer dict as
+            // declared evidence, then validates it against exact manifests,
+            // semantic widths, and packed tensor geometry.
             perLayerQuantization: baseConfig.perLayerQuantization,
             jangConfig: jangConfig,
             loadPreservedMTP: loadNativeMTP)

--- a/Libraries/MLXLMCommon/BaseConfiguration.swift
+++ b/Libraries/MLXLMCommon/BaseConfiguration.swift
@@ -99,6 +99,25 @@ public struct BaseConfiguration: Codable, Sendable {
             return nil
         }
 
+        /// True when ANY spelling of `layer` is declared `.skip`.
+        ///
+        /// A bundle that declares one spelling `.quantize` and another `.skip`
+        /// for the same tensor is self-contradictory. `explicitQuantizationOption`
+        /// resolves that by candidate ORDER, which silently makes the answer a
+        /// property of the alias list rather than of the bundle. Callers that use
+        /// a declaration to disambiguate an otherwise-ambiguous packed width ask
+        /// this first, so contradictory metadata is set aside and the width is
+        /// derived from the tensors instead — geometry cannot go stale, and a
+        /// declaration that disagrees with itself has already proven it can.
+        func declaresSkipForAnyAlias(of layer: String) -> Bool {
+            for candidate in Self.layerPathCandidates(layer) {
+                if case .skip? = perLayerQuantization[candidate] {
+                    return true
+                }
+            }
+            return false
+        }
+
         /// The quantization to apply for the given layer name or nil for no quantization.
         public func quantization(layer: String) -> Quantization? {
             if let perLayer = explicitQuantizationOption(layer: layer) {

--- a/Libraries/MLXLMCommon/JangLoader.swift
+++ b/Libraries/MLXLMCommon/JangLoader.swift
@@ -2181,29 +2181,40 @@ public struct JangLoader: Sendable {
             return nil
         }
 
-        func declaredQuantization(for basePath: String) -> BaseConfiguration.Quantization? {
-            func variants(_ key: String) -> [String] {
-                var out = [key]
-                if key.contains(".attn.") || key.hasSuffix(".attn") {
-                    out.append(key.replacingOccurrences(of: ".attn.", with: ".self_attn."))
-                    if key.hasSuffix(".attn") {
-                        out.append(String(key.dropLast(".attn".count)) + ".self_attn")
-                    }
+        func declaredPathVariants(_ key: String) -> [String] {
+            var out = [key]
+            if key.contains(".attn.") || key.hasSuffix(".attn") {
+                out.append(key.replacingOccurrences(of: ".attn.", with: ".self_attn."))
+                if key.hasSuffix(".attn") {
+                    out.append(String(key.dropLast(".attn".count)) + ".self_attn")
                 }
-                if key.hasPrefix("language_model.model.") {
-                    out.append(String(key.dropFirst("language_model.".count)))
-                } else if key.hasPrefix("language_model.") {
-                    out.append(String(key.dropFirst("language_model.".count)))
-                } else {
-                    out.append("model.\(key)")
-                    out.append("language_model.\(key)")
-                    out.append("language_model.model.\(key)")
-                }
-                return Array(Set(out))
             }
+            if key.hasPrefix("language_model.model.") {
+                out.append(String(key.dropFirst("language_model.".count)))
+            } else if key.hasPrefix("language_model.") {
+                out.append(String(key.dropFirst("language_model.".count)))
+            } else {
+                out.append("model.\(key)")
+                out.append("language_model.\(key)")
+                out.append("language_model.model.\(key)")
+            }
+            return Array(Set(out))
+        }
 
+        func declaredSpecificQuantization(
+            for basePath: String
+        ) -> BaseConfiguration.Quantization? {
             if let declaredPerLayerQuantization {
-                for key in variants(basePath) {
+                let variants = declaredPathVariants(basePath)
+                if variants.contains(where: {
+                    if case .skip? = declaredPerLayerQuantization.perLayerQuantization[$0] {
+                        return true
+                    }
+                    return false
+                }) {
+                    return nil
+                }
+                for key in variants {
                     if let declared = declaredPerLayerQuantization.perLayerQuantization[key] {
                         switch declared {
                         case .quantize(let quantization):
@@ -2217,6 +2228,24 @@ public struct JangLoader: Sendable {
             if let roleBits = declaredMXTQRoleBits(for: basePath) {
                 return BaseConfiguration.Quantization(
                     groupSize: groupSize, bits: roleBits, mode: defaultMode)
+            }
+            return nil
+        }
+
+        func hasDeclaredSkip(for basePath: String) -> Bool {
+            guard let declaredPerLayerQuantization else { return false }
+            for key in declaredPathVariants(basePath) {
+                if case .skip? = declaredPerLayerQuantization.perLayerQuantization[key] {
+                    return true
+                }
+            }
+            return false
+        }
+
+        func declaredQuantization(for basePath: String) -> BaseConfiguration.Quantization? {
+            guard !hasDeclaredSkip(for: basePath) else { return nil }
+            if let declared = declaredSpecificQuantization(for: basePath) {
+                return declared
             }
             return declaredPerLayerQuantization?.quantization
                 ?? declaredDefaultQuantization
@@ -2271,10 +2300,11 @@ public struct JangLoader: Sendable {
             let numGroups = scalesArray.shape.last ?? 1
             let (bits, inferredGroupSize): (Int, Int)
 
-            let isHiddenAnchor =
-                basePath.hasSuffix("embed_tokens")
-                || basePath.hasSuffix("embed")
-                || basePath.hasSuffix("lm_head")
+            let isLanguageHiddenAnchor =
+                basePath == "embed_tokens"
+                || basePath.hasSuffix(".embed_tokens")
+                || basePath == "lm_head"
+                || basePath.hasSuffix(".lm_head")
             let isHiddenInputProjection =
                 basePath.hasSuffix(".linear_attn.in_proj_qkv")
                 || basePath.hasSuffix(".linear_attn.in_proj_z")
@@ -2294,6 +2324,8 @@ public struct JangLoader: Sendable {
                 || basePath.hasSuffix(".switch_glu.up_proj")
                 || basePath.hasSuffix(".shared_expert.gate_proj")
                 || basePath.hasSuffix(".shared_expert.up_proj")
+                || basePath.hasSuffix(".shared_experts.gate_proj")
+                || basePath.hasSuffix(".shared_experts.up_proj")
             let isMTPFusionFC =
                 basePath.hasSuffix(".mtp.fc")
                 || basePath.hasSuffix("mtp.fc")
@@ -2345,17 +2377,67 @@ public struct JangLoader: Sendable {
                 return (first.bits, first.groupSize)
             }
 
-            // Trust the bundle's EXPLICIT declared per-module quant when it unpacks the
-            // real `.weight`/`.scales` to an inputDim that is a known model dimension.
+            func inferExactQuantization(
+                expectedInDim: Int
+            ) -> (bits: Int, groupSize: Int)? {
+                guard packedDim > 0, numGroups > 0, expectedInDim > 0 else {
+                    return nil
+                }
+                let packedBits = packedDim * 32
+                guard packedBits % expectedInDim == 0,
+                    expectedInDim % numGroups == 0
+                else {
+                    return nil
+                }
+                let bits = packedBits / expectedInDim
+                let inferredGroupSize = expectedInDim / numGroups
+                guard [2, 3, 4, 5, 6, 8].contains(bits),
+                    [32, 64, 128].contains(inferredGroupSize)
+                else {
+                    return nil
+                }
+                return (bits, inferredGroupSize)
+            }
+
+            // Exact manifests are authoritative. Language anchors and projections
+            // with a known semantic input width precede per-path declarations: their
+            // packed geometry must realize hidden_size exactly. A stale declaration
+            // can otherwise look self-consistent against another valid model width
+            // (for example a routed gate/up input of 3072 misread as the 1536 expert
+            // width). Keep roles without an exact semantic width after per-path
+            // metadata but before a generic top-level default.
+            // This avoids treating vision paths such as `visual.pos_embed` as language
+            // anchors and avoids falling back to an unrelated generic pair when an
+            // expected hidden width cannot be represented by the tensor shapes.
+            //
+            // Otherwise trust the bundle's EXPLICIT declared per-module quant when it
+            // unpacks the real `.weight`/`.scales` to a known model dimension.
             // On ambiguous packed widths (512 → bits ∈ {2,4,8}) the shape walk can pick
             // a different, WRONG bit width: Laguna-M.1 ships 4-bit dense MLP, the walk
             // re-stamped 8-bit, and the 4-bit weights dequantized to a degenerate (empty)
             // output that collapsed the forward. A self-consistent declaration whose
-            // inputDim ∈ validInDims is the author's verified intent. A genuinely stale
-            // config (claims 8-bit for 4-bit-packed) unpacks to a NON-model inputDim,
-            // fails this check, and still falls through to the shape walk.
+            // inputDim ∈ validInDims is the strongest available evidence for roles
+            // without a more specific tensor manifest or semantic width constraint.
             if let manifest = manifestQuantization(for: basePath) {
                 (bits, inferredGroupSize) = (manifest.bits, manifest.groupSize)
+            } else if isLanguageHiddenAnchor,
+                      let hiddenSize = hiddenSizeHint,
+                      let exact = inferExactQuantization(expectedInDim: hiddenSize)
+            {
+                (bits, inferredGroupSize) = exact
+            } else if isHiddenInputProjection,
+                      let hiddenSize = hiddenSizeHint,
+                      let exact = inferExactQuantization(expectedInDim: hiddenSize)
+            {
+                (bits, inferredGroupSize) = exact
+            } else if let dq = declaredSpecificQuantization(for: basePath),
+               dq.bits > 0, numGroups > 0, (packedDim * 32) % dq.bits == 0,
+               case let declaredInputDim = (packedDim * 32) / dq.bits,
+               declaredInputDim % numGroups == 0,
+               declaredInputDim / numGroups == dq.groupSize,
+               validInDims.contains(declaredInputDim)
+            {
+                (bits, inferredGroupSize) = (dq.bits, dq.groupSize)
             } else if let dq = declaredQuantization(for: basePath),
                dq.bits > 0, numGroups > 0, (packedDim * 32) % dq.bits == 0,
                case let declaredInputDim = (packedDim * 32) / dq.bits,
@@ -2364,15 +2446,6 @@ public struct JangLoader: Sendable {
                validInDims.contains(declaredInputDim)
             {
                 (bits, inferredGroupSize) = (dq.bits, dq.groupSize)
-            } else if (isHiddenAnchor || isHiddenInputProjection),
-               let hiddenSize = hiddenSizeHint, hiddenSize > 0
-            {
-                (bits, inferredGroupSize) = inferBitWidthAndGroupSize(
-                    packedDim: packedDim,
-                    numGroups: numGroups,
-                    knownGroupSize: groupSize,
-                    bitWidthsUsed: bitWidthsUsed,
-                    expectedInDim: hiddenSize)
             } else if isMTPFusionFC,
                       let hiddenSize = hiddenSizeHint, hiddenSize > 0
             {

--- a/Libraries/MLXLMCommon/JangLoader.swift
+++ b/Libraries/MLXLMCommon/JangLoader.swift
@@ -2266,7 +2266,15 @@ public struct JangLoader: Sendable {
             let (bits, inferredGroupSize): (Int, Int)
             let declaredForLayer = declaredQuantization(for: basePath)
             let explicitForLayer: BaseConfiguration.Quantization? = {
-                guard let explicit = declaredPerLayerQuantization?
+                guard let declaredPerLayerQuantization else { return nil }
+                // Contradictory aliases (one spelling `.quantize`, another
+                // `.skip`) make the declaration a coin flip decided by candidate
+                // order. Set it aside so the packed width is resolved from the
+                // tensors instead — see `declaresSkipForAnyAlias`.
+                guard !declaredPerLayerQuantization
+                    .declaresSkipForAnyAlias(of: basePath)
+                else { return nil }
+                guard let explicit = declaredPerLayerQuantization
                     .explicitQuantizationOption(layer: basePath)
                 else { return nil }
                 guard case .quantize(let quantization) = explicit else { return nil }

--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -381,10 +381,10 @@ public func loadWeights(
         // the authoritative prior — see `JangLoader.swift` for the
         // root-cause writeup of the (8, 32) ≡ (4, 64) shape ambiguity
         // that crashed Cascade-2 JANG_4M / Nemotron-Omni MXFP4 with
-        // mid-prefill rmsNorm. We do NOT merge config.json's per-layer
-        // dict here because that dict can be HF-tooling-stale (claims
-        // `(gs=32, bits=8)` for layers actually packed at `(gs=64,
-        // bits=4)`) and would re-introduce the wrong values.
+        // mid-prefill rmsNorm. Config.json's per-layer dictionary is passed
+        // through as evidence, but the shape walk accepts an entry only when
+        // it is geometrically self-consistent and no exact manifest or
+        // narrowly defined semantic-width constraint has higher precedence.
         let hiddenHint = readHiddenSizeHint(at: modelDirectory)
         let hiddenSizePerLayerInputHint = readHiddenSizePerLayerInputHint(at: modelDirectory)
         let linearAttnValueDimHint = readLinearAttnValueDimHint(at: modelDirectory)

--- a/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
@@ -1427,6 +1427,332 @@ struct MTPRuntimeFocusedTests {
         #expect(inferred?.perLayerQuantization["language_model.model.embed_tokens"] == nil)
     }
 
+    @Test("JANG hidden anchor overrides stale quantization metadata")
+    func jangHiddenAnchorOverridesStaleQuantizationMetadata() {
+        FocusedMLXTestSupport.withLock {
+            let base = "model.embed_tokens"
+            let weights: [String: MLXArray] = [
+                "\(base).weight": MLXArray.zeros([200_064, 384], dtype: .uint32),
+                "\(base).scales": MLXArray.zeros([200_064, 24], dtype: .float16),
+                "\(base).biases": MLXArray.zeros([200_064, 24], dtype: .float16),
+            ]
+            let stale = BaseConfiguration.PerLayerQuantization(
+                quantization: BaseConfiguration.Quantization(
+                    groupSize: 128, bits: 8, mode: .affine),
+                perLayerQuantization: [
+                    base: .quantize(BaseConfiguration.Quantization(
+                        groupSize: 64, bits: 8, mode: .affine))
+                ])
+
+            let inferred = JangLoader.inferPerLayerQuantization(
+                weights: weights,
+                jangConfig: JangConfig(
+                    quantization: JangQuantization(
+                        blockSize: 128,
+                        bitWidthsUsed: [3, 4, 8])),
+                hiddenSizeHint: 3_072,
+                validInDims: [1_536, 3_072],
+                declaredDefaultQuantization: stale.quantization,
+                declaredPerLayerQuantization: stale)
+
+            guard case .quantize(let actual)? = inferred.perLayerQuantization[base] else {
+                Issue.record("Expected shape-derived hidden-anchor quantization override")
+                return
+            }
+            #expect(actual.bits == 4)
+            #expect(actual.groupSize == 128)
+        }
+    }
+
+    @Test("JANG hidden-input projections override width-colliding metadata")
+    func jangHiddenInputProjectionsOverrideWidthCollidingMetadata() {
+        FocusedMLXTestSupport.withLock {
+            let gate = "model.layers.0.block_sparse_moe.switch_mlp.gate_proj"
+            let up = "model.layers.0.block_sparse_moe.switch_mlp.up_proj"
+            let sharedGate = "model.layers.0.mlp.shared_experts.gate_proj"
+            let sharedUp = "model.layers.0.mlp.shared_experts.up_proj"
+            var weights = [String: MLXArray]()
+            for base in [gate, up, sharedGate, sharedUp] {
+                weights["\(base).weight"] = MLXArray.zeros(
+                    [256, 1_536, 288], dtype: .uint32)
+                weights["\(base).scales"] = MLXArray.zeros(
+                    [256, 1_536, 24], dtype: .float16)
+                weights["\(base).biases"] = MLXArray.zeros(
+                    [256, 1_536, 24], dtype: .float16)
+            }
+            let staleProjection = BaseConfiguration.Quantization(
+                groupSize: 64, bits: 6, mode: .affine)
+            let declared = BaseConfiguration.PerLayerQuantization(
+                quantization: BaseConfiguration.Quantization(
+                    groupSize: 128, bits: 8, mode: .affine),
+                perLayerQuantization: [
+                    gate: .quantize(staleProjection),
+                    up: .quantize(staleProjection),
+                    sharedGate: .quantize(staleProjection),
+                    sharedUp: .quantize(staleProjection),
+                ])
+
+            let inferred = JangLoader.inferPerLayerQuantization(
+                weights: weights,
+                jangConfig: JangConfig(
+                    quantization: JangQuantization(
+                        blockSize: 128,
+                        bitWidthsUsed: [3, 4, 8])),
+                hiddenSizeHint: 3_072,
+                expertIntermediateSizeHint: 1_536,
+                validInDims: [1_536, 3_072],
+                declaredDefaultQuantization: declared.quantization,
+                declaredPerLayerQuantization: declared)
+
+            for base in [gate, up, sharedGate, sharedUp] {
+                guard case .quantize(let actual)? = inferred.perLayerQuantization[base] else {
+                    Issue.record("Expected hidden-width override for \(base)")
+                    continue
+                }
+                #expect(actual.bits == 3)
+                #expect(actual.groupSize == 128)
+            }
+        }
+    }
+
+    @Test("JANG vision position embedding does not inherit language hidden width")
+    func jangVisionPositionEmbeddingDoesNotInheritLanguageHiddenWidth() {
+        FocusedMLXTestSupport.withLock {
+            let base = "visual.pos_embed"
+            let weights: [String: MLXArray] = [
+                "\(base).weight": MLXArray.zeros([16, 384], dtype: .uint32),
+                "\(base).scales": MLXArray.zeros([16, 24], dtype: .float16),
+                "\(base).biases": MLXArray.zeros([16, 24], dtype: .float16),
+            ]
+            let declared = BaseConfiguration.Quantization(
+                groupSize: 64, bits: 8, mode: .affine)
+
+            let inferred = JangLoader.inferPerLayerQuantization(
+                weights: weights,
+                jangConfig: JangConfig(
+                    quantization: JangQuantization(
+                        blockSize: 64,
+                        bitWidthsUsed: [4, 8])),
+                hiddenSizeHint: 3_072,
+                validInDims: [1_536, 3_072],
+                declaredDefaultQuantization: declared)
+
+            guard case .quantize(let actual)? = inferred.perLayerQuantization[base] else {
+                Issue.record("Expected generic vision position-embedding quantization")
+                return
+            }
+            #expect(actual.bits == 8)
+            #expect(actual.groupSize == 64)
+        }
+    }
+
+    @Test("JANG declared skip blocks generic metadata before specialized geometry")
+    func jangDeclaredSkipBlocksGenericMetadataBeforeSpecializedGeometry() {
+        FocusedMLXTestSupport.withLock {
+            let base = "model.layers.0.linear_attn.out_proj"
+            let weights: [String: MLXArray] = [
+                "\(base).weight": MLXArray.zeros([16, 384], dtype: .uint32),
+                "\(base).scales": MLXArray.zeros([16, 24], dtype: .float16),
+            ]
+            let declared = BaseConfiguration.PerLayerQuantization(
+                quantization: BaseConfiguration.Quantization(
+                    groupSize: 64, bits: 8, mode: .affine),
+                perLayerQuantization: [base: .skip])
+
+            let inferred = JangLoader.inferPerLayerQuantization(
+                weights: weights,
+                jangConfig: JangConfig(
+                    quantization: JangQuantization(
+                        blockSize: 64,
+                        bitWidthsUsed: [4, 8])),
+                linearAttnValueDimHint: 3_072,
+                validInDims: [1_536, 3_072],
+                declaredDefaultQuantization: declared.quantization,
+                declaredPerLayerQuantization: declared)
+
+            guard case .quantize(let actual)? = inferred.perLayerQuantization[base] else {
+                Issue.record("Expected specialized geometry after the declared skip")
+                return
+            }
+            #expect(actual.bits == 4)
+            #expect(actual.groupSize == 128)
+        }
+    }
+
+    @Test("JANG declared skip wins across contradictory path aliases")
+    func jangDeclaredSkipWinsAcrossContradictoryPathAliases() {
+        FocusedMLXTestSupport.withLock {
+            let base = "language_model.model.layers.0.linear_attn.out_proj"
+            let alias = "model.layers.0.linear_attn.out_proj"
+            let weights: [String: MLXArray] = [
+                "\(base).weight": MLXArray.zeros([16, 384], dtype: .uint32),
+                "\(base).scales": MLXArray.zeros([16, 24], dtype: .float16),
+            ]
+            let declared = BaseConfiguration.PerLayerQuantization(
+                quantization: BaseConfiguration.Quantization(
+                    groupSize: 64, bits: 8, mode: .affine),
+                perLayerQuantization: [
+                    base: .quantize(BaseConfiguration.Quantization(
+                        groupSize: 64, bits: 8, mode: .affine)),
+                    alias: .skip,
+                ])
+
+            let inferred = JangLoader.inferPerLayerQuantization(
+                weights: weights,
+                jangConfig: JangConfig(
+                    quantization: JangQuantization(
+                        blockSize: 64,
+                        bitWidthsUsed: [4, 8])),
+                linearAttnValueDimHint: 3_072,
+                validInDims: [1_536, 3_072],
+                declaredDefaultQuantization: declared.quantization,
+                declaredPerLayerQuantization: declared)
+
+            guard case .quantize(let actual)? = inferred.perLayerQuantization[base] else {
+                Issue.record("Expected specialized geometry after the aliased skip")
+                return
+            }
+            #expect(actual.bits == 4)
+            #expect(actual.groupSize == 128)
+        }
+    }
+
+    @Test("JANG hidden anchor preserves declaration when hidden width is unrealizable")
+    func jangHiddenAnchorPreservesDeclarationWhenHiddenWidthIsUnrealizable() {
+        FocusedMLXTestSupport.withLock {
+            let base = "model.embed_tokens"
+            let weights: [String: MLXArray] = [
+                "\(base).weight": MLXArray.zeros([16, 256], dtype: .uint32),
+                "\(base).scales": MLXArray.zeros([16, 16], dtype: .float16),
+            ]
+            let declared = BaseConfiguration.PerLayerQuantization(
+                quantization: BaseConfiguration.Quantization(
+                    groupSize: 64, bits: 8, mode: .affine),
+                perLayerQuantization: [
+                    base: .quantize(BaseConfiguration.Quantization(
+                        groupSize: 128, bits: 4, mode: .affine))
+                ])
+
+            let inferred = JangLoader.inferPerLayerQuantization(
+                weights: weights,
+                jangConfig: JangConfig(
+                    quantization: JangQuantization(
+                        blockSize: 64,
+                        bitWidthsUsed: [4, 8])),
+                hiddenSizeHint: 3_072,
+                validInDims: [2_048, 3_072],
+                declaredDefaultQuantization: declared.quantization,
+                declaredPerLayerQuantization: declared)
+
+            guard case .quantize(let actual)? = inferred.perLayerQuantization[base] else {
+                Issue.record("Expected the realizable declaration to be preserved")
+                return
+            }
+            #expect(actual.bits == 4)
+            #expect(actual.groupSize == 128)
+        }
+    }
+
+    @Test("JANG exact manifest precedes hidden-anchor semantics")
+    func jangExactManifestPrecedesHiddenAnchorSemantics() {
+        FocusedMLXTestSupport.withLock {
+            let base = "model.embed_tokens"
+            let weights: [String: MLXArray] = [
+                "\(base).weight": MLXArray.zeros([16, 384], dtype: .uint32),
+                "\(base).scales": MLXArray.zeros([16, 24], dtype: .float16),
+            ]
+            let exact = BaseConfiguration.Quantization(
+                groupSize: 64, bits: 8, mode: .affine)
+
+            let inferred = JangLoader.inferPerLayerQuantization(
+                weights: weights,
+                jangConfig: JangConfig(
+                    quantization: JangQuantization(
+                        blockSize: 128,
+                        bitWidthsUsed: [4, 8])),
+                hiddenSizeHint: 3_072,
+                validInDims: [1_536, 3_072],
+                declaredManifestQuantization: [base: exact])
+
+            guard case .quantize(let actual)? = inferred.perLayerQuantization[base] else {
+                Issue.record("Expected exact manifest quantization")
+                return
+            }
+            #expect(actual == exact)
+        }
+    }
+
+    @Test("JANG missing hidden-size hint disables semantic override")
+    func jangMissingHiddenSizeHintDisablesSemanticOverride() {
+        FocusedMLXTestSupport.withLock {
+            let base = "model.embed_tokens"
+            let weights: [String: MLXArray] = [
+                "\(base).weight": MLXArray.zeros([16, 384], dtype: .uint32),
+                "\(base).scales": MLXArray.zeros([16, 24], dtype: .float16),
+            ]
+            let declared = BaseConfiguration.PerLayerQuantization(
+                quantization: BaseConfiguration.Quantization(
+                    groupSize: 128, bits: 4, mode: .affine),
+                perLayerQuantization: [
+                    base: .quantize(BaseConfiguration.Quantization(
+                        groupSize: 64, bits: 8, mode: .affine))
+                ])
+
+            let inferred = JangLoader.inferPerLayerQuantization(
+                weights: weights,
+                jangConfig: JangConfig(
+                    quantization: JangQuantization(
+                        blockSize: 128,
+                        bitWidthsUsed: [4, 8])),
+                validInDims: [1_536, 3_072],
+                declaredDefaultQuantization: declared.quantization,
+                declaredPerLayerQuantization: declared)
+
+            guard case .quantize(let actual)? = inferred.perLayerQuantization[base] else {
+                Issue.record("Expected declared quantization without a hidden-size hint")
+                return
+            }
+            #expect(actual.bits == 8)
+            #expect(actual.groupSize == 64)
+        }
+    }
+
+    @Test("JANG lm_head uses uniquely realizable hidden width")
+    func jangLMHeadUsesUniquelyRealizableHiddenWidth() {
+        FocusedMLXTestSupport.withLock {
+            let base = "lm_head"
+            let weights: [String: MLXArray] = [
+                "\(base).weight": MLXArray.zeros([200_064, 384], dtype: .uint32),
+                "\(base).scales": MLXArray.zeros([200_064, 24], dtype: .float16),
+            ]
+            let stale = BaseConfiguration.PerLayerQuantization(
+                quantization: BaseConfiguration.Quantization(
+                    groupSize: 128, bits: 8, mode: .affine),
+                perLayerQuantization: [
+                    base: .quantize(BaseConfiguration.Quantization(
+                        groupSize: 64, bits: 8, mode: .affine))
+                ])
+
+            let inferred = JangLoader.inferPerLayerQuantization(
+                weights: weights,
+                jangConfig: JangConfig(
+                    quantization: JangQuantization(
+                        blockSize: 128,
+                        bitWidthsUsed: [4, 8])),
+                hiddenSizeHint: 3_072,
+                validInDims: [1_536, 3_072],
+                declaredDefaultQuantization: stale.quantization,
+                declaredPerLayerQuantization: stale)
+
+            guard case .quantize(let actual)? = inferred.perLayerQuantization[base] else {
+                Issue.record("Expected hidden-width lm_head quantization")
+                return
+            }
+            #expect(actual.bits == 4)
+            #expect(actual.groupSize == 128)
+        }
+    }
+
     @Test("shape-walk quantization uses Gemma4 PLE input width")
     func shapeWalkQuantizationUsesGemma4PLEInputWidth() {
         let projection = "language_model.model.layers.0.per_layer_projection"


### PR DESCRIPTION
Carries #159 (@mimeding) forward onto current `main`, which has moved under it. Same thesis:
**architecture-derived geometry should outrank stale per-path metadata**, not the reverse.

## What changed vs #159

`main` gained a centralized `PerLayerQuantization.explicitQuantizationOption` /
`layerPathCandidates` that already normalizes `model.` prefixes, attention aliases and the DSV4
shared-expert rename in one place. #159's parallel `declaredPathVariants` / `declaredSpecificQuantization`
lookup duplicates that (and orders its candidates through `Array(Set(...))`, which is not stable),
so this keeps main's helper and layers on only what main genuinely lacks:

1. **Precedence.** The exact-width branches for the language hidden anchor and hidden-input
   projections now run **before** the declared-metadata branch. Previously a stale declaration that
   happened to width-collide with the packed tensors won over the architecture's own `hidden_size`.
2. **Anchor tightening.** `isHiddenAnchor` matched `basePath.hasSuffix("embed")`, which also catches
   **`vision_tower.pos_embed`** — a vision tensor forced onto the language `hidden_size`. Now
   restricted to `embed_tokens` / `lm_head` spellings.
3. **Contradictory aliases.** #159's `hasDeclaredSkip` rule is re-expressed on main's helper as
   `declaresSkipForAnyAlias`. When one spelling declares `.quantize` and another `.skip`, the winner
   used to be decided by candidate *order* — a property of the alias list, not the bundle. That
   declaration is now set aside and the width comes from the tensors.

#159's test for (3) is kept and passes against this implementation.

## The DSV4 scare, checked

Claim (2) looked dangerous: DSV4-Flash's language embedding is literally named `embed`
(`embed.weight` + `embed.scales`, quantized, and the bundle has **no** `lm_head`), so tightening the
anchor looked like it would drop the flagship's embedding.

It does not — the shape walk sees **runtime** module paths, not checkpoint names, and DSV4's `embed`
arrives already renamed to `model.embed_tokens`. Verified directly rather than reasoned about:
```
[QDUMP] model.embed_tokens bits=8 gs=64
```

## Blast radius, measured per layer

Count-level equality is not proof, so I dumped the **full resolved per-layer quantization map** on
both sides (temporary `VMLX_QUANT_DUMP` instrumentation, not committed) and diffed:

| bundle | layers | result |
|---|---|---|
| `LFM2.5-VL-3B-JANG_4M` | 169 | IDENTICAL |
| `Ornith-1.0-9B-JANG_6M` | 250 | IDENTICAL |
| `LFM2.5-2.6B-JANG_6M` | 167 | IDENTICAL |
| `VibeThinker-3B-JANG_4M` | 253 | IDENTICAL |
| `DeepSeek-V4-Flash-0731-JANG-CRACK` | 641 | IDENTICAL |

1,480 layers, zero differences. Since the resolved quant map is bit-identical, the loaded weights
are identical and generation cannot diverge.

## Is the fix even reachable?

Worth stating, because a guard that is correct but never reached is worth nothing. Scanning tensor
manifests across 76 bundles, **13** carry a `*embed` path that is not `embed_tokens` — 11×
`vision_tower.pos_embed` (Ornith 9B/35B, Bonsai 27b, Qwen3.6 family) plus DSV4's `embed`.

So the mis-anchor is reachable in principle. In practice today it changes nothing: `pos_embed` is
not quantized, so it never enters the shape walk, and DSV4's path is renamed before it gets there.
This is therefore **latent-defect hardening**, not an observable fix — a VL bundle that *did* ship a
quantized `pos_embed` would be mis-anchored on `main` today.

## Tests

`swift test --filter 'MTPRuntimeFocusedTests|DSV4 segmented pool quantization'` → **92/92 pass**,
including #159's 326 lines of new coverage (anchor, manifest, alias, vision, routed-expert).