### PR TITLE
Expose native-MTP per-generation stats on GenerateCompletionInfo (supersedes #131)

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -945,6 +945,7 @@ public protocol TokenIteratorProtocol: Sequence, IteratorProtocol where Element 
     var promptPrefillTime: TimeInterval { get }
     var promptTokenIds: [Int] { get }
     var turboQuantCompressionCount: Int { get }
+    var nativeMTPStats: NativeMTPGenerationStats? { get }
     mutating func storeCacheAfterGeneration(
         generatedTokenIds: [Int],
         includeGeneratedBoundary: Bool)
@@ -953,6 +954,7 @@ public protocol TokenIteratorProtocol: Sequence, IteratorProtocol where Element 
 extension TokenIteratorProtocol {
     public var promptTokenIds: [Int] { [] }
     public var turboQuantCompressionCount: Int { 0 }
+    public var nativeMTPStats: NativeMTPGenerationStats? { nil }
 
     public mutating func storeCacheAfterGeneration(
         generatedTokenIds: [Int],
@@ -3523,15 +3525,6 @@ private func generateLoopTask<Handler: TokenLoopHandler>(
             MLXPressGenerationProfile.dumpAndReset(
                 reason: "generation-end tokens=\(tokenCount)")
 
-            let info = GenerateCompletionInfo(
-                promptTokenCount: promptTokenCount,
-                generationTokenCount: tokenCount,
-                promptTime: promptTime + iterator.promptPrefillTime,
-                generationTime: generateTime,
-                stopReason: stopReason ?? .cancelled,
-                turboQuantCompressions: iterator.turboQuantCompressionCount,
-                unclosedReasoning: unclosedReasoning
-            )
             // Multi-tier cache: drain the final async token eval before cache
             // snapshot/store, then keep completion info behind the cache-store
             // drain. Local chat/tool consumers may start a post-tool decode as
@@ -3543,6 +3536,27 @@ private func generateLoopTask<Handler: TokenLoopHandler>(
                 includeGeneratedBoundary: stopReason == .stop
                     && !handler.stopSequenceHit
                     && !handler.emittedToolCall)
+
+            // Build completion info only after `storeCacheAfterGeneration`
+            // returns: the native-MTP iterator snapshots `nativeMTPStats`
+            // there, from the same source values its `[NativeMTP]` stderr
+            // summary line prints for the corresponding keys (`outputTokens`
+            // depends on `generatedTokenIds`, which the iterator only sees
+            // in that call). `.info` is yielded
+            // further below, after the cache-store drain, exactly as before —
+            // only the construction moved — and no iterator mutates
+            // `turboQuantCompressionCount` or `promptPrefillTime` during the
+            // cache store, so every existing field is unchanged.
+            let info = GenerateCompletionInfo(
+                promptTokenCount: promptTokenCount,
+                generationTokenCount: tokenCount,
+                promptTime: promptTime + iterator.promptPrefillTime,
+                generationTime: generateTime,
+                stopReason: stopReason ?? .cancelled,
+                turboQuantCompressions: iterator.turboQuantCompressionCount,
+                unclosedReasoning: unclosedReasoning,
+                nativeMTPStats: iterator.nativeMTPStats
+            )
 
             Stream().synchronize()
 
@@ -3643,6 +3657,16 @@ public struct GenerateCompletionInfo: Sendable {
     /// (no behavior change on non-reasoning workloads).
     public let unclosedReasoning: Bool
 
+    /// Structured native-MTP speculative-decoding diagnostics for this
+    /// generation: the headline counters of the `[NativeMTP]` summary line
+    /// written to stderr, assigned from the same source values at the same
+    /// lifecycle point. Representation differs where
+    /// ``NativeMTPGenerationStats`` says so (rounding, `nil` vs `none`,
+    /// dense histogram), and the stderr line carries additional keys the
+    /// struct omits. `nil` for any generation that did not run the
+    /// native-MTP iterator.
+    public let nativeMTPStats: NativeMTPGenerationStats?
+
     /// The number of tokens processed per second during the prompt phase.
     public var promptTokensPerSecond: Double {
         Double(promptTokenCount) / promptTime
@@ -3660,7 +3684,8 @@ public struct GenerateCompletionInfo: Sendable {
         generationTime: TimeInterval,
         stopReason: GenerateStopReason = .stop,
         turboQuantCompressions: Int = 0,
-        unclosedReasoning: Bool = false
+        unclosedReasoning: Bool = false,
+        nativeMTPStats: NativeMTPGenerationStats? = nil
     ) {
         self.promptTokenCount = promptTokenCount
         self.generationTokenCount = generationTokenCount
@@ -3669,6 +3694,7 @@ public struct GenerateCompletionInfo: Sendable {
         self.stopReason = stopReason
         self.turboQuantCompressions = turboQuantCompressions
         self.unclosedReasoning = unclosedReasoning
+        self.nativeMTPStats = nativeMTPStats
     }
 
     public func summary() -> String {

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -45,6 +45,119 @@ private struct NativeMTPCacheCheckpoint {
     }
 }
 
+/// Structured per-generation diagnostics for native-MTP speculative decoding.
+///
+/// Carries the headline engagement/acceptance counters of the `[NativeMTP]`
+/// summary line the iterator writes to stderr at the end of every generation.
+/// Each field documents the `key=` entry it is assigned from; the assignment
+/// reads the same source values, at the same lifecycle point, as the
+/// `String(format:)` that renders the line, but representation can differ
+/// where a field's doc says so (rounding, `nil` vs `none`, dense histogram).
+/// The struct is a subset: the stderr line remains the complete diagnostic
+/// surface and additionally carries repair/commit counters
+/// (`residualCorrection=`, `prefixCommit=`, `rollbackRepair=`,
+/// `mtpCacheRefresh=`), forward-pass counters, per-phase timing fields,
+/// GDN-replay diagnostics, `phaseDiag=`, and `samplingMode=`, none of which
+/// appear here. Hosts that only need these headline counters can read them
+/// from ``GenerateCompletionInfo/nativeMTPStats`` instead of parsing stderr;
+/// that property is `nil` for any generation that did not run the native-MTP
+/// iterator.
+public struct NativeMTPGenerationStats: Sendable, Equatable {
+    /// Requested draft depth (`depth=`).
+    public let depth: Int
+
+    /// Draft depth in effect at end of generation, after any adaptive
+    /// downshifts (`activeDepth=`).
+    public let activeDepth: Int
+
+    /// Number of verify cycles executed (`verifyCalls=`).
+    public let verifyCalls: Int
+
+    /// The `generatedTokenIds.count` the generate loop passed to
+    /// `storeCacheAfterGeneration` — identical to the stderr `outputTokens=`
+    /// value. Because a generation-ending stop token is counted by the loop
+    /// but never appended to `generatedTokenIds`, this can be one less than
+    /// ``GenerateCompletionInfo/generationTokenCount`` on stop-token paths
+    /// (`outputTokens=`).
+    public let outputTokens: Int
+
+    /// Tokens produced by the autoregressive fallback path
+    /// (`arFallbackTokens=`).
+    public let arFallbackTokens: Int
+
+    /// Histogram of verify cycles by accepted draft count:
+    /// `acceptedByDepth[n]` is the number of cycles that accepted exactly `n`
+    /// draft tokens. Dense representation of the same counts the stderr line
+    /// prints sparsely as non-zero `n:count` pairs — and as the literal
+    /// `none` when the histogram is empty, which here is `[]`
+    /// (`acceptedByDepth=`).
+    public let acceptedByDepth: [Int]
+
+    /// Bonus tokens sampled from the target after full acceptance (`bonus=`).
+    public let bonusTokens: Int
+
+    /// Rejected draft tokens (`rejected=`).
+    public let rejectedTokens: Int
+
+    /// Average committed tokens per verify cycle over the speculative output.
+    /// Stores the same source double the stderr line prints, at full
+    /// precision — the line renders it rounded to two decimals via `%.2f`
+    /// (`avgCommittedPerVerify=`).
+    public let avgCommittedPerVerify: Double
+
+    /// Average draft acceptance probability; 0 under greedy sampling. Stores
+    /// the same source double the stderr line prints, at full precision — the
+    /// line renders it rounded to three decimals via `%.3f` (`avgAcceptP=`).
+    public let avgAcceptProbability: Double
+
+    /// Number of adaptive depth downshifts (`adaptiveDownshifts=`).
+    public let adaptiveDownshifts: Int
+
+    /// Why the adaptive controller fell back to autoregressive decode, or
+    /// `nil` when it did not. `nil` here corresponds exactly to the stderr
+    /// line printing `adaptiveFallback=none`; a non-`nil` reason is printed
+    /// verbatim (`adaptiveFallback=`).
+    public let adaptiveFallbackReason: String?
+
+    /// Verifier mode used for this generation (`verifierMode=`).
+    public let verifierMode: String
+
+    /// Cache handling mode (`cacheMode=`).
+    public let cacheMode: String
+
+    public init(
+        depth: Int,
+        activeDepth: Int,
+        verifyCalls: Int,
+        outputTokens: Int,
+        arFallbackTokens: Int,
+        acceptedByDepth: [Int],
+        bonusTokens: Int,
+        rejectedTokens: Int,
+        avgCommittedPerVerify: Double,
+        avgAcceptProbability: Double,
+        adaptiveDownshifts: Int,
+        adaptiveFallbackReason: String?,
+        verifierMode: String,
+        cacheMode: String
+    ) {
+        self.depth = depth
+        self.activeDepth = activeDepth
+        self.verifyCalls = verifyCalls
+        self.outputTokens = outputTokens
+        self.arFallbackTokens = arFallbackTokens
+        self.acceptedByDepth = acceptedByDepth
+        self.bonusTokens = bonusTokens
+        self.rejectedTokens = rejectedTokens
+        self.avgCommittedPerVerify = avgCommittedPerVerify
+        self.avgAcceptProbability = avgAcceptProbability
+        self.adaptiveDownshifts = adaptiveDownshifts
+        self.adaptiveFallbackReason = adaptiveFallbackReason
+        self.verifierMode = verifierMode
+        self.cacheMode = cacheMode
+    }
+}
+
 struct NativeMTPTokenIterator: TokenIteratorProtocol {
     let model: any NativeMTPModel
     var cache: [KVCache]
@@ -108,6 +221,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private var hybridSafetyWarmupComplete = false
     private var adaptiveWindow: [AdaptiveCycle] = []
     private var adaptiveFallbackReason: String?
+    private(set) var nativeMTPStats: NativeMTPGenerationStats?
     private let iteratorStartTime = Date.timeIntervalSinceReferenceDate
 
     private var usesHybridMambaCache: Bool {
@@ -560,6 +674,34 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         } else {
             verifierMode = "sequential_repair"
         }
+        // Structured snapshot of the headline counters of the stderr summary
+        // line below: each stats field is assigned here from the same source
+        // value the corresponding `key=` entry prints, at this same point.
+        // Representation differs where documented (the line rounds
+        // `avgCommittedPerVerify`/`avgAcceptP`, prints a nil fallback reason
+        // as `none`, and renders the histogram sparsely); the line's
+        // repair/forward/timing/diagnostic keys have no struct counterpart.
+        // `generateLoopTask` reads this after `storeCacheAfterGeneration`
+        // returns and carries it on `GenerateCompletionInfo.nativeMTPStats`.
+        let acceptedHistogram: [Int] = {
+            guard let maxAccepted = acceptedByDepth.keys.max() else { return [] }
+            return (0...maxAccepted).map { acceptedByDepth[$0] ?? 0 }
+        }()
+        nativeMTPStats = NativeMTPGenerationStats(
+            depth: depth,
+            activeDepth: currentDepth,
+            verifyCalls: verifyCalls,
+            outputTokens: generatedTokenIds.count,
+            arFallbackTokens: autoregressiveFallbackTokenCount,
+            acceptedByDepth: acceptedHistogram,
+            bonusTokens: bonusCount,
+            rejectedTokens: rejectedCount,
+            avgCommittedPerVerify: avgCommitted,
+            avgAcceptProbability: avgAcceptP,
+            adaptiveDownshifts: adaptiveDepthDownshiftCount,
+            adaptiveFallbackReason: adaptiveFallbackReason,
+            verifierMode: verifierMode,
+            cacheMode: "private-mtp+verifier-prefix-commit")
         let line = String(
             format:
                 "[NativeMTP] depth=%d activeDepth=%d verifyCalls=%d outputTokens=%d arFallbackTokens=%d acceptedByDepth=%@ bonus=%d rejected=%d residualCorrection=%d prefixCommit=%d rollbackRepair=%d mtpCacheRefresh=%d targetForwards=%d verifyInputTokens=%d repairForwards=%d seedMainForwards=%d verifyMainForwards=%d replayMainForwards=%d mtpForwards=%d avgCommittedPerVerify=%.2f avgAcceptP=%.3f adaptiveDownshifts=%d adaptiveFallback=%@ targetVerifySec=%.3f seedMainSec=%.3f verifyMainSec=%.3f replayMainSec=%.3f mtpDraftSec=%.3f samplingSec=%.3f cacheCommitSec=%.3f materializeSyncSec=%.3f cacheStateSec=%.3f iteratorWallSec=%.3f gdnReplayCalls=%d gdnReplayStates=%d gdnReplaySec=%.3f phaseDiag=%@ samplingMode=%@ verifierMode=%@ cacheMode=private-mtp+verifier-prefix-commit\n",

--- a/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
@@ -1307,6 +1307,102 @@ struct MTPRuntimeFocusedTests {
         }
     }
 
+    @Test("token iterators report nil native MTP stats by default")
+    func tokenIteratorsReportNilNativeMTPStatsByDefault() {
+        // `TokenIterator`, `SpeculativeTokenIterator`, and
+        // `BlockDiffusionTokenIterator` all inherit the same
+        // protocol-extension default this stub exercises; only
+        // `NativeMTPTokenIterator` overrides it.
+        var iterator = FocusedDefaultStatsIterator()
+
+        #expect(iterator.nativeMTPStats == nil)
+        #expect(iterator.next() == nil)
+    }
+
+    @Test("native MTP generation stats round-trip their fields")
+    func nativeMTPGenerationStatsRoundTripFields() {
+        func makeStats() -> NativeMTPGenerationStats {
+            NativeMTPGenerationStats(
+                depth: 3,
+                activeDepth: 2,
+                verifyCalls: 7,
+                outputTokens: 21,
+                arFallbackTokens: 4,
+                acceptedByDepth: [1, 3, 2, 1],
+                bonusTokens: 2,
+                rejectedTokens: 5,
+                avgCommittedPerVerify: 2.43,
+                avgAcceptProbability: 0.875,
+                adaptiveDownshifts: 1,
+                adaptiveFallbackReason: "acceptance-collapse",
+                verifierMode: "chunk_commit",
+                cacheMode: "private-mtp+verifier-prefix-commit")
+        }
+
+        let stats = makeStats()
+        #expect(stats.depth == 3)
+        #expect(stats.activeDepth == 2)
+        #expect(stats.verifyCalls == 7)
+        #expect(stats.outputTokens == 21)
+        #expect(stats.arFallbackTokens == 4)
+        #expect(stats.acceptedByDepth == [1, 3, 2, 1])
+        #expect(stats.bonusTokens == 2)
+        #expect(stats.rejectedTokens == 5)
+        #expect(stats.avgCommittedPerVerify == 2.43)
+        #expect(stats.avgAcceptProbability == 0.875)
+        #expect(stats.adaptiveDownshifts == 1)
+        #expect(stats.adaptiveFallbackReason == "acceptance-collapse")
+        #expect(stats.verifierMode == "chunk_commit")
+        #expect(stats.cacheMode == "private-mtp+verifier-prefix-commit")
+        #expect(stats == makeStats())
+    }
+
+    @Test("completion info defaults native MTP stats to nil")
+    func completionInfoDefaultsNativeMTPStatsToNil() {
+        let info = GenerateCompletionInfo(
+            promptTokenCount: 3,
+            generationTokenCount: 4,
+            promptTime: 0.1,
+            generationTime: 0.2)
+
+        #expect(info.nativeMTPStats == nil)
+    }
+
+    @Test("active native MTP generation carries structured stats on completion info")
+    func activeNativeMTPGenerationCarriesStructuredStats() async throws {
+        try await FocusedMLXTestSupport.withLock {
+            let model = FocusedNativeMTPProbeTarget()
+            let context = Self.nativeMTPDispatchContext(model: model)
+            let engine = BatchEngine(context: context, maxBatchSize: 2)
+            var params = GenerateParameters(maxTokens: 4, temperature: 0)
+            params.draftStrategy = .nativeMTP(depth: 3)
+
+            let stream = await engine.generate(
+                input: LMInput(tokens: MLXArray([3, 5, 7])),
+                parameters: params)
+            var completionInfo: GenerateCompletionInfo?
+            for await event in stream {
+                if case .info(let info) = event {
+                    completionInfo = info
+                }
+            }
+
+            let info = try #require(completionInfo)
+            let stats = try #require(info.nativeMTPStats)
+            #expect(stats.depth == 3)
+            #expect(stats.verifyCalls >= 1)
+            // No stop token fires with the zero-logit probe target, so the
+            // info's emitted-token count and the iterator's
+            // `generatedTokenIds.count` snapshot must agree.
+            #expect(stats.outputTokens == info.generationTokenCount)
+            // Every completed verify cycle records exactly one accepted-count
+            // histogram entry.
+            #expect(stats.acceptedByDepth.reduce(0, +) == stats.verifyCalls)
+            #expect(stats.cacheMode == "private-mtp+verifier-prefix-commit")
+            #expect(!stats.verifierMode.isEmpty)
+        }
+    }
+
     @Test("shape-walk quantization preserves MXFP4 mode")
     func shapeWalkQuantizationPreservesMXFP4Mode() {
         let weights: [String: MLXArray] = [
@@ -2216,4 +2312,14 @@ private final class FocusedNativeMTPProbeTarget: Module, LanguageModel, NativeMT
     private func hiddenStates(for inputs: MLXArray) -> MLXArray {
         MLXArray.zeros([1, sequenceLength(inputs), 4])
     }
+}
+
+/// Minimal conformer that relies on every `TokenIteratorProtocol`
+/// protocol-extension default, so tests can assert those defaults directly.
+private struct FocusedDefaultStatsIterator: TokenIteratorProtocol {
+    let maxTokens: Int? = nil
+    let tokenCount = 0
+    let promptPrefillTime: TimeInterval = 0
+
+    mutating func next() -> Int? { nil }
 }


### PR DESCRIPTION
Carries #131 (@mimeding) onto current `main`. Same goal: the `[NativeMTP]` per-generation summary is
stderr-only, so a host that wants speculative-decoding health has to grep stderr. This puts the
headline counters on `GenerateCompletionInfo`, following the existing `turboQuantCompressions`
pattern.

## Conflicts resolved (8, all in the two hottest files)

- **`GenerateCompletionInfo` keeps every field.** `main` added `turboQuantCacheTransition` and
  `toolCallProtocolFailure` after this branch was written; a straight merge would have dropped both.
  The stored property, initializer parameters, initializer body and construction site now carry all
  three additions.
- **`NativeMTPGenerationStats` moved out of `NativeMTPHybridWarmupMemo`.** `main` added that memo in
  the same region; the naive union nested the new struct inside the enum.
- **`depth` semantics corrected.** `main` caps native MTP at `VMLX_MTP_DEPTH_CAP` (default `1`) —
  depths above 1 only ever won on a deterministic counting prompt and measured ~14% slower than
  plain AR decode on prose. So `depth` is the **effective** depth: a host asking for
  `.nativeMTP(depth: 3)` reads `1`. The branch documented it as the *requested* depth and its test
  asserted `3`. Both now match shipped behaviour — and that request-vs-effective gap is exactly the
  kind of thing this surface exists to make visible without reading stderr.

## The ordering change, checked

To populate the stats the completion-info construction moves **after**
`storeCacheAfterGeneration` (the iterator snapshots there, since `outputTokens` depends on
`generatedTokenIds`, which it only sees in that call). `.info` is still yielded at the same point.

That is a real reorder in the hot generate path, so I did not take the branch's word for it:

- `generateTime` / `promptTime` are captured **before** the move, so timings are unaffected.
- `lastTurboQuantCacheTransition` is written in `maybeQuantizeCacheForStep()` — a per-decode-step
  call — not during the cache store.
- End-to-end A/B, branch vs `main`, on `VibeThinker-3B-MXFP8` and `Bonsai-27b-Ternary-JANG-CRACK`
  (growing-chat cache, reasoning on): **IDENTICAL**, including the `TurboQuant compressions` line.

## Tests

`swift test --filter MTPRuntimeFocusedTests` → **80/80 pass**.