### PR TITLE
Mark Hub.Repo and Hub.RepoType Sendable

### DIFF
--- a/Vendors/swift-transformers/Sources/Hub/Hub.swift
+++ b/Vendors/swift-transformers/Sources/Hub/Hub.swift
@@ -77,7 +77,7 @@ public extension Hub {
     }
 
     /// The type of repository on the Hugging Face Hub.
-    enum RepoType: String, Codable {
+    enum RepoType: String, Codable, Sendable {
         /// Model repositories containing machine learning models.
         case models
         /// Dataset repositories containing training and evaluation data.
@@ -90,7 +90,7 @@ public extension Hub {
     ///
     /// A repository is identified by its unique ID and type, allowing access to
     /// different kinds of resources hosted on the Hub platform.
-    struct Repo: Codable {
+    struct Repo: Codable, Sendable {
         /// The unique identifier for the repository (e.g., "microsoft/DialoGPT-medium").
         public let id: String
         /// The type of repository (models, datasets, or spaces).


### PR DESCRIPTION
Merges #71 (@Foscoe63). `Hub.Repo` is `let id: String` + `let type: RepoType`, and `RepoType` is a
`String`-raw-value enum — both are trivially `Sendable`, so the conformance is a statement of an
invariant that already holds, not a new guarantee.

Value is for **downstream** consumers: a host compiling under Swift 6 strict concurrency cannot
carry a `Hub.Repo` across an isolation boundary without the conformance, even though the type is
immutable.

## Honest scope

This does **not** fix a build failure in this repo today. The package compiles clean on the
toolchain here (Apple Swift 6.3.3) — I built `RunBench` in release against unmodified `main`
repeatedly this session. The region-isolation over-report these PRs were filed against does not
reproduce on 6.2+, which is exactly what the comment above `mlxLMCommonSwiftSettings` in
`Package.swift` already says.

So: correct, minimal, and worth having — but it is hygiene, not a repair.

## Verification

- Release build of `RunBench`: clean.
- `VibeThinker-3B-MXFP8` growing-chat cache run: **IDENTICAL to main** (a conformance cannot change
  runtime behaviour, and the run confirms it).

## Related PRs

- **#151** is byte-identical to #71 (same blob hashes `919bc53e..403e6533`) — closing as a duplicate.
- **#81** solves the same report differently, by adding `.swiftLanguageMode(.v5)` to
  `transformersSwiftSettings`. That downgrades the **entire** vendored transformers target out of
  Swift 6 checking to silence one over-report, which would mask real concurrency defects in that
  target from then on. Declining in favour of the targeted conformance.