### PR TITLE
Block-diffusion: guard against an empty (all-EOS) first canvas

### DIFF
--- a/Libraries/MLXLMCommon/Diffusion/BlockDiffusionTokenIterator.swift
+++ b/Libraries/MLXLMCommon/Diffusion/BlockDiffusionTokenIterator.swift
@@ -376,10 +376,36 @@ public struct BlockDiffusionTokenIterator: TokenIteratorProtocol {
                 tMin: options.tMin, tMax: options.tMax)
             let processed = logits.asType(.float32) / temperature
 
+            // No-empty-response guard. Block-diffusion collapses terse prompts (e.g. boolq's
+            // "Respond with one of: yes, no.") to an all-EOS first canvas → empty output, even
+            // though the model answers correctly whenever it emits anything. On the FIRST canvas,
+            // forbid EOS at position 0 so at least one content token is produced; later canvases
+            // end normally, so a genuinely complete reply can still stop. (-1e9, not -inf, keeps
+            // entropy finite.)
+            //
+            // The write is IN PLACE, and that is load-bearing rather than accidental. `MLXArray` is
+            // a `final class`, so `var sampled = processed` binds a second reference to the same
+            // object and `sampled[0, 0, eos] = …` rewrites `processed` too (`_updateInternal` →
+            // `mlx_array_set`). The suppression therefore also reaches `selfConditioning =
+            // processed` below, and persists across denoising steps.
+            //
+            // That persistence is what makes the guard work. Building the mask out-of-place — e.g.
+            // `sampled = processed + bias` — leaves self-conditioning unmasked, the model re-asserts
+            // its EOS preference on the next step, and the canvas collapses again: MEASURED at
+            // boolq gen-nothink 70.0% (35/50, in place) versus 0.0% with 8/8 extraction failures
+            // (out of place). An earlier version of this comment claimed self-conditioning kept the
+            // UNMASKED logits; that was false, and making it true broke the guard.
+            var sampled = processed
+            if canvasesEmitted == 0 {
+                for eos in options.eosTokenIds {
+                    sampled[0, 0, eos] = MLXArray(Float(-1e9))
+                }
+            }
+
             let denoiserKey = nextRandomKey()
-            let denoiserCanvas = MLX.categorical(processed, key: denoiserKey).asType(.int32)
-            let argmaxCanvas = argMax(processed, axis: -1).asType(.int32)
-            let entropy = canvasTokenEntropy(processedLogits: processed)
+            let denoiserCanvas = MLX.categorical(sampled, key: denoiserKey).asType(.int32)
+            let argmaxCanvas = argMax(sampled, axis: -1).asType(.int32)
+            let entropy = canvasTokenEntropy(processedLogits: sampled)
             let acceptMask = entropyBoundAcceptMask(
                 tokenEntropy: entropy, entropyBound: options.entropyBound)
 

--- a/Tests/MLXLMTests/BlockDiffusionEOSGuardAliasingTests.swift
+++ b/Tests/MLXLMTests/BlockDiffusionEOSGuardAliasingTests.swift
@@ -1,0 +1,82 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Pins the aliasing semantics the block-diffusion no-empty-response guard
+// depends on.
+
+import Foundation
+import MLX
+import Testing
+
+@testable import MLXLMCommon
+
+/// The first-canvas EOS guard in `BlockDiffusionTokenIterator` suppresses EOS by writing
+/// **in place**:
+///
+/// ```swift
+/// var sampled = processed
+/// sampled[0, 0, eos] = MLXArray(Float(-1e9))
+/// ```
+///
+/// That is load-bearing, not incidental. `MLXArray` is a `final class`, so `sampled` is a second
+/// reference to the same buffer and the write also reaches `processed` — which is what later
+/// becomes `selfConditioning`. Without that reach, the model re-asserts its EOS preference on the
+/// next denoising step and the canvas collapses to empty again: measured at boolq gen-nothink
+/// **70.0% (35/50)** in place versus **0.0% with 8/8 extraction failures** when the same mask is
+/// built out of place.
+///
+/// So this file guards a dependency that is invisible at the call site. If `MLXArray` ever gains
+/// value semantics for subscript assignment — or someone "cleans up" the guard into
+/// `sampled = processed + bias` — the fix silently degrades to producing no output at all, with no
+/// other test failing. The whole point is that the *aliasing* is the mechanism.
+///
+/// Note the inverse trap also exists and is equally real: when the goal is to keep the caller's
+/// logits untouched, a mask MUST be built out of place (`MLX.where` over an `arange`), because this
+/// same aliasing makes a "copy" not a copy. Both rules follow from `MLXArray` being a class.
+@Suite("Block-diffusion EOS guard relies on MLXArray subscript aliasing")
+struct BlockDiffusionEOSGuardAliasingTests {
+
+    @Test("subscript assignment through a second binding mutates the original")
+    func subscriptAssignmentAliasesTheOriginal() {
+        let mlxTestLock = lockSerializedMLXTest()
+        defer { mlxTestLock.unlock() }
+
+        let processed = MLXArray(converting: [1.0, 2.0, 3.0, 4.0]).reshaped(1, 1, 4)
+        let eos = 2
+
+        var sampled = processed
+        sampled[0, 0, eos] = MLXArray(Float(-1e9))
+
+        // The guard's correctness rests on this: `processed` — the value that goes on to become
+        // self-conditioning — must carry the suppression even though it was never assigned to.
+        let carried = processed[0, 0, eos].item(Float.self)
+        #expect(
+            carried == Float(-1e9),
+            """
+            MLXArray subscript assignment no longer aliases: the block-diffusion first-canvas EOS \
+            guard now leaves self-conditioning unmasked, which measured 0% output (8/8 extraction \
+            failures) on boolq gen-nothink. The guard must be rewritten to mask self-conditioning \
+            explicitly.
+            """)
+
+        // Untouched positions must be unchanged — the guard suppresses exactly one id.
+        #expect(processed[0, 0, 0].item(Float.self) == 1.0)
+        #expect(processed[0, 0, 3].item(Float.self) == 4.0)
+    }
+
+    /// The complement, so the two rules are pinned together rather than one being "discovered"
+    /// again later: an out-of-place mask leaves the source intact. This is the form to use when a
+    /// caller still owns the logits.
+    @Test("out-of-place masking leaves the source untouched")
+    func outOfPlaceMaskingDoesNotAliasTheSource() {
+        let mlxTestLock = lockSerializedMLXTest()
+        defer { mlxTestLock.unlock() }
+
+        let logits = MLXArray(converting: [1.0, 2.0, 3.0, 4.0]).reshaped(1, 1, 4)
+        let ids = MLXArray(Int32(0) ..< Int32(4)).reshaped(1, 1, 4)
+        let masked = MLX.where(ids .== MLXArray(Int32(2)), MLXArray(Float(-1e9)), logits)
+
+        #expect(masked[0, 0, 2].item(Float.self) == Float(-1e9))
+        #expect(logits[0, 0, 2].item(Float.self) == 3.0)
+    }
+}


### PR DESCRIPTION
Merges #170 (@rcfa) plus a regression test for the mechanism it depends on.

## The fix

Block diffusion collapses terse prompts (boolq's *"Respond with one of: yes, no."*) to an all-EOS
first canvas, so the output is empty even though the model answers correctly whenever it emits
anything. On the **first** canvas only, EOS is forbidden at position 0 so at least one content token
is produced; later canvases end normally, so a genuinely complete reply can still stop.

Measured by the author: boolq gen-nothink **70.0% (35/50)**, versus empty output before.

## What I added, and why

The guard works by writing **in place**, deliberately relying on `MLXArray` being a `final class`:
`var sampled = processed` is a second reference, so masking `sampled` also masks `processed`, which
is what later becomes `selfConditioning`. That persistence is the entire mechanism — building the
mask out of place (`sampled = processed + bias`) leaves self-conditioning unmasked, the model
re-asserts EOS on the next denoising step, and the canvas collapses again: **0.0%, 8/8 extraction
failures**.

Nothing at the call site makes that visible. A future cleanup to the "obviously correct"
out-of-place form would silently return the model to producing nothing, and no existing test would
notice. So `BlockDiffusionEOSGuardAliasingTests` pins both directions:

- subscript assignment through a second binding **does** mutate the original (the guard's mechanism)
- `MLX.where` over an `arange` **does not** (the form to use when the caller still owns the logits)

Worth stating plainly because the two rules look contradictory: *both* follow from `MLXArray` being
a class. Elsewhere in this codebase the same aliasing was a **bug** — a logit mask built by writing
into a `full(-inf)` array silently rewrote the caller's logits. Here it is the feature. The test
records which is which so the next person does not have to rediscover it by measuring.

## Verification

- Release build clean; `swift test --filter DiffusionGemmaTests` → **15/15 pass**; new suite → 2/2.
- **Not live-proven, and I want to be explicit about that.** `BlockDiffusionModel` is implemented
  only by `DiffusionGemmaModel`, and no diffusion bundle is installed here — the local library is
  `deepseek_v3/v4`, `gemma4`, `hy_v3`, `laguna`, `lfm2*`, `minimax_m2`, `muse_glimmer`, `nanbeige`,
  `nemotron_*`, `qwen2`, `qwen3_5*`, `step3p7`, `zaya*`. So I am relying on the author's measured
  boolq numbers for efficacy, and on the fact that the change is confined to
  `BlockDiffusionTokenIterator` for safety: no other family reaches this code path at all.