### PR TITLE
Repair two stale Gemma4 source-matching assertions

### DIFF
--- a/Tests/MLXLMTests/Gemma4PLECoherenceTests.swift
+++ b/Tests/MLXLMTests/Gemma4PLECoherenceTests.swift
@@ -229,7 +229,19 @@ struct Gemma4PLECoherenceTests {
         #expect(split.allSatisfy { $0.shape == [1, tokenCount, width] })
     }
 
-    @Test("Gemma4 E-series scaled projection initializes JANG affine biases slot")
+    /// Originally this pinned `self._biases.wrappedValue = MLXArray.mlxNone` in a hand-rolled
+    /// scaled projection: the slot had to be explicitly emptied or MLX would try to load into an
+    /// uninitialized `biases` parameter.
+    ///
+    /// `c7613dcc` ("Fix Gemma4 QAT loading") deleted that projection entirely — along with its
+    /// `@ParameterInfo(key: "biases")` declaration — and moved Gemma4 onto plain `bias: false`
+    /// projections, with JANG affine biases resolved by the loader instead. Re-asserting the old
+    /// line would demand the return of a design that was removed on purpose.
+    ///
+    /// So the assertion is inverted to pin the outcome that still matters: neither file
+    /// re-introduces a hand-rolled `biases` parameter slot, which is what made the original bug
+    /// possible.
+    @Test("Gemma4 declares no hand-rolled JANG affine biases parameter slot")
     func eSeriesScaledProjectionInitializesAffineBiasSlot() throws {
         let repo = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
@@ -243,7 +255,13 @@ struct Gemma4PLECoherenceTests {
             encoding: .utf8)
 
         for source in [textSource, vlmSource] {
-            #expect(source.contains("self._biases.wrappedValue = MLXArray.mlxNone"))
+            #expect(
+                !source.contains("@ParameterInfo(key: \"biases\")"),
+                """
+                Gemma4 re-declared a `biases` parameter slot. If that is intentional, the slot must \
+                be explicitly initialized to `MLXArray.mlxNone`, or loading a JANG affine bundle \
+                will attempt to populate an uninitialized parameter.
+                """)
         }
     }
 

--- a/Tests/MLXLMTests/Gemma4VLMTests.swift
+++ b/Tests/MLXLMTests/Gemma4VLMTests.swift
@@ -461,7 +461,12 @@ private func maskedScatter(input: MLXArray, mask: MLXArray, source: MLXArray) ->
     #expect(source.contains("exp.append(contentsOf: Array(repeating: audioId, count: tokenCount))"))
     #expect(source.contains("audio: processedAudio"))
     #expect(source.contains("preEncodedEmbedding: embedding"))
-    #expect(source.contains("Gemma4 raw audio feature extraction is not implemented"))
+    // Raw audio is IMPLEMENTED now (35a4f5a7, unified raw-waveform chunking), so the old
+    // "not implemented" bail no longer exists. What must still hold is that an unrecognised
+    // feature_extractor_type is rejected by NAME rather than silently mis-decoded — assert the
+    // replacement diagnostic instead of pinning a state the runtime has moved past.
+    #expect(source.contains("which has no Swift pipeline"))
+    #expect(source.contains("Gemma4UnifiedAudioFeatureExtractor"))
     #expect(!source.contains("pre-encoded 640-dim"))
 }
 


### PR DESCRIPTION
`swift test --filter Gemma4` is **red on `main`** — 2 failures / 3 issues — and neither is a real
defect. Both tests assert against the literal *text* of `Gemma4.swift` / `Gemma4Text.swift`, so they
fail whenever the implementation moves, and both are pinning states the runtime deliberately left.

| test | pinned | reality |
|---|---|---|
| `gemma4ProcessorExpandsPreEncodedAudioSoftTokens` | error string `"Gemma4 raw audio feature extraction is not implemented"` | raw audio **was** implemented in `35a4f5a7` (unified raw-waveform chunking); that bail is gone |
| `eSeriesScaledProjectionInitializesAffineBiasSlot` | `self._biases.wrappedValue = MLXArray.mlxNone` | `c7613dcc` deleted that hand-rolled projection **and** its `@ParameterInfo(key: "biases")` slot; Gemma4 now uses plain `bias: false` |

## Fix

Neither assertion is restored, because both would demand back something removed on purpose. Instead
each is re-pointed at the invariant that still matters:

- audio: assert the **replacement** diagnostic — an unrecognised `feature_extractor_type` is
  rejected **by name** (`"which has no Swift pipeline"`, naming
  `Gemma4UnifiedAudioFeatureExtractor`) rather than silently mis-decoded.
- biases: **invert** it. The original bug was an uninitialized `biases` parameter slot that MLX
  would try to load into, so assert that neither file re-declares
  `@ParameterInfo(key: "biases")`. Same regression, expressed against the design that shipped.

Both carry a comment naming the commit that moved the ground, so the next reader does not have to
re-derive it.

## Result

`swift test --filter Gemma4` → **112/112 pass in 22 suites** (was 112 with 3 issues).

Worth noting as a pattern: source-text assertions rot silently and then fail loudly at an unrelated
moment. I hit both of these while reviewing an unrelated Gemma4 PR (#43), which is exactly the cost
— a red baseline makes it harder to tell whether the PR under review broke something.