### PR TITLE
Handle Gemma4 suffixless expert tensors

### DIFF
--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -1242,11 +1242,21 @@ public class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
             if nk.contains(".switch_mlp.") { nk = nk.replacingOccurrences(of: ".switch_mlp.", with: ".experts.switch_glu.") }
             if nk.contains(".experts.down_proj.") {
                 nk = nk.replacingOccurrences(of: ".experts.down_proj.", with: ".experts.switch_glu.down_proj.")
+            } else if nk.hasSuffix(".experts.down_proj") {
+                nk = String(nk.dropLast(".experts.down_proj".count)) + ".experts.switch_glu.down_proj"
             }
-            if nk.contains(".experts.gate_up_proj.") {
+            if nk.contains(".experts.gate_up_proj.") || nk.hasSuffix(".experts.gate_up_proj") {
                 let mid = config.textConfig.moeIntermediateSize
-                let gateKey = nk.replacingOccurrences(of: ".experts.gate_up_proj.", with: ".experts.switch_glu.gate_proj.")
-                let upKey = nk.replacingOccurrences(of: ".experts.gate_up_proj.", with: ".experts.switch_glu.up_proj.")
+                let gateKey: String
+                let upKey: String
+                if nk.contains(".experts.gate_up_proj.") {
+                    gateKey = nk.replacingOccurrences(of: ".experts.gate_up_proj.", with: ".experts.switch_glu.gate_proj.")
+                    upKey = nk.replacingOccurrences(of: ".experts.gate_up_proj.", with: ".experts.switch_glu.up_proj.")
+                } else {
+                    let base = String(nk.dropLast(".experts.gate_up_proj".count))
+                    gateKey = base + ".experts.switch_glu.gate_proj"
+                    upKey = base + ".experts.switch_glu.up_proj"
+                }
                 if v.shape.count >= 3 {
                     p[gateKey] = v[0..., ..<mid, 0...]
                     p[upKey] = v[0..., mid..., 0...]

--- a/Tests/MLXLMTests/Gemma4VLMTests.swift
+++ b/Tests/MLXLMTests/Gemma4VLMTests.swift
@@ -466,42 +466,56 @@ private func maskedScatter(input: MLXArray, mask: MLXArray, source: MLXArray) ->
 }
 
 @Test func gemma4SanitizeSplitsFusedMoEExpertWeights() throws {
-    let json = """
-    {
-      "model_type": "gemma4",
-      "text_config": {
-        "hidden_size": 8,
-        "intermediate_size": 4,
-        "moe_intermediate_size": 4,
-        "num_hidden_layers": 1,
-        "num_experts": 2,
-        "top_k_experts": 1,
-        "enable_moe_block": true
-      },
-      "vision_config": {
-        "hidden_size": 8,
-        "output_proj_dims": 8,
-        "default_output_length": 2
-      }
-    }
-    """
-    let config = try JSONDecoder().decode(Gemma4Configuration.self, from: Data(json.utf8))
-    let model = Gemma4(config)
-    let sanitized = model.sanitize(weights: [
-        "language_model.model.layers.0.experts.gate_up_proj.weight": MLXArray.zeros([2, 8, 3]),
-        "language_model.model.layers.0.experts.gate_up_proj.scales": MLXArray.zeros([2, 8, 2]),
-        "language_model.model.layers.0.experts.down_proj.weight": MLXArray.zeros([2, 8, 4]),
-        "language_model.model.layers.0.experts.down_proj.scales": MLXArray.zeros([2, 8, 1]),
-    ])
+    try MLXMetalTestLock.withLock {
+        let json = """
+        {
+          "model_type": "gemma4",
+          "text_config": {
+            "hidden_size": 8,
+            "intermediate_size": 4,
+            "moe_intermediate_size": 4,
+            "num_hidden_layers": 1,
+            "num_experts": 2,
+            "top_k_experts": 1,
+            "enable_moe_block": true
+          },
+          "vision_config": {
+            "hidden_size": 8,
+            "output_proj_dims": 8,
+            "default_output_length": 2
+          }
+        }
+        """
+        let config = try JSONDecoder().decode(Gemma4Configuration.self, from: Data(json.utf8))
+        let model = Gemma4(config)
+        let sanitized = model.sanitize(weights: [
+            "model.language_model.layers.0.experts.gate_up_proj": MLXArray.zeros([2, 8, 3]),
+            "model.language_model.layers.0.experts.down_proj": MLXArray.zeros([2, 3, 4]),
+            "language_model.model.layers.0.experts.gate_up_proj.weight": MLXArray.zeros([2, 8, 3]),
+            "language_model.model.layers.0.experts.gate_up_proj.scales": MLXArray.zeros([2, 8, 2]),
+            "language_model.model.layers.0.experts.down_proj.weight": MLXArray.zeros([2, 3, 4]),
+            "language_model.model.layers.0.experts.down_proj.scales": MLXArray.zeros([2, 3, 1]),
+        ])
 
-    #expect(sanitized["language_model.model.layers.0.experts.gate_up_proj.weight"] == nil)
-    #expect(sanitized["language_model.model.layers.0.experts.down_proj.weight"] == nil)
-    #expect(sanitized["language_model.model.layers.0.experts.switch_glu.gate_proj.weight"]?.shape == [2, 4, 3])
-    #expect(sanitized["language_model.model.layers.0.experts.switch_glu.up_proj.weight"]?.shape == [2, 4, 3])
-    #expect(sanitized["language_model.model.layers.0.experts.switch_glu.gate_proj.scales"]?.shape == [2, 4, 2])
-    #expect(sanitized["language_model.model.layers.0.experts.switch_glu.up_proj.scales"]?.shape == [2, 4, 2])
-    #expect(sanitized["language_model.model.layers.0.experts.switch_glu.down_proj.weight"]?.shape == [2, 8, 4])
-    #expect(sanitized["language_model.model.layers.0.experts.switch_glu.down_proj.scales"]?.shape == [2, 8, 1])
+        // Source/BF16 Gemma4 MoE bundles store suffixless fused expert tensors,
+        // e.g. `model.language_model.layers.0.experts.gate_up_proj`. Quantized
+        // QAT bundles store suffixed tensors such as `.weight` and `.scales`.
+        // Both layouts must be consumed by the same `experts.switch_glu` module
+        // tree; otherwise loading fails with unhandled `gate_up_proj/down_proj`.
+        #expect(sanitized["language_model.model.layers.0.experts.gate_up_proj"] == nil)
+        #expect(sanitized["language_model.model.layers.0.experts.down_proj"] == nil)
+        #expect(sanitized["language_model.model.layers.0.experts.gate_up_proj.weight"] == nil)
+        #expect(sanitized["language_model.model.layers.0.experts.down_proj.weight"] == nil)
+        #expect(sanitized["language_model.model.layers.0.experts.switch_glu.gate_proj"]?.shape == [2, 4, 3])
+        #expect(sanitized["language_model.model.layers.0.experts.switch_glu.up_proj"]?.shape == [2, 4, 3])
+        #expect(sanitized["language_model.model.layers.0.experts.switch_glu.down_proj"]?.shape == [2, 3, 4])
+        #expect(sanitized["language_model.model.layers.0.experts.switch_glu.gate_proj.weight"]?.shape == [2, 4, 3])
+        #expect(sanitized["language_model.model.layers.0.experts.switch_glu.up_proj.weight"]?.shape == [2, 4, 3])
+        #expect(sanitized["language_model.model.layers.0.experts.switch_glu.gate_proj.scales"]?.shape == [2, 4, 2])
+        #expect(sanitized["language_model.model.layers.0.experts.switch_glu.up_proj.scales"]?.shape == [2, 4, 2])
+        #expect(sanitized["language_model.model.layers.0.experts.switch_glu.down_proj.weight"]?.shape == [2, 3, 4])
+        #expect(sanitized["language_model.model.layers.0.experts.switch_glu.down_proj.scales"]?.shape == [2, 3, 1])
+    }
 }
 
 @Test func imageSeqLengthMatchesVisionOutput() throws {

--- a/docs/GEMMA4_EXPERT_KEY_SANITIZE_CONTRACT_2026_06_11.md
+++ b/docs/GEMMA4_EXPERT_KEY_SANITIZE_CONTRACT_2026_06_11.md
@@ -1,0 +1,75 @@
+# Gemma4 Expert Key Sanitizer Contract - 2026-06-11
+
+## Regression
+
+Gemma4 MoE source/BF16 bundles can store fused expert tensors as suffixless
+keys:
+
+- `model.language_model.layers.N.experts.gate_up_proj`
+- `model.language_model.layers.N.experts.down_proj`
+
+If those keys reach `TextExperts` unchanged, load fails with:
+
+```text
+Unhandled keys ["down_proj", "gate_up_proj"] in language_model.model.layers.0.experts in Gemma4.G4LanguageModel.TextModel.TextLayer.TextExperts
+```
+
+This is a loader/sanitizer regression, not a prompt, sampler, tool-call, or
+cache-policy issue.
+
+## Observed Layouts
+
+`google--gemma-4-26B-A4B-it-qat-q4_0-unquantized` source/BF16 row:
+
+- `model.language_model.layers.0.experts.down_proj`
+  shape `[128, 2816, 704]`, dtype `BF16`
+- `model.language_model.layers.0.experts.gate_up_proj`
+  shape `[128, 1408, 2816]`, dtype `BF16`
+
+`OsaurusAI/gemma-4-26B-A4B-it-qat-MXFP4` quantized row:
+
+- `language_model.model.layers.0.experts.down_proj.weight`
+- `language_model.model.layers.0.experts.down_proj.scales`
+- `language_model.model.layers.0.experts.gate_up_proj.weight`
+- `language_model.model.layers.0.experts.gate_up_proj.scales`
+
+`OsaurusAI/gemma-4-26B-A4B-it-qat-JANG_4M` quantized row is already normalized
+to the runtime module tree:
+
+- `language_model.model.layers.0.experts.switch_glu.gate_proj.*`
+- `language_model.model.layers.0.experts.switch_glu.up_proj.*`
+- `language_model.model.layers.0.experts.switch_glu.down_proj.*`
+
+E2B did not expose this because it has no MoE expert tensors.
+
+## Required Normalization
+
+The Gemma4 sanitizer must:
+
+1. Strip a leading `model.` prefix.
+2. Normalize `language_model.layers.` to `language_model.model.layers.`.
+3. Rewrite suffixless and suffixed direct down projections:
+   - `.experts.down_proj`
+   - `.experts.down_proj.<suffix>`
+   to:
+   - `.experts.switch_glu.down_proj`
+   - `.experts.switch_glu.down_proj.<suffix>`
+4. Split suffixless and suffixed fused gate/up projections:
+   - `.experts.gate_up_proj`
+   - `.experts.gate_up_proj.<suffix>`
+   into:
+   - `.experts.switch_glu.gate_proj`
+   - `.experts.switch_glu.up_proj`
+   using `moe_intermediate_size` as the split point on axis 1.
+
+## Regression Test
+
+Run from `vmlx-swift`:
+
+```bash
+swift test --filter gemma4SanitizeSplitsFusedMoEExpertWeights
+```
+
+This test must include both source/BF16 suffixless keys and quantized suffixed
+keys. Removing either layout from the test reopens this class of Gemma4 load
+regression.


### PR DESCRIPTION
Rebases #43 onto current `main`.

Gemma4 source/BF16 MoE bundles ship expert tensors as suffixless `experts.gate_up_proj` /
`experts.down_proj`, which sanitize did not normalize — the load failed with:

```
Unhandled keys ["down_proj", "gate_up_proj"] in language_model.model.layers.0.experts
```

These are now normalized into `experts.switch_glu`, alongside the existing quantized
`.weight`/`.scales` fused remapping, and the BF16/source vs MXFP4/JANG_4M expert-key contract is
documented in `docs/GEMMA4_EXPERT_KEY_SANITIZE_CONTRACT_2026_06_11.md`.

## Verification

`swift test --filter Gemma4` → **112/112 pass in 22 suites**.

Live A/B on `gemma-4-26B-A4B-it-qat-JANG_4M` (the installed Gemma4 **MoE** bundle, growing-chat
cache): **IDENTICAL to main** — turn-2 prompt boundary probe, `paged{hits=4,misses=3}`,
`disk{stores=7}`, and the recall phrase all match, so the existing quantized expert path is
undisturbed.

## Reachability — stated plainly

The new branch is **not** exercised by anything installed here. All ten local Gemma4 bundles ship
the quantized fused form (`experts.switch_glu.*.weight/.scales`); none has a suffixless key, so the
normalization added by this PR never fires locally. What the A/B proves is the thing that could
have gone wrong — that touching expert sanitize did not disturb the MoE bundle that does load.
Efficacy for the BF16/source case rests on the regression test and the original report.

## Note on the A/B

The first comparison I ran was worthless and I nearly reported it: the merge was already committed,
so `git stash` had nothing to revert and both "sides" ran the same binary — a 0.43s no-op build
that printed IDENTICAL. Redone by checking `Libraries`/`Tests` back to `main`, confirming a real
73s rebuild and a new binary timestamp, then restoring. Same trap as #137; worth watching for.