### PR TITLE
Add Qwen 3.5 TB5 TP proof suite

### DIFF
--- a/Libraries/MLXDistributedTP/ShardingPlans+Qwen35.swift
+++ b/Libraries/MLXDistributedTP/ShardingPlans+Qwen35.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+extension ShardingPlan {
+    /// Qwen 3.5 / Qwen3-family first-pass tensor-parallel plan.
+    ///
+    /// This plan covers the projection names shared by Qwen3 dense,
+    /// Qwen3 MoE, and Qwen 3.5 text models:
+    ///
+    /// - self-attention q/k/v are output-sharded
+    /// - self-attention o is input-sharded and all-reduced
+    /// - dense MLP and shared expert gate/up are output-sharded
+    /// - dense MLP and shared expert down are input-sharded and all-reduced
+    ///
+    /// Qwen 3.5 GatedDelta / SSM companion layers are intentionally not
+    /// sharded here. Routed SwitchGLU experts are also left replicated until
+    /// the SwitchLinear sharding path is part of the same clean proof. Both
+    /// require separate parity proof for recurrent state, prefix replay, and
+    /// L2/companion-cache restore before they can be treated as
+    /// tensor-parallel data-plane proof.
+    public static let qwen35 = ShardingPlan(
+        directives: [
+            "self_attn.q_proj": .allToSharded(segments: 1),
+            "self_attn.k_proj": .allToSharded(segments: 1),
+            "self_attn.v_proj": .allToSharded(segments: 1),
+            "self_attn.o_proj": .shardedToAll(segments: 1),
+
+            "mlp.gate_proj": .allToSharded(segments: 1),
+            "mlp.up_proj": .allToSharded(segments: 1),
+            "mlp.down_proj": .shardedToAll(segments: 1),
+
+            "shared_expert.gate_proj": .allToSharded(segments: 1),
+            "shared_expert.up_proj": .allToSharded(segments: 1),
+            "shared_expert.down_proj": .shardedToAll(segments: 1),
+            "shared_experts.gate_proj": .allToSharded(segments: 1),
+            "shared_experts.up_proj": .allToSharded(segments: 1),
+            "shared_experts.down_proj": .shardedToAll(segments: 1),
+        ])
+}

--- a/Package.swift
+++ b/Package.swift
@@ -325,6 +325,7 @@ let package = Package(
         .executable(name: "ANEProbe", targets: ["ANEProbe"]),
         .executable(name: "OmniAudioLatencyBench", targets: ["OmniAudioLatencyBench"]),
         .executable(name: "OmniAudioChunkStabilityBench", targets: ["OmniAudioChunkStabilityBench"]),
+        .executable(name: "Qwen35TPProofRunner", targets: ["Qwen35TPProofRunner"]),
         .executable(name: "mlxpress", targets: ["MLXPressCLI"]),
         .executable(name: "mlxpress-selfcheck", targets: ["MLXPressSelfCheck"]),
     ],
@@ -671,6 +672,19 @@ let package = Package(
             name: "DistributedReplicaSmoke",
             dependencies: ["MLXDistributedCore"],
             path: "tools/DistributedReplicaSmoke"
+        ),
+        .executableTarget(
+            name: "Qwen35TPProofRunner",
+            dependencies: [
+                "MLX",
+                "MLXNN",
+                "MLXLMCommon",
+                "MLXLLM",
+                "MLXHuggingFace",
+                "MLXDistributedTP",
+                "VMLXTokenizers",
+            ],
+            path: "tools/Qwen35TPProofRunner"
         ),
         .executableTarget(
             name: "ANEProbe",

--- a/docs/QWEN35_TB5_TP_PROOF_PLAN_2026_06_10.md
+++ b/docs/QWEN35_TB5_TP_PROOF_PLAN_2026_06_10.md
@@ -1,0 +1,81 @@
+# Qwen 3.5 TB5/RDMA Tensor-Parallel Proof Plan
+
+Last updated: 2026-06-10
+
+## Purpose
+
+This note defines the first vMLX-side proof lane for Qwen 3.5 distributed
+tensor-parallel inference over a Thunderbolt data plane. It is intentionally
+separate from active Gemma 4 release work.
+
+## Current Test Entry Point
+
+```sh
+QWEN35_TP_MODEL=/path/to/qwen35/model \
+QWEN35_TP_ARTIFACT_DIR=.artifacts/qwen35-tb5-tp-live \
+scripts/vmlx-qwen35-tb5-tp-proof.sh
+```
+
+Without `QWEN35_TP_MODEL`, the suite still builds the distributed tools and
+runs the encrypted peer smoke plus single-rank collective/kernel smoke. That
+is only `PARTIAL_NO_MODEL`.
+
+## What The Suite Exercises
+
+- builds `Qwen35TPProofRunner` and `DistributedPeerSmoke`
+- verifies the encrypted distributed metadata path
+- runs an MLX collective smoke path through the Swift distributed wrapper
+- loads a Qwen 3.5 model when `QWEN35_TP_MODEL` is set
+- runs deterministic decode with:
+  - Qwen 3.5 sharding plan selected
+  - prefix cache coordinator enabled
+  - disk L2 cache enabled
+  - TurboQuant KV mode enabled
+- repeats the same prompt as a warm replay and requires disk L2 hit evidence
+- writes a machine-readable `SUMMARY.json`
+
+## Qwen 3.5 Architecture Boundary
+
+The first sharding plan covers Qwen-style normal attention and MoE/MLP
+projection modules:
+
+- `self_attn.q_proj`, `k_proj`, `v_proj`, `o_proj`
+- dense `mlp.gate_proj`, `up_proj`, `down_proj`
+- shared expert projections
+
+Qwen 3.5 GatedDelta / SSM companion layers are deliberately left replicated.
+They need a separate proof for recurrent state, SSM companion cache restore,
+prefix replay, and L2 disk compatibility before being called TP-ready.
+Routed `switch_mlp` experts are also left replicated in this clean checkpoint
+until SwitchLinear sharding support is proven in the same branch.
+
+## Required Artifacts For A Real TB5 RDMA Row
+
+The simulated local row is not enough for release. A real row needs:
+
+- two Macs with Osaurus/vMLX running the same commit
+- Thunderbolt data-plane IPs accepted by `TensorDataPlanePolicy`
+- no Tailscale or VPN address in the tensor data plane
+- `QWEN35_TP_BACKEND=jaccl`
+- rank 0 and rank 1 logs
+- model load success on all ranks
+- nonzero sharding rewrites
+- visible decoded output from rank 0
+- token/s or equivalent generation timing
+- prefix cache evidence
+- disk L2 hit/store evidence
+- Qwen hybrid SSM companion cache or explicit replicated-companion boundary
+- no native crash or hanging collective
+
+## Status
+
+- `FIXED`: Qwen-family sharding plan exists for attention and MoE/MLP
+  projection modules.
+- `FIXED`: proof runner captures build, peer smoke, collective smoke,
+  model decode, warm replay, TurboQuant KV mode, and disk L2 stats.
+- `PARTIAL`: local single-host run simulates the distributed path but does not
+  prove TB5 RDMA transport.
+- `PARTIAL`: Qwen 3.5 GatedDelta/SSM layers and routed SwitchGLU experts are
+  replicated pending companion cache and expert-sharding parity proof.
+- `BLOCKED`: real multi-node RDMA row until two Thunderbolt-connected Macs are
+  available with JACCL/RDMA initialized and matching model bundles.

--- a/scripts/vmlx-qwen35-tb5-tp-proof.sh
+++ b/scripts/vmlx-qwen35-tb5-tp-proof.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
+ARTIFACT_DIR="${QWEN35_TP_ARTIFACT_DIR:-$ROOT/.artifacts/qwen35-tb5-tp-$(date +%Y%m%d-%H%M%S)}"
+MODEL_PATH="${QWEN35_TP_MODEL:-}"
+BACKEND="${QWEN35_TP_BACKEND:-ring}"
+RDMA_BACKEND="${QWEN35_TP_RDMA_BACKEND:-jaccl}"
+PROMPT_TOKENS="${QWEN35_TP_PROMPT_TOKEN_IDS:-151644,8948,198,2610,525,264,10950,17847,13,151645,198,151644,872,198,3838,264,1290,3984,624,151645,198,151644,77091,198}"
+MAX_NEW_TOKENS="${QWEN35_TP_MAX_NEW_TOKENS:-8}"
+TIMEOUT_SECONDS="${QWEN35_TP_TIMEOUT_SECONDS:-900}"
+CACHE_DIR="${QWEN35_TP_CACHE_DIR:-$ARTIFACT_DIR/cache}"
+SWIFTCMD="${SWIFTCMD:-swift}"
+
+mkdir -p "$ARTIFACT_DIR" "$CACHE_DIR"
+
+log() {
+  printf '[qwen35-tb5-tp-proof] %s\n' "$*"
+}
+
+write_json() {
+  local path="$1"
+  shift
+  python3 - "$path" "$@" <<'PY'
+import json, pathlib, sys
+path = pathlib.Path(sys.argv[1])
+payload = dict(arg.split("=", 1) for arg in sys.argv[2:])
+path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+PY
+}
+
+run_with_timeout() {
+  local seconds="$1"
+  shift
+  python3 - "$seconds" "$@" <<'PY'
+import os, signal, subprocess, sys
+timeout = int(sys.argv[1])
+cmd = sys.argv[2:]
+proc = subprocess.Popen(cmd)
+try:
+    rc = proc.wait(timeout=timeout)
+except subprocess.TimeoutExpired:
+    proc.send_signal(signal.SIGTERM)
+    try:
+        proc.wait(timeout=10)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+    print(f"timeout after {timeout}s: {' '.join(cmd)}", file=sys.stderr)
+    sys.exit(124)
+sys.exit(rc)
+PY
+}
+
+build_products() {
+  log "building Qwen35TPProofRunner and DistributedPeerSmoke"
+  "$SWIFTCMD" build --package-path "$ROOT" --product Qwen35TPProofRunner --product DistributedPeerSmoke \
+    2>&1 | tee "$ARTIFACT_DIR/build.log"
+}
+
+prepare_mlx_metal() {
+  log "preparing MLX metallib for command-line kernel smoke"
+  if "$ROOT/scripts/prepare-mlx-metal.sh" > "$ARTIFACT_DIR/metal-prep.log" 2> "$ARTIFACT_DIR/metal-prep.err"; then
+    return 0
+  fi
+  log "MLX metallib preparation failed; kernel/model rows will be blocked"
+  return 1
+}
+
+run_peer_smoke() {
+  log "running encrypted loopback peer smoke"
+  "$SWIFTCMD" run --package-path "$ROOT" DistributedPeerSmoke --self-test --interface loopback \
+    > "$ARTIFACT_DIR/peer-smoke.json" 2> "$ARTIFACT_DIR/peer-smoke.stderr"
+}
+
+run_collective_smoke() {
+  log "running single-rank collective/kernel smoke"
+  run_with_timeout "$TIMEOUT_SECONDS" env \
+    MLX_RANK=0 \
+    MLX_WORLD_SIZE=1 \
+    MLX_DIST_BACKEND="$BACKEND" \
+    TP_STRICT=0 \
+    TP_SMOKE=1 \
+    TP_OUTPUT_PATH="$ARTIFACT_DIR/collective-smoke.json" \
+    "$SWIFTCMD" run --package-path "$ROOT" Qwen35TPProofRunner \
+    > "$ARTIFACT_DIR/collective-smoke.log" 2>&1
+}
+
+run_model_baseline() {
+  log "running Qwen 3.5 baseline load/decode with prefix + disk L2 + TurboQuant KV"
+  run_with_timeout "$TIMEOUT_SECONDS" env \
+    MLX_RANK=0 \
+    MLX_WORLD_SIZE=1 \
+    MLX_DIST_BACKEND="$BACKEND" \
+    TP_MODEL_PATH="$MODEL_PATH" \
+    TP_OUTPUT_PATH="$ARTIFACT_DIR/baseline-cold.json" \
+    TP_SHARDING_PLAN=qwen35 \
+    TP_MAX_NEW_TOKENS="$MAX_NEW_TOKENS" \
+    TP_PROMPT_TOKEN_IDS="$PROMPT_TOKENS" \
+    TP_ENABLE_CACHE_COORDINATOR=1 \
+    TP_PREFIX_CACHE=1 \
+    TP_L2_DISK_CACHE=1 \
+    TP_CACHE_DIR="$CACHE_DIR/baseline" \
+    TP_KV_MODE=turboquant \
+    TP_TEMPERATURE=0 \
+    "$SWIFTCMD" run --package-path "$ROOT" Qwen35TPProofRunner \
+    > "$ARTIFACT_DIR/baseline-cold.log" 2>&1
+
+  log "running Qwen 3.5 warm replay for prefix/L2 hit evidence"
+  run_with_timeout "$TIMEOUT_SECONDS" env \
+    MLX_RANK=0 \
+    MLX_WORLD_SIZE=1 \
+    MLX_DIST_BACKEND="$BACKEND" \
+    TP_MODEL_PATH="$MODEL_PATH" \
+    TP_OUTPUT_PATH="$ARTIFACT_DIR/baseline-warm.json" \
+    TP_SHARDING_PLAN=qwen35 \
+    TP_MAX_NEW_TOKENS="$MAX_NEW_TOKENS" \
+    TP_PROMPT_TOKEN_IDS="$PROMPT_TOKENS" \
+    TP_ENABLE_CACHE_COORDINATOR=1 \
+    TP_PREFIX_CACHE=1 \
+    TP_L2_DISK_CACHE=1 \
+    TP_CACHE_DIR="$CACHE_DIR/baseline" \
+    TP_KV_MODE=turboquant \
+    TP_TEMPERATURE=0 \
+    "$SWIFTCMD" run --package-path "$ROOT" Qwen35TPProofRunner \
+    > "$ARTIFACT_DIR/baseline-warm.log" 2>&1
+}
+
+validate_outputs() {
+  log "validating JSON outputs and cache evidence"
+  python3 - "$ARTIFACT_DIR" <<'PY'
+import json, pathlib, sys
+root = pathlib.Path(sys.argv[1])
+summary = {
+    "artifact_dir": str(root),
+    "status": "PARTIAL",
+    "proof_rows": [],
+    "blocked": [],
+}
+
+peer = root / "peer-smoke.json"
+if peer.exists():
+    try:
+        peer_json = json.loads(peer.read_text())
+        summary["proof_rows"].append({
+            "name": "encrypted_peer_smoke",
+            "ok": bool(peer_json.get("ok")),
+            "rdma_ready": peer_json.get("route", {}).get("rdmaReady"),
+            "rdma_blocked_reason": peer_json.get("route", {}).get("rdmaBlockedReason"),
+        })
+    except Exception as exc:
+        summary["blocked"].append(f"peer smoke JSON parse failed: {exc}")
+else:
+    summary["blocked"].append("peer smoke did not produce JSON")
+
+for name in ["baseline-cold", "baseline-warm"]:
+    path = root / f"{name}.json"
+    if not path.exists():
+        summary["blocked"].append(f"{name} output missing")
+        continue
+    data = json.loads(path.read_text())
+    disk = data.get("cache_stats", {}).get("disk", {})
+    ssm = data.get("cache_stats", {}).get("ssm", {})
+    engine = data.get("engine", {})
+    summary["proof_rows"].append({
+        "name": name,
+        "model_type": data.get("model_type"),
+        "generated_token_count": len(data.get("generated_tokens", [])),
+        "decoded_preview": data.get("decoded", "")[:160],
+        "tokens_per_second": data.get("tokens_per_second"),
+        "kv_mode": data.get("kv_mode"),
+        "disk_hits": disk.get("hit_count"),
+        "disk_misses": disk.get("miss_count"),
+        "disk_stores": disk.get("stores"),
+        "ssm_hits": ssm.get("hit_count"),
+        "ssm_re_derives": ssm.get("re_derives"),
+        "turboquant_compressions": engine.get("turboquant_compressions"),
+    })
+    if not data.get("generated_tokens"):
+        summary["blocked"].append(f"{name} generated no tokens")
+
+warm = root / "baseline-warm.json"
+if warm.exists():
+    warm_data = json.loads(warm.read_text())
+    disk_hits = warm_data.get("cache_stats", {}).get("disk", {}).get("hit_count", 0) or 0
+    if disk_hits <= 0:
+        summary["blocked"].append("warm replay did not report disk L2 hits")
+
+summary["qwen35_tp_boundary"] = (
+    "Qwen 3.5 normal attention/MoE projections have a TP plan. "
+    "GatedDelta/SSM companion layers are replicated until recurrent-state "
+    "and companion-cache parity is proven."
+)
+summary["rdma_boundary"] = (
+    "Loopback/ring proof exercises the Swift distributed path and MLX "
+    "collective kernel. Real TB5 RDMA proof requires two Macs with allowed "
+    "Thunderbolt data-plane addresses and QWEN35_TP_BACKEND=jaccl."
+)
+if not summary["blocked"] and len(summary["proof_rows"]) >= 3:
+    summary["status"] = "FIXED_FOR_SINGLE_HOST_SIMULATED_TP"
+summary_path = root / "SUMMARY.json"
+summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+print(summary_path)
+if summary["blocked"]:
+    for item in summary["blocked"]:
+        print(f"BLOCKED: {item}", file=sys.stderr)
+    sys.exit(20)
+PY
+}
+
+main() {
+  build_products
+  run_peer_smoke
+  metal_status="ok"
+  if ! prepare_mlx_metal; then
+    metal_status="blocked"
+  fi
+  collective_status="skipped"
+  if [[ "$metal_status" == "ok" ]]; then
+    if run_collective_smoke; then
+      collective_status="ok"
+    else
+      collective_status="blocked"
+    fi
+  fi
+
+  if [[ -z "$MODEL_PATH" ]]; then
+    write_json "$ARTIFACT_DIR/SUMMARY.json" \
+      artifact_dir="$ARTIFACT_DIR" \
+      status="PARTIAL_NO_MODEL" \
+      metal_status="$metal_status" \
+      collective_status="$collective_status" \
+      blocked="set QWEN35_TP_MODEL to run model load/decode/cache proof" \
+      rdma_backend="$RDMA_BACKEND" \
+      rdma_boundary="set QWEN35_TP_BACKEND=jaccl and use real Thunderbolt data-plane addresses for TB5 RDMA proof"
+    log "no QWEN35_TP_MODEL set; wrote partial summary to $ARTIFACT_DIR/SUMMARY.json"
+    return 0
+  fi
+
+  if [[ "$metal_status" != "ok" || "$collective_status" != "ok" ]]; then
+    write_json "$ARTIFACT_DIR/SUMMARY.json" \
+      artifact_dir="$ARTIFACT_DIR" \
+      status="BLOCKED_METAL_OR_COLLECTIVE_SMOKE" \
+      metal_status="$metal_status" \
+      collective_status="$collective_status" \
+      blocked="kernel smoke must pass before model load/decode/cache proof" \
+      rdma_backend="$RDMA_BACKEND"
+    return 20
+  fi
+
+  run_model_baseline
+  validate_outputs
+  log "summary: $ARTIFACT_DIR/SUMMARY.json"
+}
+
+main "$@"

--- a/tools/Qwen35TPProofRunner/main.swift
+++ b/tools/Qwen35TPProofRunner/main.swift
@@ -1,0 +1,235 @@
+import Foundation
+import MLX
+import MLXDistributedTP
+import MLXHuggingFace
+import MLXLLM
+import MLXLMCommon
+import MLXNN
+@preconcurrency import VMLXTokenizers
+
+@main
+enum Qwen35TPProofRunner {
+    static func main() async {
+        setvbuf(stdout, nil, _IONBF, 0)
+        let env = ProcessInfo.processInfo.environment
+        let rank = Int(env["MLX_RANK"] ?? "0") ?? 0
+        let worldSize = Int(env["MLX_WORLD_SIZE"] ?? "1") ?? 1
+        let backend = env["MLX_DIST_BACKEND"] ?? "ring"
+        let strict = (env["TP_STRICT"] ?? "1") != "0"
+        let modelPath = env["TP_MODEL_PATH"] ?? ""
+        let outputPath = env["TP_OUTPUT_PATH"] ?? "/tmp/qwen35_tp_rank\(rank).json"
+        let promptTokens = parseTokens(
+            env["TP_PROMPT_TOKEN_IDS"],
+            fallback: [151644, 8948, 198, 2610, 525, 264, 10950, 17847, 13])
+        let maxNewTokens = Int(env["TP_MAX_NEW_TOKENS"] ?? "8") ?? 8
+        let cacheDir = env["TP_CACHE_DIR"] ?? "/tmp/vmlx-qwen35-tp-cache/rank\(rank)"
+        let enableDiskCache = env["TP_L2_DISK_CACHE"] != "0"
+        let kvMode = parseKVMode(env["TP_KV_MODE"])
+
+        log("rank=\(rank) world_size=\(worldSize) backend=\(backend) strict=\(strict)")
+        log("model_path=\(modelPath)")
+        log("output_path=\(outputPath)")
+        log("max_new_tokens=\(maxNewTokens) kv_mode=\(describe(kvMode))")
+        log("cache_dir=\(cacheDir) disk_l2=\(enableDiskCache)")
+
+        if env["TP_SMOKE"] == "1" {
+            let group = Group(strict: strict, backend: backend)
+            let input = MLXArray((0 ..< 8).map(Float.init))
+            let summed = Collectives.allSum(input, group: group)
+            MLX.eval(summed)
+            writeJSON(outputPath, [
+                "mode": "smoke",
+                "rank": rank,
+                "world_size": group.size,
+                "backend": backend,
+                "all_sum": summed.asArray(Float.self),
+            ])
+        }
+
+        guard !modelPath.isEmpty else {
+            fail("TP_MODEL_PATH not set")
+        }
+
+        let group = Group(strict: strict, backend: backend)
+        log("group rank=\(group.rank) size=\(group.size) multi=\(group.isMultiRank)")
+
+        let context: ModelContext
+        do {
+            context = try await loadModel(
+                from: URL(fileURLWithPath: modelPath),
+                using: #huggingFaceTokenizerLoader())
+        } catch {
+            fail("loadModel failed: \(error)")
+        }
+        log("loaded model \(type(of: context.model))")
+
+        var replaced: Set<String> = []
+        if group.isMultiRank {
+            replaced = ShardingPlan.qwen35.apply(to: context.model, group: group)
+            log("qwen35 sharding replacements=\(replaced.count)")
+            if replaced.isEmpty {
+                fail("Qwen35 sharding plan produced zero replacements for \(type(of: context.model))")
+            }
+            MLX.eval(context.model)
+        }
+
+        var parameters = GenerateParameters(
+            maxTokens: maxNewTokens,
+            kvMode: kvMode,
+            temperature: 0,
+            prefillStepSize: 512)
+        parameters.topP = 1.0
+        parameters.topK = 0
+        parameters.minP = 0
+
+        let coordinator = CacheCoordinator(config: CacheCoordinatorConfig(
+            usePagedCache: true,
+            enableDiskCache: enableDiskCache,
+            diskCacheDir: URL(fileURLWithPath: cacheDir),
+            modelKey: "qwen35-tp-rank\(rank)-world\(group.size)-\(type(of: context.model))",
+            defaultKVMode: kvMode))
+
+        let input = LMInput(text: LMInput.Text(tokens: MLXArray(promptTokens.map(Int32.init)).reshaped([1, promptTokens.count])))
+
+        let started = Date()
+        var iterator: TokenIterator
+        do {
+            iterator = try TokenIterator(
+                input: input,
+                model: context.model,
+                parameters: parameters,
+                cacheCoordinator: coordinator)
+        } catch {
+            fail("TokenIterator init failed: \(error)")
+        }
+        let prefillElapsed = Date().timeIntervalSince(started)
+
+        let decodeStarted = Date()
+        var generated: [Int] = []
+        while let token = iterator.next() {
+            generated.append(token)
+            log("generated[\(generated.count - 1)]=\(token)")
+            if generated.count >= maxNewTokens {
+                break
+            }
+        }
+        let decodeElapsed = Date().timeIntervalSince(decodeStarted)
+        iterator.storeCacheAfterGeneration(generatedTokenIds: generated, includeGeneratedBoundary: false)
+        let snapshot = coordinator.snapshotStats()
+        let decoded = context.tokenizer.decode(tokenIds: generated, skipSpecialTokens: false)
+
+        writeJSON(outputPath, [
+            "mode": "qwen35_tp_decode",
+            "rank": rank,
+            "world_size": group.size,
+            "backend": backend,
+            "model_type": String(describing: type(of: context.model)),
+            "sharding_plan": "qwen35",
+            "sharding_replacements": replaced.sorted(),
+            "sharding_replacement_count": replaced.count,
+            "qwen35_ssm_boundary": "GatedDelta/SSM companion layers are replicated pending recurrent-state cache parity proof.",
+            "prompt_tokens": promptTokens,
+            "generated_tokens": generated,
+            "decoded": decoded,
+            "kv_mode": describe(kvMode),
+            "cache_stats": cacheStats(snapshot),
+            "prefill_seconds": prefillElapsed,
+            "decode_seconds": decodeElapsed,
+            "tokens_per_second": tokensPerSecond(generated.count, decodeElapsed),
+        ])
+    }
+}
+
+private func parseTokens(_ raw: String?, fallback: [Int]) -> [Int] {
+    guard let raw, !raw.isEmpty else { return fallback }
+    let parsed = raw.split(separator: ",").compactMap { Int($0.trimmingCharacters(in: .whitespaces)) }
+    return parsed.isEmpty ? fallback : parsed
+}
+
+private func parseKVMode(_ raw: String?) -> KVQuantizationMode {
+    guard let raw = raw?.lowercased(), !raw.isEmpty, raw != "none" else {
+        return .none
+    }
+    if raw == "turboquant" || raw == "tq" {
+        return .turboQuant(keyBits: 3, valueBits: 3)
+    }
+    if raw.hasPrefix("tq:") || raw.hasPrefix("turboquant:") {
+        let bits = raw.split(separator: ":", maxSplits: 1).dropFirst().first ?? ""
+        let parts = bits.split(separator: ",").compactMap { Int($0) }
+        return .turboQuant(
+            keyBits: parts.first ?? 3,
+            valueBits: parts.dropFirst().first ?? parts.first ?? 3)
+    }
+    fail("unsupported TP_KV_MODE=\(raw)")
+}
+
+private func describe(_ mode: KVQuantizationMode) -> String {
+    switch mode {
+    case .none:
+        return "none"
+    case .affine(let bits, let groupSize):
+        return "affine(bits:\(bits),group:\(groupSize))"
+    case .turboQuant(let keyBits, let valueBits):
+        return "turboquant(keyBits:\(keyBits),valueBits:\(valueBits))"
+    }
+}
+
+private func cacheStats(_ snapshot: CacheCoordinatorStatsSnapshot) -> [String: Any] {
+    var out: [String: Any] = [
+        "paged_enabled": snapshot.pagedEnabled,
+        "disk_enabled": snapshot.diskEnabled,
+        "is_hybrid": snapshot.isHybrid,
+        "is_paged_incompatible": snapshot.isPagedIncompatible,
+        "ssm": [
+            "hit_count": snapshot.ssmStats.hits,
+            "miss_count": snapshot.ssmStats.misses,
+            "re_derives": snapshot.ssmStats.reDerives,
+        ],
+    ]
+    if let disk = snapshot.diskStats {
+        out["disk"] = [
+            "hit_count": disk.hits,
+            "miss_count": disk.misses,
+            "stores": disk.stores,
+            "max_size_bytes": disk.maxSizeBytes,
+        ]
+    }
+    if let paged = snapshot.pagedStats {
+        out["paged"] = [
+            "total_blocks": paged.totalBlocks,
+            "allocated_blocks": paged.allocatedBlocks,
+            "free_blocks": paged.freeBlocks,
+            "hit_count": paged.cacheHits,
+            "miss_count": paged.cacheMisses,
+            "evictions": paged.evictions,
+        ]
+    }
+    return out
+}
+
+private func tokensPerSecond(_ count: Int, _ elapsed: TimeInterval) -> Double {
+    guard count > 0, elapsed > 0 else { return 0 }
+    let value = Double(count) / elapsed
+    return value.isFinite ? value : 0
+}
+
+private func writeJSON(_ path: String, _ payload: [String: Any]) -> Never {
+    do {
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: URL(fileURLWithPath: path))
+        exit(0)
+    } catch {
+        fail("failed to write JSON \(path): \(error)")
+    }
+}
+
+@inline(__always) private func log(_ message: String) {
+    let rank = ProcessInfo.processInfo.environment["MLX_RANK"] ?? "?"
+    print("[Qwen35TPProofRunner rank=\(rank)] \(message)")
+}
+
+private func fail(_ message: String) -> Never {
+    let rank = ProcessInfo.processInfo.environment["MLX_RANK"] ?? "?"
+    FileHandle.standardError.write(Data("[Qwen35TPProofRunner rank=\(rank)] ERROR: \(message)\n".utf8))
+    exit(2)
+}


### PR DESCRIPTION
Rebases #42 onto current `main`. Adds the tensor-parallel proof tooling for Qwen 3.5 over TB5/RDMA:

- `tools/Qwen35TPProofRunner` — standalone runner for kernel smoke plus model/cache decode rows
- `Libraries/MLXDistributedTP/ShardingPlans+Qwen35.swift` — conservative Qwen-family sharding plan
  (attention + dense/shared projections)
- `scripts/vmlx-qwen35-tb5-tp-proof.sh` and a plan doc covering peer smoke, MLX collective smoke,
  model load/decode, prefix cache, disk L2 and TurboQuant KV evidence

## Blast radius: none on the decode path

`MLXDistributedTP` is imported by **no** shipped library — `grep -rn "import MLXDistributedTP"
Libraries/` returns nothing. It is referenced only by tool and test targets, so this cannot affect
ordinary generation for any family. That is the argument for safety here, and it is stronger than a
behavioural A/B because it is structural.

## Verification

- `swift build -c release --product Qwen35TPProofRunner` → clean
- `swift build -c release --product RunBench` → clean (the existing product still builds with the
  new target in `Package.swift`)
- `swift test --filter 'ShardingPlan|DistributedTP|Qwen35'` → **12/12 pass in 6 suites**
- runner argument handling exercised: with no `TP_MODEL_PATH` it reports
  `ERROR: TP_MODEL_PATH not set` and exits cleanly rather than trapping

## What is NOT proven here

The suite's actual purpose — multi-rank TP over TB5 — cannot run on a single machine. With a real
model path and `world_size=1` the run stops at:

```
MLX error: Cannot initialize ring distributed backend.
  at Libraries/CmlxDistributedShim/MlxCDistributedGroup.cpp:62
```

which is correct behaviour for a ring backend with no peer, not a defect. So this lands as tooling
whose end-to-end path still needs a two-box TB5 run to exercise. I would rather have it in the tree
and honestly labelled than keep it out of review indefinitely.