### PR TITLE
Repair six stale focused-test assertions; MLXLMCommonFocusedTests is green again

### DIFF
--- a/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
@@ -66,7 +66,14 @@ struct BatchEngineGrowingChatCacheSourceTests {
             "slot.originalInput.cachePromptIntent == .reusablePrefixWarmup"))
         #expect(mtp.contains(
             "originalInput.cachePromptIntent == .reusablePrefixWarmup"))
-        #expect(mtp.contains("originalInput.canCaptureHybridStripBoundary("))
+        // `ec1bc597` (#249) replaced the MTP iterator's inline
+        // `originalInput.canCaptureHybridStripBoundary(...)` with the shared
+        // `TokenIterator.hybridStripBoundaryIndex(...)`, which performs that same check
+        // internally (`Evaluate.swift:1990`) along with the coordinator/hybrid/strip-index
+        // guards. Assert the shared helper so all three paths are pinned to ONE
+        // implementation instead of three drifting copies.
+        #expect(mtp.contains("TokenIterator.hybridStripBoundaryIndex("))
+        #expect(evaluate.contains("input.canCaptureHybridStripBoundary("))
         #expect(evaluate.contains("shouldPersistExactPromptBoundary("))
         #expect(batch.contains("shouldPersistExactPromptBoundary("))
         #expect(mtp.contains("shouldPersistExactPromptBoundary("))
@@ -216,10 +223,18 @@ struct BatchEngineGrowingChatCacheSourceTests {
         #expect(source.contains("shouldSkipHistoryBoundaryRederiveAfterTrimMiss(storageSnapshot)"))
         #expect(source.contains("TokenIterator: skipped history-boundary cache rederive after trim miss"))
         #expect(source.contains("cacheStablePrefixTokenCounts.contains(boundary)"))
-        #expect(source.contains(
-            "allowDiskBackedRederive: shouldForceStableBoundaryRederive("))
+        // The gate is now bound to a local before use rather than passed as an
+        // `allowDiskBackedRederive:` argument; the predicate itself is unchanged.
+        #expect(source.contains("shouldForceStableBoundaryRederive("))
         #expect(source.contains("let storeBoundary = isStableBoundary"))
-        #expect(source.contains("coordinator.hasValidatedDiskEntry("))
+        // `hasValidatedDiskEntry` → `hasDurableDiskEntry` was a deliberate fix, not a rename.
+        // `hasValidated…` trusts only entries this process wrote, so after a restart — or on any
+        // turn that restored from cache, where prefill never crosses the earlier boundaries — an
+        // entry already on disk was rebuilt anyway. That rebuild replays the prefix through the
+        // model and is cancellable, so a Stop mid-turn killed it as `rederive-failed …
+        // CancellationError()`. Pin the durable form so the process-local check cannot return.
+        #expect(source.contains("coordinator.hasDurableDiskEntry("))
+        #expect(!source.contains("coordinator.hasValidatedDiskEntry("))
         #expect(!source.contains("let unsafePartial = !remainingTokens.isEmpty &&\n                        (hasMediaContent || hasSSMLayer)"))
     }
 

--- a/Tests/MLXLMCommonFocusedTests/DSV4AgenticToolSourceTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/DSV4AgenticToolSourceTests.swift
@@ -13,18 +13,19 @@ struct DSV4AgenticToolSourceTests {
         #expect(bench.contains("BENCH_DSV4_AGENTIC_TOOL"))
         #expect(bench.contains("func runDSV4AgenticToolCheck("))
         #expect(bench.contains("context.configuration.toolCallFormat == .dsml"))
-        #expect(bench.contains("ReasoningParser.fromCapabilityName("))
-        #expect(bench.contains("reasoningParser?.startTag == \"<think>\""))
-        #expect(bench.contains("reasoningParser?.endTag == \"</think>\""))
-        #expect(bench.contains("BENCH_DSV4_AGENTIC_CACHE_PAGED\"] == \"1\""))
-        #expect(bench.contains("toolCall.function.arguments[\"launch_id\"] == .string(launchID)"))
-        #expect(bench.contains("toolTurn.toolProgressDeltas > 0"))
+        // The row gates on the reasoning STAMP rather than comparing parser tags: a bundle that
+        // is not `think_xml` is rejected before any generation happens, which is the stronger
+        // check (it cannot pass by accident on a family whose tags merely look similar).
+        #expect(bench.contains(#"context.configuration.reasoningParserName == "think_xml""#))
+        #expect(bench.contains("DSV4 agentic row requires think_xml reasoning parser"))
         #expect(bench.contains("generationConfig: ctx.configuration.generationDefaults"))
-        #expect(bench.contains("BENCH_DSV4_AGENTIC_INTERLEAVED"))
-        #expect(bench.contains("reasoningContent: toolTurn.reasoning.isEmpty ? nil : toolTurn.reasoning"))
-        #expect(bench.contains("chat.append(.tool(statusResultJSON, toolCallId: toolCallId))"))
-        #expect(bench.contains("reasoning->tool1->result1->reasoning->tool2->result2"))
-        #expect(bench.contains("->reasoning->final->thinkingOffFollowup"))
+        // NOT asserted, deliberately: `BENCH_DSV4_AGENTIC_INTERLEAVED` and the
+        // `reasoning->tool1->result1->…->thinkingOffFollowup` transcript shape. Those strings
+        // appear in NO commit on any ref — this file was added in `dcc81227` describing a harness
+        // variant that was never landed, so the suite has been failing since it was written.
+        // Asserting them again would just re-red the suite; asserting what the row DOES enforce
+        // keeps the guard real. The interleaved transcript remains genuinely uncovered here.
+        #expect(bench.contains(".tool("))
         #expect(!bench.contains("Now use \\(windowToolName)"))
         #expect(bench.contains("markerLeaks(in: result.text)"))
         #expect(bench.contains("snapshot.isPagedIncompatible"))

--- a/Tests/MLXLMCommonFocusedTests/DeepseekV4ChatTemplateFallbackFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/DeepseekV4ChatTemplateFallbackFocusedTests.swift
@@ -890,11 +890,15 @@ struct DeepseekV4ChatTemplateFallbackFocusedTests {
             "enable_thinking": false,
         ])
 
-        #expect(rendered.contains("Available functions:"))
-        #expect(rendered.contains("- line_count:"))
-        #expect(rendered.contains("required arguments: text"))
-        #expect(!rendered.contains("List of tools:"))
-        #expect(!rendered.contains("\"name\":\"line_count\""))
+        // LFM2 is trained on the FULL JSON tool schemas under `List of tools: [...]`, not a
+        // name/description summary. `46973d1` ("Remove LFM tool schema markup") replaced the
+        // schemas with a summary and silently broke auto tool-calling for every lfm2/lfm2_moe
+        // model; restoring the native list is what lets the model emit <|tool_call_start|>.
+        // These assertions used to require the summary, i.e. they pinned the regression.
+        #expect(rendered.contains("List of tools:"))
+        #expect(rendered.contains("\"name\":\"line_count\""))
+        #expect(!rendered.contains("Available functions:"))
+        #expect(!rendered.contains("required arguments: text"))
         #expect(!rendered.contains("<tools>"))
         #expect(!rendered.contains("</tool_call>"))
         #expect(rendered.contains("<|tool_call_start|>") == false)
@@ -938,8 +942,9 @@ struct DeepseekV4ChatTemplateFallbackFocusedTests {
         #expect(rendered.contains("Do not double any line break."))
         #expect(!rendered.contains("argument value"))
         #expect(!rendered.contains("..."))
-        #expect(!rendered.contains("List of tools:"))
-        #expect(!rendered.contains("\"name\":\"line_count\""))
+        // Native JSON schemas are REQUIRED for LFM2 tool calling (see 46973d1 note above).
+        #expect(rendered.contains("List of tools:"))
+        #expect(rendered.contains("\"name\":\"line_count\""))
         #expect(!rendered.contains("<tools>"))
         #expect(rendered.contains("Do not write reasoning, XML-style tool tags, markdown, or prose."))
         #expect(rendered.contains("Copy the `text` value exactly from the current user request."))
@@ -1025,9 +1030,17 @@ struct DeepseekV4ChatTemplateFallbackFocusedTests {
             let rendered = try Template(templateSource).renderDSV4(context)
 
             #expect(rendered.contains("Required call shape for the current request:"))
-            #expect(rendered.contains(#"<|tool_call>call:line_count{text:<|"|>alpha\nbeta\ngamma<|"|>}<tool_call|>"#))
-            #expect(rendered.contains(#"Do not replace \n with a physical newline, do not insert a space after it"#))
-            #expect(!rendered.contains(#"alpha\nbeta\n gamma"#))
+            // `a87d3012` ("Fix Gemma4 required tool multiline prompt") removed the
+            // `replace("\n", "\\n")` from `exact_escaped` AND the paired "Do not replace \n with a
+            // physical newline…" instruction: the grounded value is now carried through with REAL
+            // newlines rather than escape sequences the model then had to un-escape. Backslashes
+            // and tabs are still escaped. Assert the shipped shape.
+            #expect(
+                rendered.contains(
+                    "<|tool_call>call:line_count{text:<|\"|>alpha\nbeta\ngamma<|\"|>}<tool_call|>"))
+            #expect(!rendered.contains(#"Do not replace \n with a physical newline"#))
+            // The grounded value must still be exact — no stray space after a line break.
+            #expect(!rendered.contains("alpha\nbeta\n gamma"))
             #expect(rendered.hasSuffix("<|turn>model\n"))
         }
     }
@@ -1085,7 +1098,8 @@ struct DeepseekV4ChatTemplateFallbackFocusedTests {
         #expect(beforeFinalUser.contains("Do not double any line break."))
         #expect(beforeFinalUser.contains("Do not add a blank line, leading space, trailing newline, or any other character to the copied value."))
         #expect(beforeFinalUser.contains("Do not invent placeholders, summaries, ellipsis, or prior-turn text."))
-        #expect(!beforeFinalUser.contains("List of tools:"))
+        // The tool list stays in the rendered history — removing it broke tool calling.
+        #expect(beforeFinalUser.contains("List of tools:"))
         #expect(!beforeFinalUser.contains("<tools>"))
         #expect(!beforeFinalUser.contains("<|tool_call_start|>[line_count(text='red\\ngreen\\nblue')]<|tool_call_end|>"))
         #expect(!afterFinalUser.contains("<real string value>"))
@@ -1200,8 +1214,18 @@ struct DeepseekV4ChatTemplateFallbackFocusedTests {
 
         #expect(source.contains(#"upstream.bosToken == "<|startoftext|>""#))
         #expect(source.contains(#"upstream.eosToken == "<|im_end|>""#))
-        #expect(source.contains(#"upstream.convertTokenToId("<|tool_call_start|>") != nil"#))
-        #expect(source.contains(#"upstream.convertTokenToId("<|tool_call_end|>") != nil"#))
+        // `d4dcb4d3` replaced the bare `!= nil` existence checks with round-trips.
+        // That was a real fix, not a refactor: `convertTokenToId` returns the UNK id for an
+        // unknown token, so `!= nil` says yes for every vocabulary and mis-detected LFM2.
+        // Assert the round-trip form so the weaker check cannot come back.
+        #expect(
+            source.contains(
+                #"upstream.convertTokenToId("<|tool_call_start|>").flatMap { upstream.convertIdToToken($0) } == "<|tool_call_start|>""#
+            ))
+        #expect(
+            source.contains(
+                #"upstream.convertTokenToId("<|tool_call_end|>").flatMap { upstream.convertIdToToken($0) } == "<|tool_call_end|>""#
+            ))
         #expect(source.contains("MLXLMCommon.ChatTemplateFallbacks.lfm2ToolMinimal"))
         #expect(source.contains("[vmlx] chat-template tools -> LFM2ToolMinimal fallback engaged"))
     }


### PR DESCRIPTION
`swift test --filter MLXLMCommonFocusedTests` was **red on `main`**: 6 failing tests, 29 issues.
None was a real defect. Every one asserts against the *text* of a source file and pinned a state
the runtime deliberately moved past — so each was actively harmful, pressuring the next person to
reintroduce a bug that had already been fixed.

**542/542 pass** after this (1 explicitly-marked known issue).

| test | pinned | why that is wrong now |
|---|---|---|
| LFM2 tool fallback detection | `convertTokenToId(x) != nil` | `d4dcb4d3` made it a round-trip: `convertTokenToId` returns the **UNK id** for unknown tokens, so `!= nil` is true for *every* vocabulary and mis-detected LFM2 |
| LFM2 optional tools / required named choice / repeat-after-history (3 tests) | require `"Available functions:"` summary, **forbid** `"List of tools:"` | backwards. `46973d1` replaced the native JSON schemas with a summary and **silently broke auto tool-calling for every lfm2/lfm2_moe model**; the template comment says so. These pinned the regression |
| Gemma4 required-tool grounding | `\n` escapes + `"Do not replace \n with a physical newline"` | `a87d3012` removed both; the grounded value now carries real newlines |
| cache-boundary source test | `coordinator.hasValidatedDiskEntry(` | replaced by `hasDurableDiskEntry` on purpose — the validated form trusts only entries *this process* wrote, so after a restart the entry was rebuilt, and that rebuild is cancellable: a Stop mid-turn killed it as `rederive-failed … CancellationError()` |
| MTP hybrid-strip guard | inline `originalInput.canCaptureHybridStripBoundary(` | `ec1bc597` (#249, mine) centralized it into `TokenIterator.hybridStripBoundaryIndex`, which runs the same check plus the coordinator/strip-index guards. I left this one stale myself |
| DSV4 agentic row | 11 strings incl. `BENCH_DSV4_AGENTIC_INTERLEAVED` | those strings exist in **no commit on any ref**. The file was added in `dcc81227` describing a harness variant that was never landed, so it has failed since it was written |

## Approach

No assertion was simply deleted to get green. Each is re-pointed at the invariant that still
matters, and where the newer design is the *fix*, the assertion is **inverted** so the old form
cannot come back — e.g. `#expect(!source.contains("coordinator.hasValidatedDiskEntry("))`, and the
LFM2 tests now require the JSON schemas they used to forbid.

Every replacement carries a comment naming the commit that moved the ground, so the next reader
does not have to re-derive it.

## One gap kept visible

The DSV4 agentic row's interleaved transcript (`reasoning->tool1->result1->…->thinkingOffFollowup`)
is **not** covered by the shipped bench and is now marked as such in a comment, rather than being
quietly dropped. Re-asserting it would just re-red the suite; pretending it was covered would be
worse.

## Why this matters beyond a green bar

A red baseline makes every PR harder to review — you cannot tell whether the change under review
broke something. I hit these while reviewing unrelated PRs (#43 in Gemma4, and this batch), which
is exactly the cost. Two more of the same class were fixed separately in #259.