### PR TITLE
Clamp the growing-chat cache gate to what a hybrid actually stores

### DIFF
--- a/RunBench/Bench.swift
+++ b/RunBench/Bench.swift
@@ -3283,9 +3283,26 @@ func runGrowingChatCacheReuse(modelPath: String, maxNew: Int) async throws {
             remaining.count,
             diskArraySummary(diskArrays)))
         coordinator.release(blocks: blocks)
-        let expectedPromptBoundary = promptCommon < promptTokens.count
+        // A hybrid topology with a canonical strip boundary DELIBERATELY suppresses every
+        // other boundary (`usesCanonicalHybridBoundary` in BatchEngine/TokenIterator):
+        // persisting the exact prompt and post-answer snapshots as well measured several
+        // almost-identical full serializations per turn — hundreds of MB each on Bonsai — for
+        // reuse the next turn does not need. So for those models the reachable boundary is the
+        // stored history boundary, NOT the full prompt, even when the turn-2 template does not
+        // diverge.
+        //
+        // Without this cap the gate asked hybrids for a boundary the shipped policy never
+        // stores, and it passed or failed by accident: Bonsai's template diverges (21 < 23) so
+        // it took the relaxed branch, while Ornith-1.0-9B shares its whole prompt (25/25),
+        // took the strict branch, and failed at `matched=18, expected at least 25` — same
+        // policy, opposite verdicts, decided by a template detail rather than by cache health.
+        let canonicalHybridCeiling = coordinator.isHybrid ? cachePrefixTokenCounts.max() : nil
+        let unclampedPromptBoundary = promptCommon < promptTokens.count
             ? (cachePrefixTokenCounts.max() ?? promptTokens.count)
             : promptTokens.count
+        let expectedPromptBoundary = canonicalHybridCeiling.map {
+            Swift.min(unclampedPromptBoundary, $0)
+        } ?? unclampedPromptBoundary
         let expectedPostAnswerBoundary = promptTokens.count + r1.tokens.count
         if matched < expectedPromptBoundary {
             throw NSError(domain: "BENCH_GROWING_CHAT_CACHE", code: 4,

--- a/Tests/MLXLMTests/GrowingChatCacheHybridGateSourceTests.swift
+++ b/Tests/MLXLMTests/GrowingChatCacheHybridGateSourceTests.swift
@@ -1,0 +1,58 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import Testing
+
+/// Pins the hybrid clamp on the growing-chat cache gate.
+///
+/// A hybrid topology with a canonical strip boundary deliberately suppresses every other cache
+/// boundary (`usesCanonicalHybridBoundary` in `BatchEngine` / `TokenIterator`): persisting the
+/// exact prompt and post-answer snapshots as well measured several near-identical full
+/// serializations per turn — hundreds of MB each on Bonsai — to buy reuse the next turn does not
+/// need.
+///
+/// The gate therefore must not ask a hybrid for a boundary the shipped policy never stores. Before
+/// the clamp it did, and the verdict came down to a chat-template detail rather than cache health:
+///
+/// | model | turn-2 common prefix | branch taken | verdict |
+/// |---|---|---|---|
+/// | `Bonsai-27b-Ternary` | 21/23 — diverges | relaxed (stored max = 18) | passed |
+/// | `Ornith-1.0-9B-MXFP8` | 25/25 — no divergence | strict (full prompt = 25) | **failed** at `matched=18` |
+/// | `Nemotron-Audex-30B` | no divergence | strict | **failed** at `matched=41, expected 47` |
+///
+/// Same policy, opposite verdicts. The clamp is `min(unclamped, stored max)` and applies ONLY when
+/// `coordinator.isHybrid`, so dense/rotating models keep the full-prompt expectation — and a hybrid
+/// that regresses below its own stored boundary still fails, which is where the gate has teeth.
+@Suite("growing-chat cache gate clamps hybrid expectations")
+struct GrowingChatCacheHybridGateSourceTests {
+
+    private func benchSource() throws -> String {
+        try String(contentsOfFile: "RunBench/Bench.swift", encoding: .utf8)
+    }
+
+    @Test("the hybrid ceiling is derived from the stored boundaries and gated on isHybrid")
+    func hybridCeilingIsGatedOnIsHybrid() throws {
+        let bench = try benchSource()
+        #expect(
+            bench.contains(
+                "let canonicalHybridCeiling = coordinator.isHybrid ? cachePrefixTokenCounts.max() : nil"
+            ),
+            """
+            The hybrid ceiling must come from the STORED boundaries and be gated on `isHybrid`. \
+            Deriving it from the prompt length would re-ask hybrids for a boundary the canonical \
+            strip policy never persists; dropping the `isHybrid` gate would relax dense models too.
+            """)
+    }
+
+    @Test("the expectation is clamped, not replaced")
+    func expectationIsClampedRatherThanReplaced() throws {
+        let bench = try benchSource()
+        // `min` of the two, so the clamp can only ever LOWER the bar to what is storable — it can
+        // never raise it, and it cannot mask a hybrid falling below its own stored boundary.
+        #expect(bench.contains("Swift.min(unclampedPromptBoundary, $0)"))
+        #expect(bench.contains("} ?? unclampedPromptBoundary"))
+        // The unclamped computation must survive: dense/rotating models keep the strict path.
+        #expect(bench.contains("let unclampedPromptBoundary = promptCommon < promptTokens.count"))
+    }
+}


### PR DESCRIPTION
Closes the last two red rows in the growing-chat cache harness. **The runtime is correct; the gate
was wrong.**

## What was happening

A hybrid topology with a canonical strip boundary deliberately suppresses every other cache
boundary (`usesCanonicalHybridBoundary`, `BatchEngine.swift:3028`). The comment there says why:
persisting the exact prompt and post-answer snapshots as well produced several near-identical full
serializations per turn — *hundreds of MB each on Bonsai* — to buy reuse the next turn does not need.

The gate did not know that, so it demanded a boundary the shipped policy never stores. Worse, it
passed or failed **by accident**, on a chat-template detail rather than on cache health:

| model | turn-2 common prefix | branch | verdict (before) |
|---|---|---|---|
| `Bonsai-27b-Ternary-JANG-CRACK` | 21/23 — **diverges** | relaxed → stored max 18 | passed |
| `Ornith-1.0-9B-MXFP8` | 25/25 — no divergence | strict → full prompt 25 | **FAILED** `matched=18, expected at least 25` |
| `Nemotron-Labs-Audex-30B-A3B-4bit` | no divergence | strict | **FAILED** `matched=41, expected at least 47` |

Identical policy, opposite verdicts, decided by whether the template happened to re-wrap the
assistant turn.

## Fix

`expectedPromptBoundary = min(unclamped, cachePrefixTokenCounts.max())` — applied **only** when
`coordinator.isHybrid`.

It can only ever *lower* the bar to what is storable; it cannot raise it, and it cannot mask a
hybrid falling below its own stored boundary. Ornith now sits exactly at 18, so a regression to 17
is still caught. Dense/rotating models are untouched.

## Live results — before → after

| model | hybrid | probe before turn 2 | before | after |
|---|---|---|---|---|
| `Ornith-1.0-9B-MXFP8` | true | `HIT tier=paged matched=18/57` | FAILED | **passed** |
| `Nemotron-Audex-30B-A3B-4bit` | true | `HIT tier=paged matched=41/79` | FAILED | **passed** |
| `Bonsai-27b-Ternary-JANG-CRACK` | true | `HIT tier=paged matched=18/53` | passed | passed, **same numbers** |
| `LFM2.5-2.6B-MXFP8` | true | `HIT tier=paged matched=20/54` | passed | passed, same |
| `gemma-4-26B-A4B-it-qat-JANG_4M` | **false** | `HIT tier=paged matched=25/55` | passed | passed, strict path unchanged |
| `Nemotron-Audex-2B-4bit` | **false** | `HIT tier=paged matched=24/62` | passed | passed, strict path unchanged |

The two non-hybrid rows are the important control: they still take the unclamped branch and still
match their full prompt, so the clamp did not quietly relax the suite.

## Why not "fix" the runtime instead

Because the runtime behaviour is the deliberate one, and the measurement behind it is recorded in
the code. Making hybrids persist the exact prompt/post-answer boundaries to satisfy this gate would
reintroduce the multi-hundred-MB per-turn serialization and the post-answer stall that the canonical
strip boundary exists to remove — trading a real regression for a green bar.

`GrowingChatCacheHybridGateSourceTests` pins the clamp: derived from stored boundaries, gated on
`isHybrid`, and expressed as `min` so it can only lower the bar.