### PR TITLE
Route the Gemma-4 tool template on sentinels, not on <bos>

### DIFF
--- a/Libraries/MLXHuggingFaceMacros/HuggingFaceIntegrationMacros.swift
+++ b/Libraries/MLXHuggingFaceMacros/HuggingFaceIntegrationMacros.swift
@@ -211,9 +211,22 @@ public struct TokenizerAdaptorMacro: ExpressionMacro {
                                 tools: chatTemplateTools,
                                 additionalContext: additionalContext)
                         }
+                        // Route on Gemma-4's OWN tool sentinels, never on `<bos>` alone.
+                        //
+                        // `<bos>` is not a Gemma marker — ZAYA1-VL-8B also uses it while being a
+                        // ChatML model (`<bos><|im_start|>system …`). The bare bos disjunct
+                        // therefore swapped Zaya onto the Gemma-4 turn-marker template the moment
+                        // tools were offered, so the prompt arrived as `<|turn>model … <turn|>`
+                        // instead of `<|im_start|>assistant`. The model echoed that alien format
+                        // back as literal text (`<|turn>user`) and emitted no tool call at all —
+                        // on BOTH shipped quants, and only ever on tool turns.
+                        //
+                        // `hasGemma4NativeToolSentinels` round-trips `<|tool_call>` and `<|turn>`
+                        // through the vocabulary. Every shipped Gemma-4 bundle carries both; Zaya
+                        // carries neither, so it separates them cleanly where `<bos>` cannot.
                         let gemmaToolSchemasPresent =
                             !(chatTemplateTools?.isEmpty ?? true)
-                            && (upstream.bosToken == "<bos>" || hasGemma4NativeToolSentinels)
+                            && hasGemma4NativeToolSentinels
                             && (env["VMLX_CHAT_TEMPLATE_FALLBACK_DISABLE"] ?? "0") != "1"
                         if gemmaToolSchemasPresent {
                             if (env["VMLX_CHAT_TEMPLATE_FALLBACK_LOG"] ?? "0") == "1" {
@@ -621,9 +634,22 @@ public struct TokenizerAdaptorMacro: ExpressionMacro {
                                 tools: chatTemplateTools,
                                 additionalContext: additionalContext)
                         }
+                        // Route on Gemma-4's OWN tool sentinels, never on `<bos>` alone.
+                        //
+                        // `<bos>` is not a Gemma marker — ZAYA1-VL-8B also uses it while being a
+                        // ChatML model (`<bos><|im_start|>system …`). The bare bos disjunct
+                        // therefore swapped Zaya onto the Gemma-4 turn-marker template the moment
+                        // tools were offered, so the prompt arrived as `<|turn>model … <turn|>`
+                        // instead of `<|im_start|>assistant`. The model echoed that alien format
+                        // back as literal text (`<|turn>user`) and emitted no tool call at all —
+                        // on BOTH shipped quants, and only ever on tool turns.
+                        //
+                        // `hasGemma4NativeToolSentinels` round-trips `<|tool_call>` and `<|turn>`
+                        // through the vocabulary. Every shipped Gemma-4 bundle carries both; Zaya
+                        // carries neither, so it separates them cleanly where `<bos>` cannot.
                         let gemmaToolSchemasPresent =
                             !(chatTemplateTools?.isEmpty ?? true)
-                            && (upstream.bosToken == "<bos>" || hasGemma4NativeToolSentinels)
+                            && hasGemma4NativeToolSentinels
                             && (env["VMLX_CHAT_TEMPLATE_FALLBACK_DISABLE"] ?? "0") != "1"
                         if gemmaToolSchemasPresent {
                             if (env["VMLX_CHAT_TEMPLATE_FALLBACK_LOG"] ?? "0") == "1" {

--- a/Tests/MLXLMCommonFocusedTests/NoHiddenReasoningCloseBiasFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NoHiddenReasoningCloseBiasFocusedTests.swift
@@ -1976,7 +1976,14 @@ struct Gemma4VLMFocusedSourceContractsTests {
         #expect(overload.contains("upstream.convertTokenToId(\"<|tool_call>\").flatMap { upstream.convertIdToToken($0) } == \"<|tool_call>\""))
         #expect(overload.contains("upstream.convertTokenToId(\"<|turn>\").flatMap { upstream.convertIdToToken($0) } == \"<|turn>\""))
         #expect(overload.contains("!(chatTemplateTools?.isEmpty ?? true)"))
-        #expect(overload.contains("upstream.bosToken == \"<bos>\" || hasGemma4NativeToolSentinels"))
+        // The Gemma-4 tool fallback keys on the SENTINELS only. `<bos>` alone used to be
+        // sufficient here, which hijacked any ChatML bundle sharing that bos — ZAYA1-VL-8B
+        // received Gemma's `<|turn>`/`<turn|>` markers on every tool turn, echoed them back as
+        // literal text and emitted no tool call. Assert the narrow form, and assert the weak
+        // disjunct cannot come back.
+        #expect(overload.contains("&& hasGemma4NativeToolSentinels"))
+        #expect(
+            !overload.contains("upstream.bosToken == \"<bos>\" || hasGemma4NativeToolSentinels"))
         #expect(overload.contains("upstream.bosToken == \"<s>\""))
         #expect(overload.contains("upstream.convertTokenToId(\"<|im_end|>\").flatMap { upstream.convertIdToToken($0) } == \"<|im_end|>\""))
         #expect(!overload.contains("upstream.convertTokenToId(\"[AVAILABLE_TOOLS]\")"))

--- a/Tests/MLXLMTests/Gemma4ToolFallbackRoutingSourceTests.swift
+++ b/Tests/MLXLMTests/Gemma4ToolFallbackRoutingSourceTests.swift
@@ -1,0 +1,74 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import Testing
+
+/// Pins the Gemma-4 tool-template routing condition.
+///
+/// The fallback that swaps a bundle onto `gemma4WithTools` must key on Gemma-4's OWN tool
+/// sentinels, never on `bosToken == "<bos>"`. `<bos>` is not a Gemma marker:
+///
+/// | bundle | bos | `<\|tool_call>` | `<\|turn>` |
+/// |---|---|---|---|
+/// | `gemma-4-12B-it-MXFP8` | `<bos>` | yes | yes |
+/// | `gemma-4-26B-A4B-it-qat-JANG_4M` | `<bos>` | yes | yes |
+/// | `ZAYA1-VL-8B-JANGTQ_K` | `<bos>` | **no** | **no** |
+///
+/// ZAYA1-VL is ChatML (`<bos><|im_start|>system …`). Routing on `<bos>` alone swapped it onto the
+/// Gemma turn-marker template the moment tools were offered, so its prompt arrived as
+/// `<|turn>model … <turn|>` instead of `<|im_start|>assistant`. The model echoed that alien format
+/// back as literal text (`<|turn>user`) and emitted no tool call — on both shipped quants, and only
+/// ever on tool turns. Verified live through `VMLX_CHAT_TEMPLATE_FALLBACK_LOG=1`:
+/// `chat-template tools -> Gemma4WithTools fallback engaged` on Zaya before the fix, absent after,
+/// while gemma-4-12B still engages it and passes the full variating pattern including
+/// image+tools in one turn.
+@Suite("Gemma-4 tool fallback routes on sentinels, not <bos>")
+struct Gemma4ToolFallbackRoutingSourceTests {
+
+    private func macroSource() throws -> String {
+        try String(
+            contentsOfFile: "Libraries/MLXHuggingFaceMacros/HuggingFaceIntegrationMacros.swift",
+            encoding: .utf8)
+    }
+
+    @Test("routing requires the Gemma-4 sentinels")
+    func routingRequiresSentinels() throws {
+        let source = try macroSource()
+        #expect(
+            source.contains(
+                """
+                !(chatTemplateTools?.isEmpty ?? true)
+                                            && hasGemma4NativeToolSentinels
+                """),
+            "the Gemma-4 tool fallback must gate on hasGemma4NativeToolSentinels")
+    }
+
+    @Test("<bos> alone can never select the Gemma-4 tool template")
+    func bosAloneCannotSelectGemmaTools() throws {
+        let source = try macroSource()
+        #expect(
+            !source.contains(#"(upstream.bosToken == "<bos>" || hasGemma4NativeToolSentinels)"#),
+            """
+            `<bos>` was re-added as a sufficient condition. It is shared by ChatML bundles such as \
+            ZAYA1-VL-8B, which then receive Gemma's <|turn>/<turn|> markers on every tool turn and \
+            stop emitting tool calls entirely.
+            """)
+    }
+
+    /// The sentinel check itself must stay a round-trip, not a bare id lookup — `convertTokenToId`
+    /// returns the unk id for unknown tokens, so `!= nil` would be true for every vocabulary and
+    /// re-break exactly what this routing fix repaired.
+    @Test("the sentinel check round-trips both markers")
+    func sentinelCheckRoundTrips() throws {
+        let source = try macroSource()
+        #expect(
+            source.contains(
+                #"(upstream.convertTokenToId("<|tool_call>").flatMap { upstream.convertIdToToken($0) } == "<|tool_call>")"#
+            ))
+        #expect(
+            source.contains(
+                #"(upstream.convertTokenToId("<|turn>").flatMap { upstream.convertIdToToken($0) } == "<|turn>")"#
+            ))
+    }
+}


### PR DESCRIPTION
Offering tools to **ZAYA1-VL-8B** silently swapped it onto **Gemma-4's** chat template, and it
stopped emitting tool calls entirely.

## The bug

```swift
let gemmaToolSchemasPresent =
    !(chatTemplateTools?.isEmpty ?? true)
    && (upstream.bosToken == "<bos>" || hasGemma4NativeToolSentinels)   // ← `<bos>` alone
```

`<bos>` is not a Gemma marker. ZAYA1-VL is ChatML and *also* uses it
(`<bos><|im_start|>system …`), so the moment a request carried tools, Zaya's prompt was rendered
with Gemma's turn markers:

| turn | prompt tail |
|---|---|
| 1–2 (no tools) | `<bos><|im_start|>system … <|im_end|>\n<|im_start|>assistant\n` ✅ its own format |
| 3 (**tools**) | `…<turn|>\n<|turn>model\nParis<turn|>\n<|turn>user\n…<|turn>model\n` ❌ Gemma's |

The model then echoed the alien format back as literal text — `text="<|turn>user…"` — and produced
**no tool call**, on **both** shipped quants (`JANGTQ4`, `JANGTQ_K`), and only ever on tool turns.

The bundle itself was never at fault: its `chat_template.json` is correct ChatML with
`<|vision_start|>`, and vmlx already ships a proper `zayaVLVisionToolMinimal` fallback that this
condition was pre-empting.

## The fix

Gate on Gemma-4's own sentinels, which already round-trip `<|tool_call>` and `<|turn>` through the
vocabulary. That separates the families cleanly where `<bos>` cannot:

| bundle | bos | `<\|tool_call>` | `<\|turn>` |
|---|---|---|---|
| `gemma-4-12B-it-MXFP8` | `<bos>` | ✅ | ✅ |
| `gemma-4-26B-A4B-it-qat-JANG_4M` | `<bos>` | ✅ | ✅ |
| `ZAYA1-VL-8B-JANGTQ_K` | `<bos>` | ❌ | ❌ |

Applied to **both** emitted paths — the plain and the `addGenerationPrompt` overload — since the
macro generates the condition twice.

## Live verification (`VMLX_CHAT_TEMPLATE_FALLBACK_LOG=1`)

| | before | after |
|---|---|---|
| **ZAYA1-VL-8B-JANGTQ_K** | `tools -> Gemma4WithTools fallback engaged`, leaks `<\|turn>user` | **no fallback engaged** (uses its own template), leak becomes its own `<tools>` |
| **gemma-4-12B-it-MXFP8** | engages, passes | **still engages, still passes** — `toolCalls=1` on turn 3, **and on turns 4 / 4b (image+tools)** |

Gemma-4 passing the whole variating pattern is the regression control that matters: the family this
template belongs to is unaffected, including tool calls on image-bearing turns.

## Honest scope

This fixes the **misrouting**. It does **not** make Zaya tool-calling work — with its own template
it now echoes its native `<tools>` block instead of Gemma's markers, still without a structured
call. That is the separate template-priming issue already known for this family, and it is not
claimed as fixed here.

## Tests

`Gemma4ToolFallbackRoutingSourceTests` (3 tests) pins the narrow condition, asserts the `<bos>`
disjunct **cannot return**, and pins that the sentinel check stays a round-trip rather than a bare
`!= nil` (which returns the unk id for unknown tokens and would silently re-break this).

`NoHiddenReasoningCloseBiasFocusedTests` had pinned the old disjunct verbatim — that assertion is
inverted rather than deleted. `swift test --filter MLXLMCommonFocusedTests` → **542/542 pass**.