### PR TITLE
Add Apertus 1.5 (apertus1p5) — discrete-token omni: text, vision, audio, and its reasoning rail

### DIFF
--- a/Libraries/MLXLMCommon/ReasoningBudget.swift
+++ b/Libraries/MLXLMCommon/ReasoningBudget.swift
@@ -71,6 +71,7 @@ public enum ReasoningBudget {
         "</thinking>",
         "<|/think|>",
         "<|end_thought|>",
+        "<|inner_suffix|>",  // Apertus 1.5 (apertus1p5)
         "<end_of_turn>",
     ]
 
@@ -81,6 +82,8 @@ public enum ReasoningBudget {
     /// that only armed on a primed tail would silently skip that second group.
     public static let openTokenCandidates: [String] = [
         "<think>", "<thinking>", "<|think|>", "<|start_thought|>",
+        "<|inner_prefix|>",  // Apertus 1.5: its template primes neither tag, so the model
+                             // emits the open marker itself as its first generated token.
     ]
 
     /// Resolve the open-token ids that exist in this bundle's vocab, so a

--- a/Libraries/MLXLMCommon/ReasoningParser.swift
+++ b/Libraries/MLXLMCommon/ReasoningParser.swift
@@ -872,6 +872,37 @@ extension ReasoningParser {
             return ReasoningParser(startInReasoning: true)
         }
 
+        // Apertus 1.5 wraps its inner monologue in two dedicated vocabulary tokens
+        // rather than XML. Its chat template sets them explicitly (lines 152-153):
+        //
+        //     {%- set inner_token = '<|inner_prefix|>' -%}
+        //     {%- set outer_token = '<|inner_suffix|>' -%}
+        //
+        // and the generation prompt tail is a bare `<|assistant|>` — no prefilled
+        // opener — so the model emits `<|inner_prefix|>` itself and
+        // `startInReasoning` stays false, as for Gemma-4.
+        //
+        // Observed on cubiculum/Apertus-v1.5-8B-Jang_6M (gsm8k, 3/3 turns):
+        //
+        //   <|inner_prefix|>We need to parse the question. …3.7 kB of monologue…
+        //   <|inner_suffix|>The friend gave \(24\) outfits. … \boxed{87}
+        //
+        // Opens and closes were balanced 3/3, so the unclosed-block hazard the
+        // Hunyuan entry documents does not apply. Both markers are single special
+        // tokens that cannot occur in prose, so strays are stripped.
+        //
+        // SCOPED TO 1.5 DELIBERATELY. Plain `apertus` is Apertus 1.0, which has no
+        // monologue and is enumerated as a non-thinking family in
+        // `ReasoningStampFromModelTypeTests.testPlainFamiliesGetNone`; matching the
+        // bare `apertus` prefix here would contradict that contract.
+        if normalized.hasPrefix("apertus1p5") {
+            return ReasoningParser(
+                startTag: "<|inner_prefix|>",
+                endTag: "<|inner_suffix|>",
+                startInReasoning: false,
+                stripStrayTags: true)
+        }
+
         if normalized.hasPrefix("mistral4")
             || normalized.hasPrefix("mistral_4")
             || normalized.hasPrefix("mistral_small_4")
@@ -1258,6 +1289,20 @@ public func reasoningStampFromModelType(_ modelType: String?) -> String {
     // Harmony marker leak.
     if compact.hasPrefix("gptoss") {
         return "harmony"
+    }
+
+    // Apertus 1.5 — dedicated `<|inner_prefix|>` / `<|inner_suffix|>` monologue
+    // markers, resolved by `fromCapabilityName`. Without this stamp `apertus1p5`
+    // falls through to the terminal "none", no parser is selected, and the entire
+    // monologue — raw markers included — streams into the user-visible chunk.
+    // Measured on Apertus-v1.5-8B before this entry: text=3998ch reasoning=0ch,
+    // with the answer buried 3.7 kB deep. Same failure shape as the `gptoss`
+    // Harmony leak and the `muse_glimmer` fall-through.
+    //
+    // Matches 1.5 ONLY: plain `apertus` (1.0) has no monologue and must keep its
+    // "none" stamp — see `testPlainFamiliesGetNone`.
+    if compact.hasPrefix("apertus1p5") {
+        return "apertus1p5"
     }
 
     // ZAYA1-VL is a sibling multimodal architecture, not the text

--- a/Tests/MLXLMTests/ApertusReasoningNoLeakTests.swift
+++ b/Tests/MLXLMTests/ApertusReasoningNoLeakTests.swift
@@ -1,0 +1,155 @@
+// Pin the Apertus 1.5 reasoning-no-leak contract.
+//
+// Apertus 1.5 does not use `<think>` XML. Its chat template defines two dedicated
+// vocabulary tokens (chat_template.jinja lines 152-153):
+//
+//     {%- set inner_token = '<|inner_prefix|>' -%}
+//     {%- set outer_token = '<|inner_suffix|>' -%}
+//
+// and the generation prompt tail is a bare `<|assistant|>` — the template prefills
+// NO opener — so the model emits `<|inner_prefix|>` itself when it decides to think.
+//
+// THE DEFECT THIS PINS. `reasoningStampFromModelType("apertus1p5")` returned "none",
+// so `JangLoader` selected NO parser, so the monologue and the raw marker streamed
+// straight into the user-visible channel. Measured on
+// cubiculum/Apertus-v1.5-8B-Jang_6M before the fix, gsm8k, 3 turns:
+//
+//     ── GEN channels: text=3998ch reasoning=0ch finish=stop tokens=1033
+//
+// Zero reasoning characters on every turn, with the actual answer buried 3.7 kB
+// deep behind the monologue. This is the same shape as the `gptoss` Harmony marker
+// leak and the `muse_glimmer` fall-through that the neighbouring stamps exist to
+// prevent — and, as the `muse_glimmer` comment records, the parser is the half
+// people fix while the stamp is the half that makes it reachable. BOTH halves are
+// required: a test that only checked `fromCapabilityName("apertus")` would pass
+// against a build where real Apertus bundles still leak.
+//
+// Source-coverage style — no MLX runtime needed.
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite("Apertus 1.5 reasoning-parser no-leak contract")
+struct ApertusReasoningNoLeakTests {
+
+    /// Drains a parser into `(content, reasoning)` strings.
+    private static func drain(
+        _ parser: inout ReasoningParser, _ feed: String
+    ) -> (content: String, reasoning: String) {
+        var content = ""
+        var reasoning = ""
+        for segment in parser.feed(feed) {
+            switch segment {
+            case .content(let text): content += text
+            case .reasoning(let text): reasoning += text
+            }
+        }
+        for segment in parser.flush() {
+            switch segment {
+            case .content(let text): content += text
+            case .reasoning(let text): reasoning += text
+            }
+        }
+        return (content, reasoning)
+    }
+
+    /// THE REACHABILITY HALF. Without this the parser below is dead code for every
+    /// real bundle, because `model_type` is what the loader actually has in hand.
+    @Test("apertus1p5 stamps to its own parser while apertus 1.0 stays none")
+    func stampResolves() {
+        // `apertus1p5` is the model_type in the shipped config.json, in the spellings
+        // `normalizedReasoningAlias` / `compactReasoningAlias` can produce.
+        for modelType in ["apertus1p5", "Apertus1p5", "apertus_1p5", "apertus-1p5"] {
+            let stamp = reasoningStampFromModelType(modelType)
+            let why = "model_type \(modelType) stamped \(stamp) — \"none\" means no parser "
+                + "is selected and the monologue leaks into the visible answer"
+            #expect(stamp == "apertus1p5", "\(why)")
+        }
+
+        // AND THE OTHER HALF OF THE CONTRACT. Plain `apertus` is Apertus 1.0, which has
+        // no inner monologue; `testPlainFamiliesGetNone` enumerates it as a non-thinking
+        // family. A prefix match broad enough to catch it would hand 1.0 a parser it must
+        // not have — the first draft of this fix did exactly that and turned that suite
+        // red. Pin both directions so the scoping cannot silently widen later.
+        #expect(reasoningStampFromModelType("apertus") == "none",
+            "Apertus 1.0 must keep its non-thinking stamp")
+        #expect(ReasoningParser.fromCapabilityName("apertus") == nil,
+            "the 1.0 capability name must not resolve to a monologue parser")
+    }
+
+    @Test("the apertus stamp resolves to a parser with the template's own markers")
+    func capabilityResolves() throws {
+        let parser = try #require(ReasoningParser.fromCapabilityName("apertus1p5"),
+            "apertus1p5 stamp did not resolve to a parser")
+        #expect(parser.startTag == "<|inner_prefix|>")
+        #expect(parser.endTag == "<|inner_suffix|>")
+        // Both markers are single special tokens that cannot occur in prose, so a
+        // stray must be stripped rather than shown to the user as literal text.
+        #expect(parser.stripStrayTags)
+    }
+
+    /// THE DEFECT ITSELF, replayed from a real generation.
+    ///
+    /// Text is taken verbatim from cubiculum/Apertus-v1.5-8B-Jang_6M answering a gsm8k
+    /// item (Laurel's baby outfits, gold answer 87) — the monologue's opening words and
+    /// the post-closer answer are the model's own, not a hand-written imitation. Before
+    /// the fix ALL of this arrived as content.
+    @Test("a real Apertus turn routes the monologue to reasoning and the answer to content")
+    func realTurnDoesNotLeak() throws {
+        var parser = try #require(
+            ReasoningParser.forPrompt(stampName: "apertus1p5", promptTail: "<|assistant|>"))
+
+        let (content, reasoning) = Self.drain(&parser,
+            "<|inner_prefix|>We need to parse the question. It's a straightforward "
+            + "arithmetic problem. The user says: \"Laurel's friend gave her 24 baby "
+            + "outfits\". So 24, then twice as many, then 15 more."
+            + "<|inner_suffix|>The friend gave \\(24\\) outfits.\n"
+            + "Total outfits:\n\\[\n24 + 48 + 15 = 87\n\\]\n\n\\[\n\\boxed{87}\n\\]")
+
+        // The answer, and ONLY the answer, is visible.
+        #expect(content.contains("\\boxed{87}"), "the answer must reach the user")
+        #expect(!content.contains("We need to parse the question"),
+            "the monologue must NOT be visible; got content: \(content.prefix(200))")
+        #expect(!content.contains("<|inner_prefix|>") && !content.contains("<|inner_suffix|>"),
+            "raw markers must never be shown to the user; got: \(content.prefix(200))")
+
+        // And the monologue is preserved on the reasoning rail rather than discarded —
+        // osaurus renders it in the think pane.
+        #expect(reasoning.contains("We need to parse the question"))
+        #expect(!reasoning.contains("\\boxed{87}"),
+            "the answer must not be swallowed into the think pane: \(reasoning.suffix(120))")
+    }
+
+    /// A turn with NO thinking must be untouched. Apertus answers directly for easy
+    /// prompts, and a parser that invented a reasoning block — or ate the first
+    /// characters waiting for one — would break the common case to fix the rare one.
+    @Test("a turn with no monologue is passed through unchanged")
+    func nonThinkingTurnUnchanged() throws {
+        var parser = try #require(
+            ReasoningParser.forPrompt(stampName: "apertus1p5", promptTail: "<|assistant|>"))
+        let (content, reasoning) = Self.drain(&parser, "The capital of France is Paris.")
+        #expect(content == "The capital of France is Paris.")
+        #expect(reasoning.isEmpty, "no opener was emitted, so nothing is reasoning")
+    }
+
+    /// THE FAILURE MODE THAT WOULD BE WORSE THAN THE BUG. If a turn opens a block and
+    /// never closes it, everything after the opener is reasoning and the visible reply
+    /// is EMPTY — the "trapped thinking" the Hunyuan entry documents.
+    ///
+    /// This is pinned rather than asserted-away because it is a real risk of the fix,
+    /// not a hypothetical: 3/3 observed turns closed their block, but 3 turns is not a
+    /// proof. `flush()` must surface the unterminated text rather than dropping it, so
+    /// a future regression shows up as misplaced text and never as silence.
+    @Test("an unclosed monologue still surfaces its text rather than vanishing")
+    func unclosedBlockIsNotSilentlyDropped() throws {
+        var parser = try #require(
+            ReasoningParser.forPrompt(stampName: "apertus1p5", promptTail: "<|assistant|>"))
+        let (content, reasoning) = Self.drain(&parser,
+            "<|inner_prefix|>thinking that never terminates")
+        #expect(!(content + reasoning).isEmpty,
+            "an unterminated block must not swallow the turn into nothing")
+        #expect((content + reasoning).contains("never terminates"))
+    }
+}

--- a/Tests/MLXLMTests/ReasoningBudgetTests.swift
+++ b/Tests/MLXLMTests/ReasoningBudgetTests.swift
@@ -186,6 +186,51 @@ class ReasoningBudgetTests: XCTestCase {
                 tokenizer: ThinkVocabTokenizer(), promptTail: "<think>", tokenCount: -5))
     }
 
+    /// APERTUS 1.5. Its monologue markers are neither `<think>` nor any of the other
+    /// spellings the candidate lists carried, so `arm` could not resolve a close token
+    /// for an Apertus bundle and the ceiling stayed inert no matter what budget the
+    /// caller asked for — the budget silently did nothing rather than failing loudly.
+    ///
+    /// The template primes NEITHER tag (the generation prompt tail is a bare
+    /// `<|assistant|>`), so this is the self-opening case: the count must start when the
+    /// model emits `<|inner_prefix|>` itself, which is what `startTokenIDs` expresses.
+    private struct ApertusVocabTokenizer: MLXLMCommon.Tokenizer {
+        let vocab: [String: Int] = [
+            "<|inner_prefix|>": 32, "<|inner_suffix|>": 33, "hello": 12,
+        ]
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] { [12] }
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "hello" }
+        func convertTokenToId(_ token: String) -> Int? { vocab[token] }
+        func convertIdToToken(_ id: Int) -> String? { vocab.first { $0.value == id }?.key }
+        var bosToken: String? { nil }
+        var eosToken: String? { "<|endoftext|>" }
+        var unknownToken: String? { nil }
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] { [12] }
+    }
+
+    func testApertusMonologueMarkersArmTheCeiling() {
+        let armed = ReasoningBudget.arm(
+            tokenizer: ApertusVocabTokenizer(),
+            promptTail: "<|assistant|>",
+            tokenCount: 96
+        )
+        XCTAssertNotNil(
+            armed,
+            "Apertus markers must resolve, or a requested budget is silently inert for every Apertus bundle."
+        )
+        XCTAssertEqual(armed?.tokenCount, 96)
+        XCTAssertEqual(armed?.closeTokenID, 33, "<|inner_suffix|> closes the monologue")
+        XCTAssertEqual(
+            armed?.startTokenIDs, [32],
+            "The template primes no opener, so the count starts when the model emits <|inner_prefix|>."
+        )
+        XCTAssertEqual(armed?.openTokenIDs, [32])
+    }
+
     func testEnvArmedPathStillDelegatesToTheSameResolution() {
         // Without VMLX_REASONING_BUDGET in the environment the legacy entry
         // point must stay nil even though the vocab could arm.


### PR DESCRIPTION
Add Apertus 1.5 (apertus1p5) — discrete-token omni: text, vision, audio

Apertus 1.5 is multimodal in a way no other model in this repo is, and it shapes
the whole port. Instead of an encoder plus a projector feeding continuous
embeddings into the hidden space, it QUANTISES each modality into ids from a
codebook that lives inside the token embedding table, and feeds them as ORDINARY
TOKENS. The config arithmetic states the design exactly:

    image_token_offset 131272 + image codebook 131072 == 262344 == audio_token_offset
    audio_token_offset 262344 + audio codebook   4096 == 266440 <= vocab 266752

So the language model needs no architectural change at all: `ApertusModel` is
reused unmodified, and the port is "pixels -> integers" and "waveform ->
integers".

WHAT IS ADDED

* `Apertus1p5VisionTokenizer` — the encoder half of a VQ-VAE (taming-transformers
  `Encoder`): conv_in, five stages [256,256,512,512,1024] over four downsamples,
  attention at the 16x16 stage, mid block, then conv_out -> quant_conv ->
  nearest-neighbour in a [131072, 256] codebook. Only the encoder ships in the
  checkpoint (247 tensors, no decoder), which is right for a model that consumes
  images and never generates them.
* `Apertus1p5AudioTokenizer` — the encoder half of WavTokenizer (EnCodec/SEANet):
  input conv, four downsampling stages (strides 4*5*5*6 = 600, the documented
  hop), a 2-layer LSTM, output conv, then a [4096, 512] codebook. Of the 226
  audio tensors only ~63 are used; `backbone.convnext`, `backbone.pos_net` and
  `head.linear` [2402, 768] are the ISTFT vocoder that turns tokens back INTO
  audio, which a consuming model never runs.
* `Apertus1p5` — the model, holding both tokenizers plus `ApertusModel`. Media
  ids are spliced in `prepare` and the ordinary text path takes over.
* `Apertus1p5Processor` — preprocessing and the media token framing.

DETAILS THAT ARE SILENT IF WRONG, each commented at its site

* the image grid is written as LITERAL TEXT: the framing is
  `<|img_start|>{H}*{W}<|img_token_start|>{rows}<|img_end|>` where rows are
  `<|image|>` repeated W times, joined by `<|img_end_of_row|>`. The dimensions
  are an ordinary tokenised string — that is how the model is told the geometry —
  and each patch gets its OWN placeholder, substituted one code per placeholder.
* resolution is DYNAMIC: `smart_resize` clamps AREA to [256^2, 1400^2] preserving
  aspect ratio, then rounds both sides half-up to a multiple of 16. A 640x480
  photo becomes a 30x40 grid (1200 tokens), not 16x16.
* audio convolutions are stored under PyTorch weight-norm (`original0` = g,
  `original1` = v); the effective weight is `g * v / ||v||`.
* the audio residual block NUMBERS its parameterless activations (`block.1`,
  `block.3`), so the convolutions are not at indices 0/1.
* torch's 2-layer LSTM maps onto MLX's `Wx`/`Wh`/`bias` with the two biases
  SUMMED; gate order needs no change, as both split i,f,g,o.
* audio clips are peak-normalised to -3 dBFS before the codec, as the reference
  pipeline does (its feature extractor deliberately does not normalise).
* quantised bundles ship each codebook twice — plain float plus a packed
  `.weight`/`.scales`/`.biases` triple — and the packed copies are dropped.

All of the above is ported from the reference implementation
(github.com/swiss-ai/transformers, branch `add-apertus1p5`), not inferred.

VERIFICATION, on device (M4 Max, macOS 27)

* structural: every checkpoint tensor binds to the module tree with matching
  shapes and nothing is left unbound, under strict `.all` verification, for both
  tokenizers;
* weight-norm: one weight is rebuilt by hand from its own g and v and must match
  the loaded parameter — and must NOT equal the bare direction;
* vision: 75.0% on POPE (40 items). A known-good VLM scores 72.5% on the same
  items;
* audio: given a clip it was not told the content of, and asked only "what do you
  hear?", the model answers "The numbers one, two, three, four, five, six,
  seven, eight, nine, ten." — an exact transcription.

Quantised bundles load and run: verified on a 6-bit JANG conversion (8.1 GB) for
text, vision and audio. An earlier draft of this description reported quantised
bundles as broken; that turned out to be a defect in the CONVERSION — the
multimodal encoders were shadowed by de-listed raw tensors — and not in the
runtime. Repairing the bundle was sufficient; no runtime change was needed.

## Reasoning rail (0022 + 0023)

Apertus 1.5 marks its inner monologue with two dedicated vocabulary tokens rather
than `<think>` XML — the chat template sets `inner_token = '<|inner_prefix|>'` and
`outer_token = '<|inner_suffix|>'` (lines 152-153) — so both the reasoning parser
and the reasoning budget need entries, or the model's monologue is indistinguishable
from its answer.

`reasoningStampFromModelType` had no entry for the family, so `apertus1p5` fell
through to the terminal `"none"` and NO parser was selected. Measured on
Apertus-v1.5-8B before the fix, gsm8k, three turns:

    text=3998ch reasoning=0ch     text=1531ch reasoning=0ch     text=886ch reasoning=0ch

Zero reasoning characters on every turn: the whole monologue, raw markers included,
went to the user-visible channel with the answer buried behind it. After:

    text=10ch  reasoning=2839ch   text=10ch  reasoning=1069ch   text=409ch reasoning=512ch

The 10-character turns are `\boxed{87}` and `\boxed{34}` — the model does its
working in the monologue and emits only the boxed result, which is exactly the
intended split. gsm8k 3/3 on the same run; zero raw markers anywhere in the output.

Scoped to 1.5 deliberately: plain `apertus` is Apertus 1.0, which has no monologue
and is enumerated as a non-thinking family in `testPlainFamiliesGetNone`. A first
draft matched the bare `apertus` prefix and turned that suite red; the regression
test now pins both directions.

0022 additionally lets a reasoning BUDGET arm for Apertus: without its two entries
`ReasoningBudget.arm` cannot resolve a close token for an Apertus bundle, so a
requested ceiling was silently inert rather than failing loudly.

## Prefix normalisation delegates to the shared helper

The language tower is routed through one prefix normalisation, because the bf16
release and the MLX quantisations disagree about where the `language_model`
segment sits:

```
bf16 (HF layout):  model.language_model.layers.0...   lm_head.weight
MLX quantisations: language_model.model.layers.0...   language_model.lm_head.weight
```

That rule is `Weights.stripLanguageModelPrefix`, not a local loop. The rule
itself is byte-identical — what the helper adds is the **contested key**:

> a mixed-provenance re-bake can carry **both** spellings … resolving that by
> last-write-wins would make the bind depend on `Dictionary`'s iteration order,
> which is **seeded per process**

A local `lm[key] = v` has exactly that shape. The model would load, generate,
and be wrong some fraction of the runs — the one failure nothing downstream
reports.

The traffic is real, not hypothetical:

| bundle | tensors through this path | of which `lm_head` |
|---|---|---|
| `Apertus-v1.5-8B-Jang_6M` | 836 | 3 |
| `Apertus-v1.5-70B-Jang_6M` | 2,084 | 3 |

Three of them are the head, which is why the earlier head-scoped
`only: ["lm_head."]` fix on `ApertusModel` did not cover this.

**Mutation-checked**: restoring the local loop fails the guard, naming both
re-derived lines. The behavioural claim is asserted against the helper — both
layouts normalising, and a contested key binding the unprefixed spelling the
same way whichever order the dictionary is built in.
