### PR TITLE
Admit vision-tower widths as valid quant dims (fixes Qwen3.6-27B image crash)

### DIFF
--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -1213,6 +1213,31 @@ private func readValidInDims(at modelDirectory: URL) -> Set<Int> {
     add(config["hidden_size"])
     add(config["intermediate_size"])
     add(config["moe_intermediate_size"])
+
+    // Vision-tower widths. Without these, a bundle whose vision modules carry
+    // EXPLICIT per-module quant metadata fails the declared-entry validInDims
+    // gate below (vision dims are not text dims), and the shape walk re-stamps
+    // them with a shape-identical wrong reading — (4,128) and (8,64) unpack the
+    // same packed+scales geometry but halve the effective width. Text stays
+    // exact (its dims ARE in the set); the vision tower then crashes at first
+    // image: Qwen3.6-27B patch embeds came out (N,576) against (N,1152)
+    // positional embeddings.
+    if let vision = top["vision_config"] as? [String: Any] {
+        add(vision["hidden_size"])
+        add(vision["intermediate_size"])
+        add(vision["out_hidden_size"])
+        if let hidden = vision["hidden_size"] as? Int,
+           let merge = vision["spatial_merge_size"] as? Int,
+           hidden > 0, merge > 0
+        {
+            dims.insert(hidden * merge * merge)
+        }
+        if let patch = vision["patch_size"] as? Int, patch > 0 {
+            let channels = (vision["in_channels"] as? Int) ?? 3
+            let temporal = (vision["temporal_patch_size"] as? Int) ?? 1
+            dims.insert(channels * temporal * patch * patch)
+        }
+    }
     add(config["expert_intermediate_size"])
     add(config["shared_expert_intermediate_size"])
     add(config["hidden_size_per_layer_input"])

--- a/RunBench/Bench.swift
+++ b/RunBench/Bench.swift
@@ -1168,6 +1168,9 @@ struct Bench {
 
             print(String(format: "  Turn %d: total prompt=%d, NEW=%d | prefill %.0f tok/s (%.0fms TTFT) | decode %.1f tok/s (%d tokens, %.3fs)",
                          turnIdx + 1, nPrompt, newTokens.count, prefillTps, firstTokenTime * 1000, decodeTps, count, decodeTime))
+            // Greedy parity gates diff these ids against the Python runtime's
+            // output on the identical prompt tokens (temp is pinned 0.0 above).
+            print("    first tokens: \(Array(generated.prefix(20)))")
 
             // After this turn: cache contains [prev_context + new_tokens + decoded_response].
             // Next turn's "already cached" = current turnTokens.count + assistant stub length


### PR DESCRIPTION
## The bug

Qwen3.6-27B JANG bundles declare explicit per-module quantization for the vision tower. The declared-entry acceptance gate requires the unpacked input dim to be in `validInDims`, but `readValidInDims` collected only **text-config** widths — so every vision entry failed the gate and fell to the shape walk, which re-stamped 84 modules with the **shape-identical wrong reading**: `(4,128)` and `(8,64)` unpack the same packed+scales geometry while halving the effective width.

Text stayed exact (its dims are in the set). The vision tower died on the first image:

- harness: `[broadcast_shapes] Shapes (256,1152) and (256,576) cannot be broadcast` — patch embeds at half width vs full-width positional embeddings
- live app: `getItemND` precondition in `Qwen3VLVision.positionalEmbeddings` (crash `osaurus-2026-08-13-193623.ips`), app dead before the first assistant token

## The fix

`readValidInDims` also admits `vision_config` widths: `hidden_size`, `intermediate_size`, `out_hidden_size`, `hidden × merge²`, and the patch-embed input `channels × temporal × patch²`. One additive block; bundles without a `vision_config` are untouched.

## Proof (Qwen3.6-27B-JANG_2D, variating pattern per house rule)

Before: fatal at the first image turn. After — full `BENCH_VL_VARIATING` pattern completes, exit 0:

| turn | shape | result |
|---|---|---|
| 1 | think+text | reasoning 114ch ✓ |
| 2 | image, no-think | "smooth color gradient … red at the top to blue at the bottom" ✓ (gradient asset) |
| 3 | tools, no-think | toolCalls=1 ✓ |
| 4 / 4b | **image + tools same turn** | toolCalls=1 ✓ |
| 5b | **two images one turn** | "2" ✓ |
| 6 / 7 | grow A / B | "Red" / "Blue" ✓ (opposite pairs) |
| 5 | **verbatim replay of turn 1** | reasoning 114ch reproduced ✓ |

The `config-metadata mismatch … 84 per-layer overrides` re-stamp line is **gone** — declared metadata now wins for vision modules.

**No text regression:** greedy parity vs the Python runtime (`mlx_lm`, same prompt tokens, temp 0) remains **EXACT (20/20 tokens)** after the change — and was verified EXACT on **all four quants** (JANG_2D/4D/6D/MXFP8) this session, including MXFP8's two-tensor MX path.

Also included: the multiturn bench prints the first 20 generated token ids per turn, which is how the parity gates diff Swift against the Python runtime.

## Follow-ups (tracked, not in this PR)

- Live GUI re-verification of the exact crashing turn needs an osaurus repin to this fix.
- The bits×gs ambiguity class `(4,128) ≡ (8,64)` remains for any future module role whose width is in neither text nor vision configs.