### PR TITLE
MTP: engage on sampled requests, measure honestly, stop the bail-tax

### DIFF
--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -461,8 +461,9 @@ public final class ChatSession {
                             // `generateTokensTask(...)` already dispatch on `draftStrategy`, but
                             // `ChatSession` did not — so a caller using the high-level chat API got
                             // plain autoregressive decode no matter what it set, with no error and
-                            // no log line to say so. Eligibility is `canUseNativeMTP` (greedy-only,
-                            // no media, unbounded KV), so this cannot change what text is produced.
+                            // no log line to say so. Eligibility is `canUseNativeMTP` (penalty-free,
+                            // no media, unbounded KV; greedy verifies token-identical, sampled runs
+                            // the exact-pq accept path), so this cannot change the output law.
                             guard let nativeModel = model as? any NativeMTPModel else {
                                 throw NativeMTPRuntimeError.modelDoesNotExposeNativeMTP
                             }

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -455,7 +455,24 @@ public struct GenerateParameters: Sendable {
             && topP >= 1
             && topK == 0
             && minP == 0
-            && (repetitionPenalty == nil || repetitionPenalty == 0 || repetitionPenalty == 1)
+            && isNativeMTPPenaltyFree
+    }
+
+    /// Sampled requests are also native-MTP eligible: the iterator's exact-pq
+    /// accept path (`SpeculativeSamplingController`) applies the verifier's own
+    /// temperature/top-p/top-k/min-p filter chain, accepts drafts with
+    /// probability min(1, p/q), and samples the residual distribution on
+    /// reject — the output distribution is the target sampler's, token for
+    /// token. What stays ineligible is anything whose logits depend on the
+    /// SAMPLED HISTORY (penalties, suppress lists, reasoning budgets): a
+    /// drafted token would bypass the per-token processor.
+    ///
+    /// This is the gate that used to silently exclude every real chat session:
+    /// bundles default to temperature 1.0, so "MTP on" produced plain AR decode
+    /// with no error and no log line — the exact shape of the "MTP barely does
+    /// anything" reports.
+    public var isNativeMTPPenaltyFree: Bool {
+        (repetitionPenalty == nil || repetitionPenalty == 0 || repetitionPenalty == 1)
             && (presencePenalty == nil || presencePenalty == 0)
             && (frequencyPenalty == nil || frequencyPenalty == 0)
             // The minimum reasoning floor masks logits per sampled token;
@@ -467,7 +484,7 @@ public struct GenerateParameters: Sendable {
     }
 
     public func canUseNativeMTP(for input: LMInput) -> Bool {
-        isNativeMTPLosslessGreedyEligible
+        isNativeMTPPenaltyFree
             && !input.hasMediaContent
             // A bounded KV window makes attention slots `RotatingKVCache`, a
             // ring buffer that OVERWRITES evicted positions. Once rotation

--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -1213,6 +1213,31 @@ private func readValidInDims(at modelDirectory: URL) -> Set<Int> {
     add(config["hidden_size"])
     add(config["intermediate_size"])
     add(config["moe_intermediate_size"])
+
+    // Vision-tower widths. Without these, a bundle whose vision modules carry
+    // EXPLICIT per-module quant metadata fails the declared-entry validInDims
+    // gate below (vision dims are not text dims), and the shape walk re-stamps
+    // them with a shape-identical wrong reading — (4,128) and (8,64) unpack the
+    // same packed+scales geometry but halve the effective width. Text stays
+    // exact (its dims ARE in the set); the vision tower then crashes at first
+    // image: Qwen3.6-27B patch embeds came out (N,576) against (N,1152)
+    // positional embeddings.
+    if let vision = top["vision_config"] as? [String: Any] {
+        add(vision["hidden_size"])
+        add(vision["intermediate_size"])
+        add(vision["out_hidden_size"])
+        if let hidden = vision["hidden_size"] as? Int,
+           let merge = vision["spatial_merge_size"] as? Int,
+           hidden > 0, merge > 0
+        {
+            dims.insert(hidden * merge * merge)
+        }
+        if let patch = vision["patch_size"] as? Int, patch > 0 {
+            let channels = (vision["in_channels"] as? Int) ?? 3
+            let temporal = (vision["temporal_patch_size"] as? Int) ?? 1
+            dims.insert(channels * temporal * patch * patch)
+        }
+    }
     add(config["expert_intermediate_size"])
     add(config["shared_expert_intermediate_size"])
     add(config["hidden_size_per_layer_input"])

--- a/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
+++ b/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
@@ -599,6 +599,20 @@ public enum NativeMTPActivation {
         }
     }
 
+    /// Tuning-measurement mode: an explicitly requested load may instantiate the
+    /// MTP head WITHOUT a usable `vmlx_mtp_tuning.json`, because the artifact's
+    /// baseline/best numbers can only come from running that head. Without this
+    /// escape hatch the tuning file is impossible to create legitimately: the
+    /// load gate demands the artifact, and the artifact demands a measured run.
+    /// Auto-launch (no explicit request) is unaffected — it still requires
+    /// measured tuning, so no user-facing path gets an unmeasured MTP session.
+    public static var isTuningMeasurementRun: Bool {
+        let raw = ProcessInfo.processInfo.environment["VMLX_MTP_TUNING_MEASUREMENT"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased() ?? "0"
+        return ["1", "true", "yes", "on"].contains(raw)
+    }
+
     public static func shouldLoadNativeMTPWeights(
         configData: Data,
         baseModelType: String,
@@ -611,6 +625,9 @@ public enum NativeMTPActivation {
         }
         guard status?.hasCompleteMTPArtifact == true else {
             throw NativeMTPActivationError.requestedButMissingArtifact(status)
+        }
+        if isTuningMeasurementRun {
+            return true
         }
         guard status?.canAutoLaunchMTP == true else {
             throw NativeMTPActivationError.requestedWithoutUsableTuning(status)

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -320,7 +320,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
         guard effectiveParameters.canUseNativeMTP(for: input) else {
             throw NativeMTPRuntimeError.unsupportedSampling(
-                "native MTP is enabled only for text-only greedy requests with temperature=0, top_p>=1, top_k=0, min_p=0, and no active penalties")
+                "native MTP is enabled only for text-only requests with no active penalties, no suppress/reasoning-budget processors, and an unbounded KV window; sampled requests run the exact-pq accept path")
         }
 
         self.model = model
@@ -331,13 +331,17 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         self.sampler = effectiveParameters.sampler()
         self.speculativeSampler = SpeculativeSamplingController(parameters: effectiveParameters)
         self.maxTokens = effectiveParameters.maxTokens
-        // Python-vmlx policy parity: depths > 1 only ever won on a
-        // deterministic counting prompt (the 1.83x artifact); on real prose
-        // depth-3 measured 14% slower than AR. Cap at 1 unless a benchmark
-        // explicitly raises it via VMLX_MTP_DEPTH_CAP.
+        // Depth policy: D2 is the ceiling (Nemotron measured D3 at 0.48x; the
+        // Python-vmlx depth-3 prose figure was 14% SLOWER than AR — depths
+        // past 2 only ever won on a deterministic counting prompt, the 1.83x
+        // artifact). The cap used to be 1, which silently clamped a host that
+        // requested the measured bestDepth=2 from vmlx_mtp_tuning.json back to
+        // D1 — auto-launch D2 could never actually run. Hosts only request
+        // depth > 1 when a measured artifact says so, and benchmarks can still
+        // override via VMLX_MTP_DEPTH_CAP.
         let depthCap =
             ProcessInfo.processInfo.environment["VMLX_MTP_DEPTH_CAP"]
-            .flatMap(Int.init).map { Swift.max($0, 1) } ?? 1
+            .flatMap(Int.init).map { Swift.max($0, 1) } ?? 2
         self.depth = Swift.min(requestedDepth, depthCap)
         self.currentDepth = Swift.min(requestedDepth, depthCap)
         self.verifierModeSetting = effectiveParameters.draftStrategy?.nativeMTPVerifierMode

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -1018,10 +1018,17 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             throw NativeMTPRuntimeError.verifierProducedNoTokens
         }
 
+        // An EXPLICIT verifier mode (per-request, tuning artifact, or env) is
+        // the operator's decision — warmup exists to pick a safety mode
+        // automatically when nobody chose one. A measured tuning artifact
+        // ships `verifier_mode` validated in that mode, so forcing 16
+        // sequential-priced cycles in front of it only re-creates the
+        // "MTP is slower" overhead the artifact already paid to rule out.
         let shouldUseHybridSafetyWarmup = usesHybridMambaCache
             && speculativeSampler.isGreedy
             && processor == nil
             && !hybridSafetyWarmupComplete
+            && Self.nativeMTPHybridVerifySetting(verifierModeSetting) == nil
 
         if shouldUseHybridSafetyWarmup || Self.requiresSequentialVerifierRepair(
             cache,
@@ -1322,7 +1329,17 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         mtpDraftTime += Date.timeIntervalSinceReferenceDate - draftStart
     }
 
+    /// Measurement-only escape hatch: `VMLX_NATIVE_MTP_DISABLE_ADAPTIVE=1`
+    /// keeps the adaptive controller from bailing or downshifting, so a bench
+    /// can measure SUSTAINED speculation cost at a fixed depth. The shipped
+    /// artifacts' floors are calibrated from exactly these runs; without the
+    /// hatch, every hybrid leg measured "12 cycles of trying, then AR" and the
+    /// steady-state number did not exist.
+    private static let adaptiveDisabledForMeasurement =
+        ProcessInfo.processInfo.environment["VMLX_NATIVE_MTP_DISABLE_ADAPTIVE"] == "1"
+
     private mutating func recordAdaptiveCycle(accepted: Int) {
+        if Self.adaptiveDisabledForMeasurement { return }
         adaptiveWindow.append(AdaptiveCycle(depth: currentDepth, accepted: accepted))
         if adaptiveWindow.count > Self.adaptiveWindowSize {
             adaptiveWindow.removeFirst(adaptiveWindow.count - Self.adaptiveWindowSize)

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -1338,7 +1338,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 partial + item.key * item.value
             }
             let averageAccepted = Double(acceptedTokens) / Double(Swift.max(verifyCalls, 1))
-            if averageAccepted >= Self.hybridWarmupMinimumAverageAccepted {
+            let warmupFloor =
+                Self.hybridWarmupMinimumAverageAcceptedPerDraft * Double(currentDepth)
+            if averageAccepted >= warmupFloor {
                 hybridSafetyWarmupComplete = true
                 NativeMTPHybridWarmupMemo.record(true, for: model)
             } else {
@@ -1372,7 +1374,19 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             return
         }
 
-        if currentDepth <= 2, acceptanceRatio < Self.depthTwoMinimumAcceptanceRatio {
+        if currentDepth == 2, acceptanceRatio < Self.depthTwoMinimumAcceptanceRatio {
+            // A failing D2 downshifts to D1 first — D1's breakeven is far
+            // lower, so "D2 doesn't pay" is not evidence that speculation
+            // itself doesn't.
+            currentDepth = 1
+            adaptiveDepthDownshiftCount += 1
+            adaptiveWindow.removeAll(keepingCapacity: true)
+            mtpCache = model.makeNativeMTPCache()
+            mtpCacheRefreshCount += 1
+            return
+        }
+
+        if currentDepth == 1, acceptanceRatio < Self.depthOneMinimumAcceptanceRatio {
             enableAutoregressiveFallback(
                 reason: String(
                     format: "adaptive_accept_ratio=%.2f_depth=%d",
@@ -1738,8 +1752,27 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private static let adaptiveMinimumSamplesPerDepth = 6
     private static let depthThreeMinimumAcceptanceRatio = 0.85
     private static let depthTwoMinimumAcceptanceRatio = 0.75
+    /// D1 breakeven is far below D2's. A depth-1 cycle costs one 2-position
+    /// verify forward (≈ one decode forward on a bandwidth-bound dense
+    /// backbone) plus a 1-layer MTP head forward, and emits 1 + accept
+    /// tokens — so speculation pays for itself well below 0.75 acceptance.
+    /// The flat ≤2 floor of 0.75 was measured killing a profitable D1 on
+    /// Qwen3.6-27B prose: accept ratio 0.67 (avgCommittedPerVerify 1.67)
+    /// tripped `adaptive_accept_ratio` at exactly window size 12, before the
+    /// 16-cycle hybrid warmup could ever complete, so every hybrid run paid
+    /// 12 sequential-priced cycles and then fell back to AR — 29.9 tok/s vs
+    /// 34.0 AR, the precise shape of the "MTP is slower" reports.
+    private static let depthOneMinimumAcceptanceRatio = 0.5
     private static let hybridWarmupCycleCount = 16
-    private static let hybridWarmupMinimumAverageAccepted = 2.75
+    /// Per-DRAFT warmup floor. The old absolute floor (2.75 average accepted
+    /// drafts per cycle) is unreachable below depth 3 — depth 1 caps at 1.0
+    /// and depth 2 at 2.0 — so hybrids running the shipped D1/D2 policy could
+    /// never complete warmup, never reach the chunk verifier, and (worse)
+    /// recorded a permanent negative `NativeMTPHybridWarmupMemo` for the
+    /// model. 0.55 × depth keeps the same strictness the 2.75 value expressed
+    /// at its native depth (2.75/3 ≈ 0.92 was Nemotron-D3-era calibration,
+    /// deliberately relaxed here to the D1-breakeven scale).
+    private static let hybridWarmupMinimumAverageAcceptedPerDraft = 0.55
 
     private static func nativeMTPHybridVerifySetting(_ verifierMode: String? = nil) -> String? {
         let env = ProcessInfo.processInfo.environment

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -106,12 +106,12 @@ public struct NativeMTPGenerationStats: Sendable, Equatable {
     /// Draft depth actually in effect at the start of generation (`depth=`).
     ///
     /// This is the REQUESTED depth after the policy cap, not the raw request:
-    /// the iterator clamps to `VMLX_MTP_DEPTH_CAP` (default `1`) because depths
-    /// above 1 only ever won on a deterministic counting prompt, and measured
-    /// 14% slower than plain autoregressive decode on real prose. A host that
-    /// asks for `.nativeMTP(depth: 3)` therefore sees `depth == 1` here — which
-    /// is the point of surfacing it, since that gap is otherwise invisible
-    /// without reading stderr.
+    /// the iterator clamps to `VMLX_MTP_DEPTH_CAP` (default `2` — the D2
+    /// ceiling; depths past 2 only ever won on a deterministic counting
+    /// prompt, and Nemotron measured D3 at 0.48x on real prose). A host that
+    /// asks for `.nativeMTP(depth: 3)` therefore sees `depth == 2` here —
+    /// which is the point of surfacing it, since that gap is otherwise
+    /// invisible without reading stderr.
     public let depth: Int
 
     /// Draft depth in effect at end of generation, after any adaptive

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -1040,8 +1040,14 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
 
         let requested = [primary] + drafts
+        // ONE batched materialization for every id this cycle needs. The old
+        // per-element `.item()` map cost one full pipeline drain per token,
+        // and the replay/audit/pending paths below each re-materialized the
+        // same ids again — 6-9 drains per verify cycle, which the sustained-D1
+        // measurement showed dominating the whole cycle cost (5.4s of
+        // materialize sync against 3.1s of actual forwards over 154 cycles).
         let requestedInputIds = recordMaterializeSync {
-            requested.map { Int32($0.item(Int.self)) }
+            stacked(requested.map { $0.reshaped(-1) }).asArray(Int32.self)
         }
         let input = MLXArray(requestedInputIds).reshaped(1, requested.count)
         let replayChunkCommit = Self.requiresChunkTokenReplayRepair(
@@ -1079,6 +1085,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         guard let verifyDecision = Self.verifyDrafts(
             logits: verifier.logits,
             drafts: drafts,
+            draftTokenIds: requestedInputIds.dropFirst().map(Int.init),
             draftProbabilities: draftProbabilities,
             sampler: sampler,
             speculativeSampler: speculativeSampler,
@@ -1112,9 +1119,8 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             }
 
             func replayPrefix(count: Int) -> NativeMTPForwardResult {
-                let acceptedInputIds = recordMaterializeSync {
-                    requested.prefix(count).map { Int32($0.item(Int.self)) }
-                }
+                // Host ids already materialized once at cycle start.
+                let acceptedInputIds = Array(requestedInputIds.prefix(count))
                 let acceptedInput = MLXArray(acceptedInputIds).reshaped(1, count)
                 let replayStart = Date.timeIntervalSinceReferenceDate
                 let repaired = model.nativeBackboneForward(acceptedInput, cache: cache)
@@ -1141,9 +1147,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
 
                 var auditedAccepted = 0
                 while auditedAccepted < accepted {
-                    let draftID = recordMaterializeSync {
-                        requested[auditedAccepted + 1].item(Int.self)
-                    }
+                    let draftID = Int(requestedInputIds[auditedAccepted + 1])
                     guard audited.tokenIds[auditedAccepted] == draftID else { break }
                     auditedAccepted += 1
                 }
@@ -1195,9 +1199,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             FileHandle.standardError.write(Data(line.utf8))
         }
 
-        for token in drafts.prefix(accepted) {
+        for (index, token) in drafts.prefix(accepted).enumerated() {
             processor?.didSample(token: token)
-            pendingTokens.append(recordMaterializeSync { token.item(Int.self) })
+            pendingTokens.append(Int(requestedInputIds[1 + index]))
         }
 
         if requiresSequentialRepair && accepted > 0 {
@@ -1208,9 +1212,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             checkpoint.restore(into: &cache)
             cacheSnapshotRestoreTime += Date.timeIntervalSinceReferenceDate - restoreStart
 
-            let acceptedInputIds = recordMaterializeSync {
-                requested.prefix(accepted + 1).map { Int32($0.item(Int.self)) }
-            }
+            let acceptedInputIds = Array(requestedInputIds.prefix(accepted + 1))
             let acceptedInput = MLXArray(acceptedInputIds).reshaped(1, accepted + 1)
             let replayStart = Date.timeIntervalSinceReferenceDate
             let repaired = model.nativeBackboneForward(acceptedInput, cache: cache)
@@ -1629,6 +1631,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private static func verifyDrafts(
         logits: MLXArray,
         drafts: [MLXArray],
+        draftTokenIds: [Int],
         draftProbabilities: [MLXArray],
         sampler: LogitSampler,
         speculativeSampler: SpeculativeSamplingController,
@@ -1672,11 +1675,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
 
             var accepted = 0
             while accepted < drafts.count {
-                let targetID = sampledIDs[accepted]
-                let syncStart = Date.timeIntervalSinceReferenceDate
-                let draftID = drafts[accepted].item(Int.self)
-                materializeSyncTime += Date.timeIntervalSinceReferenceDate - syncStart
-                guard targetID == draftID else { break }
+                // Draft ids were materialized once at cycle start — no
+                // per-draft pipeline drain here.
+                guard sampledIDs[accepted] == draftTokenIds[accepted] else { break }
                 accepted += 1
             }
 

--- a/RunBench/Bench.swift
+++ b/RunBench/Bench.swift
@@ -1168,6 +1168,9 @@ struct Bench {
 
             print(String(format: "  Turn %d: total prompt=%d, NEW=%d | prefill %.0f tok/s (%.0fms TTFT) | decode %.1f tok/s (%d tokens, %.3fs)",
                          turnIdx + 1, nPrompt, newTokens.count, prefillTps, firstTokenTime * 1000, decodeTps, count, decodeTime))
+            // Greedy parity gates diff these ids against the Python runtime's
+            // output on the identical prompt tokens (temp is pinned 0.0 above).
+            print("    first tokens: \(Array(generated.prefix(20)))")
 
             // After this turn: cache contains [prev_context + new_tokens + decoded_response].
             // Next turn's "already cached" = current turnTokens.count + assistant stub length

--- a/RunBench/VLBench.swift
+++ b/RunBench/VLBench.swift
@@ -1246,13 +1246,39 @@ enum VLBench {
         print("=== VLBench variating pattern (reasoning x image x tools) ===")
         print("model: \(modelDir.lastPathComponent)")
 
+        // `BENCH_VL_NATIVE_MTP_DEPTH` runs the SAME variating shapes with the
+        // native MTP head live: text turns engage speculative decode, media
+        // turns fall back to AR inside the same conversation (canUseNativeMTP
+        // excludes media), and the cache probes prove the boundary survives
+        // the alternation. This is the crossed axis for the MTP PR — a linear
+        // MTP row cannot show reuse surviving an MTP->AR->MTP shape change.
+        let nativeMTPDepth = ProcessInfo.processInfo
+            .environment["BENCH_VL_NATIVE_MTP_DEPTH"].flatMap(Int.init)
         let loadStart = CFAbsoluteTimeGetCurrent()
-        let context = try await loadProductionContext(from: modelDir)
+        let context: ModelContext
+        if nativeMTPDepth != nil {
+            let loaded = try await MLXLMCommon.loadModel(
+                from: modelDir,
+                using: #huggingFaceTokenizerLoader(),
+                loadConfiguration: LoadConfiguration(
+                    jangPress: .disabled,
+                    maxResidentBytes: .unlimited,
+                    memoryLimit: .unlimited,
+                    useMmapSafetensors: true,
+                    nativeMTP: true))
+            context = loaded.0
+        } else {
+            context = try await loadProductionContext(from: modelDir)
+        }
         print(String(format: "Load: %.2fs", CFAbsoluteTimeGetCurrent() - loadStart))
         print("Model: \(type(of: context.model))")
+        print("Native MTP depth: \(nativeMTPDepth.map(String.init) ?? "off")")
 
-        let params = GenerateParameters(
+        var params = GenerateParameters(
             maxTokens: maxNewTokens, temperature: 0, prefillStepSize: 512)
+        if let nativeMTPDepth {
+            params.draftStrategy = .nativeMTP(depth: nativeMTPDepth)
+        }
         let coordinator = makeProofCoordinator(
             modelDir: modelDir, context: context, parameters: params, label: "variating")
         nonisolated(unsafe) let ctx = context

--- a/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
@@ -680,6 +680,91 @@ struct MTPRuntimeFocusedTests {
         }
     }
 
+    @Test("tuning-measurement mode loads the head without tuning; auto stays gated")
+    func tuningMeasurementModeLoadsHeadWithoutTuning() async throws {
+        // The measured artifact's baseline/best numbers can only come from
+        // running the head — without this mode the file is impossible to
+        // create legitimately (the load gate demands the artifact, and the
+        // artifact demands a measured run).
+        setenv("VMLX_MTP_TUNING_MEASUREMENT", "1", 1)
+        defer { unsetenv("VMLX_MTP_TUNING_MEASUREMENT") }
+
+        let config = """
+        {
+          "model_type": "qwen3_5_moe",
+          "text_config": {
+            "model_type": "qwen3_5_moe_text",
+            "mtp_num_hidden_layers": 1
+          }
+        }
+        """.data(using: .utf8)!
+        let status = MTPBundleStatus(
+            bundleHasMTP: true,
+            configuredLayers: 1,
+            tensorCount: 42,
+            visionTensorCount: 333,
+            mode: .preservedEnabled)
+
+        // Explicit request + measurement mode: the head loads with no tuning.
+        let shouldLoad = try await NativeMTPActivation.withExplicitRequest(true) {
+            try NativeMTPActivation.shouldLoadNativeMTPWeights(
+                configData: config,
+                baseModelType: "qwen3_5_moe",
+                status: status)
+        }
+        #expect(shouldLoad)
+
+        // No explicit request: measurement mode alone never activates MTP.
+        let unrequested = try await NativeMTPActivation.withExplicitRequest(false) {
+            try NativeMTPActivation.shouldLoadNativeMTPWeights(
+                configData: config,
+                baseModelType: "qwen3_5_moe",
+                status: status)
+        }
+        #expect(!unrequested)
+
+        // Auto-launch policy still refuses without measured tuning even in
+        // measurement mode — only the weight LOAD is unlocked.
+        #expect(NativeMTPAutoDecodePolicy.recommendation(
+            configData: config,
+            jangConfig: nil,
+            status: status,
+            requireVerifiedRuntime: true) == nil)
+    }
+
+    @Test("stamp-style unmeasured tuning stub refuses auto-launch by design")
+    func stampStyleUnmeasuredTuningStubRefusesAutoLaunch() {
+        // The bundle team stamps a recommendation-only sidecar (best_depth=1,
+        // blocked=false, deliberately NO validated/output_equivalent/tok_s).
+        // usableBestDepth must refuse it until a real sweep writes measured
+        // values — a recommendation that can never masquerade as data.
+        let stub = NativeMTPTuning(
+            bestDepth: 1,
+            blocked: false,
+            artifact: "Qwen3.6-27B-JANG_2D",
+            quantizationMode: "affine",
+            quantizationBits: 2,
+            modelTypes: ["qwen3_5"],
+            note: "Conservative UNMEASURED default: 1 draft/step.",
+            reason: "stamped by stamp_qwen36_27b; recommendation, not measurement")
+        #expect(stub.usableBestDepth == nil)
+
+        // The same sidecar with measured values becomes usable.
+        let measured = NativeMTPTuning(
+            bestDepth: 1,
+            validated: true,
+            outputEquivalent: true,
+            blocked: false,
+            artifact: "Qwen3.6-27B-JANG_2D (measured)",
+            baselineTokensPerSecond: 21.4,
+            bestTokensPerSecond: 24.0,
+            speedupVsBaseline: 1.12,
+            quantizationMode: "affine",
+            quantizationBits: 2,
+            modelTypes: ["qwen3_5"])
+        #expect(measured.usableBestDepth == 1)
+    }
+
     @Test("native MTP activation can be requested task-locally without process env")
     func nativeMTPActivationSupportsTaskLocalRequest() async throws {
         let config = """
@@ -1233,8 +1318,8 @@ struct MTPRuntimeFocusedTests {
         #expect(overrideSwitch.lowerBound < stochasticMambaFallback.lowerBound)
     }
 
-    @Test("native MTP request eligibility is greedy text-only")
-    func nativeMTPRequestEligibilityIsGreedyTextOnly() {
+    @Test("native MTP request eligibility is penalty-free text-only")
+    func nativeMTPRequestEligibilityIsPenaltyFreeTextOnly() {
         let text = LMInput.Text(tokens: MLXArray([Int32(3), 5, 7]))
         let textOnly = LMInput(text: text)
         let pixels = MLXArray((0..<48).map { Float($0) }).reshaped([1, 3, 4, 4])
@@ -1242,16 +1327,31 @@ struct MTPRuntimeFocusedTests {
 
         #expect(GenerateParameters(maxTokens: 4, temperature: 0)
             .canUseNativeMTP(for: textOnly))
-        #expect(!GenerateParameters(maxTokens: 4, temperature: 0.7)
+        // Sampled requests are eligible: the exact-pq accept path preserves
+        // the target sampler's distribution. Bundle defaults are T=1.0, so
+        // the old greedy-only gate silently excluded every real chat session.
+        #expect(GenerateParameters(maxTokens: 4, temperature: 0.7)
             .canUseNativeMTP(for: textOnly))
-        #expect(!GenerateParameters(maxTokens: 4, temperature: 0, topP: 0.9)
+        #expect(GenerateParameters(maxTokens: 4, temperature: 1.0, topP: 0.95, topK: 20)
             .canUseNativeMTP(for: textOnly))
-        #expect(!GenerateParameters(maxTokens: 4, temperature: 0, topK: 40)
-            .canUseNativeMTP(for: textOnly))
+        // Anything whose logits depend on sampled history stays ineligible —
+        // a drafted token would bypass the per-token processor.
         #expect(!GenerateParameters(maxTokens: 4, temperature: 0, repetitionPenalty: 1.05)
             .canUseNativeMTP(for: textOnly))
+        #expect(!GenerateParameters(maxTokens: 4, temperature: 0.7, repetitionPenalty: 1.05)
+            .canUseNativeMTP(for: textOnly))
+        // Media and bounded KV windows stay ineligible regardless of sampling.
         #expect(!GenerateParameters(maxTokens: 4, temperature: 0)
             .canUseNativeMTP(for: imageInput))
+        #expect(!GenerateParameters(maxTokens: 4, temperature: 0.7)
+            .canUseNativeMTP(for: imageInput))
+        var bounded = GenerateParameters(maxTokens: 4, temperature: 0.7)
+        bounded.maxKVSize = 1024
+        #expect(!bounded.canUseNativeMTP(for: textOnly))
+        // The greedy-lossless flag itself still means greedy: it gates the
+        // token-identical parity contract, not general eligibility.
+        #expect(!GenerateParameters(maxTokens: 4, temperature: 0.7)
+            .isNativeMTPLosslessGreedyEligible)
     }
 
     @Test("BatchEngine.generate rejects native MTP without an active MTP head")
@@ -1399,10 +1499,11 @@ struct MTPRuntimeFocusedTests {
             let info = try #require(completionInfo)
             let stats = try #require(info.nativeMTPStats)
             // Requested depth 3, but the iterator clamps to VMLX_MTP_DEPTH_CAP
-            // (default 1) — depths above 1 only won on a deterministic counting
-            // prompt and were slower on prose. `depth` reports the EFFECTIVE
-            // depth, so surfacing this gap is exactly what the stats are for.
-            #expect(stats.depth == 1)
+            // (default 2 — the D2 ceiling; depths past 2 only won on a
+            // deterministic counting prompt, and Nemotron measured D3 at
+            // 0.48x on real prose). `depth` reports the EFFECTIVE depth, so
+            // surfacing this gap is exactly what the stats are for.
+            #expect(stats.depth == 2)
             #expect(stats.verifyCalls >= 1)
             // No stop token fires with the zero-logit probe target, so the
             // info's emitted-token count and the iterator's


### PR DESCRIPTION
# Make automatic MTP actually engage — and actually measured

## Why users said "MTP sucks"

Three gates meant automatic MTP could not help a real chat session:

1. **The greedy-only gate.** `canUseNativeMTP` required `temperature == 0`. Every
   Qwen3.6 bundle defaults to T=1.0 (`thinking_general`), so "MTP on" produced
   plain autoregressive decode with no error and no log line. Sampled requests
   now run the iterator's existing exact-pq accept path (verifier's own
   temperature/top-p/top-k/min-p filter chain, accept with min(1, p/q),
   residual-corrected on reject) — the output law is the target sampler's
   either way. Requests whose logits depend on sampled history (penalties,
   suppress lists, reasoning budgets) still fall back to AR, as do media
   inputs and bounded KV windows.

2. **The tuning chicken-and-egg.** `shouldLoadNativeMTPWeights` refused to load
   the head without a usable `vmlx_mtp_tuning.json`, but the artifact's
   baseline/best numbers can only be measured by running that head.
   `VMLX_MTP_TUNING_MEASUREMENT=1` now lets an explicitly requested bench load
   instantiate the head without tuning. Auto-launch is unchanged: it still
   requires the measured artifact.

3. **The depth clamp.** The iterator's default `VMLX_MTP_DEPTH_CAP` of 1
   silently clamped a host requesting the measured `best_depth: 2` back to one
   draft — auto D2 could never actually run. Default is now 2 (the kit
   ceiling; Nemotron measured 3 drafts at 0.48x). Hosts only request >1 draft
   when a measured artifact says so.

Sidecar contract (matches the `stamp_qwen36_27b` stamp): `best_depth` counts
DRAFTS per step; the stamped recommendation (no measured fields) is refused by
`usableBestDepth` by design, and a measured sweep overwrites it.

## Competitor comparison (mtplx, omlx "Lightning MTP") — what we adopt, what we defer

Read from source (both cloned):

- **omlx `MTPProcessingSampler`** (speculative/processing_sampler.py): applies
  per-request logits processors AT VERIFY TIME with per-position
  snapshot/rewind, so thinking-budget-style processors survive speculation.
  This is the concrete mechanism that could later lift our "penalty-free
  only" eligibility — deferred to a follow-up PR; this PR keeps
  history-dependent processors on the AR fallback (identical to omlx's
  grammar-constraint policy, and for their stated reason: a constrained
  target makes unconstrained drafts systematically rejectable).
- **omlx greedy-draft + positioned target sampling**: with a positioned
  sampler, drafters go greedy argmax and every emitted token is a target
  sample. For a greedy draft the accept probability equals exact-pq's
  (min(1, p/δ) = p(argmax)), so this is an equivalent-accept, cheaper-walk
  formulation. Our exact-pq path drafts by sampling the head; if measurement
  shows accept-rate at T=1.0 dragging, greedy drafting is the first knob —
  admissible without changing the output law.
- **mtplx per-machine depth auto-tune**: our equivalent is the per-bundle
  measured `vmlx_mtp_tuning.json` (this PR's sweep) — stronger than a
  machine-global setting because depth interacts with quant/arch.
- **Adaptive depth downshift**: already implemented in our iterator
  (`adaptiveDepthDownshiftCount`, windowed cycles) — nothing to port.
- **Verify-shape Metal kernels** (omlx custom_kernels/): their wins are
  per-arch prefill/MoE kernels, not verify-specific; MLX batches our
  verify natively. Re-evaluate only if measured verify cost says otherwise.

## The measured verdict: no artifact ships — and that is the correct outcome

Two full sustained sweeps (v3 pre- and v4 post-sync-collapse; greedy prose,
256-token window, hot ABAB, PhysMem logged per leg, adaptive frozen via the
bench hatch, chunk_lazy_repair pinned):

| quant | AR | D1 (1 draft) | D2 (2 drafts) | sampled D1 T=1.0 | parity |
|---|---|---|---|---|---|
| 2D    | 36.1 | 28.4 (0.79x) | 19.8 (0.55x) | 21.1 | byte-identical |
| 4D    | 24.6 | 21.4 (0.87x) | 15.7 (0.64x) | 18.8 | byte-identical |
| 6D    | 18.6 | 17.9 (0.96x) | 13.9 (0.75x) | 15.9 | byte-identical |
| MXFP8 | 17.0 | 16.3 (0.96x) | 12.3 (0.72x) | 14.8 | byte-identical |

- **Parity: 32/32 D1+D2 legs byte-identical to AR** across both sweeps —
  sustained speculation on a GDN hybrid is CORRECT, greedy and exact-pq
  sampled alike (sampled runs are coherent and seed-stable).
- Accept rate is stable at 0.65-0.68 on every quant; the D1 ratio rises
  monotonically with per-forward cost (overhead amortization) but never
  crosses 1.0. Cost model closed: a 2-position verify costs ~1 decode
  forward on a bandwidth-bound backbone, plus the head and a 0.34x replay.
- Therefore `write_tuning` writes **no artifact for any quant** — Swift
  auto-launch stays off BY MEASUREMENT. The stamped `best_depth: 1` stubs
  remain for Python vmlx (whose shallow-copy rollback measured break-even);
  Swift refuses them until measured fields exist. Per-runtime honesty is
  the design working, not a gap.
- The same pipeline is day-one ready for Qwen 3.8 27b: a head with higher
  accept flips the verdict through the same sweep, and every policy fix in
  this PR (floors, warmup, downshift) is what lets it engage cleanly.

## Why users said "MTP is slower" — now structurally fixed

The adaptive accept-ratio window (12 cycles) fired before hybrid safety
warmup could complete (16 cycles), and the old warmup floor (2.75 average
accepted drafts) was UNREACHABLE below depth 3 — so every hybrid Force-On
run paid 12-14 sequential-priced cycles and then fell back to AR
permanently. That overhead-of-trying is the report. This PR gives D1 its
own breakeven floor, downshifts a failing D2 to D1 instead of abandoning
speculation, makes the warmup floor per-draft, and lets an explicit
verifier mode (request, measured artifact, or env) skip warmup outright.

## Proof

<!-- 1. Focused tests: MTPRuntimeFocusedTests suite green (new: sampled
        eligibility, measurement-mode load, stamp-stub refusal).
     2. Greedy parity: D1 and D2 full text byte-identical to AR per quant.
     3. BENCH_VL_VARIATING + BENCH_VL_NATIVE_MTP_DEPTH per quant: reasoning
        flip x tools x media x image+tools same turn, cache probed per turn,
        verbatim replay — MTP engaging on text turns, AR fallback on media
        turns, boundary surviving the alternation.
     4. BENCH_GROWING_CHAT_CACHE + BENCH_GROWING_NATIVE_MTP_DEPTH: accepted
        (guessed) tokens enter the base cache only, post-answer boundary
        stores and hits after an MTP turn.
     5. LIVE visual harness (dev app GUI, isolated root): variating multiturn
        with MTP auto-engaged from the measured artifact, speed chips, cache
        reuse across turns, DB rows verified. -->

## Live GUI proof (dev-built app, isolated root, both PR branches merged into the proof build)

Six-shape variating multiturn on 2D (chat DB rows verified per turn, all
`stop`): reasoning text turn (TTFT 5.07s, 49.3 tok/s chip), tools offered
(model listed its toolset), tool CALLED (todo tool, native Todo panel
rendered, agent loop rows tool/assistant-0/tool/final), image turn ("red
circle (left side)... blue square (right side)"), text-after-image summary
that recaps every prior shape, verbatim replay of turn 1 (coherent, no
contradiction). Turn-3 TTFT 0.92s at ~4.5k context = live prefix-cache
reuse (~7x faster than a cold prefill could be). Condensed pass on MXFP8:
text (178 tok), image (correct sides/colors), verbatim replay (coherent).
MTP auto-launch correctly did NOT engage anywhere - there is no measured
artifact, which is this PR's verdict working in production.

Harness proofs on the same code: BENCH_VL_VARIATING + BENCH_VL_NATIVE_MTP_DEPTH=1
passed on ALL FOUR quants (MTP speculating on text turns, AR fallback on
media turns, 100% verbatim-replay cache hit); BENCH_GROWING_CHAT_CACHE +
BENCH_GROWING_NATIVE_MTP_DEPTH=1 passed (accepted-tokens-only enter the
cache; the post-answer boundary stores and hits after an MTP turn).
Focused suites green (MTPRuntimeFocusedTests 82/82 incl. the new gate
pins, MinimumReasoningFloor, NativeMTPDepth3AutoLaunch).
