### PR TITLE
Kill the post-answer whole-prompt replay on long hybrid turns

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -2123,7 +2123,18 @@ public actor BatchEngine {
     ) -> (head: LMInput?, tail: LMInput)? {
         let size = input.text.tokens.size
         guard size > 0 else { return nil }
-        let split = size - 1
+        return splitPrefillInput(input, at: size - 1)
+    }
+
+    /// Split the still-unprocessed prompt at an arbitrary index. Same metadata
+    /// contract as ``splitPrefillInputBeforeFinalToken`` — the head keeps
+    /// request metadata, the tail is text-only, and callers admit this path
+    /// only for non-media inputs.
+    private func splitPrefillInput(
+        _ input: LMInput, at split: Int
+    ) -> (head: LMInput?, tail: LMInput)? {
+        let size = input.text.tokens.size
+        guard size > 0, split >= 0, split < size else { return nil }
 
         var flatMask: MLXArray? = nil
         if let mask = input.text.mask {
@@ -2275,6 +2286,90 @@ public actor BatchEngine {
                         completedInPrepare: remainingPromptUnits - 1)
                     return try context.model.prepare(
                         split.tail,
+                        cache: slot.cache,
+                        windowSize: slot.prefillStepSize)
+                }
+
+                // Hybrid-SSM strip-boundary capture during prefill (§440 /
+                // Python #109). The post-answer store needs GDN companion
+                // state at the turn-start strip boundary, and recurrent state
+                // cannot rewind — so without a checkpoint captured HERE, the
+                // store path replays the whole prompt after the answer
+                // finishes. Measured on a 13,823-token growing turn: ~18-22s
+                // of post-answer re-derive with the stream still open, which
+                // presented as "decode collapsed to 1-6 tok/s" until the wall
+                // was decomposed. Splitting the prefill at the boundary and
+                // capturing the live state makes the turn's own forward pass
+                // the only forward pass.
+                let hybridBoundarySplit: Int? = {
+                    guard cacheCoordinator?.isHybrid == true,
+                          !slot.originalInput.hasMediaContent,
+                          slot.diskSeedSnapshot == nil
+                    else { return nil }
+                    let fullLen = slot.cachePromptTokenIds.count
+                    let remainingLen = inputForPrepare.text.tokens.size
+                    let processed = fullLen - remainingLen
+                    guard processed >= 0 else { return nil }
+                    guard let boundary = slot.originalInput.cachePrefixTokenCounts
+                        .filter({ $0 > processed && $0 < fullLen })
+                        .max()
+                    else { return nil }
+                    let split = boundary - processed
+                    return (split > 0 && split < remainingLen) ? split : nil
+                }()
+                // The store path derives companion state at BOTH the strip
+                // boundary and its N-1 sibling (the boundary set mirrors the
+                // KV N-1 restore pattern), so capture both: pause one token
+                // before the boundary, capture, advance the single boundary
+                // token, capture again, then continue the tail. Missing the
+                // N-1 sibling costs a full post-answer prompt replay for a
+                // boundary one token away from state we already computed.
+                if let splitAt = hybridBoundarySplit,
+                   splitAt > 1,
+                   let coordinator = cacheCoordinator,
+                   let split = splitPrefillInput(inputForPrepare, at: splitAt - 1),
+                   let head = split.head,
+                   let boundaryTokenSplit = splitPrefillInput(split.tail, at: 1)
+                {
+                    let fullLen = slot.cachePromptTokenIds.count
+                    let remainingLen = inputForPrepare.text.tokens.size
+                    let boundary = (fullLen - remainingLen) + splitAt
+
+                    func completePrefill(_ input: LMInput) throws {
+                        let result = try context.model.prepare(
+                            input,
+                            cache: slot.cache,
+                            windowSize: slot.prefillStepSize)
+                        if case .tokens(let remainingTail) = result {
+                            _ = context.model(
+                                remainingTail[text: .newAxis],
+                                cache: slot.cache,
+                                state: nil)
+                        }
+                        MLX.eval(slot.cache)
+                    }
+
+                    try completePrefill(head)
+                    captureCleanSSMStateInline(
+                        coordinator: coordinator,
+                        liveCache: slot.cache,
+                        promptTokenIds: slot.cachePromptTokenIds,
+                        genPromptLen: fullLen - (boundary - 1),
+                        enableSSMReDerive: true,
+                        mediaSalt: slot.mediaSalt)
+                    if let boundaryHead = boundaryTokenSplit.head {
+                        try completePrefill(boundaryHead)
+                    }
+                    captureCleanSSMStateInline(
+                        coordinator: coordinator,
+                        liveCache: slot.cache,
+                        promptTokenIds: slot.cachePromptTokenIds,
+                        genPromptLen: fullLen - boundary,
+                        enableSSMReDerive: true,
+                        mediaSalt: slot.mediaSalt)
+                    progressAccumulator.report(completedInPrepare: splitAt)
+                    return try context.model.prepare(
+                        boundaryTokenSplit.tail,
                         cache: slot.cache,
                         windowSize: slot.prefillStepSize)
                 }
@@ -3142,6 +3237,46 @@ public actor BatchEngine {
                 {
                     MLX.eval(trimmed)
                     return trimmed
+                }
+
+                // Hybrid fast path: only the recurrent layers make the trim
+                // fail — the KV layers trim fine. When the companion state for
+                // this exact boundary is already in the SSM cache (captured
+                // inline during this turn's prefill, or stored by an earlier
+                // turn), rebuild the boundary as trimmed-KV + restored-SSM
+                // instead of falling through to the fresh full prefill below.
+                // That replay is a whole-prompt forward that runs synchronously
+                // in finishSlot — measured ~21s at a 13.8k prompt, a fixed tail
+                // every turn paid AFTER its answer, which presented as "decode
+                // collapsed at depth" until the wall was decomposed.
+                if let coordinator = cacheCoordinator,
+                   coordinator.isHybrid,
+                   let states = coordinator.ssmStateCache.fetch(
+                       tokens: tokens,
+                       boundary: tokens.count,
+                       mediaSalt: slot.mediaSalt),
+                   !states.isEmpty
+                {
+                    let rebuilt = storageTopologySnapshot.map { $0.copy() }
+                    let nonTrimmableAreRecurrent = rebuilt.allSatisfy { layer in
+                        layer.isTrimmable || layer is MambaCache
+                            || layer is ArraysCache
+                    }
+                    if nonTrimmableAreRecurrent {
+                        var trimmedAll = true
+                        for layer in rebuilt where layer.isTrimmable {
+                            if layer.trim(trimCount) != trimCount {
+                                trimmedAll = false
+                                break
+                            }
+                        }
+                        if trimmedAll {
+                            restoreSSMStates(
+                                states, into: rebuilt, boundary: tokens.count)
+                            MLX.eval(rebuilt)
+                            return rebuilt
+                        }
+                    }
                 }
 
                 // `forceRederive` bypasses the disk-backed skip-guard for the

--- a/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
@@ -14,16 +14,24 @@ import MLX
 /// valid while carrying generated-token state under a prompt-only key.
 func makePromptBoundaryCacheSnapshot(from cache: [any KVCache]) -> [any KVCache] {
     let snapshot = cache.map { $0.copy() }
-    // ArraysCache/MambaCache update their recurrent tensors in place. Their
-    // copy implementations create independent `* 1` graph nodes; materialize
-    // the whole list before decode mutates the live cache so the prompt
-    // snapshot cannot inherit later tool/output state. One batched eval keeps
-    // this substantially cheaper than synchronizing every recurrent layer.
-    if snapshot.contains(where: {
-        $0 is HybridPoolCache || cacheContainsPathDependentState([$0])
-    }) {
-        MLX.eval(snapshot)
-    }
+    // Materialize the whole list unconditionally, for two reasons:
+    //
+    // 1. ArraysCache/MambaCache update their recurrent tensors in place;
+    //    the snapshot must be sealed before decode mutates the live cache so
+    //    the prompt boundary cannot inherit later tool/output state.
+    // 2. Every copy() now builds owned `* 1` nodes (`ownedStateCopy`), but an
+    //    UNEVALUATED node still holds a graph reference to the live cache's
+    //    buffers. A snapshot retained lazily through decode (the slot lane's
+    //    `promptCacheSnapshot`) keeps those buffers multiply-referenced,
+    //    which blocks buffer donation on the per-token in-place KV update and
+    //    turns each decode step into a full-capacity copy — measured 32 -> 6.1
+    //    tok/s on a 13.8k prompt. Evaluating here pays one boundary-sized
+    //    copy per turn and releases the live buffers back to unique ownership
+    //    before the first decode step.
+    //
+    // One batched eval keeps this substantially cheaper than synchronizing
+    // every layer separately.
+    MLX.eval(snapshot)
     return snapshot
 }
 

--- a/Libraries/MLXLMCommon/Cache/SSMReDerive.swift
+++ b/Libraries/MLXLMCommon/Cache/SSMReDerive.swift
@@ -199,7 +199,8 @@ public func captureCleanSSMStateInline(
     liveCache: [KVCache],
     promptTokenIds: [Int],
     genPromptLen: Int,
-    enableSSMReDerive: Bool
+    enableSSMReDerive: Bool,
+    mediaSalt: String? = nil
 ) {
     func log(_ status: String) {
         let line = "[vmlx][cache/ssm-rederive] inline-capture/\(status) hybrid=\(coordinator.isHybrid) genGP=\(genPromptLen) promptLen=\(promptTokenIds.count) enabled=\(enableSSMReDerive)\n"
@@ -219,10 +220,15 @@ public func captureCleanSSMStateInline(
     let states = extractSSMStates(from: liveCache)
     guard !states.isEmpty else { log("skip/no-ssm-states"); return }
 
+    // Store under the SAME salt the post-answer store path probes with —
+    // a nil-salt capture against a salted store key is a silent miss that
+    // sends the store straight back to the full-prompt replay this capture
+    // exists to avoid.
     coordinator.ssmStateCache.store(
         ssmStates: states,
         tokens: stripped,
         boundary: stripped.count,
+        mediaSalt: mediaSalt,
         persistToDisk: false
     )
     coordinator.ssmStateCache.markReDeriveFired()
@@ -454,6 +460,7 @@ public func reDeriveAndStoreSSMStatesAtPromptBoundaries(
     if promptTokenIds.count > 1 {
         boundaries.insert(promptTokenIds.count - 1)
     }
+    let primaryBoundaries = boundaries
 
     if coordinator.pagedCache != nil, !coordinator.isPagedIncompatible {
         let blockSize = max(1, coordinator.config.pagedBlockSize)
@@ -468,24 +475,94 @@ public func reDeriveAndStoreSSMStatesAtPromptBoundaries(
         let maximumRetainedTokens = retainedCapacity.overflow
             ? Int.max
             : retainedCapacity.partialValue
+        var blockBoundaries: [Int] = []
         var boundary = blockSize
         while boundary < promptTokenIds.count,
               boundary <= maximumRetainedTokens
         {
-            boundaries.insert(boundary)
+            blockBoundaries.append(boundary)
             boundary += blockSize
         }
+        // The companion cache holds at most `ssmMaxEntries` states — deriving
+        // more block boundaries than it can retain is pure LRU churn: a 13.8k
+        // prompt produced 216 per-block derive pauses feeding a 64-entry
+        // cache, and the excess evicted on arrival. Keep the LARGEST
+        // boundaries (closest to the strip/prompt boundaries, where every
+        // observed cross-turn hit actually lands); shorter-prefix restores
+        // fall back to the nearest retained boundary.
+        let reservedNonBlockEntries = 4
+        let retainableBlockStates = max(
+            0, coordinator.config.ssmMaxEntries - reservedNonBlockEntries)
+        if blockBoundaries.count > retainableBlockStates {
+            blockBoundaries = Array(blockBoundaries.suffix(retainableBlockStates))
+        }
+        boundaries.formUnion(blockBoundaries)
+    }
+    let blockOnlyBoundaries = boundaries.subtracting(primaryBoundaries)
+
+    // Probe-and-skip: a boundary whose companion state already sits in the
+    // SSM cache (e.g. captured inline during this turn's own prefill, or
+    // stored by an earlier turn) must not cost a fresh prompt replay. The
+    // measured failure shape without this: a 13.8k growing-chat turn spent
+    // ~18-22s AFTER its answer re-deriving a strip boundary whose state the
+    // prefill had already computed — the stream stayed open the whole time,
+    // which read as "decode collapsed to 1-6 tok/s" until the wall was
+    // decomposed. Re-derive now runs only for boundaries that are actually
+    // missing; present ones are re-stored from memory when the caller wants
+    // disk persistence (fetch + store is tensor-copy cheap, forward-free).
+    var presentByBoundary: [Int: [MLXArray]] = [:]
+    var missing: [Int] = []
+    for boundary in boundaries.sorted() {
+        if coordinator.ssmStateCache.contains(
+            tokens: promptTokenIds, boundary: boundary, mediaSalt: mediaSalt)
+        {
+            if let states = coordinator.ssmStateCache.fetch(
+                tokens: promptTokenIds, boundary: boundary, mediaSalt: mediaSalt),
+                !states.isEmpty
+            {
+                presentByBoundary[boundary] = states
+                if persistCapturedStatesToDisk {
+                    coordinator.ssmStateCache.store(
+                        ssmStates: states,
+                        tokens: promptTokenIds,
+                        boundary: boundary,
+                        mediaSalt: mediaSalt,
+                        persistToDisk: true)
+                }
+                continue
+            }
+        }
+        missing.append(boundary)
+    }
+    // Per-block companion boundaries ride along free: they improve
+    // partial-prefix restore granularity, but they never justify a
+    // whole-prompt replay by THEMSELVES. When every primary boundary (the
+    // prompt end, its N-1 sibling, and the caller-supplied strip boundaries)
+    // is already captured — the inline prefill capture makes that the common
+    // case — skip the forward outright. Cross-turn reuse in the growing-chat
+    // proof hits the strip boundary every time; the per-block states only
+    // matter for a DIFFERENT future prompt sharing a partial prefix, and that
+    // caller pays for its own prefill anyway.
+    let primaryMissing = missing.filter { !blockOnlyBoundaries.contains($0) }
+    if primaryMissing.isEmpty {
+        trace(
+            "primary-boundaries-present skip-forward present=\(presentByBoundary.count) blockOnlySkipped=\(missing.count)")
+        return presentByBoundary
+    }
+    if missing.isEmpty {
+        trace("all-boundaries-present skip-forward count=\(presentByBoundary.count)")
+        return presentByBoundary
     }
 
     do {
         let statesByBoundary = try reDeriveSSMStatesAtBoundaries(
             model: model,
             tokens: promptTokenIds,
-            boundaries: Array(boundaries).sorted(),
+            boundaries: missing,
             prefillStepSize: prefillStepSize)
-        trace("statesByBoundary=\(statesByBoundary.keys.sorted())")
+        trace("statesByBoundary=\(statesByBoundary.keys.sorted()) reused=\(presentByBoundary.keys.sorted())")
 
-        for boundary in boundaries.sorted() {
+        for boundary in missing.sorted() {
             guard let states = statesByBoundary[boundary], !states.isEmpty else {
                 continue
             }
@@ -500,7 +577,7 @@ public func reDeriveAndStoreSSMStatesAtPromptBoundaries(
         if !statesByBoundary.isEmpty {
             coordinator.ssmStateCache.markReDeriveFired()
         }
-        return statesByBoundary
+        return statesByBoundary.merging(presentByBoundary) { derived, _ in derived }
     } catch {
         let line = "[vmlx][cache/ssm-rederive] prompt-boundaries/fail \(error) promptLen=\(promptTokenIds.count)\n"
         FileHandle.standardError.write(Data(line.utf8))

--- a/Libraries/MLXLMCommon/Cache/ZayaCCACache.swift
+++ b/Libraries/MLXLMCommon/Cache/ZayaCCACache.swift
@@ -214,8 +214,12 @@ public final class ZayaCCACache: KVCache {
             convChannels: convChannels,
             hiddenSize: hiddenSize)
         dup.kv = kv.copy()
-        dup.convState = convState[.ellipsis]
-        dup.prevHS = prevHS[.ellipsis]
+        // Owned copies, not `[.ellipsis]` views — a retained slot-lane
+        // snapshot built from views keeps the live CCA buffers
+        // multiply-referenced and blocks in-place-update donation
+        // (see `ownedStateCopy`).
+        dup.convState = ownedStateCopy(convState)
+        dup.prevHS = ownedStateCopy(prevHS)
         return dup
     }
 

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -76,6 +76,31 @@ public protocol KVCache: Evaluatable, Updatable {
     func copy() -> any KVCache
 }
 
+/// Materialize an OWNED copy of a cache state array for `copy()`.
+///
+/// The previous idiom, `x[.ellipsis]`, is a slice — and `Slice::eval` shares
+/// the source buffer (`copy_shared_buffer` in
+/// `mlx/backend/common/slicing.cpp`), so a retained cache copy built from
+/// slices keeps the LIVE cache's buffers multiply-referenced. That blocks
+/// MLX's buffer donation on the per-token in-place update
+/// (`keys[..., offset ..< offset+1, ...] = newKeys`), which degrades every
+/// decode step into a full-capacity buffer copy. Measured on Qwen3.6-27B at a
+/// 13,823-token prompt: TokenIterator (no retained copy) decoded at 32 tok/s
+/// while the BatchEngine slot lane — which retains exactly such a copy as
+/// `promptCacheSnapshot` — fell to 6.1 tok/s with the coordinator off and
+/// 1.5 tok/s with paged+disk on. Short prompts hide the cost because the
+/// copied capacity is tiny.
+///
+/// `* 1` is the same materializing idiom `ArraysCache.copy()` already uses:
+/// a real elementwise op whose output cannot alias a multiply-referenced
+/// input, so once evaluated the copy owns its buffer and the live cache is
+/// uniquely referenced again. The stale-read protection callers rely on is
+/// preserved — it becomes a guarantee of the owned buffer rather than an
+/// accident of blocked donation.
+func ownedStateCopy(_ x: MLXArray) -> MLXArray {
+    x * 1
+}
+
 /// Protocol for caches that support efficient quantized operations
 ///
 /// **Usage Example:**
@@ -560,7 +585,7 @@ public class KVCacheSimple: BaseKVCache, CustomDebugStringConvertible {
         new.step = self.step
         let s = self.state
         if !s.isEmpty {
-            new.state = s.map { $0[.ellipsis] }
+            new.state = s.map(ownedStateCopy)
         }
         return new
     }
@@ -903,7 +928,7 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
         let new = RotatingKVCache(maxSize: maxCacheSize, keep: keep, step: step)
         let s = self.state
         if !s.isEmpty {
-            new.state = s.map { $0[.ellipsis] }
+            new.state = s.map(ownedStateCopy)
         }
         new.metaState = self.metaState
         return new
@@ -1158,7 +1183,7 @@ public class QuantizedKVCache: BaseKVCache, QuantizedKVCacheProtocol {
         let new = QuantizedKVCache(groupSize: groupSize, bits: bits, mode: mode)
         let s = self.state
         if !s.isEmpty {
-            new.state = s.map { $0[.ellipsis] }
+            new.state = s.map(ownedStateCopy)
         }
         new.metaState = self.metaState
         return new
@@ -1258,7 +1283,7 @@ public class ChunkedKVCache: KVCacheSimple {
         new.step = self.step
         let s = self.state
         if !s.isEmpty {
-            new.state = s.map { $0[.ellipsis] }
+            new.state = s.map(ownedStateCopy)
         }
         new.metaState = self.metaState
         return new

--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -1213,6 +1213,31 @@ private func readValidInDims(at modelDirectory: URL) -> Set<Int> {
     add(config["hidden_size"])
     add(config["intermediate_size"])
     add(config["moe_intermediate_size"])
+
+    // Vision-tower widths. Without these, a bundle whose vision modules carry
+    // EXPLICIT per-module quant metadata fails the declared-entry validInDims
+    // gate below (vision dims are not text dims), and the shape walk re-stamps
+    // them with a shape-identical wrong reading — (4,128) and (8,64) unpack the
+    // same packed+scales geometry but halve the effective width. Text stays
+    // exact (its dims ARE in the set); the vision tower then crashes at first
+    // image: Qwen3.6-27B patch embeds came out (N,576) against (N,1152)
+    // positional embeddings.
+    if let vision = top["vision_config"] as? [String: Any] {
+        add(vision["hidden_size"])
+        add(vision["intermediate_size"])
+        add(vision["out_hidden_size"])
+        if let hidden = vision["hidden_size"] as? Int,
+           let merge = vision["spatial_merge_size"] as? Int,
+           hidden > 0, merge > 0
+        {
+            dims.insert(hidden * merge * merge)
+        }
+        if let patch = vision["patch_size"] as? Int, patch > 0 {
+            let channels = (vision["in_channels"] as? Int) ?? 3
+            let temporal = (vision["temporal_patch_size"] as? Int) ?? 1
+            dims.insert(channels * temporal * patch * patch)
+        }
+    }
     add(config["expert_intermediate_size"])
     add(config["shared_expert_intermediate_size"])
     add(config["hidden_size_per_layer_input"])

--- a/RunBench/Bench.swift
+++ b/RunBench/Bench.swift
@@ -1168,6 +1168,9 @@ struct Bench {
 
             print(String(format: "  Turn %d: total prompt=%d, NEW=%d | prefill %.0f tok/s (%.0fms TTFT) | decode %.1f tok/s (%d tokens, %.3fs)",
                          turnIdx + 1, nPrompt, newTokens.count, prefillTps, firstTokenTime * 1000, decodeTps, count, decodeTime))
+            // Greedy parity gates diff these ids against the Python runtime's
+            // output on the identical prompt tokens (temp is pinned 0.0 above).
+            print("    first tokens: \(Array(generated.prefix(20)))")
 
             // After this turn: cache contains [prev_context + new_tokens + decoded_response].
             // Next turn's "already cached" = current turnTokens.count + assistant stub length


### PR DESCRIPTION
# Stop paying a whole-prompt replay after every long hybrid turn

## The bug that looked like a decode collapse

A 13,823-token growing-chat turn on Qwen3.6-27B measured `tokps=1.3` in the
harness and read as "decode collapses ~20x at depth". Decomposing the wall
proved decode was NEVER slow (28-30 tok/s at 13.8k, TokenIterator and slot
lane alike). The wall was eaten AFTER the answer:

- `finishSlot`'s `boundarySnapshot` fell through to a **fresh full prefill of
  the 13,818-token strip boundary** (~21s, untraced, every turn — hybrid
  recurrent state cannot rewind, so the trim path fails), even on
  length-stop.
- With paged+disk tiers, the companion re-derive replayed the prompt pausing
  at **every 64-token block — 216 boundaries feeding a 64-entry LRU** that
  evicted 70% of them on arrival (~120s total tail).

The theory graveyard is preserved in the measurement log: retained-snapshot
aliasing (refuted by fixarm A/B), coordinator presence (refuted by
perf-submit+coordinator at 27.8 tok/s), and the submit lane itself (27.9
tok/s) were all cleared before the tail was found.

## The fix set

1. **Inline capture during prefill**: the prefill pauses at the known strip
   boundary and its N-1 sibling and captures the live GDN state
   (`captureCleanSSMStateInline`, finally wired into the production path,
   salted to match the store keys). The turn's own forward pass is the only
   forward pass.
2. **`boundarySnapshot` hybrid fast path**: trim the trimmable KV layers,
   restore the captured companion state, replay nothing.
3. **Probe-and-skip re-derive**: only MISSING boundaries are derived, and
   block-only boundaries never justify a forward by themselves.
4. **Block-companion cap**: derived block boundaries are capped to the SSM
   cache's capacity, keeping the largest (every observed cross-turn hit
   lands at the strip boundary).
5. **Owned cache copies** (`ownedStateCopy`): `copy()` no longer hands out
   slice views that alias the live KV buffers — staleness becomes a
   guarantee of the owned buffer instead of an accident of blocked donation.

## Measured (Qwen3.6-27B 2D, 13,823-token prompt, growing row, hot ABAB, PhysMem/leg)

| config | turn-1 wall before | after | turn-2 before | after |
|---|---|---|---|---|
| tiers off | 49.0s | **24.1s** | — | — |
| paged+disk | 159.6s | **90.6s** | 80.6s | **46.7s** |

Zero SSM re-derive traces after the fix. Full growing matrix (4 quants ×
short + 13.8k maxctx) re-run on this branch: **8/8 passed** — recall exact,
think-strip replay boundary held, turn-2 prefill-skip ratio 0.01, maxctx
turn walls down 30-40% on every quant (2D 132→94, 4D 152→107, 6D 175→108,
MXFP8 181→125). The residual paged-arm tail is KV block/disk serialization
(`extractLayerData` per-block slicing) — the existing composite block-disk
serialization workstream, deliberately out of scope here.

## Live GUI proof

Same proof build as vmlx-swift#268 (both branches merged): six-shape
variating multiturn on 2D + condensed pass on MXFP8 in the dev-built app,
isolated root, every turn's DB row verified `stop` — reasoning, tools
offered, tool CALLED (native Todo panel), image (correct sides/colors on
both quants), text-after-image recap, verbatim replays. Turn-3 TTFT 0.92s
at ~4.5k context shows the prefix cache doing its job live.
