### PR TITLE
Let a caller arm the reasoning budget per request

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -474,10 +474,16 @@ public actor BatchEngine {
             parameters.initialSuppressTokens = [floor.closeTokenID]
             parameters.initialSuppressCount = floor.tokenCount
         }
-        // Upper bound. Inert unless VMLX_REASONING_BUDGET names a token count,
-        // so this changes nothing for callers who do not ask for it.
+        // Upper bound. Armed by the process-global VMLX_REASONING_BUDGET env
+        // (which wins) or a caller's per-request
+        // `requestedReasoningBudgetTokens`; inert when neither asks, so this
+        // changes nothing for callers who do not opt in.
         if let budget = ReasoningBudget.armIfNeeded(
             tokenizer: context.tokenizer, promptTail: promptTail)
+            ?? parameters.requestedReasoningBudgetTokens.flatMap({
+                ReasoningBudget.arm(
+                    tokenizer: context.tokenizer, promptTail: promptTail, tokenCount: $0)
+            })
         {
             parameters.reasoningBudgetTokens = budget.tokenCount
             parameters.reasoningBudgetCloseTokenID = budget.closeTokenID
@@ -601,8 +607,14 @@ public actor BatchEngine {
         // (via `startSoloFastPath`), so arming only in `submit` left the
         // ceiling inert for every GUI turn — verified live: env set on the
         // process, sampling trace writing, and zero budget trace lines.
+        // Same env-then-request resolution as `submit` so a caller's
+        // per-request ceiling holds on whichever path serves the request.
         if let budget = ReasoningBudget.armIfNeeded(
             tokenizer: tokenizer, promptTail: promptTail)
+            ?? parameters.requestedReasoningBudgetTokens.flatMap({
+                ReasoningBudget.arm(
+                    tokenizer: tokenizer, promptTail: promptTail, tokenCount: $0)
+            })
         {
             parameters.reasoningBudgetTokens = budget.tokenCount
             parameters.reasoningBudgetCloseTokenID = budget.closeTokenID

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -223,6 +223,15 @@ public struct GenerateParameters: Sendable {
     /// which also documents why this is not the banned automatic close bias.
     public var reasoningBudgetTokens: Int? = nil
 
+    /// Caller-requested reasoning ceiling, resolved by the engine at submit
+    /// time via `ReasoningBudget.arm(tokenizer:promptTail:tokenCount:)` —
+    /// unlike the four resolved fields below/above, this one needs no token
+    /// ids from the caller, so a serving layer can bound a single request
+    /// (an OpenAI-compatible client with a finite `max_tokens` that reads
+    /// only `content`) without the process-global `VMLX_REASONING_BUDGET`
+    /// env. The env, when set, wins. `nil` (the default) changes nothing.
+    public var requestedReasoningBudgetTokens: Int? = nil
+
     /// Close token required once ``reasoningBudgetTokens`` is spent. Resolved
     /// per family by round-tripping candidate spellings through the tokenizer.
     public var reasoningBudgetCloseTokenID: Int? = nil
@@ -481,6 +490,11 @@ public struct GenerateParameters: Sendable {
             // past the ceiling unchecked.
             && initialSuppressTokens.isEmpty
             && reasoningBudgetTokens == nil
+            // The requested form resolves into `reasoningBudgetTokens` only
+            // at submit time — after this eligibility check runs — so it
+            // must disqualify MTP here too or a drafted token could sail
+            // past the ceiling before the budget arms.
+            && requestedReasoningBudgetTokens == nil
     }
 
     public func canUseNativeMTP(for input: LMInput) -> Bool {

--- a/Libraries/MLXLMCommon/ReasoningBudget.swift
+++ b/Libraries/MLXLMCommon/ReasoningBudget.swift
@@ -126,6 +126,24 @@ public enum ReasoningBudget {
         promptTail: String?
     ) -> Armed? {
         guard let budget = configuredTokenCount else { return nil }
+        return arm(tokenizer: tokenizer, promptTail: promptTail, tokenCount: budget)
+    }
+
+    /// Arm with an explicitly requested token count — the per-request form of
+    /// the env-armed `armIfNeeded`, for serving layers that must bound
+    /// reasoning on SOME requests without a process-global setting. The
+    /// canonical case: an OpenAI-compatible client sends a finite
+    /// `max_tokens` and reads only `content` — a think block that spends the
+    /// whole cap returns an empty answer to a client that cannot see
+    /// `reasoning_content` at all. Same opt-in discipline as the env path:
+    /// the caller names a positive count, nothing arms by default, and the
+    /// primed-vs-self-opening resolution is identical.
+    public static func arm(
+        tokenizer: any Tokenizer,
+        promptTail: String?,
+        tokenCount: Int
+    ) -> Armed? {
+        guard tokenCount > 0 else { return nil }
         guard let closeID = closeTokenID(tokenizer: tokenizer) else { return nil }
         let primed = promptTail.map(promptTailOpensReasoning) ?? false
         let openIDs = primed ? [] : openTokenIDs(tokenizer: tokenizer)
@@ -133,7 +151,7 @@ public enum ReasoningBudget {
         // reasoning block, so stay inert rather than counting plain output.
         guard primed || !openIDs.isEmpty else { return nil }
         return Armed(
-            closeTokenID: closeID, tokenCount: budget, startTokenIDs: openIDs,
+            closeTokenID: closeID, tokenCount: tokenCount, startTokenIDs: openIDs,
             openTokenIDs: openTokenIDs(tokenizer: tokenizer))
     }
 

--- a/Tests/MLXLMTests/ReasoningBudgetTests.swift
+++ b/Tests/MLXLMTests/ReasoningBudgetTests.swift
@@ -113,4 +113,80 @@ class ReasoningBudgetTests: XCTestCase {
             p.isNativeMTPLosslessGreedyEligible,
             "A drafted token could sail past the ceiling unchecked.")
     }
+
+    func testMTPIsRefusedWhileARequestedBudgetIsPending() {
+        var p = GenerateParameters(temperature: 0, topP: 1.0, topK: 0)
+        XCTAssertTrue(p.isNativeMTPLosslessGreedyEligible)
+        p.requestedReasoningBudgetTokens = 32
+        XCTAssertFalse(
+            p.isNativeMTPLosslessGreedyEligible,
+            "The requested form arms at submit — after this check — so it must disqualify MTP here."
+        )
+    }
+
+    // MARK: - Per-request arming (requestedReasoningBudgetTokens)
+
+    /// Fixed-vocab stub whose think tags genuinely round-trip, unlike the
+    /// random-vocab `TestTokenizer`.
+    private struct ThinkVocabTokenizer: MLXLMCommon.Tokenizer {
+        let vocab: [String: Int] = ["<think>": 10, "</think>": 11, "hello": 12]
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] { [12] }
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "hello" }
+        func convertTokenToId(_ token: String) -> Int? { vocab[token] }
+        func convertIdToToken(_ id: Int) -> String? {
+            vocab.first { $0.value == id }?.key
+        }
+        var bosToken: String? { nil }
+        var eosToken: String? { "</s>" }
+        var unknownToken: String? { nil }
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] { [12] }
+    }
+
+    func testRequestedCountArmsOnAPrimedTail() {
+        let armed = ReasoningBudget.arm(
+            tokenizer: ThinkVocabTokenizer(),
+            promptTail: "…assistant<think>",
+            tokenCount: 96
+        )
+        XCTAssertEqual(armed?.tokenCount, 96)
+        XCTAssertEqual(armed?.closeTokenID, 11)
+        XCTAssertEqual(
+            armed?.startTokenIDs, [],
+            "A primed tail counts immediately — waiting for an open tag that was already rendered would leave the ceiling inert."
+        )
+        XCTAssertEqual(armed?.openTokenIDs, [10])
+    }
+
+    func testRequestedCountArmsForASelfOpeningFamily() {
+        let armed = ReasoningBudget.arm(
+            tokenizer: ThinkVocabTokenizer(),
+            promptTail: "…assistant\n",
+            tokenCount: 64
+        )
+        XCTAssertEqual(
+            armed?.startTokenIDs, [10],
+            "Un-primed families start the count only when the model opens reasoning itself."
+        )
+    }
+
+    func testANonPositiveRequestedCountStaysInert() {
+        XCTAssertNil(
+            ReasoningBudget.arm(
+                tokenizer: ThinkVocabTokenizer(), promptTail: "<think>", tokenCount: 0))
+        XCTAssertNil(
+            ReasoningBudget.arm(
+                tokenizer: ThinkVocabTokenizer(), promptTail: "<think>", tokenCount: -5))
+    }
+
+    func testEnvArmedPathStillDelegatesToTheSameResolution() {
+        // Without VMLX_REASONING_BUDGET in the environment the legacy entry
+        // point must stay nil even though the vocab could arm.
+        XCTAssertNil(
+            ReasoningBudget.armIfNeeded(
+                tokenizer: ThinkVocabTokenizer(), promptTail: "<think>"))
+    }
 }


### PR DESCRIPTION
OpenAI-compatible clients with a finite max_tokens that read only content get an empty answer when thinking spends the whole cap (the live Anarlog report: 'AI generation did not return any text'). Adds GenerateParameters.requestedReasoningBudgetTokens, resolved at submit on both engine paths through the exact same ReasoningBudget.arm resolution as the env path (primed vs self-opening, round-tripped close token, env wins when set). Requested budgets also disqualify native MTP in isNativeMTPPenaltyFree since they resolve after that check. Proof: ReasoningBudgetTests grew to 14 (primed arm with empty start ids, self-opening arm, non-positive inert, env delegation, MTP disqualification); NoHiddenReasoningCloseBias + MTPRuntimeFocused suites unchanged and green.