### PR TITLE
Ignore trailing whitespace when detecting a primed reasoning tail

### DIFF
--- a/Libraries/MLXLMCommon/ReasoningBudget.swift
+++ b/Libraries/MLXLMCommon/ReasoningBudget.swift
@@ -158,9 +158,21 @@ public enum ReasoningBudget {
     /// True when the rendered prompt ends with an opened, unclosed reasoning
     /// block. Mirrors the floor's `…<think>` test but covers the other
     /// families' open spellings too.
+    ///
+    /// Trailing whitespace is ignored before the suffix check: Qwen 3.x
+    /// templates prime `<think>\n` — with the literal newline — so a strict
+    /// `hasSuffix("<think>")` classified those prompts as un-primed, the
+    /// counter waited for an open tag the model never emits, and the ceiling
+    /// stayed silently inert on exactly the family that needed it (verified
+    /// live on Qwen3.8: a 300-token cap produced 300 reasoning tokens and an
+    /// empty answer with a budget requested).
     public static func promptTailOpensReasoning(_ tail: String) -> Bool {
         let openers = ["<think>", "<thinking>", "<|think|>", "<|start_thought|>"]
-        return openers.contains { tail.hasSuffix($0) }
+        var trimmed = Substring(tail)
+        while let last = trimmed.last, last.isWhitespace || last.isNewline {
+            trimmed = trimmed.dropLast()
+        }
+        return openers.contains { trimmed.hasSuffix($0) }
     }
 }
 

--- a/Tests/MLXLMTests/ReasoningBudgetTests.swift
+++ b/Tests/MLXLMTests/ReasoningBudgetTests.swift
@@ -99,6 +99,10 @@ class ReasoningBudgetTests: XCTestCase {
     func testOnlyAnOpenReasoningTailArms() {
         XCTAssertTrue(ReasoningBudget.promptTailOpensReasoning("…assistant<think>"))
         XCTAssertTrue(ReasoningBudget.promptTailOpensReasoning("<thinking>"))
+        // Qwen 3.x primes with a trailing newline; the strict suffix check
+        // classified that as un-primed and left the ceiling silently inert.
+        XCTAssertTrue(ReasoningBudget.promptTailOpensReasoning("…assistant\n<think>\n"))
+        XCTAssertTrue(ReasoningBudget.promptTailOpensReasoning("<think>  \n"))
         XCTAssertFalse(
             ReasoningBudget.promptTailOpensReasoning("…</think>"),
             "The chat rail (already-closed tail) must never arm a budget.")


### PR DESCRIPTION
Qwen 3.x primes '<think>\n' with a literal newline, so the strict hasSuffix check classified those prompts as un-primed and the reasoning ceiling (env or per-request) stayed silently inert on the family that needed it most — verified live on Qwen3.8 JANG_2D where a 300-token cap with a requested budget produced 300 reasoning tokens and an empty answer. Trims trailing whitespace/newlines before the suffix check; DSV4's exact tail unchanged. ReasoningBudgetTests pins both newline shapes; 14 tests green.