### PR TITLE
Variating pattern: add the requested-reasoning-budget axis

### DIFF
--- a/RunBench/VLBench.swift
+++ b/RunBench/VLBench.swift
@@ -1279,6 +1279,19 @@ enum VLBench {
         if let nativeMTPDepth {
             params.draftStrategy = .nativeMTP(depth: nativeMTPDepth)
         }
+        // `BENCH_REQUESTED_REASONING_BUDGET` runs the SAME variating shapes
+        // with the per-request reasoning ceiling armed on every turn — the
+        // crossed axis for the answer-reserve feature: a think close forced
+        // by the ceiling must coexist with image turns, tool calls, the
+        // grow-turn cache reuse, and the verbatim replay, not just with the
+        // single text shape the live A/B measured.
+        let requestedReasoningBudget = ProcessInfo.processInfo
+            .environment["BENCH_REQUESTED_REASONING_BUDGET"].flatMap(Int.init)
+        if let requestedReasoningBudget {
+            params.requestedReasoningBudgetTokens = requestedReasoningBudget
+        }
+        print(
+            "Requested reasoning budget: \(requestedReasoningBudget.map(String.init) ?? "off")")
         let coordinator = makeProofCoordinator(
             modelDir: modelDir, context: context, parameters: params, label: "variating")
         nonisolated(unsafe) let ctx = context


### PR DESCRIPTION
Extends BENCH_VL_VARIATING with BENCH_REQUESTED_REASONING_BUDGET per the extend-don't-add-rows rule: the per-request reasoning ceiling (vmlx #270/#271) armed on every turn of the crossed pattern. Proof run on Qwen3.8 JANG_4D at budget 200: byte-identical to the unbudgeted arm across reasoning/image/tools/image+tools/two-images/grow-reuse(56%)/verbatim-replay(100%) — the under-budget pass-through contract holds against every shape, and default-off remains byte-identical to the pre-#270 baseline.