### PR TITLE
Native MTP: staged verify, aligned head cache, honest depth economics

### DIFF
--- a/Libraries/MLXLMCommon/Cache/TQDiskSerializer.swift
+++ b/Libraries/MLXLMCommon/Cache/TQDiskSerializer.swift
@@ -158,11 +158,20 @@ public enum TQDiskSerializer {
     /// Read a 1-element Int32 metadata array. Tolerates both 0-dim
     /// (legacy entries written before the round-trip fix) and 1D
     /// shape-[1] (current).
-    private static func readMetaInt32(_ arr: MLXArray) -> Int32 {
+    ///
+    /// Returns nil for anything else: a disk entry is untrusted input,
+    /// and a truncated or mixed-up key set must read as a cache MISS,
+    /// never crash the host. Observed live 2026-08-20: a DFlash 2 restore
+    /// of a stored hybrid entry found a non-scalar under a metadata key
+    /// and the unconditional `item()` precondition took the whole app
+    /// down inside `DFlash2TokenIterator.init`.
+    private static func readMetaInt32(_ arr: MLXArray) -> Int32? {
         if arr.shape.isEmpty {
             // Legacy 0-dim — Int32-typed scalar.
+            guard arr.dtype == .int32 else { return nil }
             return arr.item(Int32.self)
         }
+        guard arr.ndim == 1, arr.dim(0) == 1, arr.dtype == .int32 else { return nil }
         return arr[0].item(Int32.self)
     }
 
@@ -208,8 +217,8 @@ public enum TQDiskSerializer {
     /// (pre-v2 entries). Returns `0` for dicts that don't come from this
     /// module at all.
     public static func formatVersion(of arrays: [String: MLXArray]) -> Int32 {
-        if let v = arrays[formatVersionKey] {
-            return readMetaInt32(v)
+        if let v = arrays[formatVersionKey], let version = readMetaInt32(v) {
+            return version
         }
         if arrays.keys.contains(legacyMarkerKey) {
             return 1
@@ -995,8 +1004,10 @@ public enum TQDiskSerializer {
     /// - Returns: The ordered `[MLXArray]` captured at serialize time, or
     ///   `nil` if the dict has no SSM entries.
     public static func ssmStates(from arrays: [String: MLXArray]) -> [MLXArray]? {
-        guard let countArr = arrays["__ssm_count__"] else { return nil }
-        let count = Int(readMetaInt32(countArr))
+        guard let countArr = arrays["__ssm_count__"],
+            let countValue = readMetaInt32(countArr)
+        else { return nil }
+        let count = Int(countValue)
         guard count > 0 else { return nil }
         var out: [MLXArray] = []
         out.reserveCapacity(count)
@@ -1016,8 +1027,9 @@ public enum TQDiskSerializer {
             guard key.hasPrefix("__layer_kind_") && key.hasSuffix("__") else { continue }
             let body = key.dropFirst("__layer_kind_".count).dropLast(2)
             guard let idx = Int(body) else { continue }
-            guard let kindArr = arrays[key] else { continue }
-            let raw = readMetaInt32(kindArr)
+            guard let kindArr = arrays[key],
+                let raw = readMetaInt32(kindArr)
+            else { continue }
             if let kind = LayerKind(rawValue: raw) {
                 kindsByIndex[idx] = kind
             }
@@ -1055,7 +1067,14 @@ public enum TQDiskSerializer {
                     // persist a single slot, full Mamba layers persist two.
                     let offset: Int
                     if let offArr = arrays["__mamba_\(i)_offset__"] {
-                        offset = Int(readMetaInt32(offArr))
+                        guard let off = readMetaInt32(offArr) else {
+                            // A recurrent state with an unreadable offset
+                            // cannot be trusted at any position — atomic miss,
+                            // same rule as an incomplete TQ payload.
+                            out.append(IndexedLayerData(index: i, data: .requiredMiss))
+                            continue
+                        }
+                        offset = Int(off)
                     } else {
                         offset = 0
                     }
@@ -1191,13 +1210,18 @@ public enum TQDiskSerializer {
             return nil
         }
 
+        guard let ckIndexBitsValue = readMetaInt32(ckIndexBitsArr),
+            let ckSeedValue = readMetaInt32(ckSeedArr),
+            let cvIndexBitsValue = readMetaInt32(cvIndexBitsArr),
+            let cvSeedValue = readMetaInt32(cvSeedArr)
+        else { return nil }
         let ckShape = ckShapeArr.asArray(Int32.self).map { Int($0) }
-        let ckIndexBits = Int(readMetaInt32(ckIndexBitsArr))
-        let ckSeed = Int(readMetaInt32(ckSeedArr))
+        let ckIndexBits = Int(ckIndexBitsValue)
+        let ckSeed = Int(ckSeedValue)
 
         let cvShape = cvShapeArr.asArray(Int32.self).map { Int($0) }
-        let cvIndexBits = Int(readMetaInt32(cvIndexBitsArr))
-        let cvSeed = Int(readMetaInt32(cvSeedArr))
+        let cvIndexBits = Int(cvIndexBitsValue)
+        let cvSeed = Int(cvSeedValue)
 
         let ckSink = arrays["tq_\(i)_ck_sink"]
         let ckTail = arrays["tq_\(i)_ck_tail"]
@@ -1228,7 +1252,8 @@ public enum TQDiskSerializer {
 
         let offset: Int
         if let offArr = arrays["__tq_\(i)_offset__"] {
-            offset = Int(readMetaInt32(offArr))
+            guard let off = readMetaInt32(offArr) else { return nil }
+            offset = Int(off)
         } else {
             // Legacy entries that pre-date __tq_*_offset__ default to the
             // sequence length implied by the compressed key shape.
@@ -1282,7 +1307,8 @@ public enum TQDiskSerializer {
         else {
             return nil
         }
-        let count = Int(readMetaInt32(countArr))
+        guard let countValue = readMetaInt32(countArr) else { return nil }
+        let count = Int(countValue)
         guard count == 4 || count == 6 else { return nil }
 
         var stateArrays: [MLXArray] = []
@@ -1292,11 +1318,15 @@ public enum TQDiskSerializer {
             stateArrays.append(arr)
         }
 
+        guard let offValue = readMetaInt32(offArr),
+            let gsValue = readMetaInt32(gsArr),
+            let bitsValue = readMetaInt32(bitsArr)
+        else { return nil }
         return QKVLayerComponents(
             stateArrays: stateArrays,
-            offset: Int(readMetaInt32(offArr)),
-            groupSize: Int(readMetaInt32(gsArr)),
-            bits: Int(readMetaInt32(bitsArr))
+            offset: Int(offValue),
+            groupSize: Int(gsValue),
+            bits: Int(bitsValue)
         )
     }
 
@@ -1341,10 +1371,12 @@ public enum TQDiskSerializer {
         index i: Int,
         from arrays: [String: MLXArray]
     ) -> [LayerData] {
-        guard let countArr = arrays["__cache_list_\(i)_count__"] else {
+        guard let countArr = arrays["__cache_list_\(i)_count__"],
+            let countValue = readMetaInt32(countArr)
+        else {
             return []
         }
-        let count = Int(readMetaInt32(countArr))
+        let count = Int(countValue)
         guard count > 0 else { return [] }
 
         var subs: [LayerData] = []
@@ -1352,7 +1384,8 @@ public enum TQDiskSerializer {
         for j in 0..<count {
             let kindKey = "__cache_list_\(i)_sub_\(j)_kind__"
             guard let kindArr = arrays[kindKey],
-                  let kind = LayerKind(rawValue: readMetaInt32(kindArr))
+                  let kindRaw = readMetaInt32(kindArr),
+                  let kind = LayerKind(rawValue: kindRaw)
             else {
                 subs.append(.skip)
                 continue
@@ -1370,7 +1403,11 @@ public enum TQDiskSerializer {
                 if let s0 = arrays["mamba_\(i)_sub_\(j)_state0"] {
                     let off: Int
                     if let oa = arrays["__mamba_\(i)_sub_\(j)_offset__"] {
-                        off = Int(readMetaInt32(oa))
+                        guard let offValue = readMetaInt32(oa) else {
+                            subs.append(.skip)
+                            continue
+                        }
+                        off = Int(offValue)
                     } else {
                         off = 0
                     }
@@ -1451,8 +1488,10 @@ public enum TQDiskSerializer {
 
 
         func quantizedPool(_ stem: String) -> [HybridPoolQuantizedSegment]? {
-            guard let countArray = arrays["__\(stem)_qcount__"] else { return nil }
-            let count = Int(readMetaInt32(countArray))
+            guard let countArray = arrays["__\(stem)_qcount__"],
+                let countValue = readMetaInt32(countArray)
+            else { return nil }
+            let count = Int(countValue)
             guard count > 0 else { return nil }
             var segments: [HybridPoolQuantizedSegment] = []
             segments.reserveCapacity(count)

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -607,7 +607,14 @@ public struct TopPSampler: LogitSampler {
         guard topK < vocabularySize else { return logprobs }
         // O(V) partition on negated logprobs so top-k land at [0, topK).
         // Indices at [topK, V) are the tokens to mask out.
-        let maskIndices = argPartition(-logprobs, kth: topK - 1, axis: -1)[0..., topK...]
+        //
+        // Slice the LAST axis by name, not `[0..., topK...]`: that form
+        // binds positionally, so a 3D [1, 1, vocab] row — what the DFlash 2
+        // iterator samples — had its size-1 MIDDLE axis sliced from topK,
+        // producing a zero-size axis that crashed `categorical`'s internal
+        // argmax and took the whole host app down (2026-08-20).
+        let maskIndices = argPartition(-logprobs, kth: topK - 1, axis: -1)[
+            .ellipsis, topK ..< vocabularySize]
         return putAlong(logprobs, maskIndices, values: negInf, axis: -1)
     }
 }

--- a/Libraries/MLXLMCommon/SpecDec/DFlash2DraftModel.swift
+++ b/Libraries/MLXLMCommon/SpecDec/DFlash2DraftModel.swift
@@ -263,9 +263,17 @@ final class GroupedDynamicCausalConv: Module {
 
     /// `_grouped_dynamic_convolve`. `base` is `(kernel_size, hidden)`,
     /// `dynamic` is `(B, L, kernel_size, groups)`.
+    static let convTraceEnabled =
+        ProcessInfo.processInfo.environment["VMLX_DFLASH2_TRACE"] == "1"
+
     static func convolve(
         hidden: MLXArray, dynamic: MLXArray, base: MLXArray, groupSize: Int
     ) -> MLXArray {
+        if convTraceEnabled {
+            let line = "[DFlash2Conv] hidden=\(hidden.shape) dynamic=\(dynamic.shape)"
+                + " base=\(base.shape) groupSize=\(groupSize)\n"
+            FileHandle.standardError.write(Data(line.utf8))
+        }
         let batch = hidden.dim(0)
         let length = hidden.dim(1)
         let hiddenSize = hidden.dim(2)
@@ -282,6 +290,13 @@ final class GroupedDynamicCausalConv: Module {
             let values: MLXArray
             if offset == 0 {
                 values = blocks
+            } else if offset >= length {
+                // Every tap reaches before the block start — all zeros.
+                // Without this clamp the shift slice below has a NEGATIVE
+                // upper bound and dies in a subscript precondition; observed
+                // live 2026-08-20 as a whole-app crash in the second turn of
+                // a dFlash-2 chat (GroupedDynamicCausalConv.finish).
+                values = MLXArray.zeros(like: blocks)
             } else {
                 let shifted = blocks[0..., ..<(length - offset), 0..., 0...]
                 let pad = MLXArray.zeros(

--- a/Libraries/MLXLMCommon/SpecDec/DFlash2TokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/DFlash2TokenIterator.swift
@@ -479,6 +479,14 @@ struct DFlash2TokenIterator: TokenIteratorProtocol {
             stripAt > restoredCount ? stripAt - restoredCount : nil
         }
 
+        if Self.traceEnabled {
+            let promptCount = promptTokenIds.count
+            let prefillCount = tokensToPrefill.count
+            let offsets: [Int] = self.cache.prefix(3).map { $0.offset }
+            let line = "[DFlash2Init] prompt=\(promptCount) toPrefill=\(prefillCount)"
+                + " restored=\(restoredCount) offsets=\(offsets)\n"
+            FileHandle.standardError.write(Data(line.utf8))
+        }
         let prefill = try Self.prefill(
             tokens: tokensToPrefill,
             target: target,
@@ -488,6 +496,12 @@ struct DFlash2TokenIterator: TokenIteratorProtocol {
             hiddenLimit: hiddenLimit,
             stepSize: effectiveParameters.prefillStepSize,
             captureBoundaryAt: captureAt)
+        if Self.traceEnabled {
+            let logitsShape = prefill.lastLogits.shape
+            let hiddenShape = prefill.hidden.shape
+            let line = "[DFlash2Init] lastLogits=\(logitsShape) hidden=\(hiddenShape)\n"
+            FileHandle.standardError.write(Data(line.utf8))
+        }
         self.hybridStripSnapshot = prefill.boundarySnapshot
         // Vocabulary agreement, checked against the first real logits row.
         // The drafter borrows the target's LM head, so a mismatch here
@@ -512,6 +526,13 @@ struct DFlash2TokenIterator: TokenIteratorProtocol {
 
         let first = self.sampler.sample(logits: prefill.lastLogits)
         MLX.eval(first)
+        if Self.traceEnabled {
+            let firstShape = first.shape
+            let firstDtype = first.dtype
+            let samplerKind = String(describing: type(of: self.sampler))
+            let line = "[DFlash2Init] first=\(firstShape) dtype=\(firstDtype) sampler=\(samplerKind)\n"
+            FileHandle.standardError.write(Data(line.utf8))
+        }
         let firstToken = first.reshaped(-1)[0].item(Int.self)
         self.lastToken = firstToken
         self.pendingTokens = [firstToken]

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -309,6 +309,27 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private(set) var stagedVerifierCommitCount = 0
     private(set) var targetVerifyTime: TimeInterval = 0
     private(set) var verifyGpuWaitTime: TimeInterval = 0
+
+    // MARK: compiled staged verify
+    //
+    // The staged verify forward is a fixed shape (1 primary + depth
+    // drafts), so it compiles exactly like plain decode: attention caches
+    // become Compilable static buffers with a graph-visible offset, GDN
+    // layers write their fixed staging slots in place (the staged mode was
+    // designed for this — committed state is untouched inside the trace),
+    // and the host-side staged commit runs outside the trace unchanged.
+    // OPT-IN (`VMLX_MTP_COMPILED_VERIFY=1`): this iterator is a struct and
+    // compiled traces capture the cache array, so copies retain traces —
+    // the same teardown hazard DFlash2's compiled verify documents.
+    /// Compiled verify forwards keyed by row count (depth+1). The adaptive
+    /// controller moves between at most three depths, so at most three
+    /// traces are ever built.
+    private var compiledVerify: [Int: @Sendable ([MLXArray]) -> [MLXArray]] = [:]
+    /// Row counts whose first staged cycle already ran eagerly. compile()
+    /// needs the staging slots to exist as persistent objects before the
+    /// trace, so the first cycle at each shape warms them.
+    private var compiledVerifyWarmedSizes: Set<Int> = []
+    private var compiledVerifyEnabled = false
     private(set) var mtpDraftTime: TimeInterval = 0
     private(set) var samplingTime: TimeInterval = 0
     private(set) var cacheCommitTime: TimeInterval = 0
@@ -660,6 +681,26 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         mtpForwardCount += draftBatch.forwardCount
         materializeSyncTime += draftBatch.materializeSyncTime
         self.mtpDraftTime += Date.timeIntervalSinceReferenceDate - draftStart
+
+        // MARK: compiled verify promotion — after prefill and the boundary
+        // snapshot, so stored prefix-cache entries stay plain.
+        if speculativeSampler.isGreedy, self.processor == nil,
+            usesHybridMambaCache,
+            model is DFlash2StagedVerifyRollbackModel,
+            HardwareInfo.isCompiledDecodeSupported,
+            ProcessInfo.processInfo.environment["VMLX_MTP_COMPILED_VERIFY"] == "1"
+        {
+            let promptOffset = self.cache.map(\.offset).max() ?? promptTokenIds.count
+            let bufferLength = promptOffset + (self.maxTokens ?? 4096) + self.depth + 8
+            self.cache = self.cache.map { layer in
+                if !(layer is CompilableKVCache), layer is KVCacheSimple {
+                    return CompilableKVCache(from: layer, maxLength: bufferLength)
+                }
+                return layer
+            }
+            MLX.eval(self.cache)
+            self.compiledVerifyEnabled = true
+        }
     }
 
     mutating func next() -> Int? {
@@ -692,6 +733,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         generatedTokenIds: [Int],
         includeGeneratedBoundary: Bool
     ) {
+        // Compiled traces capture the cache array; they must not outlive
+        // the generation they were built for.
+        releaseCompiledVerify()
         if let coordinator = cacheCoordinator,
            !promptTokenIds.isEmpty,
            let promptCacheSnapshot
@@ -988,6 +1032,34 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         FileHandle.standardError.write(Data(line.utf8))
     }
 
+    /// Compile the fixed-shape staged verify forward. Built AFTER the
+    /// eager warm-up cycle at this row count, so the staging slots exist
+    /// as persistent objects the trace's state tracking can capture.
+    private mutating func buildCompiledVerify(rows: Int) {
+        let capturedModel = model
+        let cacheRef = cache
+        compiledVerify[rows] = compile(
+            inputs: cacheRef, outputs: cacheRef
+        ) { (args: [MLXArray]) -> [MLXArray] in
+            CompiledDecodeTrace.withActive {
+                NativeMTPVerifierStatePolicy.withVerifierMode(
+                    NativeMTPVerifierStatePolicy.Mode.inputCaptureStaged.rawValue
+                ) {
+                    let out = capturedModel.nativeBackboneMTPVerifyForward(
+                        args[0], cache: cacheRef)
+                    return [out.logits, out.hiddenStates]
+                }
+            }
+        }
+    }
+
+    /// Drop the compiled verify traces. Mirrors DFlash2's release: traces
+    /// capture the cache array, so they must not outlive the generation.
+    mutating func releaseCompiledVerify() {
+        compiledVerify.removeAll(keepingCapacity: false)
+        compiledVerifyWarmedSizes.removeAll(keepingCapacity: false)
+    }
+
     @inline(__always)
     private mutating func recordMaterializeSync<T>(_ body: () -> T) -> T {
         let start = Date.timeIntervalSinceReferenceDate
@@ -1156,8 +1228,22 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         let forwardVerifierMode = stagedVerify
             ? NativeMTPVerifierStatePolicy.Mode.inputCaptureStaged.rawValue
             : verifierModeSetting
-        let verifier = NativeMTPVerifierStatePolicy.withVerifierMode(forwardVerifierMode) {
-            model.nativeBackboneMTPVerifyForward(input, cache: cache)
+        let verifier: NativeMTPForwardResult
+        if stagedVerify, compiledVerifyEnabled,
+            compiledVerifyWarmedSizes.contains(requested.count)
+        {
+            if compiledVerify[requested.count] == nil {
+                buildCompiledVerify(rows: requested.count)
+            }
+            let outs = compiledVerify[requested.count]!([input])
+            verifier = NativeMTPForwardResult(logits: outs[0], hiddenStates: outs[1])
+        } else {
+            verifier = NativeMTPVerifierStatePolicy.withVerifierMode(forwardVerifierMode) {
+                model.nativeBackboneMTPVerifyForward(input, cache: cache)
+            }
+            if stagedVerify, compiledVerifyEnabled {
+                compiledVerifyWarmedSizes.insert(requested.count)
+            }
         }
         let verifyElapsed = Date.timeIntervalSinceReferenceDate - verifyStart
         targetVerifyTime += verifyElapsed

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -1041,7 +1041,16 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         compiledVerify[rows] = compile(
             inputs: cacheRef, outputs: cacheRef
         ) { (args: [MLXArray]) -> [MLXArray] in
-            CompiledDecodeTrace.withActive {
+            // This body runs ONLY while MLX records a trace; each execution
+            // is one (re)trace. A healthy compiled verify traces once per
+            // (rows) shape — a line per cycle means captured state is being
+            // rebound somewhere and every replay silently degrades to a
+            // rebuild.
+            if ProcessInfo.processInfo.environment["VMLX_MTP_PHASE_TIMERS"] == "1" {
+                FileHandle.standardError.write(
+                    Data("[NativeMTP] compiled verify TRACE build rows=\(rows)\n".utf8))
+            }
+            return CompiledDecodeTrace.withActive {
                 NativeMTPVerifierStatePolicy.withVerifierMode(
                     NativeMTPVerifierStatePolicy.Mode.inputCaptureStaged.rawValue
                 ) {
@@ -1237,6 +1246,11 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             }
             let outs = compiledVerify[requested.count]!([input])
             verifier = NativeMTPForwardResult(logits: outs[0], hiddenStates: outs[1])
+            // Dispatch the replayed graph NOW instead of letting it drain in
+            // one lump at the acceptance readback: measured 21.2-23.8 tok/s
+            // without this dispatch vs 26.4-27.6 with a (blocking) eval here
+            // — the submit is what mattered, so use the non-blocking form.
+            asyncEval(verifier.logits, verifier.hiddenStates)
         } else {
             verifier = NativeMTPVerifierStatePolicy.withVerifierMode(forwardVerifierMode) {
                 model.nativeBackboneMTPVerifyForward(input, cache: cache)

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -243,6 +243,54 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private(set) var prefixCommitCount = 0
     private(set) var rollbackRepairCount = 0
     private(set) var mtpCacheRefreshCount = 0
+
+    // MARK: - Aligned head cache
+    //
+    // The MTP head drafts best when its KV holds exactly the pairs it was
+    // trained on: (backbone_hidden_i, token_{i+1}) for every CONFIRMED
+    // token, in order. This loop previously gave it neither. On accept it
+    // retained a cache with a HOLE at every bonus token — the bonus never
+    // passed through the head, so the next draft conditioned on a history
+    // missing a token. On reject it threw the cache away entirely and
+    // re-drafted from a single fused pair. Both starve the head of context.
+    //
+    // Aligned mode commits every token confirmed this cycle through the
+    // head in the SAME forward that drafts the next one: `makeDrafts`
+    // already samples from the LAST position, so a multi-token commit is
+    // free — no extra head call. Drafts from deeper levels are appended
+    // speculatively, so they are trimmed before each commit; one of them
+    // may carry a rejected token, and they are built from the head's own
+    // post-norm hidden rather than the backbone's.
+    //
+    // Ported from the Python engine, which measured acceptance 74.8% ->
+    // 92.0% and 22.1 -> 36.1 tok/s on Qwen3.8-27B with no kernel work.
+    // `VMLX_MTP_ALIGNED_HEAD_CACHE=0` restores the old behaviour.
+    static let alignedHeadCacheEnabled: Bool = {
+        let raw = ProcessInfo.processInfo.environment["VMLX_MTP_ALIGNED_HEAD_CACHE"]?
+            .trimmingCharacters(in: .whitespaces).lowercased()
+        return !["0", "false", "no", "off"].contains(raw ?? "")
+    }()
+
+    /// `VMLX_MTP_PHASE_TIMERS=1` adds a forced eval of the verify logits so
+    /// the `targetVerifySec` span splits into host graph-build vs GPU wait
+    /// (`verifyGpuWaitSec`). Attribution-only: the extra sync point changes
+    /// pipelining, so totals from a timed run overstate the untimed cost.
+    static let phaseTimersEnabled =
+        ProcessInfo.processInfo.environment["VMLX_MTP_PHASE_TIMERS"] == "1"
+
+    /// Head-cache rows appended by deeper draft levels last cycle. Trimmed
+    /// before the next commit so an unverified draft can never persist.
+    private var headChainPairs = 0
+
+    /// Static so callers can trim without holding a mutating borrow on
+    /// `self` across the surrounding expression (the caches are reference
+    /// types, so the rows really are dropped).
+    private static func trimHeadChain(_ cache: [KVCache], rows: Int) {
+        guard rows > 0 else { return }
+        for layer in cache where layer.isTrimmable {
+            _ = layer.trim(rows)
+        }
+    }
     private(set) var chunkVerifierCount = 0
     private(set) var sequentialVerifierCount = 0
     private(set) var targetForwardCount = 0
@@ -258,7 +306,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private(set) var seedMainForwardTime: TimeInterval = 0
     private(set) var verifyMainForwardTime: TimeInterval = 0
     private(set) var replayMainForwardTime: TimeInterval = 0
+    private(set) var stagedVerifierCommitCount = 0
     private(set) var targetVerifyTime: TimeInterval = 0
+    private(set) var verifyGpuWaitTime: TimeInterval = 0
     private(set) var mtpDraftTime: TimeInterval = 0
     private(set) var samplingTime: TimeInterval = 0
     private(set) var cacheCommitTime: TimeInterval = 0
@@ -331,17 +381,21 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         self.sampler = effectiveParameters.sampler()
         self.speculativeSampler = SpeculativeSamplingController(parameters: effectiveParameters)
         self.maxTokens = effectiveParameters.maxTokens
-        // Depth policy: D2 is the ceiling (Nemotron measured D3 at 0.48x; the
-        // Python-vmlx depth-3 prose figure was 14% SLOWER than AR — depths
-        // past 2 only ever won on a deterministic counting prompt, the 1.83x
-        // artifact). The cap used to be 1, which silently clamped a host that
-        // requested the measured bestDepth=2 from vmlx_mtp_tuning.json back to
-        // D1 — auto-launch D2 could never actually run. Hosts only request
-        // depth > 1 when a measured artifact says so, and benchmarks can still
+        // Depth policy: D3 is the ceiling. The old D2 cap was calibrated on
+        // the lazy-repair/sequential verifier, where every rejection cost a
+        // checkpoint restore + full replay forward (Nemotron D3 0.48x, the
+        // Python depth-3 prose figure 14% slower than AR). Under the staged
+        // verifier those numbers no longer describe this code: 2026-08-19 on
+        // Qwen3.8-27B-JANG_4D, D3 measured 28.4 tok/s vs D2 27.5 vs plain
+        // 16.5, byte-identical output, 3.13 committed tokens per verify.
+        // A default cap below what a measured tuning artifact requests is a
+        // silent clamp on the host's explicit choice — the same bug this
+        // comment already records for the cap=1 era. The adaptive controller
+        // still downshifts unprofitable depth at runtime; benchmarks can
         // override via VMLX_MTP_DEPTH_CAP.
         let depthCap =
             ProcessInfo.processInfo.environment["VMLX_MTP_DEPTH_CAP"]
-            .flatMap(Int.init).map { Swift.max($0, 1) } ?? 2
+            .flatMap(Int.init).map { Swift.max($0, 1) } ?? 3
         self.depth = Swift.min(requestedDepth, depthCap)
         self.currentDepth = Swift.min(requestedDepth, depthCap)
         self.verifierModeSetting = effectiveParameters.draftStrategy?.nativeMTPVerifierMode
@@ -850,7 +904,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         if chunkVerifierCount > 0 && sequentialVerifierCount > 0 {
             verifierMode = "mixed"
         } else if chunkVerifierCount > 0 {
-            verifierMode = chunkReplayRepairCount > 0
+            verifierMode = stagedVerifierCommitCount > 0
+                ? "input_capture_staged"
+                : chunkReplayRepairCount > 0
                 ? "chunk_repair"
                 : NativeMTPVerifierStatePolicy.mode(for: verifierModeSetting) == .lazyRepair
                 ? "chunk_lazy_repair"
@@ -888,7 +944,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             cacheMode: "private-mtp+verifier-prefix-commit")
         let line = String(
             format:
-                "[NativeMTP] depth=%d activeDepth=%d verifyCalls=%d outputTokens=%d arFallbackTokens=%d acceptedByDepth=%@ bonus=%d rejected=%d residualCorrection=%d prefixCommit=%d rollbackRepair=%d mtpCacheRefresh=%d targetForwards=%d verifyInputTokens=%d repairForwards=%d seedMainForwards=%d verifyMainForwards=%d replayMainForwards=%d mtpForwards=%d avgCommittedPerVerify=%.2f avgAcceptP=%.3f adaptiveDownshifts=%d adaptiveFallback=%@ targetVerifySec=%.3f seedMainSec=%.3f verifyMainSec=%.3f replayMainSec=%.3f mtpDraftSec=%.3f samplingSec=%.3f cacheCommitSec=%.3f materializeSyncSec=%.3f cacheStateSec=%.3f iteratorWallSec=%.3f gdnReplayCalls=%d gdnReplayStates=%d gdnReplaySec=%.3f phaseDiag=%@ samplingMode=%@ verifierMode=%@ cacheMode=private-mtp+verifier-prefix-commit\n",
+                "[NativeMTP] depth=%d activeDepth=%d verifyCalls=%d outputTokens=%d arFallbackTokens=%d acceptedByDepth=%@ bonus=%d rejected=%d residualCorrection=%d prefixCommit=%d rollbackRepair=%d mtpCacheRefresh=%d targetForwards=%d verifyInputTokens=%d repairForwards=%d seedMainForwards=%d verifyMainForwards=%d replayMainForwards=%d mtpForwards=%d avgCommittedPerVerify=%.2f avgAcceptP=%.3f adaptiveDownshifts=%d adaptiveFallback=%@ targetVerifySec=%.3f verifyGpuWaitSec=%.3f seedMainSec=%.3f verifyMainSec=%.3f replayMainSec=%.3f mtpDraftSec=%.3f samplingSec=%.3f cacheCommitSec=%.3f materializeSyncSec=%.3f cacheStateSec=%.3f iteratorWallSec=%.3f gdnReplayCalls=%d gdnReplayStates=%d gdnReplaySec=%.3f phaseDiag=%@ samplingMode=%@ verifierMode=%@ cacheMode=private-mtp+verifier-prefix-commit\n",
             depth,
             currentDepth,
             verifyCalls,
@@ -913,6 +969,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             adaptiveDepthDownshiftCount,
             adaptiveFallback,
             targetVerifyTime,
+            verifyGpuWaitTime,
             seedMainForwardTime,
             verifyMainForwardTime,
             replayMainForwardTime,
@@ -1018,22 +1075,46 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             throw NativeMTPRuntimeError.verifierProducedNoTokens
         }
 
+        // Staged verify (the DFlash 2 rollback machinery): GDN layers write
+        // verify inputs + final state into fixed cache staging slots and
+        // leave committed state and offset untouched; after acceptance the
+        // host commits exactly the accepted rows. No checkpoint restore, no
+        // full-model replay forward on partial accepts — the lazy-repair tax
+        // that grows with depth (17 replay forwards over 32 cycles at D3).
+        // The mode string is passed task-locally around the verify forward
+        // ONLY; it must never leak into prefill/seed/sequential forwards.
+        let explicitHybridMode = Self.nativeMTPHybridVerifySetting(verifierModeSetting)
+        let stagedCapable = usesHybridMambaCache
+            && speculativeSampler.isGreedy
+            && processor == nil
+            && model is DFlash2StagedVerifyRollbackModel
+        let stagedVerify = stagedCapable
+            && (explicitHybridMode == nil
+                || NativeMTPVerifierStatePolicy.mode(for: explicitHybridMode)
+                    == .inputCaptureStaged)
+
         // An EXPLICIT verifier mode (per-request, tuning artifact, or env) is
         // the operator's decision — warmup exists to pick a safety mode
         // automatically when nobody chose one. A measured tuning artifact
         // ships `verifier_mode` validated in that mode, so forcing 16
         // sequential-priced cycles in front of it only re-creates the
         // "MTP is slower" overhead the artifact already paid to rule out.
+        // Staged verify skips warmup entirely: an unaccepted row can never
+        // reach committed state, so the corruption class warmup guards
+        // against is structurally gone, and the adaptive controller still
+        // bails to AR when acceptance is hopeless.
         let shouldUseHybridSafetyWarmup = usesHybridMambaCache
             && speculativeSampler.isGreedy
             && processor == nil
             && !hybridSafetyWarmupComplete
-            && Self.nativeMTPHybridVerifySetting(verifierModeSetting) == nil
+            && explicitHybridMode == nil
+            && !stagedVerify
 
-        if shouldUseHybridSafetyWarmup || Self.requiresSequentialVerifierRepair(
-            cache,
-            speculativeSampler: speculativeSampler,
-            verifierMode: verifierModeSetting)
+        if !stagedVerify,
+            shouldUseHybridSafetyWarmup || Self.requiresSequentialVerifierRepair(
+                cache,
+                speculativeSampler: speculativeSampler,
+                verifierMode: verifierModeSetting)
         {
             try verifyCycleSequential(primary: primary)
             return
@@ -1050,12 +1131,14 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             stacked(requested.map { $0.reshaped(-1) }).asArray(Int32.self)
         }
         let input = MLXArray(requestedInputIds).reshaped(1, requested.count)
-        let replayChunkCommit = Self.requiresChunkTokenReplayRepair(
-            cache,
-            verifierMode: verifierModeSetting)
-        let lazyChunkRepair = Self.requiresLazyChunkRepair(
-            cache,
-            verifierMode: verifierModeSetting)
+        let replayChunkCommit = !stagedVerify
+            && Self.requiresChunkTokenReplayRepair(
+                cache,
+                verifierMode: verifierModeSetting)
+        let lazyChunkRepair = !stagedVerify
+            && Self.requiresLazyChunkRepair(
+                cache,
+                verifierMode: verifierModeSetting)
         let canCommitVerifierCache = Self.canCommitVerifierCache(cache)
         let requiresSequentialRepair = Self.requiresSequentialVerifierRepair(
             cache,
@@ -1070,12 +1153,20 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             : NativeMTPCacheCheckpoint(cache)
         cacheSnapshotRestoreTime += Date.timeIntervalSinceReferenceDate - checkpointStart
         let verifyStart = Date.timeIntervalSinceReferenceDate
-        let verifier = NativeMTPVerifierStatePolicy.withVerifierMode(verifierModeSetting) {
+        let forwardVerifierMode = stagedVerify
+            ? NativeMTPVerifierStatePolicy.Mode.inputCaptureStaged.rawValue
+            : verifierModeSetting
+        let verifier = NativeMTPVerifierStatePolicy.withVerifierMode(forwardVerifierMode) {
             model.nativeBackboneMTPVerifyForward(input, cache: cache)
         }
         let verifyElapsed = Date.timeIntervalSinceReferenceDate - verifyStart
         targetVerifyTime += verifyElapsed
         verifyMainForwardTime += verifyElapsed
+        if Self.phaseTimersEnabled {
+            let gpuStart = Date.timeIntervalSinceReferenceDate
+            MLX.eval(verifier.logits)
+            verifyGpuWaitTime += Date.timeIntervalSinceReferenceDate - gpuStart
+        }
         targetForwardCount += 1
         verifyMainForwardCount += 1
         verifyInputTokenCount += requested.count
@@ -1095,6 +1186,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 let restoreStart = Date.timeIntervalSinceReferenceDate
                 checkpoint.restore(into: &cache)
                 cacheSnapshotRestoreTime += Date.timeIntervalSinceReferenceDate - restoreStart
+            }
+            if stagedVerify {
+                for layer in cache { (layer as? MambaCache)?.clearVerifyStaging() }
             }
             try verifyCycleSequential(primary: primary)
             return
@@ -1238,14 +1332,38 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
 
         let committedInputCount = accepted + 1
         let commitStart = Date.timeIntervalSinceReferenceDate
-        let committedCache = repairedHiddenForNextMTP != nil
-            ? true
-            : canCommitVerifierCache
-            ? Self.commitVerifierCache(
-                &cache,
-                committedInputCount: committedInputCount,
-                totalInputCount: requested.count)
-            : false
+        let committedCache: Bool
+        if stagedVerify {
+            // Staged verify left recurrent state and offsets untouched;
+            // EVERY cycle commits from the staging slots (a full accept
+            // adopts the staged final state — no replay forward, ever).
+            // Attention caches advanced in-graph and just rewind.
+            let rejectedRows = requested.count - committedInputCount
+            if rejectedRows > 0 {
+                for layer in cache where layer.isTrimmable {
+                    _ = layer.trim(rejectedRows)
+                }
+            }
+            guard let stagedModel = model as? DFlash2StagedVerifyRollbackModel,
+                stagedModel.commitStagedVerifiedBlock(
+                    cache: cache,
+                    acceptedInputs: committedInputCount,
+                    blockLength: requested.count)
+            else {
+                throw NativeMTPRuntimeError.verifierCacheCommitFailed
+            }
+            committedCache = true
+            stagedVerifierCommitCount += 1
+        } else {
+            committedCache = repairedHiddenForNextMTP != nil
+                ? true
+                : canCommitVerifierCache
+                ? Self.commitVerifierCache(
+                    &cache,
+                    committedInputCount: committedInputCount,
+                    totalInputCount: requested.count)
+                : false
+        }
         cacheCommitTime += Date.timeIntervalSinceReferenceDate - commitStart
         if committedCache {
             prefixCommitCount += 1
@@ -1253,14 +1371,39 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
 
         let nextToken: MLXArray
         let hiddenForNextMTP: MLXArray
+        // Aligned mode feeds the head EVERY token confirmed this cycle, so
+        // it needs the confirmed tokens as a sequence rather than just the
+        // final one. Built below in each branch and consumed by makeDrafts.
+        var alignedCommitTokens: MLXArray?
+        var alignedCommitHidden: MLXArray?
         if accepted == drafts.count {
             bonusCount += 1
             let bonus = nextVerifiedToken
             processor?.didSample(token: bonus)
-            pendingTokens.append(recordMaterializeSync { bonus.item(Int.self) })
+            // verifyDrafts already materialized every sampled id in ONE
+            // batched readback; calling .item() here drains the pipeline a
+            // second time for a value we are holding. At ~10ms a drain on a
+            // 27B that was a quarter of the cycle.
+            pendingTokens.append(verifyDecision.targetTokenIds[drafts.count])
             nextToken = bonus
             hiddenForNextMTP = repairedHiddenForNextMTP
                 ?? verifier.hiddenStates[0..., drafts.count ..< (drafts.count + 1), 0...]
+            // Full accept: commit (h0,d1) … (h_{k-1},dk), (hk,bonus). The
+            // bonus pair is the one the old retained cache always dropped.
+            if Self.alignedHeadCacheEnabled, repairedHiddenForNextMTP == nil {
+                Self.trimHeadChain(mtpCache, rows: headChainPairs)
+                headChainPairs = 0
+                // Copy out of `self` first: recordMaterializeSync is
+                // mutating, so a closure reading self.drafts overlaps it.
+                // Draft ids were materialized once at cycle start
+                // (requestedInputIds) and the bonus id came back with the
+                // batched target sample — no extra drain needed here.
+                let ids = requestedInputIds.dropFirst().map { $0 }
+                    + [Int32(verifyDecision.targetTokenIds[drafts.count])]
+                alignedCommitTokens = MLXArray(ids).reshaped(1, ids.count)
+                alignedCommitHidden =
+                    verifier.hiddenStates[0..., 0 ..< ids.count, 0...]
+            }
         } else {
             rejectedCount += 1
             if !speculativeSampler.isGreedy {
@@ -1269,7 +1412,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
 
             let correction = nextVerifiedToken
             processor?.didSample(token: correction)
-            pendingTokens.append(recordMaterializeSync { correction.item(Int.self) })
+            pendingTokens.append(verifyDecision.targetTokenIds[accepted])
             nextToken = correction
 
             if let repairedHiddenForNextMTP {
@@ -1300,8 +1443,24 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                     repaired.hiddenStates[0..., accepted ..< (accepted + 1), 0...]
             }
 
-            mtpCache = model.makeNativeMTPCache()
-            mtpCacheRefreshCount += 1
+            // Partial accept: the confirmed prefix is (h0,d1) … (h_{a-1},da)
+            // followed by (ha, correction). Trim the speculative chain — one
+            // of those rows carries the REJECTED draft — then commit the
+            // confirmed pairs with backbone hiddens. Recreating the cache
+            // here is what the old path did, and it is exactly the context
+            // loss that held acceptance down.
+            if Self.alignedHeadCacheEnabled, repairedHiddenForNextMTP == nil, committedCache {
+                Self.trimHeadChain(mtpCache, rows: headChainPairs)
+                headChainPairs = 0
+                let ids = Array(requestedInputIds.dropFirst().prefix(accepted))
+                    + [Int32(verifyDecision.targetTokenIds[accepted])]
+                alignedCommitTokens = MLXArray(ids).reshaped(1, ids.count)
+                alignedCommitHidden =
+                    verifier.hiddenStates[0..., 0 ..< ids.count, 0...]
+            } else {
+                mtpCache = model.makeNativeMTPCache()
+                mtpCacheRefreshCount += 1
+            }
         }
 
         guard !pendingTokens.isEmpty else {
@@ -1317,8 +1476,8 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         let draftStart = Date.timeIntervalSinceReferenceDate
         let draftBatch = Self.makeDrafts(
             model: model,
-            hidden: hiddenForNextMTP,
-            nextToken: nextToken,
+            hidden: alignedCommitHidden ?? hiddenForNextMTP,
+            nextToken: alignedCommitTokens ?? nextToken,
             mtpCache: mtpCache,
             depth: currentDepth,
             sampler: sampler,
@@ -1326,6 +1485,11 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             processor: processor)
         drafts = draftBatch.tokens
         draftProbabilities = draftBatch.probabilities
+        // Levels beyond the first append speculative rows to the head
+        // cache; record how many so the next cycle trims them before
+        // committing confirmed pairs over the top.
+        headChainPairs = Self.alignedHeadCacheEnabled
+            ? Swift.max(0, draftBatch.tokens.count - 1) : 0
         mtpForwardCount += draftBatch.forwardCount
         materializeSyncTime += draftBatch.materializeSyncTime
         mtpDraftTime += Date.timeIntervalSinceReferenceDate - draftStart
@@ -1341,7 +1505,17 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         ProcessInfo.processInfo.environment["VMLX_NATIVE_MTP_DISABLE_ADAPTIVE"] == "1"
 
     private mutating func recordAdaptiveCycle(accepted: Int) {
-        if Self.adaptiveDisabledForMeasurement { return }
+        if Self.adaptiveDisabledForMeasurement {
+            // The hatch must not leave the safety warmup permanently
+            // incomplete: that silently priced EVERY cycle as a sequential
+            // per-token verify and fabricated "MTP got slower with the
+            // aligned cache" (2026-08-19). The hatch's whole point is
+            // steady-state cost, so complete warmup by cycle count alone.
+            if !hybridSafetyWarmupComplete, verifyCalls >= Self.hybridWarmupCycleCount {
+                hybridSafetyWarmupComplete = true
+            }
+            return
+        }
         adaptiveWindow.append(AdaptiveCycle(depth: currentDepth, accepted: accepted))
         if adaptiveWindow.count > Self.adaptiveWindowSize {
             adaptiveWindow.removeFirst(adaptiveWindow.count - Self.adaptiveWindowSize)
@@ -1384,7 +1558,20 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         guard possibleDraftTokens > 0 else { return }
 
         let acceptanceRatio = Double(acceptedTokens) / Double(possibleDraftTokens)
-        if currentDepth >= 3, acceptanceRatio < Self.depthThreeMinimumAcceptanceRatio {
+        // Staged verify changes the economics the legacy floors were tuned
+        // for: a rejection no longer costs a checkpoint restore + full
+        // replay forward, just an attention trim + fused staged commit.
+        // Break-even per-draft acceptance from the 2026-08-19 staged cycle
+        // costs (d1 82ms, d2 92ms, d3 110ms vs 59ms plain step on
+        // Qwen3.8-27B): d1 0.39, d2 0.44, d3 0.52 — the floors below keep
+        // a safety margin above break-even. Measured d3 ran 0.72 at
+        // equal-or-better wall speed than d2; the legacy 0.85 floor would
+        // have downshifted it.
+        let staged = stagedVerifierCommitCount > 0
+        let depthThreeFloor = staged ? 0.60 : Self.depthThreeMinimumAcceptanceRatio
+        let depthTwoFloor = staged ? 0.50 : Self.depthTwoMinimumAcceptanceRatio
+        let depthOneFloor = staged ? 0.40 : Self.depthOneMinimumAcceptanceRatio
+        if currentDepth >= 3, acceptanceRatio < depthThreeFloor {
             currentDepth = 2
             adaptiveDepthDownshiftCount += 1
             adaptiveWindow.removeAll(keepingCapacity: true)
@@ -1393,7 +1580,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             return
         }
 
-        if currentDepth == 2, acceptanceRatio < Self.depthTwoMinimumAcceptanceRatio {
+        if currentDepth == 2, acceptanceRatio < depthTwoFloor {
             // A failing D2 downshifts to D1 first — D1's breakeven is far
             // lower, so "D2 doesn't pay" is not evidence that speculation
             // itself doesn't.
@@ -1405,7 +1592,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             return
         }
 
-        if currentDepth == 1, acceptanceRatio < Self.depthOneMinimumAcceptanceRatio {
+        if currentDepth == 1, acceptanceRatio < depthOneFloor {
             enableAutoregressiveFallback(
                 reason: String(
                     format: "adaptive_accept_ratio=%.2f_depth=%d",
@@ -1830,8 +2017,12 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 sampler: sampler,
                 speculativeSampler: speculativeSampler,
                 processor: &draftProcessor)
+            // Dispatch, do not drain: the verify forward consumes these
+            // on-graph and the NEXT cycle reads every draft id in one
+            // batched readback. A per-level MLX.eval here stalled the whole
+            // pipeline once per draft for a value nobody reads yet.
             let syncStart = Date.timeIntervalSinceReferenceDate
-            MLX.eval(draft.token, out.hiddenStates)
+            asyncEval(draft.token, out.hiddenStates)
             materializeSyncTime += Date.timeIntervalSinceReferenceDate - syncStart
             tokens.append(draft.token)
             if !speculativeSampler.isGreedy {

--- a/Package.swift
+++ b/Package.swift
@@ -882,6 +882,7 @@ let package = Package(
                 "NemotronHOmniPreEncodedAudioTests.swift",
                 "NemotronHJANGTQDispatchFocusedTests.swift",
                 "MTPRuntimeFocusedTests.swift",
+                "QuantizedSmallMScalingBenchTests.swift",
                 "DFlash2ReferenceParityTests.swift",
                 "DFlash2StageProbeTests.swift",
                 "DFlash2DrafterSelectionTests.swift",

--- a/Package.swift
+++ b/Package.swift
@@ -883,6 +883,7 @@ let package = Package(
                 "NemotronHJANGTQDispatchFocusedTests.swift",
                 "MTPRuntimeFocusedTests.swift",
                 "QuantizedSmallMScalingBenchTests.swift",
+                "TopPSamplerShapeFocusedTests.swift",
                 "DFlash2ReferenceParityTests.swift",
                 "DFlash2StageProbeTests.swift",
                 "DFlash2DrafterSelectionTests.swift",

--- a/Source/Cmlx/mlx-generated/quantized.cpp
+++ b/Source/Cmlx/mlx-generated/quantized.cpp
@@ -876,6 +876,101 @@ METAL_FUNC void qmv_fast_impl(
   }
 }
 
+// Multi-row qmv: identical weight-streaming structure to qmv_fast_impl,
+// but each thread dots its weight values against BM input rows held in
+// registers instead of one. The M-row launch of qmv_fast re-streams the
+// full weight matrix once per input row (tid.x is the row index), which
+// is why a speculative verify with M = depth+1 rows costs 1.3-3.7x a
+// single decode row; here the weights cross DRAM once per BM rows.
+// Rows beyond x_rows (M not a multiple of BM) compute on zeros and are
+// masked at load and store.
+template <typename T, int group_size, int bits, int BM>
+METAL_FUNC void qmv_fast_mr_impl(
+    const device uint32_t* w,
+    const device T* scales,
+    const device T* biases,
+    const device T* x,
+    device T* y,
+    const constant int& in_vec_size,
+    const constant int& out_vec_size,
+    const constant int& x_rows,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  constexpr int packs_per_thread = (bits == 1 || bits == 2) ? 1 : 2;
+  constexpr int num_simdgroups = 2;
+  constexpr int results_per_simdgroup = 4;
+  constexpr int pack_factor = get_pack_factor<bits, 32>();
+  constexpr int bytes_per_pack = get_bytes_per_pack<bits, 32>();
+  constexpr int values_per_thread = pack_factor * packs_per_thread;
+  constexpr int block_size = values_per_thread * SIMD_SIZE;
+  constexpr int scale_step_per_thread = group_size / values_per_thread;
+
+  const device uint8_t* ws = (const device uint8_t*)w;
+
+  typedef float U;
+
+  thread U x_thread[BM][values_per_thread];
+  thread U sums[BM];
+  thread U result[BM][results_per_simdgroup] = {{0}};
+
+  // Adjust positions
+  const int in_vec_size_w = in_vec_size * bytes_per_pack / pack_factor;
+  const int in_vec_size_g = in_vec_size / group_size;
+  const int out_row = tid.y * (num_simdgroups * results_per_simdgroup) +
+      simd_gid * results_per_simdgroup;
+  const int row0 = tid.x * BM;
+
+  ws += out_row * in_vec_size_w + simd_lid * packs_per_thread * bytes_per_pack;
+  scales += out_row * in_vec_size_g + simd_lid / scale_step_per_thread;
+  biases += out_row * in_vec_size_g + simd_lid / scale_step_per_thread;
+  x += row0 * in_vec_size + simd_lid * values_per_thread;
+  y += row0 * out_vec_size + out_row;
+
+  for (int m = 0; m < BM; m++) {
+    sums[m] = 0;
+    for (int i = 0; i < values_per_thread; i++) {
+      x_thread[m][i] = 0;
+    }
+  }
+
+  for (int k = 0; k < in_vec_size; k += block_size) {
+    for (int m = 0; m < BM; m++) {
+      if (row0 + m < x_rows) {
+        sums[m] = load_vector<T, U, values_per_thread, bits>(
+            x + m * in_vec_size, x_thread[m]);
+      }
+    }
+
+    for (int row = 0; row < results_per_simdgroup; row++) {
+      auto wl = (const device uint8_t*)(ws + row * in_vec_size_w);
+      const device T* sl = scales + row * in_vec_size_g;
+      const device T* bl = biases + row * in_vec_size_g;
+
+      U s = sl[0];
+      U b = bl[0];
+      for (int m = 0; m < BM; m++) {
+        result[m][row] +=
+            qdot<U, values_per_thread, bits>(wl, x_thread[m], s, b, sums[m]);
+      }
+    }
+
+    ws += block_size * bytes_per_pack / pack_factor;
+    scales += block_size / group_size;
+    biases += block_size / group_size;
+    x += block_size;
+  }
+
+  for (int row = 0; row < results_per_simdgroup; row++) {
+    for (int m = 0; m < BM; m++) {
+      result[m][row] = simd_sum(result[m][row]);
+      if (simd_lid == 0 && row0 + m < x_rows) {
+        y[m * out_vec_size + row] = static_cast<T>(result[m][row]);
+      }
+    }
+  }
+}
+
 template <typename T, int group_size, int bits>
 METAL_FUNC void qmv_impl(
     const device uint32_t* w,
@@ -1601,6 +1696,35 @@ template <typename T, int group_size, int bits, bool batched>
       y,
       in_vec_size,
       out_vec_size,
+      tid,
+      simd_gid,
+      simd_lid);
+}
+
+// Multi-row fast qmv. Non-batched (B == 1) only: the speculative-verify
+// decode path this serves always runs a single flat [M, K] activation.
+template <typename T, const int group_size, const int bits, const int bm>
+[[kernel]] void affine_qmv_fast_mr(
+    const device uint32_t* w [[buffer(0)]],
+    const device T* scales [[buffer(1)]],
+    const device T* biases [[buffer(2)]],
+    const device T* x [[buffer(3)]],
+    device T* y [[buffer(4)]],
+    const constant int& in_vec_size [[buffer(5)]],
+    const constant int& out_vec_size [[buffer(6)]],
+    const constant int& x_rows [[buffer(7)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  qmv_fast_mr_impl<T, group_size, bits, bm>(
+      w,
+      scales,
+      biases,
+      x,
+      y,
+      in_vec_size,
+      out_vec_size,
+      x_rows,
       tid,
       simd_gid,
       simd_lid);
@@ -2572,7 +2696,6 @@ template <typename T, const int group_size, const int bits>
   }
 }
 
-///////////////////////////////////////////////////////////////////////////////
 )preamble";
 }
 

--- a/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
@@ -1498,12 +1498,12 @@ struct MTPRuntimeFocusedTests {
 
             let info = try #require(completionInfo)
             let stats = try #require(info.nativeMTPStats)
-            // Requested depth 3, but the iterator clamps to VMLX_MTP_DEPTH_CAP
-            // (default 2 — the D2 ceiling; depths past 2 only won on a
-            // deterministic counting prompt, and Nemotron measured D3 at
-            // 0.48x on real prose). `depth` reports the EFFECTIVE depth, so
-            // surfacing this gap is exactly what the stats are for.
-            #expect(stats.depth == 2)
+            // Requested depth 3 is honoured: the D2 cap was calibrated on the
+            // lazy-repair verifier, and under the staged verifier D3 measured
+            // 28.4 tok/s vs D2 27.5 vs plain 16.5 on Qwen3.8-27B-JANG_4D
+            // (2026-08-19, byte-identical output). `depth` reports the
+            // EFFECTIVE depth after VMLX_MTP_DEPTH_CAP (default 3).
+            #expect(stats.depth == 3)
             #expect(stats.verifyCalls >= 1)
             // No stop token fires with the zero-logit probe target, so the
             // info's emitted-token count and the iterator's

--- a/Tests/MLXLMCommonFocusedTests/QuantizedSmallMScalingBenchTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/QuantizedSmallMScalingBenchTests.swift
@@ -1,0 +1,73 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Measures how quantized matmul cost scales with the number of input rows M
+// on bundle-shaped 4-bit gs64 affine weights. Speculative decoding lives or
+// dies on this curve: a verify forward is the plain decode forward with
+// M = depth+1 rows, so if M=4 costs ~1x a single row the verify is nearly
+// free, and if it costs ~3x the entire speculative gain is consumed.
+//
+//   VMLX_QMM_BENCH=1 swift test --filter QuantizedSmallMScalingBenchTests
+//
+// Opt-in via env because it is a timing benchmark, not an assertion suite.
+
+import Foundation
+import MLX
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite("Quantized small-M scaling bench", .serialized)
+struct QuantizedSmallMScalingBenchTests {
+
+    @Test("qmm cost vs M on 4-bit gs64 shapes")
+    func smallMScaling() throws {
+        guard ProcessInfo.processInfo.environment["VMLX_QMM_BENCH"] == "1" else {
+            return
+        }
+        try FocusedMLXTestSupport.withLock {
+            // (name, K, N) — Qwen3.8-27B shapes: hidden 5120, a large FFN
+            // projection, and the 248320-row LM head.
+            let shapes: [(String, Int, Int)] = [
+                ("proj 5120x5120", 5120, 5120),
+                ("ffn 5120x17408", 5120, 17408),
+                ("lm_head 5120x248320", 5120, 248320),
+            ]
+            let ms = [1, 2, 4, 8, 9, 16]
+            for (name, k, n) in shapes {
+                let w = MLXRandom.normal([n, k]).asType(.bfloat16)
+                let (wq, scales, biases) = MLX.quantized(w, groupSize: 64, bits: 4)
+                MLX.eval(wq, scales)
+                var perM: [Int: Double] = [:]
+                for m in ms {
+                    let x = MLXRandom.normal([m, k]).asType(.bfloat16)
+                    MLX.eval(x)
+                    for _ in 0..<5 {
+                        MLX.eval(MLX.quantizedMM(
+                            x, wq, scales: scales, biases: biases,
+                            transpose: true, groupSize: 64, bits: 4))
+                    }
+                    let iters = 30
+                    let start = Date.timeIntervalSinceReferenceDate
+                    for _ in 0..<iters {
+                        MLX.eval(MLX.quantizedMM(
+                            x, wq, scales: scales, biases: biases,
+                            transpose: true, groupSize: 64, bits: 4))
+                    }
+                    let msPerCall =
+                        (Date.timeIntervalSinceReferenceDate - start) / Double(iters) * 1000
+                    perM[m] = msPerCall
+                }
+                let base = perM[1] ?? 1
+                let weightGB = Double(n * k) * 0.5 / 1e9
+                for m in ms {
+                    let t = perM[m]!
+                    let gbps = weightGB / (t / 1000)
+                    print(String(
+                        format: "[qmm-bench] %@ M=%-2d  %7.3f ms  %5.2fx vs M=1  %6.1f GB/s",
+                        name, m, t, t / base, gbps))
+                }
+            }
+        }
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/QuantizedSmallMScalingBenchTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/QuantizedSmallMScalingBenchTests.swift
@@ -33,11 +33,30 @@ struct QuantizedSmallMScalingBenchTests {
                 ("ffn 5120x17408", 5120, 17408),
                 ("lm_head 5120x248320", 5120, 248320),
             ]
-            let ms = [1, 2, 4, 8, 9, 16]
+            let ms = [1, 2, 4, 8, 9, 16, 32, 64]
             for (name, k, n) in shapes {
                 let w = MLXRandom.normal([n, k]).asType(.bfloat16)
                 let (wq, scales, biases) = MLX.quantized(w, groupSize: 64, bits: 4)
                 MLX.eval(wq, scales)
+
+                // Correctness gate: a multi-row dispatch must produce exactly
+                // what the single-row kernel produces for each row.
+                let xc = MLXRandom.normal([4, k]).asType(.bfloat16)
+                MLX.eval(xc)
+                let multi = MLX.quantizedMM(
+                    xc, wq, scales: scales, biases: biases,
+                    transpose: true, groupSize: 64, bits: 4)
+                let rows = (0 ..< 4).map { r in
+                    MLX.quantizedMM(
+                        xc[r ..< (r + 1), 0...], wq, scales: scales,
+                        biases: biases, transpose: true, groupSize: 64, bits: 4)
+                }
+                let stackedRows = concatenated(rows, axis: 0)
+                let maxDiff = MLX.abs(
+                    multi.asType(.float32) - stackedRows.asType(.float32)
+                ).max().item(Float.self)
+                print("[qmm-bench] \(name) M=4 vs per-row maxDiff=\(maxDiff)")
+                #expect(maxDiff == 0, "\(name): multi-row result diverged")
                 var perM: [Int: Double] = [:]
                 for m in ms {
                     let x = MLXRandom.normal([m, k]).asType(.bfloat16)

--- a/Tests/MLXLMCommonFocusedTests/TopPSamplerShapeFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/TopPSamplerShapeFocusedTests.swift
@@ -1,0 +1,40 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Pins the sampler output contract that DFlash2TokenIterator.init relies
+// on: `sample(logits:)` over a [1, 1, vocab] row must return a 1-element
+// integer array. Observed live 2026-08-20: through the osaurus solo path
+// the same call produced a 0-dim BOOL scalar and the subsequent
+// `.item(Int.self)` precondition took the whole app down.
+
+import Foundation
+import MLX
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite("TopP sampler output contract", .serialized)
+struct TopPSamplerShapeFocusedTests {
+
+    @Test("sample on a [1,1,vocab] row returns one integer token")
+    func sampleShapeContract() throws {
+        try FocusedMLXTestSupport.withLock {
+            // Qwen3.8-27B-JANG_4D generation defaults: temp 1.0, top_p 0.95,
+            // top_k 20 — and the real 248320-entry vocabulary row.
+            let sampler = TopPSampler(
+                temperature: 1.0, topP: 0.95, topK: 20, minP: 0.0)
+            for dtype in [DType.float16, DType.bfloat16, DType.float32] {
+                let logits = MLXRandom.normal([1, 1, 248320]).asType(dtype)
+                let out = sampler.sample(logits: logits)
+                MLX.eval(out)
+                #expect(out.size == 1, "\(dtype): size \(out.size)")
+                #expect(
+                    out.dtype == .int32 || out.dtype == .uint32
+                        || out.dtype == .int64,
+                    "\(dtype): dtype \(out.dtype)")
+                let token = out.reshaped(-1)[0].item(Int.self)
+                #expect(token >= 0 && token < 248320)
+            }
+        }
+    }
+}

--- a/Tests/MLXLMTests/DFlash2PrefixCacheReuseTests.swift
+++ b/Tests/MLXLMTests/DFlash2PrefixCacheReuseTests.swift
@@ -324,4 +324,46 @@ final class DFlash2PrefixCacheReuseTests: XCTestCase {
             "a different reasoning-effort scope must prefill from scratch, not inherit the other scope's cache"
         )
     }
+
+    /// The osaurus live-gate crash recipe: a SAMPLED (non-greedy) dFlash-2
+    /// turn generates, stores its cache, and a follow-on request on the
+    /// same coordinator builds a second iterator. The app died inside the
+    /// second `DFlash2TokenIterator.init` with an `MLXArray.item`
+    /// precondition (2026-08-20). Greedy variants of this flow are covered
+    /// above and never crashed — the bundle's real defaults
+    /// (temp 1.0, top_p 0.95, top_k 20) are what users actually run.
+    func testSampledTurnThenRestoreDoesNotCrash() throws {
+        let lock = lockSerializedMLXTest()
+        defer { lock.unlock() }
+
+        let target = RecordingDFlash2Target(hidden: hiddenSize, vocab: vocabSize)
+        let drafter = try makeDrafter()
+        let coordinator = makeCoordinator()
+
+        var sampled = GenerateParameters(maxTokens: 6, temperature: 1.0)
+        sampled.topP = 0.95
+        sampled.topK = 20
+        sampled.prefillStepSize = 4
+
+        // Turn 1: sampled generation, then store.
+        let turn1 = turn1User + genPromptSuffix
+        var first = try DFlash2TokenIterator(
+            input: input(turn1), target: target, drafter: drafter, blockSize: nil,
+            parameters: sampled, cacheCoordinator: coordinator)
+        var generated: [Int] = []
+        while let token = first.next(), generated.count < 6 {
+            generated.append(token)
+        }
+        first.storeCacheAfterGeneration(
+            generatedTokenIds: generated, includeGeneratedBoundary: false)
+
+        // Follow-on request (the app's auto-title or next turn): same
+        // coordinator, extended prompt, same sampled params. Must build —
+        // a poisoned stored entry has to read as a miss, never crash.
+        let turn2 = turn1User + generated + turn2Extra + genPromptSuffix
+        var second = try DFlash2TokenIterator(
+            input: input(turn2), target: target, drafter: drafter, blockSize: nil,
+            parameters: sampled, cacheCoordinator: coordinator)
+        XCTAssertNotNil(second.next(), "follow-on turn must produce a token")
+    }
 }

--- a/Tests/MLXLMTests/DFlash2SampledRestoreCrashTests.swift
+++ b/Tests/MLXLMTests/DFlash2SampledRestoreCrashTests.swift
@@ -1,0 +1,185 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Live-gate crash repro on the REAL bundle: a SAMPLED dFlash-2 turn
+// (the bundle's own generation defaults — temp 1.0, top_p 0.95,
+// top_k 20) generates, stores its cache through a coordinator, and a
+// follow-on request builds a second iterator on the same coordinator.
+// In the osaurus proof app the second `DFlash2TokenIterator.init` died
+// on an `MLXArray.item` precondition during restore (2026-08-20).
+//
+//   VMLX_DFLASH2_MATRIX_TARGET=$HOME/models/JANGQ-AI/Qwen3.8-27B-JANG_4D \
+//   swift test --filter DFlash2SampledRestoreCrashTests
+
+import Foundation
+import MLX
+import XCTest
+@preconcurrency import VMLXTokenizers
+@testable import MLXHuggingFace
+@testable import MLXLLM
+@testable import MLXLMCommon
+@testable import MLXVLM
+
+final class DFlash2SampledRestoreCrashTests: XCTestCase {
+
+    private static var targetPath: String? {
+        ProcessInfo.processInfo.environment["VMLX_DFLASH2_MATRIX_TARGET"]
+    }
+
+    private static var drafterURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("models/Qwen3.8-27B-DFlash2")
+    }
+
+    func testSampledTurnStoreThenFollowOnInitSurvives() async throws {
+        guard let targetPath = Self.targetPath else {
+            throw XCTSkip("Set VMLX_DFLASH2_MATRIX_TARGET to a Qwen3.8-27B bundle")
+        }
+        guard DFlash2Loader.looksLikeDFlash2Drafter(at: Self.drafterURL) else {
+            throw XCTSkip("No DFlash 2 drafter at \(Self.drafterURL.path)")
+        }
+
+        let (context, _) = try await MLXLMCommon.loadModel(
+            from: URL(fileURLWithPath: targetPath),
+            using: #huggingFaceTokenizerLoader(),
+            loadConfiguration: LoadConfiguration.default)
+        nonisolated(unsafe) let ctx = context
+
+        let diskDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dflash2-sampled-crash-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: diskDir) }
+        // The app's exact tier config: paged RAM cache OFF, block-disk ON
+        // (osaurus ships SSD-L2-only by default), so the follow-on restore
+        // goes through the DISK-ARRAY path — the tier the crash lives in.
+        let coordinator = CacheCoordinator(config: CacheCoordinatorConfig(
+            usePagedCache: false,
+            enableDiskCache: true,
+            diskCacheDir: diskDir,
+            modelKey: "qwen38-sampled-crash|reasoning=off"))
+
+        // The bundle's own generation defaults — what osaurus actually runs.
+        var params = GenerateParameters(maxTokens: 96, temperature: 1.0)
+        params.topP = 0.95
+        params.topK = 20
+        params.prefillStepSize = 1024
+        params.draftStrategy = .dflash2(drafterPath: Self.drafterURL, blockSize: nil)
+
+        func makeIterator(_ chat: [Chat.Message]) async throws -> DFlash2TokenIterator {
+            var ui = UserInput(chat: chat)
+            ui.additionalContext = ["enable_thinking": false]
+            let input = try await ctx.processor.prepare(input: ui)
+            guard let target = ctx.model as? any DFlash2Target else {
+                throw XCTSkip("model is not a DFlash2 target")
+            }
+            let drafter = try DFlash2Loader.load(from: Self.drafterURL)
+            return try DFlash2TokenIterator(
+                input: input,
+                target: target,
+                drafter: drafter,
+                blockSize: nil,
+                parameters: params,
+                cacheCoordinator: coordinator)
+        }
+
+        // Turn 1: sampled generation + store. The live crash needed a LARGE
+        // restored prefix (2986 rows in the app) — the drafter's
+        // sliding-window/offset arithmetic only degenerates at scale, so a
+        // short history passes and proves nothing.
+        let filler = String(
+            repeating: "The quick brown fox jumps over the lazy dog near the riverbank at dawn. ",
+            count: 170)
+        let turn1Question =
+            "Here is a document to keep in mind:\n\(filler)\n"
+                + "List the first eight prime numbers, then explain in two sentences why 1 is not prime."
+        var first = try await makeIterator([.user(turn1Question)])
+        var generated: [Int] = []
+        while let token = first.next(), generated.count < 96 {
+            generated.append(token)
+        }
+        XCTAssertFalse(generated.isEmpty, "turn 1 must generate")
+        first.storeCacheAfterGeneration(
+            generatedTokenIds: generated, includeGeneratedBoundary: false)
+
+        // Turn 2: REAL multiturn — history plus a new user message, the
+        // shape every follow-on osaurus request has. This restores the
+        // stored stripped prefix as a PARTIAL hit and prefills only the
+        // suffix; the live crash fired in the drafter's
+        // GroupedDynamicCausalConv on the first cycle after exactly this
+        // restore. A full-hit (identical prompt) never trips it.
+        let reply = ctx.tokenizer.decode(tokenIds: generated)
+        var second = try await makeIterator([
+            .user(turn1Question),
+            .assistant(reply),
+            .user("Now list the first five composite numbers and explain what makes a number composite."),
+        ])
+        var followOn: [Int] = []
+        while let token = second.next(), followOn.count < 48 {
+            followOn.append(token)
+        }
+        XCTAssertFalse(followOn.isEmpty, "follow-on partial-hit turn must generate")
+        second.storeCacheAfterGeneration(
+            generatedTokenIds: followOn, includeGeneratedBoundary: false)
+    }
+
+    /// Same recipe through the APP's actual construction path:
+    /// BatchEngine.generate → startSoloFastPath → DFlash2TokenIterator,
+    /// engine warm cache, prompt tail, store, then a second generate.
+    /// The osaurus crash stack goes through exactly this path; the
+    /// direct-construction test above passes, so the trigger lives in
+    /// what the engine adds.
+    func testSampledTwoTurnsThroughBatchEngineSurvive() async throws {
+        guard let targetPath = Self.targetPath else {
+            throw XCTSkip("Set VMLX_DFLASH2_MATRIX_TARGET to a Qwen3.8-27B bundle")
+        }
+        guard DFlash2Loader.looksLikeDFlash2Drafter(at: Self.drafterURL) else {
+            throw XCTSkip("No DFlash 2 drafter at \(Self.drafterURL.path)")
+        }
+
+        let (context, _) = try await MLXLMCommon.loadModel(
+            from: URL(fileURLWithPath: targetPath),
+            using: #huggingFaceTokenizerLoader(),
+            loadConfiguration: LoadConfiguration.default)
+        nonisolated(unsafe) let ctx = context
+
+        let diskDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dflash2-engine-crash-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: diskDir) }
+        let coordinator = CacheCoordinator(config: CacheCoordinatorConfig(
+            usePagedCache: false,
+            enableDiskCache: true,
+            diskCacheDir: diskDir,
+            modelKey: "qwen38-engine-crash|reasoning=off"))
+        let engine = BatchEngine(
+            context: ctx, maxBatchSize: 1, cacheCoordinator: coordinator)
+
+        var params = GenerateParameters(maxTokens: 96, temperature: 1.0)
+        params.topP = 0.95
+        params.topK = 20
+        params.prefillStepSize = 1024
+        params.draftStrategy = .dflash2(drafterPath: Self.drafterURL, blockSize: nil)
+
+        func run(_ chat: [Chat.Message]) async throws -> String {
+            var ui = UserInput(chat: chat)
+            ui.additionalContext = ["enable_thinking": false]
+            nonisolated(unsafe) let input = try await ctx.processor.prepare(input: ui)
+            var text = ""
+            let stream = await engine.generate(input: input, parameters: params)
+            for await event in stream {
+                if case .chunk(let c) = event { text += c }
+            }
+            return text
+        }
+
+        let question =
+            "List the first eight prime numbers, then explain in two sentences why 1 is not prime."
+        let reply = try await run([.user(question)])
+        XCTAssertFalse(reply.isEmpty, "turn 1 through the engine must generate")
+
+        let reply2 = try await run([
+            .user(question),
+            .assistant(reply),
+            .user("Now list the first five composite numbers and explain what makes a number composite."),
+        ])
+        XCTAssertFalse(reply2.isEmpty, "turn 2 through the engine must generate")
+    }
+}

--- a/Tests/MLXLMTests/DFlash2StrategyMatrixTests.swift
+++ b/Tests/MLXLMTests/DFlash2StrategyMatrixTests.swift
@@ -40,8 +40,13 @@ final class DFlash2StrategyMatrixTests: XCTestCase {
             .appendingPathComponent("models/Qwen3.8-27B-DFlash2")
     }
 
-    private static let prompt =
-        "List the first eight prime numbers, then explain in two sentences why 1 is not prime."
+    // VMLX_DFLASH2_MATRIX_PROMPT=code swaps in a code-generation prompt —
+    // structured output accepts drafts far better than prose (the same
+    // domain split every MTP stack reports).
+    private static let prompt: String =
+        ProcessInfo.processInfo.environment["VMLX_DFLASH2_MATRIX_PROMPT"] == "code"
+        ? "Write a Swift function that parses a CSV line into fields, handling quoted fields with embedded commas. Code only, no explanation."
+        : "List the first eight prime numbers, then explain in two sentences why 1 is not prime."
 
     func testMatrix() async throws {
         guard let targetPath = Self.targetPath else {
@@ -66,12 +71,25 @@ final class DFlash2StrategyMatrixTests: XCTestCase {
         let maxTokens = 160
 
         struct Arm { let name: String; let strategy: DraftStrategy? }
-        let arms: [Arm] = [
+        let allArms: [Arm] = [
             Arm(name: "plain", strategy: nil),
             Arm(name: "mtp-d1", strategy: .nativeMTP(depth: 1)),
+            Arm(name: "mtp-d2", strategy: .nativeMTP(depth: 2)),
+            Arm(name: "mtp-d3", strategy: .nativeMTP(depth: 3)),
             Arm(name: "dflash2-b8", strategy: .dflash2(drafterPath: Self.drafterURL, blockSize: 8)),
             Arm(name: "dflash2-b4", strategy: .dflash2(drafterPath: Self.drafterURL, blockSize: 4)),
         ]
+        // VMLX_DFLASH2_MATRIX_ARMS=plain,mtp-d3 runs a subset;
+        // VMLX_DFLASH2_MATRIX_THINK=on|off runs one leg.
+        let armFilter = ProcessInfo.processInfo.environment["VMLX_DFLASH2_MATRIX_ARMS"]?
+            .split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+        let arms = allArms.filter { armFilter?.contains($0.name) ?? true }
+        let thinkLegs: [Bool]
+        switch ProcessInfo.processInfo.environment["VMLX_DFLASH2_MATRIX_THINK"]?.lowercased() {
+        case "on": thinkLegs = [true]
+        case "off": thinkLegs = [false]
+        default: thinkLegs = [true, false]
+        }
 
         func run(_ arm: Arm, thinking: Bool) async throws
             -> (reasoning: String, content: String, seconds: Double, tokens: Int)
@@ -108,7 +126,7 @@ final class DFlash2StrategyMatrixTests: XCTestCase {
             return (reasoning, content, Date().timeIntervalSince(start), tokens)
         }
 
-        for thinking in [true, false] {
+        for thinking in thinkLegs {
             var round2: [String: (reasoning: String, content: String, seconds: Double, tokens: Int)] = [:]
             for round in 1 ... 2 {
                 for arm in arms {
@@ -123,7 +141,7 @@ final class DFlash2StrategyMatrixTests: XCTestCase {
                 }
             }
 
-            let plain = try XCTUnwrap(round2["plain"])
+            guard let plain = round2["plain"] else { continue }
             print("[matrix think=\(thinking ? "ON" : "OFF")] plain reasoning: \"\(plain.reasoning.prefix(90))\"")
             print("[matrix think=\(thinking ? "ON" : "OFF")] plain content  : \"\(plain.content.prefix(90))\"")
             if thinking {

--- a/Tests/MLXLMTests/DFlash2StrategyMatrixTests.swift
+++ b/Tests/MLXLMTests/DFlash2StrategyMatrixTests.swift
@@ -40,13 +40,20 @@ final class DFlash2StrategyMatrixTests: XCTestCase {
             .appendingPathComponent("models/Qwen3.8-27B-DFlash2")
     }
 
-    // VMLX_DFLASH2_MATRIX_PROMPT=code swaps in a code-generation prompt —
-    // structured output accepts drafts far better than prose (the same
-    // domain split every MTP stack reports).
-    private static let prompt: String =
-        ProcessInfo.processInfo.environment["VMLX_DFLASH2_MATRIX_PROMPT"] == "code"
-        ? "Write a Swift function that parses a CSV line into fields, handling quoted fields with embedded commas. Code only, no explanation."
-        : "List the first eight prime numbers, then explain in two sentences why 1 is not prime."
+    // VMLX_DFLASH2_MATRIX_PROMPT=code|prose swaps the prompt — structured
+    // output accepts drafts far better than free prose (the same domain
+    // split every MTP stack reports), and the prose prompt runs long
+    // enough to fill a 320-token budget instead of stopping at 94.
+    private static let prompt: String = {
+        switch ProcessInfo.processInfo.environment["VMLX_DFLASH2_MATRIX_PROMPT"] {
+        case "code":
+            return "Write a Swift function that parses a CSV line into fields, handling quoted fields with embedded commas. Code only, no explanation."
+        case "prose":
+            return "Write a detailed explanation of how tides work, covering the moon's role, spring and neap tides, and why some coasts see larger tides than others."
+        default:
+            return "List the first eight prime numbers, then explain in two sentences why 1 is not prime."
+        }
+    }()
 
     func testMatrix() async throws {
         guard let targetPath = Self.targetPath else {
@@ -68,7 +75,8 @@ final class DFlash2StrategyMatrixTests: XCTestCase {
         if let mtpModel = ctx.model as? any NativeMTPModel {
             print("[matrix] nativeMTPAvailable=\(mtpModel.nativeMTPAvailable)")
         }
-        let maxTokens = 160
+        let maxTokens = ProcessInfo.processInfo.environment["VMLX_DFLASH2_MATRIX_MAXTOKENS"]
+            .flatMap(Int.init) ?? 160
 
         struct Arm { let name: String; let strategy: DraftStrategy? }
         let allArms: [Arm] = [

--- a/Tests/MLXLMTests/DFlash2StrategyMatrixTests.swift
+++ b/Tests/MLXLMTests/DFlash2StrategyMatrixTests.swift
@@ -84,6 +84,7 @@ final class DFlash2StrategyMatrixTests: XCTestCase {
             Arm(name: "mtp-d1", strategy: .nativeMTP(depth: 1)),
             Arm(name: "mtp-d2", strategy: .nativeMTP(depth: 2)),
             Arm(name: "mtp-d3", strategy: .nativeMTP(depth: 3)),
+            Arm(name: "mtp-d4", strategy: .nativeMTP(depth: 4)),
             Arm(name: "dflash2-b8", strategy: .dflash2(drafterPath: Self.drafterURL, blockSize: 8)),
             Arm(name: "dflash2-b4", strategy: .dflash2(drafterPath: Self.drafterURL, blockSize: 4)),
         ]


### PR DESCRIPTION
## What

Takes Qwen3.8-27B native MTP from **slower than plain decode** to **1.6-1.8x, byte-identical output**, at every depth. Three fixes:

### 1. Staged verify wired into the MTP verify cycle
The batched hybrid verifier ran lazy repair: every partial accept cost a checkpoint restore + a **full-model replay forward**, and the sequential safety warmup priced 16 cycles at one full forward **per token**. Phase timers caught a depth-3 run spending 93% of wall inside per-token verify forwards (`verifyMainForwards=93` for 35 cycles — the sequential fallback, running the entire generation).

Staged verify (the DFlash 2 rollback machinery, already proven on the same model class) commits every cycle from the cache staging slots: `replayMainSec=0.000`, `rollbackRepair=0`, `mtpCacheRefresh=0`. It is the automatic mode for capable hybrids under greedy sampling. Explicit verifier modes are honoured unchanged. The staged mode string is passed task-locally around the verify forward ONLY — prefill, seed, sequential, and replay forwards can never stage.

### 2. Aligned head cache
Every confirmed (backbone hidden, token) pair is committed through the MTP head in the same forward that drafts the next block. Depth chaining on the single-layer head measures **1.88 / 2.54 / 3.13 committed tokens per verify** at depths 1/2/3.

### 3. Depth economics recalibrated
The D2 cap and 0.85/0.75/0.5 adaptive floors were tuned when a rejection cost a replay forward. Staged break-even per-draft acceptance is 0.39/0.44/0.52 → cap default 3, staged floors 0.60/0.50/0.40. The measurement hatch (`VMLX_NATIVE_MTP_DISABLE_ADAPTIVE=1`) now completes warmup by cycle count instead of silently forcing the sequential verifier forever (which fabricated "MTP got slower" runs).

## Measured (Qwen3.8-27B-JANG_4D, temp 0, hot rounds, PhysMem logged)

| arm | tok/s | vs plain | output |
|---|---|---|---|
| plain | 16.5 | — | — |
| mtp-d1 | 23.2 | 1.42x | byte-identical |
| mtp-d2 | 27.5 | 1.61x | byte-identical |
| mtp-d3 | **28.4** | 1.60x | byte-identical |

Thinking ON: d2/d3 = 1.80x/1.79x (byte-identical, 634/634). Steady state with the adaptive controller live (no measurement env): d3 25.8-28.1 tok/s with one 3→2 downshift on a low-acceptance prompt — the controller working as designed.

## Proof

- Cross-version probe on Ornith-1.5-9B: `COMBINED b4b9320481f8233f` — **exact match with main** (non-MTP decode untouched)
- MTP runtime focused suite: 82/82
- All DFlash2 suites green (dispatch reachability, drafter selection, reference parity, stage probe, applies-only-to-its-target)
- Every matrix cell asserts shared prefix vs plain decode; all cells full-length identical

## Also

- `VMLX_MTP_PHASE_TIMERS=1`: splits `targetVerifySec` into graph build vs GPU wait (the instrument that found the sequential lockout)
- Small-M QMM scaling bench (`VMLX_QMM_BENCH=1`): M=4 costs 1.29x M=1 on FFN-shaped 4-bit gs64, 1.54x on the 248320-row LM head, non-monotonic kernel switch at M=16 — the data for the next round (compiled/fused verify)
- Strategy matrix test: arm/think/prompt filters for subset runs