### PR TITLE
Add an MTP launch-plan probe test that replays the host's resolution chain

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -884,6 +884,7 @@ let package = Package(
                 "MTPRuntimeFocusedTests.swift",
                 "QuantizedSmallMScalingBenchTests.swift",
                 "TopPSamplerShapeFocusedTests.swift",
+                "MTPLaunchPlanProbeTests.swift",
                 "DFlash2ReferenceParityTests.swift",
                 "DFlash2StageProbeTests.swift",
                 "DFlash2DrafterSelectionTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/MTPLaunchPlanProbeTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/MTPLaunchPlanProbeTests.swift
@@ -1,0 +1,48 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Replays the exact osaurus load-plan decision chain against a real
+// bundle and prints every gate — the probe that answers "why did the
+// app load this model without native MTP" without rebuilding the app.
+//
+//   VMLX_MTP_PROBE_BUNDLE=$HOME/models/JANGQ-AI/Qwen3.8-27B-JANG_4D \
+//   swift test --filter MTPLaunchPlanProbeTests
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite("MTP launch-plan probe")
+struct MTPLaunchPlanProbeTests {
+
+    @Test("print the resolved launch plan for a real bundle")
+    func launchPlanProbe() throws {
+        guard let path = ProcessInfo.processInfo.environment["VMLX_MTP_PROBE_BUNDLE"] else {
+            return
+        }
+        let dir = URL(fileURLWithPath: path)
+        let status = try MTPBundleInspector.inspect(modelDirectory: dir)
+        print("[probe] statusLine=\(status.statusLine)")
+        print("[probe] hasCompleteMTPArtifact=\(status.hasCompleteMTPArtifact)")
+        print("[probe] canAutoLaunchMTP=\(status.canAutoLaunchMTP)")
+        print("[probe] hasUsableNativeMTPTuning=\(status.hasUsableNativeMTPTuning)")
+        print("[probe] tuning=\(String(describing: status.nativeMTPTuning?.usableBestDepth))")
+
+        let configData = try? Data(
+            contentsOf: dir.appendingPathComponent("config.json"))
+        let settings = VMLXServerRuntimeSettings()
+        let launch = settings.resolvedMTPLaunch(
+            configData: configData, jangConfig: nil, status: status)
+        print("[probe] launchMode=\(launch.launchMode) reason=\(launch.reason)")
+        let strategy = settings.resolvedMTPDraftStrategy(
+            configData: configData, jangConfig: nil, status: status)
+        print("[probe] strategy=\(String(describing: strategy))")
+        if launch.launchMode != .speculative {
+            let reject = NativeMTPAutoDecodePolicy.rejectionReason(
+                configData: configData, jangConfig: nil, status: status,
+                requireVerifiedRuntime: true)
+            print("[probe] rejection=\(String(describing: reject))")
+        }
+    }
+}


### PR DESCRIPTION
Env-gated diagnostic: `VMLX_MTP_PROBE_BUNDLE=<bundle> swift test --filter MTPLaunchPlanProbeTests` prints every gate of the host load-plan decision — inspector status line, tuning usability, launch mode, resolved strategy, rejection reason.

This is the tool that caught the silent AR fallback: a `vmlx_mtp_tuning.json` written as a bare tuning object decodes as **nil** (the loader reads only the `{"native_mtp": {...}}` envelope key), the bundle inspects as `speculative=off (tuning required)`, and MTP auto quietly runs autoregressive. With the envelope fixed, the same bundle resolves `nativeMTP(depth: 3, input_capture_staged)` and the app measures 32.7–34.7 tok/s against a 24.7–25.3 AR baseline on the same prompt (proof table on osaurus#2419).

No runtime changes — one env-gated test plus its Package.swift source entry.