### PR TITLE
DFlash2: contain drafter failures — AR fallback instead of a host crash

### DIFF
--- a/Libraries/MLXLMCommon/SpecDec/DFlash2DraftModel.swift
+++ b/Libraries/MLXLMCommon/SpecDec/DFlash2DraftModel.swift
@@ -243,11 +243,17 @@ final class GroupedDynamicCausalConv: Module {
     /// dynamic kernel that ``finish(_:dynamic:)`` will apply to the
     /// sublayer's output.
     func prepare(_ hidden: MLXArray) -> (MLXArray, MLXArray) {
+        // Degraded husk (#123): propagate instead of dying on host-side
+        // dim reads; the iterator rejects the degenerate proposal.
+        guard hidden.ndim == 3 else { return (hidden, hidden) }
         let groups = hidden.dim(-1) / groupSize
         let b = hidden.dim(0)
         let l = hidden.dim(1)
         let dynamic = kernelProjection(hidden)
             .reshaped(b, l, 2, kernelSize, groups)
+        // A failed projection/reshape degrades to a husk (#123); slicing
+        // it with five axes is a host precondition crash. Propagate.
+        guard dynamic.ndim == 5 else { return (dynamic, dynamic) }
         let convolved = Self.convolve(
             hidden: hidden,
             dynamic: dynamic[0..., 0..., 0, 0..., 0...],
@@ -274,6 +280,12 @@ final class GroupedDynamicCausalConv: Module {
                 + " base=\(base.shape) groupSize=\(groupSize)\n"
             FileHandle.standardError.write(Data(line.utf8))
         }
+        // A degraded upstream result (an MLX error inside an earlier op
+        // collapses to a 0-dim husk, #123) must flow OUT of the drafter
+        // so the iterator can fall back to AR — dying here on a dim()
+        // precondition took the whole host down (observed live
+        // 2026-08-20).
+        guard hidden.ndim == 3, dynamic.ndim >= 3 else { return hidden }
         let batch = hidden.dim(0)
         let length = hidden.dim(1)
         let hiddenSize = hidden.dim(2)
@@ -359,6 +371,9 @@ final class DFlash2Attention: Module {
     func callAsFunction(
         _ x: MLXArray, context: MLXArray, rope: RoPE, cache: KVCache
     ) -> MLXArray {
+        // Degraded husk (#123): propagate instead of dying on host-side
+        // dim reads; the iterator rejects the degenerate proposal.
+        guard x.ndim == 3, context.ndim == 3 else { return x }
         let b = x.dim(0)
         let l = x.dim(1)
         var xCtx = context
@@ -456,7 +471,35 @@ extension KVCache {
     var offsetForDFlash2: Int {
         get { offset }
         nonmutating set {
-            if let base = self as? BaseKVCache {
+            // A rotating cache keeps a separate ring cursor (`idx`).
+            // Rewinding `offset` alone desyncs the two once the ring has
+            // wrapped, and `temporalOrder` slices `keep ..< idx`, so a
+            // cursor that lands below `keep` builds a negative-width slice
+            // ("[full] Negative dimensions not allowed" — observed live
+            // 2026-08-20 in the drafter attention after a fully-rejected
+            // block past the drafter's 2048-token window, taking the whole
+            // host down through a degraded-husk cascade). Rewind the cursor
+            // within the ROTATING span [keep, width). The slots the
+            // rejected rows overwrote stand in for the window's oldest rows
+            // — bounded staleness that can only cost draft acceptance,
+            // never output correctness: the target verifies every token.
+            if let rotating = self as? RotatingKVCache {
+                let delta = rotating.offset - newValue
+                if delta > 0 {
+                    let ringWidth = rotating.keys?.dim(2) ?? 0
+                    if ringWidth > 0, rotating.offset >= ringWidth {
+                        let rotSpan = ringWidth - rotating.keep
+                        if rotSpan > 0 {
+                            var rel = (rotating.idx - rotating.keep - delta) % rotSpan
+                            if rel < 0 { rel += rotSpan }
+                            rotating.idx = rotating.keep + rel
+                        }
+                    } else {
+                        rotating.idx = Swift.max(0, rotating.idx - delta)
+                    }
+                }
+                rotating.offset = newValue
+            } else if let base = self as? BaseKVCache {
                 base.offset = newValue
             }
         }
@@ -495,6 +538,10 @@ final class DFlash2DecoderLayer: Module {
     func callAsFunction(
         _ x: MLXArray, context: MLXArray, rope: RoPE, cache: KVCache
     ) -> MLXArray {
+        // Short-circuit a degraded husk (#123) through the stack instead
+        // of dying on a host-side dim() read; the iterator detects the
+        // degenerate proposal and falls back to AR.
+        guard x.ndim == 3 else { return x }
         var residual = x
         var (h, kernel) = attentionConv.prepare(inputLayerNorm(x))
         h = residual
@@ -691,6 +738,9 @@ public final class DFlash2DraftModel: Module, @unchecked Sendable {
         for (layer, c) in zip(layers, cache) {
             h = layer(h, context: context, rope: rope, cache: c)
         }
+        // A degraded husk (#123) from the layer stack must flow out to
+        // the caller's rank check, not die in a 3-axis slice here.
+        guard h.ndim == 3 else { return h }
         if logitsStart > 0 {
             h = h[0..., logitsStart..., 0...]
         }
@@ -792,6 +842,13 @@ public final class DFlash2DraftModel: Module, @unchecked Sendable {
         let hidden = hiddenStates(
             inputs: inputs, targetHidden: targetHidden, cache: cache,
             embedder: embedder, logitsStart: logitsStart)
+        // A degraded husk (#123) from the backbone must reach the caller's
+        // rank check as a degenerate proposal, not die in the selector's
+        // host-side slicing. The iterator falls back to AR for the turn.
+        guard hidden.ndim == 3 else {
+            return DFlash2Proposal(
+                tokens: hidden, candidates: hidden, probabilities: nil)
+        }
         let logits = computeLogits(hidden, embedder: embedder)
         return candidateSelector.select(
             hidden: hidden, logits: logits, anchorIds: inputs[0..., 0],

--- a/Libraries/MLXLMCommon/SpecDec/DFlash2TokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/DFlash2TokenIterator.swift
@@ -173,6 +173,12 @@ struct DFlash2TokenIterator: TokenIteratorProtocol {
 
     private var inFlight: InFlightVerify?
 
+    /// Set when a drafter forward degenerates mid-turn (an MLX error in
+    /// its layer stack degraded to a husk). The rest of the turn decodes
+    /// autoregressively — a drafter can only cost acceptance, never
+    /// correctness, so its failure must never end the turn.
+    private var drafterDisabled = false
+
     /// OPT-IN (`VMLX_DFLASH2_VERIFY_PREFETCH=1`), and measured as a
     /// non-win on this runtime: through the real `generate()` path on
     /// Qwen3.8-27B-JANG_4D it is neutral-to-negative (think ON 25.95 vs
@@ -723,10 +729,27 @@ struct DFlash2TokenIterator: TokenIteratorProtocol {
         // The block spends one position on the anchor, so a block of size
         // `bs` yields at most `bs` new tokens (bs-1 drafts + 1 bonus).
         let bs = Swift.min(adaptiveBlockSize ?? blockSize, budget + 1)
-        if bs <= 1 {
+        if bs <= 1 || drafterDisabled {
             return runAutoregressiveStep()
         }
-        return completeVerify(issueVerify(bs: bs))
+        guard let flight = issueVerify(bs: bs) else {
+            // The drafter forward produced a degenerate result — an MLX
+            // error inside its layer stack degraded to a scalar husk
+            // (#123). A drafter can only ever cost acceptance, never
+            // correctness, so the failure must never take the turn (or
+            // the host) down: disable speculation for the REST of this
+            // turn and decode autoregressively. Observed live 2026-08-20
+            // after a fully-rejected block once the context passed the
+            // drafter's 2048-token sliding window.
+            drafterDisabled = true
+            FileHandle.standardError.write(Data(
+                ("[DFlash2] drafter forward degenerated at cycle "
+                    + "\(stats.verifyCalls) (ctx=\(promptTokenIds.count + stats.emittedTokens)); "
+                    + "speculation disabled for the rest of the turn, "
+                    + "continuing autoregressively.\n").utf8))
+            return runAutoregressiveStep()
+        }
+        return completeVerify(flight)
     }
 
     /// Build one cycle's draft + verify graphs and DISPATCH them, without
@@ -735,7 +758,7 @@ struct DFlash2TokenIterator: TokenIteratorProtocol {
     /// Split out from the accept phase so the next cycle's forwards can be
     /// submitted while the host is still detokenizing and streaming this
     /// cycle's tokens — see `prefetchNextVerify`.
-    private mutating func issueVerify(bs: Int) -> InFlightVerify {
+    private mutating func issueVerify(bs: Int) -> InFlightVerify? {
 
         // MARK: draft
 
@@ -744,13 +767,33 @@ struct DFlash2TokenIterator: TokenIteratorProtocol {
         blockIds.append(contentsOf: Array(repeating: Int32(maskTokenID), count: bs - 1))
         let block = MLXArray(blockIds).reshaped(1, bs)
 
-        let proposal = drafter.propose(
-            inputs: block,
-            targetHidden: contextHidden,
-            cache: draftCache,
-            embedder: target,
-            temperature: isGreedy ? 0 : temperature,
-            logitsStart: 1)
+        // The drafter runs inside its own error scope: a real MLX error in
+        // its layer stack (observed live after a fully-rejected block past
+        // the drafter's sliding window) must surface as a caught error and
+        // an AR fallback, never as a degraded husk that dies on the next
+        // host-side shape read.
+        let proposal: DFlash2Proposal
+        do {
+            proposal = try withError {
+                drafter.propose(
+                    inputs: block,
+                    targetHidden: contextHidden,
+                    cache: draftCache,
+                    embedder: target,
+                    temperature: isGreedy ? 0 : temperature,
+                    logitsStart: 1)
+            }
+        } catch {
+            FileHandle.standardError.write(Data(
+                "[DFlash2] drafter forward error: \(error)\n".utf8))
+            return nil
+        }
+        // Host-side metadata check, no sync: a degraded drafter forward
+        // (#123 husk) surfaces here as a token tensor with the wrong rank
+        // or an empty draft row. The caller falls back to AR.
+        guard proposal.tokens.ndim == 2, proposal.tokens.dim(1) == bs - 1 else {
+            return nil
+        }
         // Dispatch, don't sync: the verify graph below consumes the draft
         // tokens ON-GRAPH, so the GPU runs the drafter while the CPU is
         // still building the verify forward. The reference does the same


### PR DESCRIPTION
Fixes the last known dFlash-2 process-killer, live-reproduced 100% on the second turn of a chat once the context passed the drafter's 2048-token sliding window and a block was fully rejected.

**Root cause (finally in text, via a new error scope):** `[full] Negative dimensions not allowed` — the rejected-block rewind wrote `offset` into a WRAPPED rotating drafter cache without moving the ring cursor; `temporalOrder` slices `keep ..< idx`, so a cursor below `keep` builds a negative-width slice inside the next drafter attention. That MLX error then degraded to a 0-dim husk (#123) which crashed the host on the next host-side shape read.

**Fixes:**
1. `offsetForDFlash2` rewinds the rotating cursor within the rotating span `[keep, width)`. Overwritten slots stand in for the window's oldest rows — bounded staleness that can only cost draft acceptance, never correctness (the target verifies every token).
2. Every drafter stage propagates a husk instead of dying on it (decoder layer, attention, conv prepare/convolve, hiddenStates, propose); the drafter forward runs in an error scope that logs the real error; the iterator disables speculation for the rest of the turn and continues autoregressively.

**Live proof** on the previously 100%-fatal flow (isolated proof app, restored ~3k-token session, three consecutive turns): all complete, app alive, coherent — 35.3 / 32.0 / 60.2 tok/s on one pass, 31.3 / 29.3 on another, contained drafter errors logged and absorbed by AR fallback. All DFlash2 unit suites green; the sampled two-turn store/restore repro suite green on the real bundle.