### PR TITLE
Speed recipe part 1: physical-fill ring growth, q4 drafter, verify dispatch

### DIFF
--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -687,11 +687,17 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
         let vHeadDim = values.dim(3)
         let prev = offset
 
-        // May not have hit the max size yet, so potentially keep growing the cache
-        if self.keys == nil
-            || (prev >= self.keys!.dim(2) && self.keys!.dim(2) < maxCacheSize)
-        {
-            let newSize = min(step, maxCacheSize - prev)
+        // May not have hit the max size yet, so potentially keep growing the
+        // cache. Growth MUST key on the buffer's physical fill, never the
+        // logical `offset`: restore paths legitimately force a large absolute
+        // offset onto a fresh (or short) buffer for RoPE-position continuity,
+        // and sizing from `maxCacheSize - offset` then goes negative — the
+        // "[full] Negative dimensions not allowed" drafter failure past the
+        // sliding window. In the healthy path physical fill and offset agree,
+        // so this is behavior-identical there.
+        let physicalFill = self.keys?.dim(2) ?? 0
+        if self.keys == nil || (prev >= physicalFill && physicalFill < maxCacheSize) {
+            let newSize = min(step, maxCacheSize - physicalFill)
 
             let kShape = [B, nKVHeads, newSize, kHeadDim]
             let vShape = [B, nKVHeads, newSize, vHeadDim]
@@ -705,7 +711,7 @@ public class RotatingKVCache: BaseKVCache, CustomDebugStringConvertible {
                 self.keys = newK
                 self.values = newV
             }
-            idx = prev
+            idx = physicalFill
         }
 
         // Trim if needed

--- a/Libraries/MLXLMCommon/SpecDec/DFlash2Loader.swift
+++ b/Libraries/MLXLMCommon/SpecDec/DFlash2Loader.swift
@@ -76,6 +76,31 @@ public enum DFlash2Loader {
             throw DFlash2LoadError.weightUpdateFailed(error)
         }
 
+        // The bf16 release runs quantized in the reference runtime: the
+        // oMLX recipe's "Draft quantization enabled" is `nn.quantize(draft,
+        // group_size=64, bits=4)`, and the 60+ t/s contract was measured
+        // with it (acceptance held ~88%). Quantize AFTER the weights land
+        // so the bf16 tensors load into the still-bf16 modules first.
+        // `VMLX_DFLASH2_NO_DRAFT_QUANT=1` keeps a bf16 A/B arm for benching.
+        let alreadyQuantized = root["quantization"] != nil
+        let quantOptOut =
+            ProcessInfo.processInfo.environment["VMLX_DFLASH2_NO_DRAFT_QUANT"] == "1"
+        if !alreadyQuantized && !quantOptOut {
+            // Same predicate as Python's nn.quantize default: only modules
+            // whose weight's last dim divides the group size.
+            quantize(
+                model: model, groupSize: 64, bits: 4,
+                filter: { _, module in
+                    if let linear = module as? Linear {
+                        return linear.weight.dim(-1) % 64 == 0
+                    }
+                    if let embedding = module as? Embedding {
+                        return embedding.weight.dim(-1) % 64 == 0
+                    }
+                    return true
+                })
+        }
+
         MLX.eval(model)
         return model
     }

--- a/Libraries/MLXLMCommon/SpecDec/DFlash2TokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/DFlash2TokenIterator.swift
@@ -312,6 +312,12 @@ struct DFlash2TokenIterator: TokenIteratorProtocol {
         }
 
         let config = drafter.config
+        // The bundle's trained block width is the only output-neutral
+        // default: a narrower runtime width (the Python engine's width-5
+        // contract) measured ~2% faster here but DIVERGED from plain decode
+        // at temp 0 (sharedPrefix 429/1209 vs 1209/1209 at the trained
+        // width) — this runtime's packing is not width-neutral. A
+        // caller-pinned size still wins; it is a measurement request.
         let effectiveBlockSize = requestedBlockSize ?? config.blockSize
         guard effectiveBlockSize >= 2 else {
             throw DFlash2RuntimeError.blockSizeTooSmall(effectiveBlockSize)

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -1255,6 +1255,12 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             verifier = NativeMTPVerifierStatePolicy.withVerifierMode(forwardVerifierMode) {
                 model.nativeBackboneMTPVerifyForward(input, cache: cache)
             }
+            // Same submit-now rule the compiled branch measured (21.2-23.8
+            // tok/s draining in one lump vs 26.4+ dispatching here): without
+            // this, the whole verify graph sits unscheduled until the
+            // acceptance readback inside `verifyDrafts` forces it, and the
+            // GPU idles through all the host-side branch setup in between.
+            asyncEval(verifier.logits, verifier.hiddenStates)
             if stagedVerify, compiledVerifyEnabled {
                 compiledVerifyWarmedSizes.insert(requested.count)
             }

--- a/Package.swift
+++ b/Package.swift
@@ -857,6 +857,7 @@ let package = Package(
                 "ToolCallProgressRoutingTests.swift",
                 "FocusedMLXTestSupport.swift",
                 "CanonicalChatCacheBoundariesTests.swift",
+                "RotatingKVCachePhysicalGrowthTests.swift",
                 "BatchEngineGrowingChatCacheSourceTests.swift",
                 "CacheCoordinatorTopologyFocusedTests.swift",
                 "DiskStoreOffsetConsistencyFocusedTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/RotatingKVCachePhysicalGrowthTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/RotatingKVCachePhysicalGrowthTests.swift
@@ -1,0 +1,75 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Pins RotatingKVCache growth sizing to the buffer's PHYSICAL fill.
+//
+// Restore paths force a large absolute `offset` onto a fresh (or short)
+// drafter cache for RoPE-position continuity. Growth that sizes new buffer
+// chunks from `maxCacheSize - offset` goes negative in that state and dies
+// inside MLX as "[full] Negative dimensions not allowed" — the residual
+// DFlash2 drafter failure past the sliding window that #281 could only
+// contain. Growth keyed on physical fill is behavior-identical in the
+// healthy path (offset == fill) and correct under forced offsets.
+
+import Foundation
+import MLX
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite("RotatingKVCache physical-fill growth")
+struct RotatingKVCachePhysicalGrowthTests {
+
+    private func kv(_ s: Int) -> (MLXArray, MLXArray) {
+        (
+            MLXArray.zeros([1, 2, s, 8], dtype: .float16),
+            MLXArray.zeros([1, 2, s, 8], dtype: .float16)
+        )
+    }
+
+    @Test("fresh cache with a restore-forced offset past the window still grows and writes")
+    func forcedOffsetOnFreshCache() {
+        let cache = RotatingKVCache(maxSize: 2048, keep: 0, step: 256)
+        // Restore-style: absolute conversation offset forced onto an empty
+        // buffer. 3123 matches the live ctx where the drafter died.
+        cache.offset = 3123
+
+        let (k, v) = kv(1)
+        let (outK, _) = cache.update(keys: k, values: v)
+
+        #expect(outK.dim(2) >= 1)
+        #expect(cache.offset == 3124)
+
+        // And it keeps accepting single-token decode writes.
+        for _ in 0 ..< 8 {
+            let (k1, v1) = kv(1)
+            _ = cache.update(keys: k1, values: v1)
+        }
+        #expect(cache.offset == 3132)
+    }
+
+    @Test("forced offset onto a SHORT existing buffer grows from fill, not offset")
+    func forcedOffsetOnShortBuffer() {
+        let cache = RotatingKVCache(maxSize: 2048, keep: 0, step: 256)
+        // Seed a small physical buffer the normal way.
+        let (k0, v0) = kv(4)
+        _ = cache.update(keys: k0, values: v0)
+        // Force the logical offset far past both the fill and the window.
+        cache.offset = 2500
+
+        let (k, v) = kv(1)
+        _ = cache.update(keys: k, values: v)
+        #expect(cache.offset == 2501)
+    }
+
+    @Test("healthy growth path is unchanged: fill tracks offset through the window")
+    func healthyPathUnchanged() {
+        let cache = RotatingKVCache(maxSize: 64, keep: 0, step: 16)
+        for i in 0 ..< 96 {
+            let (k, v) = kv(1)
+            let (outK, _) = cache.update(keys: k, values: v)
+            #expect(cache.offset == i + 1)
+            #expect(outK.dim(2) <= 64)
+        }
+    }
+}

--- a/Tests/MLXLMTests/DFlash2StrategyMatrixTests.swift
+++ b/Tests/MLXLMTests/DFlash2StrategyMatrixTests.swift
@@ -87,6 +87,8 @@ final class DFlash2StrategyMatrixTests: XCTestCase {
             Arm(name: "mtp-d4", strategy: .nativeMTP(depth: 4)),
             Arm(name: "dflash2-b8", strategy: .dflash2(drafterPath: Self.drafterURL, blockSize: 8)),
             Arm(name: "dflash2-b4", strategy: .dflash2(drafterPath: Self.drafterURL, blockSize: 4)),
+            // nil = the runtime default (width 5 since the speed-recipe port).
+            Arm(name: "dflash2-auto", strategy: .dflash2(drafterPath: Self.drafterURL, blockSize: nil)),
         ]
         // VMLX_DFLASH2_MATRIX_ARMS=plain,mtp-d3 runs a subset;
         // VMLX_DFLASH2_MATRIX_THINK=on|off runs one leg.


### PR DESCRIPTION
Part 1 of the speed-recipe port from the Python engine's proven 40+/60+ contract (`MTP-DFLASH2-SPEED-ROOTCAUSES-2026-08-20`). Three levers, one revert, in-app ABAB proof below.

## Changes

1. **RotatingKVCache growth keys on physical fill, not logical offset.** Restore paths force a large absolute `offset` onto a fresh (or short) drafter cache for RoPE continuity; sizing growth from `maxCacheSize − offset` went negative there and died inside MLX as `[full] Negative dimensions not allowed` — the residual DFlash 2 drafter failure past the sliding window that #281 could only contain (degrading the rest of the turn to AR). Behavior-identical in the healthy path (fill == offset). Three tests pin the forced-offset states (`RotatingKVCachePhysicalGrowthTests`), and the sampled store/restore repro suite passes with **zero** contained drafter errors.

2. **Unquantized DFlash 2 drafters quantize to q4 g64 at load** — the reference runtime's "draft quantization enabled" (`nn.quantize(draft, group_size=64, bits=4)`), with the same last-dim divisibility predicate. Community re-quants keep their own packing (existing path). `VMLX_DFLASH2_NO_DRAFT_QUANT=1` keeps a bf16 A/B arm for benching.

3. **The eager staged-verify forward dispatches via `asyncEval`** like the compiled branch already did (that branch's own measurement: 21.2–23.8 t/s draining in one lump vs 26.4+ dispatching at issue). Without it the whole verify graph sat unscheduled until the acceptance readback.

4. **Tried and reverted:** a width-5 runtime default for DFlash 2 (the Python contract's block width). ~2 % faster, but output **diverged** from plain decode at temp 0 (sharedPrefix 429/1209 vs 1209/1209 at the trained width) — this runtime's packing is not width-neutral, so the bundle's trained width stays the default. A caller-pinned width still wins.

## Correctness

- `RotatingKVCachePhysicalGrowthTests` 3/3; `CacheCoordinatorRotatingGuardTests` 7/7; `CompilableKVCacheSnapshotTests` green; `DFlash2SampledRestoreCrashTests` (real bundles) green with zero drafter-forward errors.
- Matrix identity (temp 0, think off, code prompt): `dflash2-b8` **byte-identical to plain** — sharedPrefix 1209/1209 — with the q4 drafter and all levers active, at 2.51× plain in the debug harness. `mtp-d3`/plain ratio moved 1.43× → 1.68–1.92×.

## In-app ABAB (isolated proof app on this branch, Qwen3.8-27B-JANG_4D + incoai drafter, fresh chat per leg, temp/bundle defaults, PhysMem logged healthy before every leg)

| leg | strategy | tok/s | TTFT |
|---|---|---|---|
| D1 | DFlash 2 | **62.0** | 2.07 s |
| M1 | native MTP d3 | 32.0 | 1.17 s |
| D2 | DFlash 2 | **56.0** | 1.01 s |
| M2 | native MTP d3 | 32.7 | 1.05 s |
| A1 | plain AR | 29.3 | 1.18 s |

DFlash 2 in-app moved from the previous 28–35 typical to **56–62** (1.9–2.1× AR), with **zero** `[DFlash2] drafter forward error` lines across all legs (the merged containment build logged 6 per session on the same root). Output on every leg is coherent, correct merge-sort code.

Native MTP is unchanged in-app (32–33, ratio-only gains in the harness) — the remaining gap to the 45 target is the Python recipe's verify-prefetch overlap (+65 % for them), which is a deeper structural port tracked as part 2.
