### PR TITLE
Stop a prose first turn from locking MTP off for the whole model residency

### DIFF
--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -1650,7 +1650,19 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 hybridSafetyWarmupComplete = true
                 NativeMTPHybridWarmupMemo.record(true, for: model)
             } else {
-                NativeMTPHybridWarmupMemo.record(false, for: model)
+                // The memo's contract is "a property of the model, not the
+                // prompt" — but this floor is an acceptance criterion, and
+                // acceptance is content. Memoize the failure only when it is
+                // catastrophic (below even the depth-1 floor), which is the
+                // broken/mismatched-head case the memo exists for. A miss
+                // above that line means THIS prompt drafted badly (prose
+                // warms up around 1.0, code above 3.0 on the same model);
+                // fall back for this request and let the next one re-probe,
+                // or a prose first turn locks every later code turn out of
+                // MTP for the whole residency.
+                if Self.warmupFailureIsModelProperty(averageAccepted: averageAccepted) {
+                    NativeMTPHybridWarmupMemo.record(false, for: model)
+                }
                 enableAutoregressiveFallback(
                     reason: String(
                         format: "hybrid_warmup_avg_accept=%.2f",
@@ -2121,6 +2133,15 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     /// at its native depth (2.75/3 ≈ 0.92 was Nemotron-D3-era calibration,
     /// deliberately relaxed here to the D1-breakeven scale).
     private static let hybridWarmupMinimumAverageAcceptedPerDraft = 0.55
+
+    /// Whether a warmup miss is bad enough to blame the MODEL rather than the
+    /// prompt — i.e. safe to memoize in `NativeMTPHybridWarmupMemo`. Below the
+    /// depth-1 floor no depth could ever clear warmup, which only a broken or
+    /// mismatched MTP head produces; anything above is content variance and
+    /// must stay per-request.
+    static func warmupFailureIsModelProperty(averageAccepted: Double) -> Bool {
+        averageAccepted < hybridWarmupMinimumAverageAcceptedPerDraft
+    }
 
     private static func nativeMTPHybridVerifySetting(_ verifierMode: String? = nil) -> String? {
         let env = ProcessInfo.processInfo.environment

--- a/Package.swift
+++ b/Package.swift
@@ -858,6 +858,7 @@ let package = Package(
                 "FocusedMLXTestSupport.swift",
                 "CanonicalChatCacheBoundariesTests.swift",
                 "RotatingKVCachePhysicalGrowthTests.swift",
+                "NativeMTPWarmupMemoScopeTests.swift",
                 "BatchEngineGrowingChatCacheSourceTests.swift",
                 "CacheCoordinatorTopologyFocusedTests.swift",
                 "DiskStoreOffsetConsistencyFocusedTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/NativeMTPWarmupMemoScopeTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NativeMTPWarmupMemoScopeTests.swift
@@ -1,0 +1,56 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// The hybrid warmup memo's contract is "a property of the model, not the
+// prompt" — yet the warmup verdict it stores is an acceptance criterion,
+// and acceptance is content. Live repro (Qwen3.8-27B-JANG_4D, temp 0): a
+// prose turn warms up at averageAccepted 1.00 and a code turn at 3.04 on
+// the SAME loaded model. Before the scope fix, the prose turn memoized a
+// permanent negative verdict and every later code turn ran pure AR
+// (verifyCalls=0, reason=hybrid_warmup_memo) until the model reloaded.
+//
+// These tests pin the boundary: only a catastrophic miss — below even the
+// depth-1 floor, which no depth could ever clear — may be blamed on the
+// model and memoized. Everything above is per-request content variance.
+
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite("NativeMTP hybrid warmup memo scope")
+struct NativeMTPWarmupMemoScopeTests {
+
+    @Test("prose-grade warmup miss is content, not a model property")
+    func contentMissIsNotMemoizable() {
+        // The live prose repro: 1.00 average accepted per verify at depth 3
+        // (floor 1.65). Failing warmup is correct; memoizing it is not.
+        #expect(!NativeMTPTokenIterator.warmupFailureIsModelProperty(averageAccepted: 1.00))
+        // Just below a depth-2 floor (1.10) but healthy for depth 1.
+        #expect(!NativeMTPTokenIterator.warmupFailureIsModelProperty(averageAccepted: 0.80))
+        // Exactly the depth-1 floor still clears depth 1, so it stays
+        // per-request.
+        #expect(!NativeMTPTokenIterator.warmupFailureIsModelProperty(averageAccepted: 0.55))
+    }
+
+    @Test("catastrophic miss below the depth-1 floor is the model")
+    func catastrophicMissIsMemoizable() {
+        // A broken or mismatched MTP head accepts near zero; no depth could
+        // ever clear warmup, so re-probing every request only burns the
+        // 16-cycle probe the memo census flagged (84% of requests).
+        #expect(NativeMTPTokenIterator.warmupFailureIsModelProperty(averageAccepted: 0.0))
+        #expect(NativeMTPTokenIterator.warmupFailureIsModelProperty(averageAccepted: 0.30))
+        #expect(NativeMTPTokenIterator.warmupFailureIsModelProperty(averageAccepted: 0.54))
+    }
+
+    @Test("memo verdict stays per model instance and passing runs still memoize")
+    func memoStillWorksForItsRealCase() {
+        final class Marker {}
+        let healthy = Marker()
+        let broken = Marker()
+        #expect(NativeMTPHybridWarmupMemo.verdict(for: healthy) == nil)
+        NativeMTPHybridWarmupMemo.record(true, for: healthy)
+        NativeMTPHybridWarmupMemo.record(false, for: broken)
+        #expect(NativeMTPHybridWarmupMemo.verdict(for: healthy) == true)
+        #expect(NativeMTPHybridWarmupMemo.verdict(for: broken) == false)
+    }
+}


### PR DESCRIPTION
## Problem

`NativeMTPHybridWarmupMemo`'s contract (its own doc comment) is that it stores *a property of the model, not the prompt*, and that acceptance-ratio fallbacks stay per-request because they are content-dependent. But the warmup verdict it memoizes IS an acceptance criterion — 0.55 × depth over the first 16 verify cycles.

Acceptance is content. Measured on the same loaded Qwen3.8-27B-JANG_4D at temp 0:

| prompt | warmup averageAccepted | floor (d3) |
|---|---|---|
| prose | **1.00** | 1.65 |
| code | **3.04** | 1.65 |

So a prose-grade *first* turn memoized a permanent negative verdict, and every later **code** turn — where MTP speculates at 1.7× — silently ran plain AR (`verifyCalls=0`, `adaptiveFallback=hybrid_warmup_memo`) until the model was reloaded. In a chat session that starts with a greeting and moves to code, MTP is off for the whole residency. Observed live in the strategy matrix: round 1 prose recorded the memo, round 2 ran zero verify calls.

## Fix

Memoize a failure only when it is **catastrophic**: below even the depth-1 floor (0.55), which no depth could ever clear — that is the broken/mismatched-head case the memo was built for (its census: 84% of requests burning the 16-cycle probe to land in AR again). A miss above that line falls back for THIS request and re-probes on the next one.

Passing verdicts still memoize; the broken-head case still memoizes; only the content-dependent band re-probes.

## Evidence (DFlash2StrategyMatrixTests, prose, temp 0, 320 tok)

Before:
```
r1 mtp-d3: verifyCalls=16 ... adaptiveFallback=hybrid_warmup_avg_accept=1.00   (records memo=false)
r2 mtp-d3: verifyCalls=0  ... adaptiveFallback=hybrid_warmup_memo              (locked out)
```
After:
```
r1 mtp-d3: verifyCalls=16 ... adaptiveFallback=hybrid_warmup_avg_accept=1.00
r2 mtp-d3: verifyCalls=16 ... adaptiveFallback=hybrid_warmup_avg_accept=1.00   (re-probed)
```
Output byte-identical to plain decode both rounds (sharedPrefix 1398/1398). Re-probe overhead on a turn that stays AR: 0.94× vs 0.91× — ~3% of a prose turn, paid only on turns that fail warmup.

## Tests

`NativeMTPWarmupMemoScopeTests` (focused suite) pins the boundary: prose-grade misses (1.00, 0.80, 0.55) are NOT memoizable; catastrophic misses (0.0, 0.30, 0.54) are; the memo still records per model instance for its real case.

Live in-app prose→code proof to follow in a comment before merge.