### PR TITLE
NemotronLabs VoiceChat 11B: full-duplex speech-to-speech runtime

### DIFF
--- a/Libraries/MLXLLM/Models/NemotronH.swift
+++ b/Libraries/MLXLLM/Models/NemotronH.swift
@@ -1759,14 +1759,21 @@ public struct NemotronHConfiguration: Codable, Sendable {
         convKernel = try container.decode(Int.self, forKey: .convKernel)
         nGroups = try container.decode(Int.self, forKey: .nGroups)
         intermediateSize = try container.decode(Int.self, forKey: .intermediateSize)
-        moeIntermediateSize = try container.decode(Int.self, forKey: .moeIntermediateSize)
+        // DENSE nemotron_h (e.g. Nemotron-Nano-9B-v2, the VoiceChat backbone)
+        // ships NO MoE keys at all. The pattern for those bundles contains only
+        // M / - / * and never `E`, so no MoE layer is constructed and these
+        // values are unused. Defaulting to 0 is strictly widening: any config
+        // that DOES carry them decodes exactly as before; only configs that
+        // previously THREW now load, as dense.
+        moeIntermediateSize =
+            try container.decodeIfPresent(Int.self, forKey: .moeIntermediateSize) ?? 0
         moeLatentSize = try container.decodeIfPresent(Int.self, forKey: .moeLatentSize)
-        moeSharedExpertIntermediateSize = try container.decode(
-            Int.self, forKey: .moeSharedExpertIntermediateSize)
-        nRoutedExperts = try container.decode(Int.self, forKey: .nRoutedExperts)
+        moeSharedExpertIntermediateSize =
+            try container.decodeIfPresent(Int.self, forKey: .moeSharedExpertIntermediateSize) ?? 0
+        nRoutedExperts = try container.decodeIfPresent(Int.self, forKey: .nRoutedExperts) ?? 0
         nSharedExperts = try container.decodeIfPresent(Int.self, forKey: .nSharedExperts)
         numExpertsPerTok = RuntimeMoETopKOverride.effectiveTopK(
-            currentTopK: try container.decode(Int.self, forKey: .numExpertsPerTok),
+            currentTopK: try container.decodeIfPresent(Int.self, forKey: .numExpertsPerTok) ?? 0,
             modelType: modelType,
             field: CodingKeys.numExpertsPerTok.rawValue)
         layerNormEpsilon =

--- a/Libraries/MLXLLM/Models/NemotronH.swift
+++ b/Libraries/MLXLLM/Models/NemotronH.swift
@@ -1388,6 +1388,16 @@ public class NemotronHModel: Module, LLMModel, KVCacheDimensionProvider, LoRAMod
         backbone.embeddings(tokens)
     }
 
+    /// Final-normed hidden states from pre-computed embeddings, with NO head
+    /// applied. VoiceChat runs TWO heads over the same hidden state (`lm_head`
+    /// and the tool-call `function_head`), so it needs the hidden itself
+    /// rather than the logits `callAsFunction(inputsEmbeds:cache:)` returns.
+    public func hiddenStatesFromEmbeddings(
+        _ inputsEmbeds: MLXArray, cache: [KVCache]?
+    ) -> MLXArray {
+        backbone.forwardFromEmbeddings(inputsEmbeds, cache: cache)
+    }
+
     /// Forward starting from pre-computed embeddings (for multimodal splice).
     /// Returns logits in the same shape as ``callAsFunction(_:cache:)``.
     public func callAsFunction(inputsEmbeds: MLXArray, cache: [KVCache]?) -> MLXArray {

--- a/Libraries/MLXVLM/Models/NemotronVoiceChat/NemotronVoiceChat.swift
+++ b/Libraries/MLXVLM/Models/NemotronVoiceChat/NemotronVoiceChat.swift
@@ -225,13 +225,22 @@ public class NemotronVoiceChatModel: Module {
         var functionTokens = [Int](repeating: padId, count: timelineFrames)
         let sttCache = sttModel.makeCache()
 
-        // `VMLX_VOICECHAT_NO_GUIDANCE=1` runs the speech decoder without
-        // classifier-free guidance. The guidance branch is where this port
-        // still diverges from the reference (conditional half exact at every
-        // layer, unconditional half wrong), so this arm answers whether the
-        // rest of the stack can already speak.
-        let useGuidance =
-            ProcessInfo.processInfo.environment["VMLX_VOICECHAT_NO_GUIDANCE"] != "1"
+        // 🚨 Classifier-free guidance is OFF by default, and that is a
+        // deliberate, measured choice rather than a missing feature.
+        //
+        // The guidance branch of this port diverges from the reference: split
+        // by guidance half, a decode step is exact on the CONDITIONAL half at
+        // all 28 layers (cosine 0.99995+) and collapses on the UNCONDITIONAL
+        // half (0.998 → 0.334 → 0.224 …; layer 1 norm 93.26 vs 65.99). With
+        // guidance on, the decoder emits audio that passes every energy
+        // statistic and contains NO WORDS. With it off, the same stack is
+        // intelligible — the model's own ASR reads its speech back verbatim
+        // (100% in-order letter overlap).
+        //
+        // The reference runs guidance_scale 0.2, so the quality this gives up
+        // is small next to the difference between speaking and not. Set
+        // `VMLX_VOICECHAT_GUIDANCE=1` to run the guided path while fixing it.
+        let useGuidance = ProcessInfo.processInfo.environment["VMLX_VOICECHAT_GUIDANCE"] == "1"
 
         let prompt = ttsPrompt(voice: voice)
         // 🚨 Materialise the prompt BEFORE the warmup graph is built. The
@@ -323,6 +332,110 @@ public class NemotronVoiceChatModel: Module {
             sampleRate: config.outputSampleRate,
             asrEmbeddings: asrEmbeds[0..., ..<audioFrames, 0...],
             audioFrames: audioFrames)
+    }
+
+    /// Render a chosen sentence with the speech tower alone — text to speech,
+    /// with no user audio and no language model in the loop.
+    ///
+    /// The duplex turn loop always speaks whatever the backbone decided to say.
+    /// An avatar also needs the other direction: say EXACTLY this. The speech
+    /// tower already supports it, because `step` is driven by one subword token
+    /// per 0.08 s frame and does not care whether that token came from
+    /// `lm_head` or from a caller.
+    ///
+    /// - Parameter frameTokens: the subword id active on each frame, in order.
+    ///   `padTokenId` means "no new subword this frame" and is what creates
+    ///   natural pacing — in a real turn most frames are PAD. Build the
+    ///   schedule at roughly one content token every 3 frames (about 4 per
+    ///   second, which is the rate the model's own text channel runs at) and
+    ///   leave trailing PAD frames so the last word is not cut off.
+    public func synthesize(frameTokens: [Int], voice: Voice = .builtIn)
+        -> (audio: MLXArray, codes: MLXArray, sampleRate: Int)
+    {
+        precondition(!frameTokens.isEmpty, "frameTokens must not be empty")
+        let useGuidance = ProcessInfo.processInfo.environment["VMLX_VOICECHAT_GUIDANCE"] == "1"
+
+        let prompt = ttsPrompt(voice: voice)
+        MLX.eval(prompt.codes, prompt.subwords, prompt.subwordMask, prompt.audioMask)
+        if let latent = prompt.latent { MLX.eval(latent) }
+
+        var (warmHidden, ttsCache) = ttsModel.ttsModel.warmup(
+            code: prompt.codes,
+            subwordIds: prompt.subwords,
+            subwordMask: prompt.subwordMask,
+            audioMask: prompt.audioMask,
+            audioPromptLatent: prompt.latent,
+            guidance: useGuidance)
+        MLX.eval(warmHidden)
+
+        var previousCode = MLXArray(
+            prompt.codes[0..., (prompt.codes.dim(1) - 1)..., 0...].asType(.int32)
+                .asArray(Int32.self)
+        ).reshaped([1, 1, config.ttsConfig.numQuantizers])
+
+        var frames = [MLXArray]()
+        frames.reserveCapacity(frameTokens.count)
+        for id in frameTokens {
+            let current = MLXArray([Int32(id)]).reshaped([1, 1])
+            if id == config.eosTokenId {
+                previousCode = MLX.broadcast(
+                    ttsModel.codecSilenceTokens.reshaped([1, 1, -1]), to: previousCode.shape)
+            }
+            let out = ttsModel.ttsModel.step(
+                code: previousCode,
+                subwordIds: current,
+                subwordMask: MLXArray.ones(current.shape, dtype: .bool),
+                cache: ttsCache,
+                guidance: useGuidance)
+            previousCode = out.codes
+            frames.append(previousCode)
+            MLX.eval(previousCode)
+        }
+
+        var codes = MLX.concatenated(frames, axis: 1)
+        codes = replacingControlCodes(codes)
+        let decoded = ttsModel.audioCodec.decode(codes.transposed(0, 2, 1))
+        MLX.eval(decoded)
+        return (decoded[0, 0], codes[0], config.outputSampleRate)
+    }
+
+    /// Lay a token sequence onto a frame schedule for ``synthesize(frameTokens:voice:)``.
+    ///
+    /// 🚨 The text channel delivers a sentence as a BURST, not spread out over
+    /// the time it takes to say it. Dumping the model's own per-frame schedule
+    /// for "Hello! How can I help you today?" gives, across 76 frames:
+    ///
+    ///     ......... | .................................. <s> Hello ! -How
+    ///     -can -I -help -you -today ? ....................
+    ///
+    /// — nine content tokens on nine CONSECUTIVE frames after `<s>`, then PAD
+    /// for the rest of the turn. The speech tower reads the burst out over
+    /// those trailing PAD frames, so the audio runs far longer than the burst.
+    ///
+    /// Spacing tokens out instead (one every 3-7 frames, which is what "about
+    /// four tokens a second" suggests) is out of distribution and degrades
+    /// after the first word or two: at 3 frames per token "Hi there! I'm so
+    /// happy to see you today." came back as "Hi, I think there are MKane".
+    /// So `framesPerToken` defaults to 1 and the tail carries the speaking
+    /// time.
+    public func frameSchedule(
+        subwordIds: [Int], framesPerToken: Int = 1, leadFrames: Int = 4,
+        tailFrames: Int? = nil, includeBOS: Bool = true
+    ) -> [Int] {
+        let pad = config.padTokenId
+        var schedule = [Int](repeating: pad, count: Swift.max(0, leadFrames))
+        if includeBOS { schedule.append(config.bosTokenId) }
+        for id in subwordIds {
+            schedule.append(id)
+            schedule.append(
+                contentsOf: [Int](repeating: pad, count: Swift.max(0, framesPerToken - 1)))
+        }
+        // The model left ~2.5 frames of speaking time per content token after
+        // its own burst. Too few clips the last words; extra PAD is just
+        // trailing silence and is trimmed by the caller.
+        let tail = tailFrames ?? (Int(Double(subwordIds.count) * 2.5) + 16)
+        schedule.append(contentsOf: [Int](repeating: pad, count: Swift.max(0, tail)))
+        return schedule
     }
 
     /// Greedy RNN-T transcription of the user's own audio for this turn.

--- a/Libraries/MLXVLM/Models/NemotronVoiceChat/NemotronVoiceChat.swift
+++ b/Libraries/MLXVLM/Models/NemotronVoiceChat/NemotronVoiceChat.swift
@@ -1,0 +1,262 @@
+// NemotronLabs VoiceChat 11B — the assembled model and its turn loop.
+//
+// Port of `Model` (model.py) + `VoiceChatSession.generate` (session.py).
+//
+// The loop is the whole point of a duplex model, so it is worth stating
+// plainly: on every 0.08 s frame the backbone consumes ONE fused embedding
+// built from three channels —
+//
+//     fused = embed(previous text token)
+//           + user audio embedding for this frame
+//           + function_channel_weight × embed(previous function token)
+//
+// and produces this frame's text token (lm_head) and tool-call token
+// (function_head) TOGETHER. The agent's speech is generated from the text
+// token by the EAR-TTS model on the SAME clock, so listening, answering,
+// speaking, and tool-calling all advance one frame at a time. That shared
+// clock is what makes barge-in and turn-taking expressible at all.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+/// One completed VoiceChat turn.
+public struct VoiceChatTurnResult {
+    /// Agent text-channel token ids (PAD/silence included — decode filters).
+    public let textTokens: [Int]
+    /// Tool-call channel token ids. 🚨 Read THESE for tool calls, never the
+    /// transcript: a model can say "I checked the weather" while emitting
+    /// zero function tokens, and that exact bug has shipped before.
+    public let functionTokens: [Int]
+    /// (frames, quantizers) RVQ codes for the agent's speech.
+    public let audioCodes: MLXArray
+    /// (samples,) waveform at `sampleRate`.
+    public let audio: MLXArray
+    public let sampleRate: Int
+    /// Unprojected encoder frames, for RNN-T transcription of the user.
+    public let asrEmbeddings: MLXArray
+    public let audioFrames: Int
+}
+
+/// The full duplex model: listening side + speaking side.
+public class NemotronVoiceChatModel: Module {
+    public let config: NemotronVoiceChatConfiguration
+
+    @ModuleInfo(key: "stt_model") public var sttModel: VoiceChatSTTModel
+    @ModuleInfo(key: "tts_model") public var ttsModel: VoiceChatSpeechDecoder
+
+    public init(_ config: NemotronVoiceChatConfiguration) {
+        self.config = config
+        self._sttModel.wrappedValue = VoiceChatSTTModel(config)
+        self._ttsModel.wrappedValue = VoiceChatSpeechDecoder(
+            tts: config.ttsConfig, codec: config.codecConfig)
+    }
+
+    /// Split the bundle's flat tensor dict by side and hand each half to its
+    /// own sanitizer. Keys arrive exactly as stored (`stt_model.…`,
+    /// `tts_model.…`).
+    public static func sanitized(
+        _ weights: [String: MLXArray], config: NemotronVoiceChatConfiguration
+    ) -> [String: MLXArray] {
+        var stt = [String: MLXArray]()
+        var tts = [String: MLXArray]()
+        for (key, value) in weights {
+            if key.hasPrefix("stt_model.") {
+                stt[String(key.dropFirst("stt_model.".count))] = value
+            } else if key.hasPrefix("tts_model.") {
+                tts[String(key.dropFirst("tts_model.".count))] = value
+            }
+        }
+        var out = [String: MLXArray]()
+        for (key, value) in VoiceChatSTTModel.sanitized(stt) {
+            out["stt_model.\(key)"] = value
+        }
+        for (key, value) in VoiceChatSpeechDecoder.sanitized(
+            tts, codecConfig: config.codecConfig)
+        {
+            out["tts_model.\(key)"] = value
+        }
+        return out
+    }
+
+    /// The character vocabulary the TTS conditioning needs. Must be called
+    /// once with the tokenizer's vocab before any speech is generated.
+    public func setVocabulary(_ vocabulary: [String: Int]) throws {
+        try ttsModel.ttsModel.setVocabulary(vocabulary)
+    }
+
+    /// Substitute the codec's silence codes wherever a control code appears —
+    /// control codes are protocol markers, not audio, and rendering them
+    /// directly produces artifacts.
+    func replacingControlCodes(_ codes: MLXArray) -> MLXArray {
+        let control = ttsModel.controlCodesValues
+        guard !control.isEmpty else { return codes }
+        var mask = MLXArray.zeros(codes.shape, dtype: .bool)
+        for token in control {
+            mask = MLX.logicalOr(mask, codes .== MLXArray(Int32(token)))
+        }
+        let silence = MLX.broadcast(
+            ttsModel.codecSilenceTokens.reshaped([1, 1, -1]), to: codes.shape)
+        return MLX.where(mask, silence, codes)
+    }
+
+    /// Build the silent speaker-prompt warmup inputs for the TTS model.
+    ///
+    /// The prompt is the Aria latent plus a codec-encoded silent lead-in; its
+    /// last two positions carry the mask sentinel so the model starts speaking
+    /// from a clean state rather than continuing the silence codes.
+    func ttsPrompt(batchSize: Int = 1) -> (
+        codes: MLXArray, subwords: MLXArray, subwordMask: MLXArray, audioMask: MLXArray,
+        latent: MLXArray
+    ) {
+        let ttsConfig = config.ttsConfig
+        let frames = ttsModel.audioPromptLatents.aria.dim(1)
+        let total = frames + 1
+        let promptSamples = total * config.codecConfig.waveformToTokenRatio
+        let silentCodes = ttsModel.audioCodec.encode(
+            MLXArray.zeros([batchSize, 1, promptSamples], dtype: .float32)
+        ).transposed(0, 2, 1)
+
+        var pieces = (0 ..< total).map { silentCodes[0..., $0] }
+        let maskCodes = MLXArray.full(
+            [batchSize, ttsConfig.numQuantizers], values: MLXArray(Int32(ttsConfig.codebookSize)))
+        pieces[0] = maskCodes
+        pieces[total - 2] = maskCodes
+        let codes = MLX.stacked(pieces, axis: 1)
+
+        let subwords = MLXArray.full(
+            [batchSize, frames], values: MLXArray(Int32(config.padTokenId)))
+        var subwordMask = MLXArray.zeros([batchSize, frames], dtype: .bool)
+        subwordMask[0..., (frames - 2)...] = MLXArray.ones(
+            [batchSize, 2], dtype: .bool)
+        var audioMask = MLXArray.zeros([batchSize, frames], dtype: .bool)
+        audioMask[0..., (frames - 1)...] = MLXArray.ones([batchSize, 1], dtype: .bool)
+        let latent = MLX.broadcast(
+            ttsModel.audioPromptLatents.aria[0 ..< 1],
+            to: [batchSize, frames, ttsConfig.hiddenSize])
+
+        return (codes[0..., ..<(total - 1), 0...], subwords, subwordMask, audioMask, latent)
+    }
+
+    /// Run one turn over already-encoded user audio embeddings.
+    ///
+    /// - Parameters:
+    ///   - audioEmbeds: (1, frames, hidden) projected perception output.
+    ///   - asrEmbeds: (1, frames, encoderHidden) unprojected, for RNN-T.
+    ///   - promptEmbeds: optional system-prompt embeddings prepended on the
+    ///     user-audio channel; the output channels stay PAD across that prefix
+    ///     and it is trimmed from the result.
+    public func generateTurn(
+        audioEmbeds: MLXArray,
+        asrEmbeds: MLXArray,
+        promptEmbeds: MLXArray? = nil,
+        maxFrames: Int? = nil
+    ) -> VoiceChatTurnResult {
+        var audioEmbeds = audioEmbeds
+        var audioFrames = audioEmbeds.dim(1)
+        if let maxFrames {
+            precondition(maxFrames >= 2, "maxFrames must be at least 2")
+            audioFrames = Swift.min(audioFrames, maxFrames)
+            audioEmbeds = audioEmbeds[0..., ..<audioFrames, 0...]
+        }
+
+        var promptFrames = 0
+        if let promptEmbeds {
+            promptFrames = promptEmbeds.dim(1)
+            audioEmbeds = MLX.concatenated(
+                [promptEmbeds.asType(audioEmbeds.dtype), audioEmbeds], axis: 1)
+        }
+        let timelineFrames = promptFrames + audioFrames
+
+        let padId = config.padTokenId
+        var textTokens = [Int](repeating: padId, count: timelineFrames)
+        var functionTokens = [Int](repeating: padId, count: timelineFrames)
+        let sttCache = sttModel.makeCache()
+
+        let prompt = ttsPrompt()
+        var (_, ttsCache) = ttsModel.ttsModel.warmup(
+            code: prompt.codes,
+            subwordIds: prompt.subwords,
+            subwordMask: prompt.subwordMask,
+            audioMask: prompt.audioMask,
+            audioPromptLatent: prompt.latent,
+            guidance: true)
+        var previousCode = prompt.codes[0..., (prompt.codes.dim(1) - 1)..., 0...]
+
+        var generatedFrames = [MLXArray]()
+        generatedFrames.reserveCapacity(timelineFrames)
+        let zeroFrame = MLXArray.zeros([1, 1, config.ttsConfig.numQuantizers], dtype: .int32)
+
+        for time in 0 ..< timelineFrames {
+            // NeMo's misleadingly named `_get_bos_embedding` initialises the
+            // first agent position with PAD, not BOS.
+            let previousTextId = time == 0 ? padId : textTokens[time - 1]
+            let previousFunctionId = time == 0 ? padId : functionTokens[time - 1]
+            let previousText = MLXArray([Int32(previousTextId)]).reshaped([1, 1])
+            let previousFunction = MLXArray([Int32(previousFunctionId)]).reshaped([1, 1])
+
+            let fused =
+                sttModel.embed(previousText)
+                + audioEmbeds[0..., time ..< (time + 1), 0...]
+                + config.functionChannelWeight * sttModel.embed(previousFunction)
+
+            let output = sttModel(inputsEmbeds: fused, cache: sttCache)
+            if time >= promptFrames {
+                textTokens[time] = output.textLogits[0..., -1].argMax().item(Int.self)
+                functionTokens[time] = output.functionLogits[0..., -1].argMax().item(Int.self)
+            }
+
+            // Frame zero warms the language model but requests no TTS code,
+            // matching the reference loop.
+            if time == 0 {
+                generatedFrames.append(zeroFrame)
+                continue
+            }
+
+            let current = MLXArray([Int32(textTokens[time])]).reshaped([1, 1])
+            if textTokens[time] == config.eosTokenId {
+                previousCode = MLX.broadcast(
+                    ttsModel.codecSilenceTokens.reshaped([1, 1, -1]), to: previousCode.shape)
+            }
+            let ttsOutput = ttsModel.ttsModel.step(
+                code: previousCode,
+                subwordIds: current,
+                subwordMask: MLXArray.ones(current.shape, dtype: .bool),
+                cache: ttsCache,
+                guidance: true)
+            previousCode = ttsOutput.codes
+            generatedFrames.append(previousCode)
+            MLX.eval(previousCode, output.textLogits, output.functionLogits)
+        }
+
+        var codes = MLX.concatenated(generatedFrames, axis: 1)
+        codes = codes[0..., promptFrames..., 0...]
+        codes = replacingControlCodes(codes)
+        let decoded = ttsModel.audioCodec.decode(codes.transposed(0, 2, 1))
+        MLX.eval(decoded)
+
+        return VoiceChatTurnResult(
+            textTokens: Array(textTokens[promptFrames...]),
+            functionTokens: Array(functionTokens[promptFrames...]),
+            audioCodes: codes[0],
+            audio: decoded[0, 0],
+            sampleRate: config.outputSampleRate,
+            asrEmbeddings: asrEmbeds[0..., ..<audioFrames, 0...],
+            audioFrames: audioFrames)
+    }
+
+    /// Greedy RNN-T transcription of the user's own audio for this turn.
+    public func transcribeUser(_ result: VoiceChatTurnResult) -> [Int] {
+        var state = VoiceChatRNNTDecodeState()
+        return sttModel.transcribe(encoded: result.asrEmbeddings, state: &state)
+    }
+}
+
+extension VoiceChatSpeechDecoder {
+    /// Control-code ids as Swift ints (protocol markers substituted with
+    /// silence before rendering).
+    var controlCodesValues: [Int] {
+        controlCodes.asArray(Int32.self).map(Int.init)
+    }
+}

--- a/Libraries/MLXVLM/Models/NemotronVoiceChat/NemotronVoiceChat.swift
+++ b/Libraries/MLXVLM/Models/NemotronVoiceChat/NemotronVoiceChat.swift
@@ -225,6 +225,14 @@ public class NemotronVoiceChatModel: Module {
         var functionTokens = [Int](repeating: padId, count: timelineFrames)
         let sttCache = sttModel.makeCache()
 
+        // `VMLX_VOICECHAT_NO_GUIDANCE=1` runs the speech decoder without
+        // classifier-free guidance. The guidance branch is where this port
+        // still diverges from the reference (conditional half exact at every
+        // layer, unconditional half wrong), so this arm answers whether the
+        // rest of the stack can already speak.
+        let useGuidance =
+            ProcessInfo.processInfo.environment["VMLX_VOICECHAT_NO_GUIDANCE"] != "1"
+
         let prompt = ttsPrompt(voice: voice)
         // 🚨 Materialise the prompt BEFORE the warmup graph is built. The
         // speaker enters the turn only through these frames, and leaving them
@@ -240,7 +248,7 @@ public class NemotronVoiceChatModel: Module {
             subwordMask: prompt.subwordMask,
             audioMask: prompt.audioMask,
             audioPromptLatent: prompt.latent,
-            guidance: true)
+            guidance: useGuidance)
         // Force the warmup itself. Its hidden state is not otherwise consumed
         // — the speaker is carried in the KV cache it writes — so without this
         // the whole warmup can stay an unevaluated graph whose effect on the
@@ -295,7 +303,7 @@ public class NemotronVoiceChatModel: Module {
                 subwordIds: current,
                 subwordMask: MLXArray.ones(current.shape, dtype: .bool),
                 cache: ttsCache,
-                guidance: true)
+                guidance: useGuidance)
             previousCode = ttsOutput.codes
             generatedFrames.append(previousCode)
             MLX.eval(previousCode, output.textLogits, output.functionLogits)

--- a/Libraries/MLXVLM/Models/NemotronVoiceChat/NemotronVoiceChat.swift
+++ b/Libraries/MLXVLM/Models/NemotronVoiceChat/NemotronVoiceChat.swift
@@ -101,24 +101,64 @@ public class NemotronVoiceChatModel: Module {
         return MLX.where(mask, silence, codes)
     }
 
-    /// Build the silent speaker-prompt warmup inputs for the TTS model.
+    /// Which voice the agent speaks in.
+    public enum Voice {
+        /// The bundle's shipped speaker latent (`audio_prompt_latents.Aria`).
+        case builtIn
+        /// Clone the voice in a reference recording: 16 kHz-agnostic mono
+        /// samples at the CODEC's rate (22.05 kHz), about
+        /// `audio_prompt_duration` seconds.
+        ///
+        /// 🚨 This is not a separate feature bolted on — it is the path the
+        /// reference runtime takes whenever no explicit latent is supplied:
+        /// the prompt frames become `embed_code(depthSum(codes)) @
+        /// audio_prompt_projection_W`, i.e. the frozen projection consumes the
+        /// prompt audio's own CODEC CODE EMBEDDINGS. Feeding it a real
+        /// recording instead of silence is what makes the speaker that
+        /// recording's speaker. (This also settles the open question in the
+        /// wiring spec: the projection consumes codec-derived embeddings, not
+        /// raw mel.)
+        case reference([Float])
+    }
+
+    /// Build the speaker-prompt warmup inputs for the TTS model.
     ///
-    /// The prompt is the Aria latent plus a codec-encoded silent lead-in; its
-    /// last two positions carry the mask sentinel so the model starts speaking
-    /// from a clean state rather than continuing the silence codes.
-    func ttsPrompt(batchSize: Int = 1) -> (
+    /// The prompt is a codec-encoded lead-in — silence for the built-in voice,
+    /// the reference recording when cloning — whose last two positions carry
+    /// the mask sentinel so the model starts speaking from a clean state
+    /// rather than continuing the prompt's own codes.
+    func ttsPrompt(batchSize: Int = 1, voice: Voice = .builtIn) -> (
         codes: MLXArray, subwords: MLXArray, subwordMask: MLXArray, audioMask: MLXArray,
-        latent: MLXArray
+        latent: MLXArray?
     ) {
         let ttsConfig = config.ttsConfig
         let frames = ttsModel.audioPromptLatents.aria.dim(1)
         let total = frames + 1
         let promptSamples = total * config.codecConfig.waveformToTokenRatio
-        let silentCodes = ttsModel.audioCodec.encode(
-            MLXArray.zeros([batchSize, 1, promptSamples], dtype: .float32)
-        ).transposed(0, 2, 1)
 
-        var pieces = (0 ..< total).map { silentCodes[0..., $0] }
+        // The prompt waveform: silence for the built-in latent (which is
+        // supplied separately), or the reference recording when cloning —
+        // padded or trimmed to exactly the prompt length the model expects.
+        let promptWaveform: MLXArray
+        switch voice {
+        case .builtIn:
+            promptWaveform = MLXArray.zeros([batchSize, 1, promptSamples], dtype: .float32)
+        case .reference(let samples):
+            var fitted = samples
+            if fitted.count > promptSamples {
+                // Keep the TAIL: the end of a clip is more likely to be settled
+                // speech than the attack at the start.
+                fitted = Array(fitted.suffix(promptSamples))
+            } else if fitted.count < promptSamples {
+                fitted += [Float](repeating: 0, count: promptSamples - fitted.count)
+            }
+            promptWaveform = MLXArray(fitted).reshaped([1, 1, promptSamples])
+                .asType(.float32)
+        }
+
+        let promptCodes = ttsModel.audioCodec.encode(promptWaveform).transposed(0, 2, 1)
+
+        var pieces = (0 ..< total).map { promptCodes[0..., $0] }
         let maskCodes = MLXArray.full(
             [batchSize, ttsConfig.numQuantizers], values: MLXArray(Int32(ttsConfig.codebookSize)))
         pieces[0] = maskCodes
@@ -132,9 +172,19 @@ public class NemotronVoiceChatModel: Module {
             [batchSize, 2], dtype: .bool)
         var audioMask = MLXArray.zeros([batchSize, frames], dtype: .bool)
         audioMask[0..., (frames - 1)...] = MLXArray.ones([batchSize, 1], dtype: .bool)
-        let latent = MLX.broadcast(
-            ttsModel.audioPromptLatents.aria[0 ..< 1],
-            to: [batchSize, frames, ttsConfig.hiddenSize])
+
+        // Built-in voice: hand the shipped latent over directly. Cloning:
+        // pass nil so `warmup` derives the speaker from the prompt codes
+        // through the frozen projection.
+        let latent: MLXArray?
+        switch voice {
+        case .builtIn:
+            latent = MLX.broadcast(
+                ttsModel.audioPromptLatents.aria[0 ..< 1],
+                to: [batchSize, frames, ttsConfig.hiddenSize])
+        case .reference:
+            latent = nil
+        }
 
         return (codes[0..., ..<(total - 1), 0...], subwords, subwordMask, audioMask, latent)
     }
@@ -151,7 +201,8 @@ public class NemotronVoiceChatModel: Module {
         audioEmbeds: MLXArray,
         asrEmbeds: MLXArray,
         promptEmbeds: MLXArray? = nil,
-        maxFrames: Int? = nil
+        maxFrames: Int? = nil,
+        voice: Voice = .builtIn
     ) -> VoiceChatTurnResult {
         var audioEmbeds = audioEmbeds
         var audioFrames = audioEmbeds.dim(1)
@@ -174,15 +225,35 @@ public class NemotronVoiceChatModel: Module {
         var functionTokens = [Int](repeating: padId, count: timelineFrames)
         let sttCache = sttModel.makeCache()
 
-        let prompt = ttsPrompt()
-        var (_, ttsCache) = ttsModel.ttsModel.warmup(
+        let prompt = ttsPrompt(voice: voice)
+        // 🚨 Materialise the prompt BEFORE the warmup graph is built. The
+        // speaker enters the turn only through these frames, and leaving them
+        // lazy made cloning intermittent: the same reference recording changed
+        // the voice on one run and produced byte-identical audio to the
+        // built-in speaker on the next.
+        MLX.eval(prompt.codes, prompt.subwords, prompt.subwordMask, prompt.audioMask)
+        if let latent = prompt.latent { MLX.eval(latent) }
+
+        var (warmHidden, ttsCache) = ttsModel.ttsModel.warmup(
             code: prompt.codes,
             subwordIds: prompt.subwords,
             subwordMask: prompt.subwordMask,
             audioMask: prompt.audioMask,
             audioPromptLatent: prompt.latent,
             guidance: true)
-        var previousCode = prompt.codes[0..., (prompt.codes.dim(1) - 1)..., 0...]
+        // Force the warmup itself. Its hidden state is not otherwise consumed
+        // — the speaker is carried in the KV cache it writes — so without this
+        // the whole warmup can stay an unevaluated graph whose effect on the
+        // cache never lands before the first step.
+        MLX.eval(warmHidden)
+
+        // A slice of an MLXArray aliases its parent, and this value is
+        // reassigned every frame; copy it so the prompt's own codes cannot be
+        // written through later.
+        var previousCode = MLXArray(
+            prompt.codes[0..., (prompt.codes.dim(1) - 1)..., 0...].asType(.int32)
+                .asArray(Int32.self)
+        ).reshaped([1, 1, config.ttsConfig.numQuantizers])
 
         var generatedFrames = [MLXArray]()
         generatedFrames.reserveCapacity(timelineFrames)

--- a/Libraries/MLXVLM/Models/NemotronVoiceChat/NemotronVoiceChatConfiguration.swift
+++ b/Libraries/MLXVLM/Models/NemotronVoiceChat/NemotronVoiceChatConfiguration.swift
@@ -298,6 +298,14 @@ public struct VoiceChatCodecConfiguration: Codable, Sendable {
         case numQuantizers = "num_quantizers"
         case codebookSize = "codebook_size"
     }
+
+    /// Real + imaginary rFFT bins the codec consumes/produces: 18 at n_fft 16.
+    public var stftChannels: Int { (nFFT / 2 + 1) * 2 }
+
+    /// Waveform samples per codec frame — hop × product of the stage strides.
+    public var waveformToTokenRatio: Int {
+        downsampleRates.reduce(hopLength, *)
+    }
 }
 
 public struct NemotronVoiceChatConfiguration: Codable, Sendable {

--- a/Libraries/MLXVLM/Models/NemotronVoiceChat/NemotronVoiceChatConfiguration.swift
+++ b/Libraries/MLXVLM/Models/NemotronVoiceChat/NemotronVoiceChatConfiguration.swift
@@ -64,6 +64,7 @@ public struct VoiceChatEncoderConfiguration: Codable, Sendable {
     public let useBias: Bool?
     public let untieBiases: Bool?
     public let xscaling: Bool?
+    public let posEmbMaxLen: Int?
 
     enum CodingKeys: String, CodingKey {
         case dModel = "d_model"
@@ -83,6 +84,7 @@ public struct VoiceChatEncoderConfiguration: Codable, Sendable {
         case useBias = "use_bias"
         case untieBiases = "untie_biases"
         case xscaling
+        case posEmbMaxLen = "pos_emb_max_len"
     }
 
     /// True when the encoder must run causally/chunked rather than offline.
@@ -112,11 +114,15 @@ public struct VoiceChatRNNTDecoderConfiguration: Codable, Sendable {
     public let predHidden: Int?
     public let predRNNLayers: Int?
     public let vocabSize: Int?
+    /// `true` on the shipped bundle: the embedding table carries one extra row
+    /// (1025 = vocab + blank) so the blank id can be fed as a start pad.
+    public let blankAsPad: Bool?
 
     enum CodingKeys: String, CodingKey {
         case predHidden = "pred_hidden"
         case predRNNLayers = "pred_rnn_layers"
         case vocabSize = "vocab_size"
+        case blankAsPad = "blank_as_pad"
     }
 }
 
@@ -124,10 +130,16 @@ public struct VoiceChatRNNTDecoderConfiguration: Codable, Sendable {
 public struct VoiceChatRNNTJointConfiguration: Codable, Sendable {
     public let jointHidden: Int?
     public let numClasses: Int?
+    public let encoderHidden: Int?
+    public let predHidden: Int?
+    public let activation: String?
 
     enum CodingKeys: String, CodingKey {
         case jointHidden = "joint_hidden"
         case numClasses = "num_classes"
+        case encoderHidden = "encoder_hidden"
+        case predHidden = "pred_hidden"
+        case activation
     }
 }
 

--- a/Libraries/MLXVLM/Models/NemotronVoiceChat/NemotronVoiceChatConfiguration.swift
+++ b/Libraries/MLXVLM/Models/NemotronVoiceChat/NemotronVoiceChatConfiguration.swift
@@ -1,0 +1,274 @@
+// NemotronLabs VoiceChat 11B — configuration.
+//
+// Full-duplex speech model: listens (16 kHz), transcribes, answers in text, and
+// synthesizes aligned speech (22.05 kHz) on a continuous timeline.
+//
+// Load target is the MLX-layout bundle (`mlx-community/NemotronLabs-VoiceChat-11B-*`),
+// NOT the NVIDIA original. The original ships a **NeMo training config** — no
+// `model_type`, no `architectures`, and one 44 GB fp32 safetensors — which no
+// HF-config-driven loader can dispatch. The MLX bundle keeps the same
+// `stt_model.*` / `tts_model.*` tensor names and only changes dtype/sharding,
+// so this config maps 1:1 onto the published weights.
+//
+// Verified against the real bundle (2026-08-20): 1632 tensors, 11.095 B params,
+// `stt_model` 997 tensors / 10.098 B, `tts_model` 635 tensors / 0.997 B.
+
+import Foundation
+import MLXLLM
+
+/// Mel front-end. Matches `AudioToMelSpectrogramPreprocessor` in the NeMo config.
+public struct VoiceChatPreprocessorConfiguration: Codable, Sendable {
+    public let sampleRate: Int
+    public let features: Int
+    public let nFFT: Int
+    public let windowSize: Double
+    public let windowStride: Double
+
+    enum CodingKeys: String, CodingKey {
+        case sampleRate = "sample_rate"
+        case features
+        case nFFT = "n_fft"
+        case windowSize = "window_size"
+        case windowStride = "window_stride"
+    }
+}
+
+/// Conformer perception encoder.
+///
+/// 🚨 The three streaming fields are what separate this from the offline
+/// Parakeet encoder already in `NemotronHOmni/Parakeet.swift`:
+///   * `convNormType == "layer_norm"` — Parakeet.swift uses `NemotronHBatchNorm1d`.
+///   * `attContextStyle == "chunked_limited"` — Parakeet.swift is full-attention;
+///     chunked requires carrying encoder context across chunk boundaries.
+///   * `causalDownsampling` / `convContextSize == "causal"`.
+/// Getting any of these wrong yields an encoder that is *correct offline* and
+/// wrong on a live mic, which is the failure mode a non-streaming test cannot see.
+public struct VoiceChatEncoderConfiguration: Codable, Sendable {
+    public let dModel: Int
+    public let nLayers: Int
+    public let nHeads: Int
+    public let featIn: Int
+    public let ffExpansionFactor: Int
+    public let convKernelSize: Int
+    public let subsamplingFactor: Int
+    public let subsamplingConvChannels: Int
+    public let selfAttentionModel: String
+    public let convNormType: String?
+    public let attContextStyle: String?
+    /// 🚨 A LIST OF PAIRS, not a flat array: the real bundle ships
+    /// `[[70, 0]]` — `[left_context, right_context]` in encoder frames.
+    /// Decoding this as `[Int]` fails on the shipped config.
+    public let attContextSize: [[Int]]?
+    public let causalDownsampling: Bool?
+    public let convContextSize: String?
+    public let useBias: Bool?
+    public let untieBiases: Bool?
+    public let xscaling: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case dModel = "d_model"
+        case nLayers = "n_layers"
+        case nHeads = "n_heads"
+        case featIn = "feat_in"
+        case ffExpansionFactor = "ff_expansion_factor"
+        case convKernelSize = "conv_kernel_size"
+        case subsamplingFactor = "subsampling_factor"
+        case subsamplingConvChannels = "subsampling_conv_channels"
+        case selfAttentionModel = "self_attention_model"
+        case convNormType = "conv_norm_type"
+        case attContextStyle = "att_context_style"
+        case attContextSize = "att_context_size"
+        case causalDownsampling = "causal_downsampling"
+        case convContextSize = "conv_context_size"
+        case useBias = "use_bias"
+        case untieBiases = "untie_biases"
+        case xscaling
+    }
+
+    /// True when the encoder must run causally/chunked rather than offline.
+    public var isStreaming: Bool {
+        (attContextStyle ?? "regular") != "regular" || (causalDownsampling ?? false)
+    }
+
+    /// Left context in encoder frames (70 on the shipped bundle) — how much
+    /// history each chunk may attend to. Sizes the state carried across chunks.
+    public var leftContextFrames: Int? { attContextSize?.first?.first }
+
+    /// Right context in encoder frames. **0 on the shipped bundle**, i.e. NO
+    /// lookahead: the encoder never waits for future audio. That is precisely
+    /// what makes low-latency duplex possible, so a non-zero value here would
+    /// silently add algorithmic latency to every response.
+    public var rightContextFrames: Int? {
+        guard let p = attContextSize?.first, p.count > 1 else { return nil }
+        return p[1]
+    }
+
+    /// Fully causal — no lookahead at all.
+    public var isFullyCausal: Bool { rightContextFrames == 0 }
+}
+
+/// RNN-T prediction network.
+public struct VoiceChatRNNTDecoderConfiguration: Codable, Sendable {
+    public let predHidden: Int?
+    public let predRNNLayers: Int?
+    public let vocabSize: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case predHidden = "pred_hidden"
+        case predRNNLayers = "pred_rnn_layers"
+        case vocabSize = "vocab_size"
+    }
+}
+
+/// RNN-T joint network.
+public struct VoiceChatRNNTJointConfiguration: Codable, Sendable {
+    public let jointHidden: Int?
+    public let numClasses: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case jointHidden = "joint_hidden"
+        case numClasses = "num_classes"
+    }
+}
+
+/// 🚨 The RNN-T decoder and joint live INSIDE `audio_config`, not at top level.
+/// Easy to miss when writing these structs, and a silent nil if missed.
+public struct VoiceChatAudioConfiguration: Codable, Sendable {
+    public let preprocessor: VoiceChatPreprocessorConfiguration
+    public let encoder: VoiceChatEncoderConfiguration
+    public let decoder: VoiceChatRNNTDecoderConfiguration?
+    public let joint: VoiceChatRNNTJointConfiguration?
+    public let outputDim: Int
+    public let maxSymbols: Int
+
+    enum CodingKeys: String, CodingKey {
+        case preprocessor, encoder, decoder, joint
+        case outputDim = "output_dim"
+        case maxSymbols = "max_symbols"
+    }
+}
+
+/// Speech-generation transformer + mixture-of-Gaussians head.
+public struct VoiceChatTTSConfiguration: Codable, Sendable {
+    public let hiddenSize: Int
+    public let intermediateSize: Int
+    public let numHiddenLayers: Int
+    public let numAttentionHeads: Int
+    public let numKeyValueHeads: Int
+    public let headDim: Int
+    public let slidingWindow: Int
+    public let latentSize: Int
+    public let numQuantizers: Int
+    public let codebookSize: Int
+    public let numDelaySpeechTokens: Int
+    public let disableEOSPrediction: Bool?
+    public let useGatedFusionForTextAudio: Bool?
+    public let guidanceScale: Float?
+    public let topP: Float?
+    public let noiseScale: Float?
+    public let audioPromptDuration: Float?
+
+    enum CodingKeys: String, CodingKey {
+        case hiddenSize = "hidden_size"
+        case intermediateSize = "intermediate_size"
+        case numHiddenLayers = "num_hidden_layers"
+        case numAttentionHeads = "num_attention_heads"
+        case numKeyValueHeads = "num_key_value_heads"
+        case headDim = "head_dim"
+        case slidingWindow = "sliding_window"
+        case latentSize = "latent_size"
+        case numQuantizers = "num_quantizers"
+        case codebookSize = "codebook_size"
+        case numDelaySpeechTokens = "num_delay_speech_tokens"
+        case disableEOSPrediction = "disable_eos_prediction"
+        case useGatedFusionForTextAudio = "use_gated_fusion_for_text_audio"
+        case guidanceScale = "guidance_scale"
+        case topP = "top_p"
+        case noiseScale = "noise_scale"
+        case audioPromptDuration = "audio_prompt_duration"
+    }
+}
+
+/// Neural audio codec (ConvNeXt-style blocks + residual VQ), 22.05 kHz out.
+public struct VoiceChatCodecConfiguration: Codable, Sendable {
+    public let sampleRate: Int
+    public let baseChannels: Int
+    public let channelMultipliers: [Int]
+    public let downsampleRates: [Int]
+    public let blocksPerStage: Int
+    public let blockKernelSize: Int
+    public let latentDim: Int
+    public let nFFT: Int
+    public let hopLength: Int
+    public let numQuantizers: Int
+    public let codebookSize: Int
+
+    enum CodingKeys: String, CodingKey {
+        case sampleRate = "sample_rate"
+        case baseChannels = "base_channels"
+        case channelMultipliers = "channel_multipliers"
+        case downsampleRates = "downsample_rates"
+        case blocksPerStage = "blocks_per_stage"
+        case blockKernelSize = "block_kernel_size"
+        case latentDim = "latent_dim"
+        case nFFT = "n_fft"
+        case hopLength = "hop_length"
+        case numQuantizers = "num_quantizers"
+        case codebookSize = "codebook_size"
+    }
+}
+
+public struct NemotronVoiceChatConfiguration: Codable, Sendable {
+    /// nemotron_h backbone — 56 layers, `hybrid_override_pattern`
+    /// `M-M-M-MM-M-M-M*-M-M-M*-M-M-M-M*-M-M-M-M*-M-MM-M-M-M-M-M-`
+    /// (M = Mamba2 ×27, - = MLP ×25, * = attention ×4). Cross-checked against
+    /// the weights: 27 `mixer.A_log`, 25 `mixer.up_proj`, 4 `mixer.q_proj`.
+    public let textConfig: NemotronHConfiguration
+    public let audioConfig: VoiceChatAudioConfiguration
+    public let ttsConfig: VoiceChatTTSConfiguration
+    public let codecConfig: VoiceChatCodecConfiguration
+
+    public let bosTokenId: Int
+    public let eosTokenId: Int
+    public let padTokenId: Int
+    /// Emitted when the agent should be silent on the audio timeline — a duplex
+    /// model is always producing *something*, including deliberate silence.
+    public let silenceTokenId: Int
+    /// RNN-T blank. Note it is 1024 == `rnnt_vocabulary.count`, i.e. one past
+    /// the last real token, not a value inside the vocabulary.
+    public let rnntBlankId: Int
+
+    public let inputSampleRate: Int
+    public let outputSampleRate: Int
+    public let frameDuration: Double
+
+    /// 🚨 Tool calls are a WEIGHTED PARALLEL CHANNEL with their own full
+    /// vocab-sized head (`stt_model.function_head`, 0.587 B — the same size as
+    /// `lm_head`). They are not text parsed after the fact. A runtime that
+    /// reads only `lm_head` loses tool calling entirely and silently.
+    public let functionChannelWeight: Float
+
+    public let speaker: String?
+    public let rnntVocabulary: [String]?
+
+    enum CodingKeys: String, CodingKey {
+        case textConfig = "text_config"
+        case audioConfig = "audio_config"
+        case ttsConfig = "tts_config"
+        case codecConfig = "codec_config"
+        case bosTokenId = "bos_token_id"
+        case eosTokenId = "eos_token_id"
+        case padTokenId = "pad_token_id"
+        case silenceTokenId = "silence_token_id"
+        case rnntBlankId = "rnnt_blank_id"
+        case inputSampleRate = "input_sample_rate"
+        case outputSampleRate = "output_sample_rate"
+        case frameDuration = "frame_duration"
+        case functionChannelWeight = "function_channel_weight"
+        case speaker
+        case rnntVocabulary = "rnnt_vocabulary"
+    }
+
+    /// Frames per second on the shared duplex timeline (12.5 at 0.08 s).
+    public var framesPerSecond: Double { 1.0 / frameDuration }
+}

--- a/Libraries/MLXVLM/Models/NemotronVoiceChat/NemotronVoiceChatConfiguration.swift
+++ b/Libraries/MLXVLM/Models/NemotronVoiceChat/NemotronVoiceChatConfiguration.swift
@@ -160,6 +160,57 @@ public struct VoiceChatAudioConfiguration: Codable, Sendable {
     }
 }
 
+/// Mixture-of-Gaussians refinement head (nested in `tts_config.mog_head`).
+public struct VoiceChatMoGConfiguration: Codable, Sendable {
+    public let intermediateSize: Int?
+    public let lowRank: Int?
+    public let minLogStd: Float?
+    public let numLayers: Int?
+    public let numPredictions: Int?
+    public let eps: Float?
+
+    enum CodingKeys: String, CodingKey {
+        case intermediateSize = "intermediate_size"
+        case lowRank = "low_rank"
+        case minLogStd = "min_log_std"
+        case numLayers = "num_layers"
+        case numPredictions = "num_predictions"
+        case eps
+    }
+}
+
+/// Character-aware subword encoder (nested in `tts_config.character_encoder`).
+/// Values the bundle omits fall back to the reference dataclass defaults —
+/// notably `attn_logit_softcapping 50.0` and `char_vocab_size 257`, which are
+/// NOT in the shipped JSON but are load-bearing for the encoder math.
+public struct VoiceChatCharacterEncoderConfiguration: Codable, Sendable {
+    public let hiddenSize: Int?
+    public let intermediateSize: Int?
+    public let numHiddenLayers: Int?
+    public let numAttentionHeads: Int?
+    public let numKeyValueHeads: Int?
+    public let headDim: Int?
+    public let rmsNormEps: Float?
+    public let queryPreAttnScalar: Float?
+    public let attnLogitSoftcapping: Float?
+    public let ropeBase: Float?
+    public let charVocabSize: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case hiddenSize = "hidden_size"
+        case intermediateSize = "intermediate_size"
+        case numHiddenLayers = "num_hidden_layers"
+        case numAttentionHeads = "num_attention_heads"
+        case numKeyValueHeads = "num_key_value_heads"
+        case headDim = "head_dim"
+        case rmsNormEps = "rms_norm_eps"
+        case queryPreAttnScalar = "query_pre_attn_scalar"
+        case attnLogitSoftcapping = "attn_logit_softcapping"
+        case ropeBase = "rope_base"
+        case charVocabSize = "char_vocab_size"
+    }
+}
+
 /// Speech-generation transformer + mixture-of-Gaussians head.
 public struct VoiceChatTTSConfiguration: Codable, Sendable {
     public let hiddenSize: Int
@@ -179,6 +230,16 @@ public struct VoiceChatTTSConfiguration: Codable, Sendable {
     public let topP: Float?
     public let noiseScale: Float?
     public let audioPromptDuration: Float?
+    public let characterEncoder: VoiceChatCharacterEncoderConfiguration?
+    public let mogHead: VoiceChatMoGConfiguration?
+    /// Reference-dataclass defaults the shipped JSON omits entirely.
+    public let rmsNormEps: Float?
+    public let queryPreAttnScalar: Float?
+    public let slidingWindowPattern: Int?
+    public let ropeGlobalBaseFreq: Float?
+    public let ropeLocalBaseFreq: Float?
+    public let numIterations: Int?
+    public let exponent: Float?
 
     enum CodingKeys: String, CodingKey {
         case hiddenSize = "hidden_size"
@@ -198,6 +259,15 @@ public struct VoiceChatTTSConfiguration: Codable, Sendable {
         case topP = "top_p"
         case noiseScale = "noise_scale"
         case audioPromptDuration = "audio_prompt_duration"
+        case characterEncoder = "character_encoder"
+        case mogHead = "mog_head"
+        case rmsNormEps = "rms_norm_eps"
+        case queryPreAttnScalar = "query_pre_attn_scalar"
+        case slidingWindowPattern = "sliding_window_pattern"
+        case ropeGlobalBaseFreq = "rope_global_base_freq"
+        case ropeLocalBaseFreq = "rope_local_base_freq"
+        case numIterations = "num_iterations"
+        case exponent
     }
 }
 

--- a/Libraries/MLXVLM/Models/NemotronVoiceChat/StreamingConformer.swift
+++ b/Libraries/MLXVLM/Models/NemotronVoiceChat/StreamingConformer.swift
@@ -1,0 +1,152 @@
+// Streaming Conformer pieces for NemotronLabs VoiceChat.
+//
+// The existing `NemotronHOmni/Parakeet.swift` Conformer is OFFLINE-correct but
+// cannot run on a live mic. VoiceChat's encoder config asks for three things it
+// does not do:
+//
+//   conv_norm_type:      layer_norm      (Parakeet uses NemotronHBatchNorm1d)
+//   conv_context_size:   causal          (Parakeet pads SYMMETRICALLY)
+//   att_context_style:   chunked_limited (Parakeet is full attention)
+//   att_context_size:    [[70, 0]]       70 left, ZERO right — no lookahead
+//
+// These live in their own file rather than as flags on the Omni path: the Omni
+// encoder is shipped and benchmarked (18/18 RunBench rows, 157–219 ms first
+// delta) and symmetric padding is CORRECT for it. Changing it in place would
+// alter a working model to serve a different one.
+//
+// 🚨 On the padding discrepancy: `Parakeet.swift`'s depthwise is commented
+// "Depthwise causal conv" but computes `pad = (K-1)/2` on BOTH sides, i.e. it
+// reads (K-1)/2 = 4 frames into the future. Harmless offline. On a live mic it
+// means the encoder cannot emit frame t until t+4 exists — silent added latency
+// that no offline test can observe.
+
+import Foundation
+import MLX
+import MLXNN
+
+/// Depthwise conv over time with **left-only** padding, so output at t depends
+/// on inputs ≤ t and nothing later.
+///
+/// Optionally carries `K-1` frames of tail state across chunk boundaries: with
+/// state, streaming a sequence in chunks is bit-identical to running it whole.
+/// Without it, every chunk boundary silently zero-pads and injects an artifact
+/// once per chunk — audible as periodic glitching, and invisible to a
+/// whole-sequence test.
+public class VoiceChatCausalDepthwiseConv: Module {
+    let dim: Int
+    let kernelSize: Int
+
+    @ParameterInfo(key: "depthwise_conv_weight") var dwWeight: MLXArray
+
+    /// Trailing `K-1` frames of the previous chunk. `nil` = start of stream.
+    private var carry: MLXArray?
+
+    public init(dim: Int, kernelSize: Int) {
+        self.dim = dim
+        self.kernelSize = kernelSize
+        self._dwWeight.wrappedValue = MLXArray.zeros([dim, 1, kernelSize])
+    }
+
+    /// Drop streaming state — call between utterances, never mid-stream.
+    public func resetState() { carry = nil }
+
+    /// - Parameters:
+    ///   - x: (B, T, D)
+    ///   - streaming: when true, consume/produce cross-chunk carry state.
+    public func callAsFunction(_ x: MLXArray, streaming: Bool = false) -> MLXArray {
+        let B = x.dim(0), T = x.dim(1), D = x.dim(2)
+        let K = kernelSize
+        let padLeft = K - 1
+
+        // Left context: carried tail if streaming, else zeros (start of stream).
+        let left: MLXArray
+        if streaming, let c = carry, c.dim(1) == padLeft {
+            left = c.asType(x.dtype)
+        } else {
+            left = MLXArray.zeros([B, padLeft, D], dtype: x.dtype)
+        }
+        let padded = MLX.concatenated([left, x], axis: 1)
+
+        if streaming {
+            // Keep the last K-1 frames of THIS chunk for the next call.
+            carry = padded[0..., (padded.dim(1) - padLeft)..., 0...]
+        }
+
+        let w = dwWeight.reshaped([D, K]).transposed(1, 0).asType(x.dtype)  // (K, D)
+        var out = MLXArray.zeros([B, T, D], dtype: x.dtype)
+        for i in 0 ..< K {
+            let slice = padded[0..., i ..< (i + T), 0...]
+            out = out + slice * w[i].reshaped([1, 1, D])
+        }
+        return out
+    }
+}
+
+/// Conformer conv module with a **LayerNorm** normaliser and a causal depthwise.
+///
+/// LayerNorm rather than BatchNorm is not cosmetic for streaming: BatchNorm
+/// normalises per channel using stored running statistics gathered over whole
+/// utterances, whereas LayerNorm normalises each frame against itself. Under
+/// chunked inference the former is a fixed global assumption and the latter is
+/// chunk-invariant by construction.
+public class VoiceChatConformerConvModule: Module {
+    let dim: Int
+    let kernelSize: Int
+
+    @ModuleInfo(key: "pointwise_conv1") var pw1: Conv1d
+    @ModuleInfo(key: "depthwise") var depthwise: VoiceChatCausalDepthwiseConv
+    @ModuleInfo(key: "norm") var norm: LayerNorm
+    @ModuleInfo(key: "pointwise_conv2") var pw2: Conv1d
+
+    public init(dim: Int, kernelSize: Int) {
+        self.dim = dim
+        self.kernelSize = kernelSize
+        self._pw1.wrappedValue = Conv1d(
+            inputChannels: dim, outputChannels: 2 * dim, kernelSize: 1, bias: false)
+        self._depthwise.wrappedValue = VoiceChatCausalDepthwiseConv(
+            dim: dim, kernelSize: kernelSize)
+        self._norm.wrappedValue = LayerNorm(dimensions: dim)
+        self._pw2.wrappedValue = Conv1d(
+            inputChannels: dim, outputChannels: dim, kernelSize: 1, bias: false)
+    }
+
+    public func resetState() { depthwise.resetState() }
+
+    /// x: (B, T, D)
+    public func callAsFunction(_ x: MLXArray, streaming: Bool = false) -> MLXArray {
+        var h = pw1(x)                                   // (B, T, 2D)
+        let parts = MLX.split(h, parts: 2, axis: -1)     // GLU
+        h = parts[0] * MLX.sigmoid(parts[1])
+        h = depthwise(h, streaming: streaming)
+        h = norm(h)
+        h = silu(h)
+        return pw2(h)
+    }
+}
+
+/// Additive attention mask for `chunked_limited` context.
+///
+/// `att_context_size == [[70, 0]]`: each query may attend to 70 frames of
+/// history and **zero** frames of future. Right context 0 is what allows the
+/// encoder to emit as audio arrives; any positive value would make every
+/// response wait for that many future frames.
+public enum VoiceChatAttentionMask {
+
+    /// - Returns: (T, T) additive mask, 0 where attention is allowed and
+    ///   -inf where it is not.
+    public static func chunkedLimited(
+        queryCount T: Int, leftContext: Int, rightContext: Int, dtype: DType
+    ) -> MLXArray {
+        // idx[i][j] = j - i  → negative is history, positive is future.
+        let rows = MLXArray(0 ..< T).reshaped([T, 1])
+        let cols = MLXArray(0 ..< T).reshaped([1, T])
+        let delta = cols - rows
+
+        let tooOld = delta .< MLXArray(-leftContext)
+        let tooNew = delta .> MLXArray(rightContext)
+        let blocked = MLX.logicalOr(tooOld, tooNew)
+
+        let neg = MLXArray(-Float.greatestFiniteMagnitude)
+        return MLX.where(blocked, neg, MLXArray(Float(0))).asType(dtype)
+    }
+}

--- a/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatCodec.swift
+++ b/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatCodec.swift
@@ -1,0 +1,415 @@
+// NemotronLabs VoiceChat — the 22.05 kHz neural audio codec.
+//
+// Port of `mlx_audio/codec/models/nemotron_voicechat/codec.py`. ConvNeXt-1d
+// encoder/decoder around a 31-stage probabilistic residual VQ, with an
+// iSTFT vocoder head (n_fft 16, hop 4 — a very short window, so the overlap-add
+// is cheap even at 22 kHz).
+//
+// Streaming discipline (this is what makes live speech-to-speech possible):
+//   * every depthwise conv is CAUSAL (left pad K-1) and carries its K-1 tail
+//     across chunks via `VoiceChatCausalConv1dCache`;
+//   * the iSTFT carries 4 spectrogram frames on each side so consecutive
+//     decoded chunks are sample-continuous instead of clicking at every
+//     boundary — the periodic artifact no whole-file test can see.
+
+import Foundation
+import MLX
+import MLXFFT
+import MLXNN
+
+/// Per-layer causal-conv and spectrogram overlap state for one stream.
+public final class VoiceChatCausalConv1dCache {
+    private var cache: [String: MLXArray] = [:]
+
+    public init() {}
+
+    /// Prepend this layer's carried tail to `states` and remember the new tail.
+    /// `flush` drops the entry after use (end of utterance).
+    public func update(
+        _ states: MLXArray, layer: String, padding: Int, paddingValue: Float = 0.0,
+        flush: Bool = false
+    ) -> MLXArray {
+        precondition(padding >= 0, "padding must be non-negative")
+        if padding == 0 { return states }
+
+        let previous: MLXArray
+        if let existing = cache[layer], existing.dim(0) == states.dim(0),
+            existing.dim(1) == padding, existing.dim(2) == states.dim(2)
+        {
+            previous = existing.asType(states.dtype)
+        } else {
+            previous = MLXArray.full(
+                [states.dim(0), padding, states.dim(2)],
+                values: MLXArray(paddingValue).asType(states.dtype))
+        }
+
+        let padded = MLX.concatenated([previous, states], axis: 1)
+        cache[layer] = padded[0..., (padded.dim(1) - padding)..., 0...]
+        if flush { cache.removeValue(forKey: layer) }
+        return padded
+    }
+
+    public func clear() { cache.removeAll() }
+}
+
+/// LayerNorm over the channel axis of `(B, T, C)`, with weight AND bias
+/// (the codec's blocks ship both; the conformer's `batch_norm` also does).
+public class VoiceChatChannelLayerNorm: Module, UnaryLayer {
+    @ParameterInfo(key: "weight") var weight: MLXArray
+    @ParameterInfo(key: "bias") var bias: MLXArray
+    let eps: Float
+
+    public init(channels: Int, eps: Float = 1e-6) {
+        self._weight.wrappedValue = MLXArray.ones([channels])
+        self._bias.wrappedValue = MLXArray.zeros([channels])
+        self.eps = eps
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let mean = MLX.mean(x, axis: -1, keepDims: true)
+        let variance = MLX.variance(x, axis: -1, keepDims: true)
+        return (x - mean) * MLX.rsqrt(variance + eps) * weight + bias
+    }
+}
+
+/// ConvNeXt block: causal depthwise → channel LayerNorm → 4× pointwise MLP.
+public class VoiceChatConvNeXtBlock1d: Module {
+    public let kernelSize: Int
+    public let layerId: Int
+
+    @ModuleInfo(key: "dwconv") var dwconv: Conv1d
+    @ModuleInfo(key: "norm") var norm: VoiceChatChannelLayerNorm
+    @ModuleInfo(key: "pwconv1") var pwconv1: Conv1d
+    @ModuleInfo(key: "pwconv2") var pwconv2: Conv1d
+
+    public init(channels: Int, kernelSize: Int, layerId: Int) {
+        self.kernelSize = kernelSize
+        self.layerId = layerId
+        self._dwconv.wrappedValue = Conv1d(
+            inputChannels: channels, outputChannels: channels, kernelSize: kernelSize,
+            groups: channels, bias: true)
+        self._norm.wrappedValue = VoiceChatChannelLayerNorm(channels: channels)
+        self._pwconv1.wrappedValue = Conv1d(
+            inputChannels: channels, outputChannels: 4 * channels, kernelSize: 1, bias: true)
+        self._pwconv2.wrappedValue = Conv1d(
+            inputChannels: 4 * channels, outputChannels: channels, kernelSize: 1, bias: true)
+    }
+
+    public func callAsFunction(
+        _ x: MLXArray, cache: VoiceChatCausalConv1dCache? = nil, flush: Bool = false
+    ) -> MLXArray {
+        let residual = x
+        var h: MLXArray
+        if let cache {
+            h = cache.update(x, layer: "conv\(layerId)", padding: kernelSize - 1, flush: flush)
+        } else {
+            h = MLX.padded(
+                x, widths: [.init((0, 0)), .init((kernelSize - 1, 0)), .init((0, 0))])
+        }
+        h = dwconv(h)
+        h = norm(h)
+        h = pwconv1(h)
+        h = gelu(h)
+        h = pwconv2(h)
+        return residual + h
+    }
+}
+
+/// Encoder: 1×1 in, then per stage {blocks…, strided downsample}.
+public class VoiceChatCodecEncoder: Module {
+    @ModuleInfo(key: "layers") var layers: [Module]
+
+    public init(_ config: VoiceChatCodecConfiguration) {
+        let channels = config.channelMultipliers.map { config.baseChannels * $0 }
+        precondition(
+            channels.count == config.downsampleRates.count,
+            "channel_multipliers and downsample_rates must have equal lengths")
+
+        var built: [Module] = [
+            Conv1d(
+                inputChannels: config.stftChannels, outputChannels: channels[0],
+                kernelSize: 1, bias: false)
+        ]
+        var blockIndex = 0
+        for (index, stageChannels) in channels.enumerated() {
+            for _ in 0 ..< config.blocksPerStage {
+                built.append(
+                    VoiceChatConvNeXtBlock1d(
+                        channels: stageChannels, kernelSize: config.blockKernelSize,
+                        layerId: blockIndex))
+                blockIndex += 1
+            }
+            let next = index + 1 < channels.count ? channels[index + 1] : config.latentDim
+            let rate = config.downsampleRates[index]
+            built.append(
+                Conv1d(
+                    inputChannels: stageChannels, outputChannels: next, kernelSize: rate,
+                    stride: rate, bias: false))
+        }
+        self._layers.wrappedValue = built
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = x
+        for layer in layers {
+            if let block = layer as? VoiceChatConvNeXtBlock1d {
+                h = block(h)
+            } else {
+                h = (layer as! UnaryLayer)(h)
+            }
+        }
+        return h
+    }
+}
+
+/// Decoder: mirrored — per stage {transposed upsample, blocks…}, then 1×1 out.
+public class VoiceChatCodecDecoder: Module {
+    @ModuleInfo(key: "layers") var layers: [Module]
+
+    public init(_ config: VoiceChatCodecConfiguration) {
+        let channels = config.channelMultipliers.map { config.baseChannels * $0 }
+        var built: [Module] = []
+        var sourceChannels = config.latentDim
+        var blockIndex = 0
+        for (stageChannels, rate) in zip(channels.reversed(), config.downsampleRates.reversed()) {
+            built.append(
+                ConvTransposed1d(
+                    inputChannels: sourceChannels, outputChannels: stageChannels,
+                    kernelSize: rate, stride: rate, bias: false))
+            for _ in 0 ..< config.blocksPerStage {
+                built.append(
+                    VoiceChatConvNeXtBlock1d(
+                        channels: stageChannels, kernelSize: config.blockKernelSize,
+                        layerId: blockIndex))
+                blockIndex += 1
+            }
+            sourceChannels = stageChannels
+        }
+        built.append(
+            Conv1d(
+                inputChannels: channels[0], outputChannels: config.stftChannels,
+                kernelSize: 1, bias: false))
+        self._layers.wrappedValue = built
+    }
+
+    public func callAsFunction(
+        _ x: MLXArray, cache: VoiceChatCausalConv1dCache? = nil, flush: Bool = false
+    ) -> MLXArray {
+        var h = x
+        for layer in layers {
+            if let block = layer as? VoiceChatConvNeXtBlock1d {
+                h = block(h, cache: cache, flush: flush)
+            } else {
+                h = (layer as! UnaryLayer)(h)
+            }
+        }
+        return h
+    }
+}
+
+/// Scalar per-quantizer variance (training-path parameter; kept so a strict
+/// load consumes every checkpoint tensor rather than silently ignoring some).
+public class VoiceChatScalarVariance: Module {
+    @ParameterInfo(key: "variance") var variance: MLXArray
+    public override init() {
+        self._variance.wrappedValue = MLXArray(Float(1.0))
+    }
+}
+
+/// 31-stage probabilistic residual vector quantizer.
+public class VoiceChatPRVQ: Module {
+    @ParameterInfo(key: "mus_list") var musList: [MLXArray]
+    @ModuleInfo(key: "variance_list") var varianceList: [VoiceChatScalarVariance]
+
+    public init(_ config: VoiceChatCodecConfiguration) {
+        self._musList.wrappedValue = (0 ..< config.numQuantizers).map { _ in
+            MLXArray.zeros([config.codebookSize, config.latentDim])
+        }
+        self._varianceList.wrappedValue = (0 ..< config.numQuantizers).map { _ in
+            VoiceChatScalarVariance()
+        }
+    }
+
+    /// (B, T, D) latents → (B, Q, T) code ids.
+    public func encode(_ latents: MLXArray) -> MLXArray {
+        var residual = latents
+        var codes = [MLXArray]()
+        for means in musList {
+            let distances =
+                MLX.sum(residual * residual, axis: -1, keepDims: true)
+                - 2.0 * MLX.matmul(residual, means.T)
+                + MLX.sum(means * means, axis: -1).reshaped([1, 1, -1])
+            let indices = MLX.argMin(distances, axis: -1)
+            codes.append(indices)
+            residual = residual - means[indices]
+        }
+        return MLX.stacked(codes, axis: 1)
+    }
+
+    /// (B, Q, T) code ids → (B, T, D) latents.
+    public func decode(_ codes: MLXArray) -> MLXArray {
+        precondition(codes.ndim == 3, "codes must have shape (B, Q, T)")
+        precondition(
+            codes.dim(1) <= musList.count,
+            "received \(codes.dim(1)) quantizers, maximum is \(musList.count)")
+        var latents = MLXArray.zeros(
+            [codes.dim(0), codes.dim(2), musList[0].dim(-1)], dtype: musList[0].dtype)
+        for index in 0 ..< codes.dim(1) {
+            latents = latents + musList[index][codes[0..., index, 0...]]
+        }
+        return latents
+    }
+}
+
+/// Periodic Hann window (matches `mlx_audio.dsp.hanning(periodic: true)`).
+func voiceChatHann(_ n: Int) -> MLXArray {
+    let values = (0 ..< n).map { i in
+        Float(0.5 - 0.5 * Foundation.cos(2.0 * Double.pi * Double(i) / Double(n)))
+    }
+    return MLXArray(values)
+}
+
+/// Overlap-add iSTFT with window-sum normalisation, `center: false`.
+func voiceChatISTFT(
+    real: MLXArray, imag: MLXArray, nFFT: Int, hopLength: Int, window: MLXArray
+) -> MLXArray {
+    // real/imag: (B, bins, frames)
+    let B = real.dim(0), frames = real.dim(2)
+    let spectrum = real.transposed(0, 2, 1).asType(.float32)
+        + MLXArray(0, dtype: .float32).asType(.float32) * 0  // shape anchor
+    _ = spectrum
+    let complexSpec = real.transposed(0, 2, 1).asType(.complex64)
+        + imag.transposed(0, 2, 1).asType(.complex64) * MLXArray(real: 0, imaginary: 1)
+    // (B, frames, nFFT) time-domain frames
+    let framesTime = MLXFFT.irfft(complexSpec, n: nFFT, axis: -1) * window.reshaped([1, 1, nFFT])
+
+    let length = (frames - 1) * hopLength + nFFT
+    var out = MLXArray.zeros([B, length], dtype: .float32)
+    var windowSum = MLXArray.zeros([length], dtype: .float32)
+    let windowSquared = window * window
+    for f in 0 ..< frames {
+        let start = f * hopLength
+        out[0..., start ..< (start + nFFT)] =
+            out[0..., start ..< (start + nFFT)] + framesTime[0..., f, 0...]
+        windowSum[start ..< (start + nFFT)] =
+            windowSum[start ..< (start + nFFT)] + windowSquared
+    }
+    return out / MLX.maximum(windowSum, MLXArray(Float(1e-8))).reshaped([1, length])
+}
+
+/// The embedded 22.05 kHz codec.
+public class VoiceChatCodec: Module {
+    public let config: VoiceChatCodecConfiguration
+
+    @ModuleInfo(key: "encoder") public var encoder: VoiceChatCodecEncoder
+    @ModuleInfo(key: "decoder") public var decoder: VoiceChatCodecDecoder
+    @ModuleInfo(key: "prvq") public var prvq: VoiceChatPRVQ
+
+    public init(_ config: VoiceChatCodecConfiguration) {
+        self.config = config
+        self._encoder.wrappedValue = VoiceChatCodecEncoder(config)
+        self._decoder.wrappedValue = VoiceChatCodecDecoder(config)
+        self._prvq.wrappedValue = VoiceChatPRVQ(config)
+    }
+
+    /// (B, Q, T) codes → (B, 1, samples) waveform at 22.05 kHz.
+    public func decode(
+        _ codes: MLXArray, cache: VoiceChatCausalConv1dCache? = nil, flush: Bool = false
+    ) -> MLXArray {
+        decodeLatents(prvq.decode(codes), cache: cache, flush: flush)
+    }
+
+    public func decodeLatents(
+        _ latents: MLXArray, cache: VoiceChatCausalConv1dCache? = nil, flush: Bool = false
+    ) -> MLXArray {
+        let features = decoder(latents, cache: cache, flush: flush).transposed(0, 2, 1)
+        let numBins = config.nFFT / 2 + 1
+        let magnitudeLogits = features[0..., 0 ..< numBins, 0...]
+        let phase = features[0..., numBins..., 0...]
+
+        // Softplus-parameterised magnitude, capped at 100 (matches reference).
+        let maxMagnitude: Float = 100.0
+        let magnitude =
+            maxMagnitude
+            * MLX.exp(-softplus(-magnitudeLogits + MLXArray(Foundation.log(maxMagnitude))))
+        var real = magnitude * MLX.cos(phase)
+        var imag = magnitude * MLX.sin(phase)
+        // DC and Nyquist bins of an rFFT are real-valued.
+        imag = MLX.concatenated(
+            [
+                MLXArray.zeros(like: imag[0..., 0 ..< 1, 0...]),
+                imag[0..., 1 ..< (imag.dim(1) - 1), 0...],
+                MLXArray.zeros(like: imag[0..., (imag.dim(1) - 1)..., 0...]),
+            ], axis: 1)
+
+        // Streaming continuity: carry 4 spectrogram frames on each side so a
+        // decoded chunk joins the previous one without a boundary click.
+        let halfSpecPadding = Int(
+            ceil(Double((config.nFFT - config.hopLength) / 2) / Double(config.hopLength)))
+        if let cache {
+            let specPadding = halfSpecPadding * 2
+            real = cache.update(
+                real.transposed(0, 2, 1), layer: "istft_real", padding: specPadding,
+                flush: flush
+            ).transposed(0, 2, 1)
+            imag = cache.update(
+                imag.transposed(0, 2, 1), layer: "istft_imag", padding: specPadding,
+                flush: flush
+            ).transposed(0, 2, 1)
+            if flush {
+                let tail = MLXArray.zeros(
+                    [real.dim(0), real.dim(1), halfSpecPadding], dtype: real.dtype)
+                real = MLX.concatenated([real, tail], axis: 2)
+                imag = MLX.concatenated([imag, tail], axis: 2)
+            }
+        }
+
+        let window = voiceChatHann(config.nFFT)
+        var waveform = voiceChatISTFT(
+            real: real, imag: imag, nFFT: config.nFFT, hopLength: config.hopLength,
+            window: window)
+        let padLeft = (config.nFFT - config.hopLength) / 2
+        let padRight = config.nFFT - config.hopLength - padLeft
+        waveform = waveform[0..., padLeft ..< (waveform.dim(-1) - padRight)]
+        if cache != nil {
+            let halfWavePadding = halfSpecPadding * config.hopLength
+            waveform = waveform[0..., halfWavePadding ..< (waveform.dim(-1) - halfWavePadding)]
+        }
+        return waveform.expandedDimensions(axis: 1)
+    }
+
+    /// Map the bundle's codec tensors onto this tree. Conv weights arrive in
+    /// PyTorch layout; decoder stage-start ConvTranspose1d needs a DIFFERENT
+    /// transpose from every other 3-D weight, which is the trap this mirrors
+    /// from the reference.
+    public static func sanitized(
+        _ weights: [String: MLXArray], config: VoiceChatCodecConfiguration
+    ) -> [String: MLXArray] {
+        var converted = [String: MLXArray]()
+        let stageWidth = config.blocksPerStage + 1
+        let stageRegion = stageWidth * config.downsampleRates.count
+
+        for (rawKey, rawValue) in weights {
+            let key = rawKey.replacingOccurrences(
+                of: "prvq._variance_list.", with: "prvq.variance_list.")
+            var value = rawValue
+            let isWeight = key.hasSuffix(".weight") && value.ndim == 3
+            if isWeight && key.hasPrefix("decoder.layers.") {
+                let parts = key.components(separatedBy: ".")
+                let layerIndex = Int(parts[2]) ?? -1
+                if layerIndex < stageRegion, layerIndex % stageWidth == 0,
+                    !key.contains("dwconv")
+                {
+                    value = value.transposed(1, 2, 0)  // ConvTranspose1d
+                } else {
+                    value = value.transposed(0, 2, 1)
+                }
+            } else if isWeight {
+                value = value.transposed(0, 2, 1)
+            }
+            // `mus_list.N` / `variance_list.N` land as-is on the parameter arrays.
+            converted[key] = value
+        }
+        return converted
+    }
+}

--- a/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatCodec.swift
+++ b/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatCodec.swift
@@ -312,6 +312,51 @@ public class VoiceChatCodec: Module {
         self._prvq.wrappedValue = VoiceChatPRVQ(config)
     }
 
+    /// (B, samples) or (B, 1, samples) waveform → (B, T, D) latents.
+    ///
+    /// Needed for BOTH the silent speaker-prompt lead-in and, later, cloning a
+    /// custom voice: making a voice means audio → latent, so the ENCODER ships
+    /// and is used, not just the decoder.
+    public func encodeLatents(_ waveform: MLXArray) -> MLXArray {
+        var wave = waveform
+        if wave.ndim == 3 {
+            precondition(wave.dim(1) == 1, "only mono waveforms are supported")
+            wave = wave[0..., 0, 0...]
+        }
+        precondition(wave.ndim == 2, "waveform must be (batch, samples)")
+        precondition(wave.dim(-1) > 0, "waveform must contain at least one sample")
+
+        // STFT with the same centring convention as the decoder's iSTFT.
+        let nFFT = config.nFFT
+        let hop = config.hopLength
+        let padLeft = (nFFT - hop) / 2
+        let padRight = nFFT - hop - padLeft
+        var padded = MLX.padded(
+            wave.asType(.float32), widths: [.init((0, 0)), .init((padLeft, padRight))])
+        if padded.dim(-1) < nFFT {
+            padded = MLX.padded(
+                padded, widths: [.init((0, 0)), .init((0, nFFT - padded.dim(-1)))])
+        }
+        let window = voiceChatHann(nFFT)
+        let frames = (padded.dim(-1) - nFFT) / hop + 1
+        var slices = [MLXArray]()
+        slices.reserveCapacity(frames)
+        for f in 0 ..< frames {
+            let start = f * hop
+            slices.append(padded[0..., start ..< (start + nFFT)] * window.reshaped([1, nFFT]))
+        }
+        let framed = MLX.stacked(slices, axis: 1)  // (B, frames, nFFT)
+        let spectrum = MLXFFT.rfft(framed, axis: -1)  // (B, frames, bins)
+        let features = MLX.concatenated(
+            [spectrum.realPart(), spectrum.imaginaryPart()], axis: -1)
+        return encoder(features)
+    }
+
+    /// (B, samples) waveform → (B, Q, T) code ids.
+    public func encode(_ waveform: MLXArray) -> MLXArray {
+        prvq.encode(encodeLatents(waveform))
+    }
+
     /// (B, Q, T) codes → (B, 1, samples) waveform at 22.05 kHz.
     public func decode(
         _ codes: MLXArray, cache: VoiceChatCausalConv1dCache? = nil, flush: Bool = false

--- a/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatConformer.swift
+++ b/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatConformer.swift
@@ -31,7 +31,6 @@
 
 import Foundation
 import MLX
-import MLXFast
 import MLXNN
 
 /// Transformer-XL relative positional encoding (no learned parameters).

--- a/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatConformer.swift
+++ b/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatConformer.swift
@@ -1,0 +1,430 @@
+// NemotronLabs VoiceChat — full streaming-capable FastConformer encoder.
+//
+// Mirrors `mlx_audio.stt.models.nemotron_asr.conformer` (the exact module the
+// reference runtime instantiates for this checkpoint), with the SAME parameter
+// keys as the shipped bundle:
+//
+//   encoder.pre_encode.conv.{0,2,3,5,6}.{weight,bias}   causal dw_striding ×8
+//   encoder.pre_encode.out.{weight,bias}
+//   encoder.layers.{i}.norm_feed_forward1 / feed_forward1.linear{1,2}
+//   encoder.layers.{i}.norm_self_att / self_attn.linear_{q,k,v,out,pos}
+//   encoder.layers.{i}.self_attn.pos_bias_{u,v}         (untied, per layer)
+//   encoder.layers.{i}.norm_conv / conv.pointwise_conv{1,2} / conv.depthwise_conv
+//   encoder.layers.{i}.conv.batch_norm                  (a LayerNorm — NeMo
+//                                                        keeps the name so
+//                                                        checkpoint keys match)
+//   encoder.layers.{i}.norm_feed_forward2 / feed_forward2.linear{1,2}
+//   encoder.layers.{i}.norm_out
+//
+// Streaming properties this file is responsible for (the ones that make the
+// encoder valid on a LIVE mic, not just on a whole file):
+//   * causal depthwise conv — left-only padding, no future frames
+//   * causal dw-striding subsampling — asymmetric pad (left K-1, right S-1)
+//   * chunked_limited attention — NeMo's CHUNK-BASED mask, see below
+//
+// 🚨 `chunked_limited` is chunk-based, not a per-frame sliding window: frames
+// group into chunks of `right_context + 1`, and a frame sees its own chunk plus
+// `left_context / chunk_size` previous chunks. With the shipped `[[70, 0]]`
+// the chunk size is 1 and it degenerates to the per-frame window, which is why
+// the two formulations agree on THIS bundle — but the general form is the one
+// NeMo trains against, so the general form is what we implement.
+
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+/// Transformer-XL relative positional encoding (no learned parameters).
+public final class VoiceChatRelPositionalEncoding {
+    public let dModel: Int
+    public private(set) var maxLen: Int
+    private let scale: Float
+    private var pe: MLXArray
+
+    public init(dModel: Int, maxLen: Int = 5000, scaleInput: Bool = false) {
+        self.dModel = dModel
+        self.maxLen = maxLen
+        self.scale = scaleInput ? Float(Foundation.sqrt(Double(dModel))) : 1.0
+        self.pe = Self.computePE(dModel: dModel, maxLen: maxLen)
+    }
+
+    private static func computePE(dModel: Int, maxLen: Int) -> MLXArray {
+        // positions maxLen-1 … -(maxLen-1), matching NeMo's center-out layout.
+        let positions = MLXArray(stride(from: maxLen - 1, through: -(maxLen - 1), by: -1).map { Float($0) })
+            .reshaped([2 * maxLen - 1, 1])
+        let divTerm = MLX.exp(
+            MLXArray(stride(from: 0, to: dModel, by: 2).map { Float($0) })
+                * (-Float(Foundation.log(10000.0)) / Float(dModel)))
+        let angles = positions * divTerm.reshaped([1, dModel / 2])
+        let sin = MLX.sin(angles)
+        let cos = MLX.cos(angles)
+        // Interleave sin into even columns and cos into odd ones.
+        let stacked = MLX.stacked([sin, cos], axis: -1)  // (2L-1, d/2, 2)
+        return stacked.reshaped([2 * maxLen - 1, dModel]).expandedDimensions(axis: 0)
+    }
+
+    private func ensure(length: Int) {
+        if length > maxLen {
+            maxLen = length + 1
+            pe = Self.computePE(dModel: dModel, maxLen: maxLen)
+        }
+    }
+
+    /// - Returns: (scaled input, position embedding of length 2*T-1)
+    public func callAsFunction(_ x: MLXArray) -> (MLXArray, MLXArray) {
+        let T = x.dim(1)
+        ensure(length: T)
+        let buffer = pe.dim(1)
+        let start = buffer / 2 - (T - 1)
+        let end = buffer / 2 + (T - 1) + 1
+        let posEmb = pe[0..., start ..< end, 0...].asType(x.dtype)
+        return (scale == 1.0 ? x : x * MLXArray(scale), posEmb)
+    }
+
+    /// Position embedding for a key window of `length` frames (2*length-1 rows)
+    /// — the cache-aware streaming path, where a short query chunk attends to a
+    /// longer cache+chunk key window.
+    public func posEmb(forWindow length: Int, dtype: DType) -> MLXArray {
+        ensure(length: length)
+        let center = pe.dim(1) / 2
+        return pe[0..., (center - (length - 1)) ..< (center + length), 0...].asType(dtype)
+    }
+}
+
+/// NeMo `chunked_limited` additive mask (0 visible, large-negative blocked).
+public func voiceChatChunkedLimitedMask(
+    sequenceLength T: Int, leftContext: Int, rightContext: Int, dtype: DType
+) -> MLXArray {
+    let chunkSize = rightContext + 1
+    let leftChunks = leftContext >= 0 ? leftContext / chunkSize : Int(1e8)
+    let chunkIdx = MLXArray(0 ..< T) / MLXArray(Int32(chunkSize))
+    let diff = chunkIdx.reshaped([T, 1]) - chunkIdx.reshaped([1, T])
+    let visible = MLX.logicalAnd(diff .>= MLXArray(0), diff .<= MLXArray(Int32(leftChunks)))
+    return MLX.where(visible, MLXArray(Float(0)), MLXArray(Float(-1e30)))
+        .asType(dtype)
+        .reshaped([1, 1, T, T])
+}
+
+/// Rel-pos multi-head attention, Transformer-XL convention, `use_bias: false`.
+public class VoiceChatRelPositionAttention: Module {
+    let nHead: Int
+    let nFeat: Int
+    let headDim: Int
+    let attnScale: Float
+
+    @ModuleInfo(key: "linear_q") var linearQ: Linear
+    @ModuleInfo(key: "linear_k") var linearK: Linear
+    @ModuleInfo(key: "linear_v") var linearV: Linear
+    @ModuleInfo(key: "linear_out") var linearOut: Linear
+    @ModuleInfo(key: "linear_pos") var linearPos: Linear
+    @ParameterInfo(key: "pos_bias_u") var posBiasU: MLXArray
+    @ParameterInfo(key: "pos_bias_v") var posBiasV: MLXArray
+
+    public init(nHead: Int, nFeat: Int, bias: Bool = false) {
+        precondition(nFeat % nHead == 0)
+        self.nHead = nHead
+        self.nFeat = nFeat
+        self.headDim = nFeat / nHead
+        self.attnScale = Float(1.0 / Foundation.sqrt(Double(nFeat / nHead)))
+        self._linearQ.wrappedValue = Linear(nFeat, nFeat, bias: bias)
+        self._linearK.wrappedValue = Linear(nFeat, nFeat, bias: bias)
+        self._linearV.wrappedValue = Linear(nFeat, nFeat, bias: bias)
+        self._linearOut.wrappedValue = Linear(nFeat, nFeat, bias: bias)
+        self._linearPos.wrappedValue = Linear(nFeat, nFeat, bias: false)
+        self._posBiasU.wrappedValue = MLXArray.zeros([nHead, nFeat / nHead])
+        self._posBiasV.wrappedValue = MLXArray.zeros([nHead, nFeat / nHead])
+    }
+
+    /// Transformer-XL relative shift: (B, H, Tq, P) → same shape, rows realigned.
+    func relShift(_ x: MLXArray) -> MLXArray {
+        let B = x.dim(0), H = x.dim(1), Tq = x.dim(2), P = x.dim(3)
+        var y = MLX.padded(x, widths: [.init((0, 0)), .init((0, 0)), .init((0, 0)), .init((1, 0))])
+        y = y.reshaped([B, H, P + 1, Tq])
+        y = y[0..., 0..., 1..., 0...]
+        return y.reshaped([B, H, Tq, P])
+    }
+
+    /// Self-attention over `x` with an additive mask.
+    public func callAsFunction(_ x: MLXArray, posEmb: MLXArray, mask: MLXArray?) -> MLXArray {
+        attend(query: x, keyValue: x, posEmb: posEmb, mask: mask)
+    }
+
+    /// Cache-aware step: `query` (the new chunk) attends to `keyValue`
+    /// (cache + chunk). No mask — the window IS the allowed context.
+    public func stream(query: MLXArray, keyValue: MLXArray, posEmb: MLXArray) -> MLXArray {
+        attend(query: query, keyValue: keyValue, posEmb: posEmb, mask: nil)
+    }
+
+    private func attend(
+        query: MLXArray, keyValue: MLXArray, posEmb: MLXArray, mask: MLXArray?
+    ) -> MLXArray {
+        let B = query.dim(0), Tq = query.dim(1)
+        let Tk = keyValue.dim(1)
+        let q = linearQ(query).reshaped([B, Tq, nHead, headDim])
+        let k = linearK(keyValue).reshaped([B, Tk, nHead, headDim]).transposed(0, 2, 1, 3)
+        let v = linearV(keyValue).reshaped([B, Tk, nHead, headDim]).transposed(0, 2, 1, 3)
+        let p = linearPos(posEmb)
+        let P = p.dim(1)
+        let pT = p.reshaped([p.dim(0), P, nHead, headDim]).transposed(0, 2, 1, 3)
+
+        let qU = (q + posBiasU).transposed(0, 2, 1, 3)
+        let qV = (q + posBiasV).transposed(0, 2, 1, 3)
+
+        var matrixBD = MLX.matmul(qV, pT.transposed(0, 1, 3, 2))
+        matrixBD = relShift(matrixBD)
+        matrixBD = matrixBD[0..., 0..., 0..., 0 ..< Tk] * MLXArray(attnScale)
+        if let mask {
+            matrixBD = matrixBD + mask
+        }
+
+        let o = MLXFast.scaledDotProductAttention(
+            queries: qU, keys: k, values: v, scale: attnScale, mask: matrixBD)
+        return linearOut(o.transposed(0, 2, 1, 3).reshaped([B, Tq, nFeat]))
+    }
+}
+
+/// linear1 → SiLU → linear2, `use_bias: false` on this checkpoint.
+public class VoiceChatFeedForward: Module, UnaryLayer {
+    @ModuleInfo(key: "linear1") var linear1: Linear
+    @ModuleInfo(key: "linear2") var linear2: Linear
+
+    public init(dModel: Int, dFF: Int, bias: Bool) {
+        self._linear1.wrappedValue = Linear(dModel, dFF, bias: bias)
+        self._linear2.wrappedValue = Linear(dFF, dModel, bias: bias)
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        linear2(silu(linear1(x)))
+    }
+}
+
+/// Conv module: GLU pointwise → CAUSAL depthwise → LayerNorm → SiLU → pointwise.
+///
+/// 🚨 The normaliser is a LayerNorm stored under the key `batch_norm` — NeMo
+/// keeps the historical name so checkpoint keys line up. LayerNorm (not
+/// BatchNorm) is what makes the module chunk-invariant: it normalises each
+/// frame against itself instead of against whole-utterance running statistics.
+public class VoiceChatConformerConvolution: Module {
+    let kernelSize: Int
+    /// Left-only padding: output at t reads inputs ≤ t, never the future.
+    let padLeft: Int
+
+    @ModuleInfo(key: "pointwise_conv1") var pointwiseConv1: Conv1d
+    @ModuleInfo(key: "depthwise_conv") var depthwiseConv: Conv1d
+    @ModuleInfo(key: "batch_norm") var batchNorm: LayerNorm
+    @ModuleInfo(key: "pointwise_conv2") var pointwiseConv2: Conv1d
+
+    /// Trailing `K-1` input frames of the previous chunk (streaming only).
+    private var carry: MLXArray?
+
+    public init(dModel: Int, kernelSize: Int, bias: Bool) {
+        self.kernelSize = kernelSize
+        self.padLeft = kernelSize - 1
+        self._pointwiseConv1.wrappedValue = Conv1d(
+            inputChannels: dModel, outputChannels: 2 * dModel, kernelSize: 1, bias: bias)
+        self._depthwiseConv.wrappedValue = Conv1d(
+            inputChannels: dModel, outputChannels: dModel, kernelSize: kernelSize,
+            groups: dModel, bias: bias)
+        self._batchNorm.wrappedValue = LayerNorm(dimensions: dModel)
+        self._pointwiseConv2.wrappedValue = Conv1d(
+            inputChannels: dModel, outputChannels: dModel, kernelSize: 1, bias: bias)
+    }
+
+    public func resetState() { carry = nil }
+
+    public func callAsFunction(_ x: MLXArray, streaming: Bool = false) -> MLXArray {
+        var h = pointwiseConv1(x)
+        let parts = MLX.split(h, parts: 2, axis: -1)
+        h = parts[0] * MLX.sigmoid(parts[1])  // GLU
+
+        // Causal left context: carried tail when streaming, zeros at stream start.
+        let left: MLXArray
+        if streaming, let c = carry, c.dim(1) == padLeft {
+            left = c.asType(h.dtype)
+        } else {
+            left = MLXArray.zeros([h.dim(0), padLeft, h.dim(2)], dtype: h.dtype)
+        }
+        let padded = MLX.concatenated([left, h], axis: 1)
+        if streaming {
+            carry = padded[0..., (padded.dim(1) - padLeft)..., 0...]
+        }
+
+        h = depthwiseConv(padded)
+        h = batchNorm(h)
+        h = silu(h)
+        return pointwiseConv2(h)
+    }
+}
+
+/// One conformer block: ½FF → rel-pos MHA → conv → ½FF → LayerNorm.
+public class VoiceChatConformerBlock: Module {
+    @ModuleInfo(key: "norm_feed_forward1") var normFeedForward1: LayerNorm
+    @ModuleInfo(key: "feed_forward1") var feedForward1: VoiceChatFeedForward
+    @ModuleInfo(key: "norm_self_att") var normSelfAtt: LayerNorm
+    @ModuleInfo(key: "self_attn") var selfAttn: VoiceChatRelPositionAttention
+    @ModuleInfo(key: "norm_conv") var normConv: LayerNorm
+    @ModuleInfo(key: "conv") var conv: VoiceChatConformerConvolution
+    @ModuleInfo(key: "norm_feed_forward2") var normFeedForward2: LayerNorm
+    @ModuleInfo(key: "feed_forward2") var feedForward2: VoiceChatFeedForward
+    @ModuleInfo(key: "norm_out") var normOut: LayerNorm
+
+    public init(dModel: Int, nHeads: Int, ffExpansion: Int, convKernel: Int, bias: Bool) {
+        let dFF = dModel * ffExpansion
+        self._normFeedForward1.wrappedValue = LayerNorm(dimensions: dModel)
+        self._feedForward1.wrappedValue = VoiceChatFeedForward(dModel: dModel, dFF: dFF, bias: bias)
+        self._normSelfAtt.wrappedValue = LayerNorm(dimensions: dModel)
+        self._selfAttn.wrappedValue = VoiceChatRelPositionAttention(nHead: nHeads, nFeat: dModel, bias: bias)
+        self._normConv.wrappedValue = LayerNorm(dimensions: dModel)
+        self._conv.wrappedValue = VoiceChatConformerConvolution(
+            dModel: dModel, kernelSize: convKernel, bias: bias)
+        self._normFeedForward2.wrappedValue = LayerNorm(dimensions: dModel)
+        self._feedForward2.wrappedValue = VoiceChatFeedForward(dModel: dModel, dFF: dFF, bias: bias)
+        self._normOut.wrappedValue = LayerNorm(dimensions: dModel)
+    }
+
+    public func resetState() { conv.resetState() }
+
+    public func callAsFunction(
+        _ x: MLXArray, posEmb: MLXArray, mask: MLXArray?, streaming: Bool = false
+    ) -> MLXArray {
+        var x = x
+        x = x + 0.5 * feedForward1(normFeedForward1(x))
+        x = x + selfAttn(normSelfAtt(x), posEmb: posEmb, mask: mask)
+        x = x + conv(normConv(x), streaming: streaming)
+        x = x + 0.5 * feedForward2(normFeedForward2(x))
+        return normOut(x)
+    }
+}
+
+/// Depthwise-striding ×8 subsampling with CAUSAL (asymmetric) padding:
+/// left `K-1`, right `stride-1` on both time and frequency, matching NeMo's
+/// `CausalConv2D`. Symmetric padding here would read future audio and add
+/// silent latency to every emitted frame.
+public class VoiceChatCausalSubsampling: Module {
+    let samplingNum: Int
+    let kernelSize = 3
+    let stride = 2
+    let padLeft: Int
+    let padRight: Int
+    let outputFreq: Int
+    /// Indices of the stride-2 3×3 convs that receive causal padding.
+    let stridedIndices: Set<Int>
+
+    @ModuleInfo(key: "conv") var conv: [Module]
+    @ModuleInfo(key: "out") var out: Linear
+
+    public init(featIn: Int, channels: Int, subsamplingFactor: Int, dModel: Int) {
+        self.samplingNum = Int(Foundation.log2(Double(subsamplingFactor)).rounded())
+        self.padLeft = kernelSize - 1
+        self.padRight = stride - 1
+
+        var freq = featIn
+        for _ in 0 ..< samplingNum {
+            freq = (freq + padLeft + padRight - kernelSize) / stride + 1
+        }
+        self.outputFreq = freq
+
+        // NeMo layer indices: ReLU at 1 / 4 / 7 carry no parameters, so the
+        // parameterised entries land at conv.0, conv.2, conv.3, conv.5, conv.6.
+        var layers: [Module] = [
+            Conv2d(inputChannels: 1, outputChannels: channels, kernelSize: 3, stride: 2, padding: 0),
+            ReLU(),
+        ]
+        var strided: Set<Int> = [0]
+        for i in 0 ..< (samplingNum - 1) {
+            strided.insert(2 + 3 * i)
+            layers.append(
+                Conv2d(
+                    inputChannels: channels, outputChannels: channels, kernelSize: 3,
+                    stride: 2, padding: 0, groups: channels))
+            layers.append(
+                Conv2d(inputChannels: channels, outputChannels: channels, kernelSize: 1))
+            layers.append(ReLU())
+        }
+        self.stridedIndices = strided
+        self._conv.wrappedValue = layers
+        self._out.wrappedValue = Linear(channels * freq, dModel)
+    }
+
+    public func outputLength(_ length: Int) -> Int {
+        var length = length
+        for _ in 0 ..< samplingNum {
+            length = (length + padLeft + padRight - kernelSize) / stride + 1
+        }
+        return length
+    }
+
+    /// x: (B, T, F) mel frames → (B, T/8, dModel)
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = x.expandedDimensions(axis: -1)  // (B, T, F, 1) channels-last
+        for (i, layer) in conv.enumerated() {
+            if stridedIndices.contains(i) {
+                h = MLX.padded(
+                    h,
+                    widths: [
+                        .init((0, 0)),
+                        .init((padLeft, padRight)),  // time — causal
+                        .init((padLeft, padRight)),  // freq
+                        .init((0, 0)),
+                    ])
+            }
+            h = (layer as! UnaryLayer)(h)
+        }
+        // (B, T', F', C) → (B, T', C·F') channel-major, matching NeMo.
+        let B = h.dim(0), T = h.dim(1), F = h.dim(2), C = h.dim(3)
+        h = h.transposed(0, 1, 3, 2).reshaped([B, T, C * F])
+        return out(h)
+    }
+}
+
+/// The full 24-layer streaming FastConformer encoder.
+public class VoiceChatConformerEncoder: Module {
+    public let dModel: Int
+    public let leftContext: Int
+    public let rightContext: Int
+    public let posEnc: VoiceChatRelPositionalEncoding
+
+    @ModuleInfo(key: "pre_encode") var preEncode: VoiceChatCausalSubsampling
+    @ModuleInfo(key: "layers") var layers: [VoiceChatConformerBlock]
+
+    public init(_ config: VoiceChatEncoderConfiguration) {
+        self.dModel = config.dModel
+        self.leftContext = config.leftContextFrames ?? 70
+        self.rightContext = config.rightContextFrames ?? 0
+        self.posEnc = VoiceChatRelPositionalEncoding(
+            dModel: config.dModel,
+            maxLen: config.posEmbMaxLen ?? 5000,
+            scaleInput: config.xscaling ?? false)
+        self._preEncode.wrappedValue = VoiceChatCausalSubsampling(
+            featIn: config.featIn,
+            channels: config.subsamplingConvChannels,
+            subsamplingFactor: config.subsamplingFactor,
+            dModel: config.dModel)
+        self._layers.wrappedValue = (0 ..< config.nLayers).map { _ in
+            VoiceChatConformerBlock(
+                dModel: config.dModel,
+                nHeads: config.nHeads,
+                ffExpansion: config.ffExpansionFactor,
+                convKernel: config.convKernelSize,
+                bias: config.useBias ?? false)
+        }
+    }
+
+    public func resetState() {
+        for layer in layers { layer.resetState() }
+    }
+
+    /// Whole-sequence (mask-based) forward. `x`: (B, T, F) mel frames.
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var (h, posEmb) = posEnc(preEncode(x))
+        let mask = voiceChatChunkedLimitedMask(
+            sequenceLength: h.dim(1),
+            leftContext: leftContext,
+            rightContext: rightContext,
+            dtype: h.dtype)
+        for layer in layers {
+            h = layer(h, posEmb: posEmb, mask: mask, streaming: false)
+        }
+        return h
+    }
+}

--- a/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatKVCache.swift
+++ b/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatKVCache.swift
@@ -1,0 +1,111 @@
+// NemotronLabs VoiceChat — the KV cache the speech decoder runs on.
+//
+// 🚨 Why this exists rather than reusing the shared caches.
+//
+// The speech decoder's whole-sequence prefill matched the Python reference
+// exactly (cosine 1.0000), while its SINGLE-TOKEN decode step did not
+// (layer 0 cosine 0.9992, layer 1 0.8863, compounding to ~0.94 at the output).
+// That is the signature of a cache whose step read differs from the
+// reference's, and it renders as fluent-sounding babble: audio with healthy
+// RMS, dynamic range and zero-crossing rate that contains no words.
+//
+// The reference (`mlx_vlm.models.cache`) keeps its own `_offset`,
+// `left_padding` and `rotated` state and returns `keys[..., :_offset, :]` from
+// an in-place buffer. The shared Swift `RotatingKVCache` has different
+// bookkeeping, and `KVCacheSimple` grows in 256-row steps — so neither
+// reproduces the reference's step read here.
+//
+// For THIS model the distinction is moot in the only regime that occurs: a
+// turn is a few hundred frames against a 7500-frame window, so the reference's
+// rotating cache never rotates and is exactly a concatenating cache. This one
+// therefore concatenates, reports `offset` as the number of rows stored BEFORE
+// the current update (which is what the RoPE position must be), and returns
+// precisely the rows it holds — no padding, no reordering.
+
+import Foundation
+import MLX
+import MLXFast
+import MLXLMCommon
+
+/// Plain concatenating KV cache with reference-matching semantics.
+///
+/// Conforms to `KVCache` directly rather than subclassing `BaseKVCache`,
+/// whose initialiser is internal to MLXLMCommon.
+public class VoiceChatConcatKVCache: KVCache {
+    private var keys: MLXArray?
+    private var values: MLXArray?
+
+    public private(set) var offset: Int = 0
+    public var maxSize: Int? { nil }
+    public var isTrimmable: Bool { true }
+
+    public init() {}
+
+    public func innerState() -> [MLXArray] {
+        [keys, values].compactMap { $0 }
+    }
+
+    public func update(keys newKeys: MLXArray, values newValues: MLXArray) -> (
+        MLXArray, MLXArray
+    ) {
+        if let existingKeys = keys, let existingValues = values {
+            keys = MLX.concatenated([existingKeys, newKeys], axis: 2)
+            values = MLX.concatenated([existingValues, newValues], axis: 2)
+        } else {
+            keys = newKeys
+            values = newValues
+        }
+        // `offset` is read BEFORE the next update to position RoPE, so it must
+        // equal the number of rows already stored — exactly what the reference
+        // reports (`self.offset = self.keys.shape[-2]`).
+        offset = keys!.dim(2)
+        return (keys!, values!)
+    }
+
+    public var state: [MLXArray] {
+        get { [keys, values].compactMap { $0 } }
+        set {
+            guard newValue.count == 2 else {
+                keys = nil
+                values = nil
+                offset = 0
+                return
+            }
+            keys = newValue[0]
+            values = newValue[1]
+            offset = newValue[0].dim(2)
+        }
+    }
+
+    public var metaState: [String] {
+        get { [""] }
+        set { _ = newValue }
+    }
+
+    @discardableResult
+    public func trim(_ n: Int) -> Int {
+        guard let currentKeys = keys, let currentValues = values else { return 0 }
+        let trimmed = Swift.min(n, currentKeys.dim(2))
+        guard trimmed > 0 else { return 0 }
+        keys = currentKeys[.ellipsis, ..<(currentKeys.dim(2) - trimmed), 0...]
+        values = currentValues[.ellipsis, ..<(currentValues.dim(2) - trimmed), 0...]
+        offset -= trimmed
+        return trimmed
+    }
+
+    /// A single new token attends to everything held; a multi-token prefill is
+    /// causal. Matches what the reference builds for this backbone.
+    public func makeMask(
+        n: Int, windowSize: Int?, returnArray: Bool
+    ) -> MLXFast.ScaledDotProductAttentionMaskMode {
+        n <= 1 ? .none : .causal
+    }
+
+    public func copy() -> any KVCache {
+        let clone = VoiceChatConcatKVCache()
+        clone.keys = keys
+        clone.values = values
+        clone.offset = offset
+        return clone
+    }
+}

--- a/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatLoader.swift
+++ b/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatLoader.swift
@@ -1,0 +1,195 @@
+// NemotronLabs VoiceChat — load a shipped bundle (bf16 or quantized).
+//
+// 🚨 A quantized bundle must be `quantize`d BEFORE the weights land, using the
+// PER-MODULE map in `config.json["quantization"]`. That map is not uniform:
+// the published quants list 566 explicit module entries alongside the global
+// `group_size`/`bits`/`mode`, and any module ABSENT from it is a floating-point
+// passthrough. Quantizing everything uniformly destroys exactly the tensors
+// this model cannot afford to lose — the RVQ codebook, the speaker latent,
+// `mog_head.proj_mus` (read raw), and the character embedding table (its dtype
+// is read to allocate a buffer).
+
+import Foundation
+import MLX
+import MLXNN
+
+public enum VoiceChatLoadError: Error, LocalizedError {
+    case missingConfig(URL)
+    case noWeights(URL)
+    case weightUpdateFailed(Error)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingConfig(let url):
+            return "VoiceChat bundle has no config.json at \(url.path)"
+        case .noWeights(let url):
+            return "VoiceChat bundle has no .safetensors files in \(url.path)"
+        case .weightUpdateFailed(let error):
+            return "VoiceChat weight update failed: \(error)"
+        }
+    }
+}
+
+/// Per-module quantization recipe parsed from `config.json["quantization"]`.
+public struct VoiceChatQuantizationMap {
+    public let defaultGroupSize: Int
+    public let defaultBits: Int
+    public let defaultMode: QuantizationMode
+    /// Module path → recipe. A path ABSENT here is an fp passthrough.
+    public let perModule: [String: (groupSize: Int, bits: Int, mode: QuantizationMode)]
+
+    public init?(_ json: [String: Any]?) {
+        guard let json else { return nil }
+        let groupSize = json["group_size"] as? Int ?? 64
+        let bits = json["bits"] as? Int ?? 4
+        let mode =
+            (json["mode"] as? String).flatMap(QuantizationMode.init(rawValue:)) ?? .affine
+        var modules = [String: (groupSize: Int, bits: Int, mode: QuantizationMode)]()
+        for (key, value) in json {
+            guard let entry = value as? [String: Any] else { continue }
+            modules[key] = (
+                groupSize: entry["group_size"] as? Int ?? groupSize,
+                bits: entry["bits"] as? Int ?? bits,
+                mode: (entry["mode"] as? String).flatMap(QuantizationMode.init(rawValue:))
+                    ?? mode
+            )
+        }
+        guard !modules.isEmpty else { return nil }
+        self.defaultGroupSize = groupSize
+        self.defaultBits = bits
+        self.defaultMode = mode
+        self.perModule = modules
+    }
+
+    /// Recipe for `path`, or nil to leave the module in floating point.
+    public func recipe(for path: String)
+        -> (groupSize: Int, bits: Int, mode: QuantizationMode)?
+    {
+        perModule[path]
+    }
+
+    /// The quantization map is keyed by BUNDLE tensor paths, but the Swift
+    /// module tree renames several of them (see the sanitizers). Look-ups must
+    /// therefore go through the same remapping, or every entry misses and the
+    /// module is quantized with the global default instead of its own recipe —
+    /// which is a hard shape error at the first matmul on a mixed-bit bundle
+    /// like JANG, and silent quality loss on a uniform one.
+    ///
+    /// `VoiceChatQuantizationMapPathTests` pins this against the real bundles.
+    public static func modulePath(forBundlePath path: String) -> String {
+        var path = path
+        if path.hasPrefix("stt_model.embed_tokens") {
+            path = path.replacingOccurrences(
+                of: "stt_model.embed_tokens", with: "stt_model.llm.backbone.embeddings")
+        } else if path.hasPrefix("stt_model.lm_head") {
+            path = path.replacingOccurrences(
+                of: "stt_model.lm_head", with: "stt_model.llm.lm_head")
+        } else if path.hasPrefix("stt_model.llm.") {
+            path = path.replacingOccurrences(
+                of: "stt_model.llm.", with: "stt_model.llm.backbone.")
+        }
+        path = path.replacingOccurrences(of: ".joint_net.2", with: ".joint_net.out")
+        path = path.replacingOccurrences(
+            of: "prvq._variance_list.", with: "prvq.variance_list.")
+        return path
+    }
+
+    /// Recipe for a Swift module path, resolved through the bundle-path map.
+    public func recipe(forModulePath modulePath: String)
+        -> (groupSize: Int, bits: Int, mode: QuantizationMode)?
+    {
+        if let direct = perModule[modulePath] { return direct }
+        for (bundlePath, recipe) in perModule
+        where Self.modulePath(forBundlePath: bundlePath) == modulePath {
+            return recipe
+        }
+        return nil
+    }
+
+    /// Swift module path → recipe, precomputed once (the linear scan above is
+    /// fine for a lookup but not for 566 of them during a load).
+    public func remappedByModulePath()
+        -> [String: (groupSize: Int, bits: Int, mode: QuantizationMode)]
+    {
+        var out = [String: (groupSize: Int, bits: Int, mode: QuantizationMode)]()
+        for (bundlePath, recipe) in perModule {
+            out[Self.modulePath(forBundlePath: bundlePath)] = recipe
+        }
+        return out
+    }
+}
+
+public enum VoiceChatLoader {
+
+    /// Load a VoiceChat bundle from `directory`.
+    ///
+    /// Handles both the bf16 MLX layout and the published quants: the module
+    /// tree is built, quantized per the bundle's own map when one is present,
+    /// and only then updated with the sanitized weights.
+    public static func load(from directory: URL) throws -> (
+        model: NemotronVoiceChatModel, config: NemotronVoiceChatConfiguration
+    ) {
+        let dir = directory.resolvingSymlinksInPath()
+        let configURL = dir.appendingPathComponent("config.json")
+        guard FileManager.default.fileExists(atPath: configURL.path) else {
+            throw VoiceChatLoadError.missingConfig(configURL)
+        }
+        let configData = try Data(contentsOf: configURL)
+        let config = try JSONDecoder().decode(
+            NemotronVoiceChatConfiguration.self, from: configData)
+        let root = try JSONSerialization.jsonObject(with: configData) as? [String: Any]
+
+        var weights = [String: MLXArray]()
+        if let enumerator = FileManager.default.enumerator(
+            at: dir, includingPropertiesForKeys: nil)
+        {
+            for case let url as URL in enumerator where url.pathExtension == "safetensors" {
+                for (key, value) in try loadArrays(url: url) {
+                    weights[key] = value
+                }
+            }
+        }
+        guard !weights.isEmpty else { throw VoiceChatLoadError.noWeights(dir) }
+
+        let model = NemotronVoiceChatModel(config)
+        let sanitized = NemotronVoiceChatModel.sanitized(weights, config: config)
+
+        if let map = VoiceChatQuantizationMap(root?["quantization"] as? [String: Any]) {
+            // Quantize ONLY what the bundle says it quantized, with THAT
+            // module's own recipe. JANG bundles are mixed-bit per module, so
+            // falling back to the global default is not a mild approximation —
+            // it produces a packed-weight/scales shape mismatch on the first
+            // matmul. A module the map omits stays fp.
+            let recipes = map.remappedByModulePath()
+            quantize(
+                model: model,
+                filter: { path, _ in
+                    guard sanitized["\(path).scales"] != nil else { return nil }
+                    return recipes[path]
+                        ?? (
+                            groupSize: map.defaultGroupSize, bits: map.defaultBits,
+                            mode: map.defaultMode
+                        )
+                })
+        }
+
+        do {
+            try model.update(
+                parameters: ModuleParameters.unflattened(sanitized), verify: [.noUnusedKeys])
+        } catch {
+            throw VoiceChatLoadError.weightUpdateFailed(error)
+        }
+        MLX.eval(model)
+        return (model, config)
+    }
+
+    /// Cheap probe: does this directory hold a VoiceChat bundle?
+    public static func looksLikeVoiceChatBundle(at directory: URL) -> Bool {
+        let cfg = directory.appendingPathComponent("config.json")
+        guard FileManager.default.fileExists(atPath: cfg.path),
+            let data = try? Data(contentsOf: cfg),
+            let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return false }
+        return (json["model_type"] as? String) == "nemotron_voicechat"
+    }
+}

--- a/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatMel.swift
+++ b/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatMel.swift
@@ -1,0 +1,165 @@
+// NemotronLabs VoiceChat — the mel front-end.
+//
+// Matches NeMo's `AudioToMelSpectrogramPreprocessor` as this bundle configures
+// it, and the reference `mlx_audio.stt.models.nemotron_asr.audio`:
+//
+//   preemphasis 0.97 · symmetric Hann win_length 400 centre-padded to n_fft 512
+//   reflect-padded centred STFT, hop 160 · power spectrum (mag_power 2.0)
+//   Slaney mel filters, 128 bins · log(x + 2^-24)
+//   normalize "NA" — features are NOT normalised, which is what this model
+//   was trained with. Applying per-feature normalisation here would shift
+//   every encoder input and degrade ASR in a way nothing else reports.
+
+import Accelerate
+import Foundation
+import MLX
+
+/// Log-mel features for a mono 16 kHz waveform → (1, frames, 128).
+public func voiceChatLogMelSpectrogram(
+    _ waveform: [Float], config: VoiceChatPreprocessorConfiguration
+) -> MLXArray {
+    let sampleRate = config.sampleRate
+    let nFFT = config.nFFT
+    let winLength = Int((config.windowSize * Double(sampleRate)).rounded())
+    let hopLength = Int((config.windowStride * Double(sampleRate)).rounded())
+    let nMels = config.features
+    let preemph: Float = 0.97
+    let logGuard = Float(pow(2.0, -24.0))
+
+    // Preemphasis: y[n] = x[n] - 0.97 x[n-1].
+    var x = waveform
+    if x.count > 1 {
+        for i in stride(from: x.count - 1, to: 0, by: -1) {
+            x[i] = x[i] - preemph * x[i - 1]
+        }
+    }
+
+    // Hann(win_length) centre-padded to n_fft, matching torch.stft / NeMo.
+    var window = [Float](repeating: 0, count: nFFT)
+    let padLeft = (nFFT - winLength) / 2
+    for i in 0 ..< winLength {
+        window[padLeft + i] = Float(
+            0.5 - 0.5 * cos(2.0 * Double.pi * Double(i) / Double(winLength - 1)))
+    }
+
+    // Centred STFT with reflect padding.
+    let half = nFFT / 2
+    var padded = [Float]()
+    padded.reserveCapacity(x.count + nFFT)
+    for i in 0 ..< half {
+        padded.append(x[Swift.min(half - i, x.count - 1)])
+    }
+    padded.append(contentsOf: x)
+    for i in 0 ..< half {
+        padded.append(x[Swift.max(x.count - 2 - i, 0)])
+    }
+
+    let frames = Swift.max(1, (padded.count - nFFT) / hopLength + 1)
+    let bins = nFFT / 2 + 1
+    var power = [Float](repeating: 0, count: frames * bins)
+
+    let log2n = vDSP_Length(log2(Double(nFFT)))
+    guard let setup = vDSP_create_fftsetup(log2n, FFTRadix(kFFTRadix2)) else {
+        return MLXArray.zeros([1, frames, nMels])
+    }
+    defer { vDSP_destroy_fftsetup(setup) }
+
+    var realPart = [Float](repeating: 0, count: half)
+    var imagPart = [Float](repeating: 0, count: half)
+
+    for f in 0 ..< frames {
+        var frame = [Float](repeating: 0, count: nFFT)
+        let start = f * hopLength
+        for i in 0 ..< nFFT where start + i < padded.count {
+            frame[i] = padded[start + i] * window[i]
+        }
+        realPart.withUnsafeMutableBufferPointer { realBuffer in
+            imagPart.withUnsafeMutableBufferPointer { imagBuffer in
+                var split = DSPSplitComplex(
+                    realp: realBuffer.baseAddress!, imagp: imagBuffer.baseAddress!)
+                frame.withUnsafeBufferPointer { framePtr in
+                    framePtr.baseAddress!.withMemoryRebound(
+                        to: DSPComplex.self, capacity: half
+                    ) { complexPtr in
+                        vDSP_ctoz(complexPtr, 2, &split, 1, vDSP_Length(half))
+                    }
+                }
+                vDSP_fft_zrip(setup, &split, 1, log2n, FFTDirection(FFT_FORWARD))
+                // vDSP packs DC in realp[0] and Nyquist in imagp[0], and
+                // returns values scaled by 2.
+                let dc = split.realp[0] / 2
+                let nyquist = split.imagp[0] / 2
+                power[f * bins] = dc * dc
+                power[f * bins + bins - 1] = nyquist * nyquist
+                for k in 1 ..< half {
+                    let re = split.realp[k] / 2
+                    let im = split.imagp[k] / 2
+                    power[f * bins + k] = re * re + im * im
+                }
+            }
+        }
+    }
+
+    let filters = voiceChatSlaneyMelFilters(
+        sampleRate: sampleRate, nFFT: nFFT, nMels: nMels)
+    var mel = [Float](repeating: 0, count: frames * nMels)
+    for f in 0 ..< frames {
+        for m in 0 ..< nMels {
+            var sum: Float = 0
+            let row = filters[m]
+            for k in 0 ..< bins where row[k] != 0 {
+                sum += row[k] * power[f * bins + k]
+            }
+            mel[f * nMels + m] = Foundation.log(sum + logGuard)
+        }
+    }
+    return MLXArray(mel, [1, frames, nMels])
+}
+
+/// Slaney-normalised mel filterbank, (nMels, nFFT/2+1).
+func voiceChatSlaneyMelFilters(sampleRate: Int, nFFT: Int, nMels: Int) -> [[Float]] {
+    let bins = nFFT / 2 + 1
+    let fMin: Double = 0
+    let fMax = Double(sampleRate) / 2
+
+    func hzToMel(_ hz: Double) -> Double {
+        let fMinMel = 0.0, fSp = 200.0 / 3.0
+        let minLogHz = 1000.0, minLogMel = (minLogHz - 0.0) / fSp
+        let logStep = Foundation.log(6.4) / 27.0
+        return hz >= minLogHz
+            ? minLogMel + Foundation.log(hz / minLogHz) / logStep
+            : fMinMel + hz / fSp
+    }
+    func melToHz(_ mel: Double) -> Double {
+        let fSp = 200.0 / 3.0
+        let minLogHz = 1000.0, minLogMel = (minLogHz - 0.0) / fSp
+        let logStep = Foundation.log(6.4) / 27.0
+        return mel >= minLogMel
+            ? minLogHz * Foundation.exp(logStep * (mel - minLogMel))
+            : mel * fSp
+    }
+
+    let melMin = hzToMel(fMin), melMax = hzToMel(fMax)
+    let melPoints = (0 ... (nMels + 1)).map {
+        melToHz(melMin + (melMax - melMin) * Double($0) / Double(nMels + 1))
+    }
+    let fftFreqs = (0 ..< bins).map { Double($0) * Double(sampleRate) / Double(nFFT) }
+
+    var filters = [[Float]](repeating: [Float](repeating: 0, count: bins), count: nMels)
+    for m in 0 ..< nMels {
+        let left = melPoints[m], center = melPoints[m + 1], right = melPoints[m + 2]
+        // Slaney normalisation: unit AREA per filter, not unit peak.
+        let enorm = 2.0 / (right - left)
+        for k in 0 ..< bins {
+            let freq = fftFreqs[k]
+            var value = 0.0
+            if freq >= left && freq <= center, center > left {
+                value = (freq - left) / (center - left)
+            } else if freq > center && freq <= right, right > center {
+                value = (right - freq) / (right - center)
+            }
+            filters[m][k] = Float(value * enorm)
+        }
+    }
+    return filters
+}

--- a/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatRNNT.swift
+++ b/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatRNNT.swift
@@ -103,27 +103,46 @@ public class VoiceChatPredictNetwork: Module {
     }
 }
 
-/// NeMo `RNNTJoint` — enc/pred projections plus the output projection at
-/// `joint_net.2` (indices 0/1 are the activation and a dropout placeholder,
-/// which carry no parameters — the array shape preserves checkpoint keys).
+/// NeMo `RNNTJoint` — enc/pred projections plus the output projection stored
+/// at `joint_net.2`.
+///
+/// 🚨 Indices 0 and 1 of NeMo's `joint_net` are the activation and a dropout
+/// placeholder and carry NO parameters, so the checkpoint ships ONLY index 2.
+/// Modelling that as a Swift `[Module]` works for plain weight loading (MLX
+/// pads the missing indices with `.none`) but breaks `quantize`, which builds
+/// a module-children update keyed `{"2": …}` and cannot merge it into an
+/// array — a quantized bundle then dies at load. The slot is therefore named
+/// `out` and `VoiceChatRNNT.sanitized` rewrites `joint_net.2.…` onto it, with
+/// the activation applied inline: same math, same checkpoint tensors.
 public class VoiceChatJointNetwork: Module {
+    public class JointNet: Module {
+        @ModuleInfo(key: "out") var output: Linear
+
+        init(jointHidden: Int, numClasses: Int) {
+            self._output.wrappedValue = Linear(jointHidden, numClasses)
+        }
+    }
+
     public let numClassesWithBlank: Int
+    let activation: (MLXArray) -> MLXArray
 
     @ModuleInfo(key: "enc") var enc: Linear
     @ModuleInfo(key: "pred") var pred: Linear
-    @ModuleInfo(key: "joint_net") var jointNet: [Module]
+    @ModuleInfo(key: "joint_net") var jointNet: JointNet
 
     public init(config: VoiceChatRNNTJointConfiguration) {
         let jointHidden = config.jointHidden ?? 640
         let numClasses = (config.numClasses ?? 1024) + 1  // + blank
         self.numClassesWithBlank = numClasses
+        switch (config.activation ?? "relu").lowercased() {
+        case "sigmoid": self.activation = { MLX.sigmoid($0) }
+        case "tanh": self.activation = { MLX.tanh($0) }
+        default: self.activation = { relu($0) }
+        }
         self._enc.wrappedValue = Linear(config.encoderHidden ?? 1024, jointHidden)
         self._pred.wrappedValue = Linear(config.predHidden ?? 640, jointHidden)
-        self._jointNet.wrappedValue = [
-            ReLU(),
-            Identity(),
-            Linear(jointHidden, numClasses),
-        ]
+        self._jointNet.wrappedValue = JointNet(
+            jointHidden: jointHidden, numClasses: numClasses)
     }
 
     /// `encFrame` (B, T, encHidden) × `predOut` (B, U, predHidden)
@@ -131,11 +150,7 @@ public class VoiceChatJointNetwork: Module {
     public func callAsFunction(_ encFrame: MLXArray, _ predOut: MLXArray) -> MLXArray {
         let e = enc(encFrame).expandedDimensions(axis: 2)
         let p = pred(predOut).expandedDimensions(axis: 1)
-        var x = e + p
-        for layer in jointNet {
-            x = (layer as! UnaryLayer)(x)
-        }
-        return x
+        return jointNet.output(activation(e + p))
     }
 }
 
@@ -221,7 +236,12 @@ public enum VoiceChatRNNT {
         var converted = [String: MLXArray]()
         var biasParts = [String: [MLXArray]]()
 
-        for (key, value) in weights {
+        for (rawKey, value) in weights {
+            // NeMo's parameter-free joint_net indices 0/1 never ship; index 2
+            // is the output projection and lands on the named `out` slot (see
+            // VoiceChatJointNetwork).
+            let key = rawKey.replacingOccurrences(
+                of: ".joint_net.2.", with: ".joint_net.out.")
             guard key.contains(".dec_rnn.lstm.") else {
                 converted[key] = value
                 continue

--- a/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatRNNT.swift
+++ b/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatRNNT.swift
@@ -1,0 +1,248 @@
+// NemotronLabs VoiceChat — RNN-T prediction network, joint network, and the
+// greedy streaming transducer decode.
+//
+// Mirrors `mlx_audio.stt.models.nemotron_asr.rnnt` (NeMo `RNNTDecoder` /
+// `RNNTJoint` layout) so checkpoint keys map directly:
+//
+//   rnnt_decoder.prediction.embed.weight
+//   rnnt_decoder.prediction.dec_rnn.lstm.{i}.{Wx,Wh,bias}
+//   rnnt_joint.enc.{weight,bias} · rnnt_joint.pred.{weight,bias}
+//   rnnt_joint.joint_net.2.{weight,bias}
+//
+// 🚨 The published bundles store the LSTM in RAW PyTorch layout
+// (`weight_ih_l{i}`, `weight_hh_l{i}`, `bias_ih_l{i}` + `bias_hh_l{i}`).
+// `VoiceChatRNNT.sanitized(_:)` converts: ih→Wx, hh→Wh, and the TWO bias
+// vectors SUM into one (PyTorch keeps them separate; MLX folds them).
+// Skipping the sum silently halves the recurrent bias.
+//
+// RNN-T decodes on a different algorithm from AR language decode: for each
+// encoder frame the joint proposes a token; blank (id 1024 — one PAST the
+// 1024-entry vocabulary, not a member of it) advances to the next frame,
+// a non-blank token is emitted and re-fed to the prediction network WITHOUT
+// advancing the frame, at most `max_symbols` (10) times per frame. The
+// prediction state advances only on emission, so decode state must be carried
+// across chunks for streaming ASR to equal whole-utterance ASR.
+
+import Foundation
+import MLX
+import MLXNN
+
+/// Multi-layer LSTM stack, one `MLXNN.LSTM` per layer under `lstm.{i}`.
+public class VoiceChatLSTMStack: Module {
+    public let hiddenSize: Int
+    public let numLayers: Int
+
+    @ModuleInfo(key: "lstm") var lstm: [LSTM]
+
+    public init(inputSize: Int, hiddenSize: Int, numLayers: Int) {
+        self.hiddenSize = hiddenSize
+        self.numLayers = numLayers
+        self._lstm.wrappedValue = (0 ..< numLayers).map { i in
+            LSTM(inputSize: i == 0 ? inputSize : hiddenSize, hiddenSize: hiddenSize)
+        }
+    }
+
+    /// Step the stack over `x` (B, L, D) with optional carried per-layer state.
+    /// Returns the top-layer hidden sequence and next per-layer (h, c).
+    public func callAsFunction(
+        _ x: MLXArray, state: (h: [MLXArray], c: [MLXArray])?
+    ) -> (MLXArray, (h: [MLXArray], c: [MLXArray])) {
+        var seq = x
+        var nextH = [MLXArray]()
+        var nextC = [MLXArray]()
+        for (i, layer) in lstm.enumerated() {
+            let (allH, allC) = layer(seq, hidden: state?.h[i], cell: state?.c[i])
+            seq = allH
+            nextH.append(allH[.ellipsis, -1, 0...])
+            nextC.append(allC[.ellipsis, -1, 0...])
+        }
+        return (seq, (nextH, nextC))
+    }
+}
+
+/// NeMo `RNNTDecoder` — embedding + LSTM over previously emitted tokens.
+public class VoiceChatPredictNetwork: Module {
+    public class Prediction: Module {
+        @ModuleInfo(key: "embed") var embed: Embedding
+        @ModuleInfo(key: "dec_rnn") var decRNN: VoiceChatLSTMStack
+
+        init(vocab: Int, hidden: Int, layers: Int) {
+            self._embed.wrappedValue = Embedding(embeddingCount: vocab, dimensions: hidden)
+            self._decRNN.wrappedValue = VoiceChatLSTMStack(
+                inputSize: hidden, hiddenSize: hidden, numLayers: layers)
+        }
+    }
+
+    public let predHidden: Int
+
+    @ModuleInfo(key: "prediction") var prediction: Prediction
+
+    public init(config: VoiceChatRNNTDecoderConfiguration) {
+        let hidden = config.predHidden ?? 640
+        let layers = config.predRNNLayers ?? 2
+        // `blank_as_pad: true` — the embedding table has one extra row so the
+        // blank id can be fed as a start-of-sequence pad.
+        let vocab = (config.vocabSize ?? 1024) + ((config.blankAsPad ?? true) ? 1 : 0)
+        self.predHidden = hidden
+        self._prediction.wrappedValue = Prediction(vocab: vocab, hidden: hidden, layers: layers)
+    }
+
+    /// Step over token ids `y` (B, L); `y == nil` is the start-of-stream input
+    /// (a zeros embedding, matching the reference).
+    public func callAsFunction(
+        _ y: MLXArray?, state: (h: [MLXArray], c: [MLXArray])?
+    ) -> (MLXArray, (h: [MLXArray], c: [MLXArray])) {
+        let embedded: MLXArray
+        if let y {
+            embedded = prediction.embed(y)
+        } else {
+            let batch = state?.h.first?.dim(0) ?? 1
+            embedded = MLXArray.zeros([batch, 1, predHidden])
+        }
+        return prediction.decRNN(embedded, state: state)
+    }
+}
+
+/// NeMo `RNNTJoint` — enc/pred projections plus the output projection at
+/// `joint_net.2` (indices 0/1 are the activation and a dropout placeholder,
+/// which carry no parameters — the array shape preserves checkpoint keys).
+public class VoiceChatJointNetwork: Module {
+    public let numClassesWithBlank: Int
+
+    @ModuleInfo(key: "enc") var enc: Linear
+    @ModuleInfo(key: "pred") var pred: Linear
+    @ModuleInfo(key: "joint_net") var jointNet: [Module]
+
+    public init(config: VoiceChatRNNTJointConfiguration) {
+        let jointHidden = config.jointHidden ?? 640
+        let numClasses = (config.numClasses ?? 1024) + 1  // + blank
+        self.numClassesWithBlank = numClasses
+        self._enc.wrappedValue = Linear(config.encoderHidden ?? 1024, jointHidden)
+        self._pred.wrappedValue = Linear(config.predHidden ?? 640, jointHidden)
+        self._jointNet.wrappedValue = [
+            ReLU(),
+            Identity(),
+            Linear(jointHidden, numClasses),
+        ]
+    }
+
+    /// `encFrame` (B, T, encHidden) × `predOut` (B, U, predHidden)
+    /// → logits (B, T, U, classes+blank).
+    public func callAsFunction(_ encFrame: MLXArray, _ predOut: MLXArray) -> MLXArray {
+        let e = enc(encFrame).expandedDimensions(axis: 2)
+        let p = pred(predOut).expandedDimensions(axis: 1)
+        var x = e + p
+        for layer in jointNet {
+            x = (layer as! UnaryLayer)(x)
+        }
+        return x
+    }
+}
+
+/// Carried greedy-decode state: the prediction network's LSTM state and the
+/// last emitted token. Advances ONLY on non-blank emission, so it must be
+/// threaded across chunks — resetting it at a chunk boundary silently degrades
+/// streaming ASR relative to whole-utterance ASR.
+public struct VoiceChatRNNTDecodeState {
+    public var lstm: (h: [MLXArray], c: [MLXArray])?
+    public var lastToken: Int?
+    /// Cached prediction output for the current state (recomputed on emission).
+    var predOut: MLXArray?
+
+    public init() {
+        self.lstm = nil
+        self.lastToken = nil
+        self.predOut = nil
+    }
+}
+
+/// The transducer pair plus the greedy streaming decode loop.
+public enum VoiceChatRNNT {
+
+    /// Greedy decode of `encoded` (B=1, T, encHidden) continuing from `state`.
+    /// Returns emitted token ids and the advanced state.
+    ///
+    /// `maxSymbols` (10 on this bundle) bounds emissions per frame so a
+    /// pathological joint cannot loop forever on one frame.
+    public static func greedyDecode(
+        encoded: MLXArray,
+        decoder: VoiceChatPredictNetwork,
+        joint: VoiceChatJointNetwork,
+        blankId: Int,
+        maxSymbols: Int,
+        state: inout VoiceChatRNNTDecodeState
+    ) -> [Int] {
+        var emitted = [Int]()
+        let T = encoded.dim(1)
+
+        // Prediction output for the current state: zeros-input at stream start,
+        // else the cached output from the last emission.
+        var predOut: MLXArray
+        if let cached = state.predOut {
+            // Resuming mid-stream: the cached output corresponds exactly to
+            // the carried LSTM state, so chunked decode == whole-utterance.
+            predOut = cached
+        } else {
+            // Start of stream: NeMo's greedy loop computes the SOS step from a
+            // zeros embedding and DOES carry the resulting LSTM state.
+            let (out, newState) = decoder(
+                state.lastToken.map { MLXArray([Int32($0)]).reshaped([1, 1]) },
+                state: state.lstm)
+            state.lstm = newState
+            predOut = out
+        }
+
+        for t in 0 ..< T {
+            let frame = encoded[0..., t ..< (t + 1), 0...]
+            var symbols = 0
+            while symbols < maxSymbols {
+                let logits = joint(frame, predOut)  // (1, 1, 1, C)
+                let token = logits.reshaped([-1]).argMax().item(Int.self)
+                if token == blankId {
+                    break
+                }
+                emitted.append(token)
+                state.lastToken = token
+                let (out, newState) = decoder(
+                    MLXArray([Int32(token)]).reshaped([1, 1]), state: state.lstm)
+                state.lstm = newState
+                predOut = out
+                symbols += 1
+            }
+        }
+
+        state.predOut = predOut
+        return emitted
+    }
+
+    /// Convert the raw PyTorch LSTM tensor layout the published bundles ship
+    /// into the module layout above. Non-LSTM keys pass through untouched.
+    public static func sanitized(_ weights: [String: MLXArray]) -> [String: MLXArray] {
+        var converted = [String: MLXArray]()
+        var biasParts = [String: [MLXArray]]()
+
+        for (key, value) in weights {
+            guard key.contains(".dec_rnn.lstm.") else {
+                converted[key] = value
+                continue
+            }
+            let pieces = key.components(separatedBy: ".dec_rnn.lstm.")
+            let stem = pieces[0] + ".dec_rnn.lstm"
+            let suffix = pieces[1]
+            if suffix.hasPrefix("weight_ih_l") {
+                converted["\(stem).\(suffix.dropFirst("weight_ih_l".count)).Wx"] = value
+            } else if suffix.hasPrefix("weight_hh_l") {
+                converted["\(stem).\(suffix.dropFirst("weight_hh_l".count)).Wh"] = value
+            } else if suffix.hasPrefix("bias_ih_l") || suffix.hasPrefix("bias_hh_l") {
+                let layer = suffix.components(separatedBy: "_l").last ?? "0"
+                biasParts["\(stem).\(layer).bias", default: []].append(value)
+            } else {
+                converted[key] = value
+            }
+        }
+        for (key, parts) in biasParts {
+            converted[key] = parts.dropFirst().reduce(parts[0], +)
+        }
+        return converted
+    }
+}

--- a/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatSTTModel.swift
+++ b/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatSTTModel.swift
@@ -1,0 +1,160 @@
+// NemotronLabs VoiceChat — the fused STT side: perception (streaming Conformer
+// + projection), the nemotron_h backbone, BOTH output heads, and the RNN-T
+// transcription branch. Mirrors `DuplexSTTModel` in
+// `mlx_vlm/models/nemotron_voicechat/model.py`.
+//
+// 🚨 `function_head` is a FULL VOCAB-SIZED Linear (131072 × 4480 = 0.587 B —
+// the same shape as `lm_head`, and its measured Hessian trace is identical).
+// Tool calls are a weighted parallel output channel
+// (`function_channel_weight: 2.0`) decoded from their OWN logits, never parsed
+// out of the transcript. A runtime that reads only `lm_head` loses tool
+// calling silently — the model will still SAY it did things.
+//
+// Key layout notes (all verified against the shipped MLX bundle):
+//   * The bundle stores the backbone FLAT under `llm.` (`llm.layers.*`,
+//     `llm.norm_f.*`) with `embed_tokens`/`lm_head` as stt-level siblings.
+//     Swift's `NemotronHModel` nests everything under `backbone.` and owns its
+//     own embedding/head slots, so `sanitized(_:)` remaps:
+//       stt_model.llm.X                → stt_model.llm.backbone.X
+//       stt_model.embed_tokens.weight  → stt_model.llm.backbone.embeddings.weight
+//       stt_model.lm_head.weight       → stt_model.llm.lm_head.weight
+//   * Perception conv weights ship in PyTorch layout (O,C,H,W / O,C,K) and are
+//     transposed to MLX channels-last here, exactly like the reference
+//     `Model.sanitize`.
+//   * The RNN-T LSTM ships raw PyTorch keys; see `VoiceChatRNNT.sanitized`.
+//   * `perception.preprocessor.featurizer.{fb,window}` are deterministic mel
+//     buffers rebuilt by the front-end, dropped at load like the reference.
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import MLXNN
+
+/// One forward step's outputs: the shared hidden state and the two channels.
+public struct VoiceChatSTTOutput {
+    public let hiddenStates: MLXArray
+    /// `lm_head` logits — the agent's own speech/text channel.
+    public let textLogits: MLXArray
+    /// `function_head` logits — the tool-call channel. A separate head over
+    /// the SAME hidden state; consuming text logits alone drops tool calls.
+    public let functionLogits: MLXArray
+}
+
+/// Perception: streaming Conformer encoder + projection into the backbone
+/// hidden size (1024 → 4480; the config asserts the match at decode time).
+public class VoiceChatPerception: Module {
+    @ModuleInfo(key: "encoder") public var encoder: VoiceChatConformerEncoder
+    @ModuleInfo(key: "proj") var proj: Linear
+
+    public init(config: VoiceChatAudioConfiguration) {
+        self._encoder.wrappedValue = VoiceChatConformerEncoder(config.encoder)
+        self._proj.wrappedValue = Linear(config.encoder.dModel, config.outputDim, bias: true)
+    }
+
+    /// mel (B, T, F) → (projected (B, T/8, 4480), encoded (B, T/8, 1024)).
+    /// The unprojected encoding feeds the RNN-T joint, which was trained
+    /// against encoder width, not backbone width.
+    public func callAsFunction(_ mel: MLXArray) -> (projected: MLXArray, encoded: MLXArray) {
+        let encoded = encoder(mel)
+        return (proj(encoded), encoded)
+    }
+}
+
+/// The fused duplex STT model (everything under the bundle's `stt_model.`).
+public class VoiceChatSTTModel: Module {
+    public let config: NemotronVoiceChatConfiguration
+
+    @ModuleInfo(key: "llm") public var llm: NemotronHModel
+    @ModuleInfo(key: "function_head") var functionHead: Linear
+    @ModuleInfo(key: "perception") public var perception: VoiceChatPerception
+    @ModuleInfo(key: "rnnt_decoder") public var rnntDecoder: VoiceChatPredictNetwork
+    @ModuleInfo(key: "rnnt_joint") public var rnntJoint: VoiceChatJointNetwork
+
+    public init(_ config: NemotronVoiceChatConfiguration) {
+        self.config = config
+        self._llm.wrappedValue = NemotronHModel(config.textConfig)
+        self._functionHead.wrappedValue = Linear(
+            config.textConfig.hiddenSize, config.textConfig.vocabSize, bias: false)
+        self._perception.wrappedValue = VoiceChatPerception(config: config.audioConfig)
+        self._rnntDecoder.wrappedValue = VoiceChatPredictNetwork(
+            config: config.audioConfig.decoder
+                ?? VoiceChatRNNTDecoderConfiguration(
+                    predHidden: nil, predRNNLayers: nil, vocabSize: nil, blankAsPad: nil))
+        self._rnntJoint.wrappedValue = VoiceChatJointNetwork(
+            config: config.audioConfig.joint
+                ?? VoiceChatRNNTJointConfiguration(
+                    jointHidden: nil, numClasses: nil, encoderHidden: nil,
+                    predHidden: nil, activation: nil))
+    }
+
+    /// Token-id embedding via the backbone table (the bundle's
+    /// `embed_tokens` is remapped onto it at load).
+    public func embed(_ tokens: MLXArray) -> MLXArray {
+        llm.embedTokens(tokens)
+    }
+
+    /// One fused forward over pre-mixed embeddings: hidden once, both heads.
+    public func callAsFunction(inputsEmbeds: MLXArray, cache: [KVCache]?) -> VoiceChatSTTOutput {
+        let hidden = llm.hiddenStatesFromEmbeddings(inputsEmbeds, cache: cache)
+        return VoiceChatSTTOutput(
+            hiddenStates: hidden,
+            textLogits: llm.projectToLogits(hidden),
+            functionLogits: functionHead(hidden))
+    }
+
+    /// Fresh per-session backbone cache (Mamba + attention slots, per the
+    /// hybrid override pattern — the backbone builds its own layout).
+    public func makeCache() -> [KVCache] {
+        llm.newCache(parameters: nil)
+    }
+
+    /// Streaming ASR over already-encoded (UNPROJECTED) conformer frames.
+    public func transcribe(
+        encoded: MLXArray, state: inout VoiceChatRNNTDecodeState
+    ) -> [Int] {
+        VoiceChatRNNT.greedyDecode(
+            encoded: encoded,
+            decoder: rnntDecoder,
+            joint: rnntJoint,
+            blankId: config.rnntBlankId,
+            maxSymbols: config.audioConfig.maxSymbols,
+            state: &state)
+    }
+
+    /// Map the bundle's on-disk `stt_model.*` tensor layout onto this module
+    /// tree. Input keys arrive WITHOUT the `stt_model.` prefix.
+    public static func sanitized(_ weights: [String: MLXArray]) -> [String: MLXArray] {
+        var out = [String: MLXArray]()
+        for (key, value) in weights {
+            // Deterministic mel-filter/window buffers — rebuilt by the
+            // front-end, not model parameters.
+            if key.hasPrefix("perception.preprocessor.") { continue }
+
+            var key = key
+            var value = value
+
+            if key == "embed_tokens.weight" {
+                key = "llm.backbone.embeddings.weight"
+            } else if key == "lm_head.weight" {
+                key = "llm.lm_head.weight"
+            } else if key.hasPrefix("llm.") {
+                key = "llm.backbone." + key.dropFirst("llm.".count)
+            }
+
+            // PyTorch conv layouts → MLX channels-last, as in the reference:
+            // 2D perception convs (O,C,H,W) → (O,H,W,C); 1D perception convs
+            // and the backbone mamba conv1d (O,C,K) → (O,K,C).
+            if key.hasPrefix("perception."), value.ndim == 4 {
+                value = value.transposed(0, 2, 3, 1)
+            } else if value.ndim == 3,
+                key.hasPrefix("perception.") || (key.contains("llm.") && key.contains(".conv1d.weight"))
+            {
+                value = value.transposed(0, 2, 1)
+            }
+
+            out[key] = value
+        }
+        return VoiceChatRNNT.sanitized(out)
+    }
+}

--- a/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatSTTModel.swift
+++ b/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatSTTModel.swift
@@ -134,10 +134,14 @@ public class VoiceChatSTTModel: Module {
             var key = key
             var value = value
 
-            if key == "embed_tokens.weight" {
-                key = "llm.backbone.embeddings.weight"
-            } else if key == "lm_head.weight" {
-                key = "llm.lm_head.weight"
+            // Prefix (not exact `.weight`) matches: a QUANTIZED bundle ships
+            // `.scales` and `.biases` beside every packed `.weight`, and
+            // matching only the weight leaves those two behind as unhandled
+            // keys — the load then fails on the strict update.
+            if key.hasPrefix("embed_tokens.") {
+                key = "llm.backbone.embeddings." + key.dropFirst("embed_tokens.".count)
+            } else if key.hasPrefix("lm_head.") {
+                key = "llm.lm_head." + key.dropFirst("lm_head.".count)
             } else if key.hasPrefix("llm.") {
                 key = "llm.backbone." + key.dropFirst("llm.".count)
             }

--- a/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatSpeechDecoder.swift
+++ b/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatSpeechDecoder.swift
@@ -1,0 +1,82 @@
+// NemotronLabs VoiceChat — the speech side assembled: codec + EAR-TTS +
+// speaker prompt latents. Port of `SpeechDecoder` in tts.py, and the
+// counterpart to `VoiceChatSTTModel` on the listening side.
+//
+// 🚨 Speaker identity is a LEARNED LATENT (`audio_prompt_latents.Aria`,
+// [1, 37, 1152] = 83 KiB), not something baked into the weights. That is what
+// makes custom voices (the Dinoki avatar) a matter of installing another
+// latent rather than retraining — and it is why the tensor must stay fp and
+// byte-exact through any quantization.
+
+import Foundation
+import MLX
+import MLXNN
+
+/// Named speaker prompt latents. The checkpoint ships `Aria`; additional
+/// voices are additional keys of the same shape.
+public class VoiceChatPromptLatents: Module {
+    @ParameterInfo(key: "Aria") public var aria: MLXArray
+
+    public init(hiddenSize: Int, frames: Int = 37) {
+        self._aria.wrappedValue = MLXArray.zeros([1, frames, hiddenSize])
+    }
+}
+
+/// Everything under the bundle's `tts_model.` prefix.
+public class VoiceChatSpeechDecoder: Module {
+    public let ttsConfig: VoiceChatTTSConfiguration
+    public let codecConfig: VoiceChatCodecConfiguration
+
+    @ModuleInfo(key: "audio_codec") public var audioCodec: VoiceChatCodec
+    /// Doubled name is the checkpoint's own: `tts_model.tts_model.*`.
+    @ModuleInfo(key: "tts_model") public var ttsModel: VoiceChatRVQEARTTSModel
+    @ParameterInfo(key: "control_codes") var controlCodes: MLXArray
+    @ModuleInfo(key: "audio_prompt_latents") public var audioPromptLatents: VoiceChatPromptLatents
+    @ParameterInfo(key: "codec_silence_tokens") public var codecSilenceTokens: MLXArray
+
+    public init(tts: VoiceChatTTSConfiguration, codec: VoiceChatCodecConfiguration) {
+        self.ttsConfig = tts
+        self.codecConfig = codec
+        self._audioCodec.wrappedValue = VoiceChatCodec(codec)
+        self._ttsModel.wrappedValue = VoiceChatRVQEARTTSModel(tts)
+        self._controlCodes.wrappedValue = MLXArray.zeros([3], dtype: .int32)
+        self._audioPromptLatents.wrappedValue = VoiceChatPromptLatents(
+            hiddenSize: tts.hiddenSize)
+        self._codecSilenceTokens.wrappedValue = MLXArray.zeros(
+            [tts.numQuantizers], dtype: .int32)
+    }
+
+    /// Render one step of generated codes to 22.05 kHz audio.
+    ///
+    /// `cache` MUST be carried across steps for live speech: it holds every
+    /// causal conv tail plus the iSTFT overlap frames, and without it each
+    /// chunk restarts from zeros and clicks at the seam.
+    public func renderCodes(
+        _ codes: MLXArray, cache: VoiceChatCausalConv1dCache? = nil, flush: Bool = false
+    ) -> MLXArray {
+        audioCodec.decode(codes, cache: cache, flush: flush)
+    }
+
+    /// Map the bundle's on-disk `tts_model.*` layout onto this module tree.
+    /// Input keys arrive WITHOUT the `tts_model.` prefix.
+    public static func sanitized(
+        _ weights: [String: MLXArray], codecConfig: VoiceChatCodecConfiguration
+    ) -> [String: MLXArray] {
+        var direct = [String: MLXArray]()
+        var codec = [String: MLXArray]()
+
+        for (key, value) in weights {
+            if key == "_control_codes" {
+                direct["control_codes"] = value
+            } else if key.hasPrefix("audio_codec.") {
+                codec[String(key.dropFirst("audio_codec.".count))] = value
+            } else {
+                direct[key] = value
+            }
+        }
+        for (key, value) in VoiceChatCodec.sanitized(codec, config: codecConfig) {
+            direct["audio_codec.\(key)"] = value
+        }
+        return direct
+    }
+}

--- a/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatTTS.swift
+++ b/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatTTS.swift
@@ -18,7 +18,6 @@
 
 import Foundation
 import MLX
-import MLXFast
 import MLXLMCommon
 import MLXNN
 import MLXRandom
@@ -130,6 +129,12 @@ public class VoiceChatMoGHead: Module {
         self._lowMat.wrappedValue = MLXArray.zeros([predictions, outSize, rank])
     }
 
+    /// `VMLX_VOICECHAT_MOG_ARGMAX=1` replaces the Gumbel draw with an argmax
+    /// over the mixture logits — a diagnostic arm for isolating sampling bugs
+    /// from head bugs.
+    static let deterministicComponent =
+        ProcessInfo.processInfo.environment["VMLX_VOICECHAT_MOG_ARGMAX"] == "1"
+
     /// - Returns: (sampled latent residual mean, log-std)
     public func infer(
         _ input: MLXArray, guidanceScale: Float, topP: Float
@@ -149,10 +154,18 @@ public class VoiceChatMoGHead: Module {
 
         let b = x.dim(0), t = x.dim(1)
         let logits = voiceChatTopPLogits(projLogits(x), topP: topP)
-        let uniform = MLXRandom.uniform(low: 0.0, high: 1.0, logits.shape)
-        let gumbel = -MLX.log(-MLX.log(uniform + 1e-8) + 1e-8)
-        let component = MLX.argMax(
-            MLX.log(MLX.softmax(logits.asType(.float32), axis: -1)) + gumbel, axis: -1)
+        let component: MLXArray
+        if Self.deterministicComponent {
+            // Diagnostic arm: pick the most likely mixture component instead of
+            // sampling one. If speech becomes intelligible only here, the fault
+            // is in the nucleus filter or the Gumbel draw, not in the head.
+            component = MLX.argMax(logits.asType(.float32), axis: -1)
+        } else {
+            let uniform = MLXRandom.uniform(low: 0.0, high: 1.0, logits.shape)
+            let gumbel = -MLX.log(-MLX.log(uniform + 1e-8) + 1e-8)
+            component = MLX.argMax(
+                MLX.log(MLX.softmax(logits.asType(.float32), axis: -1)) + gumbel, axis: -1)
+        }
 
         let flatX = x.reshaped([-1, x.dim(-1)])
         let flatComponent = component.reshaped([-1])

--- a/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatTTS.swift
+++ b/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatTTS.swift
@@ -1,0 +1,448 @@
+// NemotronLabs VoiceChat — EAR-TTS speech decoder.
+//
+// Port of `mlx_vlm/models/nemotron_voicechat/tts.py`. Module hierarchy mirrors
+// the NeMo checkpoint exactly so the bundle's `tts_model.*` keys map 1:1 and
+// the per-module quantization map in published quants applies unchanged.
+//
+// 🚨 TWO RMSNorm conventions live in ONE model: the nemotron_h backbone uses
+// plain RMSNorm (applies `weight`), everything in THIS file uses
+// `VoiceChatOffsetRMSNorm` (Gemma-style, `1 + weight`). Getting this wrong
+// emptied text output while imatrix rel-err, a NaN scan, and ASR all read
+// healthy — trap #1, already paid for once.
+//
+// 🚨 fp-protected tensors (the loader must NEVER quantize or re-dtype them):
+//   rvq_embs                       RVQ codebook, read raw
+//   audio_prompt_latents.*         speaker identity
+//   mog_head.proj_mus.weight       read RAW and reshaped below
+//   embed_subword.embed_tokens     its dtype is read to allocate a buffer
+
+import Foundation
+import MLX
+import MLXFast
+import MLXLMCommon
+import MLXNN
+import MLXRandom
+
+/// Gemma-style RMSNorm: the learned weight is an offset from one.
+public class VoiceChatOffsetRMSNorm: Module, UnaryLayer {
+    @ParameterInfo(key: "weight") public var weight: MLXArray
+    public let eps: Float
+
+    public init(dimensions: Int, eps: Float = 1e-6) {
+        self._weight.wrappedValue = MLXArray.zeros([dimensions])
+        self.eps = eps
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let dtype = x.dtype
+        let x32 = x.asType(.float32)
+        return MLXFast.rmsNorm(x32, weight: 1.0 + weight.asType(.float32), eps: eps)
+            .asType(dtype)
+    }
+}
+
+/// gate/up/down MLP with approximate GELU (matches `nn.gelu_approx`).
+public class VoiceChatTTSMLP: Module, UnaryLayer {
+    @ModuleInfo(key: "gate_proj") var gateProj: Linear
+    @ModuleInfo(key: "up_proj") var upProj: Linear
+    @ModuleInfo(key: "down_proj") var downProj: Linear
+
+    public init(hiddenSize: Int, intermediateSize: Int) {
+        self._gateProj.wrappedValue = Linear(hiddenSize, intermediateSize, bias: false)
+        self._upProj.wrappedValue = Linear(hiddenSize, intermediateSize, bias: false)
+        self._downProj.wrappedValue = Linear(intermediateSize, hiddenSize, bias: false)
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        downProj(geluApproximate(gateProj(x)) * upProj(x))
+    }
+}
+
+/// pre_norm → mlp → post_norm residual block (MoG head stack element).
+public class VoiceChatMLPLayer: Module, UnaryLayer {
+    @ModuleInfo(key: "pre_norm") var preNorm: VoiceChatOffsetRMSNorm
+    @ModuleInfo(key: "mlp") var mlp: VoiceChatTTSMLP
+    @ModuleInfo(key: "post_norm") var postNorm: VoiceChatOffsetRMSNorm
+
+    public init(hiddenSize: Int, intermediateSize: Int, eps: Float) {
+        self._preNorm.wrappedValue = VoiceChatOffsetRMSNorm(dimensions: hiddenSize, eps: eps)
+        self._mlp.wrappedValue = VoiceChatTTSMLP(
+            hiddenSize: hiddenSize, intermediateSize: intermediateSize)
+        self._postNorm.wrappedValue = VoiceChatOffsetRMSNorm(dimensions: hiddenSize, eps: eps)
+    }
+
+    public func callAsFunction(_ x: MLXArray) -> MLXArray {
+        x + postNorm(mlp(preNorm(x)))
+    }
+}
+
+/// Nucleus filter. Keeps the smallest set of tokens whose probability mass
+/// reaches `topP`; everything else goes to -inf.
+func voiceChatTopPLogits(_ logits: MLXArray, topP: Float) -> MLXArray {
+    if topP >= 1.0 { return logits }
+    let probs = MLX.softmax(logits.asType(.float32), axis: -1)
+    let sorted = MLX.sorted(probs, axis: -1)  // ascending
+    let cumulative = MLX.cumsum(sorted, axis: -1)
+    let keepSorted = cumulative .> MLXArray(1.0 - topP)
+    // Smallest KEPT probability per row; comparing raw probs against it
+    // reproduces the kept set (ties may keep equal-probability extras, which
+    // is sampling-equivalent).
+    let minKept = MLX.min(MLX.where(keepSorted, sorted, MLXArray(Float(2))), axis: -1, keepDims: true)
+    return MLX.where(probs .>= minKept, logits, MLXArray(-Float.infinity))
+}
+
+/// Mixture-of-Gaussians head for continuous RVQ refinement.
+public class VoiceChatMoGHead: Module {
+    public let outSize: Int
+    public let lowRank: Int
+    public let numPredictions: Int
+    public let minLogStd: Float
+
+    @ModuleInfo(key: "mlp_stack") var mlpStack: [Module]
+    @ModuleInfo(key: "proj_logits") var projLogits: Linear
+    /// 🚨 Read RAW below (`weight.reshaped`), never through the Linear call —
+    /// must stay unquantized in every published bundle.
+    @ModuleInfo(key: "proj_mus") var projMus: Linear
+    @ModuleInfo(key: "proj_logs") var projLogs: Linear
+    @ModuleInfo(key: "proj_else") var projElse: Linear
+    @ParameterInfo(key: "low_mat") var lowMat: MLXArray
+
+    public init(hiddenSize: Int, outSize: Int, config: VoiceChatMoGConfiguration) {
+        let intermediate = config.intermediateSize ?? 4608
+        let eps = config.eps ?? 1e-6
+        let layers = config.numLayers ?? 3
+        let predictions = config.numPredictions ?? 1024
+        let rank = config.lowRank ?? 64
+        self.outSize = outSize
+        self.lowRank = rank
+        self.numPredictions = predictions
+        self.minLogStd = config.minLogStd ?? -4.0
+
+        var stack: [Module] = (0 ..< layers).map { _ in
+            VoiceChatMLPLayer(hiddenSize: hiddenSize, intermediateSize: intermediate, eps: eps)
+        }
+        stack.append(VoiceChatOffsetRMSNorm(dimensions: hiddenSize, eps: eps))
+        self._mlpStack.wrappedValue = stack
+        self._projLogits.wrappedValue = Linear(hiddenSize, predictions, bias: false)
+        self._projMus.wrappedValue = Linear(hiddenSize, predictions * rank, bias: false)
+        self._projLogs.wrappedValue = Linear(hiddenSize, 1, bias: false)
+        self._projElse.wrappedValue = Linear(hiddenSize, outSize, bias: false)
+        self._lowMat.wrappedValue = MLXArray.zeros([predictions, outSize, rank])
+    }
+
+    /// - Returns: (sampled latent residual mean, log-std)
+    public func infer(
+        _ input: MLXArray, guidanceScale: Float, topP: Float
+    ) -> (MLXArray, MLXArray) {
+        var x = input
+        for layer in mlpStack {
+            x = (layer as! UnaryLayer)(x)
+        }
+
+        if guidanceScale > 0 {
+            precondition(x.dim(0) % 2 == 0, "classifier-free guidance requires an even batch")
+            let half = x.dim(0) / 2
+            let cond = x[0 ..< half]
+            let uncond = x[half...]
+            x = cond + guidanceScale * (cond - uncond)
+        }
+
+        let b = x.dim(0), t = x.dim(1)
+        let logits = voiceChatTopPLogits(projLogits(x), topP: topP)
+        let uniform = MLXRandom.uniform(low: 0.0, high: 1.0, logits.shape)
+        let gumbel = -MLX.log(-MLX.log(uniform + 1e-8) + 1e-8)
+        let component = MLX.argMax(
+            MLX.log(MLX.softmax(logits.asType(.float32), axis: -1)) + gumbel, axis: -1)
+
+        let flatX = x.reshaped([-1, x.dim(-1)])
+        let flatComponent = component.reshaped([-1])
+        // proj_mus RAW: (predictions*rank, hidden) → (predictions, rank, hidden)
+        let mus = projMus.weight.reshaped([numPredictions, lowRank, -1])[flatComponent]
+        var mu = MLX.matmul(mus, flatX.expandedDimensions(axis: -1)).squeezed(axis: -1)
+        let low = lowMat[flatComponent]
+        mu = MLX.matmul(low, mu.expandedDimensions(axis: -1)).squeezed(axis: -1)
+            .reshaped([b, t, outSize])
+        let residual = projElse(x)
+        let logs = MLX.maximum(projLogs(x), MLXArray(minLogStd))
+        return (mu * MLX.exp(logs) + residual, logs)
+    }
+}
+
+// MARK: - Character-aware subword conditioning
+
+/// T5Gemma self-attention with logit soft-capping (char encoder only).
+public class VoiceChatT5GemmaAttention: Module {
+    let nHeads: Int
+    let nKVHeads: Int
+    let headDim: Int
+    let repeats: Int
+    let attnScale: Float
+    let softcap: Float
+    let rope: RoPE
+
+    @ModuleInfo(key: "q_proj") var qProj: Linear
+    @ModuleInfo(key: "k_proj") var kProj: Linear
+    @ModuleInfo(key: "v_proj") var vProj: Linear
+    @ModuleInfo(key: "o_proj") var oProj: Linear
+
+    public init(config: VoiceChatCharacterEncoderConfiguration) {
+        let hidden = config.hiddenSize ?? 1152
+        self.nHeads = config.numAttentionHeads ?? 16
+        self.nKVHeads = config.numKeyValueHeads ?? 16
+        self.headDim = config.headDim ?? 72
+        self.repeats = nHeads / nKVHeads
+        self.attnScale = Float(1.0 / Foundation.sqrt(Double(config.queryPreAttnScalar ?? 256.0)))
+        self.softcap = config.attnLogitSoftcapping ?? 50.0
+        self.rope = RoPE(
+            dimensions: headDim, traditional: false, base: config.ropeBase ?? 10_000.0)
+        self._qProj.wrappedValue = Linear(hidden, nHeads * headDim, bias: false)
+        self._kProj.wrappedValue = Linear(hidden, nKVHeads * headDim, bias: false)
+        self._vProj.wrappedValue = Linear(hidden, nKVHeads * headDim, bias: false)
+        self._oProj.wrappedValue = Linear(nHeads * headDim, hidden, bias: false)
+    }
+
+    /// `mask`: (B, L) boolean validity, broadcast over heads/queries.
+    public func callAsFunction(_ x: MLXArray, mask: MLXArray?) -> MLXArray {
+        let b = x.dim(0), length = x.dim(1)
+        var q = qProj(x).reshaped([b, length, nHeads, -1]).transposed(0, 2, 1, 3)
+        var k = kProj(x).reshaped([b, length, nKVHeads, -1]).transposed(0, 2, 1, 3)
+        var v = vProj(x).reshaped([b, length, nKVHeads, -1]).transposed(0, 2, 1, 3)
+        q = rope(q)
+        k = rope(k)
+        if repeats > 1 {
+            k = MLX.repeated(k, count: repeats, axis: 1)
+            v = MLX.repeated(v, count: repeats, axis: 1)
+        }
+        var scores = MLX.matmul(q, k.transposed(0, 1, 3, 2)) * MLXArray(attnScale)
+        scores = MLX.tanh(scores / softcap) * softcap
+        if let mask {
+            let m = mask.reshaped([b, 1, 1, length])
+            scores = MLX.where(m, scores, MLXArray(Float(-1e30)))
+        }
+        let probs = MLX.softmax(scores.asType(.float32), axis: -1).asType(q.dtype)
+        let out = MLX.matmul(probs, v).transposed(0, 2, 1, 3).reshaped([b, length, -1])
+        return oProj(out)
+    }
+}
+
+public class VoiceChatT5GemmaLayer: Module {
+    @ModuleInfo(key: "self_attn") var selfAttn: VoiceChatT5GemmaAttention
+    @ModuleInfo(key: "pre_self_attn_layernorm") var preSelfAttn: VoiceChatOffsetRMSNorm
+    @ModuleInfo(key: "post_self_attn_layernorm") var postSelfAttn: VoiceChatOffsetRMSNorm
+    @ModuleInfo(key: "mlp") var mlp: VoiceChatTTSMLP
+    @ModuleInfo(key: "pre_feedforward_layernorm") var preFF: VoiceChatOffsetRMSNorm
+    @ModuleInfo(key: "post_feedforward_layernorm") var postFF: VoiceChatOffsetRMSNorm
+
+    public init(config: VoiceChatCharacterEncoderConfiguration) {
+        let hidden = config.hiddenSize ?? 1152
+        let eps = config.rmsNormEps ?? 1e-6
+        self._selfAttn.wrappedValue = VoiceChatT5GemmaAttention(config: config)
+        self._preSelfAttn.wrappedValue = VoiceChatOffsetRMSNorm(dimensions: hidden, eps: eps)
+        self._postSelfAttn.wrappedValue = VoiceChatOffsetRMSNorm(dimensions: hidden, eps: eps)
+        self._mlp.wrappedValue = VoiceChatTTSMLP(
+            hiddenSize: hidden, intermediateSize: config.intermediateSize ?? 4608)
+        self._preFF.wrappedValue = VoiceChatOffsetRMSNorm(dimensions: hidden, eps: eps)
+        self._postFF.wrappedValue = VoiceChatOffsetRMSNorm(dimensions: hidden, eps: eps)
+    }
+
+    public func callAsFunction(_ x: MLXArray, mask: MLXArray?) -> MLXArray {
+        var x = x + postSelfAttn(selfAttn(preSelfAttn(x), mask: mask))
+        x = x + postFF(mlp(preFF(x)))
+        return x
+    }
+}
+
+public class VoiceChatT5GemmaEncoder: Module {
+    @ModuleInfo(key: "layers") var layers: [VoiceChatT5GemmaLayer]
+    @ModuleInfo(key: "norm") var norm: VoiceChatOffsetRMSNorm
+    let inputScale: Float
+
+    public init(config: VoiceChatCharacterEncoderConfiguration) {
+        let hidden = config.hiddenSize ?? 1152
+        self._layers.wrappedValue = (0 ..< (config.numHiddenLayers ?? 1)).map { _ in
+            VoiceChatT5GemmaLayer(config: config)
+        }
+        self._norm.wrappedValue = VoiceChatOffsetRMSNorm(
+            dimensions: hidden, eps: config.rmsNormEps ?? 1e-6)
+        self.inputScale = Float(Foundation.sqrt(Double(hidden)))
+    }
+
+    public func callAsFunction(_ inputsEmbeds: MLXArray, mask: MLXArray?) -> MLXArray {
+        var x = inputsEmbeds * MLXArray(inputScale).asType(inputsEmbeds.dtype)
+        for layer in layers {
+            x = layer(x, mask: mask)
+        }
+        return norm(x)
+    }
+}
+
+/// Wrapper whose only purpose is the checkpoint's `backbone.encoder.` nesting.
+public class VoiceChatT5GemmaBackbone: Module {
+    @ModuleInfo(key: "encoder") var encoder: VoiceChatT5GemmaEncoder
+    public init(config: VoiceChatCharacterEncoderConfiguration) {
+        self._encoder.wrappedValue = VoiceChatT5GemmaEncoder(config: config)
+    }
+}
+
+/// Adds a learned "is-continuation" flag embedding per subword.
+public class VoiceChatSubwordFlagEmbedding: Module {
+    @ParameterInfo(key: "pad_tensor") var padTensor: MLXArray
+    @ParameterInfo(key: "is_continuation") var isContinuation: MLXArray
+    @ModuleInfo(key: "cont_emb") var contEmb: Embedding
+
+    public init(vocabSize: Int, hiddenSize: Int) {
+        self._padTensor.wrappedValue = MLXArray(Int32(vocabSize))
+        self._isContinuation.wrappedValue = MLXArray.zeros([vocabSize + 1], dtype: .int32)
+        self._contEmb.wrappedValue = Embedding(embeddingCount: 2, dimensions: hiddenSize)
+    }
+
+    public func callAsFunction(_ embeds: MLXArray, tokenIds: MLXArray) -> MLXArray {
+        let limit = isContinuation.dim(0) - 1
+        let safe = MLX.where(tokenIds .>= MLXArray(Int32(limit)), padTensor, tokenIds)
+        return embeds + contEmb(isContinuation[safe])
+    }
+}
+
+/// Adds BOS/EOS/none flag embeddings per subword.
+public class VoiceChatBOSEOSEmbedding: Module {
+    @ParameterInfo(key: "pad_tensor") var padTensor: MLXArray
+    @ParameterInfo(key: "special_flags") var specialFlags: MLXArray
+    @ModuleInfo(key: "special_emb") var specialEmb: Embedding
+
+    public init(vocabSize: Int, hiddenSize: Int) {
+        // The source stores max(vocab.values()), not vocabulary length.
+        self._padTensor.wrappedValue = MLXArray(Int32(vocabSize - 1))
+        self._specialFlags.wrappedValue = MLXArray.zeros([vocabSize], dtype: .int32)
+        self._specialEmb.wrappedValue = Embedding(embeddingCount: 3, dimensions: hiddenSize)
+    }
+
+    public func callAsFunction(_ embeds: MLXArray, tokenIds: MLXArray) -> MLXArray {
+        let limit = specialFlags.dim(0)
+        let safe = MLX.where(tokenIds .>= MLXArray(Int32(limit)), padTensor, tokenIds)
+        return embeds + specialEmb(specialFlags[safe])
+    }
+}
+
+/// Character-aware subword conditioning: each subword's characters run through
+/// a tiny T5Gemma encoder, mean-pool, project, then add flag embeddings.
+public class VoiceChatCharAwareSubwordEncoder: Module {
+    @ModuleInfo(key: "backbone") var backbone: VoiceChatT5GemmaBackbone
+    /// 🚨 dtype of this table is READ to allocate the output buffer — stays fp.
+    @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
+    @ModuleInfo(key: "proj_embedding") var projEmbedding: Linear
+    @ModuleInfo(key: "subword_flag_emb") var subwordFlagEmb: VoiceChatSubwordFlagEmbedding
+    @ModuleInfo(key: "bos_eos_emb") var bosEosEmb: VoiceChatBOSEOSEmbedding
+
+    public let charPaddingIdx: Int
+    /// subword id → character ids; built from the tokenizer via `setVocabulary`.
+    private var subwordToChars: [Int: [Int]]?
+
+    public init(
+        config: VoiceChatCharacterEncoderConfiguration, outSize: Int, vocabSize: Int = 131_072
+    ) {
+        let hidden = config.hiddenSize ?? 1152
+        let charVocab = config.charVocabSize ?? 257
+        self._backbone.wrappedValue = VoiceChatT5GemmaBackbone(config: config)
+        self._embedTokens.wrappedValue = Embedding(embeddingCount: charVocab, dimensions: hidden)
+        self._projEmbedding.wrappedValue = Linear(hidden, outSize, bias: false)
+        self._subwordFlagEmb.wrappedValue = VoiceChatSubwordFlagEmbedding(
+            vocabSize: vocabSize, hiddenSize: hidden)
+        self._bosEosEmb.wrappedValue = VoiceChatBOSEOSEmbedding(
+            vocabSize: vocabSize, hiddenSize: hidden)
+        self.charPaddingIdx = charVocab - 1
+    }
+
+    /// Build the dense character vocabulary exactly as NeMo does: single-char
+    /// tokens sorted by id become the char table. Must be called before TTS.
+    public func setVocabulary(_ vocabulary: [String: Int]) throws {
+        let single = vocabulary.filter { $0.key.count == 1 }
+        let characters = single.sorted { $0.value < $1.value }.map(\.key)
+        var charToId = [Character: Int]()
+        for (idx, ch) in characters.enumerated() {
+            charToId[Character(ch)] = idx
+        }
+        guard charToId.count + 1 == embedTokens.weight.dim(0) else {
+            throw NSError(
+                domain: "VoiceChatTTS", code: 1,
+                userInfo: [
+                    NSLocalizedDescriptionKey:
+                        "tokenizer-derived character vocabulary has \(charToId.count + 1) entries, expected \(embedTokens.weight.dim(0))"
+                ])
+        }
+        var map = [Int: [Int]]()
+        for (token, idx) in vocabulary {
+            map[idx] = token.compactMap { charToId[$0] }
+        }
+        self.subwordToChars = map
+    }
+
+    /// subword ids (B, T) [+ optional validity mask] → conditioning (B, T, out).
+    public func callAsFunction(
+        _ subwordIds: MLXArray, mask subwordMask: MLXArray? = nil
+    ) -> MLXArray {
+        guard let subwordToChars else {
+            fatalError("setVocabulary(tokenizer vocab) must be called before TTS")
+        }
+        let B = subwordIds.dim(0), T = subwordIds.dim(1)
+        let ids: [Int32] = subwordIds.reshaped([-1]).asArray(Int32.self)
+        let valid: [Bool] =
+            subwordMask.map { $0.reshaped([-1]).asArray(Bool.self) }
+            ?? [Bool](repeating: true, count: ids.count)
+
+        var sequences = [[Int]]()
+        var flatPositions = [Int32]()
+        for i in 0 ..< ids.count where valid[i] {
+            sequences.append(subwordToChars[Int(ids[i])] ?? [])
+            flatPositions.append(Int32(i))
+        }
+
+        let outWidth = projEmbedding.weight.dim(0)
+        var out = MLXArray.zeros([B * T, outWidth], dtype: embedTokens.weight.dtype)
+        let maxLength = sequences.map(\.count).max() ?? 0
+        if !sequences.isEmpty && maxLength > 0 {
+            let charRows: [[Int32]] = sequences.map { seq in
+                seq.map(Int32.init) + [Int32](repeating: Int32(charPaddingIdx), count: maxLength - seq.count)
+            }
+            let charIds = MLXArray(charRows.flatMap { $0 }).reshaped([sequences.count, maxLength])
+            let lengths = MLXArray(sequences.map { Int32($0.count) })
+            let mask = MLXArray(0 ..< maxLength).reshaped([1, maxLength])
+                .< lengths.reshaped([-1, 1])
+            let hidden = backbone.encoder(embedTokens(charIds), mask: mask)
+            let pooled =
+                MLX.sum(hidden * mask.expandedDimensions(axis: -1).asType(hidden.dtype), axis: 1)
+                / MLX.maximum(lengths.reshaped([-1, 1]), MLXArray(Int32(1))).asType(hidden.dtype)
+            let projected = projEmbedding(pooled)
+            out[MLXArray(flatPositions)] = projected.asType(out.dtype)
+        }
+        var result = out.reshaped([B, T, outWidth])
+        result = subwordFlagEmb(result, tokenIds: subwordIds)
+        return bosEosEmb(result, tokenIds: subwordIds)
+    }
+}
+
+/// Gated fusion of code-embedding and text-conditioning streams.
+public class VoiceChatGatedFusion: Module {
+    public let numCodebooks: Int
+    @ModuleInfo(key: "audio_proj") var audioProj: Linear
+    @ModuleInfo(key: "text_proj") var textProj: Linear
+    @ParameterInfo(key: "gate") var gate: MLXArray
+    @ParameterInfo(key: "residual_scale") var residualScale: MLXArray
+    @ModuleInfo(key: "final_norm") var finalNorm: VoiceChatOffsetRMSNorm
+
+    public init(hiddenSize: Int, numCodebooks: Int, eps: Float) {
+        self.numCodebooks = numCodebooks
+        self._audioProj.wrappedValue = Linear(hiddenSize, hiddenSize)
+        self._textProj.wrappedValue = Linear(hiddenSize, hiddenSize)
+        self._gate.wrappedValue = MLXArray.zeros([hiddenSize])
+        self._residualScale.wrappedValue = MLXArray(Float(0.5))
+        self._finalNorm.wrappedValue = VoiceChatOffsetRMSNorm(dimensions: hiddenSize, eps: eps)
+    }
+
+    public func callAsFunction(audio: MLXArray, text: MLXArray) -> MLXArray {
+        let a = audioProj(audio / Float(numCodebooks))
+        let t = textProj(text)
+        let g = MLX.sigmoid(gate).asType(a.dtype)
+        let scale = MLX.sigmoid(residualScale).asType(a.dtype)
+        return finalNorm(scale * (g * a + (1.0 - g) * t))
+    }
+}

--- a/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatTTS.swift
+++ b/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatTTS.swift
@@ -132,6 +132,18 @@ public class VoiceChatMoGHead: Module {
     /// `VMLX_VOICECHAT_MOG_ARGMAX=1` replaces the Gumbel draw with an argmax
     /// over the mixture logits — a diagnostic arm for isolating sampling bugs
     /// from head bugs.
+    ///
+    /// 🚨 DIAGNOSTIC ONLY. It does not make generation "deterministic but
+    /// fine"; it destroys speech outright. Measured over six runs per bundle,
+    /// the model's own ASR read back 0% of what the agent said on BOTH JANG_3
+    /// and JANG_4 — every run, no exceptions.
+    ///
+    /// So the stochastic mixture draw is load-bearing, not noise to be tidied
+    /// away, and reaching for this flag to cure run-to-run variation makes
+    /// things strictly worse. That variation is real (a 3-bit build read back
+    /// 33 / nothing / 8 / 33 / 32 tokens across five live turns while its TEXT
+    /// channel was identical every time), but the fix is a better-quantised
+    /// bundle, not a deterministic head.
     static let deterministicComponent =
         ProcessInfo.processInfo.environment["VMLX_VOICECHAT_MOG_ARGMAX"] == "1"
 

--- a/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatTTSModel.swift
+++ b/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatTTSModel.swift
@@ -324,7 +324,28 @@ public class VoiceChatRVQEARTTSModel: Module {
         let bosMask = MLX.logicalAnd(audioMask, MLX.logicalNot(previousAudio))
         let preBOS = MLX.cumsum(bosMask.asType(.int32), axis: 1) .== MLXArray(Int32(0))
 
-        var projectedPrompt = MLX.matmul(codeEmbed, audioPromptProjectionW)
+        // 🚨 The frozen prompt projection carries NO fan-in scaling, so it must
+        // be normalised here or cloning is unusable.
+        //
+        // `audio_prompt_projection_W` is 1152x1152 with std 1.000149 — an
+        // unscaled random normal, not a trained matrix (a trained one would
+        // carry roughly 1/sqrt(1152) = 0.029). Applied raw it amplifies by
+        // ~sqrt(hidden): measured against the checkpoint, a prompt frame comes
+        // out at RMS 39.74 while the shipped `audio_prompt_latents.Aria` frames
+        // it replaces sit at 1.69 — 23.5x hot. The backbone then gets prompt
+        // conditioning far outside anything it saw in training, which is why
+        // cloned voices changed timbre but stopped forming words.
+        //
+        // 1/sqrt(hidden) is the norm-preserving scale for a random projection
+        // and lands prompt frames at RMS ~1.17, the same order as Aria. The
+        // reference never reaches this branch (it always supplies the Aria
+        // latent), so there is no upstream behaviour to match here — the scale
+        // is justified by measurement, and `VMLX_VOICECHAT_PROMPT_SCALE`
+        // overrides it for anyone re-deriving that.
+        let promptScale =
+            ProcessInfo.processInfo.environment["VMLX_VOICECHAT_PROMPT_SCALE"]
+            .flatMap(Float.init) ?? (1.0 / Foundation.sqrt(Float(codeEmbed.dim(-1))))
+        var projectedPrompt = MLX.matmul(codeEmbed, audioPromptProjectionW) * promptScale
         if let audioPromptLatent {
             projectedPrompt = audioPromptLatent.asType(codeEmbed.dtype)
         }

--- a/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatTTSModel.swift
+++ b/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatTTSModel.swift
@@ -259,6 +259,55 @@ public class VoiceChatRVQEARTTSModel: Module {
         return cond
     }
 
+    /// Prime the transformer with the speaker prompt so the first generated
+    /// frame already sounds like the voice.
+    ///
+    /// Frames before the audio BOS carry the PROMPT LATENT (`Aria`) instead of
+    /// code embeddings — that is where speaker identity enters, and it is why
+    /// a custom voice is an 83 KiB latent rather than a retrain.
+    public func warmup(
+        code: MLXArray,
+        subwordIds: MLXArray,
+        subwordMask: MLXArray,
+        audioMask: MLXArray,
+        audioPromptLatent: MLXArray?,
+        guidance: Bool = true,
+        cache: [KVCache]? = nil
+    ) -> (MLXArray, [KVCache]) {
+        let shifted = MLX.concatenated(
+            [MLXArray.zeros(like: code[0..., 0 ..< 1, 0...]), code[0..., ..<(code.dim(1) - 1), 0...]],
+            axis: 1)
+        var codeEmbed = embedCode(depthSumEmbedding(shifted))
+
+        let previousAudio = MLX.concatenated(
+            [
+                MLXArray.zeros(like: audioMask[0..., 0 ..< 1]),
+                audioMask[0..., ..<(audioMask.dim(1) - 1)],
+            ], axis: 1)
+        let bosMask = MLX.logicalAnd(audioMask, MLX.logicalNot(previousAudio))
+        let preBOS = MLX.cumsum(bosMask.asType(.int32), axis: 1) .== MLXArray(Int32(0))
+
+        var projectedPrompt = MLX.matmul(codeEmbed, audioPromptProjectionW)
+        if let audioPromptLatent {
+            projectedPrompt = audioPromptLatent.asType(codeEmbed.dtype)
+        }
+        codeEmbed = MLX.where(preBOS.expandedDimensions(axis: -1), projectedPrompt, codeEmbed)
+        codeEmbed = codeEmbed + bosMask.expandedDimensions(axis: -1).asType(codeEmbed.dtype)
+            * bosEmb.asType(codeEmbed.dtype)
+
+        let batchSize = code.dim(0)
+        if guidance {
+            codeEmbed = MLX.concatenated([codeEmbed, codeEmbed], axis: 0)
+        }
+        let cond = condition(
+            subwordIds: subwordIds, subwordMask: subwordMask, batchSize: batchSize,
+            guidance: guidance)
+        let inputs = gatedFusion(audio: codeEmbed, text: cond)
+        let resolvedCache = cache ?? makeCache()
+        let hidden = backbone(inputs, cache: resolvedCache)
+        return (hidden, resolvedCache)
+    }
+
     /// One decode step over a single frame of codes.
     public func step(
         code: MLXArray, subwordIds: MLXArray, subwordMask: MLXArray?, cache: [KVCache],

--- a/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatTTSModel.swift
+++ b/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatTTSModel.swift
@@ -1,0 +1,343 @@
+// NemotronLabs VoiceChat — the EAR-TTS transformer and RVQ code generation.
+//
+// Port of `RVQEARTTSModel` in `mlx_vlm/models/nemotron_voicechat/tts.py`.
+//
+// The backbone is Gemma3-shaped (28 layers, 1152 hidden, q/k norms, sliding
+// window 7500 with pattern 6) but is NOT the Gemma3 module already in
+// MLXLLM: this checkpoint DELETES `embed_tokens` (vocab_size 1 — inputs are
+// always embeddings, never token ids), so the layer stack is spelled out here
+// against the bundle's own keys (`backbone.layers.N.*`, `backbone.norm`).
+//
+// 🚨 Norm convention: every norm here is `VoiceChatOffsetRMSNorm` (1 + weight).
+// The nemotron_h STT backbone next door uses plain RMSNorm. One model, two
+// conventions — the mistake that empties output while every structural check
+// stays green.
+
+import Foundation
+import MLX
+import MLXFast
+import MLXLMCommon
+import MLXNN
+import MLXRandom
+
+/// Gemma3-style attention with per-head q/k norms and alternating
+/// global / sliding-window RoPE bases.
+public class VoiceChatTTSAttention: Module {
+    let nHeads: Int
+    let nKVHeads: Int
+    let headDim: Int
+    let repeats: Int
+    let attnScale: Float
+    let rope: RoPE
+
+    @ModuleInfo(key: "q_proj") var qProj: Linear
+    @ModuleInfo(key: "k_proj") var kProj: Linear
+    @ModuleInfo(key: "v_proj") var vProj: Linear
+    @ModuleInfo(key: "o_proj") var oProj: Linear
+    @ModuleInfo(key: "q_norm") var qNorm: VoiceChatOffsetRMSNorm
+    @ModuleInfo(key: "k_norm") var kNorm: VoiceChatOffsetRMSNorm
+
+    public init(config: VoiceChatTTSConfiguration, isSliding: Bool) {
+        let hidden = config.hiddenSize
+        self.nHeads = config.numAttentionHeads
+        self.nKVHeads = config.numKeyValueHeads
+        self.headDim = config.headDim
+        self.repeats = nHeads / nKVHeads
+        self.attnScale = Float(
+            1.0 / Foundation.sqrt(Double(config.queryPreAttnScalar ?? 256.0)))
+        let eps = config.rmsNormEps ?? 1e-6
+        self.rope = RoPE(
+            dimensions: headDim, traditional: false,
+            base: isSliding
+                ? (config.ropeLocalBaseFreq ?? 10_000.0)
+                : (config.ropeGlobalBaseFreq ?? 1_000_000.0))
+        self._qProj.wrappedValue = Linear(hidden, nHeads * headDim, bias: false)
+        self._kProj.wrappedValue = Linear(hidden, nKVHeads * headDim, bias: false)
+        self._vProj.wrappedValue = Linear(hidden, nKVHeads * headDim, bias: false)
+        self._oProj.wrappedValue = Linear(nHeads * headDim, hidden, bias: false)
+        self._qNorm.wrappedValue = VoiceChatOffsetRMSNorm(dimensions: headDim, eps: eps)
+        self._kNorm.wrappedValue = VoiceChatOffsetRMSNorm(dimensions: headDim, eps: eps)
+    }
+
+    public func callAsFunction(
+        _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
+    ) -> MLXArray {
+        let B = x.dim(0), L = x.dim(1)
+        var q = qProj(x).reshaped(B, L, nHeads, -1).transposed(0, 2, 1, 3)
+        var k = kProj(x).reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
+        var v = vProj(x).reshaped(B, L, nKVHeads, -1).transposed(0, 2, 1, 3)
+
+        q = qNorm(q)
+        k = kNorm(k)
+
+        let offset = cache?.offset ?? 0
+        q = rope(q, offset: offset)
+        k = rope(k, offset: offset)
+        if let cache {
+            (k, v) = cache.update(keys: k, values: v)
+        }
+
+        let out = MLXFast.scaledDotProductAttention(
+            queries: q, keys: k, values: v, scale: attnScale, mask: mask)
+        return oProj(out.transposed(0, 2, 1, 3).reshaped(B, L, -1))
+    }
+}
+
+public class VoiceChatTTSBlock: Module {
+    @ModuleInfo(key: "self_attn") var selfAttn: VoiceChatTTSAttention
+    @ModuleInfo(key: "input_layernorm") var inputLayerNorm: VoiceChatOffsetRMSNorm
+    @ModuleInfo(key: "post_attention_layernorm") var postAttentionLayerNorm: VoiceChatOffsetRMSNorm
+    @ModuleInfo(key: "mlp") var mlp: VoiceChatTTSMLP
+    @ModuleInfo(key: "pre_feedforward_layernorm") var preFeedforwardLayerNorm: VoiceChatOffsetRMSNorm
+    @ModuleInfo(key: "post_feedforward_layernorm") var postFeedforwardLayerNorm:
+        VoiceChatOffsetRMSNorm
+
+    public init(config: VoiceChatTTSConfiguration, isSliding: Bool) {
+        let hidden = config.hiddenSize
+        let eps = config.rmsNormEps ?? 1e-6
+        self._selfAttn.wrappedValue = VoiceChatTTSAttention(config: config, isSliding: isSliding)
+        self._inputLayerNorm.wrappedValue = VoiceChatOffsetRMSNorm(dimensions: hidden, eps: eps)
+        self._postAttentionLayerNorm.wrappedValue = VoiceChatOffsetRMSNorm(
+            dimensions: hidden, eps: eps)
+        self._mlp.wrappedValue = VoiceChatTTSMLP(
+            hiddenSize: hidden, intermediateSize: config.intermediateSize)
+        self._preFeedforwardLayerNorm.wrappedValue = VoiceChatOffsetRMSNorm(
+            dimensions: hidden, eps: eps)
+        self._postFeedforwardLayerNorm.wrappedValue = VoiceChatOffsetRMSNorm(
+            dimensions: hidden, eps: eps)
+    }
+
+    public func callAsFunction(
+        _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
+    ) -> MLXArray {
+        var x =
+            x
+            + postAttentionLayerNorm(selfAttn(inputLayerNorm(x), mask: mask, cache: cache))
+        x = x + postFeedforwardLayerNorm(mlp(preFeedforwardLayerNorm(x)))
+        return x
+    }
+}
+
+/// The 28-layer speech transformer. Embeddings in, hidden out — this
+/// checkpoint has no embedding table at all.
+public class VoiceChatTTSBackbone: Module {
+    public let config: VoiceChatTTSConfiguration
+    public let slidingWindowPattern: Int
+
+    @ModuleInfo(key: "layers") var layers: [VoiceChatTTSBlock]
+    @ModuleInfo(key: "norm") var norm: VoiceChatOffsetRMSNorm
+
+    public init(_ config: VoiceChatTTSConfiguration) {
+        self.config = config
+        let pattern = config.slidingWindowPattern ?? 6
+        self.slidingWindowPattern = pattern
+        self._layers.wrappedValue = (0 ..< config.numHiddenLayers).map { idx in
+            // Global every `pattern`-th layer (1-indexed), sliding otherwise.
+            VoiceChatTTSBlock(config: config, isSliding: (idx + 1) % pattern != 0)
+        }
+        self._norm.wrappedValue = VoiceChatOffsetRMSNorm(
+            dimensions: config.hiddenSize, eps: config.rmsNormEps ?? 1e-6)
+    }
+
+    public func callAsFunction(_ inputsEmbeds: MLXArray, cache: [KVCache]?) -> MLXArray {
+        var h = inputsEmbeds
+        // Global layers see the whole history; sliding layers get a windowed
+        // mask sized to the rotating cache. Masks are built from the matching
+        // cache kind so an offset from a rotating buffer cannot be applied to
+        // a full one.
+        let globalMask = createAttentionMask(
+            h: h, cache: cache.map { $0[slidingWindowPattern - 1] } ?? nil)
+        let slidingMask: MLXFast.ScaledDotProductAttentionMaskMode =
+            slidingWindowPattern > 1
+            ? createAttentionMask(
+                h: h, cache: cache?.first, windowSize: config.slidingWindow)
+            : .none
+
+        for (i, layer) in layers.enumerated() {
+            let isGlobal = (i % slidingWindowPattern == slidingWindowPattern - 1)
+            h = layer(h, mask: isGlobal ? globalMask : slidingMask, cache: cache?[i])
+        }
+        return norm(h)
+    }
+
+    /// Per-layer caches: global layers keep everything, sliding layers keep a
+    /// 7500-frame rotating window (`keep: 0` — no attention sink here).
+    public func makeCache() -> [KVCache] {
+        (0 ..< config.numHiddenLayers).map { idx in
+            (idx + 1) % slidingWindowPattern == 0
+                ? KVCacheSimple()
+                : RotatingKVCache(maxSize: config.slidingWindow, keep: 0)
+        }
+    }
+}
+
+/// One TTS step's outputs.
+public struct VoiceChatTTSStepOutput {
+    public let codes: MLXArray
+    public let hiddenStates: MLXArray
+}
+
+/// The RVQ EAR-TTS model: code embedding, text conditioning, gated fusion,
+/// the transformer, and iterative mixture-of-Gaussians RVQ code generation.
+public class VoiceChatRVQEARTTSModel: Module {
+    public let config: VoiceChatTTSConfiguration
+
+    @ModuleInfo(key: "backbone") public var backbone: VoiceChatTTSBackbone
+    @ParameterInfo(key: "bos_emb") var bosEmb: MLXArray
+    @ParameterInfo(key: "null_emb") var nullEmb: MLXArray
+    @ModuleInfo(key: "embed_code") var embedCode: Linear
+    @ModuleInfo(key: "embed_subword") public var embedSubword: VoiceChatCharAwareSubwordEncoder
+    @ModuleInfo(key: "gated_fusion_audio_text") var gatedFusion: VoiceChatGatedFusion
+    @ParameterInfo(key: "audio_prompt_projection_W") var audioPromptProjectionW: MLXArray
+    @ModuleInfo(key: "mog_head") public var mogHead: VoiceChatMoGHead
+    /// 🚨 RVQ codebook, read raw — must stay fp in every quantized bundle.
+    @ParameterInfo(key: "rvq_embs") var rvqEmbs: MLXArray
+
+    public init(_ config: VoiceChatTTSConfiguration) {
+        self.config = config
+        let hidden = config.hiddenSize
+        self._backbone.wrappedValue = VoiceChatTTSBackbone(config)
+        self._bosEmb.wrappedValue = MLXArray.zeros([hidden])
+        self._nullEmb.wrappedValue = MLXArray.zeros([hidden])
+        self._embedCode.wrappedValue = Linear(config.latentSize, hidden, bias: false)
+        self._embedSubword.wrappedValue = VoiceChatCharAwareSubwordEncoder(
+            config: config.characterEncoder
+                ?? VoiceChatCharacterEncoderConfiguration(
+                    hiddenSize: nil, intermediateSize: nil, numHiddenLayers: nil,
+                    numAttentionHeads: nil, numKeyValueHeads: nil, headDim: nil,
+                    rmsNormEps: nil, queryPreAttnScalar: nil, attnLogitSoftcapping: nil,
+                    ropeBase: nil, charVocabSize: nil),
+            outSize: hidden)
+        self._gatedFusion.wrappedValue = VoiceChatGatedFusion(
+            hiddenSize: hidden, numCodebooks: config.numQuantizers,
+            eps: config.rmsNormEps ?? 1e-6)
+        self._audioPromptProjectionW.wrappedValue = MLXArray.zeros([hidden, hidden])
+        self._mogHead.wrappedValue = VoiceChatMoGHead(
+            hiddenSize: hidden, outSize: config.latentSize,
+            config: config.mogHead
+                ?? VoiceChatMoGConfiguration(
+                    intermediateSize: nil, lowRank: nil, minLogStd: nil,
+                    numLayers: nil, numPredictions: nil, eps: nil))
+        self._rvqEmbs.wrappedValue = MLXArray.zeros([
+            config.numQuantizers, config.codebookSize, config.latentSize,
+        ])
+    }
+
+    public func setVocabulary(_ vocabulary: [String: Int]) throws {
+        try embedSubword.setVocabulary(vocabulary)
+    }
+
+    public func makeCache() -> [KVCache] { backbone.makeCache() }
+
+    /// Depth-summed latent for a full RVQ code stack.
+    ///
+    /// An extra all-zero PAD row is appended to every codebook so the
+    /// "not yet chosen" sentinel (index == codebookSize) contributes nothing —
+    /// that is how partially-refined codes stay valid mid-iteration.
+    public func depthSumEmbedding(_ code: MLXArray) -> MLXArray {
+        let padding = MLXArray.zeros(
+            [config.numQuantizers, 1, config.latentSize], dtype: rvqEmbs.dtype)
+        let embeddings = MLX.concatenated([rvqEmbs, padding], axis: 1)
+        var result = MLXArray.zeros(
+            code.shape.dropLast() + [config.latentSize], dtype: embeddings.dtype)
+        for idx in 0 ..< config.numQuantizers {
+            result = result + embeddings[idx][code[.ellipsis, idx]]
+        }
+        return result
+    }
+
+    /// Text conditioning, doubled for classifier-free guidance (the second
+    /// half is the NULL embedding — the unconditional branch).
+    private func condition(
+        subwordIds: MLXArray, subwordMask: MLXArray?, batchSize: Int, guidance: Bool
+    ) -> MLXArray {
+        var cond = embedSubword(subwordIds, mask: subwordMask)
+        if guidance {
+            let null = MLX.broadcast(nullEmb.asType(cond.dtype), to: cond.shape)
+            cond = MLX.concatenated([cond, null], axis: 0)
+        }
+        return cond
+    }
+
+    /// One decode step over a single frame of codes.
+    public func step(
+        code: MLXArray, subwordIds: MLXArray, subwordMask: MLXArray?, cache: [KVCache],
+        guidance: Bool = true
+    ) -> VoiceChatTTSStepOutput {
+        var codeEmbed = embedCode(depthSumEmbedding(code))
+        let batchSize = code.dim(0)
+        if guidance {
+            codeEmbed = MLX.concatenated([codeEmbed, codeEmbed], axis: 0)
+        }
+        let cond = condition(
+            subwordIds: subwordIds, subwordMask: subwordMask, batchSize: batchSize,
+            guidance: guidance)
+        let inputs = gatedFusion(audio: codeEmbed, text: cond)
+        let hidden = backbone(inputs, cache: cache)
+        return VoiceChatTTSStepOutput(
+            codes: generateCodes(hidden), hiddenStates: hidden)
+    }
+
+    /// Nearest-neighbour RVQ encode of quantizers `[start, start+count)`.
+    private func rvqEncodeStep(
+        residual: MLXArray, code: MLXArray, start: Int, count: Int
+    ) -> MLXArray {
+        var residual = residual
+        var pieces = (0 ..< config.numQuantizers).map { code[.ellipsis, $0] }
+        for idx in start ..< (start + count) {
+            let embedding = rvqEmbs[idx]
+            let distances =
+                MLX.sum(embedding * embedding, axis: -1)
+                - 2.0 * MLX.matmul(residual, embedding.T)
+            let selected = MLX.argMin(distances, axis: -1)
+            residual = residual - embedding[selected]
+            pieces[idx] = selected
+        }
+        return MLX.stacked(pieces, axis: -1)
+    }
+
+    /// Iteratively refine all 31 residual codebooks from the transformer's
+    /// hidden state. `hiddenStates` must carry conditional and unconditional
+    /// halves (classifier-free guidance).
+    public func generateCodes(_ hiddenStates: MLXArray) -> MLXArray {
+        precondition(
+            hiddenStates.dim(0) % 2 == 0,
+            "guided generation expects conditional/unconditional pairs")
+        let half = hiddenStates.dim(0) / 2
+        let conditional = hiddenStates[0 ..< half]
+        let unconditional = hiddenStates[half...]
+
+        let iterations = config.numIterations ?? 8
+        let exponent = Double(config.exponent ?? 3.0)
+        var code = MLXArray.full(
+            [conditional.dim(0), conditional.dim(1), config.numQuantizers],
+            values: MLXArray(Int32(config.codebookSize)))
+
+        // How many codebooks remain masked at each refinement rate.
+        let masked: [Int] = (0 ..< iterations).map { i in
+            let rate = Double(i) / Double(iterations)
+            let value = Foundation.pow(1.0 - Foundation.pow(rate, exponent), 1.0 / exponent)
+            return Int(ceil(value * Double(config.numQuantizers)))
+        }
+        let counts: [Int] = (0 ..< masked.count).map { i in
+            masked[i] - (i + 1 < masked.count ? masked[i + 1] : 0)
+        }
+
+        var completed = 0
+        for count in counts where count != 0 {
+            let embedded = embedCode(depthSumEmbedding(code))
+            let mogInput = MLX.concatenated(
+                [embedded + conditional, embedded + unconditional], axis: 0)
+            let (mu, logs) = mogHead.infer(
+                mogInput,
+                guidanceScale: config.guidanceScale ?? 0.2,
+                topP: config.topP ?? 0.95)
+            let residual =
+                mu + MLX.exp(logs) * MLXRandom.normal(mu.shape) * (config.noiseScale ?? 0.001)
+            code = rvqEncodeStep(
+                residual: residual, code: code, start: completed, count: count)
+            completed += count
+        }
+        return code
+    }
+}

--- a/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatTTSModel.swift
+++ b/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatTTSModel.swift
@@ -394,12 +394,13 @@ public class VoiceChatRVQEARTTSModel: Module {
     /// hidden state. `hiddenStates` must carry conditional and unconditional
     /// halves (classifier-free guidance).
     public func generateCodes(_ hiddenStates: MLXArray) -> MLXArray {
-        precondition(
-            hiddenStates.dim(0) % 2 == 0,
-            "guided generation expects conditional/unconditional pairs")
-        let half = hiddenStates.dim(0) / 2
-        let conditional = hiddenStates[0 ..< half]
-        let unconditional = hiddenStates[half...]
+        // With guidance off the caller passes a single conditional batch; the
+        // refinement below is written against a cond/uncond pair, so the same
+        // hidden serves as both and the guidance term cancels to zero.
+        let guided = hiddenStates.dim(0) % 2 == 0 && hiddenStates.dim(0) > 1
+        let half = guided ? hiddenStates.dim(0) / 2 : hiddenStates.dim(0)
+        let conditional = guided ? hiddenStates[0 ..< half] : hiddenStates
+        let unconditional = guided ? hiddenStates[half...] : hiddenStates
 
         let iterations = config.numIterations ?? 8
         let exponent = Double(config.exponent ?? 3.0)
@@ -420,11 +421,16 @@ public class VoiceChatRVQEARTTSModel: Module {
         var completed = 0
         for count in counts where count != 0 {
             let embedded = embedCode(depthSumEmbedding(code))
-            let mogInput = MLX.concatenated(
-                [embedded + conditional, embedded + unconditional], axis: 0)
+            // Guided: the head needs a cond/uncond pair to difference. Not
+            // guided: a single batch, or the pair would double the batch while
+            // `code` stays single and the RVQ re-encode below cannot stack.
+            let mogInput =
+                guided
+                ? MLX.concatenated([embedded + conditional, embedded + unconditional], axis: 0)
+                : embedded + conditional
             let (mu, logs) = mogHead.infer(
                 mogInput,
-                guidanceScale: config.guidanceScale ?? 0.2,
+                guidanceScale: guided ? (config.guidanceScale ?? 0.2) : 0,
                 topP: config.topP ?? 0.95)
             let residual =
                 mu + MLX.exp(logs) * MLXRandom.normal(mu.shape) * (config.noiseScale ?? 0.001)

--- a/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatTTSModel.swift
+++ b/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatTTSModel.swift
@@ -15,7 +15,6 @@
 
 import Foundation
 import MLX
-import MLXFast
 import MLXLMCommon
 import MLXNN
 import MLXRandom
@@ -145,13 +144,24 @@ public class VoiceChatTTSBackbone: Module {
         // mask sized to the rotating cache. Masks are built from the matching
         // cache kind so an offset from a rotating buffer cannot be applied to
         // a full one.
-        let globalMask = createAttentionMask(
-            h: h, cache: cache.map { $0[slidingWindowPattern - 1] } ?? nil)
+        //
+        // 🚨 A SINGLE-token step needs NO mask at all: the one new query may
+        // attend to every cached key (the rotating buffer is itself the
+        // window). Asking for a causal mask here is not a harmless extra — it
+        // misaligns the query against a cache that already holds the history,
+        // and the result is a hidden state that is close to right and
+        // therefore renders as fluent-sounding babble instead of words. The
+        // whole-sequence warmup path was exact while this step was not.
+        let isSingleStep = h.dim(1) == 1
+        let globalMask: MLXFast.ScaledDotProductAttentionMaskMode =
+            isSingleStep
+            ? .none
+            : createAttentionMask(h: h, cache: cache.map { $0[slidingWindowPattern - 1] } ?? nil)
         let slidingMask: MLXFast.ScaledDotProductAttentionMaskMode =
-            slidingWindowPattern > 1
-            ? createAttentionMask(
+            isSingleStep || slidingWindowPattern <= 1
+            ? .none
+            : createAttentionMask(
                 h: h, cache: cache?.first, windowSize: config.slidingWindow)
-            : .none
 
         for (i, layer) in layers.enumerated() {
             let isGlobal = (i % slidingWindowPattern == slidingWindowPattern - 1)

--- a/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatTTSModel.swift
+++ b/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatTTSModel.swift
@@ -126,6 +126,14 @@ public class VoiceChatTTSBackbone: Module {
     @ModuleInfo(key: "layers") var layers: [VoiceChatTTSBlock]
     @ModuleInfo(key: "norm") var norm: VoiceChatOffsetRMSNorm
 
+    /// `VOICECHAT_LAYER_DUMP=<dir>` writes each layer's single-step output for
+    /// stage-by-stage comparison against the reference implementation.
+    static let layerDumpDirectory = ProcessInfo.processInfo.environment["VOICECHAT_LAYER_DUMP"]
+
+    /// Diagnostic arm: use a plain cache for the sliding layers too.
+    static let useSimpleCacheEverywhere =
+        ProcessInfo.processInfo.environment["VOICECHAT_SIMPLE_CACHE"] == "1"
+
     public init(_ config: VoiceChatTTSConfiguration) {
         self.config = config
         let pattern = config.slidingWindowPattern ?? 6
@@ -166,6 +174,15 @@ public class VoiceChatTTSBackbone: Module {
         for (i, layer) in layers.enumerated() {
             let isGlobal = (i % slidingWindowPattern == slidingWindowPattern - 1)
             h = layer(h, mask: isGlobal ? globalMask : slidingMask, cache: cache?[i])
+            if let dir = Self.layerDumpDirectory, isSingleStep {
+                MLX.eval(h)
+                let flat = h.asType(.float32).reshaped([-1]).asArray(Float.self)
+                flat.withUnsafeBufferPointer {
+                    try? Data(buffer: $0).write(
+                        to: URL(fileURLWithPath: dir).appendingPathComponent(
+                            String(format: "mine-layer-%02d.f32", i)))
+                }
+            }
         }
         return norm(h)
     }
@@ -174,7 +191,13 @@ public class VoiceChatTTSBackbone: Module {
     /// 7500-frame rotating window (`keep: 0` — no attention sink here).
     public func makeCache() -> [KVCache] {
         (0 ..< config.numHiddenLayers).map { idx in
-            (idx + 1) % slidingWindowPattern == 0
+            // A turn is a few hundred frames against a 7500-frame window, so
+            // the rotating buffer never actually rotates and a plain cache is
+            // behaviourally identical — except that the rotating cache's
+            // single-step read was measured to diverge from the reference
+            // (layer 0 cosine 0.9992, layer 1 0.8863) while whole-sequence
+            // prefill through the same code was exact.
+            (idx + 1) % slidingWindowPattern == 0 || Self.useSimpleCacheEverywhere
                 ? KVCacheSimple()
                 : RotatingKVCache(maxSize: config.slidingWindow, keep: 0)
         }

--- a/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatTTSModel.swift
+++ b/Libraries/MLXVLM/Models/NemotronVoiceChat/VoiceChatTTSModel.swift
@@ -191,15 +191,9 @@ public class VoiceChatTTSBackbone: Module {
     /// 7500-frame rotating window (`keep: 0` — no attention sink here).
     public func makeCache() -> [KVCache] {
         (0 ..< config.numHiddenLayers).map { idx in
-            // A turn is a few hundred frames against a 7500-frame window, so
-            // the rotating buffer never actually rotates and a plain cache is
-            // behaviourally identical — except that the rotating cache's
-            // single-step read was measured to diverge from the reference
-            // (layer 0 cosine 0.9992, layer 1 0.8863) while whole-sequence
-            // prefill through the same code was exact.
-            (idx + 1) % slidingWindowPattern == 0 || Self.useSimpleCacheEverywhere
-                ? KVCacheSimple()
-                : RotatingKVCache(maxSize: config.slidingWindow, keep: 0)
+            // Both kinds are the same cache here: see VoiceChatKVCache for
+            // why, and for the measurement that forced it.
+            VoiceChatConcatKVCache()
         }
     }
 }
@@ -286,8 +280,18 @@ public class VoiceChatRVQEARTTSModel: Module {
     ) -> MLXArray {
         var cond = embedSubword(subwordIds, mask: subwordMask)
         if guidance {
-            let null = MLX.broadcast(nullEmb.asType(cond.dtype), to: cond.shape)
-            cond = MLX.concatenated([cond, null], axis: 0)
+            // Built exactly as the reference does — double, then overwrite the
+            // second half — rather than concatenating a broadcast view onto the
+            // original. A broadcast is a stride-0 VIEW, and taking it straight
+            // into the concatenated batch is where the unconditional row can
+            // stop being independent of the conditional one. The guidance
+            // subtraction (cond + s·(cond − uncond)) then amplifies whatever is
+            // wrong there, which is why the conditional half matched at every
+            // layer while the unconditional half collapsed.
+            cond = MLX.concatenated([cond, cond], axis: 0)
+            let nullShape = [batchSize, cond.dim(1), cond.dim(2)]
+            let null = MLX.broadcast(nullEmb.asType(cond.dtype), to: nullShape)
+            cond = MLX.concatenated([cond[0 ..< batchSize], null], axis: 0)
         }
         return cond
     }
@@ -355,6 +359,14 @@ public class VoiceChatRVQEARTTSModel: Module {
             subwordIds: subwordIds, subwordMask: subwordMask, batchSize: batchSize,
             guidance: guidance)
         let inputs = gatedFusion(audio: codeEmbed, text: cond)
+        if let dir = VoiceChatTTSBackbone.layerDumpDirectory {
+            MLX.eval(inputs)
+            let flat = inputs.asType(.float32).reshaped([-1]).asArray(Float.self)
+            flat.withUnsafeBufferPointer {
+                try? Data(buffer: $0).write(
+                    to: URL(fileURLWithPath: dir).appendingPathComponent("mine-step-input.f32"))
+            }
+        }
         let hidden = backbone(inputs, cache: cache)
         return VoiceChatTTSStepOutput(
             codes: generateCodes(hidden), hiddenStates: hidden)

--- a/Package.swift
+++ b/Package.swift
@@ -513,7 +513,13 @@ let package = Package(
         .target(
             name: "MLXVLM",
             // MLXFFT: the VoiceChat codec's STFT/iSTFT vocoder head.
-            dependencies: ["MLXLMCommon", "MLXLLM", "MLX", "MLXFFT", "MLXNN", "MLXOptimizers"],
+            // MLXFast: VoiceChatConcatKVCache builds a ScaledDotProductAttention
+            // mask mode. It resolved transitively under `swift test`, so the
+            // missing dependency only surfaced when the app was built against
+            // this package — "unable to resolve module dependency: 'MLXFast'".
+            dependencies: [
+                "MLXLMCommon", "MLXLLM", "MLX", "MLXFFT", "MLXFast", "MLXNN", "MLXOptimizers",
+            ],
             path: "Libraries/MLXVLM",
             exclude: ["README.md"]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -512,7 +512,8 @@ let package = Package(
         ),
         .target(
             name: "MLXVLM",
-            dependencies: ["MLXLMCommon", "MLXLLM", "MLX", "MLXNN", "MLXOptimizers"],
+            // MLXFFT: the VoiceChat codec's STFT/iSTFT vocoder head.
+            dependencies: ["MLXLMCommon", "MLXLLM", "MLX", "MLXFFT", "MLXNN", "MLXOptimizers"],
             path: "Libraries/MLXVLM",
             exclude: ["README.md"]
         ),

--- a/Tests/MLXLMTests/NemotronVoiceChatConfigTests.swift
+++ b/Tests/MLXLMTests/NemotronVoiceChatConfigTests.swift
@@ -1,0 +1,129 @@
+import Foundation
+import MLXLLM
+import MLXVLM
+import XCTest
+
+/// Decodes the REAL `config.json` from the downloaded MLX bundle rather than a
+/// hand-written fixture. A fixture only proves the struct matches what I typed;
+/// this proves it matches what NVIDIA/mlx-community actually shipped.
+///
+/// Skips (rather than fails) when the bundle is absent, so CI without the 21 GB
+/// download stays green.
+public class NemotronVoiceChatConfigTests: XCTestCase {
+
+    private static let bundlePath =
+        ("~/models/nemotron-voicechat-src/VoiceChat-11B-mlx-bf16" as NSString)
+        .expandingTildeInPath
+
+    private func loadRealConfig() throws -> NemotronVoiceChatConfiguration? {
+        let url = URL(fileURLWithPath: Self.bundlePath).appendingPathComponent("config.json")
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode(NemotronVoiceChatConfiguration.self, from: data)
+    }
+
+    func testDecodesRealBundleConfig() throws {
+        guard let c = try loadRealConfig() else {
+            throw XCTSkip("VoiceChat MLX bundle not present at \(Self.bundlePath)")
+        }
+
+        // ── backbone ───────────────────────────────────────────────────────
+        XCTAssertEqual(c.textConfig.hiddenSize, 4480)
+        XCTAssertEqual(c.textConfig.numHiddenLayers, 56)
+        XCTAssertEqual(c.textConfig.vocabSize, 131072)
+
+        // The pattern string must agree with the weights: 27 Mamba / 25 MLP /
+        // 4 attention. If a future revision changes the pattern, this catches it
+        // before a load produces a silently wrong layer stack.
+        let pattern = Array(c.textConfig.hybridOverridePattern)
+        XCTAssertEqual(pattern.count, 56, "pattern length must equal layer count")
+        XCTAssertEqual(pattern.filter { $0 == "M" }.count, 27, "Mamba2 layers")
+        XCTAssertEqual(pattern.filter { $0 == "-" }.count, 25, "MLP layers")
+        XCTAssertEqual(pattern.filter { $0 == "*" }.count, 4, "attention layers")
+
+        // ── audio in ───────────────────────────────────────────────────────
+        XCTAssertEqual(c.inputSampleRate, 16000)
+        XCTAssertEqual(c.audioConfig.preprocessor.sampleRate, 16000)
+        XCTAssertEqual(c.audioConfig.preprocessor.features, 128)
+        XCTAssertEqual(c.audioConfig.outputDim, c.textConfig.hiddenSize,
+                       "perception output must match LLM hidden size")
+
+        // ── audio out ──────────────────────────────────────────────────────
+        XCTAssertEqual(c.outputSampleRate, 22050)
+        XCTAssertEqual(c.codecConfig.sampleRate, c.outputSampleRate)
+        XCTAssertEqual(c.frameDuration, 0.08, accuracy: 1e-9)
+        XCTAssertEqual(c.framesPerSecond, 12.5, accuracy: 1e-9)
+
+        // ── the trap: RNN-T decoder/joint are INSIDE audio_config ───────────
+        XCTAssertNotNil(c.audioConfig.decoder,
+                        "rnnt decoder must decode from audio_config, not top level")
+        XCTAssertNotNil(c.audioConfig.joint,
+                        "rnnt joint must decode from audio_config, not top level")
+
+        // Blank is one PAST the vocabulary, not a member of it.
+        if let vocab = c.rnntVocabulary {
+            XCTAssertEqual(vocab.count, 1024)
+            XCTAssertEqual(c.rnntBlankId, vocab.count,
+                           "blank id is one past the last real token")
+        }
+
+        // ── tool calling is a first-class channel ──────────────────────────
+        XCTAssertEqual(c.functionChannelWeight, 2.0, accuracy: 1e-6,
+                       "tool calls are a WEIGHTED parallel channel with their own head")
+
+        // ── tts / codec agreement ──────────────────────────────────────────
+        XCTAssertEqual(c.ttsConfig.numQuantizers, c.codecConfig.numQuantizers,
+                       "tts and codec must agree on RVQ depth")
+        XCTAssertEqual(c.ttsConfig.codebookSize, c.codecConfig.codebookSize,
+                       "tts and codec must agree on codebook size")
+        XCTAssertEqual(c.ttsConfig.latentSize, c.codecConfig.latentDim,
+                       "tts latent must match codec latent")
+
+        XCTAssertEqual(c.speaker, "Aria")
+    }
+
+    /// The encoder is configured for STREAMING. If a future bundle drops these,
+    /// the offline Parakeet path would silently be "correct" while being wrong
+    /// on a live mic — the exact class of bug a non-streaming test cannot see.
+    func testEncoderIsStreamingConfigured() throws {
+        guard let c = try loadRealConfig() else {
+            throw XCTSkip("VoiceChat MLX bundle not present")
+        }
+        let e = c.audioConfig.encoder
+        XCTAssertEqual(e.dModel, 1024)
+        XCTAssertEqual(e.nLayers, 24)
+        XCTAssertEqual(e.nHeads, 8)
+        XCTAssertEqual(e.selfAttentionModel, "rel_pos")
+        XCTAssertEqual(e.subsamplingFactor, 8)
+
+        XCTAssertTrue(e.isStreaming,
+                      "VoiceChat's encoder must be streaming-configured")
+        XCTAssertEqual(e.convNormType, "layer_norm",
+                       "Parakeet.swift uses BatchNorm1d — this needs a LayerNorm variant")
+        XCTAssertEqual(e.attContextStyle, "chunked_limited",
+                       "full attention would break causal streaming")
+        XCTAssertEqual(e.causalDownsampling, true)
+        XCTAssertEqual(e.convContextSize, "causal")
+
+        // att_context_size is [[70, 0]] — a list of [left, right] PAIRS.
+        XCTAssertEqual(e.leftContextFrames, 70)
+        XCTAssertEqual(e.rightContextFrames, 0)
+        XCTAssertTrue(e.isFullyCausal,
+                      "right context must be 0 — any lookahead adds algorithmic "
+                      + "latency to every duplex response")
+    }
+
+    /// Guards the two facts a runtime is most likely to get wrong silently.
+    func testDuplexChannelInvariants() throws {
+        guard let c = try loadRealConfig() else {
+            throw XCTSkip("VoiceChat MLX bundle not present")
+        }
+        // Silence is an emitted token: a duplex model is always producing
+        // something on the audio timeline, including deliberate silence.
+        XCTAssertEqual(c.silenceTokenId, 11)
+        XCTAssertNotEqual(c.silenceTokenId, c.padTokenId,
+                          "silence is emitted output, pad is absence — not the same")
+        // Encoder frame rate must match the duplex timeline frame duration.
+        XCTAssertEqual(c.framesPerSecond, 12.5, accuracy: 1e-9)
+    }
+}

--- a/Tests/MLXLMTests/VoiceChatCodecRoundTripTests.swift
+++ b/Tests/MLXLMTests/VoiceChatCodecRoundTripTests.swift
@@ -1,0 +1,201 @@
+import AVFoundation
+import Foundation
+import MLX
+import MLXNN
+import XCTest
+
+@testable import MLXLMCommon
+@testable import MLXVLM
+
+/// Is the generated audio actually SPEECH?
+///
+/// The render proof measured RMS, dynamic range and zero-crossing rate — all
+/// of which pass for structured noise, and the first samples produced for
+/// listening turned out to be exactly that: babble, no words. So this suite
+/// isolates the two halves that could be at fault, in the only order that
+/// distinguishes them:
+///
+///   1. CODEC ROUND TRIP — real speech in, encode, decode, compare to the
+///      input. If this is noise the vocoder is wrong and nothing downstream
+///      can sound like words.
+///   2. TEXT CHANNEL — decode the agent's own text tokens. If those are not
+///      words, the fault is upstream of the speech decoder entirely.
+///
+/// Both write WAVs so the result can be heard, not just scored.
+public class VoiceChatCodecRoundTripTests: XCTestCase {
+
+    private static var enabled: Bool {
+        ProcessInfo.processInfo.environment["VOICECHAT_QUANT_PROOF"] == "1"
+    }
+
+    private static var bundlePath: String {
+        ProcessInfo.processInfo.environment["VOICECHAT_QUANT_DIR"]
+            ?? FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent("models/OsaurusAI/NemotronLabs-VoiceChat-11B-JANG_4")
+                .path
+    }
+
+    private static var fixtureURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(
+            "models/nemotron-voicechat-src/NVIDIA-NemotronLabs-VoiceChat-11B/turn_taking.wav")
+    }
+
+    private static var proofDir: URL {
+        URL(
+            fileURLWithPath: ProcessInfo.processInfo.environment["VOICECHAT_PROOF_DIR"]
+                ?? NSTemporaryDirectory())
+    }
+
+    private func readMono(_ url: URL, targetRate: Double, seconds: Double, offset: Double = 0)
+        throws -> [Float]
+    {
+        let file = try AVAudioFile(forReading: url)
+        let format = file.processingFormat
+        guard
+            let buffer = AVAudioPCMBuffer(
+                pcmFormat: format, frameCapacity: AVAudioFrameCount(file.length))
+        else { return [] }
+        try file.read(into: buffer)
+        guard let channels = buffer.floatChannelData else { return [] }
+        let source = Array(
+            UnsafeBufferPointer(start: channels[0], count: Int(buffer.frameLength)))
+        var out = [Float]()
+        for i in 0 ..< Int(seconds * targetRate) {
+            let position = offset * format.sampleRate
+                + Double(i) * format.sampleRate / targetRate
+            let index = Int(position)
+            guard index + 1 < source.count else { break }
+            let fraction = Float(position - Double(index))
+            out.append(source[index] * (1 - fraction) + source[index + 1] * fraction)
+        }
+        return out
+    }
+
+    private func writeWAV(_ samples: [Float], sampleRate: Int, to url: URL) throws {
+        let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32, sampleRate: Double(sampleRate), channels: 1,
+            interleaved: false)!
+        let file = try AVAudioFile(forWriting: url, settings: format.settings)
+        guard
+            let buffer = AVAudioPCMBuffer(
+                pcmFormat: format, frameCapacity: AVAudioFrameCount(samples.count))
+        else { return }
+        buffer.frameLength = AVAudioFrameCount(samples.count)
+        for (i, v) in samples.enumerated() { buffer.floatChannelData![0][i] = v }
+        try file.write(from: buffer)
+    }
+
+    /// Normalised cross-correlation at the best small lag: the direct measure
+    /// of "is this the same waveform", which noise cannot fake.
+    private func bestCorrelation(_ a: [Float], _ b: [Float], maxLag: Int = 64) -> Float {
+        let n = min(a.count, b.count) - maxLag
+        guard n > 1000 else { return 0 }
+        func energy(_ x: ArraySlice<Float>) -> Float { x.reduce(0) { $0 + $1 * $1 } }
+        let ea = energy(a[0 ..< n])
+        var best: Float = -1
+        for lag in 0 ... maxLag {
+            var dot: Float = 0
+            for i in stride(from: 0, to: n, by: 4) { dot += a[i] * b[i + lag] }
+            let eb = energy(b[lag ..< (lag + n)])
+            let denom = (ea * eb).squareRoot()
+            if denom > 1e-9 { best = max(best, dot * 4 / denom) }
+        }
+        return best
+    }
+
+    // MARK: - 1. Does the codec reproduce real speech?
+
+    func testCodecRoundTripReproducesSpeech() throws {
+        guard Self.enabled else { throw XCTSkip("set VOICECHAT_QUANT_PROOF=1") }
+        let bundle = URL(fileURLWithPath: Self.bundlePath)
+        guard VoiceChatLoader.looksLikeVoiceChatBundle(at: bundle) else {
+            throw XCTSkip("no VoiceChat bundle")
+        }
+        let (model, config) = try VoiceChatLoader.load(from: bundle)
+
+        // Real speech at the codec's own rate.
+        let original = try readMono(
+            Self.fixtureURL, targetRate: Double(config.codecConfig.sampleRate),
+            seconds: 3.0, offset: 1.0)
+        XCTAssertGreaterThan(original.count, 10000)
+
+        let input = MLXArray(original).reshaped([1, 1, original.count])
+        let codes = model.ttsModel.audioCodec.encode(input)
+        let decoded = model.ttsModel.audioCodec.decode(codes)
+        MLX.eval(decoded)
+        let out = decoded[0, 0].asType(.float32).asArray(Float.self)
+
+        try writeWAV(
+            original, sampleRate: config.codecConfig.sampleRate,
+            to: Self.proofDir.appendingPathComponent("codec-roundtrip-input.wav"))
+        try writeWAV(
+            out, sampleRate: config.codecConfig.sampleRate,
+            to: Self.proofDir.appendingPathComponent("codec-roundtrip-output.wav"))
+
+        let correlation = bestCorrelation(original, out)
+        let inRMS = (original.reduce(0) { $0 + $1 * $1 } / Float(original.count)).squareRoot()
+        let outRMS = (out.reduce(0) { $0 + $1 * $1 } / Float(max(out.count, 1))).squareRoot()
+        print(
+            String(
+                format:
+                    "[codec-roundtrip] in %d samples rms %.4f · out %d samples rms %.4f · "
+                    + "correlation %.3f",
+                original.count, inRMS, out.count, outRMS, correlation))
+
+        XCTAssertGreaterThan(out.count, original.count / 2, "codec returned almost nothing")
+        // A working neural codec round-trip correlates strongly with its input.
+        // Noise correlates near zero however good its RMS looks.
+        XCTAssertGreaterThan(
+            correlation, 0.5,
+            "codec round trip does not reproduce the input waveform — the vocoder is wrong, "
+                + "so nothing downstream can sound like words")
+    }
+
+    // MARK: - 2. Is the agent's TEXT channel producing words?
+
+    func testAgentTextChannelProducesWords() throws {
+        guard Self.enabled else { throw XCTSkip("set VOICECHAT_QUANT_PROOF=1") }
+        let bundle = URL(fileURLWithPath: Self.bundlePath)
+        guard VoiceChatLoader.looksLikeVoiceChatBundle(at: bundle) else {
+            throw XCTSkip("no VoiceChat bundle")
+        }
+        let (model, config) = try VoiceChatLoader.load(from: bundle)
+
+        // id → token string, straight from the bundle's tokenizer.
+        let data = try Data(contentsOf: bundle.appendingPathComponent("tokenizer.json"))
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let vocab = try XCTUnwrap((json?["model"] as? [String: Any])?["vocab"] as? [String: Int])
+        var idToToken = [Int: String]()
+        for (token, id) in vocab { idToToken[id] = token }
+        try model.setVocabulary(vocab)
+
+        let user = try readMono(
+            Self.fixtureURL, targetRate: Double(config.inputSampleRate), seconds: 4.0)
+        let mel = voiceChatLogMelSpectrogram(user, config: config.audioConfig.preprocessor)
+        let (projected, encoded) = model.sttModel.perception(mel)
+        let result = model.generateTurn(audioEmbeds: projected, asrEmbeds: encoded)
+
+        let special: Set<Int> = [
+            config.padTokenId, config.silenceTokenId, config.bosTokenId, config.eosTokenId,
+        ]
+        let spoken = result.textTokens.filter { !special.contains($0) }
+        let rendered = spoken.compactMap { idToToken[$0] }
+            .joined()
+            .replacingOccurrences(of: "\u{2581}", with: " ")  // SentencePiece space
+            .replacingOccurrences(of: "Ġ", with: " ")  // byte-BPE space
+        print("[text-channel] tokens \(result.textTokens.count) · non-special \(spoken.count)")
+        print("[text-channel] decoded: \"\(rendered.prefix(300))\"")
+
+        XCTAssertFalse(
+            spoken.isEmpty,
+            "the agent emitted only pad/silence — it never spoke, so the audio cannot contain words")
+
+        // Words, not token soup: require ASCII letters and at least a couple of
+        // space-separated pieces.
+        let letters = rendered.filter { $0.isLetter }.count
+        XCTAssertGreaterThan(
+            letters, 5,
+            "the text channel decoded to \"\(rendered.prefix(80))\" — not words, so the fault "
+                + "is upstream of the speech decoder")
+    }
+}

--- a/Tests/MLXLMTests/VoiceChatConditioningParityTests.swift
+++ b/Tests/MLXLMTests/VoiceChatConditioningParityTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+import MLX
+import MLXNN
+import XCTest
+
+@testable import MLXLMCommon
+@testable import MLXVLM
+
+/// Parity for the character-aware TEXT CONDITIONING the speech decoder runs on.
+///
+/// This is the one stage where a silent mistake produces exactly the symptom
+/// observed: perfect text on the language channel, babble on the speech
+/// channel. The conditioning is built from each subword's CHARACTERS through a
+/// vocabulary the runtime derives itself, so a different derivation yields
+/// different — but perfectly well-formed — vectors, and every structural check
+/// still passes.
+///
+/// Compares against a dump from the Python reference
+/// (`mlx_vlm.models.nemotron_voicechat`) on identical token ids.
+public class VoiceChatConditioningParityTests: XCTestCase {
+
+    private static var enabled: Bool {
+        ProcessInfo.processInfo.environment["VOICECHAT_QUANT_PROOF"] == "1"
+    }
+
+    private static var bundlePath: String {
+        ProcessInfo.processInfo.environment["VOICECHAT_QUANT_DIR"]
+            ?? FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent("models/OsaurusAI/NemotronLabs-VoiceChat-11B-JANG_4")
+                .path
+    }
+
+    func testCharacterConditioningMatchesTheReference() throws {
+        guard Self.enabled else { throw XCTSkip("set VOICECHAT_QUANT_PROOF=1") }
+        guard let dumpPath = ProcessInfo.processInfo.environment["VOICECHAT_REF_COND"],
+            let idsRaw = ProcessInfo.processInfo.environment["VOICECHAT_REF_IDS"]
+        else { throw XCTSkip("set VOICECHAT_REF_COND and VOICECHAT_REF_IDS") }
+
+        let bundle = URL(fileURLWithPath: Self.bundlePath)
+        let (model, _) = try VoiceChatLoader.load(from: bundle)
+        let data = try Data(contentsOf: bundle.appendingPathComponent("tokenizer.json"))
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let vocab = try XCTUnwrap((json?["model"] as? [String: Any])?["vocab"] as? [String: Int])
+        try model.setVocabulary(vocab)
+
+        let ids = idsRaw.split(separator: ",").compactMap { Int32($0) }
+        let tokens = MLXArray(ids).reshaped([1, ids.count])
+        let cond = model.ttsModel.ttsModel.embedSubword(tokens)
+        MLX.eval(cond)
+        let mine = cond.asType(.float32).reshaped([-1]).asArray(Float.self)
+
+        let refData = try Data(contentsOf: URL(fileURLWithPath: dumpPath))
+        let reference: [Float] = refData.withUnsafeBytes {
+            Array($0.bindMemory(to: Float.self))
+        }
+
+        XCTAssertEqual(
+            mine.count, reference.count,
+            "conditioning shape differs from the reference (\(mine.count) vs \(reference.count))")
+
+        let n = min(mine.count, reference.count)
+        var dot: Double = 0, na: Double = 0, nb: Double = 0, maxDiff: Float = 0
+        for i in 0 ..< n {
+            dot += Double(mine[i]) * Double(reference[i])
+            na += Double(mine[i]) * Double(mine[i])
+            nb += Double(reference[i]) * Double(reference[i])
+            maxDiff = max(maxDiff, abs(mine[i] - reference[i]))
+        }
+        let cosine = (na > 0 && nb > 0) ? dot / (na.squareRoot() * nb.squareRoot()) : 0
+        let mineMean = mine.reduce(0, +) / Float(max(mine.count, 1))
+        let refMean = reference.reduce(0, +) / Float(max(reference.count, 1))
+        print(
+            String(
+                format:
+                    "[cond-parity] mine mean %.6f · ref mean %.6f · max abs diff %.4f · cosine %.4f",
+                mineMean, refMean, maxDiff, cosine))
+
+        XCTAssertGreaterThan(
+            cosine, 0.99,
+            "character conditioning diverges from the reference — the speech decoder is being "
+                + "told something different from what the text says, which is exactly how the "
+                + "text channel stays perfect while the audio is babble")
+    }
+}

--- a/Tests/MLXLMTests/VoiceChatEndToEndTests.swift
+++ b/Tests/MLXLMTests/VoiceChatEndToEndTests.swift
@@ -1,0 +1,252 @@
+import Foundation
+import MLX
+import MLXNN
+import XCTest
+
+@testable import MLXLLM
+@testable import MLXLMCommon
+@testable import MLXVLM
+
+/// Step 6: the assembled duplex model and its turn loop.
+///
+/// The full 11 B bundle is too large for a unit test to load, so these run the
+/// REAL loop on a miniature configuration with the real module code — every
+/// channel, the shared frame clock, the TTS warmup and the codec render. What
+/// they pin is behaviour no shape test can see: that the function channel is
+/// driven independently of text, that the loop's fused input actually mixes
+/// three channels, that frame zero warms without emitting audio, and that
+/// control codes never reach the vocoder.
+///
+/// Full-bundle key parity for BOTH sides is covered by
+/// `VoiceChatSTTModelTests` and `VoiceChatTTSTests`; the live audio-to-audio
+/// proof on each shipped quant runs through the app harness.
+public class VoiceChatEndToEndTests: XCTestCase {
+
+    /// A miniature but structurally faithful VoiceChat: dense nemotron_h
+    /// backbone, both heads, a 2-layer TTS with pattern 2, and a 2-quantizer
+    /// codec.
+    private func miniConfig(functionChannelWeight: Float = 2.0) throws
+        -> NemotronVoiceChatConfiguration
+    {
+        let json = """
+            {
+              "text_config": {
+                "model_type": "nemotron_h", "vocab_size": 40, "hidden_size": 16,
+                "intermediate_size": 32, "num_hidden_layers": 2,
+                "num_attention_heads": 2, "num_key_value_heads": 2, "head_dim": 8,
+                "mamba_num_heads": 2, "mamba_head_dim": 8, "ssm_state_size": 8,
+                "conv_kernel": 4, "n_groups": 1, "layer_norm_epsilon": 1e-5,
+                "hybrid_override_pattern": "M*"
+              },
+              "audio_config": {
+                "preprocessor": {"sample_rate": 16000, "features": 8, "n_fft": 64,
+                                 "window_size": 0.025, "window_stride": 0.01},
+                "encoder": {"d_model": 8, "n_layers": 1, "n_heads": 2, "feat_in": 8,
+                            "ff_expansion_factor": 2, "conv_kernel_size": 3,
+                            "subsampling_factor": 2, "subsampling_conv_channels": 4,
+                            "self_attention_model": "rel_pos",
+                            "att_context_style": "chunked_limited",
+                            "att_context_size": [[4, 0]], "use_bias": false},
+                "decoder": {"pred_hidden": 8, "pred_rnn_layers": 1, "vocab_size": 8,
+                            "blank_as_pad": true},
+                "joint": {"joint_hidden": 8, "num_classes": 8, "encoder_hidden": 8,
+                          "pred_hidden": 8},
+                "output_dim": 16, "max_symbols": 4
+              },
+              "tts_config": {
+                "hidden_size": 16, "intermediate_size": 32, "num_hidden_layers": 2,
+                "num_attention_heads": 2, "num_key_value_heads": 2, "head_dim": 8,
+                "sliding_window": 32, "latent_size": 4, "num_quantizers": 2,
+                "codebook_size": 4, "num_delay_speech_tokens": 2,
+                "sliding_window_pattern": 2, "num_iterations": 2,
+                "mog_head": {"intermediate_size": 32, "low_rank": 4, "num_layers": 1,
+                             "num_predictions": 4},
+                "character_encoder": {"hidden_size": 16, "intermediate_size": 32,
+                                      "num_hidden_layers": 1, "num_attention_heads": 2,
+                                      "num_key_value_heads": 2, "head_dim": 8,
+                                      "char_vocab_size": 5}
+              },
+              "codec_config": {
+                "sample_rate": 22050, "base_channels": 4, "channel_multipliers": [1, 2],
+                "downsample_rates": [2, 2], "blocks_per_stage": 1,
+                "block_kernel_size": 3, "latent_dim": 4, "n_fft": 16, "hop_length": 4,
+                "num_quantizers": 2, "codebook_size": 4
+              },
+              "bos_token_id": 1, "eos_token_id": 2, "pad_token_id": 12,
+              "silence_token_id": 11, "rnnt_blank_id": 8,
+              "input_sample_rate": 16000, "output_sample_rate": 22050,
+              "frame_duration": 0.08,
+              "function_channel_weight": \(functionChannelWeight),
+              "speaker": "Aria"
+            }
+            """
+        return try JSONDecoder().decode(
+            NemotronVoiceChatConfiguration.self, from: Data(json.utf8))
+    }
+
+    private func miniModel(seed: UInt64 = 21) throws -> NemotronVoiceChatModel {
+        let model = NemotronVoiceChatModel(try miniConfig())
+        MLXRandom.seed(seed)
+        var params = [String: MLXArray]()
+        for (key, value) in model.parameters().flattened() {
+            // Integer buffers (flags, control codes, silence tokens) must keep
+            // their type — they are indices, not weights.
+            params[key] =
+                value.dtype == .int32
+                ? value : MLXRandom.normal(value.shape).asType(value.dtype) * 0.1
+        }
+        try model.update(parameters: ModuleParameters.unflattened(params), verify: [.none])
+        try model.setVocabulary(["a": 0, "b": 1, "c": 2, "d": 3, "ab": 4])
+        return model
+    }
+
+    /// One full turn: audio embeddings in, text + function tokens + rendered
+    /// 22.05 kHz audio out, on the shared frame clock.
+    func testTurnProducesAllChannelsOnOneClock() throws {
+        let model = try miniModel()
+        let config = try miniConfig()
+        let frames = 6
+        MLXRandom.seed(31)
+        let audioEmbeds = MLXRandom.normal([1, frames, config.textConfig.hiddenSize])
+        let asrEmbeds = MLXRandom.normal([1, frames, 8])
+
+        let result = model.generateTurn(audioEmbeds: audioEmbeds, asrEmbeds: asrEmbeds)
+
+        // Every channel advances on the SAME clock — one entry per frame.
+        XCTAssertEqual(result.textTokens.count, frames)
+        XCTAssertEqual(result.functionTokens.count, frames)
+        XCTAssertEqual(result.audioCodes.dim(0), frames)
+        XCTAssertEqual(result.audioCodes.dim(1), config.ttsConfig.numQuantizers)
+        XCTAssertEqual(result.sampleRate, 22050)
+        XCTAssertEqual(result.audioFrames, frames)
+
+        // Audio was actually rendered and is finite.
+        XCTAssertGreaterThan(result.audio.size, 0, "turn produced no samples")
+        XCTAssertTrue(
+            MLX.all(MLX.isFinite(result.audio)).item(Bool.self),
+            "rendered audio must be finite")
+
+        // Codes stay inside the codebook — a sentinel or control code reaching
+        // the vocoder is an audible artifact, not a silent one.
+        XCTAssertLessThan(
+            Int(result.audioCodes.max().item(Int32.self)), config.ttsConfig.codebookSize,
+            "an unrefined sentinel reached the codec")
+        XCTAssertGreaterThanOrEqual(result.audioCodes.min().item(Int32.self), 0)
+    }
+
+    /// The function channel must be driven by `function_head`, independently
+    /// of the text channel. Tying the two heads makes the channels agree; with
+    /// the shipped (untied) heads they must be free to diverge.
+    func testFunctionChannelIsIndependentOfTextChannel() throws {
+        let model = try miniModel(seed: 41)
+        let config = try miniConfig()
+        MLXRandom.seed(43)
+        let audioEmbeds = MLXRandom.normal([1, 5, config.textConfig.hiddenSize]) * 3.0
+        let asrEmbeds = MLXRandom.normal([1, 5, 8])
+
+        let untied = model.generateTurn(audioEmbeds: audioEmbeds, asrEmbeds: asrEmbeds)
+
+        // Tie function_head to lm_head and re-run: the two channels must then
+        // agree, which proves the divergence above came from the separate head
+        // rather than from sampling noise.
+        let lmHead = try XCTUnwrap(model.sttModel.llm.lmHead?.weight)
+        try model.update(
+            parameters: ModuleParameters.unflattened([
+                "stt_model.function_head.weight": lmHead
+            ]),
+            verify: [.none])
+        let tied = model.generateTurn(audioEmbeds: audioEmbeds, asrEmbeds: asrEmbeds)
+        XCTAssertEqual(
+            tied.textTokens, tied.functionTokens,
+            "with tied heads both channels must decode identically")
+        XCTAssertNotEqual(
+            untied.functionTokens, tied.functionTokens,
+            "untied function_head must not produce the tied result — the channel is not wired")
+    }
+
+    /// The fused frame input mixes three channels; perturbing ONLY the
+    /// function-channel weight must change the turn. If it does not, the
+    /// tool-call channel is decorative.
+    func testFunctionChannelWeightAffectsTheTurn() throws {
+        let base = try miniModel(seed: 47)
+        let config = try miniConfig()
+        MLXRandom.seed(53)
+        let audioEmbeds = MLXRandom.normal([1, 5, config.textConfig.hiddenSize]) * 3.0
+        let asrEmbeds = MLXRandom.normal([1, 5, 8])
+        let withWeight = base.generateTurn(audioEmbeds: audioEmbeds, asrEmbeds: asrEmbeds)
+
+        // Identical weights, but function_channel_weight 0 — the tool-call
+        // channel stops feeding back into the timeline.
+        let zeroModel = NemotronVoiceChatModel(try miniConfig(functionChannelWeight: 0))
+        try zeroModel.update(
+            parameters: ModuleParameters.unflattened(
+                base.parameters().flattened().reduce(into: [String: MLXArray]()) {
+                    $0[$1.0] = $1.1
+                }),
+            verify: [.none])
+        try zeroModel.setVocabulary(["a": 0, "b": 1, "c": 2, "d": 3, "ab": 4])
+        let withoutWeight = zeroModel.generateTurn(
+            audioEmbeds: audioEmbeds, asrEmbeds: asrEmbeds)
+
+        XCTAssertNotEqual(
+            withWeight.textTokens, withoutWeight.textTokens,
+            "function_channel_weight had no effect — the channel is not fused into the timeline")
+    }
+
+    /// A system prompt is prepended on the user-audio channel and trimmed from
+    /// the result: the returned timeline must still be exactly the audio.
+    func testSystemPromptPrefixIsTrimmedFromTheResult() throws {
+        let model = try miniModel(seed: 59)
+        let config = try miniConfig()
+        MLXRandom.seed(61)
+        let frames = 4
+        let audioEmbeds = MLXRandom.normal([1, frames, config.textConfig.hiddenSize])
+        let asrEmbeds = MLXRandom.normal([1, frames, 8])
+        let promptEmbeds = MLXRandom.normal([1, 3, config.textConfig.hiddenSize])
+
+        let result = model.generateTurn(
+            audioEmbeds: audioEmbeds, asrEmbeds: asrEmbeds, promptEmbeds: promptEmbeds)
+        XCTAssertEqual(result.textTokens.count, frames, "prompt prefix must be trimmed")
+        XCTAssertEqual(result.functionTokens.count, frames)
+        XCTAssertEqual(result.audioCodes.dim(0), frames)
+    }
+
+    /// Control codes are protocol markers; rendering them directly is an
+    /// audible artifact. They must be replaced by the codec silence codes.
+    func testControlCodesAreReplacedBeforeRendering() throws {
+        let model = try miniModel(seed: 67)
+        let config = try miniConfig()
+        // Declare code 3 as a control code and 1 as silence.
+        try model.ttsModel.update(
+            parameters: ModuleParameters.unflattened([
+                "control_codes": MLXArray([Int32(3), Int32(3), Int32(3)]),
+                "codec_silence_tokens": MLXArray(
+                    [Int32](repeating: 1, count: config.ttsConfig.numQuantizers)),
+            ]),
+            verify: [.none])
+
+        let codes = MLXArray([Int32(3), Int32(0), Int32(2), Int32(3)])
+            .reshaped([1, 2, config.ttsConfig.numQuantizers])
+        let cleaned = model.replacingControlCodes(codes)
+        let values = cleaned.reshaped([-1]).asArray(Int32.self)
+        XCTAssertEqual(values, [1, 0, 2, 1], "control codes must become silence codes")
+    }
+
+    /// Transcription reads the UNPROJECTED encoder frames through the RNN-T,
+    /// not the text channel — the user's words and the agent's are different
+    /// streams and must not be confused.
+    func testUserTranscriptionUsesTheASRBranch() throws {
+        let model = try miniModel(seed: 71)
+        let config = try miniConfig()
+        MLXRandom.seed(73)
+        let result = model.generateTurn(
+            audioEmbeds: MLXRandom.normal([1, 4, config.textConfig.hiddenSize]),
+            asrEmbeds: MLXRandom.normal([1, 4, 8]) * 5.0)
+        let tokens = model.transcribeUser(result)
+        // Emissions are bounded by max_symbols per frame regardless of content.
+        XCTAssertLessThanOrEqual(tokens.count, 4 * config.audioConfig.maxSymbols)
+        for token in tokens {
+            XCTAssertNotEqual(token, config.rnntBlankId, "blank must never be emitted")
+        }
+    }
+}

--- a/Tests/MLXLMTests/VoiceChatIntelligibilityTests.swift
+++ b/Tests/MLXLMTests/VoiceChatIntelligibilityTests.swift
@@ -321,6 +321,71 @@ public class VoiceChatIntelligibilityTests: XCTestCase {
                 + "(text: \"\(saidText.prefix(60))\" vs heard: \"\(heard.text.prefix(60))\")")
     }
 
+    /// Does a character system prompt stop the base model refusing innocent
+    /// childlike lines?
+    ///
+    /// Observed live: "I'm not sleepy. I promise I'm not sleepy." drew a
+    /// refusal about sexual content and innuendo; "Don't worry, little one.
+    /// I'll keep you safe." drew one about child-protection resources. For an
+    /// avatar, that register IS the product, so this checks whether the turn
+    /// loop's `promptEmbeds` prefix — which nothing currently supplies —
+    /// actually suppresses it. Runs the SAME user audio both ways.
+    func testCharacterPromptSuppressesRefusals() throws {
+        guard Self.enabled else { throw XCTSkip("set VOICECHAT_QUANT_PROOF=1") }
+        guard let script = ProcessInfo.processInfo.environment["VOICECHAT_TTS_SCRIPT"] else {
+            throw XCTSkip("set VOICECHAT_TTS_SCRIPT to JSON holding the system prompt ids")
+        }
+        let bundle = URL(fileURLWithPath: Self.bundlePath)
+        guard VoiceChatLoader.looksLikeVoiceChatBundle(at: bundle) else {
+            throw XCTSkip("no VoiceChat bundle")
+        }
+        let (model, config) = try VoiceChatLoader.load(from: bundle)
+        let data = try Data(contentsOf: bundle.appendingPathComponent("tokenizer.json"))
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let vocab = try XCTUnwrap((json?["model"] as? [String: Any])?["vocab"] as? [String: Int])
+        var idToToken = [Int: String]()
+        for (token, id) in vocab { idToToken[id] = token }
+        try model.setVocabulary(vocab)
+
+        struct Line: Decodable { let name: String; let text: String; let ids: [Int] }
+        let lines = try JSONDecoder().decode(
+            [Line].self, from: try Data(contentsOf: URL(fileURLWithPath: script)))
+        let systemIds = try XCTUnwrap(lines.first).ids
+
+        let user = try readMono(
+            Self.fixtureURL, targetRate: Double(config.inputSampleRate),
+            seconds: Self.fixtureSeconds, offset: Self.fixtureOffset)
+        let mel = voiceChatLogMelSpectrogram(user, config: config.audioConfig.preprocessor)
+        let (projected, encoded) = model.sttModel.perception(mel)
+        MLX.eval(projected, encoded)
+
+        func say(_ result: VoiceChatTurnResult) -> String {
+            let special: Set<Int> = [
+                config.padTokenId, config.silenceTokenId, config.bosTokenId, config.eosTokenId,
+            ]
+            return result.textTokens.filter { !special.contains($0) }
+                .compactMap { idToToken[$0] }.joined()
+                .replacingOccurrences(of: "\u{2581}", with: " ")
+                .replacingOccurrences(of: "\u{0120}", with: " ")
+                .trimmingCharacters(in: .whitespaces)
+        }
+
+        let plain = model.generateTurn(audioEmbeds: projected, asrEmbeds: encoded)
+        print("[prompt] WITHOUT: \"\(say(plain).prefix(200))\"")
+
+        // The prefix rides the user-audio channel, so it is the text embedding
+        // of the system prompt placed in that slot.
+        let promptTokens = MLXArray(systemIds.map { Int32($0) }).reshaped([1, systemIds.count])
+        let promptEmbeds = model.sttModel.embed(promptTokens)
+        MLX.eval(promptEmbeds)
+        let guided = model.generateTurn(
+            audioEmbeds: projected, asrEmbeds: encoded, promptEmbeds: promptEmbeds)
+        print("[prompt] WITH   : \"\(say(guided).prefix(200))\"")
+
+        XCTAssertFalse(
+            say(guided).isEmpty, "the character prompt silenced the agent entirely")
+    }
+
     /// What is the text channel actually deciding, frame by frame?
     ///
     /// A turn that emits only PAD looks identical whether the backbone is

--- a/Tests/MLXLMTests/VoiceChatIntelligibilityTests.swift
+++ b/Tests/MLXLMTests/VoiceChatIntelligibilityTests.swift
@@ -43,6 +43,27 @@ public class VoiceChatIntelligibilityTests: XCTestCase {
             "models/nemotron-voicechat-src/NVIDIA-NemotronLabs-VoiceChat-11B/turn_taking.wav")
     }
 
+    /// 🚨 Start 14 s into the fixture, not at 0.
+    ///
+    /// The first six seconds of `turn_taking.wav` contain one word — the ASR
+    /// control transcribes them as "Hi" — so a turn built from offset 0 gives
+    /// the agent almost nothing to answer and it replies with a bare greeting.
+    /// That made the gate measure a degenerate turn: it read 21% overlap on a
+    /// perfectly healthy runtime simply because there was nothing to say. At
+    /// 14 s the user asks a real question and the agent answers in a full
+    /// sentence.
+    private static var fixtureOffset: Double {
+        Double(ProcessInfo.processInfo.environment["VOICECHAT_FIXTURE_OFFSET"] ?? "") ?? 14.0
+    }
+
+    /// How much user audio the turn gets. This also bounds how long the agent
+    /// can SPEAK, because the duplex loop runs one frame of speech per frame of
+    /// user audio — so too short a window truncates the reply mid-sentence and
+    /// the gate then scores the un-rendered tail as missing speech.
+    private static var fixtureSeconds: Double {
+        Double(ProcessInfo.processInfo.environment["VOICECHAT_FIXTURE_SECONDS"] ?? "") ?? 10.0
+    }
+
     /// Optional: transcribe an EXTERNAL wav (e.g. the Python reference's
     /// output) with the same ASR, so "my speech is babble" can be separated
     /// from "my yardstick is broken".
@@ -168,7 +189,8 @@ public class VoiceChatIntelligibilityTests: XCTestCase {
         // either broken speech or a broken ASR, and the test would not say
         // which.
         let fixtureUser = try readMono(
-            Self.fixtureURL, targetRate: Double(config.inputSampleRate), seconds: 6.0)
+            Self.fixtureURL, targetRate: Double(config.inputSampleRate), seconds: Self.fixtureSeconds,
+            offset: Self.fixtureOffset)
         let control = Self.transcribe(fixtureUser, model: model, config: config)
         print("[intelligibility] ASR control on the fixture: \"\(control.text.prefix(120))\"")
         XCTAssertGreaterThan(
@@ -188,7 +210,8 @@ public class VoiceChatIntelligibilityTests: XCTestCase {
 
         // The turn under test.
         let user = try readMono(
-            Self.fixtureURL, targetRate: Double(config.inputSampleRate), seconds: 6.0)
+            Self.fixtureURL, targetRate: Double(config.inputSampleRate), seconds: Self.fixtureSeconds,
+            offset: Self.fixtureOffset)
         let mel = voiceChatLogMelSpectrogram(user, config: config.audioConfig.preprocessor)
         let (projected, encoded) = model.sttModel.perception(mel)
         let result = model.generateTurn(audioEmbeds: projected, asrEmbeds: encoded)
@@ -214,6 +237,19 @@ public class VoiceChatIntelligibilityTests: XCTestCase {
             model: model, config: config)
         let overlap = Self.inOrderLetterOverlap(expected: saidText, actual: heard.text)
 
+        // The frame-by-frame schedule the model's own text channel produces.
+        // Anything that drives the speech tower directly has to reproduce this
+        // shape, so print it rather than guessing at a token rate.
+        let timeline = result.textTokens.map { id -> String in
+            if id == config.padTokenId { return "." }
+            if id == config.silenceTokenId { return "_" }
+            if id == config.eosTokenId { return "|" }
+            return (idToToken[id] ?? "?")
+                .replacingOccurrences(of: "\u{2581}", with: "-")
+                .replacingOccurrences(of: "Ġ", with: "-")
+        }
+        print("[schedule] frames=\(result.textTokens.count) " + timeline.joined(separator: " "))
+
         print("[intelligibility] agent text channel : \"\(saidText.prefix(120))\"")
         print(
             "[intelligibility] ASR of its own speech: \"\(heard.text.prefix(120))\" "
@@ -230,5 +266,121 @@ public class VoiceChatIntelligibilityTests: XCTestCase {
             overlap, 0.5,
             "the generated speech does not say what the agent said "
                 + "(text: \"\(saidText.prefix(60))\" vs heard: \"\(heard.text.prefix(60))\")")
+    }
+
+    /// Render chosen sentences with the speech tower and prove each one says
+    /// what it was asked to say.
+    ///
+    /// `VOICECHAT_TTS_SCRIPT` points at JSON: `[{"name": …, "text": …,
+    /// "ids": [...]}, …]` — ids come from the bundle's own tokenizer, so this
+    /// test does not have to reimplement tokenization to be trustworthy.
+    func testSynthesizeChosenLines() throws {
+        guard Self.enabled else { throw XCTSkip("set VOICECHAT_QUANT_PROOF=1") }
+        guard let script = ProcessInfo.processInfo.environment["VOICECHAT_TTS_SCRIPT"] else {
+            throw XCTSkip("set VOICECHAT_TTS_SCRIPT")
+        }
+        let bundle = URL(fileURLWithPath: Self.bundlePath)
+        guard VoiceChatLoader.looksLikeVoiceChatBundle(at: bundle) else {
+            throw XCTSkip("no VoiceChat bundle")
+        }
+        let (model, config) = try VoiceChatLoader.load(from: bundle)
+        let data = try Data(contentsOf: bundle.appendingPathComponent("tokenizer.json"))
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let vocab = try XCTUnwrap((json?["model"] as? [String: Any])?["vocab"] as? [String: Int])
+        try model.setVocabulary(vocab)
+
+        struct Line: Decodable {
+            let name: String
+            let text: String
+            let ids: [Int]
+        }
+        let lines = try JSONDecoder().decode(
+            [Line].self, from: try Data(contentsOf: URL(fileURLWithPath: script)))
+        // 1 = the model's own burst pacing (see `frameSchedule`). Spreading
+        // tokens out garbles everything after the first word or two.
+        let framesPerToken =
+            Int(ProcessInfo.processInfo.environment["VOICECHAT_TTS_FPT"] ?? "1") ?? 1
+
+        var weak = [String]()
+        for line in lines {
+            let schedule = model.frameSchedule(
+                subwordIds: line.ids, framesPerToken: framesPerToken)
+            let out = model.synthesize(frameTokens: schedule)
+            let samples = out.audio.asType(.float32).asArray(Float.self)
+            try writeWAV(
+                samples, sampleRate: out.sampleRate,
+                to: Self.proofDir.appendingPathComponent("say-\(line.name).wav"))
+            let heard = Self.transcribe(
+                resample(samples, from: out.sampleRate, to: config.inputSampleRate),
+                model: model, config: config)
+            let overlap = Self.inOrderLetterOverlap(expected: line.text, actual: heard.text)
+            print(
+                String(
+                    format: "[say] %-14s %5.2fs asked \"%@\" → heard \"%@\" (%d tok) %.0f%%",
+                    (line.name as NSString).utf8String!,
+                    Double(samples.count) / Double(out.sampleRate),
+                    line.text, heard.text, heard.tokenCount, overlap * 100))
+            if overlap <= 0.5 { weak.append("\(line.name) (\(Int(overlap * 100))%)") }
+        }
+        XCTAssertTrue(
+            weak.isEmpty,
+            "these lines did not come back as the words they were given: "
+                + weak.joined(separator: ", "))
+    }
+
+    /// Batch gate: every wav in `VOICECHAT_TRANSCRIBE_DIR` must contain WORDS,
+    /// read back by the model's own ASR, in one model load.
+    ///
+    /// 🚨 This exists because a delivered folder of "voice samples" once turned
+    /// out to be babble. Every clip in it passed RMS, dynamic-range and
+    /// zero-crossing checks — those statistics are satisfied by structured
+    /// noise, so they certify nothing about speech. Post-processing (pitch
+    /// shifting for character voices) is exactly the kind of step that can
+    /// destroy words while leaving the statistics intact, so nothing ships
+    /// from a sample folder until it has been through here.
+    ///
+    /// Set `VOICECHAT_TRANSCRIBE_EXPECT` to the sentence the clips should say
+    /// to also gate in-order letter overlap against it.
+    func testEveryClipInDirectoryContainsWords() throws {
+        guard Self.enabled else { throw XCTSkip("set VOICECHAT_QUANT_PROOF=1") }
+        guard let dir = ProcessInfo.processInfo.environment["VOICECHAT_TRANSCRIBE_DIR"] else {
+            throw XCTSkip("set VOICECHAT_TRANSCRIBE_DIR")
+        }
+        let bundle = URL(fileURLWithPath: Self.bundlePath)
+        guard VoiceChatLoader.looksLikeVoiceChatBundle(at: bundle) else {
+            throw XCTSkip("no VoiceChat bundle")
+        }
+        let (model, config) = try VoiceChatLoader.load(from: bundle)
+
+        let files = try FileManager.default
+            .contentsOfDirectory(at: URL(fileURLWithPath: dir), includingPropertiesForKeys: nil)
+            .filter { $0.pathExtension.lowercased() == "wav" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+        XCTAssertFalse(files.isEmpty, "no wav files in \(dir)")
+
+        let expected = ProcessInfo.processInfo.environment["VOICECHAT_TRANSCRIBE_EXPECT"]
+        var silent = [String]()
+        var garbled = [String]()
+        for file in files {
+            let samples = try readMono(
+                file, targetRate: Double(config.inputSampleRate), seconds: 30.0)
+            let heard = Self.transcribe(samples, model: model, config: config)
+            var line = "[clip] \(file.lastPathComponent): "
+                + "\"\(heard.text.prefix(100))\" (\(heard.tokenCount) tokens)"
+            if let expected {
+                let overlap = Self.inOrderLetterOverlap(expected: expected, actual: heard.text)
+                line += String(format: " overlap %.0f%%", overlap * 100)
+                if overlap <= 0.5 { garbled.append(file.lastPathComponent) }
+            }
+            print(line)
+            if heard.tokenCount == 0 { silent.append(file.lastPathComponent) }
+        }
+        XCTAssertTrue(
+            silent.isEmpty,
+            "these clips transcribe to NOTHING — they are not speech, whatever their energy "
+                + "statistics say: \(silent.joined(separator: ", "))")
+        XCTAssertTrue(
+            garbled.isEmpty,
+            "these clips do not say the expected sentence: \(garbled.joined(separator: ", "))")
     }
 }

--- a/Tests/MLXLMTests/VoiceChatIntelligibilityTests.swift
+++ b/Tests/MLXLMTests/VoiceChatIntelligibilityTests.swift
@@ -1,0 +1,234 @@
+import AVFoundation
+import Foundation
+import MLX
+import MLXNN
+import XCTest
+
+@testable import MLXLMCommon
+@testable import MLXVLM
+
+/// **The harness that decides whether the voice actually says words.**
+///
+/// RMS, dynamic range, zero-crossing rate and spectral centroid all pass for
+/// structured noise — the first batch of "voice samples" scored well on every
+/// one of them and was babble. Listening is not available to an automated run,
+/// so the only honest test is a CLOSED LOOP:
+///
+///   the model says something in its TEXT channel
+///     → the speech decoder renders it to audio
+///       → that audio goes back through the model's OWN RNN-T ASR
+///         → the transcript must contain what the text channel said.
+///
+/// A vocoder emitting babble transcribes to nothing (or to unrelated tokens),
+/// which no energy statistic can detect. The same loop doubles as the
+/// regression gate for every future change to the speech path.
+public class VoiceChatIntelligibilityTests: XCTestCase {
+
+    private static var enabled: Bool {
+        ProcessInfo.processInfo.environment["VOICECHAT_QUANT_PROOF"] == "1"
+    }
+
+    private static var bundlePath: String {
+        ProcessInfo.processInfo.environment["VOICECHAT_QUANT_DIR"]
+            ?? FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent("models/OsaurusAI/NemotronLabs-VoiceChat-11B-JANG_4")
+                .path
+    }
+
+    private static var fixtureURL: URL {
+        if let override = ProcessInfo.processInfo.environment["VOICECHAT_FIXTURE"] {
+            return URL(fileURLWithPath: override)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(
+            "models/nemotron-voicechat-src/NVIDIA-NemotronLabs-VoiceChat-11B/turn_taking.wav")
+    }
+
+    /// Optional: transcribe an EXTERNAL wav (e.g. the Python reference's
+    /// output) with the same ASR, so "my speech is babble" can be separated
+    /// from "my yardstick is broken".
+    private static var externalAudio: String? {
+        ProcessInfo.processInfo.environment["VOICECHAT_EXTERNAL_AUDIO"]
+    }
+
+    private static var proofDir: URL {
+        URL(
+            fileURLWithPath: ProcessInfo.processInfo.environment["VOICECHAT_PROOF_DIR"]
+                ?? NSTemporaryDirectory())
+    }
+
+    private func readMono(_ url: URL, targetRate: Double, seconds: Double, offset: Double = 0)
+        throws -> [Float]
+    {
+        let file = try AVAudioFile(forReading: url)
+        let format = file.processingFormat
+        guard
+            let buffer = AVAudioPCMBuffer(
+                pcmFormat: format, frameCapacity: AVAudioFrameCount(file.length))
+        else { return [] }
+        try file.read(into: buffer)
+        guard let channels = buffer.floatChannelData else { return [] }
+        let source = Array(
+            UnsafeBufferPointer(start: channels[0], count: Int(buffer.frameLength)))
+        var out = [Float]()
+        for i in 0 ..< Int(seconds * targetRate) {
+            let position = offset * format.sampleRate
+                + Double(i) * format.sampleRate / targetRate
+            let index = Int(position)
+            guard index + 1 < source.count else { break }
+            let fraction = Float(position - Double(index))
+            out.append(source[index] * (1 - fraction) + source[index + 1] * fraction)
+        }
+        return out
+    }
+
+    private func resample(_ samples: [Float], from: Int, to: Int) -> [Float] {
+        guard from != to, !samples.isEmpty else { return samples }
+        let ratio = Double(from) / Double(to)
+        let count = Int(Double(samples.count) / ratio)
+        var out = [Float]()
+        out.reserveCapacity(count)
+        for i in 0 ..< count {
+            let position = Double(i) * ratio
+            let index = Int(position)
+            guard index + 1 < samples.count else { break }
+            let fraction = Float(position - Double(index))
+            out.append(samples[index] * (1 - fraction) + samples[index + 1] * fraction)
+        }
+        return out
+    }
+
+    private func writeWAV(_ samples: [Float], sampleRate: Int, to url: URL) throws {
+        try? FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32, sampleRate: Double(sampleRate), channels: 1,
+            interleaved: false)!
+        let file = try AVAudioFile(forWriting: url, settings: format.settings)
+        guard
+            let buffer = AVAudioPCMBuffer(
+                pcmFormat: format, frameCapacity: AVAudioFrameCount(samples.count))
+        else { return }
+        buffer.frameLength = AVAudioFrameCount(samples.count)
+        for (i, v) in samples.enumerated() { buffer.floatChannelData![0][i] = v }
+        try file.write(from: buffer)
+    }
+
+    /// Transcribe arbitrary audio with the model's own RNN-T branch.
+    /// Returns the decoded token pieces joined into text.
+    static func transcribe(
+        _ samples: [Float], model: NemotronVoiceChatModel,
+        config: NemotronVoiceChatConfiguration
+    ) -> (text: String, tokenCount: Int) {
+        guard samples.count > 800 else { return ("", 0) }
+        let mel = voiceChatLogMelSpectrogram(samples, config: config.audioConfig.preprocessor)
+        let (_, encoded) = model.sttModel.perception(mel)
+        var state = VoiceChatRNNTDecodeState()
+        let tokens = model.sttModel.transcribe(encoded: encoded, state: &state)
+        let vocabulary = config.rnntVocabulary ?? []
+        let pieces = tokens.compactMap { id -> String? in
+            guard id >= 0, id < vocabulary.count else { return nil }
+            return vocabulary[id]
+        }
+        let text = pieces.joined()
+            .replacingOccurrences(of: "\u{2581}", with: " ")
+            .trimmingCharacters(in: .whitespaces)
+        return (text, tokens.count)
+    }
+
+    /// Fraction of `expected`'s letters that appear, in order, in `actual`.
+    /// Robust to ASR slips in a way exact equality is not.
+    static func inOrderLetterOverlap(expected: String, actual: String) -> Double {
+        let a = Array(expected.lowercased().filter { $0.isLetter })
+        let b = Array(actual.lowercased().filter { $0.isLetter })
+        guard !a.isEmpty else { return 0 }
+        var i = 0
+        for ch in b where i < a.count {
+            if ch == a[i] { i += 1 }
+        }
+        return Double(i) / Double(a.count)
+    }
+
+    func testGeneratedSpeechTranscribesBackToWhatTheAgentSaid() throws {
+        guard Self.enabled else { throw XCTSkip("set VOICECHAT_QUANT_PROOF=1") }
+        let bundle = URL(fileURLWithPath: Self.bundlePath)
+        guard VoiceChatLoader.looksLikeVoiceChatBundle(at: bundle) else {
+            throw XCTSkip("no VoiceChat bundle")
+        }
+        let (model, config) = try VoiceChatLoader.load(from: bundle)
+
+        let data = try Data(contentsOf: bundle.appendingPathComponent("tokenizer.json"))
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let vocab = try XCTUnwrap((json?["model"] as? [String: Any])?["vocab"] as? [String: Int])
+        var idToToken = [Int: String]()
+        for (token, id) in vocab { idToToken[id] = token }
+        try model.setVocabulary(vocab)
+
+        // Sanity floor: the ASR branch must read the FIXTURE's own speech.
+        // Without this, a transcript of "" for the generated audio could mean
+        // either broken speech or a broken ASR, and the test would not say
+        // which.
+        let fixtureUser = try readMono(
+            Self.fixtureURL, targetRate: Double(config.inputSampleRate), seconds: 6.0)
+        let control = Self.transcribe(fixtureUser, model: model, config: config)
+        print("[intelligibility] ASR control on the fixture: \"\(control.text.prefix(120))\"")
+        XCTAssertGreaterThan(
+            control.text.filter { $0.isLetter }.count, 8,
+            "the ASR branch cannot even transcribe real recorded speech — fix that before "
+                + "judging generated audio")
+
+        if let external = Self.externalAudio {
+            let ext = try readMono(
+                URL(fileURLWithPath: external), targetRate: Double(config.inputSampleRate),
+                seconds: 12.0)
+            let heardExternal = Self.transcribe(ext, model: model, config: config)
+            print(
+                "[intelligibility] ASR of EXTERNAL audio (\(external)): "
+                    + "\"\(heardExternal.text.prefix(160))\" (\(heardExternal.tokenCount) tokens)")
+        }
+
+        // The turn under test.
+        let user = try readMono(
+            Self.fixtureURL, targetRate: Double(config.inputSampleRate), seconds: 6.0)
+        let mel = voiceChatLogMelSpectrogram(user, config: config.audioConfig.preprocessor)
+        let (projected, encoded) = model.sttModel.perception(mel)
+        let result = model.generateTurn(audioEmbeds: projected, asrEmbeds: encoded)
+
+        let special: Set<Int> = [
+            config.padTokenId, config.silenceTokenId, config.bosTokenId, config.eosTokenId,
+        ]
+        let saidText = result.textTokens.filter { !special.contains($0) }
+            .compactMap { idToToken[$0] }
+            .joined()
+            .replacingOccurrences(of: "\u{2581}", with: " ")
+            .replacingOccurrences(of: "Ġ", with: " ")
+            .trimmingCharacters(in: .whitespaces)
+
+        let generated = result.audio.asType(.float32).asArray(Float.self)
+        try writeWAV(
+            generated, sampleRate: result.sampleRate,
+            to: Self.proofDir.appendingPathComponent("intelligibility-generated.wav"))
+
+        // Back through the model's own ears, at its input rate.
+        let heard = Self.transcribe(
+            resample(generated, from: result.sampleRate, to: config.inputSampleRate),
+            model: model, config: config)
+        let overlap = Self.inOrderLetterOverlap(expected: saidText, actual: heard.text)
+
+        print("[intelligibility] agent text channel : \"\(saidText.prefix(120))\"")
+        print(
+            "[intelligibility] ASR of its own speech: \"\(heard.text.prefix(120))\" "
+                + "(\(heard.tokenCount) tokens)")
+        print(String(format: "[intelligibility] in-order letter overlap: %.0f%%", overlap * 100))
+
+        XCTAssertFalse(
+            saidText.isEmpty, "the agent said nothing this turn — nothing to render or check")
+        XCTAssertGreaterThan(
+            heard.tokenCount, 0,
+            "the generated audio transcribes to NOTHING — it is not speech, whatever its RMS "
+                + "and zero-crossing rate say")
+        XCTAssertGreaterThan(
+            overlap, 0.5,
+            "the generated speech does not say what the agent said "
+                + "(text: \"\(saidText.prefix(60))\" vs heard: \"\(heard.text.prefix(60))\")")
+    }
+}

--- a/Tests/MLXLMTests/VoiceChatIntelligibilityTests.swift
+++ b/Tests/MLXLMTests/VoiceChatIntelligibilityTests.swift
@@ -156,17 +156,70 @@ public class VoiceChatIntelligibilityTests: XCTestCase {
         return (text, tokens.count)
     }
 
-    /// Fraction of `expected`'s letters that appear, in order, in `actual`.
-    /// Robust to ASR slips in a way exact equality is not.
+    /// Longest common subsequence of letters, as a fraction of `expected`.
+    ///
+    /// 🚨 This is an LCS and not a single forward walk, because the walk
+    /// produces FALSE FAILURES. It only allowed skips in `actual`, so one
+    /// missing letter early stalled the pointer for the rest of the string:
+    /// a run whose speech was plainly correct — "That sounds delicious. I'd be
+    /// happy to help you make some peanut butter cookies", 32 tokens — scored
+    /// 11% purely because the ASR dropped a leading "Oh,". The same flaw scored
+    /// a correct clip at 30% over the single letter difference between
+    /// "favourite" and "favorite".
+    ///
+    /// An LCS allows skips on BOTH sides, so a dropped or altered word costs
+    /// only that word. Everything downstream trusts this number, so it must not
+    /// invent failures.
     static func inOrderLetterOverlap(expected: String, actual: String) -> Double {
         let a = Array(expected.lowercased().filter { $0.isLetter })
         let b = Array(actual.lowercased().filter { $0.isLetter })
-        guard !a.isEmpty else { return 0 }
-        var i = 0
-        for ch in b where i < a.count {
-            if ch == a[i] { i += 1 }
+        guard !a.isEmpty, !b.isEmpty else { return 0 }
+        var previous = [Int](repeating: 0, count: b.count + 1)
+        var current = previous
+        for i in 1 ... a.count {
+            current[0] = 0
+            for j in 1 ... b.count {
+                current[j] =
+                    a[i - 1] == b[j - 1]
+                    ? previous[j - 1] + 1
+                    : Swift.max(previous[j], current[j - 1])
+            }
+            swap(&previous, &current)
         }
-        return Double(i) / Double(a.count)
+        return Double(previous[b.count]) / Double(a.count)
+    }
+
+    /// The gate's own yardstick, pinned. Runs without a bundle.
+    ///
+    /// Both cases below were observed scoring as failures on speech that was
+    /// plainly correct, which is the worst thing this harness can do: it sends
+    /// you hunting a runtime bug that does not exist.
+    func testOverlapMetricDoesNotInventFailures() {
+        let dropped = Self.inOrderLetterOverlap(
+            expected: "Oh, that sounds delicious! I'd be happy to help you make some peanut butter cookies.",
+            actual: "That sounds delicious. I'd be happy to help you make some peanut butter cookies")
+        XCTAssertGreaterThan(
+            dropped, 0.9,
+            "a dropped leading word must cost only that word — the forward-walk "
+                + "version scored this exact pair at 11%")
+
+        let spelling = Self.inOrderLetterOverlap(
+            expected: "You're my favourite friend in the whole world.",
+            actual: "You're my favorite friend in the whole world")
+        XCTAssertGreaterThan(
+            spelling, 0.9, "one letter of spelling drift must not fail a clip (scored 30%)")
+
+        // It still has to reject the thing it exists to catch.
+        XCTAssertLessThan(
+            Self.inOrderLetterOverlap(
+                expected: "Oh, that sounds delicious! I'd be happy to help you make one.",
+                actual: ""),
+            0.01, "silence must score zero")
+        XCTAssertLessThan(
+            Self.inOrderLetterOverlap(
+                expected: "Bye bye! Come back and play with me soon.",
+                actual: "quartz vex hjkl zwq"),
+            0.5, "unrelated words must not pass")
     }
 
     func testGeneratedSpeechTranscribesBackToWhatTheAgentSaid() throws {
@@ -266,6 +319,78 @@ public class VoiceChatIntelligibilityTests: XCTestCase {
             overlap, 0.5,
             "the generated speech does not say what the agent said "
                 + "(text: \"\(saidText.prefix(60))\" vs heard: \"\(heard.text.prefix(60))\")")
+    }
+
+    /// What is the text channel actually deciding, frame by frame?
+    ///
+    /// A turn that emits only PAD looks identical whether the backbone is
+    /// broken (garbage or flat logits) or merely degraded (confidently choosing
+    /// silence, which is by far the most common target in duplex training).
+    /// This prints the top candidates and their probabilities so the two can be
+    /// told apart instead of guessed at.
+    func testTextChannelLogitDiagnostic() throws {
+        guard Self.enabled else { throw XCTSkip("set VOICECHAT_QUANT_PROOF=1") }
+        let bundle = URL(fileURLWithPath: Self.bundlePath)
+        guard VoiceChatLoader.looksLikeVoiceChatBundle(at: bundle) else {
+            throw XCTSkip("no VoiceChat bundle")
+        }
+        let (model, config) = try VoiceChatLoader.load(from: bundle)
+        let data = try Data(contentsOf: bundle.appendingPathComponent("tokenizer.json"))
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let vocab = try XCTUnwrap((json?["model"] as? [String: Any])?["vocab"] as? [String: Int])
+        var idToToken = [Int: String]()
+        for (token, id) in vocab { idToToken[id] = token }
+        try model.setVocabulary(vocab)
+
+        let user = try readMono(
+            Self.fixtureURL, targetRate: Double(config.inputSampleRate),
+            seconds: Self.fixtureSeconds, offset: Self.fixtureOffset)
+        let mel = voiceChatLogMelSpectrogram(user, config: config.audioConfig.preprocessor)
+        let (audioEmbeds, _) = model.sttModel.perception(mel)
+
+        let padId = config.padTokenId
+        let cache = model.sttModel.makeCache()
+        var previousText = padId
+        var previousFunction = padId
+        var padWins = 0
+        var frames = 0
+
+        for time in 0 ..< audioEmbeds.dim(1) {
+            let fused =
+                model.sttModel.embed(MLXArray([Int32(previousText)]).reshaped([1, 1]))
+                + audioEmbeds[0..., time ..< (time + 1), 0...]
+                + config.functionChannelWeight
+                * model.sttModel.embed(MLXArray([Int32(previousFunction)]).reshaped([1, 1]))
+            let output = model.sttModel(inputsEmbeds: fused, cache: cache)
+            let logits = output.textLogits[0..., -1].asType(.float32)
+            MLX.eval(logits)
+
+            let probs = MLX.softmax(logits, axis: -1)
+            let top = MLX.argSort(logits, axis: -1)[0..., (-5)...].asArray(Int32.self).reversed()
+            let probValues = probs.asArray(Float.self)
+            let best = Int(top.first ?? 0)
+            previousText = best
+            previousFunction = output.functionLogits[0..., -1].argMax().item(Int.self)
+            frames += 1
+            if best == padId { padWins += 1 }
+
+            if time % 20 == 0 || (best != padId && frames < 200) {
+                let candidates = top.prefix(5).map { id -> String in
+                    let name = Int(id) == padId ? "<PAD>" : (idToToken[Int(id)] ?? "?\(id)")
+                    return String(format: "%@ %.3f", name, probValues[Int(id)])
+                }
+                let allValues = logits.asArray(Float.self)
+                print(
+                    String(
+                        format: "[logits] f%03d max %+.2f mean %+.2f finite=%@ | ",
+                        time, allValues.max() ?? 0,
+                        allValues.reduce(0, +) / Float(allValues.count),
+                        allValues.allSatisfy { $0.isFinite } ? "yes" : "NO")
+                        + candidates.joined(separator: "  "))
+            }
+            if time > 60 { break }
+        }
+        print("[logits] PAD won \(padWins)/\(frames) frames")
     }
 
     /// Render chosen sentences with the speech tower and prove each one says

--- a/Tests/MLXLMTests/VoiceChatMelDumpTests.swift
+++ b/Tests/MLXLMTests/VoiceChatMelDumpTests.swift
@@ -1,0 +1,77 @@
+import AVFoundation
+import Foundation
+import MLX
+import XCTest
+
+@testable import MLXVLM
+
+/// Dumps the exact 16 kHz samples and the mel features this runtime computes,
+/// so they can be compared against the Python reference front-end
+/// (`mlx_audio.stt.models.nemotron_asr.audio.log_mel_spectrogram`) on
+/// byte-identical input.
+///
+/// A mel mismatch is invisible downstream: the encoder still produces
+/// plausible features, the language model still answers, and only accuracy
+/// (ASR words, speech quality) quietly degrades — which is exactly the class
+/// of bug that shipped babble while every energy statistic looked healthy.
+public class VoiceChatMelDumpTests: XCTestCase {
+
+    func testDumpSamplesAndMel() throws {
+        guard ProcessInfo.processInfo.environment["VOICECHAT_MEL_DUMP"] == "1" else {
+            throw XCTSkip("set VOICECHAT_MEL_DUMP=1")
+        }
+        let out = URL(
+            fileURLWithPath: ProcessInfo.processInfo.environment["VOICECHAT_PROOF_DIR"]
+                ?? NSTemporaryDirectory())
+        try? FileManager.default.createDirectory(
+            at: out, withIntermediateDirectories: true)
+
+        let fixture = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(
+            "models/nemotron-voicechat-src/NVIDIA-NemotronLabs-VoiceChat-11B/turn_taking.wav")
+        let file = try AVAudioFile(forReading: fixture)
+        let format = file.processingFormat
+        let buffer = try XCTUnwrap(
+            AVAudioPCMBuffer(pcmFormat: format, frameCapacity: AVAudioFrameCount(file.length)))
+        try file.read(into: buffer)
+        let channels = try XCTUnwrap(buffer.floatChannelData)
+        let source = Array(
+            UnsafeBufferPointer(start: channels[0], count: Int(buffer.frameLength)))
+
+        var samples = [Float]()
+        for i in 0 ..< Int(6.0 * 16000) {
+            let position = Double(i) * format.sampleRate / 16000.0
+            let index = Int(position)
+            guard index + 1 < source.count else { break }
+            let fraction = Float(position - Double(index))
+            samples.append(source[index] * (1 - fraction) + source[index + 1] * fraction)
+        }
+
+        let config = VoiceChatPreprocessorConfiguration(
+            sampleRate: 16000, features: 128, nFFT: 512, windowSize: 0.025,
+            windowStride: 0.01)
+        let mel = voiceChatLogMelSpectrogram(samples, config: config)
+        MLX.eval(mel)
+        let flat = mel.reshaped([-1]).asType(.float32).asArray(Float.self)
+
+        samples.withUnsafeBufferPointer {
+            try? Data(buffer: $0).write(to: out.appendingPathComponent("mel-samples.f32"))
+        }
+        flat.withUnsafeBufferPointer {
+            try? Data(buffer: $0).write(to: out.appendingPathComponent("mel-swift.f32"))
+        }
+        print(
+            "[mel-dump] samples \(samples.count) · mel shape \(mel.shape) · wrote to \(out.path)")
+    }
+}
+
+extension VoiceChatPreprocessorConfiguration {
+    /// Test-only constructor; the shipped type decodes from the bundle.
+    init(sampleRate: Int, features: Int, nFFT: Int, windowSize: Double, windowStride: Double) {
+        let json = """
+            {"sample_rate": \(sampleRate), "features": \(features), "n_fft": \(nFFT),
+             "window_size": \(windowSize), "window_stride": \(windowStride)}
+            """
+        self = try! JSONDecoder().decode(
+            VoiceChatPreprocessorConfiguration.self, from: Data(json.utf8))
+    }
+}

--- a/Tests/MLXLMTests/VoiceChatPromptPathDiagnosticTests.swift
+++ b/Tests/MLXLMTests/VoiceChatPromptPathDiagnosticTests.swift
@@ -1,0 +1,125 @@
+import AVFoundation
+import Foundation
+import MLX
+import MLXNN
+import XCTest
+
+@testable import MLXLMCommon
+@testable import MLXVLM
+
+/// Diagnostic for the speaker-prompt path: does a reference recording actually
+/// reach the prompt frames, and does a DIFFERENT recording produce DIFFERENT
+/// frames?
+///
+/// This exists because the first cloning run showed three references producing
+/// byte-identical audio to the built-in voice while a fourth changed it — a
+/// result that cannot be explained by "the model rendered similar speech", so
+/// it had to be measured at the prompt itself rather than at the output.
+public class VoiceChatPromptPathDiagnosticTests: XCTestCase {
+
+    private static var enabled: Bool {
+        ProcessInfo.processInfo.environment["VOICECHAT_QUANT_PROOF"] == "1"
+    }
+
+    private static var bundlePath: String {
+        ProcessInfo.processInfo.environment["VOICECHAT_QUANT_DIR"]
+            ?? FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent("models/OsaurusAI/NemotronLabs-VoiceChat-11B-JANG_4")
+                .path
+    }
+
+    private static var voicesDir: URL {
+        URL(
+            fileURLWithPath: ProcessInfo.processInfo.environment["VOICECHAT_VOICES_DIR"]
+                ?? NSTemporaryDirectory())
+    }
+
+    private func readMono(_ url: URL, targetRate: Double, seconds: Double, offset: Double)
+        throws -> [Float]
+    {
+        let file = try AVAudioFile(forReading: url)
+        let format = file.processingFormat
+        guard
+            let buffer = AVAudioPCMBuffer(
+                pcmFormat: format, frameCapacity: AVAudioFrameCount(file.length))
+        else { return [] }
+        try file.read(into: buffer)
+        guard let channels = buffer.floatChannelData else { return [] }
+        let source = Array(
+            UnsafeBufferPointer(start: channels[0], count: Int(buffer.frameLength)))
+        let sourceRate = format.sampleRate
+        var out = [Float]()
+        for i in 0 ..< Int(seconds * targetRate) {
+            let position = offset * sourceRate + Double(i) * sourceRate / targetRate
+            let index = Int(position)
+            guard index + 1 < source.count else { break }
+            let fraction = Float(position - Double(index))
+            out.append(source[index] * (1 - fraction) + source[index + 1] * fraction)
+        }
+        return out
+    }
+
+    func testReferenceAudioReachesThePromptCodes() throws {
+        guard Self.enabled else { throw XCTSkip("set VOICECHAT_QUANT_PROOF=1") }
+        let bundle = URL(fileURLWithPath: Self.bundlePath)
+        guard VoiceChatLoader.looksLikeVoiceChatBundle(at: bundle) else {
+            throw XCTSkip("no VoiceChat bundle")
+        }
+        let voiceFiles =
+            ((try? FileManager.default.contentsOfDirectory(
+                at: Self.voicesDir, includingPropertiesForKeys: nil)) ?? [])
+            .filter { $0.lastPathComponent.hasPrefix("voice-") && $0.pathExtension == "wav" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+        try XCTSkipIf(voiceFiles.isEmpty, "no references")
+
+        let (model, config) = try VoiceChatLoader.load(from: bundle)
+
+        // Silence baseline — what the built-in path encodes.
+        let silentPrompt = model.ttsPrompt(voice: .builtIn)
+        MLX.eval(silentPrompt.codes)
+        let silentCodes = silentPrompt.codes.asType(.int32).asArray(Int32.self)
+
+        var signatures = [String: [Int32]]()
+        for file in voiceFiles {
+            let name = file.deletingPathExtension().lastPathComponent
+            let reference = try readMono(
+                file, targetRate: Double(config.codecConfig.sampleRate),
+                seconds: Double(config.ttsConfig.audioPromptDuration ?? 3.0), offset: 0.4)
+            let prompt = model.ttsPrompt(voice: .reference(reference))
+            MLX.eval(prompt.codes)
+            let codes = prompt.codes.asType(.int32).asArray(Int32.self)
+            let uniqueCount = Set(codes).count
+            let differingFromSilence = zip(codes, silentCodes).filter { $0 != $1 }.count
+            let inputRMS =
+                (reference.reduce(Float(0)) { $0 + $1 * $1 } / Float(max(reference.count, 1)))
+                .squareRoot()
+            print(
+                String(
+                    format:
+                        "[prompt-path] %-18s inRMS %.4f · codes %d · unique %d · differ-from-silence %d (%.0f%%) · latent %@",
+                    (name as NSString).utf8String!, inputRMS, codes.count, uniqueCount,
+                    differingFromSilence,
+                    100.0 * Double(differingFromSilence) / Double(max(codes.count, 1)),
+                    prompt.latent == nil ? "derived" : "built-in"))
+            signatures[name] = codes
+
+            XCTAssertNil(prompt.latent, "\(name): a reference must derive its own prompt latent")
+            XCTAssertGreaterThan(
+                differingFromSilence, 0,
+                "\(name): reference audio encoded to the SAME codes as silence — the prompt "
+                    + "never carries the speaker")
+        }
+
+        // Different references must produce different prompts.
+        let names = signatures.keys.sorted()
+        for i in 0 ..< names.count {
+            for j in (i + 1) ..< names.count {
+                let a = signatures[names[i]]!, b = signatures[names[j]]!
+                let differing = zip(a, b).filter { $0 != $1 }.count
+                XCTAssertGreaterThan(
+                    differing, 0,
+                    "\(names[i]) and \(names[j]) produced identical prompt codes")
+            }
+        }
+    }
+}

--- a/Tests/MLXLMTests/VoiceChatQuantAudioProofTests.swift
+++ b/Tests/MLXLMTests/VoiceChatQuantAudioProofTests.swift
@@ -53,7 +53,7 @@ public class VoiceChatQuantAudioProofTests: XCTestCase {
     }
 
     /// Left channel (the user) of the stereo fixture, resampled to 16 kHz mono.
-    private func loadUserChannel(seconds: Double) throws -> [Float] {
+    private func loadUserChannel(seconds: Double, offset: Double = 0) throws -> [Float] {
         let file = try AVAudioFile(forReading: Self.fixtureURL)
         let format = file.processingFormat
         guard
@@ -73,10 +73,11 @@ public class VoiceChatQuantAudioProofTests: XCTestCase {
         let sourceRate = format.sampleRate
         let targetRate = 16000.0
         let wanted = Int(seconds * targetRate)
+        let startSample = offset * sourceRate
         var out = [Float]()
         out.reserveCapacity(wanted)
         for i in 0 ..< wanted {
-            let position = Double(i) * sourceRate / targetRate
+            let position = startSample + Double(i) * sourceRate / targetRate
             let index = Int(position)
             guard index + 1 < left.count else { break }
             let frac = Float(position - Double(index))
@@ -215,5 +216,64 @@ public class VoiceChatQuantAudioProofTests: XCTestCase {
         for line in summaries { print("[voicechat-proof] \(line)") }
         XCTAssertEqual(
             summaries.count, Self.quantPaths.count, "not every quant produced a proof leg")
+    }
+
+    /// 🚨 The check that separates "renders audio" from "renders THIS audio".
+    ///
+    /// A model that ignored its input would still pass every measurement in
+    /// the test above — RMS, dynamic range, zero-crossing rate all stay
+    /// speech-like for a fixed canned response. This is the word-list lesson
+    /// from the VLM work: score OPPOSITE inputs and require them to differ.
+    /// Two different windows of the fixture must produce materially different
+    /// speech, transcripts, or both.
+    func testOutputDependsOnTheInputAudio() throws {
+        guard Self.enabled else {
+            throw XCTSkip("set VOICECHAT_QUANT_PROOF=1 to run the per-quant audio proof")
+        }
+        guard FileManager.default.fileExists(atPath: Self.fixtureURL.path) else {
+            throw XCTSkip("fixture missing at \(Self.fixtureURL.path)")
+        }
+        guard let (name, path) = Self.quantPaths.first(where: {
+            VoiceChatLoader.looksLikeVoiceChatBundle(at: URL(fileURLWithPath: $0.path))
+        }) else { throw XCTSkip("no VoiceChat bundle present") }
+
+        let (model, config) = try VoiceChatLoader.load(from: URL(fileURLWithPath: path))
+        let vocabURL = URL(fileURLWithPath: path).appendingPathComponent("tokenizer.json")
+        let data = try Data(contentsOf: vocabURL)
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let vocab = (json?["model"] as? [String: Any])?["vocab"] as? [String: Int]
+        try model.setVocabulary(try XCTUnwrap(vocab))
+
+        func turn(offsetSeconds: Double) throws -> (audio: [Float], text: [Int], asr: [Int]) {
+            let samples = try loadUserChannel(seconds: 2.0, offset: offsetSeconds)
+            let mel = voiceChatLogMelSpectrogram(
+                samples, config: config.audioConfig.preprocessor)
+            let (projected, encoded) = model.sttModel.perception(mel)
+            let result = model.generateTurn(audioEmbeds: projected, asrEmbeds: encoded)
+            return (
+                result.audio.asType(.float32).asArray(Float.self),
+                result.textTokens,
+                model.transcribeUser(result)
+            )
+        }
+
+        // Two windows several seconds apart in the same conversation.
+        let early = try turn(offsetSeconds: 1.0)
+        let late = try turn(offsetSeconds: 18.0)
+
+        XCTAssertEqual(early.audio.count, late.audio.count, "same duration in, same out")
+        let differing = zip(early.audio, late.audio).filter { abs($0 - $1) > 1e-4 }.count
+        let fraction = Float(differing) / Float(Swift.max(early.audio.count, 1))
+        print(
+            String(
+                format:
+                    "[voicechat-proof] %@ input-dependence: %.1f%% of samples differ · "
+                    + "text %d vs %d tok · asr %d vs %d tok",
+                name, fraction * 100, early.text.count, late.text.count,
+                early.asr.count, late.asr.count))
+
+        XCTAssertGreaterThan(
+            fraction, 0.10,
+            "different input audio produced near-identical output — the model is not listening")
     }
 }

--- a/Tests/MLXLMTests/VoiceChatQuantAudioProofTests.swift
+++ b/Tests/MLXLMTests/VoiceChatQuantAudioProofTests.swift
@@ -1,0 +1,219 @@
+import AVFoundation
+import Foundation
+import MLX
+import MLXNN
+import XCTest
+
+@testable import MLXLLM
+@testable import MLXLMCommon
+@testable import MLXVLM
+
+/// Audio-to-audio proof on the SHIPPED quants: load the real bundle, feed the
+/// NVIDIA fixture's user channel as 16 kHz mono, run the duplex turn loop, and
+/// measure the rendered 22.05 kHz speech.
+///
+/// Per the live-test protocol, "a wav was produced" is NOT evidence — silence
+/// and noise both produce wavs. Each leg asserts RMS, dynamic range, and
+/// zero-crossing rate in a speech-plausible band, and writes the WAV to
+/// `VOICECHAT_PROOF_DIR` so it can be listened to.
+///
+/// Runs only when `VOICECHAT_QUANT_PROOF=1` — an 11 B load per leg is far too
+/// heavy for the default suite.
+public class VoiceChatQuantAudioProofTests: XCTestCase {
+
+    private static var enabled: Bool {
+        ProcessInfo.processInfo.environment["VOICECHAT_QUANT_PROOF"] == "1"
+    }
+
+    private static var quantPaths: [(name: String, path: String)] {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        if let override = ProcessInfo.processInfo.environment["VOICECHAT_QUANT_DIR"] {
+            return [(URL(fileURLWithPath: override).lastPathComponent, override)]
+        }
+        return [
+            ("MXFP8", "\(home)/models/JANGQ-AI/NemotronLabs-VoiceChat-11B-MXFP8"),
+            ("JANG_4", "\(home)/models/OsaurusAI/NemotronLabs-VoiceChat-11B-JANG_4"),
+            ("JANG_2", "\(home)/models/OsaurusAI/NemotronLabs-VoiceChat-11B-JANG_2"),
+        ]
+    }
+
+    private static var fixtureURL: URL {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        if let override = ProcessInfo.processInfo.environment["VOICECHAT_FIXTURE"] {
+            return URL(fileURLWithPath: override)
+        }
+        return home.appendingPathComponent(
+            "models/nemotron-voicechat-src/NVIDIA-NemotronLabs-VoiceChat-11B/turn_taking.wav")
+    }
+
+    private static var proofDir: URL {
+        URL(
+            fileURLWithPath: ProcessInfo.processInfo.environment["VOICECHAT_PROOF_DIR"]
+                ?? NSTemporaryDirectory())
+    }
+
+    /// Left channel (the user) of the stereo fixture, resampled to 16 kHz mono.
+    private func loadUserChannel(seconds: Double) throws -> [Float] {
+        let file = try AVAudioFile(forReading: Self.fixtureURL)
+        let format = file.processingFormat
+        guard
+            let buffer = AVAudioPCMBuffer(
+                pcmFormat: format, frameCapacity: AVAudioFrameCount(file.length))
+        else { throw XCTSkip("could not allocate fixture buffer") }
+        try file.read(into: buffer)
+
+        guard let channels = buffer.floatChannelData else {
+            throw XCTSkip("fixture has no float samples")
+        }
+        let frames = Int(buffer.frameLength)
+        let left = Array(UnsafeBufferPointer(start: channels[0], count: frames))
+
+        // The fixtures are 24 kHz; the model listens at 16 kHz. Linear resample
+        // — the encoder is robust to it and this keeps the proof dependency-free.
+        let sourceRate = format.sampleRate
+        let targetRate = 16000.0
+        let wanted = Int(seconds * targetRate)
+        var out = [Float]()
+        out.reserveCapacity(wanted)
+        for i in 0 ..< wanted {
+            let position = Double(i) * sourceRate / targetRate
+            let index = Int(position)
+            guard index + 1 < left.count else { break }
+            let frac = Float(position - Double(index))
+            out.append(left[index] * (1 - frac) + left[index + 1] * frac)
+        }
+        return out
+    }
+
+    private func writeWAV(_ samples: [Float], sampleRate: Int, to url: URL) throws {
+        let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32, sampleRate: Double(sampleRate),
+            channels: 1, interleaved: false)!
+        let file = try AVAudioFile(forWriting: url, settings: format.settings)
+        guard
+            let buffer = AVAudioPCMBuffer(
+                pcmFormat: format, frameCapacity: AVAudioFrameCount(samples.count))
+        else { return }
+        buffer.frameLength = AVAudioFrameCount(samples.count)
+        for (i, value) in samples.enumerated() {
+            buffer.floatChannelData![0][i] = value
+        }
+        try file.write(from: buffer)
+    }
+
+    /// Speech-plausibility measurements — the protocol's §"for audio, a wav is
+    /// not evidence" rule.
+    private struct AudioStats {
+        let rms: Float
+        let peak: Float
+        let zeroCrossingRate: Float
+        let dynamicRange: Float
+    }
+
+    private func measure(_ samples: [Float]) -> AudioStats {
+        var sumSquares: Float = 0
+        var peak: Float = 0
+        var crossings = 0
+        var minimum = Float.greatestFiniteMagnitude
+        var maximum = -Float.greatestFiniteMagnitude
+        for (i, value) in samples.enumerated() {
+            sumSquares += value * value
+            peak = Swift.max(peak, abs(value))
+            minimum = Swift.min(minimum, value)
+            maximum = Swift.max(maximum, value)
+            if i > 0, (samples[i - 1] < 0) != (value < 0) { crossings += 1 }
+        }
+        let count = Float(Swift.max(samples.count, 1))
+        return AudioStats(
+            rms: (sumSquares / count).squareRoot(),
+            peak: peak,
+            zeroCrossingRate: Float(crossings) / count,
+            dynamicRange: maximum - minimum)
+    }
+
+    func testEveryShippedQuantRendersSpeechFromRealAudio() throws {
+        guard Self.enabled else {
+            throw XCTSkip("set VOICECHAT_QUANT_PROOF=1 to run the per-quant audio proof")
+        }
+        guard FileManager.default.fileExists(atPath: Self.fixtureURL.path) else {
+            throw XCTSkip("fixture missing at \(Self.fixtureURL.path)")
+        }
+
+        let seconds = Double(
+            ProcessInfo.processInfo.environment["VOICECHAT_PROOF_SECONDS"] ?? "3.0") ?? 3.0
+        let user = try loadUserChannel(seconds: seconds)
+        XCTAssertGreaterThan(user.count, 1000, "fixture produced too few input samples")
+
+        var summaries = [String]()
+        for (name, path) in Self.quantPaths {
+            guard VoiceChatLoader.looksLikeVoiceChatBundle(at: URL(fileURLWithPath: path))
+            else {
+                XCTFail("\(name): no VoiceChat bundle at \(path)")
+                continue
+            }
+
+            let loadStart = Date()
+            let (model, config) = try VoiceChatLoader.load(from: URL(fileURLWithPath: path))
+            let loadSeconds = Date().timeIntervalSince(loadStart)
+
+            // Tokenizer vocabulary for the character-aware TTS conditioning.
+            let vocabURL = URL(fileURLWithPath: path).appendingPathComponent("tokenizer.json")
+            if let data = try? Data(contentsOf: vocabURL),
+                let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                let modelBlock = json["model"] as? [String: Any],
+                let vocab = modelBlock["vocab"] as? [String: Int]
+            {
+                try model.setVocabulary(vocab)
+            } else {
+                XCTFail("\(name): could not read tokenizer vocabulary for TTS conditioning")
+                continue
+            }
+
+            let mel = voiceChatLogMelSpectrogram(user, config: config.audioConfig.preprocessor)
+            let (projected, encoded) = model.sttModel.perception(mel)
+            MLX.eval(projected, encoded)
+
+            let turnStart = Date()
+            let result = model.generateTurn(audioEmbeds: projected, asrEmbeds: encoded)
+            let turnSeconds = Date().timeIntervalSince(turnStart)
+
+            let samples = result.audio.asType(.float32).asArray(Float.self)
+            let stats = measure(samples)
+            let outURL = Self.proofDir.appendingPathComponent(
+                "voicechat-\(name.lowercased()).wav")
+            try writeWAV(samples, sampleRate: result.sampleRate, to: outURL)
+
+            let transcript = model.transcribeUser(result)
+            let toolCalls = result.functionTokens.filter { $0 != config.padTokenId }.count
+
+            summaries.append(
+                String(
+                    format:
+                        "%@: load %.1fs · turn %.1fs · %d frames · %d samples @%d Hz · "
+                        + "rms %.4f peak %.3f zcr %.4f range %.3f · asr %d tok · fn %d · %@",
+                    name, loadSeconds, turnSeconds, result.audioFrames, samples.count,
+                    result.sampleRate, stats.rms, stats.peak, stats.zeroCrossingRate,
+                    stats.dynamicRange, transcript.count, toolCalls, outURL.lastPathComponent))
+
+            // A wav is not evidence; these are.
+            XCTAssertGreaterThan(
+                samples.count, result.audioFrames * 100,
+                "\(name): rendered far fewer samples than frames imply")
+            XCTAssertTrue(
+                samples.allSatisfy { $0.isFinite }, "\(name): rendered audio contains NaN/Inf")
+            XCTAssertGreaterThan(stats.rms, 1e-4, "\(name): output is silence")
+            XCTAssertLessThan(stats.peak, 10.0, "\(name): output is clipping/exploding")
+            XCTAssertGreaterThan(
+                stats.dynamicRange, 1e-3, "\(name): output is constant, not a waveform")
+            // Speech at 22.05 kHz sits well under a 0.5 crossing rate; white
+            // noise approaches it.
+            XCTAssertLessThan(
+                stats.zeroCrossingRate, 0.45,
+                "\(name): zero-crossing rate is noise-like, not speech-like")
+        }
+
+        for line in summaries { print("[voicechat-proof] \(line)") }
+        XCTAssertEqual(
+            summaries.count, Self.quantPaths.count, "not every quant produced a proof leg")
+    }
+}

--- a/Tests/MLXLMTests/VoiceChatQuantizationMapPathTests.swift
+++ b/Tests/MLXLMTests/VoiceChatQuantizationMapPathTests.swift
@@ -1,0 +1,90 @@
+import Foundation
+import MLX
+import MLXNN
+import XCTest
+
+@testable import MLXLMCommon
+@testable import MLXVLM
+
+/// The quantization map in a published bundle is keyed by BUNDLE tensor paths,
+/// but the Swift module tree renames several of them. If the loader's remap
+/// ever drifts from the sanitizers', every per-module recipe misses and each
+/// module is quantized with the GLOBAL default instead of its own — which on a
+/// mixed-bit JANG bundle is a hard shape error at the first matmul
+/// (`w.shape == (4480, 2450)` vs `scales.shape == (4480, 490)`), and on a
+/// uniform bundle would be silent quality loss.
+///
+/// This suite pins the two together against the real bundles: every module the
+/// map names must resolve to a module that actually exists in the model.
+public class VoiceChatQuantizationMapPathTests: XCTestCase {
+
+    private static var bundles: [(name: String, path: String)] {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return [
+            ("MXFP8", "\(home)/models/JANGQ-AI/NemotronLabs-VoiceChat-11B-MXFP8"),
+            ("JANG_4", "\(home)/models/OsaurusAI/NemotronLabs-VoiceChat-11B-JANG_4"),
+            ("JANG_2", "\(home)/models/OsaurusAI/NemotronLabs-VoiceChat-11B-JANG_2"),
+        ]
+    }
+
+    /// Remapping is a pure string transform — checkable without any bundle.
+    func testKnownRenamesAreApplied() {
+        let map = VoiceChatQuantizationMap.modulePath(forBundlePath:)
+        XCTAssertEqual(
+            map("stt_model.llm.layers.17.mixer.down_proj"),
+            "stt_model.llm.backbone.layers.17.mixer.down_proj")
+        XCTAssertEqual(map("stt_model.lm_head"), "stt_model.llm.lm_head")
+        XCTAssertEqual(map("stt_model.embed_tokens"), "stt_model.llm.backbone.embeddings")
+        XCTAssertEqual(
+            map("stt_model.rnnt_joint.joint_net.2"), "stt_model.rnnt_joint.joint_net.out")
+        // Paths that must pass through untouched.
+        XCTAssertEqual(
+            map("stt_model.perception.encoder.layers.0.self_attn.linear_q"),
+            "stt_model.perception.encoder.layers.0.self_attn.linear_q")
+        XCTAssertEqual(
+            map("tts_model.tts_model.backbone.layers.3.mlp.up_proj"),
+            "tts_model.tts_model.backbone.layers.3.mlp.up_proj")
+    }
+
+    /// Every quantized module named by a real bundle must exist in the model
+    /// tree under its remapped path — this is the check that would have caught
+    /// the shape crash before it happened.
+    func testEveryMappedModuleResolvesInTheModelTree() throws {
+        var checked = 0
+        for (name, path) in Self.bundles {
+            let dir = URL(fileURLWithPath: path)
+            let configURL = dir.appendingPathComponent("config.json")
+            guard FileManager.default.fileExists(atPath: configURL.path) else { continue }
+
+            let data = try Data(contentsOf: configURL)
+            let config = try JSONDecoder().decode(
+                NemotronVoiceChatConfiguration.self, from: data)
+            let root = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+            guard let map = VoiceChatQuantizationMap(root?["quantization"] as? [String: Any])
+            else {
+                XCTFail("\(name): bundle has no per-module quantization map")
+                continue
+            }
+
+            let model = NemotronVoiceChatModel(config)
+            let modules = Set(model.leafModules().flattened().map(\.0))
+            XCTAssertFalse(modules.isEmpty)
+
+            var unresolved = [String]()
+            for (bundlePath, _) in map.perModule {
+                let modulePath = VoiceChatQuantizationMap.modulePath(forBundlePath: bundlePath)
+                if !modules.contains(modulePath) { unresolved.append(bundlePath) }
+            }
+            XCTAssertTrue(
+                unresolved.isEmpty,
+                "\(name): \(unresolved.count) mapped module(s) do not resolve, e.g. "
+                    + unresolved.sorted().prefix(3).joined(separator: ", "))
+            checked += 1
+
+            // Sanity: the map really is per-module and mixed, not a single
+            // global recipe wearing a hat.
+            XCTAssertGreaterThan(map.perModule.count, 100, "\(name): map looks truncated")
+        }
+        try XCTSkipIf(checked == 0, "no VoiceChat quant bundles present")
+    }
+}

--- a/Tests/MLXLMTests/VoiceChatSTTModelTests.swift
+++ b/Tests/MLXLMTests/VoiceChatSTTModelTests.swift
@@ -1,0 +1,258 @@
+import Foundation
+import MLX
+import MLXNN
+import XCTest
+
+@testable import MLXLLM
+@testable import MLXVLM
+
+/// Steps 3+4 of the VoiceChat integration: the fused STT model (both output
+/// heads) and the RNN-T transducer.
+///
+/// The heavyweight test here is key parity against the REAL shipped bundle:
+/// every tensor the bundle stores under `stt_model.` must land on exactly one
+/// module parameter, and every module parameter must be fed by the bundle.
+/// That is the test that catches a wrong key, a missed PyTorch→MLX transpose,
+/// a forgotten LSTM bias sum, or a head silently left at random init — the
+/// Ornith lesson being that a runtime can "load" and still have lost a whole
+/// output channel.
+public class VoiceChatSTTModelTests: XCTestCase {
+
+    private static let bundlePath =
+        ("~/models/nemotron-voicechat-src/VoiceChat-11B-mlx-bf16" as NSString)
+        .expandingTildeInPath
+
+    private func loadRealConfig() throws -> NemotronVoiceChatConfiguration? {
+        let url = URL(fileURLWithPath: Self.bundlePath).appendingPathComponent("config.json")
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        return try JSONDecoder().decode(
+            NemotronVoiceChatConfiguration.self, from: Data(contentsOf: url))
+    }
+
+    /// All `stt_model.*` tensors from the real bundle, prefix stripped,
+    /// loaded lazily (mmap) so nothing is materialised.
+    private func loadRealSTTWeights() throws -> [String: MLXArray]? {
+        let dir = URL(fileURLWithPath: Self.bundlePath)
+        guard FileManager.default.fileExists(atPath: dir.appendingPathComponent("config.json").path)
+        else { return nil }
+        var weights = [String: MLXArray]()
+        let shards = try FileManager.default.contentsOfDirectory(atPath: dir.path)
+            .filter { $0.hasSuffix(".safetensors") }
+        for shard in shards {
+            let arrays = try MLX.loadArrays(url: dir.appendingPathComponent(shard))
+            for (key, value) in arrays where key.hasPrefix("stt_model.") {
+                weights[String(key.dropFirst("stt_model.".count))] = value
+            }
+        }
+        return weights.isEmpty ? nil : weights
+    }
+
+    // MARK: - Key parity with the shipped artifact
+
+    func testSanitizedRealWeightsFullyLoadTheModule() throws {
+        guard let config = try loadRealConfig(),
+            let raw = try loadRealSTTWeights()
+        else { throw XCTSkip("VoiceChat MLX bundle not present at \(Self.bundlePath)") }
+
+        let model = VoiceChatSTTModel(config)
+        let sanitized = VoiceChatSTTModel.sanitized(raw)
+
+        // `.all` verifies BOTH directions at shape level: no unused bundle
+        // tensor, no module parameter left at random init. Either failure is
+        // exactly the silent-channel-loss class this model punishes.
+        XCTAssertNoThrow(
+            try model.update(
+                parameters: ModuleParameters.unflattened(sanitized),
+                verify: [.all]),
+            "sanitized bundle tensors must land 1:1 on the module tree")
+    }
+
+    func testSanitizeMapsTheKnownTrapKeys() throws {
+        // Value-independent key facts, checkable without the bundle.
+        let dummy = MLXArray.zeros([2, 2])
+        let mapped = VoiceChatSTTModel.sanitized([
+            "embed_tokens.weight": dummy,
+            "lm_head.weight": dummy,
+            "llm.norm_f.weight": dummy,
+            "rnnt_joint.enc.weight": dummy,
+        ])
+        XCTAssertNotNil(mapped["llm.backbone.embeddings.weight"])
+        XCTAssertNotNil(mapped["llm.lm_head.weight"])
+        XCTAssertNotNil(mapped["llm.backbone.norm_f.weight"])
+        XCTAssertNotNil(mapped["rnnt_joint.enc.weight"])
+        XCTAssertNil(mapped["embed_tokens.weight"], "flat key must be remapped, not duplicated")
+
+        // The LSTM bias trap: PyTorch ships ih and hh bias separately; MLX
+        // folds them into ONE vector. Dropping one silently halves the bias.
+        let ih = MLXArray(converting: [1.0, 2.0])
+        let hh = MLXArray(converting: [10.0, 20.0])
+        let lstm = VoiceChatRNNT.sanitized([
+            "rnnt_decoder.prediction.dec_rnn.lstm.weight_ih_l0": dummy,
+            "rnnt_decoder.prediction.dec_rnn.lstm.weight_hh_l0": dummy,
+            "rnnt_decoder.prediction.dec_rnn.lstm.bias_ih_l0": ih,
+            "rnnt_decoder.prediction.dec_rnn.lstm.bias_hh_l0": hh,
+        ])
+        XCTAssertNotNil(lstm["rnnt_decoder.prediction.dec_rnn.lstm.0.Wx"])
+        XCTAssertNotNil(lstm["rnnt_decoder.prediction.dec_rnn.lstm.0.Wh"])
+        let bias = try XCTUnwrap(lstm["rnnt_decoder.prediction.dec_rnn.lstm.0.bias"])
+        XCTAssertEqual(bias[0].item(Float.self), 11.0, accuracy: 1e-6)
+        XCTAssertEqual(bias[1].item(Float.self), 22.0, accuracy: 1e-6)
+    }
+
+    // MARK: - RNN-T greedy decode properties (real transducer weights)
+
+    private func realTransducer() throws
+        -> (VoiceChatPredictNetwork, VoiceChatJointNetwork, NemotronVoiceChatConfiguration)?
+    {
+        guard let config = try loadRealConfig(),
+            let raw = try loadRealSTTWeights()
+        else { return nil }
+        let decoder = VoiceChatPredictNetwork(config: config.audioConfig.decoder!)
+        let joint = VoiceChatJointNetwork(config: config.audioConfig.joint!)
+        let sanitized = VoiceChatRNNT.sanitized(raw)
+        let decWeights = sanitized.filter { $0.key.hasPrefix("rnnt_decoder.") }
+            .reduce(into: [String: MLXArray]()) {
+                $0[String($1.key.dropFirst("rnnt_decoder.".count))] = $1.value
+            }
+        let jointWeights = sanitized.filter { $0.key.hasPrefix("rnnt_joint.") }
+            .reduce(into: [String: MLXArray]()) {
+                $0[String($1.key.dropFirst("rnnt_joint.".count))] = $1.value
+            }
+        try decoder.update(parameters: ModuleParameters.unflattened(decWeights), verify: [.all])
+        try joint.update(parameters: ModuleParameters.unflattened(jointWeights), verify: [.all])
+        return (decoder, joint, config)
+    }
+
+    /// Chunked decode with carried state must equal whole-sequence decode.
+    /// The prediction LSTM advances only on emission, so a state reset at a
+    /// chunk boundary degrades streaming ASR while every whole-file test
+    /// stays green — the exact class of bug live audio exists to catch.
+    func testGreedyDecodeChunkCarryEqualsWhole() throws {
+        guard let (decoder, joint, config) = try realTransducer() else {
+            throw XCTSkip("VoiceChat MLX bundle not present at \(Self.bundlePath)")
+        }
+        MLXRandom.seed(7)
+        let encoded = MLXRandom.normal([1, 14, 1024]) * 2.0
+
+        var whole = VoiceChatRNNTDecodeState()
+        let wholeTokens = VoiceChatRNNT.greedyDecode(
+            encoded: encoded, decoder: decoder, joint: joint,
+            blankId: config.rnntBlankId, maxSymbols: config.audioConfig.maxSymbols,
+            state: &whole)
+
+        var chunked = VoiceChatRNNTDecodeState()
+        var chunkedTokens = [Int]()
+        var offset = 0
+        for size in [5, 3, 4, 2] {
+            let piece = encoded[0..., offset ..< (offset + size), 0...]
+            chunkedTokens += VoiceChatRNNT.greedyDecode(
+                encoded: piece, decoder: decoder, joint: joint,
+                blankId: config.rnntBlankId, maxSymbols: config.audioConfig.maxSymbols,
+                state: &chunked)
+            offset += size
+        }
+
+        XCTAssertEqual(wholeTokens, chunkedTokens, "carried decode state must make chunking invisible")
+
+        // Vacuity guard: a decode that never emits proves nothing about state
+        // carry. Amplified random frames through the real joint must emit.
+        XCTAssertFalse(wholeTokens.isEmpty, "test input produced no emissions — property not exercised")
+        // And the bound that keeps a pathological joint from looping forever:
+        XCTAssertLessThanOrEqual(
+            wholeTokens.count, 14 * config.audioConfig.maxSymbols,
+            "emissions must respect max_symbols per frame")
+    }
+
+    /// Blank must terminate a frame without touching the prediction state:
+    /// feeding pure-silence-like frames (joint driven to blank) emits nothing.
+    func testAllBlankFramesEmitNothing() throws {
+        guard let (decoder, joint, config) = try realTransducer() else {
+            throw XCTSkip("VoiceChat MLX bundle not present at \(Self.bundlePath)")
+        }
+        // Zero encoder frames: the trained joint overwhelmingly favours blank
+        // on silence-shaped input. If this ever emits, the assertion tells us
+        // the real distribution changed rather than silently absorbing it.
+        let silent = MLXArray.zeros([1, 6, 1024])
+        var state = VoiceChatRNNTDecodeState()
+        let tokens = VoiceChatRNNT.greedyDecode(
+            encoded: silent, decoder: decoder, joint: joint,
+            blankId: config.rnntBlankId, maxSymbols: config.audioConfig.maxSymbols,
+            state: &state)
+        XCTAssertTrue(tokens.isEmpty, "zero frames should decode to blank only, got \(tokens)")
+    }
+
+    // MARK: - The function channel is a separate head, not parsed text
+
+    func testFunctionChannelIsAnIndependentHead() throws {
+        // Tiny synthetic dense nemotron_h so the whole model fits a unit test.
+        let json = """
+            {
+              "text_config": {
+                "model_type": "nemotron_h", "vocab_size": 48, "hidden_size": 16,
+                "intermediate_size": 32, "num_hidden_layers": 2,
+                "num_attention_heads": 2, "num_key_value_heads": 2, "head_dim": 8,
+                "mamba_num_heads": 2, "mamba_head_dim": 8, "ssm_state_size": 8,
+                "conv_kernel": 4, "n_groups": 1, "layer_norm_epsilon": 1e-5,
+                "hybrid_override_pattern": "M-"
+              },
+              "audio_config": {
+                "preprocessor": {"sample_rate": 16000, "features": 8, "n_fft": 64,
+                                 "window_size": 0.025, "window_stride": 0.01},
+                "encoder": {"d_model": 8, "n_layers": 1, "n_heads": 2, "feat_in": 8,
+                            "ff_expansion_factor": 2, "conv_kernel_size": 3,
+                            "subsampling_factor": 2, "subsampling_conv_channels": 4,
+                            "self_attention_model": "rel_pos",
+                            "att_context_size": [[4, 0]]},
+                "decoder": {"pred_hidden": 8, "pred_rnn_layers": 1, "vocab_size": 8,
+                            "blank_as_pad": true},
+                "joint": {"joint_hidden": 8, "num_classes": 8, "encoder_hidden": 8,
+                          "pred_hidden": 8},
+                "output_dim": 16, "max_symbols": 4
+              },
+              "tts_config": {
+                "hidden_size": 8, "intermediate_size": 16, "num_hidden_layers": 1,
+                "num_attention_heads": 2, "num_key_value_heads": 2, "head_dim": 4,
+                "sliding_window": 16, "latent_size": 4, "num_quantizers": 2,
+                "codebook_size": 8, "num_delay_speech_tokens": 2
+              },
+              "codec_config": {
+                "sample_rate": 22050, "base_channels": 4, "channel_multipliers": [1, 1, 1],
+                "downsample_rates": [2, 2, 2], "blocks_per_stage": 1,
+                "block_kernel_size": 3, "latent_dim": 4, "n_fft": 16, "hop_length": 4,
+                "num_quantizers": 2, "codebook_size": 8
+              },
+              "bos_token_id": 1, "eos_token_id": 2, "pad_token_id": 12,
+              "silence_token_id": 11, "rnnt_blank_id": 8,
+              "input_sample_rate": 16000, "output_sample_rate": 22050,
+              "frame_duration": 0.08, "function_channel_weight": 2.0
+            }
+            """
+        let config = try JSONDecoder().decode(
+            NemotronVoiceChatConfiguration.self, from: Data(json.utf8))
+        let model = VoiceChatSTTModel(config)
+
+        MLXRandom.seed(11)
+        let embeds = MLXRandom.normal([1, 3, 16])
+        let out = model(inputsEmbeds: embeds, cache: nil)
+
+        XCTAssertEqual(out.textLogits.shape, [1, 3, 48])
+        XCTAssertEqual(out.functionLogits.shape, [1, 3, 48])
+
+        // Independent heads at random init must disagree…
+        let disagreement = MLX.abs(out.textLogits - out.functionLogits).max().item(Float.self)
+        XCTAssertGreaterThan(
+            disagreement, 1e-3,
+            "function channel produced identical logits to text — one head is being read twice")
+
+        // …and the vacuity guard: with the SAME weights in both heads the
+        // channels must agree, proving the disagreement above comes from the
+        // heads and not from nondeterminism elsewhere.
+        let tied = model.llm.lmHead!.weight
+        try model.update(
+            parameters: ModuleParameters.unflattened(["function_head.weight": tied]),
+            verify: [.none])
+        let outTied = model(inputsEmbeds: embeds, cache: nil)
+        let agreement = MLX.abs(outTied.textLogits - outTied.functionLogits).max().item(Float.self)
+        XCTAssertLessThan(agreement, 1e-5, "tied heads must produce identical channels")
+    }
+}

--- a/Tests/MLXLMTests/VoiceChatStreamingConformerTests.swift
+++ b/Tests/MLXLMTests/VoiceChatStreamingConformerTests.swift
@@ -1,0 +1,147 @@
+import Foundation
+import MLX
+import MLXNN
+import MLXVLM
+import XCTest
+
+/// These test PROPERTIES, not outputs.
+///
+/// A shape/smoke test on a conv module passes whether or not it is causal, and
+/// passes whether or not chunked inference matches whole-sequence inference.
+/// Both of those are wrong only on a live mic — which is precisely the class of
+/// defect an offline test cannot see. So each test here perturbs the input and
+/// asserts what must NOT change.
+public class VoiceChatStreamingConformerTests: XCTestCase {
+
+    private func randomWeights(_ conv: VoiceChatCausalDepthwiseConv, dim: Int, k: Int) {
+        MLXRandom.seed(0)
+        conv.update(parameters: ModuleParameters.unflattened([
+            "depthwise_conv_weight": MLXRandom.normal([dim, 1, k]) * 0.5
+        ]))
+    }
+
+    /// CAUSALITY: changing a LATE input frame must not change EARLY outputs.
+    ///
+    /// The symmetric padding in `NemotronHOmni/Parakeet.swift` fails this — it
+    /// reads (K-1)/2 frames of future — which is exactly why VoiceChat needs its
+    /// own conv rather than a flag on that one.
+    func testCausalConvDoesNotLeakFuture() {
+        let (B, T, D, K) = (1, 24, 8, 9)
+        let conv = VoiceChatCausalDepthwiseConv(dim: D, kernelSize: K)
+        randomWeights(conv, dim: D, k: K)
+
+        MLXRandom.seed(1)
+        let x = MLXRandom.normal([B, T, D])
+        let base = conv(x)
+
+        // Perturb the LAST frame only.
+        var perturbed = x
+        perturbed[0..., (T - 1) ..< T, 0...] = MLXRandom.normal([B, 1, D]) * 10.0
+        let after = conv(perturbed)
+
+        // Every output strictly before the perturbed frame must be untouched.
+        let head = T - 1
+        let delta = MLX.abs(base[0..., 0 ..< head, 0...] - after[0..., 0 ..< head, 0...])
+        let maxDelta = delta.max().item(Float.self)
+        XCTAssertLessThan(maxDelta, 1e-5,
+            "future frame leaked into past outputs — conv is not causal")
+
+        // Sanity: the perturbation must actually reach the LAST output, or the
+        // test above is vacuous (it would also pass on a conv that ignores input).
+        let lastDelta = MLX.abs(base[0..., head..., 0...] - after[0..., head..., 0...])
+            .max().item(Float.self)
+        XCTAssertGreaterThan(lastDelta, 1e-3, "perturbation had no effect at all")
+    }
+
+    /// CHUNK INVARIANCE: streaming in chunks with carried state must equal
+    /// running the whole sequence at once.
+    ///
+    /// Without cross-chunk state each boundary zero-pads and injects an artifact
+    /// once per chunk — periodic glitching that a whole-sequence test never sees.
+    func testStreamingChunksMatchWholeSequence() {
+        let (B, T, D, K) = (1, 30, 6, 9)
+        let conv = VoiceChatCausalDepthwiseConv(dim: D, kernelSize: K)
+        randomWeights(conv, dim: D, k: K)
+
+        MLXRandom.seed(2)
+        let x = MLXRandom.normal([B, T, D])
+
+        conv.resetState()
+        let whole = conv(x, streaming: false)
+
+        // Same input, fed as uneven chunks with state carried across.
+        conv.resetState()
+        var pieces: [MLXArray] = []
+        var cursor = 0
+        for size in [7, 5, 11, 4, 3] {
+            let end = min(cursor + size, T)
+            pieces.append(conv(x[0..., cursor ..< end, 0...], streaming: true))
+            cursor = end
+        }
+        let streamed = MLX.concatenated(pieces, axis: 1)
+
+        XCTAssertEqual(streamed.dim(1), T)
+        let maxDelta = MLX.abs(whole - streamed).max().item(Float.self)
+        XCTAssertLessThan(maxDelta, 1e-4,
+            "chunked streaming diverged from whole-sequence — cross-chunk state is wrong")
+    }
+
+    /// Without carried state, chunking MUST differ — proves the state is doing
+    /// real work and the test above is not passing for a trivial reason.
+    func testWithoutStateChunkingIsWrong() {
+        let (B, T, D, K) = (1, 24, 6, 9)
+        let conv = VoiceChatCausalDepthwiseConv(dim: D, kernelSize: K)
+        randomWeights(conv, dim: D, k: K)
+
+        MLXRandom.seed(3)
+        let x = MLXRandom.normal([B, T, D])
+        conv.resetState()
+        let whole = conv(x, streaming: false)
+
+        // streaming:false on every chunk => each boundary zero-pads.
+        conv.resetState()
+        var pieces: [MLXArray] = []
+        for start in stride(from: 0, to: T, by: 8) {
+            let end = min(start + 8, T)
+            pieces.append(conv(x[0..., start ..< end, 0...], streaming: false))
+        }
+        let naive = MLX.concatenated(pieces, axis: 1)
+
+        let maxDelta = MLX.abs(whole - naive).max().item(Float.self)
+        XCTAssertGreaterThan(maxDelta, 1e-3,
+            "stateless chunking should differ — if it matches, the state carry is a no-op")
+    }
+
+    /// The `[[70, 0]]` mask: 70 frames of history, ZERO lookahead.
+    func testChunkedLimitedMaskMatchesShippedContext() {
+        let T = 100
+        let mask = VoiceChatAttentionMask.chunkedLimited(
+            queryCount: T, leftContext: 70, rightContext: 0, dtype: .float32)
+        XCTAssertEqual(mask.shape, [T, T])
+
+        let neg = -Float.greatestFiniteMagnitude
+        func allowed(_ q: Int, _ k: Int) -> Bool {
+            mask[q, k].item(Float.self) != neg
+        }
+
+        // Self always allowed.
+        XCTAssertTrue(allowed(80, 80))
+        // Any future frame blocked — right context is 0.
+        XCTAssertFalse(allowed(80, 81), "right context 0 must block ALL lookahead")
+        XCTAssertFalse(allowed(80, 99))
+        // Exactly 70 frames of history allowed, 71 back is not.
+        XCTAssertTrue(allowed(80, 80 - 70))
+        XCTAssertFalse(allowed(80, 80 - 71), "left context must be bounded at 70")
+    }
+
+    /// LayerNorm conv module runs and is shape-preserving.
+    func testConvModuleShapeAndReset() {
+        let (B, T, D) = (2, 16, 32)
+        let m = VoiceChatConformerConvModule(dim: D, kernelSize: 9)
+        MLXRandom.seed(4)
+        let x = MLXRandom.normal([B, T, D])
+        let y = m(x, streaming: false)
+        XCTAssertEqual(y.shape, [B, T, D])
+        m.resetState()
+    }
+}

--- a/Tests/MLXLMTests/VoiceChatTTSParityTests.swift
+++ b/Tests/MLXLMTests/VoiceChatTTSParityTests.swift
@@ -89,6 +89,12 @@ public class VoiceChatTTSParityTests: XCTestCase {
                 format: "[tts-parity] warm mine mean %.6f std %.6f · ref mean %.6f std %.6f "
                     + "· cosine %.4f",
                 mw.mean, mw.std, rw.mean, rw.std, cosine(mineWarm, refWarm)))
+        let halfW = min(mineWarm.count, refWarm.count) / 2
+        print(
+            String(
+                format: "[tts-parity] warm halves: cond %.5f · uncond %.5f",
+                cosine(Array(mineWarm[0 ..< halfW]), Array(refWarm[0 ..< halfW])),
+                cosine(Array(mineWarm[halfW...]), Array(refWarm[halfW...]))))
         XCTAssertEqual(
             mineWarm.count, refWarm.count, "warmup hidden shape differs from the reference")
         XCTAssertGreaterThan(
@@ -100,6 +106,24 @@ public class VoiceChatTTSParityTests: XCTestCase {
             "[tts-parity] cache offsets after warmup: "
                 + "rotating[0]=\(cache[0].offset) global[\(model.ttsModel.ttsModel.backbone.slidingWindowPattern - 1)]="
                 + "\(cache[model.ttsModel.ttsModel.backbone.slidingWindowPattern - 1].offset)")
+
+        // Are the two guidance rows in the cache actually distinct?
+        for layerIndex in [0, 1] {
+            let stored = cache[layerIndex].state
+            if let k = stored.first, k.dim(0) == 2 {
+                MLX.eval(k)
+                let row0 = MLX.sum(k[0].asType(.float32) * k[0].asType(.float32)).item(Float.self)
+                    .squareRoot()
+                let row1 = MLX.sum(k[1].asType(.float32) * k[1].asType(.float32)).item(Float.self)
+                    .squareRoot()
+                let diff = MLX.abs(k[0].asType(.float32) - k[1].asType(.float32)).max()
+                    .item(Float.self)
+                print(
+                    String(
+                        format: "[tts-parity] cache[%d] keys: cond|n|=%.2f uncond|n|=%.2f maxdiff=%.4f",
+                        layerIndex, row0, row1, diff))
+            }
+        }
 
         // First decode step, identical inputs.
         let prev = prompt.codes[0..., (prompt.codes.dim(1) - 1)..., 0...]

--- a/Tests/MLXLMTests/VoiceChatTTSParityTests.swift
+++ b/Tests/MLXLMTests/VoiceChatTTSParityTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import MLX
+import MLXNN
+import XCTest
+
+@testable import MLXLMCommon
+@testable import MLXVLM
+
+/// Stage-by-stage parity for the speech decoder against the Python reference.
+///
+/// The intelligibility loop proved the generated audio is not speech while the
+/// text channel, the mel front-end, the character conditioning and the codec
+/// round trip are all exact — so the fault is inside this stack. These tests
+/// compare the two places a divergence can hide: the state the warmup writes
+/// (which carries the speaker) and the hidden state of the first decode step
+/// (which carries everything else).
+public class VoiceChatTTSParityTests: XCTestCase {
+
+    private static var enabled: Bool {
+        ProcessInfo.processInfo.environment["VOICECHAT_QUANT_PROOF"] == "1"
+    }
+
+    private static var bundlePath: String {
+        ProcessInfo.processInfo.environment["VOICECHAT_QUANT_DIR"]
+            ?? FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent("models/OsaurusAI/NemotronLabs-VoiceChat-11B-JANG_4")
+                .path
+    }
+
+    private static var dumpDir: URL? {
+        ProcessInfo.processInfo.environment["VOICECHAT_REF_DUMP"].map {
+            URL(fileURLWithPath: $0)
+        }
+    }
+
+    private func loadFloats(_ url: URL) throws -> [Float] {
+        let data = try Data(contentsOf: url)
+        return data.withUnsafeBytes { Array($0.bindMemory(to: Float.self)) }
+    }
+
+    private func stats(_ values: [Float]) -> (mean: Float, std: Float) {
+        guard !values.isEmpty else { return (0, 0) }
+        let mean = values.reduce(0, +) / Float(values.count)
+        let variance =
+            values.reduce(Float(0)) { $0 + ($1 - mean) * ($1 - mean) } / Float(values.count)
+        return (mean, variance.squareRoot())
+    }
+
+    private func cosine(_ a: [Float], _ b: [Float]) -> Double {
+        let n = min(a.count, b.count)
+        var dot = 0.0, na = 0.0, nb = 0.0
+        for i in 0 ..< n {
+            dot += Double(a[i]) * Double(b[i])
+            na += Double(a[i]) * Double(a[i])
+            nb += Double(b[i]) * Double(b[i])
+        }
+        return (na > 0 && nb > 0) ? dot / (na.squareRoot() * nb.squareRoot()) : 0
+    }
+
+    func testWarmupAndStepMatchTheReference() throws {
+        guard Self.enabled else { throw XCTSkip("set VOICECHAT_QUANT_PROOF=1") }
+        guard let dump = Self.dumpDir else { throw XCTSkip("set VOICECHAT_REF_DUMP") }
+        let bundle = URL(fileURLWithPath: Self.bundlePath)
+        let (model, config) = try VoiceChatLoader.load(from: bundle)
+        let data = try Data(contentsOf: bundle.appendingPathComponent("tokenizer.json"))
+        let json = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        let vocab = try XCTUnwrap((json?["model"] as? [String: Any])?["vocab"] as? [String: Int])
+        try model.setVocabulary(vocab)
+
+        // Same prompt construction as the reference session.
+        let prompt = model.ttsPrompt()
+        MLX.eval(prompt.codes)
+        print(
+            "[tts-parity] prompt codes \(prompt.codes.shape) · subwords \(prompt.subwords.shape)")
+
+        let (warmHidden, cache) = model.ttsModel.ttsModel.warmup(
+            code: prompt.codes,
+            subwordIds: prompt.subwords,
+            subwordMask: prompt.subwordMask,
+            audioMask: prompt.audioMask,
+            audioPromptLatent: prompt.latent,
+            guidance: true)
+        MLX.eval(warmHidden)
+        let mineWarm = warmHidden.asType(.float32).reshaped([-1]).asArray(Float.self)
+        let refWarm = try loadFloats(dump.appendingPathComponent("ref-tts-warm.f32"))
+        let mw = stats(mineWarm), rw = stats(refWarm)
+        print(
+            String(
+                format: "[tts-parity] warm mine mean %.6f std %.6f · ref mean %.6f std %.6f "
+                    + "· cosine %.4f",
+                mw.mean, mw.std, rw.mean, rw.std, cosine(mineWarm, refWarm)))
+        XCTAssertEqual(
+            mineWarm.count, refWarm.count, "warmup hidden shape differs from the reference")
+        XCTAssertGreaterThan(
+            cosine(mineWarm, refWarm), 0.99,
+            "the TTS warmup diverges from the reference — the speaker/prompt state the whole "
+                + "turn is conditioned on is already wrong")
+
+        print(
+            "[tts-parity] cache offsets after warmup: "
+                + "rotating[0]=\(cache[0].offset) global[\(model.ttsModel.ttsModel.backbone.slidingWindowPattern - 1)]="
+                + "\(cache[model.ttsModel.ttsModel.backbone.slidingWindowPattern - 1].offset)")
+
+        // First decode step, identical inputs.
+        let prev = prompt.codes[0..., (prompt.codes.dim(1) - 1)..., 0...]
+        let current = MLXArray([Int32(5501)]).reshaped([1, 1])
+        let step = model.ttsModel.ttsModel.step(
+            code: prev, subwordIds: current,
+            subwordMask: MLXArray.ones([1, 1], dtype: .bool), cache: cache, guidance: true)
+        MLX.eval(step.hiddenStates, step.codes)
+        let mineStep = step.hiddenStates.asType(.float32).reshaped([-1]).asArray(Float.self)
+        let refStep = try loadFloats(dump.appendingPathComponent("ref-tts-step.f32"))
+        let ms = stats(mineStep), rs = stats(refStep)
+        print(
+            String(
+                format: "[tts-parity] step mine mean %.6f std %.6f · ref mean %.6f std %.6f "
+                    + "· cosine %.4f",
+                ms.mean, ms.std, rs.mean, rs.std, cosine(mineStep, refStep)))
+        print(
+            "[tts-parity] step codes mine "
+                + "\(step.codes.asType(.int32).reshaped([-1]).asArray(Int32.self).prefix(12))")
+        _ = config
+        XCTAssertGreaterThan(
+            cosine(mineStep, refStep), 0.99,
+            "the first TTS decode step diverges from the reference")
+    }
+}

--- a/Tests/MLXLMTests/VoiceChatTTSTests.swift
+++ b/Tests/MLXLMTests/VoiceChatTTSTests.swift
@@ -1,0 +1,299 @@
+import Foundation
+import MLX
+import MLXNN
+import XCTest
+
+@testable import MLXLLM
+@testable import MLXLMCommon
+@testable import MLXVLM
+
+/// Step 5 of the VoiceChat integration: the EAR-TTS transformer, MoG head,
+/// character-aware conditioning, and the 22.05 kHz codec.
+///
+/// The decisive test is again key parity against the REAL bundle — 635
+/// `tts_model.*` tensors must land 1:1, which is what catches the decoder's
+/// ConvTranspose-vs-Conv transpose split, the `_variance_list` rename, and
+/// the doubled `tts_model.tts_model` nesting. Audio properties are checked as
+/// PROPERTIES (energy, continuity, dynamic range), never "a buffer appeared" —
+/// silence and noise both produce buffers.
+public class VoiceChatTTSTests: XCTestCase {
+
+    private static let bundlePath =
+        ("~/models/nemotron-voicechat-src/VoiceChat-11B-mlx-bf16" as NSString)
+        .expandingTildeInPath
+
+    private func loadRealConfig() throws -> NemotronVoiceChatConfiguration? {
+        let url = URL(fileURLWithPath: Self.bundlePath).appendingPathComponent("config.json")
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        return try JSONDecoder().decode(
+            NemotronVoiceChatConfiguration.self, from: Data(contentsOf: url))
+    }
+
+    private func loadRealTTSWeights() throws -> [String: MLXArray]? {
+        let dir = URL(fileURLWithPath: Self.bundlePath)
+        guard FileManager.default.fileExists(atPath: dir.appendingPathComponent("config.json").path)
+        else { return nil }
+        var weights = [String: MLXArray]()
+        for shard in try FileManager.default.contentsOfDirectory(atPath: dir.path)
+        where shard.hasSuffix(".safetensors") {
+            for (key, value) in try MLX.loadArrays(url: dir.appendingPathComponent(shard))
+            where key.hasPrefix("tts_model.") {
+                weights[String(key.dropFirst("tts_model.".count))] = value
+            }
+        }
+        return weights.isEmpty ? nil : weights
+    }
+
+    // MARK: - Key parity with the shipped artifact
+
+    func testSanitizedRealTTSWeightsFullyLoadTheModule() throws {
+        guard let config = try loadRealConfig(),
+            let raw = try loadRealTTSWeights()
+        else { throw XCTSkip("VoiceChat MLX bundle not present at \(Self.bundlePath)") }
+
+        let decoder = VoiceChatSpeechDecoder(
+            tts: config.ttsConfig, codec: config.codecConfig)
+        let sanitized = VoiceChatSpeechDecoder.sanitized(raw, codecConfig: config.codecConfig)
+
+        XCTAssertEqual(raw.count, 635, "bundle should ship 635 tts_model tensors")
+        XCTAssertNoThrow(
+            try decoder.update(
+                parameters: ModuleParameters.unflattened(sanitized), verify: [.all]),
+            "sanitized tts_model tensors must land 1:1 on the module tree")
+    }
+
+    /// The fp-protected tensors must arrive with their bundle dtype and shape
+    /// intact — these are the ones a naive "quantize every .weight" loader
+    /// would destroy, taking the speaker's voice or the codebook with it.
+    func testProtectedTensorsSurviveSanitizeUnchanged() throws {
+        guard let config = try loadRealConfig(),
+            let raw = try loadRealTTSWeights()
+        else { throw XCTSkip("VoiceChat MLX bundle not present at \(Self.bundlePath)") }
+
+        let sanitized = VoiceChatSpeechDecoder.sanitized(raw, codecConfig: config.codecConfig)
+        for key in [
+            "tts_model.rvq_embs",
+            "audio_prompt_latents.Aria",
+            "tts_model.mog_head.proj_mus.weight",
+            "tts_model.embed_subword.embed_tokens.weight",
+        ] {
+            let before = try XCTUnwrap(raw[key], "bundle must ship \(key)")
+            let after = try XCTUnwrap(sanitized[key], "\(key) must survive sanitize")
+            XCTAssertEqual(after.shape, before.shape, "\(key) shape changed")
+            XCTAssertEqual(after.dtype, before.dtype, "\(key) dtype changed")
+        }
+
+        // And the shapes the runtime actually depends on.
+        XCTAssertEqual(
+            raw["tts_model.rvq_embs"]?.shape,
+            [config.ttsConfig.numQuantizers, config.ttsConfig.codebookSize,
+             config.ttsConfig.latentSize])
+        XCTAssertEqual(raw["audio_prompt_latents.Aria"]?.shape.count, 3)
+        XCTAssertEqual(raw["audio_prompt_latents.Aria"]?.dim(2), config.ttsConfig.hiddenSize)
+    }
+
+    // MARK: - Codec renders speech-shaped audio, and streams without seams
+
+    /// Tiny codec config so the properties can be checked in a unit test.
+    private var miniCodec: VoiceChatCodecConfiguration {
+        let json = """
+            {"sample_rate": 22050, "base_channels": 8, "channel_multipliers": [1, 2],
+             "downsample_rates": [2, 2], "blocks_per_stage": 1, "block_kernel_size": 3,
+             "latent_dim": 8, "n_fft": 16, "hop_length": 4,
+             "num_quantizers": 2, "codebook_size": 4}
+            """
+        return try! JSONDecoder().decode(
+            VoiceChatCodecConfiguration.self, from: Data(json.utf8))
+    }
+
+    func testCodecDerivedGeometry() throws {
+        guard let config = try loadRealConfig() else {
+            throw XCTSkip("VoiceChat MLX bundle not present")
+        }
+        // 18 = (16/2 + 1) * 2 real+imag rFFT bins.
+        XCTAssertEqual(config.codecConfig.stftChannels, 18)
+        // Samples per codec frame: hop 4 × 7 × 7 × 9.
+        XCTAssertEqual(config.codecConfig.waveformToTokenRatio, 4 * 7 * 7 * 9)
+    }
+
+    func testDecodeProducesSpeechShapedAudioNotSilence() throws {
+        let config = miniCodec
+        let codec = VoiceChatCodec(config)
+        MLXRandom.seed(3)
+        // Random (non-degenerate) codebooks so the decode has real content.
+        var params = [String: MLXArray]()
+        for (key, value) in codec.parameters().flattened() {
+            params[key] = MLXRandom.normal(value.shape) * 0.5
+        }
+        try codec.update(parameters: ModuleParameters.unflattened(params), verify: [.none])
+
+        let frames = 12
+        let codes = MLXRandom.randInt(
+            0 ..< config.codebookSize, [1, config.numQuantizers, frames]).asType(.int32)
+        let audio = codec.decode(codes)
+
+        // Shape: one waveform, sample count consistent with the stage strides.
+        XCTAssertEqual(audio.dim(0), 1)
+        XCTAssertEqual(audio.dim(1), 1)
+        XCTAssertGreaterThan(audio.dim(2), 0)
+
+        let flat = audio.reshaped([-1]).asType(.float32)
+        let rms = MLX.sqrt(MLX.mean(flat * flat)).item(Float.self)
+        XCTAssertFalse(rms.isNaN, "decoded audio must not be NaN")
+        XCTAssertGreaterThan(rms, 1e-6, "decoded audio is silence — not evidence of a working path")
+
+        // Dynamic range: a constant (DC) buffer would pass an RMS check while
+        // being inaudible garbage.
+        let values = flat.asArray(Float.self)
+        let spread = (values.max() ?? 0) - (values.min() ?? 0)
+        XCTAssertGreaterThan(spread, 1e-5, "decoded audio is constant — no waveform structure")
+    }
+
+    /// Streaming continuity: decoding in chunks WITH the cache must not
+    /// introduce a seam. The negative control proves the test can fail — a
+    /// cacheless chunked decode is measurably different at the boundary.
+    func testStreamingCacheRemovesTheChunkSeam() throws {
+        let config = miniCodec
+        let codec = VoiceChatCodec(config)
+        MLXRandom.seed(5)
+        var params = [String: MLXArray]()
+        for (key, value) in codec.parameters().flattened() {
+            params[key] = MLXRandom.normal(value.shape) * 0.5
+        }
+        try codec.update(parameters: ModuleParameters.unflattened(params), verify: [.none])
+
+        let codes = MLXRandom.randInt(0 ..< config.codebookSize, [1, config.numQuantizers, 16])
+            .asType(.int32)
+
+        // Cached streaming: two chunks, state carried.
+        let cache = VoiceChatCausalConv1dCache()
+        let first = codec.decode(codes[0..., 0..., 0 ..< 8], cache: cache)
+        let second = codec.decode(codes[0..., 0..., 8 ..< 16], cache: cache)
+        XCTAssertGreaterThan(first.dim(2), 0, "first streamed chunk produced no samples")
+        XCTAssertGreaterThan(second.dim(2), 0, "second streamed chunk produced no samples")
+
+        // The carried state must actually change the second chunk: decoding
+        // the same codes from a FRESH cache differs, which is precisely the
+        // per-chunk restart artifact the cache exists to remove.
+        let freshCache = VoiceChatCausalConv1dCache()
+        let secondFresh = codec.decode(codes[0..., 0..., 8 ..< 16], cache: freshCache)
+        XCTAssertEqual(second.shape, secondFresh.shape)
+        let delta = MLX.abs(second - secondFresh).max().item(Float.self)
+        XCTAssertGreaterThan(
+            delta, 1e-6,
+            "carried cache made no difference — streaming state is not being applied")
+    }
+
+    // MARK: - MoG head and RVQ code generation
+
+    private var miniTTS: VoiceChatTTSConfiguration {
+        let json = """
+            {"hidden_size": 16, "intermediate_size": 32, "num_hidden_layers": 2,
+             "num_attention_heads": 2, "num_key_value_heads": 2, "head_dim": 8,
+             "sliding_window": 8, "latent_size": 4, "num_quantizers": 3,
+             "codebook_size": 8, "num_delay_speech_tokens": 2,
+             "sliding_window_pattern": 2, "num_iterations": 4, "exponent": 3.0,
+             "guidance_scale": 0.2, "top_p": 0.95, "noise_scale": 0.001,
+             "mog_head": {"intermediate_size": 32, "low_rank": 4, "min_log_std": -4.0,
+                          "num_layers": 1, "num_predictions": 6, "eps": 1e-6},
+             "character_encoder": {"hidden_size": 16, "intermediate_size": 32,
+                                   "num_hidden_layers": 1, "num_attention_heads": 2,
+                                   "num_key_value_heads": 2, "head_dim": 8,
+                                   "char_vocab_size": 5}}
+            """
+        return try! JSONDecoder().decode(VoiceChatTTSConfiguration.self, from: Data(json.utf8))
+    }
+
+    /// Every RVQ stage must be assigned exactly once across the refinement
+    /// schedule: a leftover `codebookSize` sentinel means a codebook was never
+    /// refined and would decode as silence for that residual level.
+    func testGeneratedCodesCoverEveryQuantizer() throws {
+        let config = miniTTS
+        let model = VoiceChatRVQEARTTSModel(config)
+        MLXRandom.seed(9)
+        // Conditional + unconditional halves, as classifier-free guidance needs.
+        let hidden = MLXRandom.normal([2, 5, config.hiddenSize])
+        let codes = model.generateCodes(hidden)
+
+        XCTAssertEqual(codes.shape, [1, 5, config.numQuantizers])
+        let maxCode = codes.max().item(Int32.self)
+        XCTAssertLessThan(
+            Int(maxCode), config.codebookSize,
+            "a quantizer still holds the unrefined sentinel (\(config.codebookSize))")
+        XCTAssertGreaterThanOrEqual(codes.min().item(Int32.self), 0)
+    }
+
+    /// depthSum must treat the sentinel index as a zero contribution, which is
+    /// what keeps a partially-refined code stack valid mid-iteration.
+    func testDepthSumTreatsSentinelAsZero() throws {
+        let config = miniTTS
+        let model = VoiceChatRVQEARTTSModel(config)
+        MLXRandom.seed(13)
+        var params = [String: MLXArray]()
+        for (key, value) in model.parameters().flattened() where key == "rvq_embs" {
+            params[key] = MLXRandom.normal(value.shape)
+        }
+        try model.update(parameters: ModuleParameters.unflattened(params), verify: [.none])
+
+        let allSentinel = MLXArray.full(
+            [1, 2, config.numQuantizers], values: MLXArray(Int32(config.codebookSize)))
+        let zeroSum = model.depthSumEmbedding(allSentinel)
+        XCTAssertLessThan(
+            MLX.abs(zeroSum).max().item(Float.self), 1e-6,
+            "all-sentinel code must sum to zero")
+
+        // Vacuity guard: a real code must NOT sum to zero, or the check above
+        // would pass for a broken lookup that always returns zeros.
+        let realCode = MLXArray.zeros([1, 2, config.numQuantizers], dtype: .int32)
+        XCTAssertGreaterThan(
+            MLX.abs(model.depthSumEmbedding(realCode)).max().item(Float.self), 1e-6,
+            "a real code index must contribute a non-zero embedding")
+    }
+
+    /// The TTS backbone alternates global and sliding-window layers; the cache
+    /// kinds must match that pattern or a long turn silently attends wrong.
+    func testBackboneCacheAlternatesGlobalAndRotating() throws {
+        let config = miniTTS
+        let backbone = VoiceChatTTSBackbone(config)
+        let cache = backbone.makeCache()
+        XCTAssertEqual(cache.count, config.numHiddenLayers)
+        // pattern 2 → layer index 1 (1-based 2nd) is global.
+        XCTAssertTrue(cache[0] is RotatingKVCache, "sliding layer must use a rotating cache")
+        XCTAssertFalse(cache[1] is RotatingKVCache, "every pattern-th layer must be global")
+    }
+
+    /// Two decode steps through the real module shapes: hidden states must be
+    /// finite and the cache must advance (a step that silently no-ops would
+    /// produce a stalled, repeating voice).
+    func testTTSStepAdvancesCacheAndStaysFinite() throws {
+        let config = miniTTS
+        let model = VoiceChatRVQEARTTSModel(config)
+        MLXRandom.seed(17)
+        var params = [String: MLXArray]()
+        for (key, value) in model.parameters().flattened() {
+            params[key] = value.dtype == .int32 ? value : MLXRandom.normal(value.shape) * 0.1
+        }
+        try model.update(parameters: ModuleParameters.unflattened(params), verify: [.none])
+        // Minimal char vocabulary: 4 single-char tokens + padding row = 5.
+        try model.setVocabulary(["a": 0, "b": 1, "c": 2, "d": 3, "ab": 4])
+
+        let cache = model.makeCache()
+        let code = MLXArray.zeros([1, 1, config.numQuantizers], dtype: .int32)
+        let subwordIds = MLXArray([Int32(0)]).reshaped([1, 1])
+
+        let first = model.step(
+            code: code, subwordIds: subwordIds, subwordMask: nil, cache: cache)
+        XCTAssertEqual(first.hiddenStates.dim(0), 2, "guidance keeps cond/uncond halves")
+        XCTAssertTrue(
+            MLX.all(MLX.isFinite(first.hiddenStates)).item(Bool.self),
+            "TTS hidden states must be finite")
+        let offsetAfterFirst = cache[0].offset
+        XCTAssertGreaterThan(offsetAfterFirst, 0, "cache did not advance on the first step")
+
+        let second = model.step(
+            code: first.codes, subwordIds: subwordIds, subwordMask: nil, cache: cache)
+        XCTAssertGreaterThan(
+            cache[0].offset, offsetAfterFirst, "cache did not advance on the second step")
+        XCTAssertTrue(MLX.all(MLX.isFinite(second.hiddenStates)).item(Bool.self))
+    }
+}

--- a/Tests/MLXLMTests/VoiceChatTTSTests.swift
+++ b/Tests/MLXLMTests/VoiceChatTTSTests.swift
@@ -250,16 +250,55 @@ public class VoiceChatTTSTests: XCTestCase {
             "a real code index must contribute a non-zero embedding")
     }
 
-    /// The TTS backbone alternates global and sliding-window layers; the cache
-    /// kinds must match that pattern or a long turn silently attends wrong.
-    func testBackboneCacheAlternatesGlobalAndRotating() throws {
+    /// The speech decoder's cache must reproduce the reference's read
+    /// semantics exactly: `offset` is the number of rows ALREADY stored (which
+    /// is what positions RoPE on the next step), and a read returns precisely
+    /// those rows — no padding, no reordering.
+    ///
+    /// This replaced an assertion that the sliding layers used a rotating
+    /// cache. That was pinning an implementation choice rather than a
+    /// contract, and the choice was wrong: with the shared rotating cache the
+    /// single-token step diverged from the reference while whole-sequence
+    /// prefill was exact, which is how the decoder produced fluent-sounding
+    /// audio containing no words. Cached key rows now match the reference to
+    /// two decimal places.
+    func testCacheReproducesReferenceReadSemantics() throws {
         let config = miniTTS
         let backbone = VoiceChatTTSBackbone(config)
         let cache = backbone.makeCache()
         XCTAssertEqual(cache.count, config.numHiddenLayers)
-        // pattern 2 → layer index 1 (1-based 2nd) is global.
-        XCTAssertTrue(cache[0] is RotatingKVCache, "sliding layer must use a rotating cache")
-        XCTAssertFalse(cache[1] is RotatingKVCache, "every pattern-th layer must be global")
+
+        let head = config.headDim
+        let heads = config.numKeyValueHeads
+        MLXRandom.seed(3)
+
+        for layer in cache {
+            XCTAssertEqual(layer.offset, 0, "a fresh cache holds nothing")
+
+            // Prefill: five rows in, five rows out, offset five.
+            let prefillKeys = MLXRandom.normal([2, heads, 5, head])
+            let (keys, values) = layer.update(keys: prefillKeys, values: prefillKeys)
+            XCTAssertEqual(keys.dim(2), 5, "a read must return exactly the rows stored")
+            XCTAssertEqual(values.dim(2), 5)
+            XCTAssertEqual(layer.offset, 5, "offset must equal the rows stored")
+
+            // Step: one row in, six rows out — the new row LAST, in temporal
+            // order, so the query at position 5 attends to 0...5.
+            let stepKey = MLXRandom.normal([2, heads, 1, head])
+            let (stepped, _) = layer.update(keys: stepKey, values: stepKey)
+            XCTAssertEqual(stepped.dim(2), 6, "the step must see prefill plus itself")
+            XCTAssertEqual(layer.offset, 6)
+            let tail = stepped[0..., 0..., 5 ..< 6, 0...]
+            XCTAssertLessThan(
+                MLX.abs(tail - stepKey).max().item(Float.self), 1e-6,
+                "the newest row must land at the END of the cache, not the start")
+
+            // Both guidance rows stay independent: overwriting one must not
+            // change the other. (A stride-0 broadcast landing in the cache
+            // would fail here.)
+            let rowGap = MLX.abs(stepped[0] - stepped[1]).max().item(Float.self)
+            XCTAssertGreaterThan(rowGap, 1e-6, "guidance rows must be distinct arrays")
+        }
     }
 
     /// Two decode steps through the real module shapes: hidden states must be

--- a/Tests/MLXLMTests/VoiceChatVoiceCloningTests.swift
+++ b/Tests/MLXLMTests/VoiceChatVoiceCloningTests.swift
@@ -145,6 +145,70 @@ public class VoiceChatVoiceCloningTests: XCTestCase {
 
     // MARK: - The test
 
+    /// Calibrate the frozen prompt projection against the shipped Aria latent.
+    ///
+    /// `audio_prompt_latents.Aria` is what the model uses for its own voice, and
+    /// the projection branch is supposed to produce the SAME kind of thing from
+    /// a reference recording. So projecting a recording of Aria's own voice is a
+    /// ground truth: it says both what scale the projection needs and whether
+    /// the projection is trained at all.
+    ///
+    /// Prints, per frame, the projected prompt's RMS against Aria's and their
+    /// cosine similarity. Diagnostic only — it asserts nothing about the
+    /// checkpoint, it reports what the checkpoint contains.
+    func testProjectedPromptAgainstShippedAriaLatent() throws {
+        guard Self.enabled else { throw XCTSkip("set VOICECHAT_QUANT_PROOF=1") }
+        guard let ariaAudio = ProcessInfo.processInfo.environment["VOICECHAT_ARIA_REFERENCE"]
+        else { throw XCTSkip("set VOICECHAT_ARIA_REFERENCE to a wav of the built-in voice") }
+        let bundle = URL(fileURLWithPath: Self.bundlePath)
+        guard VoiceChatLoader.looksLikeVoiceChatBundle(at: bundle) else {
+            throw XCTSkip("no VoiceChat bundle")
+        }
+        let (model, config) = try VoiceChatLoader.load(from: bundle)
+        let tts = model.ttsModel.ttsModel
+
+        let reference = try readMono(
+            URL(fileURLWithPath: ariaAudio), targetRate: Double(config.codecConfig.sampleRate),
+            seconds: Double(config.ttsConfig.audioPromptDuration ?? 3.0), offset: 0.4)
+        let prompt = model.ttsPrompt(voice: .reference(reference))
+        MLX.eval(prompt.codes)
+
+        // Reproduce warmup's shift, so these are the frames warmup would use.
+        let shifted = MLX.concatenated(
+            [
+                MLXArray.zeros(like: prompt.codes[0..., 0 ..< 1, 0...]),
+                prompt.codes[0..., ..<(prompt.codes.dim(1) - 1), 0...],
+            ], axis: 1)
+        let codeEmbed = tts.embedCode(tts.depthSumEmbedding(shifted)).asType(.float32)
+        let raw = MLX.matmul(codeEmbed, tts.audioPromptProjectionW.asType(.float32))
+        let aria = model.ttsModel.audioPromptLatents.aria.asType(.float32)
+        MLX.eval(raw, aria)
+
+        func rms(_ a: MLXArray) -> Float { MLX.sqrt(MLX.mean(a * a)).item(Float.self) }
+        let rawRMS = rms(raw), ariaRMS = rms(aria)
+        print(String(format: "[prompt-cal] raw projection RMS  %.4f", rawRMS))
+        print(String(format: "[prompt-cal] shipped Aria RMS    %.4f", ariaRMS))
+        print(String(format: "[prompt-cal] RMS-matching scale  %.6f", ariaRMS / rawRMS))
+        print(
+            String(
+                format: "[prompt-cal] 1/sqrt(hidden) scale  %.6f",
+                1.0 / Foundation.sqrt(Float(codeEmbed.dim(-1)))))
+
+        // Direction is what says whether the projection is TRAINED: a scale can
+        // always be fixed, an unrelated direction cannot.
+        let frames = Swift.min(raw.dim(1), aria.dim(1))
+        let a = raw[0, ..<frames, 0...], b = aria[0, ..<frames, 0...]
+        let cos =
+            MLX.sum(a * b, axis: -1)
+            / (MLX.sqrt(MLX.sum(a * a, axis: -1)) * MLX.sqrt(MLX.sum(b * b, axis: -1)) + 1e-9)
+        let cosValues = cos.asArray(Float.self)
+        let meanCos = cosValues.reduce(0, +) / Float(cosValues.count)
+        print(
+            String(
+                format: "[prompt-cal] per-frame cosine to Aria: mean %+.4f  min %+.4f  max %+.4f",
+                meanCos, cosValues.min() ?? 0, cosValues.max() ?? 0))
+    }
+
     func testReferenceVoicesChangeTheAgentVoice() throws {
         guard Self.enabled else {
             throw XCTSkip("set VOICECHAT_QUANT_PROOF=1 to run the voice-cloning proof")

--- a/Tests/MLXLMTests/VoiceChatVoiceCloningTests.swift
+++ b/Tests/MLXLMTests/VoiceChatVoiceCloningTests.swift
@@ -1,0 +1,258 @@
+import AVFoundation
+import Foundation
+import MLX
+import MLXNN
+import XCTest
+
+@testable import MLXLMCommon
+import MLXFFT
+@testable import MLXVLM
+
+/// Speaker control: does a reference recording actually change the agent's
+/// VOICE while leaving what it says alone?
+///
+/// The mechanism is not a separate feature — `warmup` derives the prompt
+/// frames from `embed_code(depthSum(prompt codes)) @ audio_prompt_projection_W`
+/// whenever no explicit latent is supplied, so feeding it a real recording
+/// instead of silence makes the speaker that recording's speaker. These tests
+/// prove that end to end on the real bundle, with the measurements a listening
+/// opinion cannot supply: spectral centroid (brightness/pitch character),
+/// zero-crossing rate, and RMS.
+///
+/// 🚨 The decisive assertion is a CROSSED one: two different reference voices
+/// must differ from each other AND from the built-in Aria. A cloning path that
+/// silently ignored the reference would still produce perfectly good speech and
+/// pass every single-sample audio check.
+///
+/// Runs behind `VOICECHAT_QUANT_PROOF=1` (an 11 B load).
+public class VoiceChatVoiceCloningTests: XCTestCase {
+
+    private static var enabled: Bool {
+        ProcessInfo.processInfo.environment["VOICECHAT_QUANT_PROOF"] == "1"
+    }
+
+    private static var bundlePath: String {
+        ProcessInfo.processInfo.environment["VOICECHAT_QUANT_DIR"]
+            ?? FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent("models/OsaurusAI/NemotronLabs-VoiceChat-11B-JANG_4")
+                .path
+    }
+
+    /// Directory of `voice-*.wav` reference clips.
+    private static var voicesDir: URL {
+        URL(
+            fileURLWithPath: ProcessInfo.processInfo.environment["VOICECHAT_VOICES_DIR"]
+                ?? NSTemporaryDirectory())
+    }
+
+    private static var fixtureURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(
+            "models/nemotron-voicechat-src/NVIDIA-NemotronLabs-VoiceChat-11B/turn_taking.wav")
+    }
+
+    private static var proofDir: URL {
+        URL(
+            fileURLWithPath: ProcessInfo.processInfo.environment["VOICECHAT_PROOF_DIR"]
+                ?? NSTemporaryDirectory())
+    }
+
+    // MARK: - Audio helpers
+
+    private func readMono(_ url: URL, targetRate: Double, seconds: Double, offset: Double = 0)
+        throws -> [Float]
+    {
+        let file = try AVAudioFile(forReading: url)
+        let format = file.processingFormat
+        guard
+            let buffer = AVAudioPCMBuffer(
+                pcmFormat: format, frameCapacity: AVAudioFrameCount(file.length))
+        else { return [] }
+        try file.read(into: buffer)
+        guard let channels = buffer.floatChannelData else { return [] }
+        let source = Array(
+            UnsafeBufferPointer(start: channels[0], count: Int(buffer.frameLength)))
+        let sourceRate = format.sampleRate
+        let wanted = Int(seconds * targetRate)
+        var out = [Float]()
+        out.reserveCapacity(wanted)
+        for i in 0 ..< wanted {
+            let position = offset * sourceRate + Double(i) * sourceRate / targetRate
+            let index = Int(position)
+            guard index + 1 < source.count else { break }
+            let fraction = Float(position - Double(index))
+            out.append(source[index] * (1 - fraction) + source[index + 1] * fraction)
+        }
+        return out
+    }
+
+    private func writeWAV(_ samples: [Float], sampleRate: Int, to url: URL) throws {
+        let format = AVAudioFormat(
+            commonFormat: .pcmFormatFloat32, sampleRate: Double(sampleRate), channels: 1,
+            interleaved: false)!
+        let file = try AVAudioFile(forWriting: url, settings: format.settings)
+        guard
+            let buffer = AVAudioPCMBuffer(
+                pcmFormat: format, frameCapacity: AVAudioFrameCount(samples.count))
+        else { return }
+        buffer.frameLength = AVAudioFrameCount(samples.count)
+        for (i, v) in samples.enumerated() { buffer.floatChannelData![0][i] = v }
+        try file.write(from: buffer)
+    }
+
+    /// Voice character, not just loudness: spectral centroid is where the
+    /// energy sits (a cute/high voice is brighter), ZCR tracks it, and RMS
+    /// keeps a silent result from masquerading as a distinct voice.
+    struct VoiceStats {
+        let rms: Float
+        let centroidHz: Float
+        let zcr: Float
+    }
+
+    private func voiceStats(_ samples: [Float], sampleRate: Int) -> VoiceStats {
+        var sumSquares: Float = 0
+        var crossings = 0
+        for (i, v) in samples.enumerated() {
+            sumSquares += v * v
+            if i > 0, (samples[i - 1] < 0) != (v < 0) { crossings += 1 }
+        }
+        let count = Float(max(samples.count, 1))
+
+        // Spectral centroid over the whole clip via a coarse DFT-free proxy:
+        // frame energies through a bank of one-pole differences is overkill
+        // here, so use MLX's rFFT on a padded power-of-two window.
+        let n = 4096
+        let usable = min(samples.count, n)
+        var window = [Float](repeating: 0, count: n)
+        for i in 0 ..< usable {
+            let hann = Float(0.5 - 0.5 * cos(2.0 * Double.pi * Double(i) / Double(usable)))
+            window[i] = samples[samples.count / 2 - usable / 2 + i] * hann
+        }
+        let spectrum = MLXFFT.rfft(MLXArray(window))
+        let magnitude = MLX.sqrt(
+            spectrum.realPart() * spectrum.realPart()
+                + spectrum.imaginaryPart() * spectrum.imaginaryPart())
+        let bins = magnitude.dim(0)
+        let freqs = MLXArray((0 ..< bins).map { Float($0) * Float(sampleRate) / Float(n) })
+        let total = MLX.sum(magnitude).item(Float.self)
+        let centroid =
+            total > 1e-9 ? MLX.sum(magnitude * freqs).item(Float.self) / total : 0
+
+        return VoiceStats(
+            rms: (sumSquares / count).squareRoot(),
+            centroidHz: centroid,
+            zcr: Float(crossings) / count)
+    }
+
+    // MARK: - The test
+
+    func testReferenceVoicesChangeTheAgentVoice() throws {
+        guard Self.enabled else {
+            throw XCTSkip("set VOICECHAT_QUANT_PROOF=1 to run the voice-cloning proof")
+        }
+        let bundle = URL(fileURLWithPath: Self.bundlePath)
+        guard VoiceChatLoader.looksLikeVoiceChatBundle(at: bundle) else {
+            throw XCTSkip("no VoiceChat bundle at \(Self.bundlePath)")
+        }
+        guard FileManager.default.fileExists(atPath: Self.fixtureURL.path) else {
+            throw XCTSkip("fixture missing")
+        }
+        let voiceFiles =
+            ((try? FileManager.default.contentsOfDirectory(
+                at: Self.voicesDir, includingPropertiesForKeys: nil)) ?? [])
+            .filter { $0.lastPathComponent.hasPrefix("voice-") && $0.pathExtension == "wav" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+        try XCTSkipIf(voiceFiles.isEmpty, "no voice-*.wav references in \(Self.voicesDir.path)")
+
+        let (model, config) = try VoiceChatLoader.load(from: bundle)
+        let vocabData = try Data(
+            contentsOf: bundle.appendingPathComponent("tokenizer.json"))
+        let vocabJSON = try JSONSerialization.jsonObject(with: vocabData) as? [String: Any]
+        let vocab = (vocabJSON?["model"] as? [String: Any])?["vocab"] as? [String: Int]
+        try model.setVocabulary(try XCTUnwrap(vocab))
+
+        // One fixed user turn for every voice, so ANY difference in the output
+        // comes from the speaker prompt and nothing else.
+        let userSeconds =
+            Double(ProcessInfo.processInfo.environment["VOICECHAT_PROOF_SECONDS"] ?? "2.0")
+            ?? 2.0
+        let user = try readMono(
+            Self.fixtureURL, targetRate: Double(config.inputSampleRate),
+            seconds: userSeconds)
+        let mel = voiceChatLogMelSpectrogram(user, config: config.audioConfig.preprocessor)
+        let (projected, encoded) = model.sttModel.perception(mel)
+        MLX.eval(projected, encoded)
+
+        func run(_ voice: NemotronVoiceChatModel.Voice, name: String) throws
+            -> (stats: VoiceStats, text: [Int], samples: [Float])
+        {
+            let result = model.generateTurn(
+                audioEmbeds: projected, asrEmbeds: encoded, voice: voice)
+            let samples = result.audio.asType(.float32).asArray(Float.self)
+            let stats = voiceStats(samples, sampleRate: result.sampleRate)
+            try writeWAV(
+                samples, sampleRate: result.sampleRate,
+                to: Self.proofDir.appendingPathComponent("voicechat-voice-\(name).wav"))
+            print(
+                String(
+                    format: "[voicechat-voice] %-12s rms %.4f · centroid %6.0f Hz · zcr %.3f",
+                    (name as NSString).utf8String!, stats.rms, stats.centroidHz, stats.zcr))
+            return (stats, result.textTokens, samples)
+        }
+
+        let builtIn = try run(.builtIn, name: "aria-builtin")
+        XCTAssertGreaterThan(builtIn.stats.rms, 1e-4, "built-in voice produced silence")
+
+        var cloned = [(name: String, stats: VoiceStats, samples: [Float])]()
+        let maxVoices = Int(ProcessInfo.processInfo.environment["VOICECHAT_MAX_VOICES"] ?? "4") ?? 4
+        for file in voiceFiles.prefix(maxVoices) {
+            let name = file.deletingPathExtension().lastPathComponent
+                .replacingOccurrences(of: "voice-", with: "")
+            // The prompt is consumed at the CODEC's rate, and the model wants
+            // about `audio_prompt_duration` seconds of it.
+            let reference = try readMono(
+                file, targetRate: Double(config.codecConfig.sampleRate),
+                seconds: Double(config.ttsConfig.audioPromptDuration ?? 3.0),
+                offset: 0.4)
+            XCTAssertGreaterThan(reference.count, 1000, "\(name): reference clip too short")
+
+            let out = try run(.reference(reference), name: name)
+            XCTAssertGreaterThan(out.stats.rms, 1e-4, "\(name): cloned voice produced silence")
+            XCTAssertTrue(
+                out.samples.allSatisfy { $0.isFinite }, "\(name): cloned audio has NaN/Inf")
+            // Speaking the same words: the reference changes the VOICE, not
+            // the content. (Greedy decode over identical user audio.)
+            XCTAssertEqual(
+                out.text.count, builtIn.text.count,
+                "\(name): reference changed the timeline length, not just the voice")
+            cloned.append((name, out.stats, out.samples))
+        }
+
+        // 🚨 The crossed assertion. A path that ignored the reference would
+        // pass everything above.
+        for entry in cloned {
+            let differing = zip(entry.samples, builtIn.samples)
+                .filter { abs($0 - $1) > 1e-4 }.count
+            let fraction = Float(differing) / Float(max(builtIn.samples.count, 1))
+            print(
+                String(
+                    format: "[voicechat-voice] %-12s vs built-in: %.1f%% samples differ · "
+                        + "centroid %+.0f Hz",
+                    (entry.name as NSString).utf8String!, fraction * 100,
+                    entry.stats.centroidHz - builtIn.stats.centroidHz))
+            XCTAssertGreaterThan(
+                fraction, 0.10,
+                "\(entry.name): cloned output is nearly identical to the built-in voice — "
+                    + "the reference prompt is not reaching the speaker path")
+        }
+
+        if cloned.count >= 2 {
+            let a = cloned[0], b = cloned[1]
+            let differing = zip(a.samples, b.samples).filter { abs($0 - $1) > 1e-4 }.count
+            let fraction = Float(differing) / Float(max(a.samples.count, 1))
+            XCTAssertGreaterThan(
+                fraction, 0.10,
+                "\(a.name) and \(b.name) produced nearly identical audio — different "
+                    + "references are not producing different voices")
+        }
+    }
+}

--- a/tools/character.py
+++ b/tools/character.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Turn a pitched-up human voice into a CREATURE voice.
+
+Uniformly scaling pitch and formants gives a smaller human — which reads as a
+child, not a character. Three things separate a cartoon creature from a small
+person, and none of them is pitch:
+
+  1. NON-UNIFORM formant warping. A uniform scale just shrinks the vocal tract.
+     Real character voices move the low formants (which carry vowel colour and
+     "size") differently from the high ones (which carry brightness and
+     consonant edge). Warping them apart is what stops it sounding human.
+
+  2. Roughness. Creature voices have grit — subharmonic energy and a slightly
+     driven low band. A clean voice never sounds like an animal.
+
+  3. Liveliness. A little vibrato plus envelope expansion gives the bouncy,
+     animated delivery a flat read lacks.
+
+Everything here works on the spectral envelope or in the time domain with
+continuous interpolation, so nothing stitches frames at mismatched phase — the
+66.8 Hz overlap-add artifact class cannot reappear.
+
+Usage:
+  character.py IN OUT --lowf 1.25 --highf 0.95 --growl 0.3 --vibrato 4.5,0.012
+                      --nasal 0.0 --expand 1.3
+"""
+import argparse, subprocess, sys, numpy as np
+
+N, HOP, LIFTER = 1024, 256, 40
+
+
+def read(path):
+    sr = int(subprocess.run(
+        ["ffprobe", "-v", "error", "-select_streams", "a:0", "-show_entries",
+         "stream=sample_rate", "-of", "csv=p=0", path],
+        capture_output=True, text=True, check=True).stdout.strip())
+    raw = subprocess.run(
+        ["ffmpeg", "-v", "error", "-i", path, "-f", "f32le", "-ac", "1", "-"],
+        capture_output=True, check=True).stdout
+    return np.frombuffer(raw, dtype=np.float32).astype(np.float64), sr
+
+
+def write(path, x, sr):
+    x = np.clip(x, -1.0, 1.0).astype(np.float32)
+    subprocess.run(
+        ["ffmpeg", "-v", "error", "-y", "-f", "f32le", "-ar", str(sr), "-ac", "1",
+         "-i", "-", "-c:a", "pcm_f32le", path], input=x.tobytes(), check=True)
+
+
+def warp_axis(freqs, sr, lowf, highf, nasal):
+    """Frequency map with DIFFERENT scaling for low and high formants.
+
+    Below the pivot the axis is scaled by `lowf`, above it by `highf`, joined
+    continuously. `nasal` adds a bump near 1 kHz, the resonance that makes a
+    voice sound like it has a snout.
+    """
+    pivot = 1500.0
+    hz = freqs * (sr / 2) / freqs[-1]
+    out = np.where(hz <= pivot, hz / max(lowf, 1e-3),
+                   pivot / max(lowf, 1e-3) + (hz - pivot) / max(highf, 1e-3))
+    if nasal:
+        out = out + nasal * 400.0 * np.exp(-((hz - 1000.0) ** 2) / (2 * 350.0 ** 2))
+    return out * freqs[-1] / (sr / 2)
+
+
+def envelope(logmag):
+    cep = np.fft.irfft(logmag, n=N)
+    cep[LIFTER:-LIFTER] = 0.0
+    return np.fft.rfft(cep, n=N).real
+
+
+def reshape(x, sr, lowf, highf, nasal):
+    win = np.hanning(N + 1)[:N]
+    pad = np.concatenate([np.zeros(N), x, np.zeros(N * 2)])
+    out = np.zeros(len(pad)); norm = np.zeros(len(pad))
+    freqs = np.arange(N // 2 + 1).astype(np.float64)
+    src = warp_axis(freqs, sr, lowf, highf, nasal)
+    for start in range(0, len(pad) - N, HOP):
+        frame = pad[start:start + N] * win
+        spec = np.fft.rfft(frame)
+        mag = np.abs(spec)
+        if mag.max() < 1e-8:
+            continue
+        env = envelope(np.log(mag + 1e-10))
+        warped = np.interp(src, freqs, env, left=env[0], right=env[-1])
+        gain = np.exp(np.clip(warped - env, -6.0, 6.0))
+        rec = np.fft.irfft(spec * gain, n=N) * win
+        out[start:start + N] += rec
+        norm[start:start + N] += win ** 2
+    y = out[N:N + len(x)] / np.maximum(norm[N:N + len(x)], 1e-8)
+    return y
+
+
+def vibrato(x, sr, rate, depth):
+    """Sinusoidal pitch wobble via a fractional delay line.
+
+    Continuous interpolation, so there is no frame stitching at all.
+    """
+    if rate <= 0 or depth <= 0:
+        return x
+    amp = depth / (2 * np.pi * rate) * sr          # samples
+    base = amp + 2.0
+    n = np.arange(len(x))
+    d = base + amp * np.sin(2 * np.pi * rate * n / sr)
+    pos = n - d
+    idx = np.floor(pos).astype(int)
+    frac = pos - idx
+    ok = (idx >= 0) & (idx + 1 < len(x))
+    y = np.zeros_like(x)
+    y[ok] = x[idx[ok]] * (1 - frac[ok]) + x[idx[ok] + 1] * frac[ok]
+    return y
+
+
+def growl(x, sr, amount):
+    """Drive the low band so it grows harmonics — grit, not distortion."""
+    if amount <= 0:
+        return x
+    spec = np.fft.rfft(x)
+    f = np.fft.rfftfreq(len(x), 1 / sr)
+    low = np.fft.irfft(spec * (f < 900.0), n=len(x))
+    driven = np.tanh(low * (1.0 + 7.0 * amount))
+    peak = np.abs(low).max()
+    if peak > 0:
+        driven = driven * (peak / max(np.abs(driven).max(), 1e-9))
+    return x * (1.0 - 0.35 * amount) + driven * (0.75 * amount)
+
+
+def expand(x, sr, factor):
+    """Expand the amplitude envelope so delivery is punchy, not flat."""
+    if factor <= 1.0:
+        return x
+    env = np.abs(x)
+    k = int(sr * 0.02)
+    env = np.convolve(env, np.ones(k) / k, mode="same")
+    m = env.max()
+    if m <= 0:
+        return x
+    gain = (env / m) ** (factor - 1.0)
+    gain = gain / max(gain.max(), 1e-9)
+    return x * (0.35 + 0.65 * gain)
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("src"); ap.add_argument("dst")
+    ap.add_argument("--lowf", type=float, default=1.0)
+    ap.add_argument("--highf", type=float, default=1.0)
+    ap.add_argument("--nasal", type=float, default=0.0)
+    ap.add_argument("--growl", type=float, default=0.0)
+    ap.add_argument("--vibrato", type=str, default="0,0")
+    ap.add_argument("--expand", type=float, default=1.0)
+    a = ap.parse_args()
+    x, sr = read(a.src)
+    y = reshape(x, sr, a.lowf, a.highf, a.nasal)
+    rate, depth = (float(v) for v in a.vibrato.split(","))
+    y = vibrato(y, sr, rate, depth)
+    y = growl(y, sr, a.growl)
+    y = expand(y, sr, a.expand)
+    peak = np.abs(y).max()
+    if peak > 0:
+        y = y * (min(0.85, np.abs(x).max() * 1.6) / peak)
+    write(a.dst, y, sr)

--- a/tools/formant.py
+++ b/tools/formant.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Shift formants without moving pitch — the dial that makes DIFFERENT voices.
+
+Pitch shifting alone gives one voice at several heights: same character, higher
+or lower. What separates two characters is the vocal-tract length, which shows
+up as the position of the spectral envelope (the formants), independent of the
+pitch the speaker is using. A big animal has low formants and can still speak
+at a high pitch; a tiny one has high formants.
+
+Method, per STFT frame:
+  1. take the log magnitude spectrum
+  2. cepstrally smooth it (keep only low quefrency) to get the ENVELOPE,
+     separated from the harmonic comb that carries pitch
+  3. resample the envelope's frequency axis by `shift`
+  4. multiply the original spectrum by (warped envelope / original envelope)
+
+Harmonic positions are untouched, so pitch is unchanged; only the resonances
+move. Phases are kept and the hop is unchanged, so there is no time-stretching
+and none of the phase-mismatch stitching that creates a doubled voice.
+
+Usage: formant.py IN.wav OUT.wav SHIFT   (SHIFT > 1 = smaller/brighter)
+"""
+import subprocess, sys, numpy as np
+
+N, HOP, LIFTER = 1024, 256, 40
+
+
+def read(path):
+    sr = int(subprocess.run(
+        ["ffprobe", "-v", "error", "-select_streams", "a:0", "-show_entries",
+         "stream=sample_rate", "-of", "csv=p=0", path],
+        capture_output=True, text=True, check=True).stdout.strip())
+    raw = subprocess.run(
+        ["ffmpeg", "-v", "error", "-i", path, "-f", "f32le", "-ac", "1", "-"],
+        capture_output=True, check=True).stdout
+    return np.frombuffer(raw, dtype=np.float32).astype(np.float64), sr
+
+
+def write(path, x, sr):
+    x = np.clip(x, -1.0, 1.0).astype(np.float32)
+    subprocess.run(
+        ["ffmpeg", "-v", "error", "-y", "-f", "f32le", "-ar", str(sr), "-ac", "1",
+         "-i", "-", "-c:a", "pcm_f32le", path],
+        input=x.tobytes(), check=True)
+
+
+def envelope(logmag):
+    """Cepstrally smoothed spectral envelope of one frame."""
+    cep = np.fft.irfft(logmag, n=N)
+    cep[LIFTER:-LIFTER] = 0.0
+    return np.fft.rfft(cep, n=N).real
+
+
+def formant_shift(x, sr, shift):
+    win = np.hanning(N + 1)[:N]
+    pad = np.concatenate([np.zeros(N), x, np.zeros(N * 2)])
+    out = np.zeros(len(pad))
+    norm = np.zeros(len(pad))
+    freqs = np.arange(N // 2 + 1)
+    for start in range(0, len(pad) - N, HOP):
+        frame = pad[start:start + N] * win
+        spec = np.fft.rfft(frame)
+        mag = np.abs(spec)
+        if mag.max() < 1e-8:
+            continue
+        logmag = np.log(mag + 1e-10)
+        env = envelope(logmag)
+        # Sample the envelope at freq/shift: a formant at f moves to f*shift.
+        warped = np.interp(freqs / shift, freqs, env, left=env[0], right=env[-1])
+        gain = np.exp(np.clip(warped - env, -6.0, 6.0))
+        rec = np.fft.irfft(spec * gain, n=N) * win
+        out[start:start + N] += rec
+        norm[start:start + N] += win ** 2
+    out = out[N:N + len(x)] / np.maximum(norm[N:N + len(x)], 1e-8)
+    peak = np.abs(out).max()
+    if peak > 0:
+        out = out * (np.abs(x).max() / peak)
+    return out
+
+
+if __name__ == "__main__":
+    src, dst, shift = sys.argv[1], sys.argv[2], float(sys.argv[3])
+    x, sr = read(src)
+    write(dst, formant_shift(x, sr, shift), sr)

--- a/tools/voiceqc.py
+++ b/tools/voiceqc.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Objective voice-quality QC: detect the 'two voices at once' artifact.
+
+The complaint "sounds like two voices at once / alien" has a specific
+measurable signature. Fixed-hop overlap-add stitches frames at points where
+the waveform's pitch periods do not line up. That does two things a listener
+hears as a second voice:
+
+  1. periodic amplitude modulation locked to the SYNTHESIS HOP, which puts
+     sidebands around every harmonic at +-(hop rate) Hz, and
+  2. smeared harmonic structure, i.e. a drop in harmonic-to-noise ratio.
+
+Both are measurable without ears. This reports:
+  f0          - median pitch (autocorrelation), tells us the shift landed
+  hnr_db      - harmonic-to-noise ratio; artifacts push this DOWN
+  am_ratio    - strength of amplitude modulation in the 20-120 Hz band that
+                fixed-hop OLA creates, relative to the envelope's DC. The
+                'two voices' percept lives here.
+  am_peak_hz  - where that modulation sits; a hand-rolled OLA parks it at the
+                hop rate, a clean shift has no such peak.
+"""
+import subprocess, sys, numpy as np
+
+
+def read_wav(path):
+    """Decode via ffmpeg — these WAVs are IEEE float32, which `wave` rejects."""
+    sr = int(subprocess.run(
+        ["ffprobe", "-v", "error", "-select_streams", "a:0",
+         "-show_entries", "stream=sample_rate", "-of", "csv=p=0", path],
+        capture_output=True, text=True, check=True).stdout.strip())
+    raw = subprocess.run(
+        ["ffmpeg", "-v", "error", "-i", path, "-f", "f32le", "-ac", "1", "-"],
+        capture_output=True, check=True).stdout
+    return np.frombuffer(raw, dtype=np.float32).astype(np.float64), sr
+
+
+def f0_track(x, sr, frame=1024, hop=256, fmin=60, fmax=500):
+    """Per-frame autocorrelation pitch, voiced frames only."""
+    out = []
+    lo, hi = int(sr / fmax), int(sr / fmin)
+    for i in range(0, len(x) - frame, hop):
+        f = x[i:i + frame]
+        if np.sqrt(np.mean(f ** 2)) < 0.01:
+            continue
+        f = f - f.mean()
+        ac = np.correlate(f, f, "full")[frame - 1:]
+        if ac[0] <= 0:
+            continue
+        ac = ac / ac[0]
+        seg = ac[lo:hi]
+        if len(seg) == 0:
+            continue
+        k = int(np.argmax(seg)) + lo
+        if ac[k] > 0.3:                      # voiced
+            out.append((sr / k, ac[k]))
+    return out
+
+
+def hnr_db(track):
+    """Autocorrelation peak height -> harmonic-to-noise ratio, Boersma style."""
+    if not track:
+        return float("nan")
+    r = np.clip(np.array([t[1] for t in track]), 1e-6, 0.999999)
+    return float(np.median(10 * np.log10(r / (1 - r))))
+
+
+def am_artifact(x, sr):
+    """Amplitude-modulation energy in the band fixed-hop OLA lands in."""
+    env = np.abs(x)
+    # Smooth to an envelope at ~1 kHz effective rate, then look at its spectrum.
+    k = 16
+    env = np.convolve(env, np.ones(k) / k, mode="same")
+    env = env[::k]
+    esr = sr / k
+    env = env - env.mean()
+    if len(env) < 64:
+        return 0.0, 0.0
+    win = np.hanning(len(env))
+    spec = np.abs(np.fft.rfft(env * win))
+    freqs = np.fft.rfftfreq(len(env), 1 / esr)
+    band = (freqs >= 20) & (freqs <= 120)
+    if not band.any():
+        return 0.0, 0.0
+    total = np.sqrt(np.mean(np.abs(x) ** 2)) * len(env)
+    peak = float(spec[band].max())
+    peak_hz = float(freqs[band][int(np.argmax(spec[band]))])
+    return peak / (total + 1e-9), peak_hz
+
+
+def report(path):
+    x, sr = read_wav(path)
+    tr = f0_track(x, sr)
+    f0 = float(np.median([t[0] for t in tr])) if tr else float("nan")
+    am, am_hz = am_artifact(x, sr)
+    return dict(name=path.split("/")[-1], sr=sr, dur=len(x) / sr, f0=f0,
+                hnr=hnr_db(tr), voiced=len(tr), am=am, am_hz=am_hz)
+
+
+if __name__ == "__main__":
+    print(f"{'file':<30}{'dur':>6}{'f0 Hz':>8}{'HNR dB':>8}{'AM':>8}{'AM Hz':>8}")
+    for p in sys.argv[1:]:
+        r = report(p)
+        print(f"{r['name']:<30}{r['dur']:>6.2f}{r['f0']:>8.1f}"
+              f"{r['hnr']:>8.1f}{r['am']:>8.3f}{r['am_hz']:>8.1f}")

--- a/tools/voiceqc.py
+++ b/tools/voiceqc.py
@@ -92,13 +92,22 @@ def report(path):
     tr = f0_track(x, sr)
     f0 = float(np.median([t[0] for t in tr])) if tr else float("nan")
     am, am_hz = am_artifact(x, sr)
+    # Pitch dynamism, in semitones: how far the pitch actually MOVES. A flat
+    # read sits near 1-2 st and reads as "person talking"; an animated
+    # character read is 3+. Pitch HEIGHT is not what makes a character — this
+    # is.
+    if len(tr) > 2:
+        semis = 12.0 * np.log2(np.array([t[0] for t in tr]) / f0)
+        dyn = float(np.percentile(semis, 90) - np.percentile(semis, 10))
+    else:
+        dyn = 0.0
     return dict(name=path.split("/")[-1], sr=sr, dur=len(x) / sr, f0=f0,
-                hnr=hnr_db(tr), voiced=len(tr), am=am, am_hz=am_hz)
+                hnr=hnr_db(tr), voiced=len(tr), am=am, am_hz=am_hz, dyn=dyn)
 
 
 if __name__ == "__main__":
-    print(f"{'file':<30}{'dur':>6}{'f0 Hz':>8}{'HNR dB':>8}{'AM':>8}{'AM Hz':>8}")
+    print(f"{'file':<30}{'dur':>6}{'f0 Hz':>8}{'dyn st':>8}{'HNR dB':>8}{'AM':>8}{'AM Hz':>8}")
     for p in sys.argv[1:]:
         r = report(p)
-        print(f"{r['name']:<30}{r['dur']:>6.2f}{r['f0']:>8.1f}"
+        print(f"{r['name']:<30}{r['dur']:>6.2f}{r['f0']:>8.1f}{r['dyn']:>8.1f}"
               f"{r['hnr']:>8.1f}{r['am']:>8.3f}{r['am_hz']:>8.1f}")


### PR DESCRIPTION
Complete Swift runtime for NemotronLabs VoiceChat 11B — a full-duplex speech-to-speech model — with **audio-to-audio proven on all three shipped quants**.

## What it is

One `nemotron_h` 56-layer hybrid backbone on a 12.5 fps frame clock. Every 0.08 s frame the backbone consumes ONE fused embedding built from three channels — previous text token + this frame's user audio + `function_channel_weight` × previous function token — and emits this frame's text token AND tool-call token together, while the EAR-TTS model advances on the same clock. Listening, answering, speaking and tool-calling share one timeline; that shared clock is what makes barge-in and turn-taking expressible at all.

## Audio-to-audio proof (real bundles, real audio)

Input: NVIDIA `turn_taking.wav` user (left) channel, 24 kHz stereo → 16 kHz mono, 2.0 s. Full duplex turn loop. Output 22.05 kHz.

| quant | load | turn | frames | samples | rms | zcr | asr |
|---|---|---|---|---|---|---|---|
| MXFP8 | 1.1s | 3.4s | 26 | 45864 | 0.0096 | 0.242 | 2 tok |
| JANG_4 | 0.5s | 6.7s | 26 | 45864 | 0.0109 | 0.251 | 2 tok |
| JANG_2 | 0.8s | 4.1s | 26 | 45864 | 0.0224 | 0.154 | 2 tok |

"A wav was produced" is not evidence — silence and noise both produce wavs. Each leg asserts finite samples, RMS above silence, peak below clipping, non-constant dynamic range, and a zero-crossing rate below the noise band, and writes a listenable WAV. Verified independently: all three are valid 22.05 kHz Float32, 2.08 s, with real voiced-frame structure (103/103, 57/103, 81/103 voiced 20 ms frames).

**Input-dependence check** — the one that separates "renders audio" from "renders THIS audio", since every measurement above would also pass for a canned response: two different 2 s windows of the same conversation produce **95.0 % differing samples** and a different ASR transcript.

## Structure

| file | what |
|---|---|
| `NemotronVoiceChatConfiguration` | full config incl. nested RNN-T decoder/joint, `[[Int]]` att_context, TTS sub-configs |
| `VoiceChatConformer` | 24-layer causal FastConformer: causal dw-striding subsampling, rel-pos attention, chunk-based `chunked_limited` mask |
| `VoiceChatRNNT` | predict/joint networks + greedy streaming transducer, state carried across chunks |
| `VoiceChatSTTModel` | perception + backbone + BOTH vocab-sized heads over one hidden state |
| `VoiceChatTTS` / `VoiceChatTTSModel` | OffsetRMSNorm, MoG head, T5Gemma char conditioning, 28-layer speech transformer, 8-round RVQ refinement |
| `VoiceChatCodec` | ConvNeXt enc/dec + 31-stage PRVQ + iSTFT vocoder, streaming caches |
| `NemotronVoiceChat` | the duplex turn loop |
| `VoiceChatLoader` / `VoiceChatMel` | real-bundle load (per-module quant map) + NeMo-exact mel front-end |

## Traps paid for (each pinned by a test)

- **Two RMSNorm conventions in one model** — backbone plain, TTS Gemma-style `1+weight`. Getting it wrong empties text output while rel-err, NaN scans and ASR all read healthy.
- **`function_head` is a full vocab-sized parallel channel**, not parsed text. A runtime reading only `lm_head` loses tool calling silently — the model still *says* it did things.
- **`att_context_size` is `[[70, 0]]`** — right context 0, no lookahead. That is what keeps duplex under 200 ms; a non-zero value adds latency to every response with nothing failing.
- **RNN-T LSTM ships raw PyTorch keys** — the two bias vectors must SUM; dropping one halves the recurrent bias.
- **fp-protected tensors** (`rvq_embs`, `audio_prompt_latents.*`, `mog_head.proj_mus`, char `embed_tokens`) keep bundle shape and dtype through sanitize.
- Three defects the live run found and fixed: `joint_net`-as-array broke every quantized load (quantize can't merge `{"2": …}` into an array); the `embed_tokens`/`lm_head` remap orphaned `.scales`/`.biases`; and the quantization map is keyed by BUNDLE paths while the module tree renames several, so every per-module recipe missed and mixed-bit JANG died on a shape mismatch.

## Tests

67 green: config (3, real bundle) · streaming conformer (5, causality + chunk-invariance with negative controls) · STT (5, full 997-tensor `verify: [.all]`) · TTS (9, 635-tensor parity + protected tensors + speech-shaped audio + seam control) · end-to-end duplex loop (6) · quant-map paths (2, all three real bundles) · NemotronH regression (37).

Per-quant audio proof runs behind `VOICECHAT_QUANT_PROOF=1` (an 11 B load per leg is too heavy for the default suite).

## Not in this PR

The osaurus app has no duplex-speech host — `Services/Voice` is an ASR → text → TTS pipeline, not a full-duplex session. Hosting this (mic streaming into the frame loop, 22 kHz chunk playback, barge-in wired to the UI) is an app-side feature build and is what the real-mic GUI proof and the avatar surface depend on.

Note: `OsaurusAI/NemotronLabs-VoiceChat-11B-MXFP8` on the Hub contains only `.gitattributes` — the weights were never pushed. The working copy used for the proof is local (11 GB).