### PR TITLE
Disk cache size: auto-scale to 10% of disk, and migrate existing installs

### DIFF
--- a/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
+++ b/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
@@ -837,7 +837,12 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
         }
         let diskDir = diskCacheDirectory
             ?? VMLXServerRuntimeSettings.resolvedDirectory(diskDirectory)
-        let diskMaxGB = Float(diskMaxSizeGB ?? 10.0)
+        // Unset means AUTO — a share of the cache volume, not a flat constant.
+        // Applies to every model because the cap governs the whole cache root
+        // (`CacheCoordinator.enforceSharedDiskQuota`), not one bundle.
+        let diskMaxGB = Float(
+            diskMaxSizeGB
+                ?? VMLXServerRuntimeSettings.autoDiskCacheMaxGB(for: diskDir))
 
         return CacheCoordinatorConfig(
             usePagedCache: reuseEnabled && cache.pagedKV.enabled,
@@ -852,6 +857,49 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
             defaultKVMode: cache.defaultKVMode,
             defaultMaxKVSize: cache.defaultMaxKVSize,
             longPromptMultiplier: cache.longPromptMultiplier)
+    }
+
+    /// Fraction of the cache volume's total capacity used when the user has not
+    /// set an explicit disk-cache size. Matches the "auto" convention other MLX
+    /// servers use, and is deliberately a share of the DISK rather than a flat
+    /// constant: KV cost scales with the model, so a fixed number is wrong for
+    /// every machine at once.
+    public static let autoDiskCacheFraction: Double = 0.10
+
+    /// Floor for the auto size. Equal to the historical flat default, so
+    /// resolving "auto" can only ever raise the cap, never lower it — no user
+    /// loses cache they had before, and a volume whose capacity cannot be read
+    /// falls back to exactly the old behaviour.
+    public static let autoDiskCacheFloorGB: Double = 10.0
+
+    /// Resolve the effective disk-cache cap in GB for a nil (unset) setting.
+    ///
+    /// A flat 10 GB could not hold ONE full-context conversation of a 27B: at
+    /// 64 layers / 4 KV heads / head_dim 256 the KV cost is 256 KiB per token at
+    /// bf16, so a 222k window needs ~54 GB, and the cap is shared across every
+    /// model in the cache root. Past ~18% of one window each store had to evict
+    /// earlier boundaries of the SAME conversation, so reuse collapsed exactly
+    /// as context grew — the reported symptom.
+    ///
+    /// This ADVISES a larger cap; it never refuses or blocks. If the volume's
+    /// capacity cannot be read it returns the floor rather than guessing small.
+    public static func autoDiskCacheMaxGB(for directory: URL?) -> Double {
+        guard let directory else { return autoDiskCacheFloorGB }
+        // Walk up to the nearest existing ancestor: the cache dir itself may not
+        // exist yet on first run, and `resourceValues` needs a real path.
+        var probe = directory
+        while !FileManager.default.fileExists(atPath: probe.path) {
+            let parent = probe.deletingLastPathComponent()
+            guard parent.path != probe.path else { return autoDiskCacheFloorGB }
+            probe = parent
+        }
+        guard
+            let capacity = try? probe.resourceValues(
+                forKeys: [.volumeTotalCapacityKey]
+            ).volumeTotalCapacity
+        else { return autoDiskCacheFloorGB }
+        let gb = Double(capacity) / 1_073_741_824.0 * autoDiskCacheFraction
+        return Swift.max(autoDiskCacheFloorGB, gb)
     }
 
     private static func resolvedDirectory(_ path: String?) -> URL? {

--- a/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
+++ b/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
@@ -9,7 +9,13 @@ import Foundation
 /// `nil` means "do not override the bundle/engine default"; it must not be
 /// converted into hidden sampling clamps or family-specific recovery behavior.
 public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
-    public static let contractVersion = 1
+    /// Bumped whenever a persisted default changes in a way that existing
+    /// installs must follow. `migrateToCurrentSchema()` performs the one-shot.
+    ///
+    /// 2: disk-cache size default moved from a flat 10 GB to auto (10% of the
+    ///    cache volume). Installs that had already written the literal 10.0
+    ///    must move to auto, otherwise only fresh installs benefit.
+    public static let contractVersion = 2
 
     public var network: VMLXServerNetworkSettings
     public var concurrency: VMLXServerConcurrencySettings
@@ -23,6 +29,12 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
     /// Optional so existing server-runtime.json files decode unchanged.
     /// `effectivePerformance` resolves nil to defaults.
     public var performance: VMLXServerPerformanceSettings?
+
+    /// Schema version of the persisted file this value was decoded from.
+    /// Optional so pre-existing `server-runtime.json` files decode unchanged —
+    /// nil means "written before versioning", which is exactly the population a
+    /// migration needs to catch.
+    public var schemaVersion: Int?
 
     public var effectivePerformance: VMLXServerPerformanceSettings {
         performance ?? .init()
@@ -38,8 +50,10 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
         multimodal: VMLXServerMultimodalSettings = .init(),
         mtp: VMLXServerMTPSettings = .init(),
         memorySafety: VMLXMemorySafetySettings = .init(),
-        performance: VMLXServerPerformanceSettings? = nil
+        performance: VMLXServerPerformanceSettings? = nil,
+        schemaVersion: Int? = nil
     ) {
+        self.schemaVersion = schemaVersion
         self.network = network
         self.concurrency = concurrency
         self.cache = cache
@@ -50,6 +64,39 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
         self.mtp = mtp
         self.memorySafety = memorySafety
         self.performance = performance
+    }
+
+    /// Apply one-shot migrations for persisted defaults that have changed.
+    ///
+    /// Call immediately after decoding a stored settings file, before handing
+    /// the value to the runtime. Idempotent: it stamps `schemaVersion`, so a
+    /// second call is a no-op.
+    ///
+    /// v2 — disk-cache size. The default used to be a flat 10 GB, which could
+    /// not hold one full-context conversation of a 27B (256 KiB/token at bf16
+    /// over a 222k window is ~54 GB) and is shared across every model in the
+    /// cache root. Auto (10% of the volume) only fills in for an UNSET value,
+    /// so without this migration every install that had already persisted the
+    /// literal 10.0 would keep 10 GB forever after updating and only fresh
+    /// installs would benefit.
+    ///
+    /// Deliberately version-gated rather than "rewrite any 10.0 we find": once
+    /// a user has been migrated, a later deliberate choice of 10 GB is theirs
+    /// and must survive. Same shape as the MTP-Off defect, where the fix was a
+    /// schema version rather than deleting the migration.
+    public mutating func migrateToCurrentSchema() {
+        let stored = schemaVersion ?? 1
+        if stored < 2 {
+            // Only the exact legacy default moves; any other explicit size the
+            // user chose is left alone.
+            if let size = cache.blockDisk.maxSizeGB, size == 10.0 {
+                cache.blockDisk.maxSizeGB = nil
+            }
+            if let legacy = cache.legacyDisk.maxSizeGB, legacy == 10.0 {
+                cache.legacyDisk.maxSizeGB = nil
+            }
+        }
+        schemaVersion = Self.contractVersion
     }
 
     public func validationIssues(

--- a/Tests/MLXLMTests/AutoDiskCacheSizeTests.swift
+++ b/Tests/MLXLMTests/AutoDiskCacheSizeTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+@testable import MLXLMCommon
+import Testing
+
+// MARK: - Auto disk-cache size
+//
+// The disk-cache cap used to be a flat `?? 10.0` GB. That could not hold ONE
+// full-context conversation of a 27B: at 64 layers / 4 KV heads / head_dim 256
+// the KV cost is 256 KiB per token at bf16, so a 222k window needs ~54 GB — and
+// the cap is shared across every model in the cache root, not per bundle. Past
+// roughly 18% of a single window every store had to evict earlier boundaries of
+// the SAME conversation, so reuse collapsed exactly as context grew.
+//
+// "Auto" resolves to a share of the cache volume instead. These tests pin the
+// two properties that make that safe to ship: it can only ever RAISE the cap,
+// and an unreadable volume degrades to the historical default rather than to
+// something smaller.
+
+@Test func autoDiskCacheSizeIsAtLeastTheHistoricalFlatDefault() {
+    // The floor is the old default, so no existing user can lose cache by
+    // upgrading. This is the "advises upward, never refuses" property.
+    #expect(VMLXServerRuntimeSettings.autoDiskCacheFloorGB == 10.0)
+
+    let tmp = FileManager.default.temporaryDirectory
+    let resolved = VMLXServerRuntimeSettings.autoDiskCacheMaxGB(for: tmp)
+    #expect(
+        resolved >= VMLXServerRuntimeSettings.autoDiskCacheFloorGB,
+        "auto must never resolve below the historical flat default; got \(resolved)")
+}
+
+@Test func autoDiskCacheSizeTracksTenPercentOfVolumeCapacity() throws {
+    let tmp = FileManager.default.temporaryDirectory
+    let capacity = try tmp.resourceValues(forKeys: [.volumeTotalCapacityKey])
+        .volumeTotalCapacity
+    let capacityGB = Double(try #require(capacity)) / 1_073_741_824.0
+    let expected = Swift.max(
+        VMLXServerRuntimeSettings.autoDiskCacheFloorGB,
+        capacityGB * VMLXServerRuntimeSettings.autoDiskCacheFraction)
+
+    let resolved = VMLXServerRuntimeSettings.autoDiskCacheMaxGB(for: tmp)
+    #expect(abs(resolved - expected) < 0.5)
+    #expect(VMLXServerRuntimeSettings.autoDiskCacheFraction == 0.10)
+}
+
+@Test func autoDiskCacheSizeResolvesForADirectoryThatDoesNotExistYet() {
+    // First run: the cache directory has not been created. Resolution walks up
+    // to the nearest existing ancestor rather than failing to the floor, so a
+    // fresh install still gets the full auto size.
+    let missing = FileManager.default.temporaryDirectory
+        .appendingPathComponent("auto-disk-\(UUID().uuidString)")
+        .appendingPathComponent("nested")
+        .appendingPathComponent("deeper")
+    #expect(!FileManager.default.fileExists(atPath: missing.path))
+
+    let resolved = VMLXServerRuntimeSettings.autoDiskCacheMaxGB(for: missing)
+    let viaExistingParent = VMLXServerRuntimeSettings.autoDiskCacheMaxGB(
+        for: FileManager.default.temporaryDirectory)
+    #expect(abs(resolved - viaExistingParent) < 0.5)
+}
+
+@Test func autoDiskCacheSizeFallsBackToFloorWhenThereIsNoDirectory() {
+    // Detection failure must degrade to the old behaviour, never to a smaller
+    // cap — a failed probe must not become a user-facing restriction.
+    #expect(
+        VMLXServerRuntimeSettings.autoDiskCacheMaxGB(for: nil)
+            == VMLXServerRuntimeSettings.autoDiskCacheFloorGB)
+}
+
+@Test func explicitUserSizeOverridesAutoAndReachesTheCoordinatorConfig() {
+    // The setting must still win — auto only fills in for nil. Verified through
+    // `cacheCoordinatorConfig`, the real mapping the runtime uses, not by
+    // re-reading the settings struct.
+    var settings = VMLXServerRuntimeSettings()
+    settings.cache.blockDisk.enabled = true
+    settings.cache.blockDisk.maxSizeGB = 3.5
+
+    let config = settings.cacheCoordinatorConfig(modelKey: "auto-disk-explicit")
+    #expect(config.diskCacheMaxGB == 3.5)
+}
+
+@Test func unsetSizeResolvesToAutoInTheCoordinatorConfig() {
+    // The end-to-end property: leaving the field blank yields the auto size, and
+    // that size is at least the floor. This is the mapping that was previously
+    // hardcoded to 10.0.
+    var settings = VMLXServerRuntimeSettings()
+    settings.cache.blockDisk.enabled = true
+    settings.cache.blockDisk.maxSizeGB = nil
+
+    let config = settings.cacheCoordinatorConfig(modelKey: "auto-disk-unset")
+    #expect(Double(config.diskCacheMaxGB) >= VMLXServerRuntimeSettings.autoDiskCacheFloorGB)
+}

--- a/Tests/MLXLMTests/AutoDiskCacheSizeTests.swift
+++ b/Tests/MLXLMTests/AutoDiskCacheSizeTests.swift
@@ -89,3 +89,79 @@ import Testing
     let config = settings.cacheCoordinatorConfig(modelKey: "auto-disk-unset")
     #expect(Double(config.diskCacheMaxGB) >= VMLXServerRuntimeSettings.autoDiskCacheFloorGB)
 }
+
+// MARK: - Existing-install migration
+//
+// Auto only fills in for a NIL size. Every install that had already persisted
+// the literal 10.0 would therefore have kept 10 GB forever after updating, and
+// only fresh installs would have benefited. These pin the one-shot that moves
+// those users to auto — and, just as importantly, that it does not run twice.
+
+@Test func legacyTenGigabyteSettingMigratesToAuto() {
+    var settings = VMLXServerRuntimeSettings()
+    settings.cache.blockDisk.maxSizeGB = 10.0
+    settings.schemaVersion = nil  // written before versioning existed
+
+    settings.migrateToCurrentSchema()
+
+    #expect(settings.cache.blockDisk.maxSizeGB == nil, "legacy 10 GB must become auto")
+    #expect(settings.schemaVersion == VMLXServerRuntimeSettings.contractVersion)
+}
+
+@Test func migrationLeavesADeliberateNonDefaultSizeAlone() {
+    var settings = VMLXServerRuntimeSettings()
+    settings.cache.blockDisk.maxSizeGB = 40.0
+    settings.schemaVersion = nil
+
+    settings.migrateToCurrentSchema()
+
+    #expect(settings.cache.blockDisk.maxSizeGB == 40.0)
+}
+
+@Test func migrationDoesNotRunTwiceOnADeliberateTenGigabyteChoice() {
+    // The dangerous case: a user who has ALREADY been migrated and then
+    // deliberately picks 10 GB. A blanket "rewrite any 10.0" would silently
+    // undo that on every launch.
+    var settings = VMLXServerRuntimeSettings()
+    settings.cache.blockDisk.maxSizeGB = 10.0
+    settings.schemaVersion = VMLXServerRuntimeSettings.contractVersion
+
+    settings.migrateToCurrentSchema()
+
+    #expect(
+        settings.cache.blockDisk.maxSizeGB == 10.0,
+        "a post-migration choice of 10 GB belongs to the user and must survive")
+}
+
+@Test func migrationIsIdempotent() {
+    var settings = VMLXServerRuntimeSettings()
+    settings.cache.blockDisk.maxSizeGB = 10.0
+    settings.schemaVersion = nil
+
+    settings.migrateToCurrentSchema()
+    let afterFirst = settings
+    settings.migrateToCurrentSchema()
+
+    #expect(settings == afterFirst)
+}
+
+@Test func migratedSettingsResolveToTheAutoSizeThroughTheCoordinator() {
+    // End to end: a legacy install ends up with a cap at least the floor,
+    // rather than the 10 GB it was pinned to before.
+    var settings = VMLXServerRuntimeSettings()
+    settings.cache.blockDisk.enabled = true
+    settings.cache.blockDisk.maxSizeGB = 10.0
+    settings.schemaVersion = nil
+
+    settings.migrateToCurrentSchema()
+    let config = settings.cacheCoordinatorConfig(modelKey: "auto-disk-migrated")
+
+    #expect(Double(config.diskCacheMaxGB) >= VMLXServerRuntimeSettings.autoDiskCacheFloorGB)
+}
+
+@Test func aFreshSettingsValueIsAlreadyAtTheCurrentSchema() {
+    var settings = VMLXServerRuntimeSettings()
+    settings.migrateToCurrentSchema()
+    #expect(settings.schemaVersion == 2)
+    #expect(settings.cache.blockDisk.maxSizeGB == nil)
+}

--- a/Tests/MLXLMTests/DiskCacheQuotaEnforcementTests.swift
+++ b/Tests/MLXLMTests/DiskCacheQuotaEnforcementTests.swift
@@ -1,0 +1,219 @@
+import Foundation
+import MLX
+@testable import MLXLMCommon
+import Testing
+
+// MARK: - Disk-cache quota enforcement
+//
+// These exercise the REAL DiskCache against a real directory: real safetensors
+// payloads, the real SQLite index, the real quota pass. Nothing is mocked.
+//
+// They exist because the questions that matter here cannot be answered by a
+// screenshot of the cache readout. A screenshot shows one number at one moment.
+// It cannot show that eviction fires as the cache grows, that the OLDEST entry
+// goes first, that lowering the cap re-enforces at the new value, or that a
+// purge reclaims orphaned files. Those are sequence properties, so they need a
+// test that drives the sequence.
+
+/// Store a payload of roughly `bytes` under a synthetic token prefix.
+private func store(
+    _ cache: DiskCache,
+    tokens: [Int],
+    approximateBytes: Int
+) {
+    // float32 → 4 bytes per element.
+    let count = Swift.max(1, approximateBytes / 4)
+    cache.store(tokens: tokens, arrays: ["k": MLXArray.zeros([count])])
+}
+
+private func makeCacheDir() -> URL {
+    let dir = FileManager.default.temporaryDirectory
+        .appendingPathComponent("quota-\(UUID().uuidString)")
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir
+}
+
+@Test func quotaEvictsAsTheCacheGrowsPastTheCap() throws {
+    try MLXMetalTestLock.withLock {
+        let dir = makeCacheDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let cap = 400_000
+        let cache = DiskCache(cacheDir: dir, maxSizeBytes: cap, modelKey: "grow")
+
+        var series: [(entries: Int, bytes: Int)] = []
+        for i in 0..<12 {
+            store(cache, tokens: [i, i + 1, i + 2], approximateBytes: 80_000)
+            let s = cache.snapshotStats()
+            series.append((s.currentEntryCount, s.currentPayloadBytes))
+        }
+
+        let final = cache.snapshotStats()
+
+        // The cap is enforced after each store, so the resting size must be at
+        // or under it even though 12 x 80KB were written into a 400KB budget.
+        #expect(
+            final.currentPayloadBytes <= cap,
+            "payload \(final.currentPayloadBytes) exceeded cap \(cap); series=\(series)")
+
+        // The janitor must actually have run — a cache that simply refused to
+        // store anything would also satisfy the assertion above.
+        #expect(final.evictions > 0, "no eviction recorded; series=\(series)")
+        #expect(final.currentEntryCount > 0, "everything was evicted; series=\(series)")
+
+        // And it must have grown before it plateaued, otherwise the writes were
+        // being dropped rather than the cache being trimmed.
+        let peak = series.map(\.bytes).max() ?? 0
+        #expect(peak > 0, "cache never grew; series=\(series)")
+    }
+}
+
+@Test func quotaEvictsTheOldestEntryFirst() throws {
+    try MLXMetalTestLock.withLock {
+        let dir = makeCacheDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        // Room for about two entries.
+        let cache = DiskCache(cacheDir: dir, maxSizeBytes: 250_000, modelKey: "lru")
+
+        store(cache, tokens: [1, 1, 1], approximateBytes: 100_000)
+        #expect(cache.hasDurableEntry(tokens: [1, 1, 1]))
+        // createdAt has second resolution in the index, so separate the writes.
+        Thread.sleep(forTimeInterval: 1.1)
+        store(cache, tokens: [2, 2, 2], approximateBytes: 100_000)
+        Thread.sleep(forTimeInterval: 1.1)
+        // This third write must push the FIRST one out, not the second.
+        store(cache, tokens: [3, 3, 3], approximateBytes: 100_000)
+
+        #expect(
+            !cache.hasDurableEntry(tokens: [1, 1, 1]),
+            "the oldest entry survived while newer ones were written")
+        #expect(cache.hasDurableEntry(tokens: [3, 3, 3]), "the newest entry was evicted")
+    }
+}
+
+@Test func loweringTheCapIsEnforcedOnTheNextStore() throws {
+    try MLXMetalTestLock.withLock {
+        let dir = makeCacheDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        // Fill comfortably under a roomy cap.
+        let roomy = DiskCache(cacheDir: dir, maxSizeBytes: 2_000_000, modelKey: "recap")
+        for i in 0..<6 { store(roomy, tokens: [i, 9, 9], approximateBytes: 100_000) }
+        let before = roomy.snapshotStats()
+        #expect(before.currentPayloadBytes > 300_000, "setup did not fill the cache")
+
+        // Reopen the SAME directory with a much smaller cap — this is what
+        // changing Disk Cache Size and reloading does.
+        let tightened = DiskCache(cacheDir: dir, maxSizeBytes: 250_000, modelKey: "recap")
+        store(tightened, tokens: [42, 42, 42], approximateBytes: 100_000)
+
+        let after = tightened.snapshotStats()
+        #expect(
+            after.currentPayloadBytes <= 250_000,
+            "the lowered cap was not enforced: \(after.currentPayloadBytes) > 250000")
+        #expect(after.currentPayloadBytes < before.currentPayloadBytes)
+    }
+}
+
+@Test func raisingTheCapStopsEvicting() throws {
+    try MLXMetalTestLock.withLock {
+        let dir = makeCacheDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let tight = DiskCache(cacheDir: dir, maxSizeBytes: 250_000, modelKey: "raise")
+        for i in 0..<5 { store(tight, tokens: [i, 7, 7], approximateBytes: 100_000) }
+        #expect(tight.snapshotStats().evictions > 0, "setup did not trigger eviction")
+
+        // Same directory, generous cap: further stores must accumulate.
+        let roomy = DiskCache(cacheDir: dir, maxSizeBytes: 5_000_000, modelKey: "raise")
+        let baseline = roomy.snapshotStats().currentPayloadBytes
+        for i in 10..<15 { store(roomy, tokens: [i, 7, 7], approximateBytes: 100_000) }
+        let grown = roomy.snapshotStats()
+
+        #expect(
+            grown.currentPayloadBytes > baseline,
+            "cache did not grow after the cap was raised")
+        #expect(grown.evictions == 0, "evicted despite a cap with plenty of room")
+    }
+}
+
+@Test func clearRemovesEveryPayloadIncludingOrphans() throws {
+    try MLXMetalTestLock.withLock {
+        let dir = makeCacheDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let cache = DiskCache(cacheDir: dir, maxSizeBytes: 5_000_000, modelKey: "clear")
+        for i in 0..<4 { store(cache, tokens: [i, 5, 5], approximateBytes: 60_000) }
+        #expect(cache.snapshotStats().currentPayloadBytes > 0)
+
+        // An orphan: a payload on disk that the index does not know about,
+        // exactly what a crash between the file write and the insert leaves.
+        // Quota accounting reads only cache_entries, so this is invisible to
+        // eviction and would otherwise occupy disk forever.
+        let orphan = dir.appendingPathComponent("orphaned-by-crash.safetensors")
+        try Data(repeating: 0xAB, count: 50_000).write(to: orphan)
+        #expect(FileManager.default.fileExists(atPath: orphan.path))
+
+        cache.clear()
+
+        let after = cache.snapshotStats()
+        #expect(after.currentPayloadBytes == 0)
+        #expect(after.currentEntryCount == 0)
+        #expect(
+            !FileManager.default.fileExists(atPath: orphan.path),
+            "clear left an orphaned payload behind — the one path that reclaims it")
+
+        let remaining = (try? FileManager.default.contentsOfDirectory(atPath: dir.path)) ?? []
+        #expect(
+            remaining.allSatisfy { !$0.hasSuffix(".safetensors") },
+            "safetensors survived clear: \(remaining)")
+    }
+}
+
+@Test func quotaIsSharedAcrossModelsAndEvictsTheOtherModelsOldestEntry() throws {
+    try MLXMetalTestLock.withLock {
+        let dir = makeCacheDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        // Two models, ONE cache root. The quota pass reads cache_entries with no
+        // model_key predicate, so model B's writes must be able to reclaim model
+        // A's stale entries rather than each model getting its own budget.
+        let modelA = DiskCache(cacheDir: dir, maxSizeBytes: 250_000, modelKey: "model-a")
+        store(modelA, tokens: [1, 2, 3], approximateBytes: 100_000)
+        #expect(modelA.hasDurableEntry(tokens: [1, 2, 3]))
+
+        Thread.sleep(forTimeInterval: 1.1)
+
+        let modelB = DiskCache(cacheDir: dir, maxSizeBytes: 250_000, modelKey: "model-b")
+        store(modelB, tokens: [4, 5, 6], approximateBytes: 100_000)
+        Thread.sleep(forTimeInterval: 1.1)
+        store(modelB, tokens: [7, 8, 9], approximateBytes: 100_000)
+
+        // Model A's older entry is the one that should have gone.
+        #expect(
+            !modelA.hasDurableEntry(tokens: [1, 2, 3]),
+            "a stale OTHER model's entry survived while a hot model was capped")
+        #expect(modelB.snapshotStats().currentPayloadBytes <= 250_000)
+    }
+}
+
+@Test func warningThresholdTracksRealCacheGrowth() throws {
+    try MLXMetalTestLock.withLock {
+        let dir = makeCacheDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        // Ties the UI's 75% warning to a real filling cache rather than to
+        // hand-made numbers: below the threshold before, at or above it after.
+        let cap = 500_000
+        let cache = DiskCache(cacheDir: dir, maxSizeBytes: cap, modelKey: "warn")
+
+        store(cache, tokens: [1, 1, 1], approximateBytes: 100_000)
+        let early = Double(cache.snapshotStats().currentPayloadBytes) / Double(cap)
+        #expect(early < 0.75, "cache was already past the warning threshold at setup")
+
+        for i in 2..<6 { store(cache, tokens: [i, 1, 1], approximateBytes: 100_000) }
+        let late = Double(cache.snapshotStats().currentPayloadBytes) / Double(cap)
+        #expect(late >= 0.75, "cache never reached the warning threshold; got \(late)")
+    }
+}


### PR DESCRIPTION
## Why

The disk-cache cap was `diskMaxSizeGB ?? 10.0` — a flat literal, not derived from RAM, disk, or the model.

For Qwen3.8-27B (64 layers, 4 KV heads, head_dim 256) KV costs **256 KiB/token at bf16**, so its 222k window needs **~54 GB**. The cap is enforced across the *whole cache root*, not per model, so every bundle shares it. A 10 GB cap therefore could not hold **one** full-context conversation of the flagship model — past roughly 18% of a single window, every store evicted earlier boundaries of the *same* conversation and reuse collapsed exactly as context grew.

## What changed

**Auto sizing.** Unset resolves to 10% of the cache volume, floored at the old 10 GB. The floor is the safety property: resolving auto can only ever *raise* the cap, so no existing user loses cache, and a volume whose capacity cannot be read degrades to exactly the previous behaviour rather than guessing smaller. It advises upward and never refuses — a larger ceiling on a cache cannot block anything. An explicit user value still wins.

**Existing installs migrate too.** Auto only fills in for a nil value, so anyone who had already persisted `10.0` would have kept 10 GB forever after updating — most of the fleet. There was nothing to migrate against: `contractVersion` was declared and referenced nowhere else in the package. It is now persisted as an optional `schemaVersion` (nil decodes cleanly from every existing `server-runtime.json`, and nil is exactly the population to catch) and bumped to 2, with `migrateToCurrentSchema()` applying a one-shot.

The migration moves ONLY the exact legacy `10.0`, and only when the stored version predates the change. Deliberately version-gated rather than "rewrite any 10.0 we find": once migrated, a later deliberate choice of 10 GB is the user's and must survive every launch.

## Tests — 19 passing

**Auto sizing + migration (12).** Floor equals the historical default; auto tracks 10% of capacity; a not-yet-created cache directory resolves via its nearest existing ancestor rather than collapsing to the floor; a nil directory degrades to the floor; explicit and unset both verified through `cacheCoordinatorConfig` (the mapping the runtime actually reads) rather than by re-reading the settings struct; and the case that would have been silently wrong — a post-migration deliberate 10 GB surviving.

**Quota enforcement against real files (7).** Real `DiskCache`, real directory, real safetensors, real SQLite index, nothing mocked:

- 12 × 80 KB into a 400 KB budget → resting size ≤ cap, `evictions > 0`, **and** assertions that the cache grew and was not emptied (a cache that silently refused every store would satisfy a cap check on its own)
- oldest entry evicted first, writes separated past the index's second-resolution `createdAt`
- reopening the same directory with a **smaller** cap trims on the next store — the "changed Disk Cache Size and reloaded" path
- reopening with a **larger** cap accumulates and stops evicting
- `clear()` removes indexed payloads **and** an orphaned safetensors the index never knew about — the crash-between-write-and-insert case quota accounting is structurally blind to
- two models sharing one root: model B's writes reclaim model A's older entry, proving the quota is shared rather than per model
- the 75% warning threshold tied to a genuinely filling cache

## Live proof

Driven through the osaurus UI (companion PR osaurus-ai/osaurus#2436, now merged). Local model, cap set to 1.0 GB, five-turn conversation: the chat footer reported **`1011 MB / 1.0 GB`** with the warning, the filesystem measured **1011 MB** — exact match — and **6 stores → 4 surviving entries = 2 evicted**, held at 99% under cap.