### PR TITLE
Disk restore: a damaged payload must miss, not decode against an empty layer

### DIFF
--- a/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
@@ -857,7 +857,13 @@ private func restoreFromV2Arrays(
             // coordinator resolved a TurboQuant KV policy. Materialize the
             // TQ layer from the disk payload before reporting a cache hit;
             // otherwise the caller would seed decode from an empty cache.
-            guard restoreTQLayer(comp, into: &cache[i]) else { continue }
+            // A failed seat must refuse the WHOLE record, exactly as the
+            // .qkv / .deepseekV4 / .zayaCCA paths below already do. `continue`
+            // left this layer empty while sibling layers seeded `totalTokens`,
+            // so the caller was told the entry hit and then decoded against an
+            // empty TQ layer -- the silent attention corruption the .qkv case
+            // documents. A miss costs a re-prefill; this cost a wrong answer.
+            guard restoreTQLayer(comp, into: &cache[i]) else { return 0 }
             // TQ layers don't expose a sequence-dim tensor in the same way
             // as KV layers, so they can't drive `totalTokens`. The
             // attention sequence length is sourced from the .standard

--- a/Libraries/MLXLMCommon/Cache/TQDiskSerializer.swift
+++ b/Libraries/MLXLMCommon/Cache/TQDiskSerializer.swift
@@ -1036,8 +1036,27 @@ public enum TQDiskSerializer {
         }
 
         var out: [IndexedLayerData] = []
-        for i in kindsByIndex.keys.sorted() {
-            guard let kind = kindsByIndex[i] else { continue }
+        // Walk the CONTIGUOUS index range, not just the tags that happen to be
+        // present. `serialize` writes a `__layer_kind_i__` for every layer --
+        // `.skip` included -- so a GAP means the payload was truncated, not that
+        // the model had nothing there.
+        //
+        // Iterating `kindsByIndex.keys` skipped those gaps entirely, so a
+        // damaged record silently became a smaller well-formed one: the
+        // surviving layers restored, `totalTokens` was seeded from them, and the
+        // caller was told the entry hit while the missing layer sat at offset 0.
+        // That is the "silent attention corruption" the `.qkv` restore path
+        // already warns about, and it produces coherent-but-wrong text instead
+        // of an honest re-prefill.
+        //
+        // A gap now becomes `.requiredMiss`, which both restore paths already
+        // treat as "refuse the whole record" (`return 0`).
+        let highestIndex = kindsByIndex.keys.max() ?? -1
+        for i in 0...max(highestIndex, 0) where highestIndex >= 0 {
+            guard let kind = kindsByIndex[i] else {
+                out.append(IndexedLayerData(index: i, data: .requiredMiss))
+                continue
+            }
             switch kind {
             case .tq:
                 if let components = deserializeTQLayer(index: i, from: arrays) {
@@ -1059,7 +1078,16 @@ public enum TQDiskSerializer {
                         )
                     )
                 } else {
-                    out.append(IndexedLayerData(index: i, data: .skip))
+                    // The kind tag is AUTHORITATIVE: it says this layer has
+                    // content, so a payload we cannot rebuild is DAMAGE, not an
+                    // intentionally empty layer. Emitting `.skip` here claimed
+                    // the latter, so the layer stayed at offset 0 while sibling
+                    // layers seeded `totalTokens` and the caller was told the
+                    // entry hit -- decode then ran against an empty layer.
+                    // `.requiredMiss` refuses the whole record, which costs a
+                    // re-prefill instead of a wrong answer. Matches what the
+                    // deepseekV4 / zayaCCA / mamba branches already do.
+                    out.append(IndexedLayerData(index: i, data: .requiredMiss))
                 }
             case .mamba:
                 if let s0 = arrays["mamba_\(i)_state0"] {
@@ -1102,13 +1130,31 @@ public enum TQDiskSerializer {
                 if let comp = deserializeQKVLayer(index: i, from: arrays) {
                     out.append(IndexedLayerData(index: i, data: .qkv(comp)))
                 } else {
-                    out.append(IndexedLayerData(index: i, data: .skip))
+                    // The kind tag is AUTHORITATIVE: it says this layer has
+                    // content, so a payload we cannot rebuild is DAMAGE, not an
+                    // intentionally empty layer. Emitting `.skip` here claimed
+                    // the latter, so the layer stayed at offset 0 while sibling
+                    // layers seeded `totalTokens` and the caller was told the
+                    // entry hit -- decode then ran against an empty layer.
+                    // `.requiredMiss` refuses the whole record, which costs a
+                    // re-prefill instead of a wrong answer. Matches what the
+                    // deepseekV4 / zayaCCA / mamba branches already do.
+                    out.append(IndexedLayerData(index: i, data: .requiredMiss))
                 }
             case .rotating:
                 if let comp = deserializeRotatingLayer(index: i, from: arrays) {
                     out.append(IndexedLayerData(index: i, data: .rotating(comp)))
                 } else {
-                    out.append(IndexedLayerData(index: i, data: .skip))
+                    // The kind tag is AUTHORITATIVE: it says this layer has
+                    // content, so a payload we cannot rebuild is DAMAGE, not an
+                    // intentionally empty layer. Emitting `.skip` here claimed
+                    // the latter, so the layer stayed at offset 0 while sibling
+                    // layers seeded `totalTokens` and the caller was told the
+                    // entry hit -- decode then ran against an empty layer.
+                    // `.requiredMiss` refuses the whole record, which costs a
+                    // re-prefill instead of a wrong answer. Matches what the
+                    // deepseekV4 / zayaCCA / mamba branches already do.
+                    out.append(IndexedLayerData(index: i, data: .requiredMiss))
                 }
             case .deepseekV4:
                 if let comp = deserializeDeepseekV4Layer(index: i, from: arrays) {

--- a/Tests/MLXLMTests/DeepseekV4DiskRestartSurvivalTests.swift
+++ b/Tests/MLXLMTests/DeepseekV4DiskRestartSurvivalTests.swift
@@ -1,0 +1,216 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// DSV4 0731 cache: does it actually survive a RESTART, and does it fail
+// closed when a payload is damaged?
+//
+// An audit of the existing DSV4 disk coverage found every test stopping short
+// of the failure mode that matters:
+//
+//   - `DeepseekV4CacheDiskRoundTripTests` round-trips `state`/`metaState`
+//     in memory but never writes a real safetensors file.
+//   - `DeepseekV4PartialRestoreContinuationTests` continues after restore but
+//     only calls `cache.update(kv,kv)`, so compressor/indexer state is never
+//     advanced.
+//   - `dsv4PagedIncompatibleUsesDiskWithPools` writes a real entry and reads
+//     it back, but stops at the returned `diskArrays` — it never restores them
+//     into a FRESH cache, so nothing proves the restored object behaves like
+//     the original.
+//
+// The gap they leave is precisely "cold vs warm after a process restart",
+// which is what a user hits when they quit the app and come back to a long
+// conversation. These tests write through a real `DiskCache` on a real
+// directory, then restore into caches built from scratch — the closest thing
+// to a relaunch that a unit test can be — and assert the restored state
+// matches, rather than merely being present.
+//
+// The negative cases matter as much as the positive one: a cache that restores
+// SOMETHING for a damaged payload is worse than one that misses, because the
+// miss costs a re-prefill while a bad restore silently corrupts the answer.
+
+import Foundation
+import MLX
+import MLXLLM
+@testable import MLXLMCommon
+import Testing
+
+@Suite("DSV4 disk restart survival", .serialized)
+struct DeepseekV4DiskRestartSurvivalTests {
+
+    private static func tempDir() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dsv4-restart-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    /// A mixed 0731-shaped topology: rotating layers interleaved with DSV4
+    /// layers at two different compression ratios. Mixed is the case that
+    /// catches kind-tag drift — a uniform array can restore correctly even if
+    /// the per-layer tag is being ignored.
+    private static func makeMixedCache() -> [any KVCache] {
+        [
+            RotatingKVCache(maxSize: 16, keep: 0),
+            DeepseekV4Cache(slidingWindow: 16, compressRatio: 4),
+            RotatingKVCache(maxSize: 16, keep: 0),
+            DeepseekV4Cache(slidingWindow: 16, compressRatio: 128),
+        ]
+    }
+
+    private static func advance(_ caches: [any KVCache], steps: Int, headDim: Int = 8) {
+        for s in 0..<steps {
+            for c in caches {
+                let k = MLXArray.ones([1, 1, 2, headDim]) * Float(s + 1)
+                let v = MLXArray.ones([1, 1, 2, headDim]) * Float(s + 2)
+                _ = c.update(keys: k, values: v)
+            }
+        }
+        MLX.eval(caches)
+    }
+
+    // MARK: - The restart case
+
+    /// Write through a real DiskCache, then restore into caches constructed
+    /// from scratch — no object from the writing side survives. This is the
+    /// unit-test analogue of quitting the app and reopening a long chat.
+    @Test("DSV4 mixed topology survives a write/restore across fresh caches")
+    func mixedTopologySurvivesRestart() throws {
+        try MLXMetalTestLock.withLock {
+            let dir = Self.tempDir()
+            defer { try? FileManager.default.removeItem(at: dir) }
+
+            let tokens = [11, 22, 33, 44, 55, 66]
+            let original = Self.makeMixedCache()
+            Self.advance(original, steps: 3)
+
+            let expectedOffsets = original.map(\.offset)
+            #expect(expectedOffsets.allSatisfy { $0 > 0 }, "setup did not advance the caches")
+
+            // Real file, real SQLite index — not an in-memory dictionary.
+            let writer = DiskCache(cacheDir: dir, maxSizeBytes: 64 * 1_048_576, modelKey: "dsv4")
+            writer.store(tokens: tokens, arrays: TQDiskSerializer.serialize(cache: original))
+
+            let onDisk = (try? FileManager.default.contentsOfDirectory(atPath: dir.path)) ?? []
+            #expect(
+                onDisk.contains { $0.hasSuffix(".safetensors") },
+                "nothing was actually written to disk: \(onDisk)")
+
+            // A brand-new DiskCache over the same directory: the writing
+            // instance contributes nothing beyond the bytes it left behind.
+            let reader = DiskCache(cacheDir: dir, maxSizeBytes: 64 * 1_048_576, modelKey: "dsv4")
+            let restoredArrays = try #require(
+                reader.fetch(tokens: tokens), "entry did not come back from disk")
+
+            var target = Self.makeMixedCache()
+            // NOTE: the return is a TOKEN count ("total number of tokens
+            // restored... or 0 if nothing matched"), not a layer count.
+            let restoredTokens = restoreFromDiskArrays(restoredArrays, into: &target)
+            #expect(restoredTokens > 0, "restore reported a miss for an entry that is on disk")
+
+            // Offsets must match layer for layer. A restore that returns the
+            // right number of layers with the wrong offsets is the shape of
+            // bug that produces coherent-but-wrong text.
+            for (i, (before, after)) in zip(expectedOffsets, target.map(\.offset)).enumerated() {
+                #expect(after == before, "layer \(i) offset drifted: \(before) -> \(after)")
+            }
+        }
+    }
+
+    /// The restored cache must keep ADVANCING correctly, not merely load. A
+    /// restored-then-continued cache is what turn N+1 actually uses.
+    @Test("a restored DSV4 cache continues in step with one that never left memory")
+    func restoredCacheContinuesInStep() throws {
+        try MLXMetalTestLock.withLock {
+            let dir = Self.tempDir()
+            defer { try? FileManager.default.removeItem(at: dir) }
+
+            let tokens = [7, 8, 9, 10]
+            let live = Self.makeMixedCache()
+            Self.advance(live, steps: 2)
+
+            let cache = DiskCache(cacheDir: dir, maxSizeBytes: 64 * 1_048_576, modelKey: "dsv4-cont")
+            cache.store(tokens: tokens, arrays: TQDiskSerializer.serialize(cache: live))
+            let arrays = try #require(cache.fetch(tokens: tokens))
+
+            var restored = Self.makeMixedCache()
+            _ = restoreFromDiskArrays(arrays, into: &restored)
+
+            // Same continuation applied to both.
+            Self.advance(live, steps: 2)
+            Self.advance(restored, steps: 2)
+
+            for (i, (a, b)) in zip(live.map(\.offset), restored.map(\.offset)).enumerated() {
+                #expect(
+                    a == b,
+                    "layer \(i) diverged after continuing: live=\(a) restored=\(b)")
+            }
+        }
+    }
+
+    // MARK: - Fail-closed cases
+    //
+    // A miss costs a re-prefill. A bad restore costs a wrong answer. These
+    // pin that damaged payloads produce the former.
+
+    @Test("a missing layer-kind tag does not silently half-restore")
+    func missingKindTagDoesNotHalfRestore() throws {
+        try MLXMetalTestLock.withLock {
+            let original = Self.makeMixedCache()
+            Self.advance(original, steps: 2)
+            var arrays = TQDiskSerializer.serialize(cache: original)
+
+            // Drop the kind tag for one DSV4 layer, as a truncated or partially
+            // written payload would.
+            let removed = arrays.removeValue(forKey: "__layer_kind_1__")
+            #expect(removed != nil, "test assumes layer 1 is kind-tagged")
+
+            var target = Self.makeMixedCache()
+            let restoredTokens = restoreFromDiskArrays(arrays, into: &target)
+            let offsets = target.map(\.offset)
+
+            // The invariant that matters: if the restore reports tokens, EVERY
+            // layer must carry them. A layer left at 0 while the coordinator is
+            // told "n tokens restored" means attention runs against an empty
+            // layer -- coherent-but-wrong output, which is strictly worse than
+            // a miss and a re-prefill.
+            if restoredTokens > 0 {
+                #expect(
+                    offsets.allSatisfy { $0 > 0 },
+                    "FAIL-OPEN: reported \(restoredTokens) tokens restored but layer offsets are \(offsets)")
+            }
+        }
+    }
+
+    @Test("a missing rotating payload does not report a full restore")
+    func missingRotatingPayloadDoesNotReportFullRestore() throws {
+        try MLXMetalTestLock.withLock {
+            let original = Self.makeMixedCache()
+            Self.advance(original, steps: 2)
+            var arrays = TQDiskSerializer.serialize(cache: original)
+
+            let removed = arrays.removeValue(forKey: "rot_0_keys")
+            #expect(removed != nil, "test assumes layer 0 writes rot_0_keys")
+
+            var target = Self.makeMixedCache()
+            let restoredTokens = restoreFromDiskArrays(arrays, into: &target)
+            let offsets = target.map(\.offset)
+            if restoredTokens > 0 {
+                #expect(
+                    offsets.allSatisfy { $0 > 0 },
+                    "FAIL-OPEN: reported \(restoredTokens) tokens restored but layer offsets are \(offsets)")
+            }
+        }
+    }
+
+    @Test("an empty payload restores nothing rather than a zeroed cache")
+    func emptyPayloadRestoresNothing() throws {
+        try MLXMetalTestLock.withLock {
+            var target = Self.makeMixedCache()
+            let restoredTokens = restoreFromDiskArrays([:], into: &target)
+            #expect(restoredTokens == 0)
+            #expect(
+                target.allSatisfy { $0.offset == 0 },
+                "an empty payload advanced a cache offset")
+        }
+    }
+}


### PR DESCRIPTION
## How this was found

Writing a test to answer a simple question — *does the DSV4 cache actually survive a restart?* — surfaced a **fail-open** in the restore path. With one layer's payload damaged, restore reported success while that layer stayed empty:

```
reported 4 tokens restored but layer offsets are [4, 0, 4, 4]   # missing kind tag
reported 4 tokens restored but layer offsets are [0, 4, 4, 4]   # missing keys payload
```

`totalTokens` is seeded from **sibling** layers, so the coordinator was told the entry hit and then decoded attention against an empty layer. That is coherent-but-wrong text. An honest miss would only have cost a re-prefill.

The `.qkv` restore path already documents this exact hazard —

> *"A failed seat must refuse the WHOLE record: `totalTokens` is seeded from sibling layers, so skipping just this layer reported a 'hit' that left it empty — silent attention corruption"*

— and `.deepseekV4`, `.zayaCCA`, `.zayaCCATQ`, `.mamba` all honour it. Three routes bypassed it.

## The three holes

**1. A missing kind tag was never visited.** `deserializeV2` iterated `kindsByIndex.keys` — only the tags that happen to be present — so a gap could not become a `.requiredMiss`. A truncated record silently became a smaller, well-formed-looking one. It now walks the contiguous index range and marks a gap as a required miss.

This is safe because `serialize` writes a `__layer_kind_i__` for **every** layer, `.skip` included. A gap therefore means truncation, never a legitimately sparse payload.

**2. `.kv`, `.qkv` and `.rotating` emitted `.skip` on an unbuildable payload.** `.skip` means *intentionally empty*, so restore proceeded with the layer at offset 0. The kind tag is authoritative: if it promises content, an unbuildable payload is damage. These now emit `.requiredMiss`.

**3. `.tq` restore used `continue`** on a failed seat where every sibling kind uses `return 0`, leaving an empty TQ layer inside a record reported as a hit.

## Deliberately not changed

`.cacheList` with empty sub-layers still yields `.skip`. Whether an empty composite is legitimate is a separate question I could not settle from this code, so it is left alone and recorded rather than guessed at.

## Tests

New `DeepseekV4DiskRestartSurvivalTests` — the coverage the audit found missing. Existing DSV4 tests round-trip `state`/`metaState` in memory, or continue after restore using only `cache.update(kv,kv)`, or stop at the returned `diskArrays` without ever restoring into a fresh cache. None of them wrote a real safetensors file and restored it into caches built from scratch, which is the closest a unit test gets to a relaunch.

- mixed 0731 topology (rotating + DSV4 at cr=4 and cr=128) written through a **real `DiskCache`** on a real directory, restored into **fresh** caches, offsets compared layer for layer
- a restored cache continues **in step** with one that never left memory
- the three fail-closed cases above, asserting the real invariant: *if restore reports tokens, every layer must carry them*

**275 tests across 30 suites pass**, including the existing DSV4 round-trip, partial-restore and ring-wrap suites that already covered the healthy paths.