### PR TITLE
Disk restore: close two fail-open holes the per-kind fix missed

### DIFF
--- a/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
@@ -754,6 +754,24 @@ private func restoreFromV2Arrays(
     let indexed = TQDiskSerializer.deserializeIndexed(arrays)
     guard !indexed.isEmpty else { return 0 }
 
+    // A record that describes FEWER layers than the runtime cache has is a
+    // truncated record, and must miss.
+    //
+    // `deserializeIndexed` detects a GAP in the layer-kind tags, but a gap
+    // requires a tag on both sides of it. Losing the TRAILING tags — which is
+    // what a partially-flushed write actually leaves behind — creates no gap:
+    // the contiguous walk simply ends early, and the damaged payload becomes a
+    // smaller well-formed one. The surviving layers then restore, seed
+    // `totalTokens`, and the caller is told the entry hit while the tail
+    // layers sit at offset 0. Attention runs against empty layers and the
+    // model produces confident wrong text instead of re-prefilling.
+    //
+    // The serializer writes a tag for EVERY layer, `.skip` included, so a
+    // well-formed record always describes exactly `cache.count` layers. Only
+    // the restore path knows that count, which is why this check cannot live
+    // in the deserializer. Refusing costs one re-prefill.
+    guard indexed.count >= cache.count else { return 0 }
+
     // ZAYA disk records are an all-or-nothing prompt-boundary snapshot. Restore
     // every typed layer into a private copy first, including encoded TQ state,
     // so a corrupt later CCA layer cannot leave the caller's cache half-seated.

--- a/Libraries/MLXLMCommon/Cache/TQDiskSerializer.swift
+++ b/Libraries/MLXLMCommon/Cache/TQDiskSerializer.swift
@@ -1104,7 +1104,18 @@ public enum TQDiskSerializer {
                         }
                         offset = Int(off)
                     } else {
-                        offset = 0
+                        // MISSING is damage, not "position zero".
+                        //
+                        // `serializeMambaLayer` writes `__mamba_i_offset__`
+                        // unconditionally whenever it writes `state0`, so a
+                        // payload carrying recurrent state without its offset
+                        // was truncated. Defaulting to 0 seated real state at
+                        // the wrong position and let the record report a hit —
+                        // the sibling branch two lines up already refuses an
+                        // UNREADABLE offset for exactly this reason, and a
+                        // missing one is no more trustworthy.
+                        out.append(IndexedLayerData(index: i, data: .requiredMiss))
+                        continue
                     }
                     out.append(
                         IndexedLayerData(

--- a/Tests/MLXLMTests/DiskRestoreFailClosedMatrixTests.swift
+++ b/Tests/MLXLMTests/DiskRestoreFailClosedMatrixTests.swift
@@ -1,0 +1,336 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Fail-closed disk restore, proven per ARCHITECTURE rather than per cache
+// class.
+//
+// The defect this pins: a damaged on-disk payload used to restore SOME layers
+// and report success. The coordinator was told "n tokens restored" while a
+// layer sat at offset 0, so attention ran against an empty layer — coherent,
+// confident, wrong text. A miss costs one re-prefill. A bad restore costs the
+// answer, silently, and looks like a model quality problem.
+//
+// Scoping by cache CLASS is the mistake that let this survive: the existing
+// coverage tested DSV4 and rotating topologies, and both the shipped families
+// whose caches are neither (hybrid SSM, Zaya CCA) and the families that use a
+// bare `KVCacheSimple` went unexercised. So the matrix below is indexed by the
+// shipped model families and built from the topology each one's `newCache`
+// actually returns:
+//
+//   Muse (MuseGlimmerText)          RotatingKVCache
+//   Ornith 1.5 / Qwen 3.5-3.6       MambaCache + RotatingKVCache   (hybrid SSM)
+//   DeepSeek-V4                     DeepseekV4Cache + RotatingKVCache
+//   Nanbeige / LagunaM1             KVCacheSimple      (no newCache override)
+//   LFM2 / Jamba / FalconH1         MambaCache
+//   Gemma-4 / Mistral / GPTOSS      RotatingKVCache
+//
+// Every case runs BOTH directions. The positive control is not optional: a
+// fail-closed assertion passes vacuously if restore never returns anything,
+// so each topology must first be shown to restore fully when undamaged.
+
+import Foundation
+import MLX
+import MLXLLM
+
+@testable import MLXLMCommon
+import Testing
+
+@Suite("Disk restore fails closed across architectures", .serialized)
+struct DiskRestoreFailClosedMatrixTests {
+
+    // MARK: - Topologies, named by the families that ship them
+
+    private struct Topology {
+        let name: String
+        let families: String
+        let make: () -> [any KVCache]
+    }
+
+    /// Computed rather than stored: the entries carry factory closures, and a
+    /// stored static would be shared mutable global state under strict
+    /// concurrency. Rebuilding the list per access also guarantees each test
+    /// gets fresh cache objects.
+    private static var topologies: [Topology] {
+        [
+        Topology(
+            name: "rotating",
+            families: "Muse Glimmer, Gemma-4, Mistral, GPT-OSS, AfMoE",
+            make: {
+                [
+                    RotatingKVCache(maxSize: 16, keep: 0),
+                    RotatingKVCache(maxSize: 16, keep: 4),
+                    RotatingKVCache(maxSize: 16, keep: 0),
+                ]
+            }),
+        Topology(
+            name: "hybrid-ssm",
+            families: "Ornith 1.5, Qwen 3.5/3.6, Qwen3Next, NemotronH",
+            make: {
+                [
+                    MambaCache(),
+                    RotatingKVCache(maxSize: 16, keep: 4),
+                    MambaCache(),
+                    RotatingKVCache(maxSize: 16, keep: 4),
+                ]
+            }),
+        Topology(
+            name: "deepseek-v4",
+            families: "DeepSeek-V4, DeepSeek-V4 JANGTQ",
+            make: {
+                [
+                    RotatingKVCache(maxSize: 16, keep: 0),
+                    DeepseekV4Cache(slidingWindow: 16, compressRatio: 4),
+                    RotatingKVCache(maxSize: 16, keep: 0),
+                    DeepseekV4Cache(slidingWindow: 16, compressRatio: 128),
+                ]
+            }),
+        Topology(
+            name: "plain-kv",
+            families: "Nanbeige, LagunaM1 (default cache, no newCache override)",
+            make: { [KVCacheSimple(), KVCacheSimple(), KVCacheSimple()] }),
+        Topology(
+            name: "pure-ssm",
+            families: "LFM2, LFM2MoE, Jamba, FalconH1, GraniteMoeHybrid",
+            make: { [MambaCache(), MambaCache(), MambaCache()] }),
+        ]
+    }
+
+    // MARK: - Helpers
+
+    private static func tempDir() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("failclosed-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    /// Advances every layer, dispatching on what the layer actually is.
+    ///
+    /// A `MambaCache` holds recurrent state in `ArraysCache` slots and is not
+    /// advanced by `update(keys:values:)` the way an attention cache is —
+    /// driving it through the attention path would leave its offset at 0 and
+    /// make every assertion below vacuously true.
+    private static func advance(_ caches: [any KVCache], steps: Int, headDim: Int = 8) {
+        for s in 0..<steps {
+            for c in caches {
+                if let mamba = c as? MambaCache {
+                    mamba[0] = MLXArray.ones([1, 4, headDim]) * Float(s + 1)
+                    mamba[1] = MLXArray.ones([1, 4, headDim]) * Float(s + 2)
+                    mamba.offset = s + 1
+                } else {
+                    let k = MLXArray.ones([1, 1, 2, headDim]) * Float(s + 1)
+                    let v = MLXArray.ones([1, 1, 2, headDim]) * Float(s + 2)
+                    _ = c.update(keys: k, values: v)
+                }
+            }
+        }
+        MLX.eval(caches)
+    }
+
+    /// The invariant, stated once.
+    ///
+    /// Restore may report a miss (0). What it may NOT do is report tokens
+    /// while some layer stayed at offset 0 — that is the fail-OPEN shape, and
+    /// it is the one that produces confident wrong text.
+    private static func assertFailedClosed(
+        restoredTokens: Int,
+        offsets: [Int],
+        topology: String,
+        damage: String
+    ) {
+        if restoredTokens == 0 {
+            return  // an honest miss: the caller re-prefills
+        }
+        let empty = offsets.enumerated().filter { $0.element == 0 }.map(\.offset)
+        #expect(
+            empty.isEmpty,
+            """
+            \(topology): restore reported \(restoredTokens) tokens after \(damage), \
+            but layer(s) \(empty) are still at offset 0. Attention would run \
+            against an empty layer — worse than a miss.
+            """)
+    }
+
+    // MARK: - Positive control
+    //
+    // Runs first and for every topology. Without it the fail-closed tests
+    // below could all pass on a restore path that is simply broken.
+
+    @Test("every shipped topology restores fully when the payload is intact")
+    func undamagedPayloadRestoresEveryLayer() throws {
+        try MLXMetalTestLock.withLock {
+            for topo in Self.topologies {
+                let dir = Self.tempDir()
+                defer { try? FileManager.default.removeItem(at: dir) }
+
+                let tokens = [1, 2, 3, 4, 5]
+                let original = topo.make()
+                Self.advance(original, steps: 3)
+                let expected = original.map(\.offset)
+                #expect(
+                    expected.allSatisfy { $0 > 0 },
+                    "\(topo.name): setup failed to advance — the whole suite would be vacuous")
+
+                let writer = DiskCache(
+                    cacheDir: dir, maxSizeBytes: 64 * 1_048_576, modelKey: topo.name)
+                writer.store(tokens: tokens, arrays: TQDiskSerializer.serialize(cache: original))
+
+                let reader = DiskCache(
+                    cacheDir: dir, maxSizeBytes: 64 * 1_048_576, modelKey: topo.name)
+                let arrays = try #require(
+                    reader.fetch(tokens: tokens), "\(topo.name): nothing came back from disk")
+
+                var target = topo.make()
+                let restored = restoreFromDiskArrays(arrays, into: &target)
+
+                if topo.name == "pure-ssm" {
+                    // KNOWN GAP, deliberately pinned rather than hidden.
+                    //
+                    // `restoreFromV2Arrays` seeds `totalTokens` only from
+                    // layers that carry a sequence dimension, and its `.mamba`
+                    // branch says so outright: "no sequence dim to measure ...
+                    // the attention side already provides that number." That
+                    // holds for hybrids and is FALSE for a model whose every
+                    // layer is recurrent, so LFM2 / Jamba / FalconH1 /
+                    // GraniteMoeHybrid can never report a hit and re-prefill
+                    // every turn.
+                    //
+                    // This is a PERFORMANCE defect, not a correctness one — it
+                    // misses, which is the safe direction — so it is out of
+                    // scope for the fail-closed work and tracked separately.
+                    // The `.tq` and `.qkv` branches already show the fix shape
+                    // (`if totalTokens == 0 { totalTokens = comp.offset }`),
+                    // but enabling reuse for a family that has never had it
+                    // needs its own proof that the newly-allowed path is
+                    // correct, not a drive-by change here.
+                    #expect(
+                        restored == 0,
+                        """
+                        pure-SSM now restores (\(restored) tokens) — the known gap \
+                        has been closed. Remove this branch and assert full restore.
+                        """)
+                    continue
+                }
+
+                #expect(restored > 0, "\(topo.name) [\(topo.families)]: intact payload missed")
+                for (i, (before, after)) in zip(expected, target.map(\.offset)).enumerated() {
+                    #expect(
+                        after == before,
+                        "\(topo.name): layer \(i) offset \(before) -> \(after)")
+                }
+            }
+        }
+    }
+
+    // MARK: - Damage: a dropped layer-kind tag
+
+    /// A truncated or partially-written payload loses trailing keys. Every
+    /// layer is tagged, so dropping one tag is the minimal realistic damage.
+    @Test("a dropped layer-kind tag fails closed on every architecture")
+    func droppedKindTagFailsClosed() throws {
+        try MLXMetalTestLock.withLock {
+            for topo in Self.topologies {
+                let original = topo.make()
+                Self.advance(original, steps: 2)
+
+                for victim in 0..<original.count {
+                    var arrays = TQDiskSerializer.serialize(cache: original)
+                    guard arrays.removeValue(forKey: "__layer_kind_\(victim)__") != nil else {
+                        Issue.record("\(topo.name): layer \(victim) carried no kind tag")
+                        continue
+                    }
+
+                    var target = topo.make()
+                    let restored = restoreFromDiskArrays(arrays, into: &target)
+                    Self.assertFailedClosed(
+                        restoredTokens: restored,
+                        offsets: target.map(\.offset),
+                        topology: "\(topo.name) [\(topo.families)]",
+                        damage: "dropping the kind tag for layer \(victim)")
+                }
+            }
+        }
+    }
+
+    // MARK: - Damage: a dropped data payload
+
+    /// The nastier case. The tag survives — so the record still LOOKS
+    /// well-formed and routes to a real per-kind decoder — but the tensor it
+    /// needs is gone. This is the shape that used to decode against an empty
+    /// layer rather than refuse.
+    @Test("a dropped data tensor fails closed on every architecture")
+    func droppedDataPayloadFailsClosed() throws {
+        try MLXMetalTestLock.withLock {
+            for topo in Self.topologies {
+                let original = topo.make()
+                Self.advance(original, steps: 2)
+                let intact = TQDiskSerializer.serialize(cache: original)
+
+                // Every non-tag key, one at a time: no assumption about which
+                // tensor names a given kind happens to use.
+                let dataKeys = intact.keys.filter { !$0.hasPrefix("__layer_kind_") }.sorted()
+                #expect(!dataKeys.isEmpty, "\(topo.name): serializer emitted no data tensors")
+
+                for key in dataKeys {
+                    var arrays = intact
+                    arrays.removeValue(forKey: key)
+
+                    var target = topo.make()
+                    let restored = restoreFromDiskArrays(arrays, into: &target)
+                    Self.assertFailedClosed(
+                        restoredTokens: restored,
+                        offsets: target.map(\.offset),
+                        topology: "\(topo.name) [\(topo.families)]",
+                        damage: "dropping data tensor '\(key)'")
+                }
+            }
+        }
+    }
+
+    // MARK: - Damage: truncation
+
+    /// Whole-tail loss, as a partially-flushed write leaves behind. Distinct
+    /// from single-key removal because it takes tags and data together.
+    @Test("a truncated payload fails closed on every architecture")
+    func truncatedPayloadFailsClosed() throws {
+        try MLXMetalTestLock.withLock {
+            for topo in Self.topologies {
+                let original = topo.make()
+                Self.advance(original, steps: 2)
+                let intact = TQDiskSerializer.serialize(cache: original)
+                let ordered = intact.keys.sorted()
+
+                // Keep the first half; drop the rest.
+                for keep in [1, ordered.count / 2, max(1, ordered.count - 1)] {
+                    var arrays: [String: MLXArray] = [:]
+                    for k in ordered.prefix(keep) { arrays[k] = intact[k] }
+
+                    var target = topo.make()
+                    let restored = restoreFromDiskArrays(arrays, into: &target)
+                    Self.assertFailedClosed(
+                        restoredTokens: restored,
+                        offsets: target.map(\.offset),
+                        topology: "\(topo.name) [\(topo.families)]",
+                        damage: "truncating to the first \(keep) of \(ordered.count) keys")
+                }
+            }
+        }
+    }
+
+    // MARK: - Damage: an empty payload
+
+    /// The degenerate end of truncation. Must be a miss, never a success.
+    @Test("an empty payload is always a miss")
+    func emptyPayloadIsAMiss() throws {
+        try MLXMetalTestLock.withLock {
+            for topo in Self.topologies {
+                var target = topo.make()
+                let restored = restoreFromDiskArrays([:], into: &target)
+                #expect(restored == 0, "\(topo.name): empty payload reported \(restored) tokens")
+                #expect(
+                    target.map(\.offset).allSatisfy { $0 == 0 },
+                    "\(topo.name): empty payload advanced a layer")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

`#287` made a damaged disk payload miss rather than decode against an empty layer, but it was scoped by **cache class**. Re-testing by shipped **architecture** found two paths still reporting a hit while a layer sat at offset 0 — the exact fail-open shape #287 set out to remove.

### 1. Trailing truncation (all topologies)

Gap detection walks `0...max(tagIndex)`. Losing the **last** layer's tag creates no gap — the range just ends early, so a damaged record silently becomes a smaller well-formed one. Surviving layers restore, seed `totalTokens`, and the caller is told the entry hit.

Reproduced on rotating, hybrid-SSM, DeepSeek-V4 and plain-KV alike:

```
rotating [Muse Glimmer, Gemma-4, Mistral, GPT-OSS, AfMoE]:
  restore reported 4 tokens after dropping the kind tag for layer 2,
  but layer(s) [2] are still at offset 0.
```

Only the restore path knows how many layers the runtime cache has, so the check lives there rather than in the deserializer.

### 2. Mamba offset (hybrid SSM)

A recurrent layer whose `__mamba_i_offset__` was missing defaulted to **offset 0** and seated real state at the wrong position. The sibling branch already refuses an *unreadable* offset for precisely this reason. `serializeMambaLayer` writes that key unconditionally alongside `state0`, so its absence is damage — not an older format.

```
hybrid-ssm [Ornith 1.5, Qwen 3.5/3.6, Qwen3Next, NemotronH]:
  restore reported 4 tokens after dropping data tensor '__mamba_0_offset__',
  but layer(s) [0] are still at offset 0.
```

## Proof

New matrix indexed by **shipped families**, not cache classes:

| topology | families |
|---|---|
| rotating | Muse Glimmer, Gemma-4, Mistral, GPT-OSS, AfMoE |
| hybrid-ssm | Ornith 1.5, Qwen 3.5/3.6, Qwen3Next, NemotronH |
| deepseek-v4 | DeepSeek-V4, DeepSeek-V4 JANGTQ |
| plain-kv | Nanbeige, LagunaM1 (no `newCache` override) |
| pure-ssm | LFM2, LFM2MoE, Jamba, FalconH1, GraniteMoeHybrid |

Crossed with four kinds of damage: a dropped kind tag at **every** layer position, **every** data tensor dropped one at a time, truncation at three lengths, and an empty payload.

Each topology must first restore fully when intact — otherwise the fail-closed assertions pass vacuously on a restore path that is simply broken.

```
✔ every shipped topology restores fully when the payload is intact
✔ a dropped layer-kind tag fails closed on every architecture
✔ a dropped data tensor fails closed on every architecture
✔ a truncated payload fails closed on every architecture
✔ an empty payload is always a miss
✔ Test run with 10 tests in 2 suites passed
```

Regression: `CacheHelpersTests`, `DiskCacheTests`, `CacheCoordinatorTests`, `DeepseekV4CacheDiskRoundTrip`, `DeepseekV4PartialRestoreContinuation`, `CacheCoordinatorPagedIncompatibleHybrid`, `DFlash2PrefixCacheReuse`, `HybridStripBoundaryPrefill`, `CompilableMambaCache`, `DDTreeHybridSSM`, `DFlash2SSDLongTermCache`, `GrowingChatCacheHybridGateSource`, `CacheCoordinatorRotatingGuard`, `Gemma4CacheTopology`, `CacheCoordinatorMediaSalt`, `BatchZayaCCACacheIsolation` — all pass.

## Known gap, pinned not hidden

Pure-SSM models can never report a hit: `totalTokens` is seeded only from layers carrying a sequence dimension, and a fully recurrent model has none. That **misses**, which is the safe direction, so it is a performance defect rather than a correctness one and is tracked separately. The test asserts the current behaviour and tells you to flip it when the gap closes.