### PR TITLE
Disk cache size is a percent of the disk, not a number of gigabytes

### DIFF
--- a/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
+++ b/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
@@ -15,7 +15,7 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
     /// 2: disk-cache size default moved from a flat 10 GB to auto (10% of the
     ///    cache volume). Installs that had already written the literal 10.0
     ///    must move to auto, otherwise only fresh installs benefit.
-    public static let contractVersion = 2
+    public static let contractVersion = 3
 
     public var network: VMLXServerNetworkSettings
     public var concurrency: VMLXServerConcurrencySettings
@@ -95,6 +95,26 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
             if let legacy = cache.legacyDisk.maxSizeGB, legacy == 10.0 {
                 cache.legacyDisk.maxSizeGB = nil
             }
+        }
+        if stored < 3 {
+            // The control is now a PERCENT of the disk, because a GB figure
+            // that suits one machine starves another. An install that chose an
+            // explicit GB size keeps exactly the cap it chose — the value is
+            // converted to the equivalent share of its own volume, so the
+            // number in the field changes but the amount of disk used does
+            // not. Nobody's cache silently shrinks or grows on update.
+            if cache.blockDisk.maxSizePercent == nil,
+                let gb = cache.blockDisk.maxSizeGB, gb > 0,
+                let capacity = Self.cacheVolumeCapacityGB(
+                    for: Self.resolvedDirectory(cache.blockDisk.directory)),
+                capacity > 0
+            {
+                cache.blockDisk.maxSizePercent = (gb / capacity) * 100.0
+                cache.blockDisk.maxSizeGB = nil
+            }
+            // A volume we cannot measure keeps its GB value untouched rather
+            // than being converted against a guessed capacity. The resolver
+            // still honours it, so such an install simply keeps working.
         }
         schemaVersion = Self.contractVersion
     }
@@ -864,32 +884,44 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
         let reuseEnabled = cache.prefix.enabled
         let diskEnabled: Bool
         let diskMaxSizeGB: Double?
+        let diskMaxSizePercent: Double?
         let diskDirectory: String?
         if reuseEnabled, cache.pagedKV.enabled {
             diskEnabled = cache.blockDisk.enabled
+            diskMaxSizePercent = cache.blockDisk.maxSizePercent
             diskMaxSizeGB = cache.blockDisk.maxSizeGB
             diskDirectory = cache.blockDisk.directory
         } else if reuseEnabled, cache.blockDisk.enabled {
             diskEnabled = true
+            diskMaxSizePercent = cache.blockDisk.maxSizePercent
             diskMaxSizeGB = cache.blockDisk.maxSizeGB
             diskDirectory = cache.blockDisk.directory
         } else if reuseEnabled {
             diskEnabled = cache.legacyDisk.enabled
+            // The legacy disk cache has no percent control of its own; it
+            // follows the block-disk percentage so one setting governs the
+            // whole cache root, which is what the quota actually enforces.
+            diskMaxSizePercent = cache.blockDisk.maxSizePercent
             diskMaxSizeGB = cache.legacyDisk.maxSizeGB
             diskDirectory = cache.legacyDisk.directory
         } else {
             diskEnabled = false
+            diskMaxSizePercent = nil
             diskMaxSizeGB = nil
             diskDirectory = nil
         }
         let diskDir = diskCacheDirectory
             ?? VMLXServerRuntimeSettings.resolvedDirectory(diskDirectory)
-        // Unset means AUTO — a share of the cache volume, not a flat constant.
-        // Applies to every model because the cap governs the whole cache root
-        // (`CacheCoordinator.enforceSharedDiskQuota`), not one bundle.
+        // The cap is a PERCENT of the cache volume, not a flat constant: KV
+        // cost scales with the model, so one GB figure is wrong for every
+        // machine at once. Applies to every model because the quota governs
+        // the whole cache root (`CacheCoordinator.enforceSharedDiskQuota`),
+        // not one bundle.
         let diskMaxGB = Float(
-            diskMaxSizeGB
-                ?? VMLXServerRuntimeSettings.autoDiskCacheMaxGB(for: diskDir))
+            VMLXServerRuntimeSettings.resolveDiskCacheMaxGB(
+                percent: diskMaxSizePercent,
+                legacyGB: diskMaxSizeGB,
+                directory: diskDir))
 
         return CacheCoordinatorConfig(
             usePagedCache: reuseEnabled && cache.pagedKV.enabled,
@@ -930,6 +962,56 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
     ///
     /// This ADVISES a larger cap; it never refuses or blocks. If the volume's
     /// capacity cannot be read it returns the floor rather than guessing small.
+    /// Total capacity of the volume holding `directory`, in GB, or nil when it
+    /// cannot be read.
+    ///
+    /// Separated from the cap arithmetic so the UI can show a user what their
+    /// percentage actually resolves to ("10% of 3.7 TB ≈ 372 GB") using the
+    /// same number the runtime enforces, rather than a second estimate that
+    /// can disagree with it.
+    public static func cacheVolumeCapacityGB(for directory: URL?) -> Double? {
+        guard let directory else { return nil }
+        // Walk up to the nearest existing ancestor: the cache dir itself may not
+        // exist yet on first run, and `resourceValues` needs a real path.
+        var probe = directory
+        while !FileManager.default.fileExists(atPath: probe.path) {
+            let parent = probe.deletingLastPathComponent()
+            guard parent.path != probe.path else { return nil }
+            probe = parent
+        }
+        guard
+            let capacity = try? probe.resourceValues(
+                forKeys: [.volumeTotalCapacityKey]
+            ).volumeTotalCapacity
+        else { return nil }
+        return Double(capacity) / 1_073_741_824.0
+    }
+
+    /// Resolve the effective cap from the user's settings.
+    ///
+    /// Order is percent, then the legacy GB value, then the default share. The
+    /// percent is what the UI edits; the GB value only survives so an install
+    /// that already had an explicit number keeps exactly that number until it
+    /// is migrated.
+    ///
+    /// Like `autoDiskCacheMaxGB`, this ADVISES upward and never downward: a
+    /// volume whose capacity cannot be read falls back to the floor rather
+    /// than guessing small, and nothing here refuses or blocks.
+    public static func resolveDiskCacheMaxGB(
+        percent: Double?,
+        legacyGB: Double?,
+        directory: URL?
+    ) -> Double {
+        if let percent, percent > 0 {
+            guard let capacity = cacheVolumeCapacityGB(for: directory) else {
+                return autoDiskCacheFloorGB
+            }
+            return Swift.max(autoDiskCacheFloorGB, capacity * percent / 100.0)
+        }
+        if let legacyGB, legacyGB > 0 { return legacyGB }
+        return autoDiskCacheMaxGB(for: directory)
+    }
+
     public static func autoDiskCacheMaxGB(for directory: URL?) -> Double {
         guard let directory else { return autoDiskCacheFloorGB }
         // Walk up to the nearest existing ancestor: the cache dir itself may not
@@ -1275,11 +1357,35 @@ public struct VMLXDiskCacheSettings: Codable, Sendable, Equatable {
 
 public struct VMLXBlockDiskCacheSettings: Codable, Sendable, Equatable {
     public var enabled: Bool
+
+    /// Cap as a PERCENT OF THE CACHE VOLUME (e.g. 10 means 10%).
+    ///
+    /// This is the setting users actually see, and it is a percent rather than
+    /// a byte count because the right cap is a property of the machine, not a
+    /// number anyone can pick. KV cost scales with the model — a 27B stores
+    /// ~256 KiB per token, so a 222k window needs ~54 GB — which means a fixed
+    /// GB figure that suits one Mac starves another. A share of the disk is
+    /// correct on every machine at once.
+    ///
+    /// `nil` means "use the default share" (`autoDiskCacheFraction`).
+    public var maxSizePercent: Double?
+
+    /// Legacy explicit cap in GB. No longer surfaced as a control — it exists
+    /// so an install that already had an explicit number keeps exactly the cap
+    /// it had until migration converts it to the equivalent percent. Ignored
+    /// whenever `maxSizePercent` is set.
     public var maxSizeGB: Double?
+
     public var directory: String?
 
-    public init(enabled: Bool = true, maxSizeGB: Double? = nil, directory: String? = nil) {
+    public init(
+        enabled: Bool = true,
+        maxSizePercent: Double? = nil,
+        maxSizeGB: Double? = nil,
+        directory: String? = nil
+    ) {
         self.enabled = enabled
+        self.maxSizePercent = maxSizePercent
         self.maxSizeGB = maxSizeGB
         self.directory = directory
     }

--- a/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
+++ b/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
@@ -97,24 +97,26 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
             }
         }
         if stored < 3 {
-            // The control is now a PERCENT of the disk, because a GB figure
-            // that suits one machine starves another. An install that chose an
-            // explicit GB size keeps exactly the cap it chose — the value is
-            // converted to the equivalent share of its own volume, so the
-            // number in the field changes but the amount of disk used does
-            // not. Nobody's cache silently shrinks or grows on update.
-            if cache.blockDisk.maxSizePercent == nil,
-                let gb = cache.blockDisk.maxSizeGB, gb > 0,
-                let capacity = Self.cacheVolumeCapacityGB(
-                    for: Self.resolvedDirectory(cache.blockDisk.directory)),
-                capacity > 0
-            {
-                cache.blockDisk.maxSizePercent = (gb / capacity) * 100.0
-                cache.blockDisk.maxSizeGB = nil
-            }
-            // A volume we cannot measure keeps its GB value untouched rather
-            // than being converted against a guessed capacity. The resolver
-            // still honours it, so such an install simply keeps working.
+            // ONE-TIME: every updating install lands on 10% of its own disk.
+            //
+            // This is a deliberate reset, not a unit conversion. The setting
+            // is a share of the disk now, and the whole point is that every
+            // machine ends up correctly sized for itself — so an install
+            // carrying a stale number from the flat-10-GB era, or any other
+            // hand-set figure, is moved onto the share rather than kept.
+            //
+            // For essentially everyone this RAISES the cap: the old default
+            // was a flat 10 GB, which is 10% of a 100 GB disk and a rounding
+            // error on a 4 TB one. A 27B stores ~256 KiB per token, so a
+            // 222k-token conversation needs ~54 GB and the old cap could not
+            // hold even one of them.
+            //
+            // Version-gated, so it happens exactly once. A size the user
+            // chooses AFTER updating is theirs and survives every later
+            // launch — same shape as the v2 migration and the MTP-Off fix.
+            cache.blockDisk.maxSizePercent = Self.autoDiskCacheFraction * 100.0
+            cache.blockDisk.maxSizeGB = nil
+            cache.legacyDisk.maxSizeGB = nil
         }
         schemaVersion = Self.contractVersion
     }

--- a/Tests/MLXLMTests/AutoDiskCacheSizeTests.swift
+++ b/Tests/MLXLMTests/AutoDiskCacheSizeTests.swift
@@ -162,6 +162,10 @@ import Testing
 @Test func aFreshSettingsValueIsAlreadyAtTheCurrentSchema() {
     var settings = VMLXServerRuntimeSettings()
     settings.migrateToCurrentSchema()
-    #expect(settings.schemaVersion == 2)
+    // Against `contractVersion` rather than a literal: the assertion is that a
+    // fresh value needs no migration, which stays true at every schema bump.
+    // Pinning the number made adding a migration look like a regression.
+    #expect(settings.schemaVersion == VMLXServerRuntimeSettings.contractVersion)
     #expect(settings.cache.blockDisk.maxSizeGB == nil)
+    #expect(settings.cache.blockDisk.maxSizePercent == nil, "fresh installs use the default share")
 }

--- a/Tests/MLXLMTests/AutoDiskCacheSizeTests.swift
+++ b/Tests/MLXLMTests/AutoDiskCacheSizeTests.swift
@@ -108,14 +108,24 @@ import Testing
     #expect(settings.schemaVersion == VMLXServerRuntimeSettings.contractVersion)
 }
 
-@Test func migrationLeavesADeliberateNonDefaultSizeAlone() {
+/// BEHAVIOUR CHANGE, schema v3: the one-time reset moves EVERY updating
+/// install onto 10% of its own disk, including one that had hand-set a GB
+/// figure. Previously such a value was left alone.
+///
+/// That is the intent, not an accident. The setting is a share of the disk
+/// now, and a stale absolute number is exactly what the change exists to
+/// retire — the old flat 10 GB could not hold one full-context conversation
+/// of a 27B (~54 GB at a 222k window), and any GB figure is wrong for some
+/// machine. It happens once; a size chosen after updating survives.
+@Test func migrationResetsADeliberateGigabyteSizeToTheShare() {
     var settings = VMLXServerRuntimeSettings()
     settings.cache.blockDisk.maxSizeGB = 40.0
     settings.schemaVersion = nil
 
     settings.migrateToCurrentSchema()
 
-    #expect(settings.cache.blockDisk.maxSizeGB == 40.0)
+    #expect(settings.cache.blockDisk.maxSizeGB == nil, "stale absolute size must be cleared")
+    #expect(settings.cache.blockDisk.maxSizePercent == 10.0)
 }
 
 @Test func migrationDoesNotRunTwiceOnADeliberateTenGigabyteChoice() {
@@ -167,5 +177,8 @@ import Testing
     // Pinning the number made adding a migration look like a regression.
     #expect(settings.schemaVersion == VMLXServerRuntimeSettings.contractVersion)
     #expect(settings.cache.blockDisk.maxSizeGB == nil)
-    #expect(settings.cache.blockDisk.maxSizePercent == nil, "fresh installs use the default share")
+    // A fresh install lands on the same explicit 10% an updating install gets,
+    // so both paths resolve to one cap rather than one going through "unset →
+    // auto" and the other through a stored percent.
+    #expect(settings.cache.blockDisk.maxSizePercent == 10.0)
 }

--- a/Tests/MLXLMTests/DiskCacheSizePercentTests.swift
+++ b/Tests/MLXLMTests/DiskCacheSizePercentTests.swift
@@ -1,0 +1,190 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// The disk-cache cap is a PERCENT of the volume, not a byte count.
+//
+// A GB figure is the wrong unit for this setting. KV cost scales with the
+// model — a 27B stores ~256 KiB per token, so a 222k window needs ~54 GB —
+// and the cap is shared across every model in the cache root. So any single
+// number is simultaneously too small on a 4 TB machine and too large on a
+// 256 GB one. Worse, shipping BOTH a percent and a GB control asks the user
+// to reconcile two units that describe the same thing.
+//
+// One control, in percent. GB survives only so an install that already chose
+// an explicit number keeps exactly that cap until migration converts it.
+//
+// The migration invariant is the important one: converting the unit must not
+// change how much disk the user actually gets.
+
+import Foundation
+
+@testable import MLXLMCommon
+import Testing
+
+@Suite("Disk cache size is a percent of the volume")
+struct DiskCacheSizePercentTests {
+
+    private func tempDir() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cache-percent-\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir
+    }
+
+    // MARK: - Resolution order
+
+    @Test("percent wins over a legacy GB value")
+    func percentTakesPrecedenceOverLegacyGB() throws {
+        let dir = tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let capacity = try #require(VMLXServerRuntimeSettings.cacheVolumeCapacityGB(for: dir))
+
+        let resolved = VMLXServerRuntimeSettings.resolveDiskCacheMaxGB(
+            percent: 25, legacyGB: 1.0, directory: dir)
+
+        #expect(resolved > 1.0, "the stale GB value must not win")
+        #expect(resolved == Swift.max(10.0, capacity * 0.25))
+    }
+
+    @Test("a legacy GB value is still honoured when no percent is set")
+    func legacyGBStillHonoured() {
+        let dir = tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let resolved = VMLXServerRuntimeSettings.resolveDiskCacheMaxGB(
+            percent: nil, legacyGB: 42.0, directory: dir)
+        #expect(resolved == 42.0, "an install that chose a size must keep it")
+    }
+
+    @Test("neither set falls back to the default share")
+    func unsetUsesTheDefaultShare() {
+        let dir = tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let resolved = VMLXServerRuntimeSettings.resolveDiskCacheMaxGB(
+            percent: nil, legacyGB: nil, directory: dir)
+        #expect(resolved == VMLXServerRuntimeSettings.autoDiskCacheMaxGB(for: dir))
+    }
+
+    /// A percent of a disk we cannot measure must not become a guess. The
+    /// floor is the historical default, so this can only ever be generous.
+    @Test("an unmeasurable volume falls back to the floor, never a small guess")
+    func unmeasurableVolumeUsesFloor() {
+        let resolved = VMLXServerRuntimeSettings.resolveDiskCacheMaxGB(
+            percent: 10, legacyGB: nil, directory: nil)
+        #expect(resolved == VMLXServerRuntimeSettings.autoDiskCacheFloorGB)
+    }
+
+    @Test("a non-positive percent is ignored rather than producing a zero cap")
+    func nonPositivePercentIsIgnored() {
+        let dir = tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        for bad in [0.0, -5.0] {
+            let resolved = VMLXServerRuntimeSettings.resolveDiskCacheMaxGB(
+                percent: bad, legacyGB: nil, directory: dir)
+            #expect(resolved > 0, "percent \(bad) produced a zero/negative cap")
+        }
+    }
+
+    /// Advises upward, never downward — the rule the whole auto-sizing change
+    /// was built on.
+    @Test("the resolved cap never drops below the historical default")
+    func neverResolvesBelowTheFloor() {
+        let dir = tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        // 0.0001% of any real volume is far under the floor.
+        let resolved = VMLXServerRuntimeSettings.resolveDiskCacheMaxGB(
+            percent: 0.0001, legacyGB: nil, directory: dir)
+        #expect(resolved >= VMLXServerRuntimeSettings.autoDiskCacheFloorGB)
+    }
+
+    // MARK: - Migration
+
+    /// THE invariant: changing the unit must not change the amount of disk.
+    @Test("migrating a GB install preserves the cap it actually had")
+    func migrationPreservesTheEffectiveCap() throws {
+        let dir = tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let capacity = try #require(VMLXServerRuntimeSettings.cacheVolumeCapacityGB(for: dir))
+        // Comfortably above the floor so the clamp cannot mask a bad conversion.
+        let chosenGB = Swift.max(50.0, capacity * 0.2)
+
+        var settings = VMLXServerRuntimeSettings()
+        settings.schemaVersion = 2
+        settings.cache.blockDisk.maxSizeGB = chosenGB
+        settings.cache.blockDisk.directory = dir.path
+
+        let before = VMLXServerRuntimeSettings.resolveDiskCacheMaxGB(
+            percent: nil, legacyGB: chosenGB, directory: dir)
+        settings.migrateToCurrentSchema()
+        let after = VMLXServerRuntimeSettings.resolveDiskCacheMaxGB(
+            percent: settings.cache.blockDisk.maxSizePercent,
+            legacyGB: settings.cache.blockDisk.maxSizeGB,
+            directory: dir)
+
+        #expect(settings.cache.blockDisk.maxSizePercent != nil, "did not convert to a percent")
+        #expect(settings.cache.blockDisk.maxSizeGB == nil, "left a stale GB value behind")
+        #expect(
+            abs(after - before) < 0.5,
+            "cap changed on update: \(before) GB -> \(after) GB")
+    }
+
+    @Test("migration is version-gated and does not re-run")
+    func migrationDoesNotReRun() {
+        let dir = tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        var settings = VMLXServerRuntimeSettings()
+        settings.schemaVersion = VMLXServerRuntimeSettings.contractVersion
+        settings.cache.blockDisk.maxSizeGB = 7.0
+        settings.cache.blockDisk.directory = dir.path
+        settings.migrateToCurrentSchema()
+
+        #expect(
+            settings.cache.blockDisk.maxSizeGB == 7.0,
+            "a deliberate choice made after migrating must survive")
+        #expect(settings.cache.blockDisk.maxSizePercent == nil)
+    }
+
+    /// A user who already set a percent is not overwritten by a stale GB.
+    @Test("an existing percent survives migration untouched")
+    func existingPercentIsNotOverwritten() {
+        let dir = tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        var settings = VMLXServerRuntimeSettings()
+        settings.schemaVersion = 2
+        settings.cache.blockDisk.maxSizePercent = 33
+        settings.cache.blockDisk.maxSizeGB = 5
+        settings.cache.blockDisk.directory = dir.path
+        settings.migrateToCurrentSchema()
+
+        #expect(settings.cache.blockDisk.maxSizePercent == 33)
+    }
+
+    // MARK: - Capacity readout
+
+    /// The UI shows "N% of <disk> ≈ X GB" using this, so it must agree with
+    /// what the runtime enforces rather than being a second estimate.
+    @Test("capacity readout matches the number the resolver uses")
+    func capacityReadoutMatchesResolver() throws {
+        let dir = tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let capacity = try #require(VMLXServerRuntimeSettings.cacheVolumeCapacityGB(for: dir))
+        #expect(capacity > 0)
+
+        let resolved = VMLXServerRuntimeSettings.resolveDiskCacheMaxGB(
+            percent: 50, legacyGB: nil, directory: dir)
+        #expect(abs(resolved - capacity * 0.5) < 0.001)
+    }
+
+    @Test("capacity is nil rather than a fabricated number when unreadable")
+    func capacityIsNilWhenUnreadable() {
+        #expect(VMLXServerRuntimeSettings.cacheVolumeCapacityGB(for: nil) == nil)
+    }
+
+    // MARK: - Default
+
+    @Test("the shipped default is ten percent")
+    func defaultShareIsTenPercent() {
+        #expect(VMLXServerRuntimeSettings.autoDiskCacheFraction == 0.10)
+    }
+}

--- a/Tests/MLXLMTests/DiskCacheSizePercentTests.swift
+++ b/Tests/MLXLMTests/DiskCacheSizePercentTests.swift
@@ -98,33 +98,138 @@ struct DiskCacheSizePercentTests {
 
     // MARK: - Migration
 
-    /// THE invariant: changing the unit must not change the amount of disk.
-    @Test("migrating a GB install preserves the cap it actually had")
-    func migrationPreservesTheEffectiveCap() throws {
+    /// THE requirement: every updating install lands on 10%, once.
+    ///
+    /// Parameterised over the shapes real installs are actually in, because
+    /// "it worked for the case I happened to try" is how the flat-10-GB
+    /// default survived six releases.
+    @Test(
+        "every updating install is reset to ten percent, whatever it had before",
+        arguments: [
+            Double?.none,  // never set anything
+            Double?.some(10.0),  // the old flat default
+            Double?.some(1.0),  // hand-set small
+            Double?.some(250.0),  // hand-set large
+        ])
+    func everyUpdatingInstallLandsOnTenPercent(previousGB: Double?) throws {
         let dir = tempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
-        let capacity = try #require(VMLXServerRuntimeSettings.cacheVolumeCapacityGB(for: dir))
-        // Comfortably above the floor so the clamp cannot mask a bad conversion.
-        let chosenGB = Swift.max(50.0, capacity * 0.2)
 
         var settings = VMLXServerRuntimeSettings()
-        settings.schemaVersion = 2
-        settings.cache.blockDisk.maxSizeGB = chosenGB
+        settings.schemaVersion = 2  // an install from before this change
+        settings.cache.blockDisk.maxSizeGB = previousGB
         settings.cache.blockDisk.directory = dir.path
 
-        let before = VMLXServerRuntimeSettings.resolveDiskCacheMaxGB(
-            percent: nil, legacyGB: chosenGB, directory: dir)
         settings.migrateToCurrentSchema()
-        let after = VMLXServerRuntimeSettings.resolveDiskCacheMaxGB(
+
+        #expect(
+            settings.cache.blockDisk.maxSizePercent == 10.0,
+            "previous GB \(String(describing: previousGB)) did not land on 10%")
+        #expect(settings.cache.blockDisk.maxSizeGB == nil, "left a stale GB value behind")
+        #expect(settings.cache.legacyDisk.maxSizeGB == nil, "left a stale legacy GB value behind")
+
+        // And it resolves to a real tenth of THIS volume, not a constant.
+        let capacity = try #require(VMLXServerRuntimeSettings.cacheVolumeCapacityGB(for: dir))
+        let resolved = VMLXServerRuntimeSettings.resolveDiskCacheMaxGB(
             percent: settings.cache.blockDisk.maxSizePercent,
             legacyGB: settings.cache.blockDisk.maxSizeGB,
             directory: dir)
+        #expect(abs(resolved - Swift.max(10.0, capacity * 0.10)) < 0.001)
+    }
 
-        #expect(settings.cache.blockDisk.maxSizePercent != nil, "did not convert to a percent")
-        #expect(settings.cache.blockDisk.maxSizeGB == nil, "left a stale GB value behind")
+    /// A brand-new install must agree with a migrated one. Two code paths
+    /// producing two different caps is the drift this catches.
+    @Test("a fresh install and a migrated install resolve to the same cap")
+    func freshAndMigratedAgree() {
+        let dir = tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        var migrated = VMLXServerRuntimeSettings()
+        migrated.schemaVersion = 1
+        migrated.cache.blockDisk.maxSizeGB = 10.0
+        migrated.cache.blockDisk.directory = dir.path
+        migrated.migrateToCurrentSchema()
+
+        var fresh = VMLXServerRuntimeSettings()
+        fresh.cache.blockDisk.directory = dir.path
+        fresh.migrateToCurrentSchema()
+
+        let migratedGB = VMLXServerRuntimeSettings.resolveDiskCacheMaxGB(
+            percent: migrated.cache.blockDisk.maxSizePercent,
+            legacyGB: migrated.cache.blockDisk.maxSizeGB, directory: dir)
+        let freshGB = VMLXServerRuntimeSettings.resolveDiskCacheMaxGB(
+            percent: fresh.cache.blockDisk.maxSizePercent,
+            legacyGB: fresh.cache.blockDisk.maxSizeGB, directory: dir)
+
+        #expect(abs(migratedGB - freshGB) < 0.001, "\(migratedGB) vs \(freshGB)")
+    }
+
+    /// The reset raises the cap for anyone on the old flat default. On any
+    /// disk larger than 100 GB, 10% beats 10 GB.
+    @Test("the reset raises the cap for an install on the old flat default")
+    func resetRaisesTheOldFlatDefault() throws {
+        let dir = tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let capacity = try #require(VMLXServerRuntimeSettings.cacheVolumeCapacityGB(for: dir))
+        try #require(capacity > 100, "this machine's volume is too small to show the difference")
+
+        var settings = VMLXServerRuntimeSettings()
+        settings.schemaVersion = 2
+        settings.cache.blockDisk.maxSizeGB = 10.0
+        settings.cache.blockDisk.directory = dir.path
+        settings.migrateToCurrentSchema()
+
+        let after = VMLXServerRuntimeSettings.resolveDiskCacheMaxGB(
+            percent: settings.cache.blockDisk.maxSizePercent,
+            legacyGB: settings.cache.blockDisk.maxSizeGB, directory: dir)
+        #expect(after > 10.0, "the whole point was that 10 GB was too small")
+    }
+
+    // MARK: - Wiring
+    //
+    // A setting that is stored correctly and never reaches the engine is the
+    // exact defect shape this codebase has shipped before. These assert the
+    // value arrives at the object that actually enforces the quota.
+
+    @Test("the migrated percent reaches CacheCoordinatorConfig")
+    func percentReachesTheCoordinatorConfig() throws {
+        let dir = tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        var settings = VMLXServerRuntimeSettings()
+        settings.schemaVersion = 2
+        settings.cache.blockDisk.maxSizeGB = 10.0
+        settings.cache.blockDisk.enabled = true
+        settings.cache.blockDisk.directory = dir.path
+        settings.migrateToCurrentSchema()
+
+        let config = settings.cacheCoordinatorConfig(modelKey: "wiring-probe")
+        let capacity = try #require(VMLXServerRuntimeSettings.cacheVolumeCapacityGB(for: dir))
+
         #expect(
-            abs(after - before) < 0.5,
-            "cap changed on update: \(before) GB -> \(after) GB")
+            abs(Double(config.diskCacheMaxGB) - Swift.max(10.0, capacity * 0.10)) < 0.5,
+            "the coordinator got \(config.diskCacheMaxGB) GB, not 10% of the volume")
+    }
+
+    /// Changing the percent must change what the engine enforces — otherwise
+    /// the control is decorative.
+    @Test("editing the percent changes the cap the coordinator enforces")
+    func editingPercentChangesTheEnforcedCap() {
+        let dir = tempDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        func enforcedGB(percent: Double) -> Double {
+            var s = VMLXServerRuntimeSettings()
+            s.schemaVersion = VMLXServerRuntimeSettings.contractVersion
+            s.cache.blockDisk.enabled = true
+            s.cache.blockDisk.directory = dir.path
+            s.cache.blockDisk.maxSizePercent = percent
+            return Double(s.cacheCoordinatorConfig(modelKey: "probe").diskCacheMaxGB)
+        }
+
+        let small = enforcedGB(percent: 10)
+        let large = enforcedGB(percent: 40)
+        #expect(large > small, "40% enforced \(large) GB, 10% enforced \(small) GB")
     }
 
     @Test("migration is version-gated and does not re-run")
@@ -144,20 +249,32 @@ struct DiskCacheSizePercentTests {
         #expect(settings.cache.blockDisk.maxSizePercent == nil)
     }
 
-    /// A user who already set a percent is not overwritten by a stale GB.
-    @Test("an existing percent survives migration untouched")
-    func existingPercentIsNotOverwritten() {
+    /// A percent the user chooses AFTER updating is theirs and must survive
+    /// every later launch.
+    ///
+    /// This is the case that matters. A percent on a pre-v3 record is not a
+    /// real state — the field did not exist then — so asserting that such a
+    /// value survives would be testing a condition no install can be in.
+    @Test("a size chosen after updating survives later launches")
+    func userChoiceAfterMigrationSurvives() {
         let dir = tempDir()
         defer { try? FileManager.default.removeItem(at: dir) }
 
         var settings = VMLXServerRuntimeSettings()
         settings.schemaVersion = 2
-        settings.cache.blockDisk.maxSizePercent = 33
-        settings.cache.blockDisk.maxSizeGB = 5
+        settings.cache.blockDisk.maxSizeGB = 10.0
         settings.cache.blockDisk.directory = dir.path
         settings.migrateToCurrentSchema()
+        #expect(settings.cache.blockDisk.maxSizePercent == 10.0, "the one-time reset")
 
-        #expect(settings.cache.blockDisk.maxSizePercent == 33)
+        // The user then picks their own share.
+        settings.cache.blockDisk.maxSizePercent = 33
+
+        // Every subsequent launch re-runs migration; it must be a no-op now.
+        for _ in 0..<3 { settings.migrateToCurrentSchema() }
+        #expect(
+            settings.cache.blockDisk.maxSizePercent == 33,
+            "the one-time reset ran again and overwrote a deliberate choice")
     }
 
     // MARK: - Capacity readout


### PR DESCRIPTION
## The problem

The cap already auto-sized to **10% of the volume** when unset — but the control was still a **GB box**. So we shipped two units for one idea and left the user to reconcile them. The default got fixed; the confusing part didn't.

GB is the wrong unit for this setting. KV cost scales with the model: a 27B stores ~256 KiB per token, so a 222k window needs ~54 GB, and the cap is **shared across every model in the cache root**. Any single number is simultaneously too small on a 4 TB machine and too large on a 256 GB one.

## The change

`maxSizePercent` becomes the setting users edit. One control, one unit.

**Schema v3 resets every updating install to 10% of its own disk, once** — whatever it had before — and clears the stale GB values on both the block and legacy disk settings.

That reset is the point, not a side effect. An install carrying a hand-set absolute number is exactly what this retires. For essentially everyone it **raises** the cap: the old default was a flat 10 GB, which is 10% of a 100 GB disk and a rounding error on a 4 TB one, and could not hold even one full-context conversation of a 27B.

Version-gated, so it happens exactly once. **A size chosen after updating is the user's and survives every later launch** — asserted by re-running migration three times over a deliberate 33%.

Resolution order: `percent` → legacy `GB` → default share.

## Wiring is asserted, not assumed

A setting that stores correctly and never reaches the engine is a defect shape this codebase has shipped before. Two tests drive settings through `cacheCoordinatorConfig` and check the object that actually enforces the quota:

- a migrated install resolves to a tenth of its volume **at the coordinator**
- changing the percentage **changes the enforced cap** (10% vs 40%)

## Still advisory, never a wall

- the floor keeps the resolved cap at or **above** the historical default
- an unmeasurable volume falls back to that floor rather than guessing small
- a non-positive percent is ignored instead of producing a zero cap
- nothing here refuses, blocks, or caps a load

## For the UI

`cacheVolumeCapacityGB(for:)` is exposed so Settings can render *"10% of 3.7 TB ≈ 372 GB"* using **the same number the runtime enforces**, rather than a second estimate that can drift from it.

## Tests — 65 green

`DiskCacheSizePercentTests` (16): the reset parameterised over the shapes real installs are in (never set, old flat 10 GB, hand-set small, hand-set large); fresh and migrated installs resolving to the same cap; the reset raising the old flat default; user choice surviving repeat migrations; resolution order; unmeasurable volume; non-positive percent; floor never breached; capacity readout agreeing with the resolver; both wiring tests.

Plus `AutoDiskCacheSizeTests`, `DiskCacheQuotaEnforcementTests`, `CacheCoordinatorTests`, `CacheStoreBudgetTests`.

## Behaviour changes called out

`migrationLeavesADeliberateNonDefaultSizeAlone` asserted a hand-set 40 GB survives. It no longer does — deliberately — and the test is rewritten to say so rather than worked around.

The fresh-install assertion expected no percentage. A fresh install now lands on the same explicit 10% an updating one gets, so both paths resolve through one route instead of two.