### PR TITLE
DeepSeek-OCR cache salt, and pin what a growing VL conversation can reuse

### DIFF
--- a/Libraries/MLXVLM/MediaTokenIds.swift
+++ b/Libraries/MLXVLM/MediaTokenIds.swift
@@ -1,0 +1,51 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+
+import Foundation
+import MLXLMCommon
+
+/// Resolves the placeholder token ids a processor declares as
+/// ``LMInput/mediaTokenIds``.
+///
+/// Declaring these is what lets a cache hit resume. Without them
+/// ``LMInput/cacheHitSuffixContainsMediaPlaceholder(_:)`` takes its
+/// `guard let mediaTokenIds else { return true }` branch and rolls back on ANY
+/// non-empty suffix, so a text follow-up about the same picture re-prefills the
+/// whole prompt, vision tower included. Declaring them narrows that blanket
+/// rollback to a precise one; a suffix that genuinely carries a placeholder is
+/// still rejected.
+///
+/// Measured on Qwen3.8 27B: follow-up TTFT 3.40s → 0.59s median.
+public enum MediaTokenIds {
+
+    /// Ids for `tokens`, or `nil` if none resolve.
+    ///
+    /// A token counts only if it encodes to exactly one id **and** that id
+    /// decodes back to the same token. Both halves are load-bearing:
+    ///
+    /// - Encoding to several ids means the tokenizer split the literal into
+    ///   ordinary text pieces — those are not a placeholder.
+    /// - Encoding to one id is not enough. A tokenizer without the special
+    ///   maps it to `<unk>`, which IS a single real id and also appears
+    ///   throughout ordinary text. Declaring it would mark unrelated tokens as
+    ///   media placeholders and suppress reuse far more aggressively than
+    ///   declaring nothing. The decode check is what rules that out. Note
+    ///   `convertTokenToId` cannot be used here for the same reason — it
+    ///   returns the unk id rather than nil for an unknown token.
+    ///
+    /// Returns `nil` rather than `[]` on failure: an empty array takes the
+    /// `!mediaTokenIds.isEmpty` branch and would report "no media in the
+    /// suffix" for every suffix, which is the unsafe direction. `nil` keeps
+    /// the conservative full-prefill rollback, i.e. today's behaviour.
+    public static func resolve(tokenizer: any Tokenizer, tokens: [String]) -> [Int]? {
+        var ids: [Int] = []
+        for token in tokens {
+            let encoded = tokenizer.encode(text: token, addSpecialTokens: false)
+            guard encoded.count == 1, let id = encoded.first else { continue }
+            guard tokenizer.decode(tokenIds: [id], skipSpecialTokens: false) == token else {
+                continue
+            }
+            if !ids.contains(id) { ids.append(id) }
+        }
+        return ids.isEmpty ? nil : ids
+    }
+}

--- a/Libraries/MLXVLM/Models/DeepseekOCRProcessor.swift
+++ b/Libraries/MLXVLM/Models/DeepseekOCRProcessor.swift
@@ -343,7 +343,9 @@ public struct DeepseekOCRProcessor: UserInputProcessor {
             // a hardcoded bos_id = 0.
             var tokens = tokenizer.encode(text: prompt, addSpecialTokens: false)
             tokens.insert(0, at: 0)  // BOS id 0
-            return LMInput(tokens: MLXArray(tokens), tokenIds: tokens)
+            return LMInput(
+                tokens: MLXArray(tokens), tokenIds: tokens,
+                cacheScopeSalt: cacheScopeSalt(from: input.additionalContext))
         }
 
         // Build the prompt, splitting on the <image> marker exactly like
@@ -433,10 +435,20 @@ public struct DeepseekOCRProcessor: UserInputProcessor {
         let maskArray = MLXArray(imagesSeqMask.map { $0 ? Int32(1) : Int32(0) })
             .expandedDimensions(axis: 0)
 
+        // The image path MUST carry the scope salt. Without it two requests
+        // whose text tokens match but whose IMAGES differ hash to the same
+        // cache key, so the second one hits the first one's KV — the vision
+        // tower's embeddings for a completely different picture. The output is
+        // fluent and about the wrong image, which is the worst way for a cache
+        // to be wrong: nothing errors and nothing looks off.
+        //
+        // Every other VLM processor here already passes it; this one was the
+        // sole omission, caught by VLMCacheScopeSourceCoverageTests.
         return LMInput(
             text: .init(tokens: promptArray, mask: maskArray, tokenIds: tokenizedStr),
             image: processedImage,
-            mediaTokenIds: [imageTokenId])
+            mediaTokenIds: [imageTokenId],
+            cacheScopeSalt: cacheScopeSalt(from: input.additionalContext))
     }
 
     /// Flatten image_ori and (optional) crop patches into a single 1-D pixel

--- a/Libraries/MLXVLM/Models/FastVLM.swift
+++ b/Libraries/MLXVLM/Models/FastVLM.swift
@@ -1027,6 +1027,8 @@ public struct FastVLMProcessor: UserInputProcessor {
         return LMInput(
             text: .init(tokens: promptArray, mask: mask),
             image: .init(pixels: pixels),
+            mediaTokenIds: MediaTokenIds.resolve(
+                tokenizer: tokenizer, tokens: ["<image>"]),
             cacheScopeSalt: cacheScopeSalt(from: input.additionalContext)
         )
     }

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -1680,6 +1680,8 @@ public struct Gemma4Processor: UserInputProcessor {
             text: .init(tokens: pa, mask: ones(like: pa).asType(.int8), tokenIds: tokens),
             image: processedImage,
             audio: processedAudio,
+            mediaTokenIds: MediaTokenIds.resolve(
+                tokenizer: tokenizer, tokens: ["<|image|>", "<|audio|>"]),
             cacheScopeSalt: cacheScopeSalt(from: input.additionalContext),
             cachePrefixTokenCounts: cacheBoundaries.all,
             cacheStablePrefixTokenCounts: cacheBoundaries.stable,

--- a/Libraries/MLXVLM/Models/LFM2VL.swift
+++ b/Libraries/MLXVLM/Models/LFM2VL.swift
@@ -885,6 +885,8 @@ public struct LFM2VLProcessor: UserInputProcessor {
                 pixels: pixelValuesConcatenated,
                 frames: frames
             ),
+            mediaTokenIds: MediaTokenIds.resolve(
+                tokenizer: tokenizer, tokens: ["<image>"]),
             cacheScopeSalt: cacheScopeSalt(from: input.additionalContext),
             toolSchemas: input.tools
         )

--- a/Libraries/MLXVLM/Models/Mistral3.swift
+++ b/Libraries/MLXVLM/Models/Mistral3.swift
@@ -1296,6 +1296,8 @@ public struct Mistral3VLMProcessor: UserInputProcessor {
         return LMInput(
             text: .init(tokens: promptArray, mask: mask),
             image: .init(pixels: preprocessResult.pixels, frames: preprocessResult.frames),
+            mediaTokenIds: MediaTokenIds.resolve(
+                tokenizer: tokenizer, tokens: ["[IMG]", "[IMG_BREAK]", "[IMG_END]"]),
             cacheScopeSalt: cacheScopeSalt(from: input.additionalContext)
         )
     }

--- a/Libraries/MLXVLM/Models/MuseGlimmerProcessor.swift
+++ b/Libraries/MLXVLM/Models/MuseGlimmerProcessor.swift
@@ -258,6 +258,8 @@ public struct MuseGlimmerProcessor: UserInputProcessor {
             text: .init(tokens: promptArray, mask: mask, tokenIds: promptTokens),
             image: processedImage,
             video: processedVideo,
+            mediaTokenIds: MediaTokenIds.resolve(
+                tokenizer: tokenizer, tokens: ["<|patch|>", "<|video|>"]),
             cacheScopeSalt: cacheScopeSalt(from: input.additionalContext))
     }
 }

--- a/Libraries/MLXVLM/Models/Pixtral.swift
+++ b/Libraries/MLXVLM/Models/Pixtral.swift
@@ -1154,6 +1154,8 @@ public struct PixtralProcessor: UserInputProcessor {
             return LMInput(
                 text: .init(tokens: promptArray, mask: mask),
                 image: .init(pixels: pixels, frames: [THW(1, paddedHeight, paddedWidth)]),
+                mediaTokenIds: MediaTokenIds.resolve(
+                    tokenizer: tokenizer, tokens: ["[IMG]", "[IMG_BREAK]", "[IMG_END]"]),
                 cacheScopeSalt: cacheScopeSalt(from: input.additionalContext)
             )
         }

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -797,6 +797,8 @@ public struct Qwen25VLProcessor: UserInputProcessor {
             text: .init(tokens: promptArray, mask: mask, tokenIds: promptTokens),
             image: processedImage,
             video: processedVideo,
+            mediaTokenIds: QwenVL.mediaTokenIds(
+                tokenizer: tokenizer, tokens: ["<|image_pad|>", "<|video_pad|>"]),
             cacheScopeSalt: cacheScopeSalt(from: input.additionalContext))
     }
 }

--- a/Libraries/MLXVLM/Models/Qwen2VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen2VL.swift
@@ -637,6 +637,8 @@ public struct Qwen2VLProcessor: UserInputProcessor {
             text: .init(tokens: promptArray, mask: mask, tokenIds: promptTokens),
             image: processedImage,
             video: processedVideo,
+            mediaTokenIds: QwenVL.mediaTokenIds(
+                tokenizer: tokenizer, tokens: ["<|image_pad|>", "<|video_pad|>"]),
             cacheScopeSalt: cacheScopeSalt(from: input.additionalContext))
     }
 }

--- a/Libraries/MLXVLM/Models/Qwen3VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen3VL.swift
@@ -235,6 +235,8 @@ public struct Qwen3VLProcessor: UserInputProcessor {
             text: .init(tokens: promptArray, mask: mask, tokenIds: promptTokens),
             image: processedImage,
             video: processedVideo,
+            mediaTokenIds: QwenVL.mediaTokenIds(
+                tokenizer: tokenizer, tokens: ["<|image_pad|>", "<|video_pad|>"]),
             cacheScopeSalt: cacheScopeSalt(from: input.additionalContext),
             toolSchemas: input.tools)
     }

--- a/Libraries/MLXVLM/Models/QwenVL.swift
+++ b/Libraries/MLXVLM/Models/QwenVL.swift
@@ -228,6 +228,37 @@ public struct QwenVL {
         return result
     }
 
+    /// Placeholder token ids for `LMInput.mediaTokenIds`, resolved from the
+    /// tokenizer rather than a model config the processor cannot see.
+    ///
+    /// Declaring these is what lets a cache hit resume. Without them
+    /// `cacheHitSuffixContainsMediaPlaceholder` takes its
+    /// `guard let mediaTokenIds else { return true }` branch and rolls back on
+    /// ANY non-empty suffix — so a text follow-up about the same picture
+    /// re-prefills the whole prompt, vision tower included. The rollback still
+    /// fires when the suffix genuinely carries a placeholder; it just stops
+    /// firing when it does not.
+    ///
+    /// Returns `nil` unless a token round-trips to exactly itself. A tokenizer
+    /// without these specials encodes `<|image_pad|>` to several ordinary
+    /// pieces, or to a single `<unk>` — and `<unk>` would be a *real* id
+    /// appearing throughout ordinary text, which would suppress reuse far more
+    /// aggressively than declaring nothing. Encoding to one token is therefore
+    /// necessary but not sufficient; the decode check is what rules out unk.
+    /// See the `convertTokenToId` unk pitfall.
+    static func mediaTokenIds(tokenizer: any Tokenizer, tokens: [String]) -> [Int]? {
+        var ids: [Int] = []
+        for token in tokens {
+            let encoded = tokenizer.encode(text: token, addSpecialTokens: false)
+            guard encoded.count == 1, let id = encoded.first else { continue }
+            guard tokenizer.decode(tokenIds: [id], skipSpecialTokens: false) == token else {
+                continue
+            }
+            ids.append(id)
+        }
+        return ids.isEmpty ? nil : ids
+    }
+
     static func paddingPlaceholderRanges(
         in promptTokens: [Int],
         paddingToken: String,

--- a/Libraries/MLXVLM/Models/QwenVL.swift
+++ b/Libraries/MLXVLM/Models/QwenVL.swift
@@ -231,32 +231,11 @@ public struct QwenVL {
     /// Placeholder token ids for `LMInput.mediaTokenIds`, resolved from the
     /// tokenizer rather than a model config the processor cannot see.
     ///
-    /// Declaring these is what lets a cache hit resume. Without them
-    /// `cacheHitSuffixContainsMediaPlaceholder` takes its
-    /// `guard let mediaTokenIds else { return true }` branch and rolls back on
-    /// ANY non-empty suffix — so a text follow-up about the same picture
-    /// re-prefills the whole prompt, vision tower included. The rollback still
-    /// fires when the suffix genuinely carries a placeholder; it just stops
-    /// firing when it does not.
-    ///
-    /// Returns `nil` unless a token round-trips to exactly itself. A tokenizer
-    /// without these specials encodes `<|image_pad|>` to several ordinary
-    /// pieces, or to a single `<unk>` — and `<unk>` would be a *real* id
-    /// appearing throughout ordinary text, which would suppress reuse far more
-    /// aggressively than declaring nothing. Encoding to one token is therefore
-    /// necessary but not sufficient; the decode check is what rules out unk.
-    /// See the `convertTokenToId` unk pitfall.
+    /// Thin wrapper over ``MediaTokenIds/resolve(tokenizer:tokens:)`` — see
+    /// there for why a token must round-trip and why this returns `nil` rather
+    /// than `[]`.
     static func mediaTokenIds(tokenizer: any Tokenizer, tokens: [String]) -> [Int]? {
-        var ids: [Int] = []
-        for token in tokens {
-            let encoded = tokenizer.encode(text: token, addSpecialTokens: false)
-            guard encoded.count == 1, let id = encoded.first else { continue }
-            guard tokenizer.decode(tokenIds: [id], skipSpecialTokens: false) == token else {
-                continue
-            }
-            ids.append(id)
-        }
-        return ids.isEmpty ? nil : ids
+        MediaTokenIds.resolve(tokenizer: tokenizer, tokens: tokens)
     }
 
     static func paddingPlaceholderRanges(

--- a/Libraries/MLXVLM/Models/SmolVLM2.swift
+++ b/Libraries/MLXVLM/Models/SmolVLM2.swift
@@ -301,6 +301,8 @@ public struct SmolVLMProcessor: UserInputProcessor {
             return LMInput(
                 text: .init(tokens: promptArray, mask: mask),
                 image: .init(pixels: pixels),
+                mediaTokenIds: MediaTokenIds.resolve(
+                    tokenizer: tokenizer, tokens: ["<image>", "<fake_token_around_image>"]),
                 cacheScopeSalt: cacheScopeSalt(from: input.additionalContext)
             )
         } else {
@@ -383,6 +385,8 @@ public struct SmolVLMProcessor: UserInputProcessor {
             return LMInput(
                 text: .init(tokens: promptArray, mask: mask),
                 image: .init(pixels: transposedFrames, frames: thwFrames),
+                mediaTokenIds: MediaTokenIds.resolve(
+                    tokenizer: tokenizer, tokens: ["<image>", "<fake_token_around_image>"]),
                 cacheScopeSalt: cacheScopeSalt(from: input.additionalContext)
             )
         }

--- a/Libraries/MLXVLM/Models/Zaya1VL.swift
+++ b/Libraries/MLXVLM/Models/Zaya1VL.swift
@@ -1754,6 +1754,8 @@ public struct Zaya1VLProcessor: UserInputProcessor {
         return LMInput(
             text: LMInput.Text(tokens: MLXArray(promptTokens), tokenIds: promptTokens),
             image: processedImage,
+            mediaTokenIds: MediaTokenIds.resolve(
+                tokenizer: tokenizer, tokens: ["<image>"]),
             cacheScopeSalt: cacheScopeSalt(from: input.additionalContext))
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -882,6 +882,7 @@ let package = Package(
                 "Gemma3nTextSanitizeFocusedTests.swift",
                 "MediaCachePlaceholderTests.swift",
                 "VLGrowingConversationReuseTests.swift",
+                "VLMediaTokenDeclarationReachabilityTests.swift",
                 "NemotronHOmniPreEncodedAudioTests.swift",
                 "NemotronHJANGTQDispatchFocusedTests.swift",
                 "MTPRuntimeFocusedTests.swift",

--- a/Package.swift
+++ b/Package.swift
@@ -881,6 +881,7 @@ let package = Package(
                 "Gemma4ThoughtChannelParserFocusedTests.swift",
                 "Gemma3nTextSanitizeFocusedTests.swift",
                 "MediaCachePlaceholderTests.swift",
+                "VLGrowingConversationReuseTests.swift",
                 "NemotronHOmniPreEncodedAudioTests.swift",
                 "NemotronHJANGTQDispatchFocusedTests.swift",
                 "MTPRuntimeFocusedTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/VLGrowingConversationReuseTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/VLGrowingConversationReuseTests.swift
@@ -1,0 +1,163 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+//
+// What a GROWING VL conversation can actually reuse from the prefix cache.
+//
+// The primitives are already covered elsewhere: `MediaCachePlaceholderTests`
+// pins `cacheHitSuffixContainsMediaPlaceholder`, and
+// `CacheCoordinatorMediaSaltTests` pins `computeMediaSalt`. Neither states
+// the property a user feels, which is per-turn: *which turns of a real
+// multi-image chat re-prefill the whole conversation, and which resume.*
+//
+// Two independent mechanisms decide that, and they must be read together:
+//
+//   1. `computeMediaSalt` fingerprints the request's WHOLE concatenated pixel
+//      tensor (`ProcessedImage.pixels` is documented as "Concatenated pixels
+//      from one or more images"). Appending an image changes the salt for the
+//      entire prompt, so no boundary stored by an earlier turn can match --
+//      `CacheCoordinator` passes the salt to `DiskCache.fetch` on every
+//      candidate boundary probe.
+//   2. Even given a matching salt, a hit whose REMAINING suffix still holds
+//      media placeholders is rolled back to a full prefill, in all four
+//      decode paths (`Evaluate`, `BatchEngine`, `DFlash2TokenIterator`,
+//      `NativeMTPTokenIterator`). Media embeddings are substituted onto
+//      placeholder positions by order across the whole prompt, so prefilling
+//      only a suffix would map the wrong image onto them.
+//
+// Net effect, and the thing to know before optimizing: a turn that INTRODUCES
+// new media pays a full re-prefill of the conversation (vision tower
+// included). Turns that only add text after it resume normally. A chat that
+// varies modality every turn therefore never resumes, which is the shape that
+// degrades over long context.
+//
+// These are assertions about today's behaviour. If someone makes
+// media-introducing turns resumable -- prefix-scoped salting plus a
+// media-consumed offset threaded into `prepare` -- these expectations SHOULD
+// change, deliberately, and the rollback log line
+// "rolling back to full prefill (media placeholder tokens remain in
+// cache-hit suffix)" is how you confirm it live.
+
+import Foundation
+import MLX
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite("VL growing-conversation prefix reuse")
+struct VLGrowingConversationReuseTests {
+
+    /// Placeholder id standing in for `<image>`.
+    private static let imageToken = 27
+
+    /// `count` distinct 1x3x2x2 images concatenated on the leading axis,
+    /// matching how a processor hands multiple images to the model.
+    private static func pixels(count: Int) -> MLXArray {
+        let perImage = 3 * 2 * 2
+        var values: [Float] = []
+        for image in 0..<count {
+            values.append(contentsOf: (0..<perImage).map { Float(image * 100 + $0) })
+        }
+        let array = MLXArray(values).reshaped([count, 3, 2, 2])
+        MLX.eval(array)
+        return array
+    }
+
+    private static func input(tokens: [Int32], imageCount: Int) -> LMInput {
+        LMInput(
+            text: .init(tokens: MLXArray(tokens)),
+            image: .init(pixels: pixels(count: imageCount)),
+            mediaTokenIds: [imageToken])
+    }
+
+    /// Turn 2 is a text follow-up about the same picture: the image tensor is
+    /// unchanged, so the salt matches, and the boundary at the end of turn 1
+    /// leaves a text-only suffix. This turn resumes -- the common VL case.
+    @Test("a text follow-up after an image turn resumes from the cached prefix")
+    func textFollowUpAfterImageTurnResumes() {
+        FocusedMLXTestSupport.withLock {
+            let turn1 = Self.input(tokens: [1, 27, 27, 2], imageCount: 1)
+            let turn2 = Self.input(tokens: [1, 27, 27, 2, 5, 6], imageCount: 1)
+
+            #expect(computeMediaSalt(for: turn1) == computeMediaSalt(for: turn2))
+
+            // Boundary = end of turn 1 (4 tokens); suffix is [5, 6].
+            #expect(!turn2.cacheHitSuffixContainsMediaPlaceholder([5, 6]))
+        }
+    }
+
+    /// The turn that adds a SECOND image cannot resume, for two separate
+    /// reasons. Assert both, so removing one and declaring victory is not
+    /// possible: the salt alone still leaves the suffix rollback, and lifting
+    /// the suffix rollback alone still leaves an unmatchable salt.
+    @Test("adding a second image blocks reuse twice over")
+    func addingASecondImageBlocksReuseTwice() {
+        FocusedMLXTestSupport.withLock {
+            let turn1 = Self.input(tokens: [1, 27, 27, 2], imageCount: 1)
+            let turn2 = Self.input(tokens: [1, 27, 27, 2, 5, 27, 27, 6], imageCount: 2)
+
+            // (1) Whole-tensor salt: turn 1's stored boundaries are keyed
+            // under a salt turn 2 never presents, so every probe misses.
+            #expect(computeMediaSalt(for: turn1) != computeMediaSalt(for: turn2))
+
+            // (2) Suffix rollback: even at the turn-1 boundary the remaining
+            // suffix carries the new image's placeholders.
+            #expect(turn2.cacheHitSuffixContainsMediaPlaceholder([5, 27, 27, 6]))
+        }
+    }
+
+    /// Reuse is not lost permanently -- it resumes on the next text-only turn,
+    /// because that turn presents the same two-image tensor as the turn before
+    /// it. The cost is per media-introducing turn, not cumulative.
+    @Test("reuse resumes on the text turn after a media-introducing turn")
+    func reuseResumesAfterTheMediaIntroducingTurn() {
+        FocusedMLXTestSupport.withLock {
+            let turn2 = Self.input(tokens: [1, 27, 27, 2, 5, 27, 27, 6], imageCount: 2)
+            let turn3 = Self.input(tokens: [1, 27, 27, 2, 5, 27, 27, 6, 7, 8], imageCount: 2)
+
+            #expect(computeMediaSalt(for: turn2) == computeMediaSalt(for: turn3))
+            #expect(!turn3.cacheHitSuffixContainsMediaPlaceholder([7, 8]))
+        }
+    }
+
+    /// A boundary that lands INSIDE a placeholder run must never be treated as
+    /// capturable. This is the media analogue of the alignment lesson: the
+    /// interesting boundary is the one that does not divide evenly.
+    @Test("a boundary inside the placeholder run is not capturable")
+    func boundaryInsideThePlaceholderRunIsNotCapturable() {
+        FocusedMLXTestSupport.withLock {
+            let prompt: [Int] = [1, 27, 27, 27, 2]
+            let turn = Self.input(tokens: prompt.map(Int32.init), imageCount: 1)
+
+            // Splitting the run at 2 or 3 leaves placeholders on both sides.
+            #expect(!turn.canCaptureHybridStripBoundary(promptTokenIds: prompt, boundary: 2))
+            #expect(!turn.canCaptureHybridStripBoundary(promptTokenIds: prompt, boundary: 3))
+
+            // After the complete run the boundary has a stable token identity.
+            #expect(turn.canCaptureHybridStripBoundary(promptTokenIds: prompt, boundary: 4))
+
+            // Before the run there is no media in the prefix to anchor it.
+            #expect(!turn.canCaptureHybridStripBoundary(promptTokenIds: prompt, boundary: 1))
+        }
+    }
+
+    /// Audio and video ride the same two mechanisms as images, so a chat that
+    /// alternates modality introduces new media on every turn and therefore
+    /// never resumes. Pin that explicitly -- it is the "variating
+    /// multimodality per turn" shape.
+    @Test("alternating modality changes the salt every turn")
+    func alternatingModalityChangesTheSaltEveryTurn() {
+        FocusedMLXTestSupport.withLock {
+            let waveform = MLXArray((0..<8).map { Float($0) }).reshaped([1, 8])
+            MLX.eval(waveform)
+
+            let imageTurn = Self.input(tokens: [1, 27, 2], imageCount: 1)
+            let plusAudioTurn = LMInput(
+                text: .init(tokens: MLXArray([Int32(1), 27, 2, 5, 27])),
+                image: .init(pixels: Self.pixels(count: 1)),
+                audio: .init(waveform: waveform),
+                mediaTokenIds: [Self.imageToken])
+
+            #expect(computeMediaSalt(for: imageTurn) != computeMediaSalt(for: plusAudioTurn))
+            #expect(plusAudioTurn.cacheHitSuffixContainsMediaPlaceholder([5, 27]))
+        }
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/VLMediaTokenDeclarationReachabilityTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/VLMediaTokenDeclarationReachabilityTests.swift
@@ -5,10 +5,14 @@
 // `VLGrowingConversationReuseTests` builds every `LMInput` with
 // `mediaTokenIds: [imageToken]` and shows a text follow-up resuming from the
 // cached prefix. That is what the mechanism does when it is fed. It is not
-// what ships: of the VLM processors that construct an `LMInput` carrying
-// media, only **three** declare `mediaTokenIds` — Audex, DeepSeek-OCR and
-// Nemotron-H Omni. Qwen3-VL, Qwen2.5-VL, Gemma 4, Muse Glimmer, LFM2-VL,
-// Mistral 3, GLM-4V, Zaya1-VL and the rest pass none.
+// what shipped: of the VLM processors that construct an `LMInput` carrying
+// media, only **three** declared `mediaTokenIds` — Audex, DeepSeek-OCR and
+// Nemotron-H Omni. Qwen3-VL, Qwen2.5-VL, Qwen2-VL, Gemma 4, Muse Glimmer,
+// LFM2-VL, Mistral 3, GLM-4V, Zaya1-VL and the rest passed none.
+//
+// The three Qwen VL processors now declare theirs through
+// `QwenVL.mediaTokenIds`. Every other family still does not, so the assertions
+// below are half regression guard and half worklist.
 //
 // Without declared ids `cacheHitSuffixContainsMediaPlaceholder` takes its
 // `guard let mediaTokenIds else { return true }` branch and rolls back on ANY
@@ -29,6 +33,7 @@ import MLX
 import Testing
 
 @testable import MLXLMCommon
+@testable import MLXVLM
 
 @Suite("VL media-token declaration reachability")
 struct VLMediaTokenDeclarationReachabilityTests {
@@ -83,8 +88,13 @@ struct VLMediaTokenDeclarationReachabilityTests {
     }
 
     /// The reachability claim itself: which processors feed the mechanism.
-    @Test("only three VLM processors declare mediaTokenIds today")
-    func onlyThreeProcessorsDeclareMediaTokenIds() throws {
+    ///
+    /// The three Qwen VL processors were added here — they share the
+    /// `<|image_pad|>` / `<|video_pad|>` scheme and resolve their ids through
+    /// `QwenVL.mediaTokenIds`. Every other family still declares nothing and
+    /// still takes the blanket rollback.
+    @Test("the declaring set is the three original processors plus Qwen VL")
+    func declaringSetIsTheThreeOriginalsPlusQwenVL() throws {
         let declaring =
             try Self.vlmSources()
             .filter { $0.text.contains("mediaTokenIds:") }
@@ -92,20 +102,22 @@ struct VLMediaTokenDeclarationReachabilityTests {
             .sorted()
 
         #expect(
-            declaring == ["Audex.swift", "DeepseekOCRProcessor.swift", "NemotronHOmni.swift"],
+            declaring == [
+                "Audex.swift", "DeepseekOCRProcessor.swift", "NemotronHOmni.swift",
+                "Qwen25VL.swift", "Qwen2VL.swift", "Qwen3VL.swift",
+            ],
             "declaring processors changed: \(declaring)")
     }
 
     /// Named individually so the failure message says WHICH family regained or
     /// lost the declaration, instead of only that a count moved.
-    @Test("the mainstream VL families still declare nothing")
-    func mainstreamFamiliesDeclareNothing() throws {
+    @Test("the families that were not converted still declare nothing")
+    func unconvertedFamiliesDeclareNothing() throws {
         let sources = try Self.vlmSources()
         let mainstream = [
-            "Qwen3VL.swift", "Qwen25VL.swift", "Qwen2VL.swift", "Gemma4.swift",
-            "Gemma3.swift", "MuseGlimmerProcessor.swift", "LFM2VL.swift",
-            "Mistral3.swift", "Glm4v.swift", "Zaya1VL.swift", "Idefics3.swift",
-            "Pixtral.swift", "SmolVLM2.swift", "FastVLM.swift",
+            "Gemma4.swift", "Gemma3.swift", "MuseGlimmerProcessor.swift",
+            "LFM2VL.swift", "Mistral3.swift", "Glm4v.swift", "Zaya1VL.swift",
+            "Idefics3.swift", "Pixtral.swift", "SmolVLM2.swift", "FastVLM.swift",
         ]
 
         for name in mainstream {
@@ -145,5 +157,114 @@ struct VLMediaTokenDeclarationReachabilityTests {
         // The media construction passes image/video and stops there.
         #expect(source.contains("image: processedImage"))
         #expect(source.contains("video: processedVideo"))
+    }
+}
+
+/// A tokenizer whose special-token behaviour is scripted, so the resolver's
+/// guards can be exercised without a real bundle.
+private struct ScriptedTokenizer: MLXLMCommon.Tokenizer {
+    /// token text -> ids it encodes to.
+    let table: [String: [Int]]
+    /// id -> token text it decodes back to.
+    let reverse: [Int: String]
+
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] { table[text] ?? [] }
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+        tokenIds.compactMap { reverse[$0] }.joined()
+    }
+    func convertTokenToId(_ token: String) -> Int? { table[token]?.first }
+    func convertIdToToken(_ id: Int) -> String? { reverse[id] }
+
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var eosTokenId: Int? { nil }
+    var unknownToken: String? { "<unk>" }
+    var unknownTokenId: Int? { 0 }
+
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] { [] }
+}
+
+@Suite("QwenVL media token id resolution")
+struct QwenVLMediaTokenIdResolutionTests {
+
+    private static let image = "<|image_pad|>"
+    private static let video = "<|video_pad|>"
+
+    @Test("a tokenizer that knows both specials yields both ids")
+    func bothSpecialsResolve() {
+        let tokenizer = ScriptedTokenizer(
+            table: [Self.image: [151_655], Self.video: [151_656]],
+            reverse: [151_655: Self.image, 151_656: Self.video])
+
+        let ids = QwenVL.mediaTokenIds(
+            tokenizer: tokenizer, tokens: [Self.image, Self.video])
+        #expect(ids == [151_655, 151_656])
+    }
+
+    /// The dangerous case. A tokenizer without these specials maps them to
+    /// `<unk>` — a single, real id that also appears in ordinary text. Taking
+    /// it would declare a "media placeholder" that matches unrelated tokens and
+    /// suppress reuse far more aggressively than declaring nothing. The decode
+    /// round-trip is what rejects it; the `count == 1` check alone would not,
+    /// because unk IS one token.
+    @Test("an unk-mapping tokenizer resolves to nothing, not to unk")
+    func unkMappingResolvesToNil() {
+        let tokenizer = ScriptedTokenizer(
+            table: [Self.image: [0], Self.video: [0]],
+            reverse: [0: "<unk>"])
+
+        #expect(
+            QwenVL.mediaTokenIds(tokenizer: tokenizer, tokens: [Self.image, Self.video]) == nil)
+    }
+
+    /// A tokenizer that splits the literal into ordinary pieces is also not a
+    /// declaration — those ids are pieces of text, not a placeholder.
+    @Test("a token that splits into pieces is not declared")
+    func splitTokenIsNotDeclared() {
+        let tokenizer = ScriptedTokenizer(
+            table: [Self.image: [10, 11, 12]],
+            reverse: [10: "<|", 11: "image_pad", 12: "|>"])
+
+        #expect(QwenVL.mediaTokenIds(tokenizer: tokenizer, tokens: [Self.image]) == nil)
+    }
+
+    /// Partial knowledge is still useful: an image-only bundle declares the
+    /// image id and simply has no video id to declare.
+    @Test("one resolvable token is enough")
+    func partialResolutionStillDeclares() {
+        let tokenizer = ScriptedTokenizer(
+            table: [Self.image: [151_655], Self.video: [0]],
+            reverse: [151_655: Self.image, 0: "<unk>"])
+
+        #expect(
+            QwenVL.mediaTokenIds(tokenizer: tokenizer, tokens: [Self.image, Self.video])
+                == [151_655])
+    }
+
+    /// Returning `nil` rather than `[]` matters: an empty array takes the
+    /// `!mediaTokenIds.isEmpty` branch and would report "no media in the
+    /// suffix" for every suffix, which is the unsafe direction.
+    @Test("nil, never empty — empty would disable the rollback entirely")
+    func nilRatherThanEmpty() {
+        FocusedMLXTestSupport.withLock {
+            let pixels = MLXArray((0..<12).map { Float($0) }).reshaped([1, 3, 2, 2])
+            MLX.eval(pixels)
+
+            let empty = LMInput(
+                text: .init(tokens: MLXArray([Int32(1), 27, 2])),
+                image: .init(pixels: pixels),
+                mediaTokenIds: [])
+            // Empty declares "nothing is a placeholder" — a suffix carrying the
+            // real placeholder is waved through. This is exactly what the
+            // resolver must never produce.
+            #expect(!empty.cacheHitSuffixContainsMediaPlaceholder([27]))
+
+            let tokenizer = ScriptedTokenizer(table: [Self.image: [0]], reverse: [0: "<unk>"])
+            #expect(QwenVL.mediaTokenIds(tokenizer: tokenizer, tokens: [Self.image]) == nil)
+        }
     }
 }

--- a/Tests/MLXLMCommonFocusedTests/VLMediaTokenDeclarationReachabilityTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/VLMediaTokenDeclarationReachabilityTests.swift
@@ -89,12 +89,10 @@ struct VLMediaTokenDeclarationReachabilityTests {
 
     /// The reachability claim itself: which processors feed the mechanism.
     ///
-    /// The three Qwen VL processors were added here — they share the
-    /// `<|image_pad|>` / `<|video_pad|>` scheme and resolve their ids through
-    /// `QwenVL.mediaTokenIds`. Every other family still declares nothing and
-    /// still takes the blanket rollback.
-    @Test("the declaring set is the three original processors plus Qwen VL")
-    func declaringSetIsTheThreeOriginalsPlusQwenVL() throws {
+    /// Every processor whose placeholder tokens could be established now
+    /// declares them, through the shared `MediaTokenIds.resolve`.
+    @Test("every processor with knowable placeholder tokens declares them")
+    func declaringSetCoversEveryKnowableProcessor() throws {
         let declaring =
             try Self.vlmSources()
             .filter { $0.text.contains("mediaTokenIds:") }
@@ -103,28 +101,83 @@ struct VLMediaTokenDeclarationReachabilityTests {
 
         #expect(
             declaring == [
-                "Audex.swift", "DeepseekOCRProcessor.swift", "NemotronHOmni.swift",
-                "Qwen25VL.swift", "Qwen2VL.swift", "Qwen3VL.swift",
+                "Audex.swift", "DeepseekOCRProcessor.swift", "FastVLM.swift",
+                "Gemma4.swift", "LFM2VL.swift", "Mistral3.swift",
+                "MuseGlimmerProcessor.swift", "NemotronHOmni.swift", "Pixtral.swift",
+                "Qwen25VL.swift", "Qwen2VL.swift", "Qwen3VL.swift", "SmolVLM2.swift",
+                "Zaya1VL.swift",
             ],
             "declaring processors changed: \(declaring)")
     }
 
-    /// Named individually so the failure message says WHICH family regained or
-    /// lost the declaration, instead of only that a count moved.
-    @Test("the families that were not converted still declare nothing")
-    func unconvertedFamiliesDeclareNothing() throws {
+    /// The remaining three carry their placeholder only as a numeric config id
+    /// the processor cannot see, so there is no string to round-trip. They keep
+    /// the conservative blanket rollback rather than a guessed id — a WRONG id
+    /// is worse than none, because it would wave through a suffix that really
+    /// does carry a placeholder.
+    @Test("config-id-only families are deliberately left undeclared")
+    func configIdOnlyFamiliesRemainUndeclared() throws {
         let sources = try Self.vlmSources()
-        let mainstream = [
-            "Gemma4.swift", "Gemma3.swift", "MuseGlimmerProcessor.swift",
-            "LFM2VL.swift", "Mistral3.swift", "Glm4v.swift", "Zaya1VL.swift",
-            "Idefics3.swift", "Pixtral.swift", "SmolVLM2.swift", "FastVLM.swift",
-        ]
-
-        for name in mainstream {
+        for name in ["Gemma3.swift", "Glm4v.swift", "Idefics3.swift"] {
             guard let file = sources.first(where: { $0.name == name }) else { continue }
             #expect(
                 !file.text.contains("mediaTokenIds:"),
-                "\(name) now declares mediaTokenIds — update the reuse table in the audit")
+                "\(name) declared ids — verify the token string round-trips first")
+        }
+    }
+
+    /// A family that emits more than one KIND of placeholder must declare all
+    /// of them. Declaring only some is the dangerous direction: a suffix
+    /// carrying the undeclared kind matches nothing, reads as media-free, and
+    /// resumes onto the wrong media.
+    @Test("multi-modality families declare every placeholder kind they emit")
+    func multiModalityFamiliesDeclareEveryKind() throws {
+        let sources = try Self.vlmSources()
+
+        func text(_ name: String) -> String {
+            sources.first(where: { $0.name == name })?.text ?? ""
+        }
+
+        // Gemma 4 builds an LMInput carrying image AND audio.
+        let gemma4 = text("Gemma4.swift")
+        #expect(gemma4.contains(#""<|image|>""#))
+        #expect(gemma4.contains(#""<|audio|>""#))
+
+        // Muse Glimmer expands `<|patch|>` for stills and `<|video|>` for clips.
+        let muse = text("MuseGlimmerProcessor.swift")
+        #expect(muse.contains(#""<|patch|>""#))
+        #expect(muse.contains(#""<|video|>""#))
+
+        // Qwen VL: image and video pads.
+        for name in ["Qwen3VL.swift", "Qwen25VL.swift", "Qwen2VL.swift"] {
+            #expect(text(name).contains(#""<|image_pad|>", "<|video_pad|>""#), "\(name)")
+        }
+
+        // Mistral/Pixtral repeat [IMG] and separate spans with BREAK/END.
+        for name in ["Mistral3.swift", "Pixtral.swift"] {
+            let t = text(name)
+            #expect(t.contains(#""[IMG]""#), "\(name)")
+            #expect(t.contains(#""[IMG_BREAK]""#), "\(name)")
+            #expect(t.contains(#""[IMG_END]""#), "\(name)")
+        }
+    }
+
+    /// Named individually so the failure message says WHICH family regained or
+    /// lost the declaration, instead of only that a count moved.
+    /// Resolution goes through the one shared helper, so the round-trip and
+    /// nil-not-empty guarantees hold everywhere rather than per copy.
+    @Test("every declaration resolves through the shared helper")
+    func everyDeclarationUsesTheSharedResolver() throws {
+        let declaring = try Self.vlmSources().filter { $0.text.contains("mediaTokenIds:") }
+
+        for file in declaring {
+            #expect(
+                file.text.contains("MediaTokenIds.resolve")
+                    || file.text.contains("QwenVL.mediaTokenIds")
+                    || file.name == "Audex.swift"
+                    || file.name == "DeepseekOCRProcessor.swift"
+                    || file.name == "NemotronHOmni.swift",
+                "\(file.name) hand-rolls its ids instead of using MediaTokenIds.resolve")
         }
     }
 

--- a/Tests/MLXLMCommonFocusedTests/VLMediaTokenDeclarationReachabilityTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/VLMediaTokenDeclarationReachabilityTests.swift
@@ -1,0 +1,149 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+//
+// The VL reuse mechanism is correct and almost nothing reaches it.
+//
+// `VLGrowingConversationReuseTests` builds every `LMInput` with
+// `mediaTokenIds: [imageToken]` and shows a text follow-up resuming from the
+// cached prefix. That is what the mechanism does when it is fed. It is not
+// what ships: of the VLM processors that construct an `LMInput` carrying
+// media, only **three** declare `mediaTokenIds` — Audex, DeepSeek-OCR and
+// Nemotron-H Omni. Qwen3-VL, Qwen2.5-VL, Gemma 4, Muse Glimmer, LFM2-VL,
+// Mistral 3, GLM-4V, Zaya1-VL and the rest pass none.
+//
+// Without declared ids `cacheHitSuffixContainsMediaPlaceholder` takes its
+// `guard let mediaTokenIds else { return true }` branch and rolls back on ANY
+// non-empty suffix. So on those families even a pure-text follow-up — the case
+// the characterization tests show resuming — re-prefills the whole prompt,
+// vision tower included.
+//
+// This file asserts the reachability rather than the mechanism, because the
+// mechanism already has tests and they pass regardless. It is the same shape
+// as the guards that shipped correct-but-unreached twice before.
+//
+// These are characterization assertions about TODAY. When a family starts
+// declaring its ids, the count here SHOULD be updated deliberately rather than
+// quietly relaxed.
+
+import Foundation
+import MLX
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite("VL media-token declaration reachability")
+struct VLMediaTokenDeclarationReachabilityTests {
+
+    private static func repoRoot() -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+
+    private static func vlmSources() throws -> [(name: String, text: String)] {
+        let dir = repoRoot().appendingPathComponent("Libraries/MLXVLM/Models")
+        let urls = try FileManager.default.subpathsOfDirectory(atPath: dir.path)
+            .filter { $0.hasSuffix(".swift") }
+            .map { dir.appendingPathComponent($0) }
+        return try urls.map {
+            (name: $0.lastPathComponent, text: try String(contentsOf: $0, encoding: .utf8))
+        }
+    }
+
+    /// The undeclared case is not "slightly worse" — it is a blanket rollback.
+    /// Pin the branch itself so a refactor cannot quietly make undeclared mean
+    /// "no media in the suffix", which would substitute the wrong image.
+    @Test("an undeclared media token set rolls back on ANY non-empty suffix")
+    func undeclaredIdsRollBackUnconditionally() {
+        FocusedMLXTestSupport.withLock {
+            let pixels = MLXArray((0..<12).map { Float($0) }).reshaped([1, 3, 2, 2])
+            MLX.eval(pixels)
+
+            let undeclared = LMInput(
+                text: .init(tokens: MLXArray([Int32(1), 27, 27, 2, 5, 6])),
+                image: .init(pixels: pixels))
+            let declared = LMInput(
+                text: .init(tokens: MLXArray([Int32(1), 27, 27, 2, 5, 6])),
+                image: .init(pixels: pixels),
+                mediaTokenIds: [27])
+
+            // Identical prompt, identical pixels, pure-text suffix [5, 6].
+            // The only difference is whether the processor declared its ids.
+            #expect(undeclared.cacheHitSuffixContainsMediaPlaceholder([5, 6]))
+            #expect(!declared.cacheHitSuffixContainsMediaPlaceholder([5, 6]))
+
+            // Declaring ids does NOT weaken the real rollback: a suffix that
+            // still carries a placeholder is rejected either way.
+            #expect(declared.cacheHitSuffixContainsMediaPlaceholder([5, 27, 6]))
+
+            // And a prompt with no media is untouched by any of this.
+            let textOnly = LMInput(text: .init(tokens: MLXArray([Int32(1), 2, 3])))
+            #expect(!textOnly.cacheHitSuffixContainsMediaPlaceholder([2, 3]))
+        }
+    }
+
+    /// The reachability claim itself: which processors feed the mechanism.
+    @Test("only three VLM processors declare mediaTokenIds today")
+    func onlyThreeProcessorsDeclareMediaTokenIds() throws {
+        let declaring =
+            try Self.vlmSources()
+            .filter { $0.text.contains("mediaTokenIds:") }
+            .map(\.name)
+            .sorted()
+
+        #expect(
+            declaring == ["Audex.swift", "DeepseekOCRProcessor.swift", "NemotronHOmni.swift"],
+            "declaring processors changed: \(declaring)")
+    }
+
+    /// Named individually so the failure message says WHICH family regained or
+    /// lost the declaration, instead of only that a count moved.
+    @Test("the mainstream VL families still declare nothing")
+    func mainstreamFamiliesDeclareNothing() throws {
+        let sources = try Self.vlmSources()
+        let mainstream = [
+            "Qwen3VL.swift", "Qwen25VL.swift", "Qwen2VL.swift", "Gemma4.swift",
+            "Gemma3.swift", "MuseGlimmerProcessor.swift", "LFM2VL.swift",
+            "Mistral3.swift", "Glm4v.swift", "Zaya1VL.swift", "Idefics3.swift",
+            "Pixtral.swift", "SmolVLM2.swift", "FastVLM.swift",
+        ]
+
+        for name in mainstream {
+            guard let file = sources.first(where: { $0.name == name }) else { continue }
+            #expect(
+                !file.text.contains("mediaTokenIds:"),
+                "\(name) now declares mediaTokenIds — update the reuse table in the audit")
+        }
+    }
+
+    /// The second half of why VL prompts do not resume, and the one that is
+    /// easy to miss: Qwen3-VL's TEXT branch computes canonical boundaries and
+    /// passes them, while its MEDIA branch returns an `LMInput` with neither
+    /// `cachePrefixTokenCounts` nor `cacheStablePrefixTokenCounts`. A prompt
+    /// that declares no boundaries has nothing for the coordinator to probe,
+    /// so the rollback above is never even reached — there is no candidate hit
+    /// to roll back.
+    @Test("Qwen3-VL declares cache boundaries on the text path but not the media path")
+    func qwen3VLMediaPathDeclaresNoBoundaries() throws {
+        let source = try String(
+            contentsOf: Self.repoRoot()
+                .appendingPathComponent("Libraries/MLXVLM/Models/Qwen3VL.swift"),
+            encoding: .utf8)
+
+        // The text-only branch is the one that carries boundaries.
+        #expect(source.contains("cachePrefixTokenCounts: cacheBoundaries.all"))
+        #expect(source.contains("cacheStablePrefixTokenCounts: cacheBoundaries.stable"))
+
+        // Exactly one construction site does, and it is not the media one.
+        let boundaryDeclarations = source.components(
+            separatedBy: "cachePrefixTokenCounts: cacheBoundaries.all"
+        ).count - 1
+        #expect(
+            boundaryDeclarations == 1,
+            "expected the single text-path declaration, found \(boundaryDeclarations)")
+
+        // The media construction passes image/video and stops there.
+        #expect(source.contains("image: processedImage"))
+        #expect(source.contains("video: processedVideo"))
+    }
+}


### PR DESCRIPTION
Two commits: one fix, one characterization of the behaviour around it.

## DeepSeek-OCR built `LMInput` without a cache scope salt

`DeepseekOCRProcessor` was the only media-bearing processor constructing
`LMInput` without `cacheScopeSalt`. A swept re-check across the tree now shows
**32 of 32** media-bearing constructions carrying it; the six without it are
internal post-restore suffix inputs built with `image: nil, video: nil`, which
carry no media and are not cache-key sources.

An unsalted image path is the failure mode where the model answers fluently
about the **wrong picture**.

## Pin what a growing VL conversation can actually reuse

The primitives were already covered — `MediaCachePlaceholderTests` pins
`cacheHitSuffixContainsMediaPlaceholder`, `CacheCoordinatorMediaSaltTests`
pins `computeMediaSalt`. Neither stated the property a user feels: which turns
of a real multi-image chat re-prefill the whole conversation, and which resume.

Two independent mechanisms decide it:

1. `computeMediaSalt` fingerprints the **whole** concatenated pixel tensor
   (`ProcessedImage.pixels` is documented as "Concatenated pixels from one or
   more images"), so appending an image changes the salt for the entire
   prompt and no boundary stored by an earlier turn can match — the salt goes
   to `DiskCache.fetch` on every candidate boundary probe.
2. A hit whose remaining **suffix** still holds media placeholders rolls back
   to a full prefill, in all four decode paths. That one is a correctness
   requirement: media embeddings are substituted onto placeholder positions by
   order across the whole prompt, so prefilling only a suffix would map the
   wrong image onto them.

| turn shape | reuses? |
|---|---|
| text follow-up after an image turn | yes |
| turn that ADDS image / video / audio | no — both mechanisms block it |
| text turn after a media-introducing turn | yes |

So the cost is **per media-introducing turn**, not cumulative — but a chat that
varies modality every turn introduces media every turn and never resumes,
re-running the vision tower over all prior images each time.

**Worth recording before anyone optimizes this:** the suffix rollback is the
binding constraint. Prefix-scoped salting on its own buys *nothing* — every
case it would unlock is still rejected by the rollback. A real fix has to
thread a media-consumed offset into each VLM's `prepare` first, and only then
is prefix-scoped salting worth adding.

These 5 tests assert today's behaviour and SHOULD change, deliberately, when
that lands. The rollback announces itself in the log, so the change is
verifiable live:

    Slot N: cache hit — rolling back to full prefill
            (media placeholder tokens remain in cache-hit suffix)

## Tests

`swift test --filter VLGrowingConversationReuseTests` → 5/5.
`--filter MediaCachePlaceholderTests` → 4/4 (unchanged).
The new file is registered in `Package.swift`'s explicit source list — without
that it compiles and silently never runs.

---

## Update: the mechanism was correct and almost nothing reached it — now fixed for Qwen VL

The characterization above builds every `LMInput` with
`mediaTokenIds: [imageToken]` and shows a text follow-up resuming. That is what
the mechanism does when it is fed. It was not what shipped: three processors
declared `mediaTokenIds` (Audex, DeepSeek-OCR, Nemotron-H Omni) and the rest
declared none, so `cacheHitSuffixContainsMediaPlaceholder` took its
`guard let mediaTokenIds else { return true }` branch and rolled back on ANY
non-empty suffix. On Qwen VL a pure-text follow-up about the same picture
re-prefilled the whole prompt, vision tower included.

`QwenVL.mediaTokenIds` now resolves `<|image_pad|>` / `<|video_pad|>` through
the tokenizer, and Qwen3-VL / Qwen2.5-VL / Qwen2-VL pass them. A token counts
only if it encodes to exactly one id **and** that id decodes back to the same
token — a tokenizer without these specials maps them to `<unk>`, a single real
id that also appears in ordinary text, so `count == 1` alone would declare a
placeholder matching unrelated tokens. Returns `nil`, never `[]`, because an
empty array takes the `!isEmpty` branch and would report "no media in the
suffix" for every suffix.

Nothing else needed changing: the resume branch already builds its suffix as
`LMInput(text: remainingArray, image: nil, video: nil)`, `storeAfterGeneration`
stores at the full prompt length, and candidates come from
`SELECT DISTINCT token_count FROM cache_entries`.

### Live A/B, two osaurus builds differing only in the vmlx pin

Same machine, model `Qwen3.8 27B JANG_2D`, same agent, same images, same
prompts, driven through the real chat UI:

| turn | baseline pin | with the declaration |
|---|---|---|
| 1 — image + "what digit / what colour" | 4.19s, 3.27s | 4.10s (cold), 0.60s (warm root) |
| 2 — "spell that digit as an English word" | 3.45s, 3.37s | 0.59s, 0.74s |
| 3 — "and what colour was it again?" | 3.30s, 3.42s | 0.48s |

Follow-ups: baseline **3.30 / 3.37 / 3.42 / 3.45** (median 3.40s), fixed
**0.48 / 0.59 / 0.74** (median 0.59s) — **5.8×, no overlap**, few-percent
spread inside each leg. Cold turn 1 matched at 4.19 vs 4.10, which is the
noise indicator.

Correctness is scored against opposite images (a blue 7 and a red 3), so a
constant answer fails. Both legs answered "7 … blue", then "seven", then
"Blue". A no-history control answered "zero", confirming the follow-up depends
on retained image context. Disk L2 counters moved 2/11/6 → 5/20/11.

Gemma 4, Muse Glimmer, LFM2-VL, Mistral 3, GLM-4V, Zaya1-VL and the rest still
declare nothing and keep today's behaviour. `VLMediaTokenDeclarationReachabilityTests`
names them individually so the list cannot silently drift.


### Second commit: the other families, and an honest negative

Every processor whose placeholder tokens could be established now declares them
through one shared `MediaTokenIds.resolve` — Gemma 4 (`<|image|>`, `<|audio|>`),
Muse Glimmer (`<|patch|>`, `<|video|>`), LFM2-VL, Zaya1-VL, FastVLM, SmolVLM2
(`<image>`), Mistral 3 and Pixtral (`[IMG]`, `[IMG_BREAK]`, `[IMG_END]`).

A family that emits more than one KIND declares all of them. Declaring only
some is the dangerous direction: a suffix carrying the undeclared kind matches
nothing, reads as media-free, and resumes onto the wrong media. Pinned by
`multiModalityFamiliesDeclareEveryKind`.

Gemma 3, GLM-4V and Idefics3 are deliberately left undeclared — the placeholder
exists only as a numeric config id the processor cannot see, and a wrong id is
worse than none. `configIdOnlyFamiliesRemainUndeclared` records that as a
decision.

**Gemma 4 live: correct, but reuse still does not engage.** Same three-turn
harness on `Gemma 4 26B A4B it JANG_4M CRACK`: 1.70s / 1.52s / 1.58s, answers
"…digit 7 … background is blue" → "Seven" → "Blue". Correct throughout, which
is the safety result for a newly-declared family. But Disk L2 read
**0 hits / 55 misses / 12 stores**. Live Activity showed `Cache-enabled
models 1`, `Hybrid caches 0`, `Paged-incompatible caches 0`, so it is not
topology.

For Gemma the declaration is necessary but **not sufficient** — a second gate
still blocks the hit, not chased here. Only the Qwen VL families are proven
end-to-end; the rest are declared and verified non-corrupting.
