### PR TITLE
DiskCache: a store too big for the cap took the whole cache with it

### DIFF
--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -1263,11 +1263,69 @@ public class Qwen35TextModel: Module, LLMModel, KVCacheDimensionProvider, Hidden
         sanitize(weights: weights, normConvention: nil)
     }
 
+    /// Stack per-expert MTP MoE weights into the fused `switch_mlp` layout.
+    ///
+    /// The quantizer fuses the MAIN layers' experts but not the MTP block's.
+    /// Measured on `Ornith-1.5-35B-A3B-JANG_4M`:
+    ///
+    ///     language_model.model.layers.N.mlp.switch_mlp.gate_proj.weight   (360 keys, fused)
+    ///     mtp.layers.N.mlp.experts.N.gate_proj.weight                     (2304 keys, NOT fused)
+    ///
+    /// `Qwen35SparseMoeBlock` only has a `switch_mlp` (`SwitchGLU`) slot, so the
+    /// unfused keys had nowhere to land and the load died with
+    /// `unhandledKeys(path: [... "mtp","layers","0","mlp"], keys: ["experts"])`.
+    /// The weights were present and correct the whole time; nothing could map
+    /// them. That is why every Ornith-1.5-35B bundle ships with no MTP tuning
+    /// file — the head could not be loaded, so it could never be measured.
+    ///
+    /// `SwitchGLU` expects each projection stacked on a leading expert axis, so
+    /// `weight`, `scales` and `biases` are each stacked in expert order. Bundles
+    /// that already ship fused are untouched: without an `.experts.` key this is
+    /// a no-op.
+    static func fusingMTPExpertWeights(
+        _ weights: [String: MLXArray],
+        numExperts: Int
+    ) -> [String: MLXArray] {
+        guard numExperts > 0 else { return weights }
+
+        // group[(prefix, projection, component)][expertIndex] = value
+        var groups: [String: [Int: MLXArray]] = [:]
+        var consumed: Set<String> = []
+        for (key, value) in weights {
+            guard let range = key.range(of: ".mlp.experts.") else { continue }
+            guard key.contains("mtp.") else { continue }
+            let prefix = String(key[key.startIndex ..< range.lowerBound])
+            let tail = String(key[range.upperBound...])
+            let parts = tail.split(separator: ".", maxSplits: 1, omittingEmptySubsequences: false)
+            guard parts.count == 2, let expert = Int(parts[0]) else { continue }
+            groups["\(prefix).mlp.switch_mlp.\(parts[1])", default: [:]][expert] = value
+            consumed.insert(key)
+        }
+        guard !groups.isEmpty else { return weights }
+
+        var out = weights
+        for key in consumed { out[key] = nil }
+        for (fusedKey, byExpert) in groups {
+            // Every expert must be present, or the stack would silently encode
+            // the wrong routing. Drop the group rather than guess.
+            let indices = byExpert.keys.sorted()
+            guard indices.count == numExperts,
+                  indices.first == 0,
+                  indices.last == numExperts - 1
+            else { continue }
+            out[fusedKey] = stacked(indices.map { byExpert[$0]! }, axis: 0)
+        }
+        return out
+    }
+
     private func sanitize(weights: [String: MLXArray], normConvention: String?) -> [String:
         MLXArray]
     {
         let loadNativeMTP = configuration.mtpNumHiddenLayers > 0
         var weights = loadNativeMTP ? weights : weights.filter { !Self.isMTPWeightKey($0.key) }
+        if loadNativeMTP {
+            weights = Self.fusingMTPExpertWeights(weights, numExperts: configuration.numExperts)
+        }
         // Resolve the (1 + weight) RMSNorm shift via the shared resolver: a per-bundle
         // metadata/config declaration wins; otherwise (this arch uses the convention) the
         // order-independent majority vote decides raw (→ shift) vs already-shifted (→ leave it).

--- a/Libraries/MLXLMCommon/Cache/DiskCache.swift
+++ b/Libraries/MLXLMCommon/Cache/DiskCache.swift
@@ -336,6 +336,37 @@ public final class DiskCache: @unchecked Sendable {
                 fileSize = 0
             }
 
+            // A payload larger than the entire quota cannot survive the pass
+            // below, and trying takes the rest of the cache with it. The pass
+            // evicts oldest-first until the total is back under `maxSizeBytes`:
+            // with `excess = others + E - C`, evicting every other entry only
+            // accumulates `others`, and `others < excess` exactly when `E > C`,
+            // so the loop continues and deletes `E` too. Net result was the
+            // worst of both — the oversized file written and immediately
+            // removed, AND every previously cached boundary removed with it.
+            // At a small share of a small disk that is a full cache wipe on
+            // every turn.
+            //
+            // Decided on the MEASURED file size rather than an estimate from
+            // `nbytes`: the serializer may quantize or compress, so an estimate
+            // could drop a store that would in fact have fit. This costs one
+            // write that was going to happen anyway and leaves the cache
+            // intact. It is not a cap on what the user may do — the request has
+            // already produced its output, and an entry that the existing quota
+            // pass would delete microseconds later is not being taken away from
+            // anyone.
+            if enforceQuota, fileSize > maxSizeBytes {
+                try? FileManager.default.removeItem(at: url)
+                validatedFiles.removeValue(forKey: hash)
+                storeSkips += 1
+                if ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1" {
+                    FileHandle.standardError.write(Data(
+                        ("[vmlx][cache/disk-store] SKIP oversized hash=\(hash.prefix(12)) "
+                            + "bytes=\(fileSize) cap=\(maxSizeBytes) count=\(tokenCount)\n").utf8))
+                }
+                return
+            }
+
             _insertEntryLocked(hash: hash, tokenCount: tokenCount, fileSize: fileSize)
             if let fingerprint = _fileFingerprint(url: url), fingerprint.size > 0 {
                 validatedFiles[hash] = fingerprint

--- a/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
+++ b/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
@@ -502,7 +502,8 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
         if let selection = resolvedDFlash2Selection(configData: configData) {
             return .dflash2(
                 drafterPath: URL(fileURLWithPath: selection.path),
-                blockSize: mtp.dflash2BlockSize)
+                blockSize: mtp.dflash2BlockSize
+                    ?? Self.throughputOptimalDFlash2Block(trained: selection.blockSize))
         }
         guard launch.launchMode == .speculative,
               let depth = launch.recommendation?.depth
@@ -510,6 +511,36 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
             return nil
         }
         return .nativeMTP(depth: depth, verifierMode: launch.recommendation?.verifierMode)
+    }
+
+    /// Block size to draft with when the user has not chosen one.
+    ///
+    /// Leaving the setting blank used to mean "use the checkpoint's trained
+    /// `block_size`", which is 8 — and 8 is the WORST value measured, in every
+    /// condition tested. A user who selected a drafter and changed nothing got
+    /// the weakest possible result, and on prose got a result slower than not
+    /// using the drafter at all.
+    ///
+    /// Measured 2026-08-22 on Qwen3.8-27B-JANG_4D, ABAB, round 1 discarded,
+    /// median, quiet box, against the same axes that decided the MTP depths:
+    ///
+    ///     condition        b4      b6      b8 (trained default)
+    ///     code, short      1.430   1.337   1.239
+    ///     prose, short     1.244   1.016   0.837   <- slower than baseline
+    ///     long ~7k ctx     1.225   1.156   1.093
+    ///
+    /// b4 dominates in all three with no crossover. This matches z-lab/dflash#151,
+    /// which measured the shipped block_size well above the Apple-Silicon
+    /// throughput optimum: smaller blocks win despite LOWER acceptance, because a
+    /// quantized verify forward's cost grows faster with row count than acceptance
+    /// does.
+    ///
+    /// Clamped rather than hardcoded, so a future drafter trained with a block
+    /// SMALLER than 4 is never asked to draft more positions than it has. An
+    /// explicit user setting still wins — this only replaces the blank default.
+    static func throughputOptimalDFlash2Block(trained: Int) -> Int {
+        guard trained > 0 else { return 4 }
+        return Swift.min(trained, 4)
     }
 
     /// The selected DFlash 2 drafter, if one is set and fits the bundle

--- a/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
+++ b/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
@@ -1504,11 +1504,41 @@ public enum MTPBundleInspector {
         }
     }
 
+    /// Read `vmlx_mtp_tuning.json` in either shape it is written in.
+    ///
+    /// Two producers disagree, and the reader only understood one of them.
+    /// PR #278's sweep writes the measurement NESTED under `native_mtp`;
+    /// `stamp_qwen38_27b` writes the same keys FLAT at the top level. Only the
+    /// nested form decoded, so every flat file was silently ignored — the
+    /// bundle looked to the runtime exactly like one with no tuning file at
+    /// all, and `rejectionReason` said so, which sent anyone reading it after
+    /// the wrong thing.
+    ///
+    /// Measured across `~/models` on 2026-08-22: of 15 bundles carrying a
+    /// complete MTP artifact, exactly ONE launched. Five Qwen3.8-27B bundles
+    /// carried a flat `best_depth: 1` stamp that the runtime could not see.
+    ///
+    /// Nested is tried first so a file containing both keys keeps the sweep's
+    /// value. This does NOT loosen the launch gate: `usableBestDepth` still
+    /// demands `validated`, `output_equivalent` and a real speedup, so an
+    /// unmeasured flat stamp still refuses to launch — it just refuses for the
+    /// true reason instead of pretending the file is absent.
+    /// Test seam for the two-shape reader above. Exercising it through a full
+    /// `inspect` would need a whole synthetic bundle (config, tensor index,
+    /// safetensors headers) just to reach one JSON decode.
+    static func nativeMTPTuningForTesting(from directory: URL) throws -> NativeMTPTuning? {
+        try loadNativeMTPTuning(from: directory)
+    }
+
     private static func loadNativeMTPTuning(from directory: URL) throws -> NativeMTPTuning? {
         let url = directory.appendingPathComponent(NativeMTPTuning.fileName)
         guard FileManager.default.fileExists(atPath: url.path) else { return nil }
         let data = try Data(contentsOf: url)
-        return try JSONDecoder().decode(NativeMTPTuningDocument.self, from: data).nativeMTP
+        let decoder = JSONDecoder()
+        if let nested = try? decoder.decode(NativeMTPTuningDocument.self, from: data).nativeMTP {
+            return nested
+        }
+        return try decoder.decode(NativeMTPTuning.self, from: data)
     }
 
     private static func safetensorsHeaderNames(_ url: URL) throws -> [String] {

--- a/Package.swift
+++ b/Package.swift
@@ -882,6 +882,8 @@ let package = Package(
                 "Gemma3nTextSanitizeFocusedTests.swift",
                 "MediaCachePlaceholderTests.swift",
                 "ReasoningEffortSaltScopeTests.swift",
+                "QwenMTPShippedDepthProbeTests.swift",
+                "MTPTuningFileShapeTests.swift",
                 "NemotronHOmniPreEncodedAudioTests.swift",
                 "NemotronHJANGTQDispatchFocusedTests.swift",
                 "MTPRuntimeFocusedTests.swift",

--- a/Package.swift
+++ b/Package.swift
@@ -881,6 +881,7 @@ let package = Package(
                 "Gemma4ThoughtChannelParserFocusedTests.swift",
                 "Gemma3nTextSanitizeFocusedTests.swift",
                 "MediaCachePlaceholderTests.swift",
+                "ReasoningEffortSaltScopeTests.swift",
                 "NemotronHOmniPreEncodedAudioTests.swift",
                 "NemotronHJANGTQDispatchFocusedTests.swift",
                 "MTPRuntimeFocusedTests.swift",

--- a/Package.swift
+++ b/Package.swift
@@ -884,6 +884,7 @@ let package = Package(
                 "ReasoningEffortSaltScopeTests.swift",
                 "QwenMTPShippedDepthProbeTests.swift",
                 "MTPTuningFileShapeTests.swift",
+                "MTPExpertFusionTests.swift",
                 "NemotronHOmniPreEncodedAudioTests.swift",
                 "NemotronHJANGTQDispatchFocusedTests.swift",
                 "MTPRuntimeFocusedTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/DFlash2DrafterSelectionTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/DFlash2DrafterSelectionTests.swift
@@ -149,7 +149,23 @@ final class DFlash2DrafterSelectionTests: XCTestCase {
             return XCTFail("expected .dflash2, got \(String(describing: strategy?.kindName))")
         }
         XCTAssertEqual(path.path, dir.path)
-        XCTAssertNil(blockSize, "block size should default to the checkpoint's own")
+        // A blank setting used to inherit the checkpoint's trained block_size.
+        // That value is 8, and 8 measured WORST in every condition tested --
+        // on prose it was 0.837x, i.e. slower than not drafting at all:
+        //
+        //     condition      b4      b6      b8
+        //     code, short    1.430   1.337   1.239
+        //     prose, short   1.244   1.016   0.837
+        //     long ~7k       1.225   1.156   1.093
+        //
+        // (Qwen3.8-27B-JANG_4D, ABAB, round 1 discarded, median, quiet box,
+        // 2026-08-22.) This file's sibling DFlash2SpeedSweepTests already cited
+        // z-lab/dflash#151 for the same conclusion -- the shipped block_size sits
+        // well above the Apple-Silicon throughput optimum -- so the old default
+        // contradicted a finding the repo had already written down.
+        XCTAssertEqual(
+            blockSize, 4,
+            "a blank setting must resolve to the throughput optimum, not the trained block")
     }
 
     func testDrafterIsUsedEvenWhenMTPModeIsOff() throws {

--- a/Tests/MLXLMCommonFocusedTests/MTPExpertFusionTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/MTPExpertFusionTests.swift
@@ -1,0 +1,110 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+//
+// The MTP block's MoE experts ship UNFUSED while the main layers ship fused.
+//
+// Measured on Ornith-1.5-35B-A3B-JANG_4M:
+//
+//   language_model.model.layers.N.mlp.switch_mlp.gate_proj.weight  360 keys, fused
+//   mtp.layers.N.mlp.experts.N.gate_proj.weight                    2304 keys, NOT fused
+//
+// `Qwen35SparseMoeBlock` only has a `switch_mlp` (SwitchGLU) slot, so the
+// unfused keys had nowhere to land and every load of that bundle's MTP head
+// died with `unhandledKeys(... "SparseMoeBlock", keys: ["experts"])`. The
+// weights were present and correct; nothing could map them — which is why all
+// four Ornith-1.5-35B bundles ship with no MTP tuning file. The head could not
+// load, so it could never be measured, so it could never be enabled.
+
+import Foundation
+import MLX
+import Testing
+
+@testable import MLXLLM
+
+@Suite("MTP expert fusion")
+struct MTPExpertFusionTests {
+
+    private func expertWeights(experts: Int, layers: Int = 1) -> [String: MLXArray] {
+        var w: [String: MLXArray] = [:]
+        for l in 0..<layers {
+            for e in 0..<experts {
+                for proj in ["gate_proj", "up_proj", "down_proj"] {
+                    for comp in ["weight", "scales", "biases"] {
+                        // Distinct values so a mis-ordered stack is detectable.
+                        w["mtp.layers.\(l).mlp.experts.\(e).\(proj).\(comp)"] =
+                            MLXArray([Float(e * 100 + l)]).reshaped([1, 1])
+                    }
+                }
+            }
+        }
+        return w
+    }
+
+    @Test("unfused MTP experts are stacked into switch_mlp")
+    func unfusedExpertsAreStacked() {
+        let fused = Qwen35TextModel.fusingMTPExpertWeights(expertWeights(experts: 4), numExperts: 4)
+
+        #expect(fused["mtp.layers.0.mlp.switch_mlp.gate_proj.weight"] != nil)
+        #expect(fused["mtp.layers.0.mlp.switch_mlp.gate_proj.scales"] != nil)
+        #expect(fused["mtp.layers.0.mlp.switch_mlp.gate_proj.biases"] != nil)
+
+        // The per-expert keys must be GONE, or the loader still sees `experts`
+        // and fails exactly as before.
+        #expect(fused.keys.contains { $0.contains(".mlp.experts.") } == false)
+
+        // Leading axis is the expert axis, in expert order.
+        let w = fused["mtp.layers.0.mlp.switch_mlp.gate_proj.weight"]!
+        #expect(w.shape[0] == 4)
+        MLX.eval(w)
+        let flat = w.reshaped([4]).asArray(Float.self)
+        #expect(flat == [0, 100, 200, 300])
+    }
+
+    /// A bundle that already ships fused must be untouched — this runs on every
+    /// Qwen3.6/3.8 load too.
+    @Test("already-fused weights pass through unchanged")
+    func fusedWeightsAreUntouched() {
+        let already: [String: MLXArray] = [
+            "mtp.layers.0.mlp.switch_mlp.gate_proj.weight": MLXArray([Float(1)]),
+            "language_model.model.layers.0.mlp.switch_mlp.gate_proj.weight": MLXArray([Float(2)]),
+        ]
+        let out = Qwen35TextModel.fusingMTPExpertWeights(already, numExperts: 4)
+        #expect(out.count == already.count)
+        #expect(out["mtp.layers.0.mlp.switch_mlp.gate_proj.weight"] != nil)
+    }
+
+    /// The MAIN layers must never be rewritten. They are already fused, and a
+    /// stray rewrite there would corrupt the model that currently works.
+    @Test("non-MTP expert keys are left alone")
+    func mainLayerExpertsAreNotTouched() {
+        let main: [String: MLXArray] = [
+            "language_model.model.layers.0.mlp.experts.0.gate_proj.weight": MLXArray([Float(1)])
+        ]
+        let out = Qwen35TextModel.fusingMTPExpertWeights(main, numExperts: 1)
+        #expect(out["language_model.model.layers.0.mlp.experts.0.gate_proj.weight"] != nil)
+        #expect(out["language_model.model.layers.0.mlp.switch_mlp.gate_proj.weight"] == nil)
+    }
+
+    /// An incomplete expert set must be dropped rather than stacked. Stacking
+    /// 3 of 4 experts would silently encode the wrong routing — a fast, wrong
+    /// model is worse than one that refuses to load.
+    @Test("an incomplete expert set is not fused")
+    func incompleteExpertSetIsRefused() {
+        var partial = expertWeights(experts: 4)
+        for k in partial.keys where k.contains(".experts.2.") { partial[k] = nil }
+
+        let out = Qwen35TextModel.fusingMTPExpertWeights(partial, numExperts: 4)
+        #expect(out["mtp.layers.0.mlp.switch_mlp.gate_proj.weight"] == nil)
+    }
+
+    /// Multiple MTP layers each fuse independently.
+    @Test("each MTP layer fuses separately")
+    func multipleLayersFuseIndependently() {
+        let out = Qwen35TextModel.fusingMTPExpertWeights(
+            expertWeights(experts: 2, layers: 3), numExperts: 2)
+        for l in 0..<3 {
+            let w = out["mtp.layers.\(l).mlp.switch_mlp.up_proj.weight"]
+            #expect(w != nil, "layer \(l) did not fuse")
+            #expect(w?.shape[0] == 2)
+        }
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/MTPExpertFusionTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/MTPExpertFusionTests.swift
@@ -96,6 +96,32 @@ struct MTPExpertFusionTests {
         #expect(out["mtp.layers.0.mlp.switch_mlp.gate_proj.weight"] == nil)
     }
 
+    /// MXFP8 ships no `biases`. Measured across the four Ornith-1.5-35B
+    /// bundles: JANG_2L/4M/6M each carry 2304 unfused MTP expert keys
+    /// (256 experts x 3 projections x weight/scales/biases) while MXFP8 carries
+    /// 1536 (256 x 3 x weight/scales). Fusing must therefore group per
+    /// (projection, component) rather than assuming a fixed component set --
+    /// otherwise the quant that ships two components silently fuses nothing.
+    @Test("an MXFP8-shaped expert set with no biases still fuses")
+    func mxfp8ShapeWithoutBiasesFuses() {
+        var w: [String: MLXArray] = [:]
+        for e in 0..<4 {
+            for proj in ["gate_proj", "up_proj", "down_proj"] {
+                for comp in ["weight", "scales"] {  // no biases, as MXFP8 ships
+                    w["mtp.layers.0.mlp.experts.\(e).\(proj).\(comp)"] =
+                        MLXArray([Float(e)]).reshaped([1, 1])
+                }
+            }
+        }
+        let out = Qwen35TextModel.fusingMTPExpertWeights(w, numExperts: 4)
+
+        #expect(out["mtp.layers.0.mlp.switch_mlp.gate_proj.weight"]?.shape[0] == 4)
+        #expect(out["mtp.layers.0.mlp.switch_mlp.gate_proj.scales"]?.shape[0] == 4)
+        // Must not invent a biases tensor the checkpoint never shipped.
+        #expect(out["mtp.layers.0.mlp.switch_mlp.gate_proj.biases"] == nil)
+        #expect(out.keys.contains { $0.contains(".mlp.experts.") } == false)
+    }
+
     /// Multiple MTP layers each fuse independently.
     @Test("each MTP layer fuses separately")
     func multipleLayersFuseIndependently() {

--- a/Tests/MLXLMCommonFocusedTests/MTPTuningFileShapeTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/MTPTuningFileShapeTests.swift
@@ -1,0 +1,128 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+//
+// `vmlx_mtp_tuning.json` is written in two shapes, and the reader understood
+// one of them.
+//
+// PR #278's depth sweep writes the measurement NESTED under `native_mtp`.
+// `stamp_qwen38_27b` writes the same keys FLAT at the top level. Only nested
+// decoded, so every flat file was silently ignored — indistinguishable, to the
+// runtime and to `rejectionReason`, from a bundle with no tuning file at all.
+//
+// Measured across ~/models on 2026-08-22 with the real inspector and the real
+// policy: of 15 bundles carrying a complete MTP artifact, exactly ONE
+// launched. Five Qwen3.8-27B bundles carried a flat `best_depth: 1` stamp the
+// runtime could not see.
+//
+// The second half matters as much as the first: reading the flat file must NOT
+// start launching unmeasured stamps. The launch gate is deliberately
+// fail-closed — depth has to come from artifact-local measurement, never from
+// a name or a hopeful default.
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite("MTP tuning file shape")
+struct MTPTuningFileShapeTests {
+
+    private func decode(_ json: String) throws -> NativeMTPTuning? {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mtptune-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try json.write(
+            to: dir.appendingPathComponent(NativeMTPTuning.fileName),
+            atomically: true,
+            encoding: .utf8)
+        return try MTPBundleInspector.nativeMTPTuningForTesting(from: dir)
+    }
+
+    /// The shape the sweep writes.
+    @Test("nested native_mtp still decodes")
+    func nestedShapeDecodes() throws {
+        let t = try decode(#"""
+        {"native_mtp": {"best_depth": 3, "validated": true, "output_equivalent": true,
+         "blocked": false, "baseline_tok_s": 17.5, "best_tok_s": 25.1,
+         "speedup_vs_baseline": 1.43}}
+        """#)
+        #expect(t?.bestDepth == 3)
+        #expect(t?.usableBestDepth == 3)
+    }
+
+    /// The shape the stamper writes — silently invisible before this.
+    @Test("flat top-level keys decode too")
+    func flatShapeDecodes() throws {
+        let t = try decode(#"""
+        {"best_depth": 1, "blocked": false, "quantization_mode": "affine",
+         "quantization_bits": 2, "model_types": ["qwen3_5"]}
+        """#)
+        #expect(t != nil, "a flat tuning file must not read as 'no tuning file'")
+        #expect(t?.bestDepth == 1)
+    }
+
+    /// …and reading it must not make it launchable. This is the shipped state
+    /// of five Qwen3.8-27B bundles: a `best_depth: 1` stamp whose own note says
+    /// "Conservative UNMEASURED default … run a depth sweep".
+    @Test("a flat UNMEASURED stamp still refuses to launch")
+    func flatUnmeasuredStampStillRefusesToLaunch() throws {
+        let t = try decode(#"""
+        {"best_depth": 1, "blocked": false,
+         "note": "Conservative UNMEASURED default: 1 draft/step."}
+        """#)
+        #expect(t?.bestDepth == 1)
+        #expect(
+            t?.usableBestDepth == nil,
+            "an unmeasured stamp must never auto-launch; depth comes from measurement")
+    }
+
+    /// Each missing measurement field independently blocks the launch, so a
+    /// partially-filled stamp cannot sneak through.
+    ///
+    /// Built by omitting one key at a time rather than by editing a JSON
+    /// string — a first cut did string surgery, one pattern silently failed to
+    /// match because of a newline, and the "drop" case still contained the key
+    /// it claimed to drop. A fixture that does not actually remove the thing
+    /// tests nothing.
+    @Test func everyMeasurementFieldIsRequired() throws {
+        let fields: [String: String] = [
+            "validated": "true",
+            "output_equivalent": "true",
+            "baseline_tok_s": "20.0",
+            "best_tok_s": "28.0",
+            "speedup_vs_baseline": "1.4",
+        ]
+
+        func json(omitting omitted: String?) -> String {
+            var pairs = ["\"best_depth\": 1", "\"blocked\": false"]
+            for (k, v) in fields.sorted(by: { $0.key < $1.key }) where k != omitted {
+                pairs.append("\"\(k)\": \(v)")
+            }
+            return "{" + pairs.joined(separator: ", ") + "}"
+        }
+
+        #expect(
+            try decode(json(omitting: nil))?.usableBestDepth == 1,
+            "a fully measured stamp must launch, or the omission cases below are vacuous")
+
+        for key in fields.keys.sorted() {
+            let body = json(omitting: key)
+            #expect(!body.contains(key), "fixture failed to omit \(key)")
+            #expect(
+                try decode(body)?.usableBestDepth == nil,
+                "omitting \(key) must block the launch")
+        }
+    }
+
+    /// A speedup that is not actually a speedup must not launch. Shipping MTP
+    /// that is slower than plain decode is the exact complaint that started
+    /// the MTP work.
+    @Test("a non-speedup never launches")
+    func nonSpeedupNeverLaunches() throws {
+        let t = try decode(#"""
+        {"best_depth": 2, "blocked": false, "validated": true, "output_equivalent": true,
+         "baseline_tok_s": 30.0, "best_tok_s": 29.0, "speedup_vs_baseline": 0.97}
+        """#)
+        #expect(t?.usableBestDepth == nil)
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/MTPTuningFileShapeTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/MTPTuningFileShapeTests.swift
@@ -126,3 +126,45 @@ struct MTPTuningFileShapeTests {
         #expect(t?.usableBestDepth == nil)
     }
 }
+
+@Suite("DFlash 2 default block size")
+struct DFlash2DefaultBlockSizeTests {
+
+    /// Blank used to mean "use the checkpoint's trained block_size", which is 8
+    /// — the worst value measured in every condition, and on prose slower than
+    /// not drafting at all:
+    ///
+    ///     condition       b4      b6      b8
+    ///     code, short     1.430   1.337   1.239
+    ///     prose, short    1.244   1.016   0.837  <- below baseline
+    ///     long ~7k        1.225   1.156   1.093
+    @Test("a blank setting no longer inherits the trained block size of 8")
+    func blankDefaultsToTheThroughputOptimum() {
+        #expect(VMLXServerRuntimeSettings.throughputOptimalDFlash2Block(trained: 8) == 4)
+        #expect(VMLXServerRuntimeSettings.throughputOptimalDFlash2Block(trained: 16) == 4)
+    }
+
+    /// Never ask a drafter to draft more positions than it was trained with.
+    @Test("a drafter trained smaller than the optimum is not overdriven")
+    func smallTrainedBlockIsNotExceeded() {
+        #expect(VMLXServerRuntimeSettings.throughputOptimalDFlash2Block(trained: 2) == 2)
+        #expect(VMLXServerRuntimeSettings.throughputOptimalDFlash2Block(trained: 3) == 3)
+    }
+
+    /// A nonsense value must not produce a zero or negative block.
+    @Test("a non-positive trained block falls back to the optimum")
+    func nonPositiveTrainedBlockFallsBack() {
+        #expect(VMLXServerRuntimeSettings.throughputOptimalDFlash2Block(trained: 0) == 4)
+        #expect(VMLXServerRuntimeSettings.throughputOptimalDFlash2Block(trained: -1) == 4)
+    }
+
+    /// An explicit user choice still wins — this changed the blank default only.
+    @Test("an explicit user block size is still honoured")
+    func explicitUserChoiceStillWins() {
+        var s = VMLXServerRuntimeSettings()
+        s.mtp.dflash2BlockSize = 8
+        #expect(s.mtp.dflash2BlockSize == 8)
+        s.mtp.dflash2BlockSize = nil
+        #expect(s.mtp.dflash2BlockSize == nil)
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/QwenMTPShippedDepthProbeTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/QwenMTPShippedDepthProbeTests.swift
@@ -28,7 +28,16 @@ struct QwenMTPShippedDepthProbeTests {
             let configData = try? Data(contentsOf: dir.appendingPathComponent("config.json"))
             let jang = try? JangLoader.loadConfig(at: dir)
             let status = try? MTPBundleInspector.inspect(modelDirectory: dir, jangConfig: jang)
-            guard let status, status.hasCompleteMTPArtifact else { continue }
+            guard let status else { continue }
+            let declaresMTP = (try? Data(contentsOf: url))
+                .flatMap { String(data: $0, encoding: .utf8) }?
+                .contains("\"mtp\"") ?? false
+            guard status.hasCompleteMTPArtifact || declaresMTP else { continue }
+            if !status.hasCompleteMTPArtifact {
+                print("MTPPROBE \(dir.path.replacingOccurrences(of: root.path + "/", with: "")) "
+                    + "-> DECLARES mtp BUT ARTIFACT INCOMPLETE: \(status.statusLine ?? "no status")")
+                continue
+            }
             let tuning = status.nativeMTPTuning
             let rec = NativeMTPAutoDecodePolicy.recommendation(
                 configData: configData, jangConfig: jang, status: status)

--- a/Tests/MLXLMCommonFocusedTests/QwenMTPShippedDepthProbeTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/QwenMTPShippedDepthProbeTests.swift
@@ -1,0 +1,45 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+//
+// Probe: what depth do the Qwen bundles ON THIS DISK actually launch at?
+//
+// Skips cleanly when ~/models is absent, so it is a local instrument rather
+// than a CI gate.
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite("qwen shipped MTP depth probe")
+struct QwenMTPShippedDepthProbeTests {
+    @Test("report the resolved launch depth for every local Qwen MTP bundle")
+    func reportShippedDepths() throws {
+        let root = URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("models")
+        guard FileManager.default.fileExists(atPath: root.path) else { return }
+
+        var found: [(String, String)] = []
+        let fm = FileManager.default
+        guard let e = fm.enumerator(at: root, includingPropertiesForKeys: nil) else { return }
+        for case let url as URL in e {
+            guard url.lastPathComponent == "config.json" else { continue }
+            let dir = url.deletingLastPathComponent()
+            if dir.path.contains("/Logs/") { continue }
+            let name = dir.path.replacingOccurrences(of: root.path + "/", with: "")
+            let configData = try? Data(contentsOf: dir.appendingPathComponent("config.json"))
+            let jang = try? JangLoader.loadConfig(at: dir)
+            let status = try? MTPBundleInspector.inspect(modelDirectory: dir, jangConfig: jang)
+            guard let status, status.hasCompleteMTPArtifact else { continue }
+            let tuning = status.nativeMTPTuning
+            let rec = NativeMTPAutoDecodePolicy.recommendation(
+                configData: configData, jangConfig: jang, status: status)
+            let verdict =
+                rec.map { "LAUNCHES depth=\($0.depth) verifier=\($0.verifierMode ?? "-")" }
+                ?? "NO MTP (tuning decoded=\(tuning != nil), usableBestDepth=\(String(describing: tuning?.usableBestDepth)), bestDepth=\(String(describing: tuning?.bestDepth)))"
+            found.append((name, verdict))
+        }
+        for (n, v) in found.sorted(by: { $0.0 < $1.0 }) {
+            print("MTPPROBE \(n) -> \(v)")
+        }
+        print("MTPPROBE total=\(found.count)")
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/ReasoningEffortSaltScopeTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/ReasoningEffortSaltScopeTests.swift
@@ -1,0 +1,121 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+//
+// What `effort=` in the cache scope salt actually costs.
+//
+// This file exists because of a wrong claim. The first pass looked at four
+// chat templates, wrote "all 8 templates that consume reasoning_effort render
+// it into the system message before anything else", and concluded that
+// changing effort mid-conversation always re-prefills and that the salt was
+// therefore free. Measured against the real library:
+//
+//   - 97 chat templates in ~/models
+//   - 8 files consume `reasoning_effort` — but only **2 distinct bodies**
+//     (6 + 2 copies across quant / CRACK variants, both in-house)
+//   - 75 use `enable_thinking`; 3 use `reasoning_strength` (Muse Glimmer)
+//
+// Two templates out of ninety-seven is not a property of the library, and for
+// the other ~89 the conclusion INVERTS. Their template never references
+// `reasoning_effort`, so the rendered prompt cannot depend on it — output
+// cannot vary with a variable the template never reads. The host still injects
+// `reasoning_effort` into `additionalContext` for the Qwen / Nemotron / Zaya /
+// generic branches, so the salt changes while the tokens do not.
+//
+// Identical tokens, different key, guaranteed miss. That is reuse thrown away
+// for nothing, which is the opposite of "the salt is free".
+//
+// These tests pin the mechanism so the cost is visible. If someone narrows the
+// salt to key off what the template actually consumes, the expectations here
+// SHOULD change deliberately rather than quietly.
+
+import Foundation
+import MLX
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite("reasoning-effort salt scope")
+struct ReasoningEffortSaltScopeTests {
+
+    /// The mechanism itself: two efforts, same everything else, different salt.
+    @Test("effort level alone changes the cache scope salt")
+    func effortLevelAloneChangesTheScopeSalt() {
+        let low = cacheScopeSalt(from: ["enable_thinking": true, "reasoning_effort": "low"])
+        let high = cacheScopeSalt(from: ["enable_thinking": true, "reasoning_effort": "high"])
+
+        #expect(low == "reasoning=on|effort=low")
+        #expect(high == "reasoning=on|effort=high")
+        #expect(low != high)
+    }
+
+    /// And it reaches the composed key, which is what the tiers actually probe.
+    /// A component that changed the scope string but washed out of the final
+    /// hash would cost nothing; this one does not wash out.
+    @Test("the effort difference survives into the composed cache salt")
+    func effortDifferenceSurvivesIntoTheComposedSalt() {
+        let tokens = MLXArray([Int32(1), 2, 3])
+        let lowInput = LMInput(
+            text: .init(tokens: tokens),
+            cacheScopeSalt: cacheScopeSalt(from: ["reasoning_effort": "low"]))
+        let highInput = LMInput(
+            text: .init(tokens: tokens),
+            cacheScopeSalt: cacheScopeSalt(from: ["reasoning_effort": "high"]))
+
+        let lowSalt = computeCacheSalt(for: lowInput)
+        let highSalt = computeCacheSalt(for: highInput)
+
+        #expect(lowSalt != nil)
+        #expect(lowSalt != highSalt)
+    }
+
+    /// Absent effort must NOT invent a component. A model that never receives
+    /// `reasoning_effort` has to keep the salt it would have had, or every
+    /// non-reasoning model would fragment its own cache.
+    @Test("no effort key means no effort component")
+    func absentEffortAddsNothing() {
+        #expect(cacheScopeSalt(from: ["enable_thinking": true]) == "reasoning=on")
+        #expect(cacheScopeSalt(from: [:]) == nil)
+        #expect(cacheScopeSalt(from: nil) == nil)
+
+        // Whitespace-only is absent, not a distinct level.
+        #expect(cacheScopeSalt(from: ["reasoning_effort": "   "]) == nil)
+    }
+
+    /// Case and surrounding whitespace must not fragment the cache: "High",
+    /// "high" and " HIGH " are one level, not three cache scopes.
+    @Test("effort is normalized so equivalent spellings share a scope")
+    func effortSpellingsShareOneScope() {
+        let a = cacheScopeSalt(from: ["reasoning_effort": "High"])
+        let b = cacheScopeSalt(from: ["reasoning_effort": " HIGH "])
+        let c = cacheScopeSalt(from: ["reasoning_effort": "high"])
+        #expect(a == c)
+        #expect(b == c)
+    }
+
+    /// Muse Glimmer is the family Eric named, and it is genuinely different:
+    /// it has no thinking tags, ignores `reasoning_effort` entirely, and reads
+    /// `reasoning_strength` — which the template DOES render, so there the
+    /// prompt really does change and the salt really is earning its keep.
+    @Test("Muse reasoning_strength is a separate, template-rendered scope")
+    func museStrengthIsItsOwnScope() {
+        let low = cacheScopeSalt(from: ["reasoning_strength": "low"])
+        let xhigh = cacheScopeSalt(from: ["reasoning_strength": "xhigh"])
+
+        #expect(low == "strength=low")
+        #expect(xhigh == "strength=xhigh")
+        #expect(low != xhigh)
+
+        // It composes with, rather than replaces, the reasoning flag.
+        #expect(
+            cacheScopeSalt(from: ["enable_thinking": true, "reasoning_strength": "medium"])
+                == "reasoning=on|strength=medium")
+    }
+
+    /// Turning thinking on and off is the case where the salt is unambiguously
+    /// correct: 75 of 97 templates branch on `enable_thinking`, so the rendered
+    /// prompt genuinely differs and the two scopes must not share KV.
+    @Test("thinking on/off remains a legitimately distinct scope")
+    func thinkingOnOffStaysDistinct() {
+        #expect(cacheScopeSalt(from: ["enable_thinking": true]) == "reasoning=on")
+        #expect(cacheScopeSalt(from: ["enable_thinking": false]) == "reasoning=off")
+    }
+}

--- a/Tests/MLXLMTests/DiskCacheQuotaEnforcementTests.swift
+++ b/Tests/MLXLMTests/DiskCacheQuotaEnforcementTests.swift
@@ -217,3 +217,69 @@ private func makeCacheDir() -> URL {
         #expect(late >= 0.75, "cache never reached the warning threshold; got \(late)")
     }
 }
+
+/// One boundary bigger than the whole cap must not take the cache down with it.
+///
+/// It used to. The store path writes the payload, indexes it, and only then
+/// runs the quota pass, which evicts oldest-first until the total is back under
+/// the cap. Work the arithmetic for a single entry `E` larger than the cap `C`,
+/// with `others` already resident: `excess = others + E - C`. Evicting every
+/// other entry accumulates only `others`, and `others < excess` exactly when
+/// `E > C` — so the loop kept going and evicted `E` as well.
+///
+/// The result was the worst of both: the oversized payload written to the SSD
+/// and immediately deleted, AND every previously-cached boundary deleted with
+/// it. Measured before the fix: two 70 KB entries under a 300 KB cap, then one
+/// 430 KB store — `currentEntryCount` went 2 → 0.
+///
+/// The store now measures the written file and drops just that file when it
+/// cannot possibly survive. The sizes here deliberately do not divide evenly
+/// into the cap.
+@Test func aSingleOversizedEntryDoesNotWipeTheRestOfTheCache() throws {
+    try MLXMetalTestLock.withLock {
+        let dir = makeCacheDir()
+        defer { try? FileManager.default.removeItem(at: dir) }
+
+        let cap = 300_000
+        let cache = DiskCache(cacheDir: dir, maxSizeBytes: cap, modelKey: "oversize")
+
+        // Two entries that comfortably coexist under the cap.
+        store(cache, tokens: [1, 1, 1], approximateBytes: 70_000)
+        store(cache, tokens: [2, 2, 2], approximateBytes: 70_000)
+
+        let before = cache.snapshotStats()
+        #expect(before.currentEntryCount == 2, "setup did not land two entries")
+
+        // One boundary larger than the entire cap — a long context on a model
+        // whose KV does not fit the configured share.
+        store(cache, tokens: [3, 3, 3], approximateBytes: 430_000)
+
+        let after = cache.snapshotStats()
+
+        // The oversized entry still cannot be resident; nothing it could evict
+        // makes room for it. That was never the defect.
+        #expect(
+            !cache.hasDurableEntry(tokens: [3, 3, 3]),
+            "an entry larger than the cap must not be left resident")
+
+        // The defect: the two innocent entries must survive.
+        #expect(
+            cache.hasDurableEntry(tokens: [1, 1, 1]),
+            "the oldest entry was evicted for a store that could never survive")
+        #expect(
+            cache.hasDurableEntry(tokens: [2, 2, 2]),
+            "an entry was evicted for a store that could never survive")
+        #expect(after.currentEntryCount == 2, "the cache was wiped by a doomed store")
+
+        // And no file was left behind on disk for the skipped payload.
+        #expect(
+            after.currentPayloadBytes <= cap,
+            "payload \(after.currentPayloadBytes) exceeded cap \(cap)")
+
+        // Nothing was evicted at all: the doomed write is dropped before the
+        // quota pass ever runs, so it cannot cost an existing boundary.
+        #expect(
+            after.evictions == before.evictions,
+            "a doomed store must not trigger eviction")
+    }
+}

--- a/Tests/MLXLMTests/QwenNativeMTPDepthSweepTests.swift
+++ b/Tests/MLXLMTests/QwenNativeMTPDepthSweepTests.swift
@@ -198,9 +198,22 @@ final class QwenNativeMTPDepthSweepTests: XCTestCase {
         let verifier = ProcessInfo.processInfo.environment["VMLX_MTP_SWEEP_VERIFIER"]
             .flatMap { $0.isEmpty ? nil : $0 }
 
-        struct Arm { let name: String; let depth: Int? }
-        let arms: [Arm] = [Arm(name: "baseline", depth: nil)]
-            + Self.depths.map { Arm(name: "mtp-d\($0)", depth: $0) }
+        // DFlash 2 block sizes, so the same prompt-class and context axes that
+        // decided the MTP depths can decide the block size too. The
+        // checkpoint's own trained block_size is what ships when the user
+        // leaves the setting blank, so "is the default the right value" is a
+        // question the harness has to be able to answer.
+        let dflashPath = ProcessInfo.processInfo.environment["VMLX_MTP_SWEEP_DFLASH2"]
+            .map { URL(fileURLWithPath: NSString(string: $0).expandingTildeInPath) }
+        let dflashBlocks = (ProcessInfo.processInfo.environment["VMLX_MTP_SWEEP_DFLASH2_BLOCKS"]
+            ?? "4,6,8").split(separator: ",").compactMap { Int($0.trimmingCharacters(in: .whitespaces)) }
+
+        struct Arm { let name: String; let depth: Int?; let dflashBlock: Int? }
+        var arms: [Arm] = [Arm(name: "baseline", depth: nil, dflashBlock: nil)]
+        arms += Self.depths.map { Arm(name: "mtp-d\($0)", depth: $0, dflashBlock: nil) }
+        if dflashPath != nil {
+            arms += dflashBlocks.map { Arm(name: "dflash-b\($0)", depth: nil, dflashBlock: $0) }
+        }
 
         func run(_ arm: Arm) async throws
             -> (text: String, seconds: Double, tokens: Int, mtp: String)
@@ -224,7 +237,13 @@ final class QwenNativeMTPDepthSweepTests: XCTestCase {
             p.topP = 1
             p.topK = 0
             p.minP = 0
-            p.draftStrategy = arm.depth.map { DraftStrategy.nativeMTP(depth: $0, verifierMode: verifier) }
+            if let block = arm.dflashBlock, let dflashPath {
+                p.draftStrategy = .dflash2(drafterPath: dflashPath, blockSize: block)
+            } else {
+                p.draftStrategy = arm.depth.map {
+                    DraftStrategy.nativeMTP(depth: $0, verifierMode: verifier)
+                }
+            }
 
             var text = ""
             var tokens = 0
@@ -287,7 +306,7 @@ final class QwenNativeMTPDepthSweepTests: XCTestCase {
                      baselineTPS, samples["baseline"]?.count ?? 0))
 
         var best: (depth: Int, tps: Double, equivalent: Bool)?
-        for arm in arms where arm.depth != nil {
+        for arm in arms where arm.depth != nil || arm.dflashBlock != nil {
             let tps = median(samples[arm.name] ?? [])
             let text = lastText[arm.name] ?? ""
             let equivalent = text == baselineText
@@ -308,8 +327,8 @@ final class QwenNativeMTPDepthSweepTests: XCTestCase {
                 try? baselineText.write(toFile: dir + "/baseline.txt", atomically: true, encoding: .utf8)
                 try? text.write(toFile: dir + "/\(arm.name).txt", atomically: true, encoding: .utf8)
             }
-            if best == nil || tps > best!.tps {
-                best = (arm.depth!, tps, equivalent)
+            if let d = arm.depth, best == nil || tps > best!.tps {
+                best = (d, tps, equivalent)
             }
         }
 

--- a/Tests/MLXLMTests/QwenNativeMTPDepthSweepTests.swift
+++ b/Tests/MLXLMTests/QwenNativeMTPDepthSweepTests.swift
@@ -57,11 +57,32 @@ final class QwenNativeMTPDepthSweepTests: XCTestCase {
     /// Prose, deliberately. A counting/deterministic prompt once produced a
     /// 1.83x MTP figure that did not survive contact with real text — an
     /// artifact of a prompt the drafter could trivially predict.
-    private static let prompt = """
-        Explain, in three well-developed paragraphs, how a write-ahead log lets a \
-        database survive a crash without losing committed transactions. Cover \
-        durability, recovery, and the trade-off against write amplification.
-        """
+    /// Prompt class is an axis, not a constant. The JANG_4D artifact records
+    /// prose 1.43x and code 1.80x — acceptance differs enough by content that
+    /// measuring one and generalising is how a 1.83x MTP number once got
+    /// published off a counting prompt.
+    private static var promptClass: String {
+        ProcessInfo.processInfo.environment["VMLX_MTP_SWEEP_PROMPT"]?.lowercased() ?? "prose"
+    }
+
+    private static var prompt: String {
+        switch promptClass {
+        case "code":
+            return """
+                Write a complete Swift implementation of a thread-safe LRU cache \
+                with a fixed capacity. Include the node type, the doubly-linked \
+                list operations, get and put, and a brief comment on why the lock \
+                is held where it is.
+                """
+        default:
+            return """
+                Explain, in three well-developed paragraphs, how a write-ahead log \
+                lets a database survive a crash without losing committed \
+                transactions. Cover durability, recovery, and the trade-off \
+                against write amplification.
+                """
+        }
+    }
 
     private func freeMemoryGB() -> Double {
         var stats = vm_statistics64_data_t()

--- a/Tests/MLXLMTests/QwenNativeMTPDepthSweepTests.swift
+++ b/Tests/MLXLMTests/QwenNativeMTPDepthSweepTests.swift
@@ -67,6 +67,25 @@ final class QwenNativeMTPDepthSweepTests: XCTestCase {
 
     private static var prompt: String {
         switch promptClass {
+        case "long":
+            // A realistic long conversation, not a short probe. The 56-token
+            // boundary measured earlier stored 124 MB in 27ms; DiskCache's own
+            // note records a ~357MB boundary taking ~25s, so the store cost has
+            // to be measured at depth before "SSD caching is free" can be said
+            // about real chats rather than about short prompts.
+            let para = """
+                The write-ahead log appends every mutation to durable storage \
+                before the corresponding page is modified in the buffer pool, so \
+                a crash can always be reconciled by replaying the log forward \
+                from the last checkpoint. Recovery proceeds in three phases: \
+                analysis rebuilds the dirty page table, redo reapplies committed \
+                work, and undo rolls back transactions that never reached a \
+                commit record.
+                """
+            return "Read the following notes, then write a detailed design "
+                + "review of the recovery protocol they describe.\n\n"
+                + Array(repeating: para, count: 40).joined(separator: "\n\n")
+                + "\n\nNow write the design review."
         case "code":
             return """
                 Write a complete Swift implementation of a thread-safe LRU cache \

--- a/Tests/MLXLMTests/QwenNativeMTPDepthSweepTests.swift
+++ b/Tests/MLXLMTests/QwenNativeMTPDepthSweepTests.swift
@@ -317,11 +317,39 @@ final class QwenNativeMTPDepthSweepTests: XCTestCase {
                 equivalent ? "YES" : "no", shared, baselineText.count,
                 lastMTP[arm.name] ?? "-"))
 
-            // A speculative path that diverges immediately is a broken forward,
-            // not a quantized near-tie. Say so rather than recording a number.
-            XCTAssertGreaterThan(
-                shared, 80,
-                "\(arm.name) diverged from baseline almost immediately — broken forward, not a near-tie")
+            // Different mechanisms promise different things, so assert what
+            // each one actually guarantees.
+            //
+            // Native MTP verifies against the target's own logits and is
+            // byte-identical on every bundle measured here, so any divergence
+            // is a real defect.
+            //
+            // DFlash 2 does NOT promise byte-equality on a quantized target.
+            // Its guarantee is that every emitted token is the verify forward's
+            // own argmax; a quantized matmul's reduction order depends on row
+            // count, so an M = 1+block verify produces logits a few ulp from
+            // the M = 1 decode forward and a greedy near-tie can legitimately
+            // flip — at ANY position, including an early one.
+            //
+            // Measured instance: on JANG_2D the b4 arm diverges at char 76 of
+            // 967 because the model wrote "LRU cache with fixed capacity" where
+            // the baseline wrote "LRU (Least Recently Used) cache with a fixed
+            // capacity", then continued coherently for another ~900 chars
+            // (981 vs 967 total). A shared-prefix threshold would call that a
+            // broken forward. It is not one — so the DFlash arms are held to
+            // the property that actually distinguishes a near-tie from a
+            // broken forward: the completion keeps going and stays comparable
+            // in length, rather than truncating or degenerating.
+            if arm.depth != nil {
+                XCTAssertEqual(
+                    text, baselineText,
+                    "\(arm.name) is native MTP and must be byte-identical to baseline")
+            } else {
+                XCTAssertFalse(text.isEmpty, "\(arm.name) produced no text")
+                XCTAssertGreaterThan(
+                    Double(text.count), Double(baselineText.count) * 0.6,
+                    "\(arm.name) truncated or degenerated (\(text.count) vs \(baselineText.count) chars)")
+            }
 
             if let dir = ProcessInfo.processInfo.environment["VMLX_MTP_SWEEP_DUMP"] {
                 try? baselineText.write(toFile: dir + "/baseline.txt", atomically: true, encoding: .utf8)

--- a/Tests/MLXLMTests/QwenNativeMTPDepthSweepTests.swift
+++ b/Tests/MLXLMTests/QwenNativeMTPDepthSweepTests.swift
@@ -1,0 +1,252 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+//
+// Depth sweep that produces the artifact `NativeMTPAutoDecodePolicy` demands.
+//
+// The launch gate is deliberately fail-closed: `usableBestDepth` returns nil
+// unless the bundle's own `vmlx_mtp_tuning.json` carries `validated`,
+// `output_equivalent`, `baseline_tok_s`, `best_tok_s` and a `speedup_vs_baseline`
+// above 1. Five Qwen3.8-27B bundles ship a `best_depth: 1` stamp whose own note
+// says "Conservative UNMEASURED default: 1 draft/step. Run a depth sweep." —
+// so they do not launch. This is that sweep. It writes nothing on its own; it
+// prints a JSON block to paste into the bundle, because a measurement that the
+// runtime will trust must come from a run someone can point at.
+//
+// Method follows the rules those numbers are held to:
+//
+//   - ABAB interleaved, never A-then-B. Sequential A/B on a loaded box once
+//     fabricated a 29% regression that did not exist.
+//   - >= 3 hot rounds at a FIXED condition, MEDIAN reported. One sample is not
+//     a finding, and the first round after load is discarded as cold.
+//   - Free memory logged before EVERY leg. A timing claim taken while the box
+//     is paging is a claim about the box, not the code.
+//   - Greedy (temp 0) so `output_equivalent` means something.
+//
+// Usage:
+//   VMLX_MTP_SWEEP_TARGET=~/models/JANGQ-AI/Qwen3.8-27B-JANG_2D \
+//   DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
+//   swift test --filter QwenNativeMTPDepthSweepTests
+
+import Foundation
+import MLX
+import XCTest
+@preconcurrency import VMLXTokenizers
+
+@testable import MLXHuggingFace
+@testable import MLXLLM
+@testable import MLXLMCommon
+@testable import MLXVLM
+
+final class QwenNativeMTPDepthSweepTests: XCTestCase {
+
+    private static var targetPath: String? {
+        ProcessInfo.processInfo.environment["VMLX_MTP_SWEEP_TARGET"]
+            .map { NSString(string: $0).expandingTildeInPath }
+    }
+
+    /// Depths to sweep. `1` is the shipping question; the others are context,
+    /// because "depth 1 is best" is only meaningful against a neighbour.
+    private static var depths: [Int] {
+        (ProcessInfo.processInfo.environment["VMLX_MTP_SWEEP_DEPTHS"] ?? "1,2,3")
+            .split(separator: ",").compactMap { Int($0.trimmingCharacters(in: .whitespaces)) }
+    }
+
+    private static var rounds: Int {
+        Int(ProcessInfo.processInfo.environment["VMLX_MTP_SWEEP_ROUNDS"] ?? "4") ?? 4
+    }
+
+    /// Prose, deliberately. A counting/deterministic prompt once produced a
+    /// 1.83x MTP figure that did not survive contact with real text — an
+    /// artifact of a prompt the drafter could trivially predict.
+    private static let prompt = """
+        Explain, in three well-developed paragraphs, how a write-ahead log lets a \
+        database survive a crash without losing committed transactions. Cover \
+        durability, recovery, and the trade-off against write amplification.
+        """
+
+    private func freeMemoryGB() -> Double {
+        var stats = vm_statistics64_data_t()
+        var count = mach_msg_type_number_t(
+            MemoryLayout<vm_statistics64_data_t>.size / MemoryLayout<integer_t>.size)
+        let result = withUnsafeMutablePointer(to: &stats) {
+            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                host_statistics64(mach_host_self(), HOST_VM_INFO64, $0, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else { return -1 }
+        let page = Double(sysconf(_SC_PAGESIZE))
+        return Double(stats.free_count) * page / 1_073_741_824.0
+    }
+
+    private func median(_ xs: [Double]) -> Double {
+        guard !xs.isEmpty else { return 0 }
+        let s = xs.sorted()
+        return s.count % 2 == 1
+            ? s[s.count / 2]
+            : (s[s.count / 2 - 1] + s[s.count / 2]) / 2
+    }
+
+    func testDepthSweep() async throws {
+        guard let targetPath = Self.targetPath else {
+            throw XCTSkip("Set VMLX_MTP_SWEEP_TARGET to a Qwen bundle with an MTP artifact")
+        }
+        let dir = URL(fileURLWithPath: targetPath)
+
+        let status = try MTPBundleInspector.inspect(modelDirectory: dir)
+        guard status.hasCompleteMTPArtifact else {
+            throw XCTSkip("\(dir.lastPathComponent) has no complete MTP artifact")
+        }
+
+        // The MTP head must be BUILT at load, or every speculative arm dies
+        // with "the loaded model has no active MTP head". In the product that
+        // flag comes from `resolveNativeMTPLaunchPlan`, which consults the very
+        // tuning file this sweep exists to produce — so measuring requires
+        // forcing it on here. Measured 2026-08-22 on JANG_2D: without this the
+        // baseline ran at 18.66 tok/s and all three MTP arms threw.
+        var loadConfiguration = LoadConfiguration.default
+        loadConfiguration.nativeMTP = true
+        let (context, _) = try await MLXLMCommon.loadModel(
+            from: dir,
+            using: #huggingFaceTokenizerLoader(),
+            loadConfiguration: loadConfiguration)
+        nonisolated(unsafe) let ctx = context
+        let maxTokens = 256
+
+        // The verifier mode is part of the measurement, not a detail. The
+        // shipped JANG_4D artifact records `input_capture_staged`; a sweep that
+        // leaves it nil measures a DIFFERENT decode path and would stamp a
+        // verifier it never ran.
+        let verifier = ProcessInfo.processInfo.environment["VMLX_MTP_SWEEP_VERIFIER"]
+            .flatMap { $0.isEmpty ? nil : $0 }
+
+        struct Arm { let name: String; let depth: Int? }
+        let arms: [Arm] = [Arm(name: "baseline", depth: nil)]
+            + Self.depths.map { Arm(name: "mtp-d\($0)", depth: $0) }
+
+        func run(_ arm: Arm) async throws
+            -> (text: String, seconds: Double, tokens: Int, mtp: String)
+        {
+            let input = try await ctx.processor.prepare(
+                input: UserInput(chat: [.user(Self.prompt)]))
+            var p = GenerateParameters(
+                generationConfig: ctx.configuration.generationDefaults,
+                fallback: GenerateParameters(maxTokens: maxTokens, prefillStepSize: 1024))
+            p.maxTokens = maxTokens
+            p.prefillStepSize = 1024
+            p.temperature = 0
+            p.topP = 1
+            p.topK = 0
+            p.minP = 0
+            p.draftStrategy = arm.depth.map { DraftStrategy.nativeMTP(depth: $0, verifierMode: verifier) }
+
+            var text = ""
+            var tokens = 0
+            // What actually RAN. Requesting depth 3 does not mean depth 3
+            // executed: #283 added adaptive depth (it can downshift mid-run)
+            // and #284 fixed a prose first turn locking MTP off for the whole
+            // residency. A sweep that records only the REQUESTED depth would
+            // attribute an adaptive downshift to the depth setting.
+            var mtpNote = "-"
+            let start = Date()
+            for await item in try MLXLMCommon.generate(
+                input: input, parameters: p, context: ctx)
+            {
+                switch item {
+                case .chunk(let c): text += c
+                case .reasoning(let c): text += c
+                case .info(let info):
+                    tokens = info.generationTokenCount
+                    if let s = info.nativeMTPStats {
+                        mtpNote = String(
+                            format: "active=%d/%d commit=%.2f downshifts=%d reason=%@",
+                            s.activeDepth, s.depth, s.avgCommittedPerVerify,
+                            s.adaptiveDownshifts, s.adaptiveFallbackReason ?? "-")
+                    }
+                default: break
+                }
+            }
+            return (text, Date().timeIntervalSince(start), tokens, mtpNote)
+        }
+
+        // ABAB: every round runs every arm, so drift in machine state hits all
+        // arms equally instead of being attributed to whichever ran second.
+        var samples: [String: [Double]] = [:]
+        var lastText: [String: String] = [:]
+        var lastMTP: [String: String] = [:]
+        for round in 1...Self.rounds {
+            for arm in arms {
+                Memory.clearCache()
+                let free = freeMemoryGB()
+                let r = try await run(arm)
+                let tps = Double(r.tokens) / Swift.max(r.seconds, 0.001)
+                print(String(
+                    format: "[mtpsweep r%d] %-10s free=%5.1fGB %4d tok %7.2fs %7.2f tok/s  %@",
+                    round, (arm.name as NSString).utf8String!, free, r.tokens, r.seconds, tps,
+                    r.mtp))
+                // Round 1 is cold — discard it rather than letting load and
+                // first-touch page faults masquerade as decode cost.
+                if round > 1 { samples[arm.name, default: []].append(tps) }
+                lastText[arm.name] = r.text
+                lastMTP[arm.name] = r.mtp
+            }
+        }
+
+        let baselineTPS = median(samples["baseline"] ?? [])
+        XCTAssertGreaterThan(baselineTPS, 0, "baseline produced no samples")
+        let baselineText = lastText["baseline"] ?? ""
+        XCTAssertFalse(baselineText.isEmpty, "baseline produced no text — the sweep is vacuous")
+
+        print(String(format: "\n[mtpsweep] baseline median %.2f tok/s (n=%d)",
+                     baselineTPS, samples["baseline"]?.count ?? 0))
+
+        var best: (depth: Int, tps: Double, equivalent: Bool)?
+        for arm in arms where arm.depth != nil {
+            let tps = median(samples[arm.name] ?? [])
+            let text = lastText[arm.name] ?? ""
+            let equivalent = text == baselineText
+            let shared = zip(text, baselineText).prefix { $0 == $1 }.count
+            print(String(
+                format: "[mtpsweep] %-10s median %.2f tok/s  speedup %.3fx  equivalent=%@ sharedPrefix=%d/%d  %@",
+                (arm.name as NSString).utf8String!, tps, tps / Swift.max(baselineTPS, 0.001),
+                equivalent ? "YES" : "no", shared, baselineText.count,
+                lastMTP[arm.name] ?? "-"))
+
+            // A speculative path that diverges immediately is a broken forward,
+            // not a quantized near-tie. Say so rather than recording a number.
+            XCTAssertGreaterThan(
+                shared, 80,
+                "\(arm.name) diverged from baseline almost immediately — broken forward, not a near-tie")
+
+            if best == nil || tps > best!.tps {
+                best = (arm.depth!, tps, equivalent)
+            }
+        }
+
+        guard let best else { return }
+        let speedup = best.tps / Swift.max(baselineTPS, 0.001)
+
+        // Print, never write. The gate trusts this file; a sweep that silently
+        // stamps its own result would let a bad run enable itself.
+        print("""
+
+            [mtpsweep] paste into \(dir.path)/vmlx_mtp_tuning.json —
+            {
+              "native_mtp": {
+                "best_depth": \(best.depth),
+                "validated": true,
+                "output_equivalent": \(best.equivalent),
+                "blocked": false,
+                "baseline_tok_s": \(String(format: "%.2f", baselineTPS)),
+                "best_tok_s": \(String(format: "%.2f", best.tps)),
+                "speedup_vs_baseline": \(String(format: "%.3f", speedup)),
+                "artifact": "\(dir.lastPathComponent)",
+                "measured_at": "<date>",
+                "note": "ABAB, \(Self.rounds) rounds, round 1 discarded as cold, median of the rest, prose prompt, temp 0"
+              }
+            }
+
+            [mtpsweep] NOTE: speedup \(String(format: "%.3f", speedup))x — \
+            the gate refuses anything <= 1.0, so this bundle \
+            \(speedup > 1.0 ? "would launch" : "must NOT be stamped as launchable").
+            """)
+    }
+}

--- a/Tests/MLXLMTests/QwenNativeMTPDepthSweepTests.swift
+++ b/Tests/MLXLMTests/QwenNativeMTPDepthSweepTests.swift
@@ -153,6 +153,19 @@ final class QwenNativeMTPDepthSweepTests: XCTestCase {
         // explicitly makes "none / paged / disk" a controlled comparison rather
         // than an unstated condition -- and every number measured before this
         // axis existed was a no-cache number.
+        // MLX's buffer cache regrows after every clearCache, and on a box that
+        // is already sharing RAM with another large process that overhead is
+        // what pushes free memory to ~1GB and makes timings untrustworthy
+        // (a 16GB model was consuming ~29GB resident). Capping it applies
+        // EQUALLY to every arm, so the speedup ratio stays a valid comparison
+        // while the run actually fits.
+        if let mb = ProcessInfo.processInfo.environment["VMLX_MTP_SWEEP_CACHE_MB"],
+            let bytes = Int(mb).map({ $0 * 1_048_576 })
+        {
+            MLX.GPU.set(cacheLimit: bytes)
+            print("[mtpsweep] MLX cache limit = \(mb) MB")
+        }
+
         let cacheTier = ProcessInfo.processInfo.environment["VMLX_MTP_SWEEP_CACHE"]?
             .lowercased() ?? "none"
         let (context, _) = try await MLXLMCommon.loadModel(

--- a/Tests/MLXLMTests/QwenNativeMTPDepthSweepTests.swift
+++ b/Tests/MLXLMTests/QwenNativeMTPDepthSweepTests.swift
@@ -125,11 +125,38 @@ final class QwenNativeMTPDepthSweepTests: XCTestCase {
         // baseline ran at 18.66 tok/s and all three MTP arms threw.
         var loadConfiguration = LoadConfiguration.default
         loadConfiguration.nativeMTP = true
+
+        // Cache tier is an axis. A bare `ModelContext` has NO coordinator at
+        // all -- `CacheCoordinatorConfig.enableDiskCache` defaults to false and
+        // the coordinator normally lives on `ModelContainer`. So a sweep that
+        // loads a context and calls `generate` measures the engine with ZERO
+        // caching, which is NOT what the app runs. Passing a coordinator
+        // explicitly makes "none / paged / disk" a controlled comparison rather
+        // than an unstated condition -- and every number measured before this
+        // axis existed was a no-cache number.
+        let cacheTier = ProcessInfo.processInfo.environment["VMLX_MTP_SWEEP_CACHE"]?
+            .lowercased() ?? "none"
         let (context, _) = try await MLXLMCommon.loadModel(
             from: dir,
             using: #huggingFaceTokenizerLoader(),
             loadConfiguration: loadConfiguration)
         nonisolated(unsafe) let ctx = context
+
+        let coordinator: CacheCoordinator?
+        switch cacheTier {
+        case "paged":
+            coordinator = CacheCoordinator(
+                config: CacheCoordinatorConfig(
+                    enableDiskCache: false, modelKey: dir.lastPathComponent))
+        case "disk":
+            coordinator = CacheCoordinator(
+                config: CacheCoordinatorConfig(
+                    enableDiskCache: true, modelKey: dir.lastPathComponent))
+        default:
+            coordinator = nil
+        }
+        nonisolated(unsafe) let coord = coordinator
+        print("[mtpsweep] cache tier = \(cacheTier)")
         let maxTokens = 256
 
         // The verifier mode is part of the measurement, not a detail. The
@@ -146,8 +173,16 @@ final class QwenNativeMTPDepthSweepTests: XCTestCase {
         func run(_ arm: Arm) async throws
             -> (text: String, seconds: Double, tokens: Int, mtp: String)
         {
+            // Reasoning is an axis too. With thinking on, a large share of the
+            // generated tokens are hidden reasoning, and the acceptance the
+            // controller reads is acceptance on THAT text — not on the answer
+            // the user waits for.
+            var context: [String: any Sendable]? = nil
+            if let r = ProcessInfo.processInfo.environment["VMLX_MTP_SWEEP_REASONING"] {
+                context = ["enable_thinking": !(["0", "off", "false", "no"].contains(r.lowercased()))]
+            }
             let input = try await ctx.processor.prepare(
-                input: UserInput(chat: [.user(Self.prompt)]))
+                input: UserInput(chat: [.user(Self.prompt)], additionalContext: context))
             var p = GenerateParameters(
                 generationConfig: ctx.configuration.generationDefaults,
                 fallback: GenerateParameters(maxTokens: maxTokens, prefillStepSize: 1024))
@@ -169,7 +204,7 @@ final class QwenNativeMTPDepthSweepTests: XCTestCase {
             var mtpNote = "-"
             let start = Date()
             for await item in try MLXLMCommon.generate(
-                input: input, parameters: p, context: ctx)
+                input: input, parameters: p, context: ctx, cacheCoordinator: coord)
             {
                 switch item {
                 case .chunk(let c): text += c
@@ -237,6 +272,10 @@ final class QwenNativeMTPDepthSweepTests: XCTestCase {
                 shared, 80,
                 "\(arm.name) diverged from baseline almost immediately — broken forward, not a near-tie")
 
+            if let dir = ProcessInfo.processInfo.environment["VMLX_MTP_SWEEP_DUMP"] {
+                try? baselineText.write(toFile: dir + "/baseline.txt", atomically: true, encoding: .utf8)
+                try? text.write(toFile: dir + "/\(arm.name).txt", atomically: true, encoding: .utf8)
+            }
             if best == nil || tps > best!.tps {
                 best = (arm.depth!, tps, equivalent)
             }

--- a/Tests/MLXLMTests/QwenNativeMTPDepthSweepTests.swift
+++ b/Tests/MLXLMTests/QwenNativeMTPDepthSweepTests.swift
@@ -226,6 +226,16 @@ final class QwenNativeMTPDepthSweepTests: XCTestCase {
             if let r = ProcessInfo.processInfo.environment["VMLX_MTP_SWEEP_REASONING"] {
                 context = ["enable_thinking": !(["0", "off", "false", "no"].contains(r.lowercased()))]
             }
+            // Reasoning EFFORT is its own axis. A prior measurement found b15
+            // best on code at effort `medium` while the default effort here is
+            // xhigh -- so "which block size wins" may be conditioned on how
+            // predictable the model's own output is.
+            if let e = ProcessInfo.processInfo.environment["VMLX_MTP_SWEEP_EFFORT"] {
+                var c = context ?? [:]
+                c["enable_thinking"] = true
+                c["reasoning_effort"] = e
+                context = c
+            }
             let input = try await ctx.processor.prepare(
                 input: UserInput(chat: [.user(Self.prompt)], additionalContext: context))
             var p = GenerateParameters(

--- a/Tests/MLXLMTests/QwenNativeMTPDepthSweepTests.swift
+++ b/Tests/MLXLMTests/QwenNativeMTPDepthSweepTests.swift
@@ -84,7 +84,7 @@ final class QwenNativeMTPDepthSweepTests: XCTestCase {
                 """
             return "Read the following notes, then write a detailed design "
                 + "review of the recovery protocol they describe.\n\n"
-                + Array(repeating: para, count: 40).joined(separator: "\n\n")
+                + Array(repeating: para, count: Int(ProcessInfo.processInfo.environment["VMLX_MTP_SWEEP_LONG_REPEAT"] ?? "40") ?? 40).joined(separator: "\n\n")
                 + "\n\nNow write the design review."
         case "code":
             return """


### PR DESCRIPTION
## Measured, not reasoned about

Two 70 KB entries under a 300 KB cap, then one 430 KB store:
`currentEntryCount` went **2 → 0**.

## Why

The store path writes the payload, indexes it, then runs the quota pass, which
evicts oldest-first until the total is back under the cap. For a single entry
`E` larger than the cap `C` with `others` already resident:

    excess = others + E - C

Evicting every other entry accumulates only `others`, and `others < excess`
exactly when `E > C` — so the loop kept going and evicted `E` too. Worst of
both outcomes: the oversized file written to the SSD and immediately deleted,
**and** every previously cached boundary deleted with it.

## Fix

Decide on the **measured** file size, not an estimate from `nbytes` — the
serializer may quantize or compress, so an estimate could drop a store that
would in fact have fit. Costs one write that was going to happen anyway, and
leaves the cache intact.

This is not a cap on what a caller may do: the request has already produced its
output, and an entry the existing quota pass would delete microseconds later is
not being taken away from anyone.

## Reachability — stated plainly, because it matters

**This hole is NOT on the shipping path.** `CacheCoordinator` passes
`enforceQuota: !usesCombinedQuota`, and `usesCombinedQuota =
config.enableDiskCache` — so whenever the disk cache is on, the combined pass
owns the quota, and that path already refuses an oversized newest boundary
while keeping the prior fitting prefix
(`combinedQuotaRejectsOversizedNewestBoundaryButPreservesPriorFittingPrefix`).

What this closes is the public `store(tokens:arrays:mediaSalt:)` surface, which
enforces `DiskCache`'s own quota and had no such protection. Real, measured,
and worth closing — but **defense in depth, not a live user-facing bug**. I am
not going to describe it as more than it is.

## Tests

`swift test --filter "uota|DiskCache|iskCache"` → **60/60 in 3 suites**,
including the inverted characterization
`aSingleOversizedEntryDoesNotWipeTheRestOfTheCache`, which asserted the wipe
before the fix and asserts the survivors after it.

Note this repo's `pull_request.yml` is gated on
`github.repository == 'ml-explore/mlx-swift'`, so every job reports *skipping*
on this fork — the local run above is the only gate there is.