### PR TITLE
Presence and frequency penalties apply to generated tokens only

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -928,9 +928,23 @@ public struct PresencePenaltyContext: LogitProcessor {
         self.ring = TokenRing(capacity: presenceContextSize)
     }
 
-    mutating public func prompt(_ prompt: MLXArray) {
-        ring.loadPrompt(prompt)
-    }
+    /// DELIBERATELY EMPTY: the presence penalty applies to GENERATED tokens only.
+    ///
+    /// `presence_penalty` is OpenAI's parameter, and vLLM — the reference implementation most
+    /// published values are measured against — computes it from `output_tokens` alone:
+    ///
+    ///     output_bin_counts, output_mask = get_token_bin_counts_and_mask(output_tokens_tensor, …)
+    ///     logits -= presence_penalties.unsqueeze(dim=1) * output_mask
+    ///
+    /// Seeding the ring with the prompt penalises tokens the model never chose. With a long prompt the
+    /// window can be ENTIRELY prompt at the first decode step, so the opening tokens are penalised for
+    /// the user's wording. Qwen publishes `presence_penalty: 1.5` for non-thinking operation against
+    /// that definition; applying it to prompt tokens measures something its authors did not specify.
+    ///
+    /// NOTE the contrast with `RepetitionContext`, which SHOULD keep seeding the prompt: HuggingFace's
+    /// `repetition_penalty` is defined over `input_ids`, prompt included. The parameters differ in
+    /// scope, so they differ here.
+    mutating public func prompt(_ prompt: MLXArray) {}
 
     public func process(logits: MLXArray) -> MLXArray {
         guard let indices = ring.validTokens?.asType(.uint32) else { return logits }
@@ -956,9 +970,10 @@ public struct FrequencyPenaltyContext: LogitProcessor {
         self.ring = TokenRing(capacity: frequencyContextSize)
     }
 
-    mutating public func prompt(_ prompt: MLXArray) {
-        ring.loadPrompt(prompt)
-    }
+    /// DELIBERATELY EMPTY, for the same reason as `PresencePenaltyContext.prompt`: `frequency_penalty`
+    /// is OpenAI's parameter and vLLM counts occurrences in `output_tokens` only. Counting prompt
+    /// occurrences would scale the penalty by how often the USER said a word.
+    mutating public func prompt(_ prompt: MLXArray) {}
 
     public func process(logits: MLXArray) -> MLXArray {
         guard let validTokens = ring.validTokens else { return logits }


### PR DESCRIPTION
**Correctness fix.** `presence_penalty` and `frequency_penalty` currently apply to the prompt as well as the
output, which is not what either parameter means. The change is two function bodies becoming empty.

`PresencePenaltyContext` and `FrequencyPenaltyContext` seed their ring with the prompt:

```swift
mutating public func prompt(_ prompt: MLXArray) {
    ring.loadPrompt(prompt)
}
```

so both penalise tokens **the model never chose**. `presence_penalty` and `frequency_penalty` are OpenAI's parameters, and vLLM — the implementation most published values are actually measured against — computes both from the **output** tokens alone (`vllm/model_executor/layers/sampler.py`, `apply_penalties`):

```python
output_bin_counts, output_mask = get_token_bin_counts_and_mask(
    output_tokens_tensor, vocab_size, num_seqs)
logits -= frequency_penalties.unsqueeze(dim=1) * output_bin_counts
logits -= presence_penalties.unsqueeze(dim=1) * output_mask
```

(vLLM's `prompt_tokens_tensor` feeds `repetition_penalties` only — the same split this PR makes.) HuggingFace has no `presence_penalty`/`frequency_penalty` at all, so vLLM/OpenAI is the whole of the published definition.

The divergence is not subtle at the boundary. `presenceContextSize` defaults to 20, and prompts are longer than 20 tokens essentially always, so at the **first decode step the window is 100% prompt**: every opening token is penalised for the *user's* wording, and only after 20 generated tokens does the window contain what the model actually said. `frequency_penalty` is worse in kind rather than degree — the penalty is scaled by a **count**, so a word the user repeated three times in the prompt is suppressed three times as hard.

This matters because real model cards ship these values. Qwen3 publishes `presence_penalty: 1.5` for non-thinking operation, and the Qwen3.6/3.8 bundles carry it in their sampling modes; under the current code that setting measures a quantity its authors did not specify. A user who copies a published sampling config gets neither the published behaviour nor a documented alternative.

**`RepetitionContext` is deliberately unchanged**, and that is the point of the split rather than an omission. HuggingFace defines `repetition_penalty` over `input_ids` — prompt included — in `RepetitionPenaltyLogitsProcessor`, so seeding it there is correct and matches *its* reference. The three processors share a shape but not a specification.

**Scope:** two functions in one file, each becoming a no-op body. No API change, no new parameter, nothing to migrate. Behaviour is identical wherever the prompt is shorter than the context window and no prompt token recurs across the boundary; it differs exactly where the current behaviour is wrong.

**A separate note, not part of this PR.** vLLM applies these penalties over *every* token generated so far — there is no window, because presence is a property of the whole output. The ring here is a 20-token window by default, so a token penalised at step 100 is forgiven by step 120 and penalised again at 140, which is a different function from the published one on any generation longer than the window. That one needs no patch: `presenceContextSize` is already a caller parameter, so a caller wanting conformance can size the ring to its own generation budget (we do). It may still be worth revisiting the **default** — 20 is a sensible default for `repetitionContextSize`, whose HF reference is also windowed in practice, but it is not a neutral default for a parameter whose reference has no window at all.
