### PR TITLE
Qwen3.5 VL: scatter image and video features onto their own placeholders

### DIFF
--- a/.claude/hookify.cache-percent-enforced.local.md
+++ b/.claude/hookify.cache-percent-enforced.local.md
@@ -1,0 +1,39 @@
+---
+name: cache-percent-enforced
+enabled: true
+event: stop
+pattern: .*
+action: warn
+---
+
+**Cache work: did you watch the WRITES and the EVICTIONS, against the % cap?**
+
+Only applies if this turn touched cache sizing, storage, eviction, prefix reuse,
+or the disk-L2 tier.
+
+The cap is a **percent of the SSD**, not gigabytes. Check the whole chain, not
+one link — each of these has already been found broken once:
+
+1. The share is **persisted** (`maxSizePercent` in `server-runtime.json`).
+2. Migration actually **runs** on load (`migrateToCurrentSchema` had zero call
+   sites and silently did nothing for every updating install).
+3. It reaches `CacheCoordinatorConfig.diskCacheMaxGB`.
+4. The **host-aware ceiling** is applied to what you DISPLAY, not just what is
+   enforced — Settings once promised 372 GB while the engine held 242 GB.
+5. A small share is **honoured**, not clamped up by a floor and not silently
+   disabling the tier.
+
+Then watch it actually happen:
+
+- **Writes**: is the cache still growing turn over turn? A cache that plateaus
+  BELOW its cap while turns run is not "settled", it is suspicious — that exact
+  observation is still UNEXPLAINED in the audit doc.
+- **Evictions**: measure before/after. Assert entries SURVIVE as well as
+  shrink; a cache that refused every write also looks small.
+- **Oldest-first across models**, not per-model budgets.
+
+Multimodal keying: every VLM `LMInput` must carry `cacheScopeSalt`. Unsalted
+media means same-text/different-image collides and answers fluently about the
+WRONG picture. `DeepseekOCRProcessor` was exactly this.
+
+Numbers or it did not happen. "The cap is applied" is not a measurement.

--- a/.claude/hookify.codex-parallel-today.local.md
+++ b/.claude/hookify.codex-parallel-today.local.md
@@ -1,0 +1,47 @@
+---
+name: codex-parallel-today
+enabled: true
+event: all
+pattern: .*
+action: warn
+---
+
+**TEMPORARY — today only. Delete this rule at end of day.**
+
+**Are you running Codex gpt-5.6-sol xhigh IN PARALLEL right now?**
+
+Not "spawn one and wait for it". Parallel means: fire Codex on an independent
+slice, then **keep working yourself** while it runs, and collect its report when
+it lands. If you are sitting idle waiting on a Codex call, you are doing it
+wrong. If you did a whole audit/scan/probe alone that Codex could have run
+alongside you, you wasted it.
+
+Invocation — never `fast` mode:
+
+```bash
+codex exec -m gpt-5.6-sol -c model_reasoning_effort="xhigh" \
+  --sandbox danger-full-access -C <repo> "<prompt>" > /tmp/codex-<slice>.log 2>&1 &
+```
+
+Run several at once on **disjoint** slices so their findings don't collide.
+
+**Every prompt must be specific and must demand a report back.** A vague prompt
+returns a vague answer that costs you a turn to re-ask. Each one states:
+
+1. the exact files/paths/symbols to look at
+2. the precise question, with the failure shape you suspect
+3. what would prove it either way — a command to run, a test to write, a
+   measurement to take
+4. **"Report back: what you checked, what you found, the exact file:line for
+   every claim, what you ruled OUT and why, what you could not determine, and
+   what you would look at next."**
+
+Then use what comes back — cross-check its file:line claims before acting on
+them. Codex is a second perspective, not an oracle; it has been confidently
+wrong here before. Verify, then act.
+
+Good parallel slices for the current campaign: SSD block prefix/suffix
+best-match reuse, MoE + SwiGLU JIT-compile opportunities, upstream mlx-swift /
+mlx-swift-examples / mlx_vlm commits worth porting, max-context enforcement and
+compaction trigger timing, SSM/TQ q4 correctness, tool-call JSON vs XML
+parsing.

--- a/.claude/hookify.harness-proof.local.md
+++ b/.claude/hookify.harness-proof.local.md
@@ -1,0 +1,42 @@
+---
+name: harness-proof
+enabled: true
+event: stop
+pattern: .*
+action: warn
+---
+
+**Did you prove it in the running harness — visually, with variation?**
+
+Exempt only if this turn changed no osaurus/vmlx behaviour (docs, notes, pure
+research). Say so in one line and move on.
+
+Otherwise every behaviour claim needs proof from the RUNNING app. Not curl.
+Not the HTTP API. Not RunBench. Not "the unit test passes" — a test proves
+code is CORRECT, never that it RUNS. Two migrations and a disabled cache tier
+shipped this session precisely because something was correct and unreachable.
+
+**Get that proof from instrumentation, not by driving chat turns.** The traces
+answer more, faster, and exactly: `VMLX_CACHE_FETCH_TRACE=1` for salts, store
+hashes and `SKIP validated`; `OSAURUS_TTFT_TRACE=1` for per-phase TTFT; the
+app log; the config JSON; the cache index. Driving turns is banned — see
+`no-driving-turns`.
+
+Per turn, the proof must VARY — a repeated identical prompt proves caching, not
+behaviour:
+
+- **Multimodality varies per turn**: text → image → video → audio, mixed with
+  tools in the same turn. Named families: qwen / muse / gemma VL for video and
+  image, gemma-E2B for audio.
+- **Reasoning effort changes mid-conversation**, not just between runs. Watch
+  what that does to the cached prefix: if the effort directive sits above the
+  static/dynamic boundary, changing it invalidates the whole prefix and forces
+  a full re-prefill. Measure the cost; do not assume it is cheap.
+- **Long context**: show sustained tok/s as the conversation grows, not one
+  short turn. Speed must not degrade as context grows.
+
+Screenshot with `screencapture -l <windowID>` — window-scoped, never
+full-screen (a full-screen grab once photographed Eric's API tokens).
+
+State plainly which of these you did and which you did NOT. A gap named is
+fine; a gap glossed over is not.

--- a/.claude/hookify.list-and-record.local.md
+++ b/.claude/hookify.list-and-record.local.md
@@ -1,0 +1,21 @@
+---
+name: list-and-record
+enabled: true
+event: stop
+pattern: .*
+action: warn
+---
+
+**Follow the list. Write down what you did.**
+
+- Is there an open to-do list for this work? Work the next item on it rather
+  than inventing a new direction. If you finished an item, mark it.
+- Did you record what was **done**, what was **tested**, and what is **still
+  open** — in the campaign/feature doc, not only in chat? Chat is lost; the doc
+  is what the next session reads.
+- Record **failures and dead ends too**. A ruled-out cause saves the next
+  session a day; an undocumented one gets re-derived.
+- For the feature you touched: which **edge cases** did you test, and which do
+  you know you skipped? Name them. The skipped ones are the honest part.
+- New findings become new list items immediately, with enough detail to act on
+  cold — file, symptom, and how to reproduce.

--- a/.claude/hookify.measured-not-inferred.local.md
+++ b/.claude/hookify.measured-not-inferred.local.md
@@ -1,0 +1,23 @@
+---
+name: measured-not-inferred
+enabled: true
+event: stop
+pattern: .*
+action: warn
+---
+
+**Was the number measured, or inferred?**
+
+Only applies to claims you are about to make about speed, cache behaviour or
+correctness.
+
+- Speed: hot **ABAB**, never A-then-B, and log `PhysMem` before each leg. A
+  saturated box has fabricated a 29% regression here before.
+- Long context: report the **curve** (2k/8k/16k/32k), not one point, and say
+  whether decay is depth-dependent or flat. DSV4 turned out flat when it
+  "obviously" sagged.
+- One sample is not a finding. Three at a fixed condition, median reported.
+- Suspect the harness first when a result looks alarming or reassuring. Assert
+  a non-empty baseline so an empty-vs-empty comparison cannot read as PASS.
+- Test a size that does NOT divide evenly by the step/page/block.
+- If you did not measure it, say "unverified" — never "fixed" or "working".

--- a/.claude/hookify.no-driving-turns.local.md
+++ b/.claude/hookify.no-driving-turns.local.md
@@ -1,0 +1,33 @@
+---
+name: no-driving-turns
+enabled: true
+event: bash
+action: block
+pattern: codex\s+exec
+---
+
+**Do not drive chat turns to "prove" things. Eric has said no.**
+
+Spawning Codex to click through the app and send prompts burns 40-80k tokens
+per run, takes minutes, and repeatedly produced nothing usable — six attempts
+at a cold-load chip all returned warm turns because the app warms the model on
+window open. Eric's words: *"i said no turns bs"*.
+
+Read the instrumentation instead. It is already there and it is decisive:
+
+- `VMLX_CACHE_FETCH_TRACE=1` — prints raw pre-hash salt components, store
+  hashes, `SKIP validated`, and `noRow`. This single trace explained the cache
+  "plateau" that six driven turns had failed to explain.
+- `OSAURUS_TTFT_TRACE=1` → `/tmp/osaurus_ttft_trace.log` — per-phase TTFT
+  breakdown. This is what showed `load_container_done = 0.0 ms` for a 17 GB
+  model and corrected a wrong root-cause claim.
+- The app's own log in `$OSAURUS_TEST_ROOT` — model load, mmap, quant walk.
+- The config JSON on disk — what actually persisted.
+- The cache index SQLite — entries, sizes, `created_at`.
+
+A log line with the real number beats a screenshot of a number, and costs
+nothing.
+
+If a GUI action is genuinely the only way (clicking a control that has no
+other trigger), do the SMALLEST possible one and say why the instrumentation
+could not answer it. Do not run multi-turn conversations.

--- a/.claude/hookify.no-merge-without-proof.local.md
+++ b/.claude/hookify.no-merge-without-proof.local.md
@@ -1,0 +1,29 @@
+---
+name: no-merge-without-proof
+enabled: true
+event: bash
+action: block
+pattern: gh\s+pr\s+merge
+---
+
+**Never merge without full proof.**
+
+Green CI is not proof. CI runs unit tests, and a unit test proves code is
+CORRECT, not that it RUNS. This session merged work whose migration had zero
+call sites — all checks green, feature completely inert.
+
+Before merging, you must have:
+
+1. **Live visual proof** from the running dev app for every behaviour the PR
+   changes — the GUI, not curl, not RunBench.
+2. **Variation** in that proof: multimodality varying per turn, reasoning
+   effort changed mid-conversation, sustained multiturn rather than one prompt.
+3. **Measured numbers** where the PR claims an effect — before/after, not
+   "it works now".
+4. Every issue found during proving either **fixed**, or stated plainly as
+   still open in the merge message.
+
+If you cannot say which live run proved this PR, you have not proven it.
+
+If proof genuinely exists, re-run this command and say in one line what the
+proof was — do not merge silently past this.

--- a/.claude/hookify.settings-parity.local.md
+++ b/.claude/hookify.settings-parity.local.md
@@ -1,0 +1,40 @@
+---
+name: settings-parity
+enabled: true
+event: stop
+pattern: .*
+action: warn
+---
+
+**A setting that saves but does not take effect is the default failure here.**
+
+Only applies if this turn touched settings, generation params, context sizing,
+MTP/speculative toggles, or anything the user can change in the UI.
+
+This pattern has now been found four separate times in this codebase:
+
+- `ChatConfiguration.contextLength` — a FALLBACK, last in the chain, inert for
+  every model that declares its own window.
+- `migrateToCurrentSchema()` — zero call sites.
+- Sampler defaults — the user's Settings sit BEHIND model-shipped defaults, so
+  temperature / topP / topK are likely inert for most bundles. **Still open.**
+- The `%.1f` field that rewrote 0.005 to 0, which the resolver then ignored.
+
+So for anything a user can change, verify all four:
+
+1. It **persists** to disk with the value they typed (check the JSON, not the
+   field).
+2. It is **read** on the path that runs — trace to the object that enforces it,
+   not the struct that holds it.
+3. It **wins** against defaults it should outrank, and loses to ones it should
+   not. Write down the precedence order and check it.
+4. The UI **displays** the value actually in force, including any downstream
+   clamp. Displaying the requested value while the engine holds another is a
+   lie the user cannot detect.
+
+Also check the API-server path, not just chat — a setting wired only into the
+chat UI is half-wired.
+
+MTP / speculative toggles: the gate lives in vmlx (`canUseNativeMTP`) and there
+are multiple dispatch sites. Verify the toggle agrees with the gate at EVERY
+one, and that the chat path (BatchEngine) is included — it has been missed.

--- a/Libraries/MLXVLM/MediaTokenIds.swift
+++ b/Libraries/MLXVLM/MediaTokenIds.swift
@@ -1,0 +1,51 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+
+import Foundation
+import MLXLMCommon
+
+/// Resolves the placeholder token ids a processor declares as
+/// ``LMInput/mediaTokenIds``.
+///
+/// Declaring these is what lets a cache hit resume. Without them
+/// ``LMInput/cacheHitSuffixContainsMediaPlaceholder(_:)`` takes its
+/// `guard let mediaTokenIds else { return true }` branch and rolls back on ANY
+/// non-empty suffix, so a text follow-up about the same picture re-prefills the
+/// whole prompt, vision tower included. Declaring them narrows that blanket
+/// rollback to a precise one; a suffix that genuinely carries a placeholder is
+/// still rejected.
+///
+/// Measured on Qwen3.8 27B: follow-up TTFT 3.40s → 0.59s median.
+public enum MediaTokenIds {
+
+    /// Ids for `tokens`, or `nil` if none resolve.
+    ///
+    /// A token counts only if it encodes to exactly one id **and** that id
+    /// decodes back to the same token. Both halves are load-bearing:
+    ///
+    /// - Encoding to several ids means the tokenizer split the literal into
+    ///   ordinary text pieces — those are not a placeholder.
+    /// - Encoding to one id is not enough. A tokenizer without the special
+    ///   maps it to `<unk>`, which IS a single real id and also appears
+    ///   throughout ordinary text. Declaring it would mark unrelated tokens as
+    ///   media placeholders and suppress reuse far more aggressively than
+    ///   declaring nothing. The decode check is what rules that out. Note
+    ///   `convertTokenToId` cannot be used here for the same reason — it
+    ///   returns the unk id rather than nil for an unknown token.
+    ///
+    /// Returns `nil` rather than `[]` on failure: an empty array takes the
+    /// `!mediaTokenIds.isEmpty` branch and would report "no media in the
+    /// suffix" for every suffix, which is the unsafe direction. `nil` keeps
+    /// the conservative full-prefill rollback, i.e. today's behaviour.
+    public static func resolve(tokenizer: any Tokenizer, tokens: [String]) -> [Int]? {
+        var ids: [Int] = []
+        for token in tokens {
+            let encoded = tokenizer.encode(text: token, addSpecialTokens: false)
+            guard encoded.count == 1, let id = encoded.first else { continue }
+            guard tokenizer.decode(tokenIds: [id], skipSpecialTokens: false) == token else {
+                continue
+            }
+            if !ids.contains(id) { ids.append(id) }
+        }
+        return ids.isEmpty ? nil : ids
+    }
+}

--- a/Libraries/MLXVLM/Models/DeepseekOCRProcessor.swift
+++ b/Libraries/MLXVLM/Models/DeepseekOCRProcessor.swift
@@ -343,7 +343,9 @@ public struct DeepseekOCRProcessor: UserInputProcessor {
             // a hardcoded bos_id = 0.
             var tokens = tokenizer.encode(text: prompt, addSpecialTokens: false)
             tokens.insert(0, at: 0)  // BOS id 0
-            return LMInput(tokens: MLXArray(tokens), tokenIds: tokens)
+            return LMInput(
+                tokens: MLXArray(tokens), tokenIds: tokens,
+                cacheScopeSalt: cacheScopeSalt(from: input.additionalContext))
         }
 
         // Build the prompt, splitting on the <image> marker exactly like
@@ -433,10 +435,20 @@ public struct DeepseekOCRProcessor: UserInputProcessor {
         let maskArray = MLXArray(imagesSeqMask.map { $0 ? Int32(1) : Int32(0) })
             .expandedDimensions(axis: 0)
 
+        // The image path MUST carry the scope salt. Without it two requests
+        // whose text tokens match but whose IMAGES differ hash to the same
+        // cache key, so the second one hits the first one's KV — the vision
+        // tower's embeddings for a completely different picture. The output is
+        // fluent and about the wrong image, which is the worst way for a cache
+        // to be wrong: nothing errors and nothing looks off.
+        //
+        // Every other VLM processor here already passes it; this one was the
+        // sole omission, caught by VLMCacheScopeSourceCoverageTests.
         return LMInput(
             text: .init(tokens: promptArray, mask: maskArray, tokenIds: tokenizedStr),
             image: processedImage,
-            mediaTokenIds: [imageTokenId])
+            mediaTokenIds: [imageTokenId],
+            cacheScopeSalt: cacheScopeSalt(from: input.additionalContext))
     }
 
     /// Flatten image_ori and (optional) crop patches into a single 1-D pixel

--- a/Libraries/MLXVLM/Models/FastVLM.swift
+++ b/Libraries/MLXVLM/Models/FastVLM.swift
@@ -1027,6 +1027,8 @@ public struct FastVLMProcessor: UserInputProcessor {
         return LMInput(
             text: .init(tokens: promptArray, mask: mask),
             image: .init(pixels: pixels),
+            mediaTokenIds: MediaTokenIds.resolve(
+                tokenizer: tokenizer, tokens: ["<image>"]),
             cacheScopeSalt: cacheScopeSalt(from: input.additionalContext)
         )
     }

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -1680,6 +1680,8 @@ public struct Gemma4Processor: UserInputProcessor {
             text: .init(tokens: pa, mask: ones(like: pa).asType(.int8), tokenIds: tokens),
             image: processedImage,
             audio: processedAudio,
+            mediaTokenIds: MediaTokenIds.resolve(
+                tokenizer: tokenizer, tokens: ["<|image|>", "<|audio|>"]),
             cacheScopeSalt: cacheScopeSalt(from: input.additionalContext),
             cachePrefixTokenCounts: cacheBoundaries.all,
             cacheStablePrefixTokenCounts: cacheBoundaries.stable,

--- a/Libraries/MLXVLM/Models/LFM2VL.swift
+++ b/Libraries/MLXVLM/Models/LFM2VL.swift
@@ -885,6 +885,8 @@ public struct LFM2VLProcessor: UserInputProcessor {
                 pixels: pixelValuesConcatenated,
                 frames: frames
             ),
+            mediaTokenIds: MediaTokenIds.resolve(
+                tokenizer: tokenizer, tokens: ["<image>"]),
             cacheScopeSalt: cacheScopeSalt(from: input.additionalContext),
             toolSchemas: input.tools
         )

--- a/Libraries/MLXVLM/Models/Mistral3.swift
+++ b/Libraries/MLXVLM/Models/Mistral3.swift
@@ -1296,6 +1296,8 @@ public struct Mistral3VLMProcessor: UserInputProcessor {
         return LMInput(
             text: .init(tokens: promptArray, mask: mask),
             image: .init(pixels: preprocessResult.pixels, frames: preprocessResult.frames),
+            mediaTokenIds: MediaTokenIds.resolve(
+                tokenizer: tokenizer, tokens: ["[IMG]", "[IMG_BREAK]", "[IMG_END]"]),
             cacheScopeSalt: cacheScopeSalt(from: input.additionalContext)
         )
     }

--- a/Libraries/MLXVLM/Models/MuseGlimmerProcessor.swift
+++ b/Libraries/MLXVLM/Models/MuseGlimmerProcessor.swift
@@ -258,6 +258,8 @@ public struct MuseGlimmerProcessor: UserInputProcessor {
             text: .init(tokens: promptArray, mask: mask, tokenIds: promptTokens),
             image: processedImage,
             video: processedVideo,
+            mediaTokenIds: MediaTokenIds.resolve(
+                tokenizer: tokenizer, tokens: ["<|patch|>", "<|video|>"]),
             cacheScopeSalt: cacheScopeSalt(from: input.additionalContext))
     }
 }

--- a/Libraries/MLXVLM/Models/Pixtral.swift
+++ b/Libraries/MLXVLM/Models/Pixtral.swift
@@ -1154,6 +1154,8 @@ public struct PixtralProcessor: UserInputProcessor {
             return LMInput(
                 text: .init(tokens: promptArray, mask: mask),
                 image: .init(pixels: pixels, frames: [THW(1, paddedHeight, paddedWidth)]),
+                mediaTokenIds: MediaTokenIds.resolve(
+                    tokenizer: tokenizer, tokens: ["[IMG]", "[IMG_BREAK]", "[IMG_END]"]),
                 cacheScopeSalt: cacheScopeSalt(from: input.additionalContext)
             )
         }

--- a/Libraries/MLXVLM/Models/Qwen25VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen25VL.swift
@@ -797,6 +797,8 @@ public struct Qwen25VLProcessor: UserInputProcessor {
             text: .init(tokens: promptArray, mask: mask, tokenIds: promptTokens),
             image: processedImage,
             video: processedVideo,
+            mediaTokenIds: QwenVL.mediaTokenIds(
+                tokenizer: tokenizer, tokens: ["<|image_pad|>", "<|video_pad|>"]),
             cacheScopeSalt: cacheScopeSalt(from: input.additionalContext))
     }
 }

--- a/Libraries/MLXVLM/Models/Qwen2VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen2VL.swift
@@ -637,6 +637,8 @@ public struct Qwen2VLProcessor: UserInputProcessor {
             text: .init(tokens: promptArray, mask: mask, tokenIds: promptTokens),
             image: processedImage,
             video: processedVideo,
+            mediaTokenIds: QwenVL.mediaTokenIds(
+                tokenizer: tokenizer, tokens: ["<|image_pad|>", "<|video_pad|>"]),
             cacheScopeSalt: cacheScopeSalt(from: input.additionalContext))
     }
 }

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -2128,6 +2128,18 @@ public class Qwen35: Module, VLMModel, HiddenStateCaptureModel, TokenEmbedderMod
     /// a video turn was described as the video's last frame, twice, with and
     /// without tools in the turn.
     ///
+    /// Confirmed by an A/B on the live app, same model, byte-identical files,
+    /// same prompts: turn 1 a 4-frame video (7 blue, 3 red, 5 green, 9 gold),
+    /// turn 2 a purple "4" — a digit/colour pair in no frame, so a leak is
+    /// unambiguous. Before this change the answer was "the digit 9 … on a
+    /// solid orange/amber (golden) background" (the video's LAST frame);
+    /// after, "the digit 4 on a blue (indigo) background".
+    ///
+    /// Note the bug needs media split ACROSS turns. Within one message
+    /// `Qwen3VLMessageGenerator` emits image content before video content, so
+    /// pads and rows agree and a single mixed turn cannot expose it — a
+    /// combined-attachment turn passes either way and proves nothing.
+    ///
     /// Splitting by kind is correct for any interleaving of the two kinds:
     /// `LMInput` carries one image batch and one video batch, so within a kind
     /// the rows are already in placeholder order.

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -2110,8 +2110,30 @@ public class Qwen35: Module, VLMModel, HiddenStateCaptureModel, TokenEmbedderMod
     }
 
 
+    /// Scatters vision features onto their placeholder positions.
+    ///
+    /// Image and video features are scattered SEPARATELY, each onto its own
+    /// placeholder kind. Pooling `imageMask .|| videoMask` into one scatter is
+    /// only correct while the feature rows happen to appear in the same order
+    /// as the placeholders, and they do not: `prepare` always concatenates
+    /// image pixels before video pixels, while the placeholders appear in
+    /// conversation order. A chat whose earlier turn carried a video and whose
+    /// current turn carries an image therefore has video pads FIRST and image
+    /// pads second, so a pooled scatter lays the image's rows onto the video's
+    /// pads and vice versa — the two blocks swap.
+    ///
+    /// That failed silently rather than loudly: the total element count still
+    /// matches, so the size guard passes and the model simply answers about
+    /// the wrong medium. Measured on Qwen3.8 27B — a red "3" image sent after
+    /// a video turn was described as the video's last frame, twice, with and
+    /// without tools in the turn.
+    ///
+    /// Splitting by kind is correct for any interleaving of the two kinds:
+    /// `LMInput` carries one image batch and one video batch, so within a kind
+    /// the rows are already in placeholder order.
     private func mergeInputIdsWithImageFeatures(
         imageFeatures: MLXArray,
+        imageRowCount: Int,
         inputEmbeds: MLXArray,
         inputIds: MLXArray,
         imageTokenIndex: Int,
@@ -2119,37 +2141,58 @@ public class Qwen35: Module, VLMModel, HiddenStateCaptureModel, TokenEmbedderMod
     ) throws -> (MLXArray, MLXArray) {
         let imageMask = (inputIds .== MLXArray(imageTokenIndex))
         let videoMask = (inputIds .== MLXArray(videoTokenIndex))
-        var specialMask = imageMask .|| videoMask
+        let specialMask = imageMask .|| videoMask
 
         let nImageTokens = specialMask.sum().item(Int.self)
+        let nFeatureRows = imageFeatures.dim(0)
 
-        specialMask = expandedDimensions(specialMask, axis: -1)
-        let maskExpanded = broadcast(specialMask, to: inputEmbeds.shape)
-
-        let nImageFeatures = imageFeatures.dim(0)
-        let nImageMaskElements = maskExpanded.sum().item(Int.self)
-        let imageFeatureSize = imageFeatures.size
-
-        guard nImageMaskElements == imageFeatureSize else {
-            throw Qwen35VLError.featureTokenMismatch(expected: nImageTokens, actual: nImageFeatures)
+        // Total-count check stays: a genuine mismatch must still fail loudly.
+        guard nImageTokens == nFeatureRows else {
+            throw Qwen35VLError.featureTokenMismatch(expected: nImageTokens, actual: nFeatureRows)
         }
 
         let originalShape = inputEmbeds.shape
-        let flattenedEmbeds = inputEmbeds.flattened()
-        let flattenedFeatures = imageFeatures.flattened()
-        let flattenedMask = maskExpanded.flattened()
+        var result = inputEmbeds.flattened()
+        let width = inputEmbeds.dim(-1)
 
-        let indices = nonZero(flattenedMask.asType(.bool))
+        // Rows [0, imageRowCount) belong to the image batch, the remainder to
+        // the video batch — the order `prepare` concatenated them in.
+        func scatter(mask: MLXArray, rows: MLXArray) throws {
+            let positions = nonZero(mask.flattened().asType(.bool))
+            guard !positions.isEmpty else { return }
+            guard positions.count == rows.dim(0) else {
+                throw Qwen35VLError.featureTokenMismatch(
+                    expected: positions.count, actual: rows.dim(0))
+            }
+            var flatIndices: [UInt32] = []
+            flatIndices.reserveCapacity(positions.count * width)
+            for position in positions {
+                let base = position * width
+                for offset in 0 ..< width { flatIndices.append(UInt32(base + offset)) }
+            }
+            result[MLXArray(flatIndices)] = rows.flattened()
+        }
 
-        var result = flattenedEmbeds
-        if !indices.isEmpty && indices.count == flattenedFeatures.size {
-            let indexArray = MLXArray(indices.map { UInt32($0) })
-            result[indexArray] = flattenedFeatures
+        if imageRowCount > 0 {
+            try scatter(mask: imageMask, rows: imageFeatures[0 ..< imageRowCount])
+        }
+        if nFeatureRows > imageRowCount {
+            try scatter(mask: videoMask, rows: imageFeatures[imageRowCount ..< nFeatureRows])
         }
 
         result = result.reshaped(originalShape)
-        let visualMask = specialMask.squeezed(axis: -1).asType(.bool)
+        let visualMask = specialMask.asType(.bool)
         return (result, visualMask)
+    }
+
+    /// Number of merged vision rows a frame list contributes, matching the
+    /// vision tower's output rows: each `THW` frame yields
+    /// `t*h*w / spatialMergeSize^2` rows.
+    private func mergedRowCount(for frames: [THW]?) -> Int {
+        guard let frames else { return 0 }
+        let merge = config.visionConfiguration.spatialMergeSize
+        let divisor = max(1, merge * merge)
+        return frames.reduce(0) { $0 + $1.product / divisor }
     }
 
     private func nonZero(_ mask: MLXArray) -> [Int] {
@@ -2207,6 +2250,7 @@ public class Qwen35: Module, VLMModel, HiddenStateCaptureModel, TokenEmbedderMod
 
             let (mergedEmbeds, _) = try mergeInputIdsWithImageFeatures(
                 imageFeatures: visionFeatures,
+                imageRowCount: mergedRowCount(for: imageFrames),
                 inputEmbeds: textEmbeds,
                 inputIds: inputIds,
                 imageTokenIndex: config.imageTokenIndex,

--- a/Libraries/MLXVLM/Models/Qwen3VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen3VL.swift
@@ -235,6 +235,8 @@ public struct Qwen3VLProcessor: UserInputProcessor {
             text: .init(tokens: promptArray, mask: mask, tokenIds: promptTokens),
             image: processedImage,
             video: processedVideo,
+            mediaTokenIds: QwenVL.mediaTokenIds(
+                tokenizer: tokenizer, tokens: ["<|image_pad|>", "<|video_pad|>"]),
             cacheScopeSalt: cacheScopeSalt(from: input.additionalContext),
             toolSchemas: input.tools)
     }

--- a/Libraries/MLXVLM/Models/QwenVL.swift
+++ b/Libraries/MLXVLM/Models/QwenVL.swift
@@ -228,6 +228,37 @@ public struct QwenVL {
         return result
     }
 
+    /// Placeholder token ids for `LMInput.mediaTokenIds`, resolved from the
+    /// tokenizer rather than a model config the processor cannot see.
+    ///
+    /// Declaring these is what lets a cache hit resume. Without them
+    /// `cacheHitSuffixContainsMediaPlaceholder` takes its
+    /// `guard let mediaTokenIds else { return true }` branch and rolls back on
+    /// ANY non-empty suffix — so a text follow-up about the same picture
+    /// re-prefills the whole prompt, vision tower included. The rollback still
+    /// fires when the suffix genuinely carries a placeholder; it just stops
+    /// firing when it does not.
+    ///
+    /// Returns `nil` unless a token round-trips to exactly itself. A tokenizer
+    /// without these specials encodes `<|image_pad|>` to several ordinary
+    /// pieces, or to a single `<unk>` — and `<unk>` would be a *real* id
+    /// appearing throughout ordinary text, which would suppress reuse far more
+    /// aggressively than declaring nothing. Encoding to one token is therefore
+    /// necessary but not sufficient; the decode check is what rules out unk.
+    /// See the `convertTokenToId` unk pitfall.
+    static func mediaTokenIds(tokenizer: any Tokenizer, tokens: [String]) -> [Int]? {
+        var ids: [Int] = []
+        for token in tokens {
+            let encoded = tokenizer.encode(text: token, addSpecialTokens: false)
+            guard encoded.count == 1, let id = encoded.first else { continue }
+            guard tokenizer.decode(tokenIds: [id], skipSpecialTokens: false) == token else {
+                continue
+            }
+            ids.append(id)
+        }
+        return ids.isEmpty ? nil : ids
+    }
+
     static func paddingPlaceholderRanges(
         in promptTokens: [Int],
         paddingToken: String,

--- a/Libraries/MLXVLM/Models/QwenVL.swift
+++ b/Libraries/MLXVLM/Models/QwenVL.swift
@@ -231,32 +231,11 @@ public struct QwenVL {
     /// Placeholder token ids for `LMInput.mediaTokenIds`, resolved from the
     /// tokenizer rather than a model config the processor cannot see.
     ///
-    /// Declaring these is what lets a cache hit resume. Without them
-    /// `cacheHitSuffixContainsMediaPlaceholder` takes its
-    /// `guard let mediaTokenIds else { return true }` branch and rolls back on
-    /// ANY non-empty suffix — so a text follow-up about the same picture
-    /// re-prefills the whole prompt, vision tower included. The rollback still
-    /// fires when the suffix genuinely carries a placeholder; it just stops
-    /// firing when it does not.
-    ///
-    /// Returns `nil` unless a token round-trips to exactly itself. A tokenizer
-    /// without these specials encodes `<|image_pad|>` to several ordinary
-    /// pieces, or to a single `<unk>` — and `<unk>` would be a *real* id
-    /// appearing throughout ordinary text, which would suppress reuse far more
-    /// aggressively than declaring nothing. Encoding to one token is therefore
-    /// necessary but not sufficient; the decode check is what rules out unk.
-    /// See the `convertTokenToId` unk pitfall.
+    /// Thin wrapper over ``MediaTokenIds/resolve(tokenizer:tokens:)`` — see
+    /// there for why a token must round-trip and why this returns `nil` rather
+    /// than `[]`.
     static func mediaTokenIds(tokenizer: any Tokenizer, tokens: [String]) -> [Int]? {
-        var ids: [Int] = []
-        for token in tokens {
-            let encoded = tokenizer.encode(text: token, addSpecialTokens: false)
-            guard encoded.count == 1, let id = encoded.first else { continue }
-            guard tokenizer.decode(tokenIds: [id], skipSpecialTokens: false) == token else {
-                continue
-            }
-            ids.append(id)
-        }
-        return ids.isEmpty ? nil : ids
+        MediaTokenIds.resolve(tokenizer: tokenizer, tokens: tokens)
     }
 
     static func paddingPlaceholderRanges(

--- a/Libraries/MLXVLM/Models/SmolVLM2.swift
+++ b/Libraries/MLXVLM/Models/SmolVLM2.swift
@@ -301,6 +301,8 @@ public struct SmolVLMProcessor: UserInputProcessor {
             return LMInput(
                 text: .init(tokens: promptArray, mask: mask),
                 image: .init(pixels: pixels),
+                mediaTokenIds: MediaTokenIds.resolve(
+                    tokenizer: tokenizer, tokens: ["<image>", "<fake_token_around_image>"]),
                 cacheScopeSalt: cacheScopeSalt(from: input.additionalContext)
             )
         } else {
@@ -383,6 +385,8 @@ public struct SmolVLMProcessor: UserInputProcessor {
             return LMInput(
                 text: .init(tokens: promptArray, mask: mask),
                 image: .init(pixels: transposedFrames, frames: thwFrames),
+                mediaTokenIds: MediaTokenIds.resolve(
+                    tokenizer: tokenizer, tokens: ["<image>", "<fake_token_around_image>"]),
                 cacheScopeSalt: cacheScopeSalt(from: input.additionalContext)
             )
         }

--- a/Libraries/MLXVLM/Models/Zaya1VL.swift
+++ b/Libraries/MLXVLM/Models/Zaya1VL.swift
@@ -1754,6 +1754,8 @@ public struct Zaya1VLProcessor: UserInputProcessor {
         return LMInput(
             text: LMInput.Text(tokens: MLXArray(promptTokens), tokenIds: promptTokens),
             image: processedImage,
+            mediaTokenIds: MediaTokenIds.resolve(
+                tokenizer: tokenizer, tokens: ["<image>"]),
             cacheScopeSalt: cacheScopeSalt(from: input.additionalContext))
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -882,6 +882,7 @@ let package = Package(
                 "Gemma3nTextSanitizeFocusedTests.swift",
                 "MediaCachePlaceholderTests.swift",
                 "VLGrowingConversationReuseTests.swift",
+                "VLMediaTokenDeclarationReachabilityTests.swift",
                 "NemotronHOmniPreEncodedAudioTests.swift",
                 "NemotronHJANGTQDispatchFocusedTests.swift",
                 "MTPRuntimeFocusedTests.swift",

--- a/Package.swift
+++ b/Package.swift
@@ -881,6 +881,7 @@ let package = Package(
                 "Gemma4ThoughtChannelParserFocusedTests.swift",
                 "Gemma3nTextSanitizeFocusedTests.swift",
                 "MediaCachePlaceholderTests.swift",
+                "VLGrowingConversationReuseTests.swift",
                 "NemotronHOmniPreEncodedAudioTests.swift",
                 "NemotronHJANGTQDispatchFocusedTests.swift",
                 "MTPRuntimeFocusedTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/VLGrowingConversationReuseTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/VLGrowingConversationReuseTests.swift
@@ -1,0 +1,163 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+//
+// What a GROWING VL conversation can actually reuse from the prefix cache.
+//
+// The primitives are already covered elsewhere: `MediaCachePlaceholderTests`
+// pins `cacheHitSuffixContainsMediaPlaceholder`, and
+// `CacheCoordinatorMediaSaltTests` pins `computeMediaSalt`. Neither states
+// the property a user feels, which is per-turn: *which turns of a real
+// multi-image chat re-prefill the whole conversation, and which resume.*
+//
+// Two independent mechanisms decide that, and they must be read together:
+//
+//   1. `computeMediaSalt` fingerprints the request's WHOLE concatenated pixel
+//      tensor (`ProcessedImage.pixels` is documented as "Concatenated pixels
+//      from one or more images"). Appending an image changes the salt for the
+//      entire prompt, so no boundary stored by an earlier turn can match --
+//      `CacheCoordinator` passes the salt to `DiskCache.fetch` on every
+//      candidate boundary probe.
+//   2. Even given a matching salt, a hit whose REMAINING suffix still holds
+//      media placeholders is rolled back to a full prefill, in all four
+//      decode paths (`Evaluate`, `BatchEngine`, `DFlash2TokenIterator`,
+//      `NativeMTPTokenIterator`). Media embeddings are substituted onto
+//      placeholder positions by order across the whole prompt, so prefilling
+//      only a suffix would map the wrong image onto them.
+//
+// Net effect, and the thing to know before optimizing: a turn that INTRODUCES
+// new media pays a full re-prefill of the conversation (vision tower
+// included). Turns that only add text after it resume normally. A chat that
+// varies modality every turn therefore never resumes, which is the shape that
+// degrades over long context.
+//
+// These are assertions about today's behaviour. If someone makes
+// media-introducing turns resumable -- prefix-scoped salting plus a
+// media-consumed offset threaded into `prepare` -- these expectations SHOULD
+// change, deliberately, and the rollback log line
+// "rolling back to full prefill (media placeholder tokens remain in
+// cache-hit suffix)" is how you confirm it live.
+
+import Foundation
+import MLX
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite("VL growing-conversation prefix reuse")
+struct VLGrowingConversationReuseTests {
+
+    /// Placeholder id standing in for `<image>`.
+    private static let imageToken = 27
+
+    /// `count` distinct 1x3x2x2 images concatenated on the leading axis,
+    /// matching how a processor hands multiple images to the model.
+    private static func pixels(count: Int) -> MLXArray {
+        let perImage = 3 * 2 * 2
+        var values: [Float] = []
+        for image in 0..<count {
+            values.append(contentsOf: (0..<perImage).map { Float(image * 100 + $0) })
+        }
+        let array = MLXArray(values).reshaped([count, 3, 2, 2])
+        MLX.eval(array)
+        return array
+    }
+
+    private static func input(tokens: [Int32], imageCount: Int) -> LMInput {
+        LMInput(
+            text: .init(tokens: MLXArray(tokens)),
+            image: .init(pixels: pixels(count: imageCount)),
+            mediaTokenIds: [imageToken])
+    }
+
+    /// Turn 2 is a text follow-up about the same picture: the image tensor is
+    /// unchanged, so the salt matches, and the boundary at the end of turn 1
+    /// leaves a text-only suffix. This turn resumes -- the common VL case.
+    @Test("a text follow-up after an image turn resumes from the cached prefix")
+    func textFollowUpAfterImageTurnResumes() {
+        FocusedMLXTestSupport.withLock {
+            let turn1 = Self.input(tokens: [1, 27, 27, 2], imageCount: 1)
+            let turn2 = Self.input(tokens: [1, 27, 27, 2, 5, 6], imageCount: 1)
+
+            #expect(computeMediaSalt(for: turn1) == computeMediaSalt(for: turn2))
+
+            // Boundary = end of turn 1 (4 tokens); suffix is [5, 6].
+            #expect(!turn2.cacheHitSuffixContainsMediaPlaceholder([5, 6]))
+        }
+    }
+
+    /// The turn that adds a SECOND image cannot resume, for two separate
+    /// reasons. Assert both, so removing one and declaring victory is not
+    /// possible: the salt alone still leaves the suffix rollback, and lifting
+    /// the suffix rollback alone still leaves an unmatchable salt.
+    @Test("adding a second image blocks reuse twice over")
+    func addingASecondImageBlocksReuseTwice() {
+        FocusedMLXTestSupport.withLock {
+            let turn1 = Self.input(tokens: [1, 27, 27, 2], imageCount: 1)
+            let turn2 = Self.input(tokens: [1, 27, 27, 2, 5, 27, 27, 6], imageCount: 2)
+
+            // (1) Whole-tensor salt: turn 1's stored boundaries are keyed
+            // under a salt turn 2 never presents, so every probe misses.
+            #expect(computeMediaSalt(for: turn1) != computeMediaSalt(for: turn2))
+
+            // (2) Suffix rollback: even at the turn-1 boundary the remaining
+            // suffix carries the new image's placeholders.
+            #expect(turn2.cacheHitSuffixContainsMediaPlaceholder([5, 27, 27, 6]))
+        }
+    }
+
+    /// Reuse is not lost permanently -- it resumes on the next text-only turn,
+    /// because that turn presents the same two-image tensor as the turn before
+    /// it. The cost is per media-introducing turn, not cumulative.
+    @Test("reuse resumes on the text turn after a media-introducing turn")
+    func reuseResumesAfterTheMediaIntroducingTurn() {
+        FocusedMLXTestSupport.withLock {
+            let turn2 = Self.input(tokens: [1, 27, 27, 2, 5, 27, 27, 6], imageCount: 2)
+            let turn3 = Self.input(tokens: [1, 27, 27, 2, 5, 27, 27, 6, 7, 8], imageCount: 2)
+
+            #expect(computeMediaSalt(for: turn2) == computeMediaSalt(for: turn3))
+            #expect(!turn3.cacheHitSuffixContainsMediaPlaceholder([7, 8]))
+        }
+    }
+
+    /// A boundary that lands INSIDE a placeholder run must never be treated as
+    /// capturable. This is the media analogue of the alignment lesson: the
+    /// interesting boundary is the one that does not divide evenly.
+    @Test("a boundary inside the placeholder run is not capturable")
+    func boundaryInsideThePlaceholderRunIsNotCapturable() {
+        FocusedMLXTestSupport.withLock {
+            let prompt: [Int] = [1, 27, 27, 27, 2]
+            let turn = Self.input(tokens: prompt.map(Int32.init), imageCount: 1)
+
+            // Splitting the run at 2 or 3 leaves placeholders on both sides.
+            #expect(!turn.canCaptureHybridStripBoundary(promptTokenIds: prompt, boundary: 2))
+            #expect(!turn.canCaptureHybridStripBoundary(promptTokenIds: prompt, boundary: 3))
+
+            // After the complete run the boundary has a stable token identity.
+            #expect(turn.canCaptureHybridStripBoundary(promptTokenIds: prompt, boundary: 4))
+
+            // Before the run there is no media in the prefix to anchor it.
+            #expect(!turn.canCaptureHybridStripBoundary(promptTokenIds: prompt, boundary: 1))
+        }
+    }
+
+    /// Audio and video ride the same two mechanisms as images, so a chat that
+    /// alternates modality introduces new media on every turn and therefore
+    /// never resumes. Pin that explicitly -- it is the "variating
+    /// multimodality per turn" shape.
+    @Test("alternating modality changes the salt every turn")
+    func alternatingModalityChangesTheSaltEveryTurn() {
+        FocusedMLXTestSupport.withLock {
+            let waveform = MLXArray((0..<8).map { Float($0) }).reshaped([1, 8])
+            MLX.eval(waveform)
+
+            let imageTurn = Self.input(tokens: [1, 27, 2], imageCount: 1)
+            let plusAudioTurn = LMInput(
+                text: .init(tokens: MLXArray([Int32(1), 27, 2, 5, 27])),
+                image: .init(pixels: Self.pixels(count: 1)),
+                audio: .init(waveform: waveform),
+                mediaTokenIds: [Self.imageToken])
+
+            #expect(computeMediaSalt(for: imageTurn) != computeMediaSalt(for: plusAudioTurn))
+            #expect(plusAudioTurn.cacheHitSuffixContainsMediaPlaceholder([5, 27]))
+        }
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/VLMediaTokenDeclarationReachabilityTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/VLMediaTokenDeclarationReachabilityTests.swift
@@ -5,10 +5,14 @@
 // `VLGrowingConversationReuseTests` builds every `LMInput` with
 // `mediaTokenIds: [imageToken]` and shows a text follow-up resuming from the
 // cached prefix. That is what the mechanism does when it is fed. It is not
-// what ships: of the VLM processors that construct an `LMInput` carrying
-// media, only **three** declare `mediaTokenIds` — Audex, DeepSeek-OCR and
-// Nemotron-H Omni. Qwen3-VL, Qwen2.5-VL, Gemma 4, Muse Glimmer, LFM2-VL,
-// Mistral 3, GLM-4V, Zaya1-VL and the rest pass none.
+// what shipped: of the VLM processors that construct an `LMInput` carrying
+// media, only **three** declared `mediaTokenIds` — Audex, DeepSeek-OCR and
+// Nemotron-H Omni. Qwen3-VL, Qwen2.5-VL, Qwen2-VL, Gemma 4, Muse Glimmer,
+// LFM2-VL, Mistral 3, GLM-4V, Zaya1-VL and the rest passed none.
+//
+// The three Qwen VL processors now declare theirs through
+// `QwenVL.mediaTokenIds`. Every other family still does not, so the assertions
+// below are half regression guard and half worklist.
 //
 // Without declared ids `cacheHitSuffixContainsMediaPlaceholder` takes its
 // `guard let mediaTokenIds else { return true }` branch and rolls back on ANY
@@ -29,6 +33,7 @@ import MLX
 import Testing
 
 @testable import MLXLMCommon
+@testable import MLXVLM
 
 @Suite("VL media-token declaration reachability")
 struct VLMediaTokenDeclarationReachabilityTests {
@@ -83,8 +88,13 @@ struct VLMediaTokenDeclarationReachabilityTests {
     }
 
     /// The reachability claim itself: which processors feed the mechanism.
-    @Test("only three VLM processors declare mediaTokenIds today")
-    func onlyThreeProcessorsDeclareMediaTokenIds() throws {
+    ///
+    /// The three Qwen VL processors were added here — they share the
+    /// `<|image_pad|>` / `<|video_pad|>` scheme and resolve their ids through
+    /// `QwenVL.mediaTokenIds`. Every other family still declares nothing and
+    /// still takes the blanket rollback.
+    @Test("the declaring set is the three original processors plus Qwen VL")
+    func declaringSetIsTheThreeOriginalsPlusQwenVL() throws {
         let declaring =
             try Self.vlmSources()
             .filter { $0.text.contains("mediaTokenIds:") }
@@ -92,20 +102,22 @@ struct VLMediaTokenDeclarationReachabilityTests {
             .sorted()
 
         #expect(
-            declaring == ["Audex.swift", "DeepseekOCRProcessor.swift", "NemotronHOmni.swift"],
+            declaring == [
+                "Audex.swift", "DeepseekOCRProcessor.swift", "NemotronHOmni.swift",
+                "Qwen25VL.swift", "Qwen2VL.swift", "Qwen3VL.swift",
+            ],
             "declaring processors changed: \(declaring)")
     }
 
     /// Named individually so the failure message says WHICH family regained or
     /// lost the declaration, instead of only that a count moved.
-    @Test("the mainstream VL families still declare nothing")
-    func mainstreamFamiliesDeclareNothing() throws {
+    @Test("the families that were not converted still declare nothing")
+    func unconvertedFamiliesDeclareNothing() throws {
         let sources = try Self.vlmSources()
         let mainstream = [
-            "Qwen3VL.swift", "Qwen25VL.swift", "Qwen2VL.swift", "Gemma4.swift",
-            "Gemma3.swift", "MuseGlimmerProcessor.swift", "LFM2VL.swift",
-            "Mistral3.swift", "Glm4v.swift", "Zaya1VL.swift", "Idefics3.swift",
-            "Pixtral.swift", "SmolVLM2.swift", "FastVLM.swift",
+            "Gemma4.swift", "Gemma3.swift", "MuseGlimmerProcessor.swift",
+            "LFM2VL.swift", "Mistral3.swift", "Glm4v.swift", "Zaya1VL.swift",
+            "Idefics3.swift", "Pixtral.swift", "SmolVLM2.swift", "FastVLM.swift",
         ]
 
         for name in mainstream {
@@ -145,5 +157,114 @@ struct VLMediaTokenDeclarationReachabilityTests {
         // The media construction passes image/video and stops there.
         #expect(source.contains("image: processedImage"))
         #expect(source.contains("video: processedVideo"))
+    }
+}
+
+/// A tokenizer whose special-token behaviour is scripted, so the resolver's
+/// guards can be exercised without a real bundle.
+private struct ScriptedTokenizer: MLXLMCommon.Tokenizer {
+    /// token text -> ids it encodes to.
+    let table: [String: [Int]]
+    /// id -> token text it decodes back to.
+    let reverse: [Int: String]
+
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] { table[text] ?? [] }
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+        tokenIds.compactMap { reverse[$0] }.joined()
+    }
+    func convertTokenToId(_ token: String) -> Int? { table[token]?.first }
+    func convertIdToToken(_ id: Int) -> String? { reverse[id] }
+
+    var bosToken: String? { nil }
+    var eosToken: String? { nil }
+    var eosTokenId: Int? { nil }
+    var unknownToken: String? { "<unk>" }
+    var unknownTokenId: Int? { 0 }
+
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] { [] }
+}
+
+@Suite("QwenVL media token id resolution")
+struct QwenVLMediaTokenIdResolutionTests {
+
+    private static let image = "<|image_pad|>"
+    private static let video = "<|video_pad|>"
+
+    @Test("a tokenizer that knows both specials yields both ids")
+    func bothSpecialsResolve() {
+        let tokenizer = ScriptedTokenizer(
+            table: [Self.image: [151_655], Self.video: [151_656]],
+            reverse: [151_655: Self.image, 151_656: Self.video])
+
+        let ids = QwenVL.mediaTokenIds(
+            tokenizer: tokenizer, tokens: [Self.image, Self.video])
+        #expect(ids == [151_655, 151_656])
+    }
+
+    /// The dangerous case. A tokenizer without these specials maps them to
+    /// `<unk>` — a single, real id that also appears in ordinary text. Taking
+    /// it would declare a "media placeholder" that matches unrelated tokens and
+    /// suppress reuse far more aggressively than declaring nothing. The decode
+    /// round-trip is what rejects it; the `count == 1` check alone would not,
+    /// because unk IS one token.
+    @Test("an unk-mapping tokenizer resolves to nothing, not to unk")
+    func unkMappingResolvesToNil() {
+        let tokenizer = ScriptedTokenizer(
+            table: [Self.image: [0], Self.video: [0]],
+            reverse: [0: "<unk>"])
+
+        #expect(
+            QwenVL.mediaTokenIds(tokenizer: tokenizer, tokens: [Self.image, Self.video]) == nil)
+    }
+
+    /// A tokenizer that splits the literal into ordinary pieces is also not a
+    /// declaration — those ids are pieces of text, not a placeholder.
+    @Test("a token that splits into pieces is not declared")
+    func splitTokenIsNotDeclared() {
+        let tokenizer = ScriptedTokenizer(
+            table: [Self.image: [10, 11, 12]],
+            reverse: [10: "<|", 11: "image_pad", 12: "|>"])
+
+        #expect(QwenVL.mediaTokenIds(tokenizer: tokenizer, tokens: [Self.image]) == nil)
+    }
+
+    /// Partial knowledge is still useful: an image-only bundle declares the
+    /// image id and simply has no video id to declare.
+    @Test("one resolvable token is enough")
+    func partialResolutionStillDeclares() {
+        let tokenizer = ScriptedTokenizer(
+            table: [Self.image: [151_655], Self.video: [0]],
+            reverse: [151_655: Self.image, 0: "<unk>"])
+
+        #expect(
+            QwenVL.mediaTokenIds(tokenizer: tokenizer, tokens: [Self.image, Self.video])
+                == [151_655])
+    }
+
+    /// Returning `nil` rather than `[]` matters: an empty array takes the
+    /// `!mediaTokenIds.isEmpty` branch and would report "no media in the
+    /// suffix" for every suffix, which is the unsafe direction.
+    @Test("nil, never empty — empty would disable the rollback entirely")
+    func nilRatherThanEmpty() {
+        FocusedMLXTestSupport.withLock {
+            let pixels = MLXArray((0..<12).map { Float($0) }).reshaped([1, 3, 2, 2])
+            MLX.eval(pixels)
+
+            let empty = LMInput(
+                text: .init(tokens: MLXArray([Int32(1), 27, 2])),
+                image: .init(pixels: pixels),
+                mediaTokenIds: [])
+            // Empty declares "nothing is a placeholder" — a suffix carrying the
+            // real placeholder is waved through. This is exactly what the
+            // resolver must never produce.
+            #expect(!empty.cacheHitSuffixContainsMediaPlaceholder([27]))
+
+            let tokenizer = ScriptedTokenizer(table: [Self.image: [0]], reverse: [0: "<unk>"])
+            #expect(QwenVL.mediaTokenIds(tokenizer: tokenizer, tokens: [Self.image]) == nil)
+        }
     }
 }

--- a/Tests/MLXLMCommonFocusedTests/VLMediaTokenDeclarationReachabilityTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/VLMediaTokenDeclarationReachabilityTests.swift
@@ -89,12 +89,10 @@ struct VLMediaTokenDeclarationReachabilityTests {
 
     /// The reachability claim itself: which processors feed the mechanism.
     ///
-    /// The three Qwen VL processors were added here — they share the
-    /// `<|image_pad|>` / `<|video_pad|>` scheme and resolve their ids through
-    /// `QwenVL.mediaTokenIds`. Every other family still declares nothing and
-    /// still takes the blanket rollback.
-    @Test("the declaring set is the three original processors plus Qwen VL")
-    func declaringSetIsTheThreeOriginalsPlusQwenVL() throws {
+    /// Every processor whose placeholder tokens could be established now
+    /// declares them, through the shared `MediaTokenIds.resolve`.
+    @Test("every processor with knowable placeholder tokens declares them")
+    func declaringSetCoversEveryKnowableProcessor() throws {
         let declaring =
             try Self.vlmSources()
             .filter { $0.text.contains("mediaTokenIds:") }
@@ -103,28 +101,83 @@ struct VLMediaTokenDeclarationReachabilityTests {
 
         #expect(
             declaring == [
-                "Audex.swift", "DeepseekOCRProcessor.swift", "NemotronHOmni.swift",
-                "Qwen25VL.swift", "Qwen2VL.swift", "Qwen3VL.swift",
+                "Audex.swift", "DeepseekOCRProcessor.swift", "FastVLM.swift",
+                "Gemma4.swift", "LFM2VL.swift", "Mistral3.swift",
+                "MuseGlimmerProcessor.swift", "NemotronHOmni.swift", "Pixtral.swift",
+                "Qwen25VL.swift", "Qwen2VL.swift", "Qwen3VL.swift", "SmolVLM2.swift",
+                "Zaya1VL.swift",
             ],
             "declaring processors changed: \(declaring)")
     }
 
-    /// Named individually so the failure message says WHICH family regained or
-    /// lost the declaration, instead of only that a count moved.
-    @Test("the families that were not converted still declare nothing")
-    func unconvertedFamiliesDeclareNothing() throws {
+    /// The remaining three carry their placeholder only as a numeric config id
+    /// the processor cannot see, so there is no string to round-trip. They keep
+    /// the conservative blanket rollback rather than a guessed id — a WRONG id
+    /// is worse than none, because it would wave through a suffix that really
+    /// does carry a placeholder.
+    @Test("config-id-only families are deliberately left undeclared")
+    func configIdOnlyFamiliesRemainUndeclared() throws {
         let sources = try Self.vlmSources()
-        let mainstream = [
-            "Gemma4.swift", "Gemma3.swift", "MuseGlimmerProcessor.swift",
-            "LFM2VL.swift", "Mistral3.swift", "Glm4v.swift", "Zaya1VL.swift",
-            "Idefics3.swift", "Pixtral.swift", "SmolVLM2.swift", "FastVLM.swift",
-        ]
-
-        for name in mainstream {
+        for name in ["Gemma3.swift", "Glm4v.swift", "Idefics3.swift"] {
             guard let file = sources.first(where: { $0.name == name }) else { continue }
             #expect(
                 !file.text.contains("mediaTokenIds:"),
-                "\(name) now declares mediaTokenIds — update the reuse table in the audit")
+                "\(name) declared ids — verify the token string round-trips first")
+        }
+    }
+
+    /// A family that emits more than one KIND of placeholder must declare all
+    /// of them. Declaring only some is the dangerous direction: a suffix
+    /// carrying the undeclared kind matches nothing, reads as media-free, and
+    /// resumes onto the wrong media.
+    @Test("multi-modality families declare every placeholder kind they emit")
+    func multiModalityFamiliesDeclareEveryKind() throws {
+        let sources = try Self.vlmSources()
+
+        func text(_ name: String) -> String {
+            sources.first(where: { $0.name == name })?.text ?? ""
+        }
+
+        // Gemma 4 builds an LMInput carrying image AND audio.
+        let gemma4 = text("Gemma4.swift")
+        #expect(gemma4.contains(#""<|image|>""#))
+        #expect(gemma4.contains(#""<|audio|>""#))
+
+        // Muse Glimmer expands `<|patch|>` for stills and `<|video|>` for clips.
+        let muse = text("MuseGlimmerProcessor.swift")
+        #expect(muse.contains(#""<|patch|>""#))
+        #expect(muse.contains(#""<|video|>""#))
+
+        // Qwen VL: image and video pads.
+        for name in ["Qwen3VL.swift", "Qwen25VL.swift", "Qwen2VL.swift"] {
+            #expect(text(name).contains(#""<|image_pad|>", "<|video_pad|>""#), "\(name)")
+        }
+
+        // Mistral/Pixtral repeat [IMG] and separate spans with BREAK/END.
+        for name in ["Mistral3.swift", "Pixtral.swift"] {
+            let t = text(name)
+            #expect(t.contains(#""[IMG]""#), "\(name)")
+            #expect(t.contains(#""[IMG_BREAK]""#), "\(name)")
+            #expect(t.contains(#""[IMG_END]""#), "\(name)")
+        }
+    }
+
+    /// Named individually so the failure message says WHICH family regained or
+    /// lost the declaration, instead of only that a count moved.
+    /// Resolution goes through the one shared helper, so the round-trip and
+    /// nil-not-empty guarantees hold everywhere rather than per copy.
+    @Test("every declaration resolves through the shared helper")
+    func everyDeclarationUsesTheSharedResolver() throws {
+        let declaring = try Self.vlmSources().filter { $0.text.contains("mediaTokenIds:") }
+
+        for file in declaring {
+            #expect(
+                file.text.contains("MediaTokenIds.resolve")
+                    || file.text.contains("QwenVL.mediaTokenIds")
+                    || file.name == "Audex.swift"
+                    || file.name == "DeepseekOCRProcessor.swift"
+                    || file.name == "NemotronHOmni.swift",
+                "\(file.name) hand-rolls its ids instead of using MediaTokenIds.resolve")
         }
     }
 

--- a/Tests/MLXLMCommonFocusedTests/VLMediaTokenDeclarationReachabilityTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/VLMediaTokenDeclarationReachabilityTests.swift
@@ -1,0 +1,149 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+//
+// The VL reuse mechanism is correct and almost nothing reaches it.
+//
+// `VLGrowingConversationReuseTests` builds every `LMInput` with
+// `mediaTokenIds: [imageToken]` and shows a text follow-up resuming from the
+// cached prefix. That is what the mechanism does when it is fed. It is not
+// what ships: of the VLM processors that construct an `LMInput` carrying
+// media, only **three** declare `mediaTokenIds` — Audex, DeepSeek-OCR and
+// Nemotron-H Omni. Qwen3-VL, Qwen2.5-VL, Gemma 4, Muse Glimmer, LFM2-VL,
+// Mistral 3, GLM-4V, Zaya1-VL and the rest pass none.
+//
+// Without declared ids `cacheHitSuffixContainsMediaPlaceholder` takes its
+// `guard let mediaTokenIds else { return true }` branch and rolls back on ANY
+// non-empty suffix. So on those families even a pure-text follow-up — the case
+// the characterization tests show resuming — re-prefills the whole prompt,
+// vision tower included.
+//
+// This file asserts the reachability rather than the mechanism, because the
+// mechanism already has tests and they pass regardless. It is the same shape
+// as the guards that shipped correct-but-unreached twice before.
+//
+// These are characterization assertions about TODAY. When a family starts
+// declaring its ids, the count here SHOULD be updated deliberately rather than
+// quietly relaxed.
+
+import Foundation
+import MLX
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite("VL media-token declaration reachability")
+struct VLMediaTokenDeclarationReachabilityTests {
+
+    private static func repoRoot() -> URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+
+    private static func vlmSources() throws -> [(name: String, text: String)] {
+        let dir = repoRoot().appendingPathComponent("Libraries/MLXVLM/Models")
+        let urls = try FileManager.default.subpathsOfDirectory(atPath: dir.path)
+            .filter { $0.hasSuffix(".swift") }
+            .map { dir.appendingPathComponent($0) }
+        return try urls.map {
+            (name: $0.lastPathComponent, text: try String(contentsOf: $0, encoding: .utf8))
+        }
+    }
+
+    /// The undeclared case is not "slightly worse" — it is a blanket rollback.
+    /// Pin the branch itself so a refactor cannot quietly make undeclared mean
+    /// "no media in the suffix", which would substitute the wrong image.
+    @Test("an undeclared media token set rolls back on ANY non-empty suffix")
+    func undeclaredIdsRollBackUnconditionally() {
+        FocusedMLXTestSupport.withLock {
+            let pixels = MLXArray((0..<12).map { Float($0) }).reshaped([1, 3, 2, 2])
+            MLX.eval(pixels)
+
+            let undeclared = LMInput(
+                text: .init(tokens: MLXArray([Int32(1), 27, 27, 2, 5, 6])),
+                image: .init(pixels: pixels))
+            let declared = LMInput(
+                text: .init(tokens: MLXArray([Int32(1), 27, 27, 2, 5, 6])),
+                image: .init(pixels: pixels),
+                mediaTokenIds: [27])
+
+            // Identical prompt, identical pixels, pure-text suffix [5, 6].
+            // The only difference is whether the processor declared its ids.
+            #expect(undeclared.cacheHitSuffixContainsMediaPlaceholder([5, 6]))
+            #expect(!declared.cacheHitSuffixContainsMediaPlaceholder([5, 6]))
+
+            // Declaring ids does NOT weaken the real rollback: a suffix that
+            // still carries a placeholder is rejected either way.
+            #expect(declared.cacheHitSuffixContainsMediaPlaceholder([5, 27, 6]))
+
+            // And a prompt with no media is untouched by any of this.
+            let textOnly = LMInput(text: .init(tokens: MLXArray([Int32(1), 2, 3])))
+            #expect(!textOnly.cacheHitSuffixContainsMediaPlaceholder([2, 3]))
+        }
+    }
+
+    /// The reachability claim itself: which processors feed the mechanism.
+    @Test("only three VLM processors declare mediaTokenIds today")
+    func onlyThreeProcessorsDeclareMediaTokenIds() throws {
+        let declaring =
+            try Self.vlmSources()
+            .filter { $0.text.contains("mediaTokenIds:") }
+            .map(\.name)
+            .sorted()
+
+        #expect(
+            declaring == ["Audex.swift", "DeepseekOCRProcessor.swift", "NemotronHOmni.swift"],
+            "declaring processors changed: \(declaring)")
+    }
+
+    /// Named individually so the failure message says WHICH family regained or
+    /// lost the declaration, instead of only that a count moved.
+    @Test("the mainstream VL families still declare nothing")
+    func mainstreamFamiliesDeclareNothing() throws {
+        let sources = try Self.vlmSources()
+        let mainstream = [
+            "Qwen3VL.swift", "Qwen25VL.swift", "Qwen2VL.swift", "Gemma4.swift",
+            "Gemma3.swift", "MuseGlimmerProcessor.swift", "LFM2VL.swift",
+            "Mistral3.swift", "Glm4v.swift", "Zaya1VL.swift", "Idefics3.swift",
+            "Pixtral.swift", "SmolVLM2.swift", "FastVLM.swift",
+        ]
+
+        for name in mainstream {
+            guard let file = sources.first(where: { $0.name == name }) else { continue }
+            #expect(
+                !file.text.contains("mediaTokenIds:"),
+                "\(name) now declares mediaTokenIds — update the reuse table in the audit")
+        }
+    }
+
+    /// The second half of why VL prompts do not resume, and the one that is
+    /// easy to miss: Qwen3-VL's TEXT branch computes canonical boundaries and
+    /// passes them, while its MEDIA branch returns an `LMInput` with neither
+    /// `cachePrefixTokenCounts` nor `cacheStablePrefixTokenCounts`. A prompt
+    /// that declares no boundaries has nothing for the coordinator to probe,
+    /// so the rollback above is never even reached — there is no candidate hit
+    /// to roll back.
+    @Test("Qwen3-VL declares cache boundaries on the text path but not the media path")
+    func qwen3VLMediaPathDeclaresNoBoundaries() throws {
+        let source = try String(
+            contentsOf: Self.repoRoot()
+                .appendingPathComponent("Libraries/MLXVLM/Models/Qwen3VL.swift"),
+            encoding: .utf8)
+
+        // The text-only branch is the one that carries boundaries.
+        #expect(source.contains("cachePrefixTokenCounts: cacheBoundaries.all"))
+        #expect(source.contains("cacheStablePrefixTokenCounts: cacheBoundaries.stable"))
+
+        // Exactly one construction site does, and it is not the media one.
+        let boundaryDeclarations = source.components(
+            separatedBy: "cachePrefixTokenCounts: cacheBoundaries.all"
+        ).count - 1
+        #expect(
+            boundaryDeclarations == 1,
+            "expected the single text-path declaration, found \(boundaryDeclarations)")
+
+        // The media construction passes image/video and stops there.
+        #expect(source.contains("image: processedImage"))
+        #expect(source.contains("video: processedVideo"))
+    }
+}


### PR DESCRIPTION
## The defect

`Qwen35.mergeInputIdsWithImageFeatures` pooled both placeholder kinds into one
scatter (`imageMask .|| videoMask`) and laid a single feature tensor across the
combined positions.

That is only correct while the feature rows appear in the same order as the
placeholders, and they do not. `prepare` always concatenates image pixels
before video pixels:

```swift
if let image = input.image { pixelParts.append(image.pixels…); imageFrames = image.frames }
if let video = input.video { pixelParts.append(video.pixels…); videoFrames = video.frames }
```

while the placeholders appear in conversation order. A chat whose earlier turn
carried a video and whose current turn carries an image therefore has video
pads FIRST — so the image's rows land on the video's pads and vice versa.

It fails silently. The total element count still matches, so the size guard
passes and the model simply answers about the wrong medium.

## The fix

Scatter per kind, splitting the vision rows at `mergedRowCount(for: imageFrames)`
(the image batch's merged row count). Within a kind the rows are already in
placeholder order, because `LMInput` carries one image batch and one video
batch, so this is correct for any interleaving.

## Proof

Live A/B in the app — same model (Qwen3.8 27B JANG_4D), same isolated root,
byte-identical inputs, same prompts:

- Turn 1 attaches a 4-frame video: 7 blue, 3 red, 5 green, 9 gold.
- Turn 2 attaches a purple **4**, a digit/colour pair present in no frame, so a
  leak from the video cannot be confused with a correct answer.

| build | answer to "what digit and colour is this NEW image?" |
| --- | --- |
| before | "the digit **9** in white on a solid **orange/amber (golden)** background" — the video's LAST frame |
| after | "the digit **4** on a **blue (indigo)** background" — correct |

Video reading is unaffected: turn 1 returns 7 blue, 3 red, 5 green, 9 gold in
order on both builds.

## What does NOT reproduce it

A single turn carrying both an image and a video. Within one message
`Qwen3VLMessageGenerator` emits image content before video content, so pads and
rows already agree and the pooled scatter is accidentally correct — that turn
passes on the broken build too (verified: image 4/indigo and video 7,3,5,9 all
correct pre-fix). The two kinds have to arrive in DIFFERENT turns, because
`UserInput` flattens images and videos across all messages into two arrays
while pads stay in conversation order.


---

## What I removed from this PR, and why

This branch briefly also carried a cache-boundary change: the VL processor's
media branch publishes no `cachePrefixTokenCounts`, so I added an expander so
boundaries past an image could validate. It was unit-proven and safe by
construction.

**I measured it live and it does not pay off, so it is not here.**

Same conversation shape on Ornith-1.5-9B (image turn, then text follow-ups),
settled box, PhysMem logged per leg:

| context | leg | follow-up TTFT (3 probes) | median |
| --- | --- | --- | --- |
| ~1k | control | 0.21 / 0.23 / 0.23 | 0.23s |
| ~1k | with expander | 0.23 / 0.23 / 0.24 | 0.23s |
| ~30k | control | 0.41 / 0.73 / 0.73 | **0.73s** |
| ~30k | with expander | 0.72 / 1.04 / 1.16 | **1.04s** |

No benefit at either size, and a repeatable ~0.3s COST at 30k, reproduced with
the leg order reversed so it is not a launch-order artifact.

The reason is visible in the numbers: after a 16.5s cold turn the CONTROL's
follow-ups already run at 0.4-0.7s. Same-session continuation is served by the
in-memory KV cache, so there is nothing for a published boundary to improve.
Whatever the fix is worth would have to show up where that cache is gone —
across a restart, a model switch, or an eviction — and I did not demonstrate
that, so it should not ship on the strength of a mechanism argument.

What remains here is only the feature-order fix, which is live-proven above.
