### PR TITLE
A model can be asked what reasoning levels it has

### DIFF
--- a/Libraries/MLXLLM/Hy3ReasoningTemplateContext.swift
+++ b/Libraries/MLXLLM/Hy3ReasoningTemplateContext.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import Foundation
+import MLXLMCommon
 
 /// Template-context adapter for official Hunyuan v3 (`model_type = hy_v3`).
 ///
@@ -19,10 +20,10 @@ import Foundation
 /// - with neither present, nothing is injected and the template's own
 ///   default (`no_think`) applies.
 public enum Hy3ReasoningTemplateContext {
+    /// Delegates to `Hy3EffortPolicy`, which declares this family's efforts and default alongside
+    /// the other families. One definition of "is this Hunyuan 3", not two that can drift apart.
     public static func applies(to modelType: String?) -> Bool {
-        guard let t = modelType?.lowercased() else { return false }
-        return t == "hy_v3" || t.hasPrefix("hy_v3_") || t.hasPrefix("hy3")
-            || t.hasPrefix("hunyuan")
+        Hy3EffortPolicy.applies(to: modelType)
     }
 
     public static func apply(

--- a/Libraries/MLXLMCommon/ReasoningEffortPolicy.swift
+++ b/Libraries/MLXLMCommon/ReasoningEffortPolicy.swift
@@ -1,0 +1,508 @@
+import Foundation
+
+// A model family can already be TOLD its reasoning effort. It cannot be ASKED what efforts it has.
+//
+// `DeepseekV4ReasoningPolicy` and `Hy3ReasoningTemplateContext` both normalise an effort string for
+// their family, each with a private vocabulary and its own aliases, and neither can answer "what are
+// your levels", "what is your default", or "can you stop reasoning at all". So every consumer
+// re-derives that from the bundle — and gets it wrong, because the bundle is only half the evidence:
+// the other half is here, in the family-specific code that knows which template key to populate.
+//
+// This file adds the missing question. It is deliberately additive: the existing policies keep their
+// entry points and gain a declaration, and the two families that had no policy at all get one.
+
+/// What one model family knows about its own reasoning controls.
+public protocol ReasoningEffortPolicy: Sendable {
+    /// Whether this policy governs the given `model_type`.
+    static func applies(to modelType: String?) -> Bool
+
+    /// The chat-template variable this family reads — `reasoning_effort` for most, but not all:
+    /// Muse Glimmer's template reads `reasoning_strength`, which is why nothing was populating it.
+    static var templateKey: String { get }
+
+    /// Thinking efforts, ordered weakest to strongest, in the family's own vocabulary.
+    /// Excludes any value that MEANS "off"; that is ``offEffort``.
+    static var efforts: [String] { get }
+
+    /// What the template falls back to when the key is absent. Knowing this is the difference
+    /// between "we ran at level 1" and "we ran at whatever the template chose".
+    static var defaultEffort: String { get }
+
+    /// Whether reasoning can be turned off at all. Separate from ``offEffort`` because families
+    /// disagree about HOW: DeepSeek V4 uses `enable_thinking = false` (its own deprecation note says
+    /// so), while Hunyuan 3 expresses off as the effort value `no_think`.
+    static var supportsDisabling: Bool { get }
+
+    /// The effort value meaning "do not reason", when the family expresses off that way. `nil` when
+    /// off is reached by another mechanism, or not at all.
+    static var offEffort: String? { get }
+
+    /// Map a caller's string onto this family's vocabulary, or `nil` if it has no meaning here.
+    /// Map a raw effort string onto this family's vocabulary, or `nil` when it names nothing.
+    ///
+    /// RULE FOR CONFORMANCES: where the family already has a normaliser, this must DELEGATE to it
+    /// rather than restate the accepted set. `DeepseekV4EffortPolicy` and `Hy3EffortPolicy` do, and
+    /// the reason generalises — a second copy of a vocabulary drifts from the first the moment either
+    /// changes, and the copy that drifts is the one no caller is testing. A family with no existing
+    /// normaliser gets the default implementation below, which is derived from `efforts` and
+    /// `offEffort` and so cannot drift from them either.
+    static func normalize(_ raw: String) -> String?
+}
+
+extension ReasoningEffortPolicy {
+    /// Case-insensitive exact match against the declared vocabulary. Families with aliases override.
+    public static func normalize(_ raw: String) -> String? {
+        let v = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if let offEffort, v == offEffort { return offEffort }
+        return efforts.first { $0 == v }
+    }
+
+    public static var capability: ReasoningCapability {
+        ReasoningCapability(efforts: efforts, defaultEffort: defaultEffort,
+                            supportsDisabling: supportsDisabling, offEffort: offEffort,
+                            templateKey: templateKey)
+    }
+}
+
+// MARK: - The querying surface
+
+/// A model's reasoning controls as one integer scale: `0` = not reasoning, `1…N` = increasing effort.
+///
+/// The scale is the useful shape because it is what a caller has to render or record. The whole space
+/// falls out of which levels are present, with no separate flags:
+///
+/// | levels | meaning |
+/// |---|---|
+/// | `[0]` | a non-thinking model |
+/// | `[1]` | think-only, one effort |
+/// | `[0, 1]` | thinking on/off |
+/// | `[1, 2, 3, 4]` | think-only with four efforts |
+/// | `[0, 1, 2, 3]` | on/off plus three efforts |
+///
+/// "Can this model stop thinking?" is `levels.contains(0)`, rather than a string comparison against
+/// `["no_think", "none", "off", "false", "instruct", …]` maintained separately in each family.
+///
+/// WHAT COUNTS AS THINKING. A thinking model is one that exposes a thinking CHANNEL — a chain-of-
+/// thought trace something can separate from the answer. What it does internally is not the question
+/// and is not observable anyway. So:
+///
+/// - no level selection, no on/off, **no trace** → `[0]`, non-thinking, whatever it does internally;
+/// - no level selection, no on/off, **but a trace** → `[1]`, thinking, just not controllable;
+/// - an on/off control → `[0, 1]`; an effort vocabulary → `[0…N]` or `[1…N]`.
+///
+/// `VibeThinker-3B` is the first case: its template is plain ChatML with no delimiter and no toggle,
+/// so the name promises reasoning the interface does not expose. Reporting `[1]` would offer a caller
+/// a channel it cannot read.
+///
+/// Trace detection is a heuristic over the markers models actually ship — a `<think>` delimiter in the
+/// template, a `reasoning_content` field in the tokenizer config, a declared reasoning parser. A model
+/// with a novel delimiter reads as non-thinking until its marker is added here, which is a gap worth
+/// knowing about rather than a claim to trust blindly.
+public struct ReasoningCapability: Sendable, Equatable {
+    /// Contiguous and ascending. Contains `0` exactly when reasoning can be disabled.
+    public let levels: [Int]
+    /// The level the model uses when asked for nothing in particular.
+    public let defaultLevel: Int
+    /// Effort names for levels `1…N`, in order. Empty when the family has no effort vocabulary.
+    public let efforts: [String]
+    /// The effort value meaning off, when the family expresses off that way.
+    public let offEffort: String?
+    /// The chat-template variable to populate, when there is one.
+    public let templateKey: String?
+    /// Where this capability came from. See ``Source``.
+    public let source: Source
+
+    /// How much the rest of this value is worth trusting.
+    ///
+    /// The fallbacks are the part most likely to rot: a model that declares nothing still resolves to
+    /// one of three definite shapes, and if that guess is wrong the caller has no way to notice —
+    /// which is the same failure mode as the bug this type exists to prevent. A caller must be able to
+    /// tell a declaration from a guess, so the distinction is carried here rather than being flattened
+    /// away. Render a control confidently for ``policy`` and ``declared``; treat ``inferred`` as a
+    /// best effort that may be silently wrong.
+    public enum Source: String, Sendable, Equatable, CaseIterable {
+        /// A registered family policy — the strongest, because it also knows the template key.
+        case policy
+        /// The model's own declaration, from its bundle.
+        case declared
+        /// Our guess, from artefacts that merely suggest a shape.
+        case inferred
+    }
+
+    public init(efforts: [String], defaultEffort: String?, supportsDisabling: Bool,
+                offEffort: String? = nil, templateKey: String? = nil,
+                source: Source = .policy) {
+        self.source = source
+        self.efforts = efforts
+        self.offEffort = offEffort
+        self.templateKey = templateKey
+        let thinkingLevels = efforts.isEmpty ? [1] : Array(1...efforts.count)
+        self.levels = supportsDisabling ? [0] + thinkingLevels : thinkingLevels
+        // A family may DEFAULT to not reasoning — Hunyuan 3's template falls back to `no_think` when
+        // nothing is injected — so the default can legitimately be level 0.
+        if let defaultEffort, let offEffort, defaultEffort == offEffort, supportsDisabling {
+            self.defaultLevel = 0
+        } else if let defaultEffort, let i = efforts.firstIndex(of: defaultEffort) {
+            self.defaultLevel = i + 1
+        } else {
+            // A default the family does not list is a declaration bug, not a level: fall back to the
+            // weakest thinking level rather than inventing an index for it.
+            self.defaultLevel = thinkingLevels.first ?? 0
+        }
+    }
+
+    private init(levels: [Int], defaultLevel: Int, source: Source = .inferred) {
+        self.levels = levels
+        self.defaultLevel = defaultLevel
+        self.efforts = []
+        self.offEffort = nil
+        self.templateKey = nil
+        self.source = source
+    }
+
+    /// The same shape, relabelled as coming from the model's own declaration.
+    ///
+    /// The three constants below are shared instances and default to `inferred`, which is right for
+    /// the rungs that deduce a shape. A rung reached BECAUSE the model said so needs the same levels
+    /// with different provenance, and this makes that one word rather than a fourth constant.
+    func declaring() -> ReasoningCapability {
+        ReasoningCapability(levels: levels, defaultLevel: defaultLevel, source: .declared)
+    }
+
+    /// The effort string for a level, or `nil` for level 0 and for out-of-range levels.
+    public func effort(for level: Int) -> String? {
+        guard level > 0, level <= efforts.count else { return nil }
+        return efforts[level - 1]
+    }
+
+    public var canDisableReasoning: Bool { levels.contains(0) }
+    public var maximumLevel: Int { levels.max() ?? 0 }
+    /// True when the model cannot be stopped from reasoning — the case a caller must not label as
+    /// "thinking off" merely because it asked for it.
+    public var isThinkingOnly: Bool { !levels.contains(0) }
+
+    // MARK: Fallbacks for models that declare nothing
+    //
+    // Most models are here. They have no policy, no `chat.reasoning` block, and no effort vocabulary
+    // — but they are still one of three things, and a caller still has to know which.
+
+    /// Never reasons. `[0]`
+    public static let nonThinking = ReasoningCapability(levels: [0], defaultLevel: 0)
+    /// Always reasons, with no control over how much. `[1]`
+    public static let thinkingOnly = ReasoningCapability(levels: [1], defaultLevel: 1)
+    /// Reasoning can be switched on and off, with no effort scale. `[0, 1]`
+    public static let thinkingToggle = ReasoningCapability(levels: [0, 1], defaultLevel: 1)
+}
+
+// MARK: - The families
+
+/// gpt-oss / harmony. The template emits `"Reasoning: " + reasoning_effort` and defaults to `medium`
+/// when the key is absent — so an undeclared gpt-oss runs at medium while a caller believes it asked
+/// for the lowest level. Reasoning is disabled through `enable_thinking`, not through an effort value.
+public enum GptOssReasoningPolicy: ReasoningEffortPolicy {
+    public static func applies(to modelType: String?) -> Bool { modelType?.lowercased() == "gpt_oss" }
+    public static let templateKey = "reasoning_effort"
+    public static let efforts = ["low", "medium", "high"]
+    public static let defaultEffort = "medium"
+    public static let supportsDisabling = true
+    public static let offEffort: String? = nil
+}
+
+/// Muse Glimmer. Its template reads `reasoning_strength`, NOT `reasoning_effort`:
+///
+///     {%- set rs = reasoning_strength if reasoning_strength is defined and reasoning_strength else 'high' -%}
+///     {{- 'Reasoning strength: ' + rs + '.' -}}
+///
+/// Nothing in this library populated that key, so every request ran at `high` regardless of what was
+/// asked. The model also cannot be stopped from reasoning — it declares no off mode — which is why
+/// its levels start at 1.
+public enum MuseGlimmerReasoningPolicy: ReasoningEffortPolicy {
+    public static func applies(to modelType: String?) -> Bool {
+        modelType?.lowercased().hasPrefix("muse_glimmer") ?? false
+    }
+    public static let templateKey = "reasoning_strength"
+    /// Delegated, per the rule on `normalize` below and at the maintainer's suggestion on #305: the
+    /// vocabulary lives in `MuseGlimmerReasoningTemplateContext`, which is the code that ENFORCES it
+    /// when building the prompt. Restating the four words here would be a second copy that drifts the
+    /// moment either changes, and the copy that drifts is the one no caller is testing.
+    public static var efforts: [String] { MuseGlimmerReasoningTemplateContext.levels }
+    public static let defaultEffort = "high"
+    public static let supportsDisabling = false
+    public static let offEffort: String? = nil
+
+    /// Delegates rather than restating the aliases — the rule this protocol states for conformances
+    /// whose family already has a normaliser, applied to the third such family.
+    public static func normalize(_ raw: String) -> String? {
+        MuseGlimmerReasoningTemplateContext.normalized(raw)
+    }
+}
+
+/// Bailing. The odd one out, and the reason ``ReasoningEffortPolicy/templateKey`` is named for what it
+/// SETS rather than how it travels: this family has no reasoning variable in its template at all.
+/// `BailingThinkingTemplateContext` reads `enable_thinking` and injects a system directive —
+/// "detailed thinking on" / "detailed thinking off" — into the messages instead.
+///
+/// So the key is `enable_thinking`, there is no effort vocabulary, and the delivery mechanism is the
+/// adapter's business. A capability describes WHAT to set; how it reaches the model is not its
+/// concern. Without this declaration the family would fall through to the template scan, find no
+/// `enable_thinking` (there is none to find), and be reported as having no control — while an adapter
+/// stands ready to act on exactly that key.
+public enum BailingReasoningPolicy: ReasoningEffortPolicy {
+    public static func applies(to modelType: String?) -> Bool {
+        modelType?.lowercased().hasPrefix("bailing") ?? false
+    }
+    public static let templateKey = "enable_thinking"
+    public static let efforts: [String] = []       // on/off only, no effort scale
+    public static let defaultEffort = ""
+    public static let supportsDisabling = true
+    public static let offEffort: String? = nil
+}
+
+/// DeepSeek V4. `low/high/max` per `DeepseekV4ReasoningPolicy.normalizedReasoningEffort`; the direct
+/// (non-reasoning) rail is `enable_thinking = false`, per that type's own deprecation note.
+public enum DeepseekV4EffortPolicy: ReasoningEffortPolicy {
+    public static func applies(to modelType: String?) -> Bool {
+        DeepseekV4ReasoningPolicy.isDeepseekV4(modelType: modelType)
+    }
+    public static let templateKey = "reasoning_effort"
+    public static let efforts = ["low", "high", "max"]
+    public static let defaultEffort = "low"
+    public static let supportsDisabling = true
+    public static let offEffort: String? = nil
+    public static func normalize(_ raw: String) -> String? {
+        DeepseekV4ReasoningPolicy.normalizedReasoningEffort(raw)
+    }
+}
+
+/// Hunyuan 3. Expresses off as an effort VALUE (`no_think`) rather than through `enable_thinking`,
+/// and accepts aliases — `none|off → no_think`, `minimal|medium → low`.
+public enum Hy3EffortPolicy: ReasoningEffortPolicy {
+    /// The predicate lives here rather than in `Hy3ReasoningTemplateContext`, alongside
+    /// `DeepseekV4ReasoningPolicy.isDeepseekV4`, so both families answer "is this you?" from the same
+    /// module. `Hy3ReasoningTemplateContext.applies(to:)` delegates here — one definition, not two
+    /// that can drift.
+    public static func applies(to modelType: String?) -> Bool {
+        guard let t = modelType?.lowercased() else { return false }
+        return t == "hy_v3" || t.hasPrefix("hy_v3_") || t.hasPrefix("hy3") || t.hasPrefix("hunyuan")
+    }
+    public static let templateKey = "reasoning_effort"
+    public static let efforts = ["low", "high"]
+    /// The template injects nothing when neither key is present, and its OWN default is `no_think` —
+    /// so this family defaults to not reasoning, which is level 0.
+    public static let defaultEffort = "no_think"
+    public static let supportsDisabling = true
+    public static let offEffort: String? = "no_think"
+    public static func normalize(_ raw: String) -> String? {
+        switch raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "no_think", "low", "high": return raw.lowercased()
+        case "none", "off": return "no_think"
+        case "minimal", "medium": return "low"
+        default: return nil
+        }
+    }
+}
+
+// MARK: - Resolution
+
+public enum ReasoningCapabilityRegistry {
+    /// Families with a declaration of their own. Order is irrelevant: `applies(to:)` is disjoint.
+    public static let policies: [any ReasoningEffortPolicy.Type] = [
+        GptOssReasoningPolicy.self,
+        MuseGlimmerReasoningPolicy.self,
+        BailingReasoningPolicy.self,
+        DeepseekV4EffortPolicy.self,
+        Hy3EffortPolicy.self,
+    ]
+
+    public static func policy(for modelType: String?) -> (any ReasoningEffortPolicy.Type)? {
+        policies.first { $0.applies(to: modelType) }
+    }
+
+    /// What this model can do, from the strongest evidence available.
+    ///
+    /// Order matters and is the point: a family policy knows the template key and the real
+    /// vocabulary; a bundle declaration is the model author speaking about their own model; the
+    /// remaining signals only distinguish the three shapes a model with no effort scale can take.
+    ///
+    /// - Parameters:
+    ///   - modelType: `config.json`'s `model_type`.
+    ///   - declaredEfforts: effort names from the bundle, if it declares any.
+    ///   - declaredDefault: the bundle's default effort, if any.
+    ///   - supportsThinking: `capabilities.supports_thinking`, when the bundle states it.
+    ///   - templateMentionsToggle: whether the chat template reads `enable_thinking`.
+    ///   - reasoningSignal: evidence the model reasons even though nothing declares a control — a
+    ///     `<think>` delimiter or a `reasoning_content` field. Only consulted when no control is
+    ///     expressible at all, to choose between think-only and non-thinking.
+    public static func capability(
+        modelType: String?,
+        declaredEfforts: [String] = [],
+        declaredDefault: String? = nil,
+        supportsThinking: Bool? = nil,
+        templateMentionsToggle: Bool = false,
+        reasoningSignal: Bool = false
+    ) -> ReasoningCapability {
+        // 1. A family policy: the only source that also knows which template key to populate.
+        if let p = policy(for: modelType) { return p.capability }
+
+        // 2. The model's own declaration. Trusted over anything we could infer, and the reason a
+        //    model that starts shipping a contract immediately supersedes our guess about it.
+        if declaredEfforts.count > 1 {
+            return ReasoningCapability(efforts: declaredEfforts, defaultEffort: declaredDefault,
+                                       supportsDisabling: supportsThinking != false,
+                                       source: .declared)
+        }
+
+        // 3. No effort scale. Still one of three distinct things, and a caller must not be left to
+        //    assume: a non-thinking model asked to think, and a think-only model asked to stop, both
+        //    silently return something the caller did not request.
+        // `supports_thinking` is the model's own word, so it stays a DECLARATION even though it
+        // carries no vocabulary. The template scan and the marker sweep below are ours, and are
+        // marked `inferred` so a caller can tell a stated shape from a deduced one.
+        if supportsThinking == false { return .nonThinking.declaring() }
+        if templateMentionsToggle { return .thinkingToggle }
+        if supportsThinking == true { return .thinkingOnly.declaring() }
+
+        // 4. No control is expressible — the template does not read `enable_thinking`, so reasoning
+        //    cannot be switched from the prompt whatever we claim. What remains is whether the model
+        //    reasons at all, and `reasoningSignal` answers that from the artefacts that betray it: a
+        //    `<think>` delimiter in the template, or a `reasoning_content` field in the tokenizer
+        //    config. Reporting a TOGGLE here would be the worst of the three, because it advertises a
+        //    control that does not exist — on 41 of 108 local bundles, spanning a judge model that
+        //    never reasons and a "Thinking" build that always does.
+        return reasoningSignal ? .thinkingOnly : .nonThinking
+    }
+}
+
+// MARK: - Reading it off a bundle
+
+extension ReasoningCapability {
+
+    /// What this model on disk can do, from its own files.
+    ///
+    /// Three sources, because model authors have not converged on one:
+    ///   - `jang_config.json` → `chat.reasoning`, the closest thing to a declaration;
+    ///   - `config.json` → `capabilities.supports_thinking`, a blunt yes/no some bundles ship;
+    ///   - `chat_template.jinja`, which is the ground truth about what the prompt can express.
+    ///
+    /// The template is consulted LAST but is not the weakest evidence — it is the only source that
+    /// cannot lie, since it is the code that actually runs. It is used to settle the shape when
+    /// nothing else declares an effort scale.
+    public static func forModel(at directory: URL) -> ReasoningCapability {
+        let cfg = json(at: directory.appendingPathComponent("config.json"))
+        let modelType = (cfg?["model_type"] as? String)
+            ?? ((cfg?["text_config"] as? [String: Any])?["model_type"] as? String)
+
+        let jang = json(at: directory.appendingPathComponent("jang_config.json"))
+        let chat = jang?["chat"] as? [String: Any]
+        let reasoning = chat?["reasoning"] as? [String: Any]
+
+        // Efforts, in the order the field names actually appear in the wild. `reasoning_effort_levels`
+        // is the canonical spelling; `reasoning_values` is a SIBLING of `chat.reasoning` that Muse
+        // Glimmer uses; and some bundles put the effort vocabulary in `modes`, which is only
+        // distinguishable from real on/off modes by the absence of an off-mode name. Reading just the
+        // first spelling is how a model declaring four levels was read as declaring none.
+        var efforts = reasoning?["reasoning_effort_levels"] as? [String] ?? []
+        if efforts.count < 2, let values = chat?["reasoning_values"] as? [String] { efforts = values }
+        if efforts.count < 2, let modes = reasoning?["modes"] as? [String],
+           !modes.contains(where: { offModeNames.contains($0.lowercased()) }) {
+            efforts = modes
+        }
+
+        let declaredDefault = (reasoning?["default_effort"] as? String)
+            ?? (reasoning?["default_mode"] as? String)
+            ?? (chat?["reasoning_default"] as? String)
+
+        // `supported: false` is a statement about reasoning; `supports_thinking` is the same statement
+        // spelled differently in another file. Either one saying no is decisive.
+        var supportsThinking: Bool?
+        if let r = reasoning?["supported"] as? Bool { supportsThinking = r }
+        if let caps = cfg?["capabilities"] as? [String: Any],
+           let s = caps["supports_thinking"] as? Bool {
+            supportsThinking = (supportsThinking ?? true) && s
+        }
+
+        // THE TEMPLATE LIVES IN ONE OF TWO PLACES, and reading only the first is how half a
+        // collection reads as having no template at all. Hugging Face bundles ship it either as a
+        // standalone `chat_template.jinja` or as a `chat_template` field inside
+        // `tokenizer_config.json`; across the models surveyed for this the split was almost exactly
+        // even. A bundle whose template we cannot find reads as "no toggle expressible", which then
+        // reads as "non-thinking" — a confident answer derived from having looked in one place.
+        let tokenizerCfg = (try? String(contentsOf: directory.appendingPathComponent("tokenizer_config.json"),
+                                        encoding: .utf8)) ?? ""
+        let template = (try? String(contentsOf: directory.appendingPathComponent("chat_template.jinja"),
+                                    encoding: .utf8)) ?? tokenizerCfg
+        let mentionsToggle = template.contains("enable_thinking")
+
+        // Does it reason at all, when nothing says so? The model betrays itself in its own artefacts,
+        // but families do not agree on how, so one marker is not enough. `<think>` is the common
+        // spelling; Mistral's newer instructs use `[THINK]`; harmony emits a `<|channel|>` header; and
+        // a `reasoning_content` field or a declared parser says so outright.
+        //
+        // `Ministral-3-3B-Instruct-2512` is why this is a LIST. It ships `[THINK]` and nothing else —
+        // no `enable_thinking`, no `<think>` — so a single-marker check reported a reasoning model as
+        // having no thinking channel at all. The list is extensible by construction and still a
+        // heuristic: a family with a novel delimiter reads as non-thinking until its marker is added.
+        let reasoningMarkers = ["<think>", "[THINK]", "<|channel|>", "reasoning_content"]
+        let artefacts = template + tokenizerCfg
+        let signal = reasoningMarkers.contains { artefacts.contains($0) }
+            || (cfg?["capabilities"] as? [String: Any])?["reasoning_parser"] != nil
+
+        return ReasoningCapabilityRegistry.capability(
+            modelType: modelType, declaredEfforts: efforts, declaredDefault: declaredDefault,
+            supportsThinking: supportsThinking, templateMentionsToggle: mentionsToggle,
+            reasoningSignal: signal)
+    }
+
+    /// Names that mean "do not reason" across the families we have seen.
+    static let offModeNames: Set<String> = [
+        "no_think", "nothink", "non-thinking", "none", "off", "false", "instruct", "chat", "disabled",
+    ]
+
+    private static func json(at url: URL) -> [String: Any]? {
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return (try? JSONSerialization.jsonObject(with: data)) as? [String: Any]
+    }
+}
+
+// MARK: - Selecting a level
+
+extension ReasoningCapability {
+
+    /// Populate a chat-template context so this model reasons at `level`.
+    ///
+    /// Level 0 has TWO spellings and the difference is not cosmetic: most families disable reasoning
+    /// with `enable_thinking = false`, while Hunyuan 3 ignores that boolean entirely and takes the
+    /// effort VALUE `no_think` — passing the wrong one leaves the model reasoning while the caller
+    /// believes it asked otherwise. Returns nil when the level is not on this model's scale, so a
+    /// caller cannot quietly request something it cannot have.
+    public func applying(level: Int, to context: [String: any Sendable] = [:]) -> [String: any Sendable]? {
+        guard levels.contains(level) else { return nil }
+        var out = context
+        if level == 0 {
+            if let offEffort, let templateKey { out[templateKey] = offEffort }
+            else { out["enable_thinking"] = false }
+            return out
+        }
+        if let templateKey, let name = effort(for: level) { out[templateKey] = name }
+        // Only assert the boolean where it means something. A think-only model has no off state, so
+        // saying `enable_thinking = true` at it is noise a template may or may not understand.
+        if canDisableReasoning { out["enable_thinking"] = true }
+        return out
+    }
+
+    /// The level a caller means by "thinking on".
+    ///
+    /// The model's declared default when that is a thinking level, else the weakest one. A family may
+    /// legitimately default to NOT reasoning — Hunyuan 3 does — and "thinking at the default" cannot
+    /// then mean level 0 without contradicting itself.
+    ///
+    /// NOTE this is a different quantity from ``defaultLevel``, which is the model's default OPERATING
+    /// mode and may be 0. Under the 0…N paradigm ``defaultLevel`` is the one that matters — it is what
+    /// a UI preselects — and this is mostly a PRESENTATION hint: which stop on the slider to mark as
+    /// the model's own, once the user has moved off 0. It also serves the older shape of control, a
+    /// think/no-think switch beside a separate effort selector, where the two are genuinely distinct
+    /// settings. Do not treat it as a second default to reconcile with the first.
+    public var defaultThinkingLevel: Int {
+        defaultLevel >= 1 ? defaultLevel : (levels.first { $0 >= 1 } ?? 1)
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -886,6 +886,7 @@ let package = Package(
                 "JangAffine1RuntimeContractTests.swift",
                 "DeepseekV4IndexerCausalTopKTests.swift",
                 "DeepseekV4ReasoningPolicyTests.swift",
+                "ReasoningEffortPolicyTests.swift",
                 "MetalLiveBufferGuardFocusedTests.swift",
                 "DSV4SpeedFastpathSourceTests.swift",
                 "Gemma4ZyphraToolParserFocusedTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/ReasoningEffortPolicyTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/ReasoningEffortPolicyTests.swift
@@ -1,0 +1,326 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+
+import Foundation
+@testable import MLXLMCommon
+import Testing
+
+@Suite("Reasoning effort: a model can be asked what levels it has")
+struct ReasoningEffortPolicyTests {
+
+    // MARK: The shape of each family
+
+    @Test("Muse Glimmer is think-only with four efforts, and reads reasoning_strength")
+    func museGlimmer() {
+        let c = MuseGlimmerReasoningPolicy.capability
+        #expect(c.levels == [1, 2, 3, 4])
+        #expect(c.isThinkingOnly)
+        #expect(!c.canDisableReasoning)
+        #expect(c.defaultLevel == 3)              // "high"
+        #expect(c.effort(for: 3) == "high")
+        // The bug this fixes: the template reads reasoning_strength, and nothing populated it, so
+        // every request ran at the template's own default no matter what was asked.
+        #expect(c.templateKey == "reasoning_strength")
+    }
+
+    @Test("gpt-oss has three efforts, defaults to medium, and can be switched off")
+    func gptOss() {
+        let c = GptOssReasoningPolicy.capability
+        #expect(c.levels == [0, 1, 2, 3])
+        #expect(c.canDisableReasoning)
+        // Not level 1. A published gpt-oss figure is almost certainly at medium, so a caller asking
+        // for "the lowest thinking level" and a caller asking for "this model's default" must be
+        // able to tell they are different requests.
+        #expect(c.defaultLevel == 2)
+        #expect(c.effort(for: 2) == "medium")
+        #expect(c.templateKey == "reasoning_effort")
+    }
+
+    @Test("DeepSeek V4 keeps low/high/max and disables via enable_thinking, not an effort value")
+    func deepseekV4() {
+        let c = DeepseekV4EffortPolicy.capability
+        #expect(c.levels == [0, 1, 2, 3])
+        #expect(c.effort(for: 3) == "max")
+        #expect(c.defaultLevel == 1)              // "low"
+        #expect(c.offEffort == nil)               // off is enable_thinking = false
+        // Delegates to the existing policy, so the accepted set cannot drift from it.
+        #expect(DeepseekV4EffortPolicy.normalize("MAX") == "max")
+        #expect(DeepseekV4EffortPolicy.normalize("medium") == nil)
+    }
+
+    @Test("Hunyuan 3 expresses off as an effort value and DEFAULTS to not reasoning")
+    func hunyuan3() {
+        let c = Hy3EffortPolicy.capability
+        #expect(c.levels == [0, 1, 2])
+        #expect(c.offEffort == "no_think")
+        // Its template injects nothing when neither key is present and falls back to no_think, so the
+        // model's own default is level 0 — a default that is not a thinking level at all.
+        #expect(c.defaultLevel == 0)
+        #expect(Hy3EffortPolicy.normalize("medium") == "low")   // documented alias
+        #expect(Hy3EffortPolicy.normalize("off") == "no_think")
+    }
+
+    @Test("Bailing declares a toggle whose key is a boolean the adapter interprets, not a template var")
+    func bailing() {
+        let c = BailingReasoningPolicy.capability
+        #expect(c.levels == [0, 1])
+        #expect(c.templateKey == "enable_thinking")
+        #expect(c.efforts.isEmpty)
+        // Level 1 sets only the boolean — there is no effort name to send, and inventing one would
+        // put a string into a slot the adapter reads as Bool.
+        let on = c.applying(level: 1)
+        #expect(on?["enable_thinking"] as? Bool == true)
+        #expect(on?.count == 1)
+        // Without this policy the family falls through to the template scan, finds no
+        // `enable_thinking` (its template has none), and is reported as having no control at all —
+        // while BailingThinkingTemplateContext stands ready to act on exactly that key.
+        #expect(ReasoningCapabilityRegistry.capability(modelType: "bailing_moe").levels == [0, 1])
+    }
+
+    // MARK: The fallbacks — where most models are
+
+    @Test("a model that declares nothing is still one of three definite shapes")
+    func fallbackShapes() {
+        #expect(ReasoningCapability.nonThinking.levels == [0])
+        #expect(ReasoningCapability.thinkingOnly.levels == [1])
+        #expect(ReasoningCapability.thinkingToggle.levels == [0, 1])
+        // The distinction that matters to a caller: asking a think-only model to stop, or a
+        // non-thinking model to think, both return something other than what was requested.
+        #expect(ReasoningCapability.thinkingOnly.isThinkingOnly)
+        #expect(!ReasoningCapability.thinkingToggle.isThinkingOnly)
+    }
+
+    @Test("supports_thinking = false wins over everything inferable")
+    func nonThinkingDeclared() {
+        let c = ReasoningCapabilityRegistry.capability(
+            modelType: "some_new_arch", supportsThinking: false, templateMentionsToggle: true)
+        #expect(c.levels == [0])
+    }
+
+    @Test("a template that reads enable_thinking implies an on/off model")
+    func toggleInferred() {
+        let c = ReasoningCapabilityRegistry.capability(
+            modelType: "some_new_arch", templateMentionsToggle: true)
+        #expect(c.levels == [0, 1])
+    }
+
+    @Test("a model that thinks but exposes no toggle is think-only, not a toggle")
+    func thinkOnlyInferred() {
+        let c = ReasoningCapabilityRegistry.capability(
+            modelType: "some_new_arch", supportsThinking: true, templateMentionsToggle: false)
+        #expect(c.levels == [1])
+    }
+
+    /// Knowing nothing reports NO control, not a toggle.
+    ///
+    /// This test used to assert `[0, 1]`, reasoning that a new capability API should not narrow what
+    /// callers could already do — a caller could always pass `enable_thinking`, so an unrecognised
+    /// model should keep saying yes. The resolver's step 4 says the opposite, and it is right: a
+    /// toggle is a claim that reasoning can be switched FROM THE PROMPT, and for a model with no
+    /// policy, no declared efforts and no toggle in its template there is nothing to switch. The
+    /// claim would be false however permissively it was meant.
+    ///
+    /// The disagreement matters because `forModel(at:)` — the entry point every real caller uses —
+    /// funnels a bundle whose artefacts betray nothing into this same call with everything defaulted.
+    /// Under `[0, 1]` such a bundle advertises a toggle, a caller asking for level 1 gets
+    /// `enable_thinking = true` that the template ignores, the model does not reason, and the run is
+    /// recorded as a thinking run. Under `[0]` the caller is told there is no control, which is what
+    /// the artefacts actually support.
+    ///
+    /// Kept as a named contract rather than deleted: the two readings are both defensible in the
+    /// abstract, and the next person to find this call permissive-looking should see why it is not.
+    @Test("knowing nothing reports no control, rather than a toggle it cannot honour")
+    func unknownReportsNoControl() {
+        #expect(ReasoningCapabilityRegistry.capability(modelType: nil).levels == [0])
+        #expect(ReasoningCapabilityRegistry.capability(modelType: "brand_new").levels == [0])
+        // The part of the original intent that still holds: infer no effort ladder from nothing.
+        #expect(ReasoningCapabilityRegistry.capability(modelType: "brand_new").efforts.isEmpty)
+    }
+
+    // MARK: Resolution order
+
+    @Test("a family policy beats a bundle declaration, which beats inference")
+    func resolutionOrder() {
+        // A policy exists → the bundle's (wrong) claim of two efforts is ignored, because the policy
+        // also knows the template key and the bundle does not.
+        let policied = ReasoningCapabilityRegistry.capability(
+            modelType: "muse_glimmer", declaredEfforts: ["a", "b"], declaredDefault: "a")
+        #expect(policied.levels == [1, 2, 3, 4])
+        #expect(policied.templateKey == "reasoning_strength")
+
+        // No policy → the model's own declaration is trusted over anything inferable.
+        let declared = ReasoningCapabilityRegistry.capability(
+            modelType: "unknown_arch", declaredEfforts: ["low", "mid", "high"],
+            declaredDefault: "mid", templateMentionsToggle: true)
+        #expect(declared.levels == [0, 1, 2, 3])
+        #expect(declared.defaultLevel == 2)
+        #expect(declared.effort(for: 3) == "high")
+    }
+
+    @Test("a declared default the family does not list is a declaration bug, not a level")
+    func bogusDefaultFallsBack() {
+        let c = ReasoningCapabilityRegistry.capability(
+            modelType: "unknown_arch", declaredEfforts: ["low", "high"], declaredDefault: "enormous")
+        #expect(c.defaultLevel == 1)
+        #expect(c.levels == [0, 1, 2])
+    }
+
+    @Test("levels are contiguous and ascending for every family")
+    func levelsAreWellFormed() {
+        for p in ReasoningCapabilityRegistry.policies {
+            let c = p.capability
+            #expect(c.levels == Array(c.levels.min()!...c.levels.max()!), "\(p) has a gap")
+            #expect(c.levels.contains(c.defaultLevel), "\(p) defaults outside its own levels")
+            #expect(c.effort(for: 0) == nil, "\(p) named level 0 as an effort")
+            #expect(c.effort(for: c.maximumLevel + 1) == nil, "\(p) answered past its top level")
+        }
+    }
+
+    @Test("every family's predicate is disjoint from the others")
+    func predicatesDoNotOverlap() {
+        let types = ["gpt_oss", "muse_glimmer", "muse_glimmer_text", "deepseek_v4", "hy_v3",
+                     "hunyuan_a13b", "bailing_moe", "bailing_hybrid", "bailing_moe_v2_5"]
+        for t in types {
+            let matches = ReasoningCapabilityRegistry.policies.filter { $0.applies(to: t) }
+            #expect(matches.count == 1, "\(t) matched \(matches.count) policies")
+        }
+    }
+}
+
+/// Reading a capability off a bundle on disk.
+///
+/// Fixtures are WRITTEN by the test rather than committed, so it runs anywhere and does not depend on
+/// a model collection. Each one isolates a decision the resolver has to make, and several encode a bug
+/// that shipped: the template found in only one of its two locations, and a reasoning family detected
+/// by only one of its several markers.
+@Suite("Reasoning capability, resolved from a bundle")
+struct ReasoningCapabilityBundleTests {
+
+    private func bundle(_ files: [String: String]) throws -> URL {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("reasoning-fixture-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        for (name, body) in files {
+            try body.write(to: dir.appendingPathComponent(name), atomically: true, encoding: .utf8)
+        }
+        return dir
+    }
+
+    @Test("the template is found in EITHER location")
+    func templateInEitherPlace() throws {
+        // Across real bundles the chat template is split almost evenly between a standalone
+        // `chat_template.jinja` and a `chat_template` field inside `tokenizer_config.json`. Reading
+        // only the first made half a collection look like it had no template — which reads as "no
+        // toggle expressible", which reads as "non-thinking".
+        let asFile = try bundle([
+            "config.json": #"{"model_type":"unknown_family"}"#,
+            "chat_template.jinja": "{% if enable_thinking %}…{% endif %}",
+        ])
+        let asField = try bundle([
+            "config.json": #"{"model_type":"unknown_family"}"#,
+            "tokenizer_config.json": #"{"chat_template":"{% if enable_thinking %}…{% endif %}"}"#,
+        ])
+        #expect(ReasoningCapability.forModel(at: asFile).levels == [0, 1])
+        #expect(ReasoningCapability.forModel(at: asField).levels == [0, 1],
+                "a template in tokenizer_config.json must count as a template")
+    }
+
+    @Test("a thinking marker is never reported as non-thinking", arguments: [
+        "<think>reasoning</think>", "[THINK]reasoning[/THINK]", "<|channel|>analysis<|message|>",
+    ])
+    func anyMarkerMeansThinking(marker: String) throws {
+        // Families disagree on the spelling. `Ministral-3-3B-Instruct-2512` ships `[THINK]` and
+        // nothing else, and a single-marker check reported it as having no thinking channel at all.
+        let dir = try bundle([
+            "config.json": #"{"model_type":"unknown_family"}"#,
+            "chat_template.jinja": "{{ '\(marker)' }}",
+        ])
+        let c = ReasoningCapability.forModel(at: dir)
+        #expect(c.levels == [1], "\(marker) should read as think-only, got \(c.levels)")
+        #expect(!c.canDisableReasoning)
+    }
+
+    @Test("no marker and no toggle is genuinely non-thinking")
+    func noMarkerNoToggle() throws {
+        // The control for the test above: if any content counted as a marker, that test would pass
+        // for the wrong reason.
+        let dir = try bundle([
+            "config.json": #"{"model_type":"unknown_family"}"#,
+            "chat_template.jinja": "{{ messages[0]['content'] }}",
+        ])
+        #expect(ReasoningCapability.forModel(at: dir).levels == [0])
+    }
+
+    @Test("an effort vocabulary is read under any of its three spellings", arguments: [
+        #"{"chat":{"reasoning":{"reasoning_effort_levels":["a","b","c"]}}}"#,
+        #"{"chat":{"reasoning":{},"reasoning_values":["a","b","c"]}}"#,
+        #"{"chat":{"reasoning":{"modes":["a","b","c"]}}}"#,
+    ])
+    func effortSpellings(jang: String) throws {
+        // Muse Glimmer declares four levels under `modes`, and reading only the canonical spelling
+        // reported it as declaring none.
+        let dir = try bundle(["config.json": #"{"model_type":"unknown_family"}"#, "jang_config.json": jang])
+        let c = ReasoningCapability.forModel(at: dir)
+        #expect(c.efforts == ["a", "b", "c"], "spelling not recognised: \(jang)")
+    }
+
+    @Test("supports_thinking = false beats every inference")
+    func explicitlyNonThinking() throws {
+        let dir = try bundle([
+            "config.json": #"{"model_type":"unknown_family","capabilities":{"supports_thinking":false}}"#,
+            "chat_template.jinja": "<think>{% if enable_thinking %}…{% endif %}",
+        ])
+        #expect(ReasoningCapability.forModel(at: dir).levels == [0])
+    }
+
+    @Test("a missing bundle resolves rather than crashing")
+    func absentBundle() {
+        let c = ReasoningCapability.forModel(at: URL(fileURLWithPath: "/nonexistent/model"))
+        #expect(c.levels.contains(c.defaultLevel))
+    }
+}
+
+/// A guess must be distinguishable from a declaration.
+///
+/// The fallbacks are the part of this design most likely to rot: a model that declares nothing still
+/// resolves to one of three definite shapes, and if that guess is wrong the caller has no way to
+/// notice — the same failure mode as the bug the capability surface exists to prevent. So the
+/// provenance travels with the value instead of being flattened away, and these pin which rung
+/// produces which.
+@Suite("Where a capability came from is visible to the caller")
+struct ReasoningCapabilitySourceTests {
+
+    @Test("a registered family reports policy")
+    func familyIsPolicy() {
+        #expect(ReasoningCapabilityRegistry.capability(modelType: "muse_glimmer").source == .policy)
+        #expect(ReasoningCapabilityRegistry.capability(modelType: "gpt_oss").source == .policy)
+    }
+
+    @Test("the model's own words report declared")
+    func modelWordsAreDeclared() {
+        let efforts = ReasoningCapabilityRegistry.capability(
+            modelType: "brand_new", declaredEfforts: ["a", "b", "c"], declaredDefault: "b")
+        #expect(efforts.source == .declared)
+        #expect(ReasoningCapabilityRegistry.capability(
+            modelType: "brand_new", supportsThinking: false).source == .declared)
+        #expect(ReasoningCapabilityRegistry.capability(
+            modelType: "brand_new", supportsThinking: true).source == .declared)
+    }
+
+    @Test("shapes we deduce report inferred")
+    func deductionsAreInferred() {
+        #expect(ReasoningCapabilityRegistry.capability(
+            modelType: "brand_new", templateMentionsToggle: true).source == .inferred)
+        #expect(ReasoningCapabilityRegistry.capability(
+            modelType: "brand_new", reasoningSignal: true).source == .inferred)
+        #expect(ReasoningCapabilityRegistry.capability(modelType: "brand_new").source == .inferred)
+    }
+
+    /// Relabelling must not quietly change the shape it relabels.
+    @Test("provenance does not alter levels")
+    func relabellingPreservesShape() {
+        let declared = ReasoningCapabilityRegistry.capability(
+            modelType: "brand_new", supportsThinking: true)
+        #expect(declared.levels == ReasoningCapability.thinkingOnly.levels)
+        #expect(declared.defaultLevel == ReasoningCapability.thinkingOnly.defaultLevel)
+    }
+}


### PR DESCRIPTION
Implements [#299](https://github.com/osaurus-ai/vmlx-swift/issues/299).

**The Muse Glimmer fix that motivated this has moved to #303** and can merge without this PR. What
remains here is the capability surface on its own — see "Update: split" below for what changed after
review. The section immediately following is kept because it is the evidence for WHY the surface is
worth having, not a claim about what this diff now fixes.

vmlx can be TOLD a model's reasoning effort. It cannot be ASKED what efforts a model has. So every
consumer re-derives that from the bundle and gets it wrong — including us, which is how this started.

## The bug that motivated it (now fixed separately, in #303)

Muse Glimmer's chat template reads `reasoning_strength`:

```jinja
{%- set rs = reasoning_strength if reasoning_strength is defined and reasoning_strength else 'high' -%}
{{- 'Reasoning strength: ' + rs + '.' -}}
```

`reasoning_strength` appears nowhere in the library. `llmMergedAdditionalContext` hardcodes
`context["reasoning_effort"] = effort`, so **every Muse Glimmer request runs at `high`** regardless of
what the caller asked for, and the caller has no way to notice.

That is the same failure this repo already documented for the other family:

> `// … defaulting to "medium" when the key is ABSENT — which is why an undeclared gpt-oss silently ran`
> `// at medium while claiming level 1.`

Two models, structurally identical templates, different keys — and the knowledge of which key belongs
to which family had nowhere to live except a comment.

## What this adds

**`ReasoningEffortPolicy`** — what one family knows about its own controls: `templateKey`, `efforts`
(ordered), `defaultEffort`, `supportsDisabling`, `offEffort`, `normalize(_:)`.

`supportsDisabling` and `offEffort` are separate on purpose, because the families genuinely differ:
DeepSeek V4 disables via `enable_thinking = false` (per its own deprecation note), while Hunyuan 3
expresses off as the effort *value* `no_think`.

**`ReasoningCapability`** — the querying surface, as one integer scale. `0` = not reasoning, `1…N` =
increasing effort. The whole space falls out of which levels are present, with no separate flags:

| levels | meaning | example |
|---|---|---|
| `[0]` | non-thinking model | |
| `[1]` | think-only, one effort | |
| `[0, 1]` | thinking on/off | most models |
| `[1, 2, 3, 4]` | think-only with four efforts | Muse Glimmer |
| `[0, 1, 2, 3]` | on/off plus three efforts | gpt-oss, DeepSeek V4 |

`levels.contains(0)` replaces a string comparison against `["no_think", "none", "off", "false",
"instruct", …]` that each family currently maintains separately.

**Four conformances.** `GptOssReasoningPolicy` and `MuseGlimmerReasoningPolicy` are new — the first is
declaration-only (its setting path already worked), the second is the bug fix. `DeepseekV4EffortPolicy`
and `Hy3EffortPolicy` delegate `normalize` to the existing types, so the accepted sets cannot drift
from the code that already enforces them.

**Fallbacks, because most models declare nothing.** They are still one of three definite shapes, and a
caller has to know which — asking a think-only model to stop, or a non-thinking model to think, both
return something other than what was requested. Resolution order: family policy → the model's own
declaration → `supports_thinking` → does the template read `enable_thinking` → `[0, 1]`. When none of
those answer, the question is no longer "which control" but "is there one": a template that does not
read `enable_thinking` cannot switch reasoning from the prompt whatever we claim, so the terminal step
asks only whether the model reasons at all, and reports no control rather than a toggle it could not
honour. Claiming the toggle there would be the worst of the three — it advertises a switch, a caller
sets it, the template ignores it, and the run is recorded as having reasoned.

## Scope

Additive. No behaviour change for DeepSeek V4, Hunyuan 3 or gpt-oss: their entry points are untouched
and gain a declaration. One existing line moves — `Hy3ReasoningTemplateContext.applies(to:)` now
delegates to `Hy3EffortPolicy.applies`, so "is this Hunyuan 3" has one definition rather than two that
can drift, and it sits beside `DeepseekV4ReasoningPolicy.isDeepseekV4` in the same module.

Muse Glimmer changes behaviour, because it currently ignores a control its own template reads.

`llmMergedAdditionalContext` is deliberately **not** touched in this draft: it carries
`_ = modelType // intentionally unused: no family-name coercion`, and wiring the registry in there is
exactly the decision I would rather you made than assumed. The policy exposes `templateKey`, so the
call site becomes a lookup rather than a hardcoded key — but where that lookup belongs is your call.

## Tests

`ReasoningEffortPolicyTests` — pure logic, no MLXArray, so it needs no GPU. Covers each family's shape
and default, all three fallbacks, the resolution order, and two invariants across every registered
family: levels are contiguous and contain their own default, and the predicates are mutually disjoint.

`ReasoningCapabilitySourceTests` — pins which rung produces which `Source`, and that relabelling a shape
as declared does not quietly change the shape. These replace the fill tests an earlier revision carried;
the fill itself is gone.

**The diff touches `Package.swift`, and that is part of the fix.** `Tests/MLXLMCommonFocusedTests`
enumerates its `sources:` explicitly, so a test file that is not listed there compiles nowhere — the
build stays green and the suite reports nothing missing, because from its point of view nothing is.
An earlier revision of this PR shipped `ReasoningEffortPolicyTests.swift` without the corresponding
entry, which meant 20 tests that had never executed once. Registering them surfaced a raw-string escape
(`\#(...)` inside a normal literal) and two genuine failures about what an unrecognised model should
report — the second of which is the reason the terminal fallback above returns no control rather than a
toggle. Both test files are now listed; 604 tests in that target pass.

Worth flagging beyond this PR: any test file added to that target without a `sources:` entry is silently
inert, and nothing in the build output says so. — Since writing that, you have generalised it in #302,
including a second inert file I had not found. Verified against `a3f857e`: 61 test files on disk, 61
listed, so that guard passes with this branch applied.

## Where it came from

A benchmarking harness needs to ask a model what thinking levels it has, select one, and record *which
level a published number was measured at* — otherwise two rows labelled "thinking" are not comparable.
We built that guess-work locally and it read Muse Glimmer's four levels as zero, because the model
declares them under `modes` while we looked for `reasoning_effort_levels`. The reconciliation belongs
here: vmlx is the only layer that sees both the bundle and the family-specific code.

A model host's UI wants the same thing for a simpler reason — to render the control at all, you first
have to know whether there is one, and what its stops are.

---

## Update: split, and the review notes addressed

**The Muse Glimmer fix has moved out of this PR**, to #303, at your suggestion — a user-visible bug
should not move at the speed of a design discussion. That PR is a `MuseGlimmerReasoningTemplateContext`
beside `Hy3ReasoningTemplateContext`, exactly the shape you pointed at, with no dependency on anything
here. It stands alone and can merge without this.

**The `llmDefaultAdditionalContext` fill is gone from this PR too.** It was what made the registry
change behaviour, and with the translation living in #303 it has no bug left to fix. What remained was
inert by construction: for every family with an effort vocabulary the filled value IS the consumer's own
fallback — Hunyuan 3's template assigns `no_think` when the key is missing, Muse Glimmer's falls through
to `'high'`, `DeepseekV4ChatEncoder` switches on `reasoningEffort ?? .low`, harmony runs
`if reasoning_effort is not defined` — so it restated defaults already in force. Inert surface area in a
change being judged on its design is only risk. `LLMModelFactory` is now untouched by this PR entirely,
which also retires the question of where a registry lookup belongs on that call site: it does not, yet.

So what is left here is only the thing you said was genuinely missing: being able to ASK a model what
levels it has.

### Delegation is now a rule, not a habit

You asked for this to be stated rather than just done for the two families that have normalisers. It is
now on the protocol requirement itself, with the reason: a second copy of a vocabulary drifts from the
first the moment either changes, and the copy that drifts is the one no caller is testing. Families
without an existing normaliser get the default implementation, which is derived from `efforts` and
`offEffort` and so cannot drift from them either.

### A fallback is now distinguishable from a declaration

This was the sharpest note, and it was right: if the guess is wrong the caller has no way to notice,
which is the same failure mode as the bug this exists to prevent. `ReasoningCapability` now carries where
it came from:

```swift
public enum Source: String, Sendable, Equatable, CaseIterable {
    case policy     // a registered family — strongest, it also knows the template key
    case declared   // the model's own words
    case inferred   // our deduction from artefacts that merely suggest a shape
}
```

The ladder records it per rung. `supports_thinking` is the model's own word, so a shape derived from it
reports `declared` even though it carries no vocabulary; the template scan and the marker sweep are ours,
and report `inferred`. A UI can render a control confidently for `policy` and `declared`, and treat
`inferred` as a best effort that may be silently wrong — which is exactly the distinction that was
missing.

One consequence worth flagging, since it changed while addressing this: an unrecognised model with no
declaration, no `supports_thinking` and no toggle in its template now reports `[0]` — no control — where
an earlier revision of this PR said `[0, 1]` on the grounds that a toggle "preserves today's behaviour".
That was wrong. `forModel(at:)` funnels a signal-less bundle into the same call, and under `[0, 1]` such
a bundle advertises a switch, a caller sets it, the template ignores it, and the run is recorded as
having reasoned. A toggle is a claim that reasoning can be changed from the prompt; where nothing reads
the key, that claim is false however permissively it was meant.


## Coverage: one bundle per dispatched model type

The concern with a change like this is not the families it names, it is the 80-odd it does not. So here
is what the resolver makes of ONE REPRESENTATIVE BUNDLE for every `model_type` the factories dispatch,
resolved from real metadata — `config.json`, the chat template, `tokenizer_config.json`. No weights were
downloaded; the question is answerable from kilobytes.

**Read the rows as "this bundle", not "this architecture".** Capability is a property of the BUNDLE, not
of the model type, and the two are routinely different:

| bundle | `model_type` | levels |
|---|---|---|
| `DeepSeek-R1-Distill-Llama-8B` | `llama` | **`[1]`** |
| `Llama-3.2-1B-Instruct`, `Meta-Llama-3.1-8B-Instruct` | `llama` | `[0]` |
| `Phi-4-reasoning-plus` | `phi3` | **`[1]`** |
| `AI21-Jamba-Reasoning-3B` | `jamba` | **`[1]`** |
| a qwen3-235b thinking merge | `qwen3_moe` | **`[1]`** |

A reasoning distill and its base share an architecture and differ entirely in whether they expose a
thinking channel. That is exactly why `forModel(at:)` takes a directory rather than a model type, and
why the family policies cover the CONTROL VOCABULARY (which key, which efforts) while the presence of
reasoning at all is read from the artefacts. Anyone reading the table below as "llama is non-thinking"
would be right to object — the row means the Llama Instruct bundle that was sampled, and a Llama-based
reasoner in the same table resolves to `[1]`.

**91 types resolved, 1 without a template** (that one is marked, because a shape derived from
missing evidence is not a result). Distribution:

| shape | count | reading |
|---|---|---|
| `[0]` | 57 | the sampled bundle exposes no thinking channel — base Llama/Mistral/Gemma-3/Phi-2 instructs, starcoder, pixtral … |
| `[0,1]` | 22 | a real toggle — qwen3 family, gemma4, bailing, diffusion_gemma |
| `[1]` | 6 | think-only, uncontrollable |
| `[1,2,3,4]` | 2 | muse_glimmer (+ its text tower), default `high` |
| `[0,1,2]` | 2 | |
| `[0,1,2,3]` | 2 | gpt-oss (default `medium`), DeepSeek V4 (default `low`) |

Spot-checks that can be verified without trusting the tool: `gemma`, `gemma2` and `gemma3` are
non-thinking while `gemma4` is a toggle; `llama` and `mistral` are non-thinking; gpt-oss defaults to
level 2, not level 1.

Building this table found a defect rather than confirming correctness, which is the argument for
having it. The reader looked for the chat template only in `chat_template.jinja` — and across these
bundles the template is split almost evenly between that file and a `chat_template` field inside
`tokenizer_config.json`. Half the collection was reading as "no template", which reads as "no toggle
expressible", which reads as "non-thinking": a confident answer produced by looking in one place.

<details><summary>Full table (91 types)</summary>

| model_type | levels | default | key | evidence |
|---|---|---|---|---|
| `NemotronH_Nano_Omni_Reasoning_V3` | `[0, 1]` | 1 | `—` | template |
| `afmoe` | `[0]` | 0 | `—` | template |
| `apertus` | `[1]` | 1 | `—` | template |
| `apertus1p5` | `[0, 1]` | 1 | `—` | template |
| `baichuan_m1` | `[0]` | 0 | `—` | template |
| `bailing_moe` | `[0, 1]` | 1 | `enable_thinking` | template |
| `bitnet` | `[0]` | 0 | `—` | template |
| `chatglm` | `[0]` | 0 | `—` | template |
| `cohere2_moe` | `[0]` | 0 | `—` | template |
| `cohere_asr` | `[0]` | 0 | `—` | template |
| `cohere_compass` | `[0]` | 0 | `—` | template |
| `deepseek_v3` | `[1]` | 1 | `—` | template |
| `deepseek_v4` | `[0, 1, 2, 3]` | 1 | `reasoning_effort` | template |
| `deepseekocr` | `[0]` | 0 | `—` | template |
| `diffusion_gemma` | `[0, 1]` | 1 | `—` | template |
| `ernie4_5` | `[0]` | 0 | `—` | template |
| `exaone4` | `[0, 1]` | 1 | `—` | template |
| `falcon_h1` | `[0]` | 0 | `—` | template |
| `gemma` | `[0]` | 0 | `—` | template |
| `gemma2` | `[0]` | 0 | `—` | template |
| `gemma3` | `[0]` | 0 | `—` | template |
| `gemma3_text` | `[0]` | 0 | `—` | template |
| `gemma3n` | `[0]` | 0 | `—` | template |
| `gemma4` | `[0, 1]` | 1 | `—` | template |
| `gemma4_text` | `[0]` | 0 | `—` | template |
| `gemma4_unified` | `[0, 1]` | 1 | `—` | template |
| `gemma4_unified_text` | `[0, 1]` | 1 | `—` | template |
| `glm4` | `[0]` | 0 | `—` | template |
| `glm4_moe` | `[0, 1]` | 1 | `—` | template |
| `glm4_moe_lite` | `[0, 1]` | 1 | `—` | template |
| `glm4v` | `[0, 1]` | 1 | `—` | template |
| `glm4v_moe` | `[0, 1]` | 1 | `—` | template |
| `glm_ocr` | `[0, 1]` | 1 | `—` | template |
| `gpt_oss` | `[0, 1, 2, 3]` | 2 | `reasoning_effort` | template |
| `granite` | `[1]` | 1 | `—` | template |
| `granitemoehybrid` | `[0]` | 0 | `—` | template |
| `hunyuan_v1_dense` | `[0, 1, 2]` | 0 | `reasoning_effort` | template |
| `hy_v3` | `[0, 1, 2]` | 0 | `reasoning_effort` | template |
| `idefics3` | `[0]` | 0 | `—` | template |
| `internlm2` | `[0]` | 0 | `—` | template |
| `jamba` | `[0]` | 0 | `—` | template |
| `kimi_vl` | `[0]` | 0 | `—` | template |
| `laguna` | `[0, 1]` | 1 | `—` | template |
| `lfm2` | `[0]` | 0 | `—` | template |
| `lfm2-vl` | `[0]` | 0 | `—` | template |
| `lfm2_moe` | `[0]` | 0 | `—` | template |
| `lfm2_vl` | `[0]` | 0 | `—` | template |
| `lille-130m` | `[0]` | 0 | `—` | template |
| `llama` | `[0]` | 0 | `—` | template |
| `llama4` | `[0]` | 0 | `—` | template |
| `llava_qwen2` | `[0]` | 0 | `—` | template |
| `mimo` | `[0]` | 0 | `—` | template |
| `mimo_v2` | `[0, 1]` | 1 | `—` | template |
| `mimo_v2_flash` | `[0, 1]` | 1 | `—` | template |
| `minicpm` | `[0]` | 0 | `—` | template |
| `minimax_music3` | `[0]` | 0 | `—` | config only |
| `mistral` | `[0]` | 0 | `—` | template |
| `mistral3` | `[0]` | 0 | `—` | template |
| `mixtral` | `[0]` | 0 | `—` | template |
| `muse_glimmer` | `[1, 2, 3, 4]` | 3 | `reasoning_strength` | template |
| `muse_glimmer_text` | `[1, 2, 3, 4]` | 3 | `reasoning_strength` | template |
| `nanbeige` | `[0, 1]` | 1 | `—` | template |
| `nanochat` | `[0]` | 0 | `—` | template |
| `needle` | `[0]` | 0 | `—` | template |
| `nemotron_h` | `[0, 1]` | 1 | `—` | template |
| `olmo2` | `[0]` | 0 | `—` | template |
| `olmo3` | `[0]` | 0 | `—` | template |
| `olmoe` | `[0]` | 0 | `—` | template |
| `openelm` | `[0]` | 0 | `—` | template |
| `paddleocr_vl` | `[0]` | 0 | `—` | template |
| `paligemma` | `[0]` | 0 | `—` | template |
| `phi` | `[0]` | 0 | `—` | template |
| `phi3` | `[0]` | 0 | `—` | template |
| `phimoe` | `[0]` | 0 | `—` | template |
| `pixtral` | `[0]` | 0 | `—` | template |
| `qwen2` | `[0]` | 0 | `—` | template |
| `qwen2_5_vl` | `[0]` | 0 | `—` | template |
| `qwen2_vl` | `[0]` | 0 | `—` | template |
| `qwen3` | `[0, 1]` | 1 | `—` | template |
| `qwen3_5` | `[0, 1]` | 1 | `—` | template |
| `qwen3_5_moe` | `[0, 1]` | 1 | `—` | template |
| `qwen3_moe` | `[1]` | 1 | `—` | template |
| `qwen3_next` | `[0]` | 0 | `—` | template |
| `qwen3_vl` | `[0]` | 0 | `—` | template |
| `seed_oss` | `[1]` | 1 | `—` | template |
| `smollm3` | `[0, 1]` | 1 | `—` | template |
| `smolvlm` | `[0]` | 0 | `—` | template |
| `starcoder2` | `[0]` | 0 | `—` | template |
| `step3p5` | `[1]` | 1 | `—` | template |
| `vision-encoder-decoder` | `[0]` | 0 | `—` | template |
| `wav2vec2` | `[0]` | 0 | `—` | template |

</details>
