### PR TITLE
Register a test file that had never run, and make the omission fail the build

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -859,6 +859,8 @@ let package = Package(
                 "CanonicalChatCacheBoundariesTests.swift",
                 "RotatingKVCachePhysicalGrowthTests.swift",
                 "NativeMTPWarmupMemoScopeTests.swift",
+                "NormConventionResolverTests.swift",
+                "TestSourcesAreRegisteredTests.swift",
                 "BatchEngineGrowingChatCacheSourceTests.swift",
                 "CacheCoordinatorTopologyFocusedTests.swift",
                 "DiskStoreOffsetConsistencyFocusedTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/TestSourcesAreRegisteredTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/TestSourcesAreRegisteredTests.swift
@@ -1,0 +1,83 @@
+//
+//  TestSourcesAreRegisteredTests.swift
+//  MLXLMCommonFocusedTests
+//
+//  `MLXLMCommonFocusedTests` enumerates its `sources:` explicitly in
+//  Package.swift. A test file added to the directory but not to that list
+//  compiles NOWHERE, and nothing says so: the build is green, and the suite
+//  reports no absence because from its point of view there is none. The file
+//  is not skipped, not disabled, not failing — it does not exist.
+//
+//  This has now happened twice. An earlier revision of #300 shipped
+//  `ReasoningEffortPolicyTests.swift` unregistered, so 20 tests had never
+//  executed once; registering them surfaced a raw-string escape and two
+//  genuine failures that changed a contract. And `NormConventionResolverTests.swift`
+//  was added in 36ff6201 and never appeared in Package.swift at all —
+//  `git log -S` over Package.swift returns nothing for it.
+//
+//  A green suite that silently covers less than it appears to is the worst
+//  shape a harness can take, so this asserts the invariant directly rather
+//  than trusting the next person to remember the list.
+//
+
+import Foundation
+import Testing
+
+@Suite("Every focused test file is registered in Package.swift")
+struct TestSourcesAreRegisteredTests {
+
+    /// Walk up from this file to the package root, so the check does not
+    /// depend on the working directory the test runner happens to use.
+    private static func packageRoot(from file: StaticString = #filePath) -> URL? {
+        var dir = URL(fileURLWithPath: "\(file)").deletingLastPathComponent()
+        for _ in 0 ..< 6 {
+            if FileManager.default.fileExists(atPath: dir.appendingPathComponent("Package.swift").path) {
+                return dir
+            }
+            dir = dir.deletingLastPathComponent()
+        }
+        return nil
+    }
+
+    @Test("no .swift file in the target directory is missing from sources:")
+    func everyFileOnDiskIsListed() throws {
+        let root = try #require(Self.packageRoot(), "could not locate Package.swift")
+        let manifest = try String(
+            contentsOf: root.appendingPathComponent("Package.swift"), encoding: .utf8)
+        let targetDir = root
+            .appendingPathComponent("Tests")
+            .appendingPathComponent("MLXLMCommonFocusedTests")
+
+        let onDisk = try FileManager.default
+            .contentsOfDirectory(atPath: targetDir.path)
+            .filter { $0.hasSuffix(".swift") }
+            .sorted()
+        // The directory is the source of truth for what SHOULD run; if it is
+        // empty the check has lost its subject and must not silently pass.
+        #expect(!onDisk.isEmpty, "found no .swift files — the check is looking in the wrong place")
+
+        // Scope to this target's sources array. Matching the whole manifest
+        // would let a filename registered under a DIFFERENT target satisfy
+        // the check, which is the same false pass in a new disguise.
+        let marker = "\"MLXLMCommonFocusedTests\""
+        let targetStart = try #require(
+            manifest.range(of: marker), "target declaration not found in Package.swift")
+        let afterTarget = manifest[targetStart.upperBound...]
+        let sourcesStart = try #require(
+            afterTarget.range(of: "sources:"), "target has no explicit sources: list")
+        let afterSources = afterTarget[sourcesStart.upperBound...]
+        let sourcesEnd = try #require(afterSources.firstIndex(of: "]"), "unterminated sources: list")
+        let sourcesBlock = String(afterSources[..<sourcesEnd])
+
+        let unlisted = onDisk.filter { !sourcesBlock.contains("\"\($0)\"") }
+        #expect(
+            unlisted.isEmpty,
+            """
+            These test files exist on disk but are NOT in the MLXLMCommonFocusedTests \
+            sources: list, so they compile nowhere and have never run: \
+            \(unlisted.joined(separator: ", ")). \
+            Add each to the sources: array in Package.swift.
+            """
+        )
+    }
+}


### PR DESCRIPTION
Following up on the hazard @rcfa flagged on #299: `MLXLMCommonFocusedTests` enumerates its `sources:` explicitly, so a test file added to the directory but not to that list **compiles nowhere, and nothing says so**. The build is green and the suite reports no absence, because from its point of view there is none.

I audited the target for it. One file was inert:

```
listed in sources: 57
files on disk    : 58

SILENTLY INERT: NormConventionResolverTests.swift  (~5 tests)
```

`git log -S'NormConventionResolverTests.swift' -- Package.swift` returns **nothing** — it was added in 36ff6201 and has never appeared in the manifest, so those 5 tests had not executed once.

Registered. All 5 pass, so this restores coverage rather than uncovering a defect:

```
✔ noProbeFallsBackToProvidedDefault
✔ recognizedPlusOneMarkerForcesShift
✔ recognizedMarkerWinsThroughUnrecognizedHigherPrecedence
✔ noDeclarationVotesOnWeights
✔ unrecognizedDeclarationFallsBackToVote
```

### The guard

That is the second occurrence — the first cost 20 unexecuted tests on #300, and registering *those* surfaced a raw-string escape plus two genuine failures that changed a contract. So this is not a one-off to fix and forget.

`TestSourcesAreRegisteredTests` asserts the invariant directly: every `.swift` file in the target directory appears in that target's `sources:` array. Two details that keep it honest:

- it **scopes the match to this target's array**, not the whole manifest — a filename registered under a different target would otherwise satisfy it, which is the same false pass in a new disguise
- it **refuses to pass on an empty directory listing**, which would mean the check had lost its subject rather than found nothing wrong

### Verified fail-closed, not just green

A guard that only ever passes is worth nothing, so I checked both directions. With `NormConventionResolverTests.swift` temporarily removed from the list:

```
✘ Expectation failed: (unlisted → ["NormConventionResolverTests.swift"]).isEmpty → false
↳ These test files exist on disk but are NOT in the MLXLMCommonFocusedTests sources: list,
  so they compile nowhere and have never run: NormConventionResolverTests.swift.
  Add each to the sources: array in Package.swift.
```

Restored, and it passes again.

### Scope

Only this target has the problem today; the guard is written against this target's directory. If other explicit-`sources:` targets appear it should be generalised rather than copied.