### PR TITLE
Muse Glimmer: translate the reasoning request into the key its template reads

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -1262,8 +1262,11 @@ private struct LLMUserInputProcessor: UserInputProcessor {
     }
 
     func prepare(input: UserInput) throws -> LMInput {
-        let additionalContext = Hy3ReasoningTemplateContext.apply(
-            additionalContext: try mergedAdditionalContext(input.additionalContext),
+        let additionalContext = MuseGlimmerReasoningTemplateContext.apply(
+            additionalContext: Hy3ReasoningTemplateContext.apply(
+                additionalContext: try mergedAdditionalContext(input.additionalContext),
+                modelType: modelType
+            ),
             modelType: modelType
         )
         let bailingMessages = BailingThinkingTemplateContext.apply(

--- a/Libraries/MLXLLM/MuseGlimmerReasoningTemplateContext.swift
+++ b/Libraries/MLXLLM/MuseGlimmerReasoningTemplateContext.swift
@@ -1,0 +1,98 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import MLXLMCommon
+
+/// Template-context adapter for Muse Glimmer (`model_type = muse_glimmer`, `muse_glimmer_text`).
+///
+/// The chat template keys reasoning on a `reasoning_strength` variable:
+///
+/// ```jinja
+/// {%- set rs = reasoning_strength if reasoning_strength is defined and reasoning_strength else 'high' -%}
+/// ```
+///
+/// That key appears nowhere else in this library, and no caller sends it — every request therefore
+/// renders at the template's own fallback of `high`, whatever effort was asked for, and nothing
+/// reports that the request was dropped. The bundle states the contract plainly in `jang_config.json`
+/// (`chat.reasoning_control = "reasoning_strength"`, `reasoning_values = [low, medium, high, xhigh]`,
+/// `reasoning_default = "high"`), so this is a translation gap rather than an unknown.
+///
+/// The same failure already has a name here: `ReasoningContract`'s fallback table records that an
+/// undeclared gpt-oss "silently ran at medium while claiming level 1". This is that, one family over.
+/// It survives a green suite because the tests pass `reasoning_strength` explicitly and so prove the
+/// template honours it, while no production path ever sets it.
+///
+/// This adapter translates the request surface into the template's contract, mirroring
+/// ``Hy3ReasoningTemplateContext``:
+///
+/// - explicit `reasoning_strength` wins, when it names one of the declared values.
+/// - otherwise `reasoning_effort` — the key callers actually send — is mapped into this family's
+///   vocabulary.
+/// - otherwise `enable_thinking` is honoured as far as the model allows (see below).
+/// - with none of them present nothing is injected, and the template's own `high` applies. That is
+///   deliberate: injecting the default would restate a value already in force and make an inert
+///   change look like a behavioural one.
+public enum MuseGlimmerReasoningTemplateContext {
+
+    /// The template variable this family reads. Named once, here, so a caller that wants to know
+    /// which key carries the control has somewhere to read it from rather than a string literal
+    /// buried in a translation.
+    public static let templateKey = "reasoning_strength"
+
+    /// Declared in `jang_config.json` as `chat.reasoning_values`, weakest → strongest.
+    public static let strengths = ["low", "medium", "high", "xhigh"]
+
+    public static func applies(to modelType: String?) -> Bool {
+        guard let t = modelType?.lowercased() else { return false }
+        return t == "muse_glimmer" || t.hasPrefix("muse_glimmer_")
+    }
+
+    public static func apply(
+        additionalContext: [String: any Sendable]?,
+        modelType: String?
+    ) -> [String: any Sendable]? {
+        guard applies(to: modelType) else { return additionalContext }
+        var context = additionalContext ?? [:]
+
+        let strength: String?
+        if let explicit = (context[templateKey] as? String)?.lowercased(),
+            strengths.contains(explicit)
+        {
+            strength = explicit
+        } else if let requested = (context["reasoning_effort"] as? String)?.lowercased(),
+            !requested.isEmpty
+        {
+            strength = normalize(requested)
+        } else if let enable = context["enable_thinking"] as? Bool {
+            // Muse Glimmer cannot stop reasoning — there is no value in its vocabulary that turns the
+            // rail off, and `jang_config.json` declares no off mode. A caller asking to disable it is
+            // asking for as little reasoning as possible, so honour that as the WEAKEST strength
+            // rather than either ignoring the request or pretending it was satisfied. `true` injects
+            // nothing: the template already defaults to reasoning, and restating that would be inert.
+            strength = enable ? nil : strengths.first
+        } else {
+            strength = nil
+        }
+
+        if let strength {
+            context[templateKey] = strength
+        }
+        return context.isEmpty ? nil : context
+    }
+
+    /// Map a generic effort word onto this family's vocabulary.
+    ///
+    /// Unrecognised values resolve to the declared default rather than being forwarded: the template
+    /// does not validate, so an unknown string would silently render as itself in the system prompt
+    /// (`Reasoning strength: banana.`) instead of failing loudly the way Hunyuan 3's `raise_exception`
+    /// does. Landing on the default is the behaviour a caller gets today.
+    static func normalize(_ raw: String) -> String {
+        switch raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "low", "medium", "high", "xhigh": return raw.lowercased()
+        case "minimal", "none", "off", "no_think": return "low"
+        case "max", "maximum", "highest": return "xhigh"
+        default: return "high"
+        }
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -906,6 +906,7 @@ let package = Package(
                 "TokenizerAddedTokenRegexFocusedTests.swift",
                 "LFM2ShortConvCacheRestoreFocusedTests.swift",
                 "LFM25ChatTemplateRenderFocusedTests.swift",
+                "MuseGlimmerReasoningTemplateContextTests.swift",
             ]
         ),
         .testTarget(

--- a/Tests/MLXLMCommonFocusedTests/MuseGlimmerReasoningTemplateContextTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/MuseGlimmerReasoningTemplateContextTests.swift
@@ -1,0 +1,149 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+
+import Foundation
+@testable import MLXLLM
+import Testing
+import VMLXJinja
+
+/// Muse Glimmer's reasoning control has to actually reach the template.
+///
+/// The template reads `reasoning_strength`; callers send `reasoning_effort`. Nothing translated
+/// between them, so every request rendered at the template's own fallback of `high` no matter what
+/// was asked, and nothing reported that the request had been dropped.
+///
+/// The first test is the bug. The rest pin the translation and, just as importantly, the cases where
+/// this adapter must do NOTHING — an adapter that fires on the wrong family, or injects a default
+/// that was already in force, trades a silent wrong answer for a silent behaviour change.
+@Suite("Muse Glimmer reasoning strength reaches the template")
+struct MuseGlimmerReasoningTemplateContextTests {
+
+    private func apply(_ ctx: [String: any Sendable], type: String = "muse_glimmer")
+        -> [String: any Sendable]
+    {
+        MuseGlimmerReasoningTemplateContext.apply(additionalContext: ctx, modelType: type) ?? [:]
+    }
+    private func strength(_ ctx: [String: any Sendable], type: String = "muse_glimmer") -> String? {
+        apply(ctx, type: type)["reasoning_strength"] as? String
+    }
+
+    // MARK: The bug
+
+    @Test("a requested effort is translated into the key the template reads")
+    func effortBecomesStrength() {
+        #expect(strength(["reasoning_effort": "low"]) == "low",
+                "reasoning_effort did not reach the template as reasoning_strength — this is the bug")
+        #expect(strength(["reasoning_effort": "xhigh"]) == "xhigh")
+    }
+
+    @Test("every declared value survives the round trip")
+    func vocabularyRoundTrips() {
+        for v in MuseGlimmerReasoningTemplateContext.strengths {
+            #expect(strength(["reasoning_effort": v]) == v, "\(v) did not survive translation")
+        }
+    }
+
+    @Test("generic effort words map onto this family's vocabulary")
+    func aliasesMap() {
+        #expect(strength(["reasoning_effort": "minimal"]) == "low")
+        #expect(strength(["reasoning_effort": "none"]) == "low")
+        #expect(strength(["reasoning_effort": "max"]) == "xhigh")
+        #expect(strength(["reasoning_effort": "MEDIUM"]) == "medium", "matching must be case-insensitive")
+    }
+
+    /// The template does not validate, so an unknown value would render as itself —
+    /// `Reasoning strength: banana.` — rather than failing the way Hunyuan 3's `raise_exception` does.
+    @Test("an unrecognised value lands on the default instead of rendering verbatim")
+    func unknownFallsBackToDefault() {
+        let s = strength(["reasoning_effort": "banana"])
+        #expect(s == "high")
+        #expect(MuseGlimmerReasoningTemplateContext.strengths.contains(s ?? ""),
+                "forwarded a value outside the declared vocabulary, which the template would print raw")
+    }
+
+    // MARK: Precedence
+
+    @Test("an explicit reasoning_strength wins over a generic effort")
+    func explicitWins() {
+        #expect(strength(["reasoning_strength": "medium", "reasoning_effort": "low"]) == "medium")
+    }
+
+    /// Glimmer has no off value and declares no off mode, so "stop thinking" can only be honoured as
+    /// far as the model allows. The weakest strength is that; silently leaving it at `high` is not.
+    @Test("asking to disable reasoning yields the weakest strength this family has")
+    func disableBecomesWeakest() {
+        #expect(strength(["enable_thinking": false]) == "low")
+    }
+
+    // MARK: Where it must do nothing
+
+    @Test("enable_thinking = true injects nothing, because the template already reasons")
+    func enableTrueInjectsNothing() {
+        #expect(strength(["enable_thinking": true]) == nil,
+                "injected a default that was already in force, turning an inert call into a change")
+    }
+
+    @Test("an empty request injects nothing and leaves the template's own default")
+    func silentStaysSilent() {
+        #expect(MuseGlimmerReasoningTemplateContext.apply(additionalContext: nil,
+                                                          modelType: "muse_glimmer") == nil)
+        #expect(strength([:]) == nil)
+    }
+
+    /// The control. Without it, an adapter that fired on everything would pass every test above.
+    @Test("other families are untouched")
+    func otherFamiliesUntouched() {
+        for other in ["hy_v3", "bailing_moe", "gpt_oss", "deepseek_v4", "llama", nil] as [String?] {
+            let out = MuseGlimmerReasoningTemplateContext.apply(
+                additionalContext: ["reasoning_effort": "low"], modelType: other) ?? [:]
+            #expect(out["reasoning_strength"] == nil,
+                    "wrote reasoning_strength for \(other ?? "nil"), which does not read that key")
+            #expect(out["reasoning_effort"] as? String == "low",
+                    "modified another family's reasoning_effort")
+        }
+    }
+
+    @Test("the text tower is the same family")
+    func textTowerMatches() {
+        #expect(MuseGlimmerReasoningTemplateContext.applies(to: "muse_glimmer_text"))
+        #expect(MuseGlimmerReasoningTemplateContext.applies(to: "muse_glimmer"))
+        #expect(!MuseGlimmerReasoningTemplateContext.applies(to: "muse"))
+    }
+
+    // MARK: The end-to-end proof
+
+    /// Render the template's own reasoning line, with and without this adapter.
+    ///
+    /// Everything above tests the translation in isolation, which cannot show the thing that made
+    /// this bug survive: that a request looks accepted and changes nothing. This does. The fixture is
+    /// the real line from Muse Glimmer's `chat_template.jinja` —
+    ///
+    /// ```jinja
+    /// {%- set rs = reasoning_strength if reasoning_strength is defined and reasoning_strength else 'high' -%}
+    /// ```
+    ///
+    /// — so the "before" case is not a reconstruction of the defect, it is the defect: a caller asks
+    /// for `low`, the template never sees a key it recognises, and renders `high`.
+    @Test("the request changes the rendered prompt, which is what it never did before")
+    func requestReachesTheRenderedPrompt() throws {
+        let line = """
+            {%- set rs = reasoning_strength if reasoning_strength is defined and reasoning_strength else 'high' -%}
+            Reasoning strength: {{ rs }}.
+            """
+        func render(_ ctx: [String: any Sendable]) throws -> String {
+            var values: [String: Value] = [:]
+            for (k, v) in ctx { values[k] = try Value(any: v) }
+            return try Template(line).render(values)
+        }
+
+        let asked: [String: any Sendable] = ["reasoning_effort": "low"]
+
+        let before = try render(asked)
+        #expect(before == "Reasoning strength: high.",
+                "fixture is wrong: without translation the template must fall back to high")
+
+        let after = try render(apply(asked))
+        #expect(after == "Reasoning strength: low.",
+                "the adapter ran but the rendered prompt still does not carry the requested strength")
+        #expect(before != after, "the request must change the prompt, or nothing was fixed")
+    }
+}


### PR DESCRIPTION
## The bug

Muse Glimmer's chat template keys reasoning on a `reasoning_strength` variable:

```jinja
{%- set rs = reasoning_strength if reasoning_strength is defined and reasoning_strength else 'high' -%}
{{- 'Reasoning strength: ' + rs + '.' -}}
```

`reasoning_strength` appears nowhere in vmlx production code, and no caller sends it. So every request
renders at the template's own fallback of `high`, whatever effort was asked for, and nothing reports
that the request was dropped.

The bundle is not ambiguous about the contract — `jang_config.json` carries:

```json
"reasoning_control": "reasoning_strength",
"reasoning_default": "high",
"reasoning_values": ["low", "medium", "high", "xhigh"]
```

so this is a translation gap, not an unknown. `JangChatReasoning` already parses `modes` and
`default_mode`; the control KEY is the piece nothing carries.

It survives a green suite because the tests pass `reasoning_strength` explicitly and therefore prove the
template honours it, while no production path ever sets it.

## The fix

The shape already exists here: `Hy3ReasoningTemplateContext` is a per-family adapter applied in
`LLMUserInputProcessor.prepare` that translates the request surface into the template's contract.
`MuseGlimmerReasoningTemplateContext` sits beside it and needs no new protocol.

| request | result |
|---|---|
| explicit `reasoning_strength` naming a declared value | passes through |
| `reasoning_effort` — the key callers send | mapped onto `low` / `medium` / `high` / `xhigh` |
| `enable_thinking: false` | weakest strength (see below) |
| `enable_thinking: true` | nothing injected |
| nothing | nothing injected |

Two decisions worth surfacing, because both could reasonably have gone the other way:

**`enable_thinking: false` becomes the weakest strength, not nothing.** This family has no off value and
declares no off mode, so a request to stop reasoning cannot be satisfied. Honouring it as far as the
model allows seemed better than ignoring it — leaving it at `high` would answer "reason as little as
possible" with the strongest setting available.

**An unrecognised value lands on the default rather than being forwarded.** The template does not
validate, so an unknown string renders as itself — `Reasoning strength: banana.` — rather than failing
the way Hunyuan 3's `raise_exception` does. Landing on the default is what a caller gets today.

**Nothing is injected when nothing is requested.** The template's `high` already applies; restating it
would make an inert change look like a behavioural one.

## Tests

11 tests, no GPU. They cover the translation, the precedence between the two keys, the alias mapping,
and — deliberately — the cases where the adapter must do *nothing*: other families untouched, an empty
request left alone, `enable_thinking: true` injecting nothing. The other-families case is the control;
without it an adapter that fired on everything would pass the rest.

The last test is an end-to-end proof rather than another isolated assertion. It renders the template's
own reasoning line with and without the adapter, so the "before" case is the defect itself:

```
before:  Reasoning strength: high.     ← caller asked for "low"
after:   Reasoning strength: low.
```

Mutation-checked: neutering the translation fails 12 assertions across the suite.

## Scope

Additive for every other family — the adapter returns its input untouched unless `model_type` is
`muse_glimmer` or `muse_glimmer_text`. One line changes in `prepare`, wrapping the existing Hy3 call.

Split out of #300 at your suggestion, so the user-visible fix is not queued behind the capability-surface
discussion.
