### PR TITLE
Catch degenerate repetition whose unit is longer than the character scan sees

### DIFF
--- a/Libraries/MLXLMCommon/RepetitionCycleDetector.swift
+++ b/Libraries/MLXLMCommon/RepetitionCycleDetector.swift
@@ -64,6 +64,27 @@ public struct RepetitionCycleDetector: Sendable {
     /// happens to echo itself is left alone.
     public static let minimumOutputLength = 128
 
+    /// Consecutive repeats of a LINE cycle required. Four back-to-back
+    /// repeats of a block whose every line clears `minimumLineLength` is
+    /// already unambiguous — at period 8 that is 32 identical substantial
+    /// lines in a row.
+    public static let minimumLineRepeats = 4
+
+    /// Longest line CYCLE considered, in lines.
+    ///
+    /// Must comfortably exceed the number of lines it takes to pass the
+    /// character scan's `maximumUnitLength` (512), or this scan cannot see its
+    /// own target case: a unit longer than 512 characters necessarily spans
+    /// several lines, and an earlier value of 4 here missed an 8-line block
+    /// entirely. Cost is a handful of whole-line comparisons per completed
+    /// line, not per chunk, so the headroom is cheap.
+    public static let maximumLineCycle = 12
+
+    /// A line must be at least this long, trimmed, before it can anchor a
+    /// line cycle — and must contain a letter. Keeps table rules (`|---|`),
+    /// separators, blank lines and `}` / `)` closers from ever qualifying.
+    public static let minimumLineLength = 24
+
     /// Rolling tail. Only the end of the stream can carry a cycle that is
     /// still running, and bounding this keeps `feed` O(1) in stream length.
     private static let tailCapacity = maximumUnitLength * (minimumRepeats + 1)
@@ -74,6 +95,11 @@ public struct RepetitionCycleDetector: Sendable {
 
     private var tail: [Character] = []
     private var total = 0
+    /// Completed visible lines, most recent last. Bounded by the largest
+    /// window the line scan can need.
+    private var lines: [String] = []
+    /// Bytes of the line currently being built (no newline seen yet).
+    private var pendingLine: String = ""
 
     public init(isEnabled: Bool = true) {
         self.isEnabled = isEnabled
@@ -101,7 +127,82 @@ public struct RepetitionCycleDetector: Sendable {
             tail.removeFirst(tail.count - Self.tailCapacity)
         }
         guard total >= Self.minimumOutputLength else { return nil }
-        return Self.cycle(in: tail)
+        if let cycle = Self.cycle(in: tail) { return cycle }
+        return feedLines(text)
+    }
+
+    /// Line-level cycle scan.
+    ///
+    /// The character scan bounds its unit at `maximumUnitLength` (512) because
+    /// the cost of looking for longer units on every chunk is not worth it —
+    /// the comment there says a longer cycle is "cheaper to let the token cap
+    /// handle". That trade was costed against SCAN time, never against the
+    /// user's wall clock, and the two diverge badly on slow hardware: a
+    /// runaway that reaches a 16,384-token cap is ~2 minutes on a fast Mac and
+    /// ~34 minutes at 8 tok/s on a base laptop. Reported live: a 36 KB file
+    /// task where the model "kept writing the same line over and over" and the
+    /// user gave up after 35 minutes.
+    ///
+    /// So this catches exactly the class the character scan gives up on — a
+    /// repeating unit LONGER than 512 characters — and it does so at O(1) per
+    /// completed line rather than O(unit x tail) per chunk, because it compares
+    /// whole lines instead of every possible period.
+    private mutating func feedLines(_ text: String) -> Cycle? {
+        // Only completed lines can be compared; a line still being written
+        // would false-negative on its own prefix.
+        pendingLine += text
+        guard pendingLine.contains("\n") else { return nil }
+        var parts = pendingLine.components(separatedBy: "\n")
+        pendingLine = parts.removeLast()
+        lines.append(contentsOf: parts)
+        let window = Self.maximumLineCycle * (Self.minimumLineRepeats + 1)
+        if lines.count > window { lines.removeFirst(lines.count - window) }
+        return Self.lineCycle(in: lines)
+    }
+
+    /// Shortest line cycle whose back-to-back repetition ends `lines`.
+    ///
+    /// Exposed for testing alongside `cycle(in:)`.
+    public static func lineCycle(in lines: [String]) -> Cycle? {
+        for period in 1 ... maximumLineCycle {
+            guard lines.count >= period * minimumLineRepeats else { continue }
+            let unit = Array(lines.suffix(period))
+            // Every line in the unit must be substantial. Without this a run
+            // of `|---|---|`, blank lines, or `    }` would qualify, and those
+            // are ordinary formatting rather than a collapsed model.
+            guard unit.allSatisfy({ line in
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                return trimmed.count >= minimumLineLength
+                    && trimmed.contains(where: { $0.isLetter })
+            }) else { continue }
+            // A unit that is itself a repetition of a shorter block has that
+            // shorter block as its real period — the same primitivity rule the
+            // character scan applies, so `A A` is never reported as period 2.
+            if period > 1, isRepetition(unit) { continue }
+            var repeats = 1
+            var offset = lines.count - period
+            while offset >= period, Array(lines[(offset - period) ..< offset]) == unit {
+                repeats += 1
+                offset -= period
+            }
+            guard repeats >= minimumLineRepeats else { continue }
+            return Cycle(unit: unit.joined(separator: "\n"), repeats: repeats)
+        }
+        return nil
+    }
+
+    /// True when `unit` is a whole number of copies of a shorter prefix.
+    private static func isRepetition(_ unit: [String]) -> Bool {
+        let n = unit.count
+        for period in 1 ..< n where n % period == 0 {
+            var matches = true
+            for i in period ..< n where unit[i] != unit[i - period] {
+                matches = false
+                break
+            }
+            if matches { return true }
+        }
+        return false
     }
 
     /// Shortest unit whose back-to-back repetition ends the buffer.

--- a/Tests/MLXLMTests/RepetitionCycleDetectorTests.swift
+++ b/Tests/MLXLMTests/RepetitionCycleDetectorTests.swift
@@ -139,4 +139,120 @@ extension String {
         }
         return out
     }
+
+    // MARK: - Line cycles (units longer than the character scan's 512 bound)
+
+    /// The gap the line scan exists for: a repeating unit LONGER than the
+    /// character scan's `maximumUnitLength` (512).
+    ///
+    /// A single repeated line under 512 characters is ALREADY caught by the
+    /// character scan at 4 repeats — verified by `firesOnObservedCollapse`.
+    /// The escape hatch is a longer block, where `cycle(in:)` deliberately
+    /// gives up ("cheaper to let the token cap handle"). That fallback costs
+    /// ~2 minutes on a fast Mac and ~34 minutes at 8 tok/s on a base laptop,
+    /// which is the live report this closes.
+    @Test("a repeating block LONGER than the character scan's bound is caught")
+    func blockLongerThanCharacterBoundIsCaught() throws {
+        // Six substantial lines: comfortably past 512 characters as a unit,
+        // so the character scan cannot see the period.
+        let block = [
+            "First, open the depot manifest and confirm every column header matches the schema.",
+            "Second, normalise each region code against the canonical lookup table in memory.",
+            "Third, recompute the seal codes for any row whose port number changed since import.",
+            "Fourth, write the corrected rows back out in the original order, preserving gaps.",
+            "Fifth, verify the checksum of the rewritten file against the manifest total.",
+            "Sixth, report how many rows changed and list the identifiers that were touched.",
+            "Seventh, archive the previous revision alongside a timestamped audit record.",
+            "Eighth, release the advisory lock and emit the completion summary to the log.",
+        ]
+        let unitLength = block.joined(separator: "\n").count
+        #expect(
+            unitLength > RepetitionCycleDetector.maximumUnitLength,
+            "the unit must exceed the character scan's bound or this tests nothing")
+
+        var detector = RepetitionCycleDetector()
+        var fired: RepetitionCycleDetector.Cycle?
+        outer: for _ in 0 ..< 12 {
+            for line in block {
+                if let cycle = detector.feed(line + "\n") { fired = cycle; break outer }
+            }
+        }
+        let cycle = try #require(fired, "a >512-char block repeated 12 times must be caught")
+        #expect(cycle.repeats >= RepetitionCycleDetector.minimumLineRepeats)
+    }
+
+    /// A short repeating block (under 512 characters) is caught too — by the
+    /// CHARACTER scan, not the line scan. Kept to pin that the short case did
+    /// not regress when the line path was added.
+    @Test("a short repeating multi-line block is still caught")
+    func repeatingBlockIsCaught() throws {
+        let block = [
+            "Step one: read the manifest and validate every column header.",
+            "Step two: normalise the region codes against the lookup table.",
+            "Step three: write the corrected rows back to the output file.",
+        ]
+        var detector = RepetitionCycleDetector()
+        var fired: RepetitionCycleDetector.Cycle?
+        for _ in 0 ..< 10 {
+            for line in block {
+                if let cycle = detector.feed(line + "\n") { fired = cycle; break }
+            }
+            if fired != nil { break }
+        }
+        #expect(fired != nil, "a 3-line block repeated 10 times must be caught")
+    }
+
+    /// FALSE POSITIVES ARE WORSE THAN THE BUG. Formatting that legitimately
+    /// repeats must never halt a generation.
+    @Test("ordinary repeated formatting never fires")
+    func formattingDoesNotFire() {
+        let benign: [[String]] = [
+            Array(repeating: "|---|---|---|", count: 40),          // table rule
+            Array(repeating: "", count: 40),                        // blank lines
+            Array(repeating: "    }", count: 40),                   // closers
+            Array(repeating: "- [ ] todo", count: 40),              // short list items
+            Array(repeating: "====================", count: 40),    // separators
+        ]
+        for lines in benign {
+            var detector = RepetitionCycleDetector()
+            var fired: RepetitionCycleDetector.Cycle?
+            for line in lines where fired == nil {
+                fired = detector.feed(line + "\n")
+            }
+            #expect(fired == nil, "benign formatting fired: \(lines[0])")
+        }
+    }
+
+    /// Near-repetition is NOT degeneration: a real script whose lines differ
+    /// by an index is doing useful work and must run to completion.
+    @Test("lines that vary are never treated as a cycle")
+    func varyingLinesDoNotFire() {
+        var detector = RepetitionCycleDetector()
+        var fired: RepetitionCycleDetector.Cycle?
+        for i in 0 ..< 60 where fired == nil {
+            fired = detector.feed("        data[\(i)] = transform(row_\(i), mode=\"strict\")\n")
+        }
+        #expect(fired == nil, "varying lines must not be reported as degenerate")
+    }
+
+    /// A unit that is itself a repetition has the shorter block as its real
+    /// period — `A A` must never be reported as a period-2 cycle.
+    @Test("a doubled unit reports its primitive period")
+    func doubledUnitIsNotPeriodTwo() throws {
+        let line = "The answer is AppleScript; it begins with `use AppleScript version`."
+        let lines = Array(repeating: line, count: 20)
+        let cycle = try #require(RepetitionCycleDetector.lineCycle(in: lines))
+        #expect(cycle.unit == line, "expected the primitive single line, got a multiple")
+    }
+
+    /// Disabling must restore exactly the old behaviour on the line path too.
+    @Test("VMLX_REPETITION_STOP=0 disables the line scan as well")
+    func disabledSkipsLineScan() {
+        var detector = RepetitionCycleDetector.fromEnvironment(["VMLX_REPETITION_STOP": "0"])
+        var fired: RepetitionCycleDetector.Cycle?
+        for _ in 0 ..< 30 where fired == nil {
+            fired = detector.feed("        data[index] = transform(row, mode=strict, retries=3)\n")
+        }
+        #expect(fired == nil)
+    }
 }


### PR DESCRIPTION
`RepetitionCycleDetector` halts a collapsed generation — but only for a verbatim unit of 32–512 characters. Above that it deliberately gives up:

> `/// Longest unit considered. A cycle longer than this is cheaper to let the token cap handle than to scan for on every chunk.`

That trade was costed against **scan time** and never against the **user's wall clock**, and the two diverge badly on slow hardware. "Let the token cap handle it" means running to `max_tokens` — 16,384 by default in the host:

| decode | time to 16,384 tokens |
|---|---|
| 12 tok/s | 22.8 min |
| **8 tok/s** | **34.1 min** |
| 6 tok/s | 45.5 min |

Reported live: an M4 Air, a 36 KB file task, a model that *"kept writing the same line over and over"*, user gave up after **35 minutes**. The arithmetic lands exactly on the report.

### Why not just raise `maximumUnitLength`

`cycle(in:)` is O(unit × tail) on **every chunk** — at 512 that is already ~1.3M character comparisons per chunk, and `tailCapacity` scales with the bound, so 2048 would cost ~16× that on the decode path. The 512 bound is defensible; I left it alone.

### What this adds

A scan at the granularity the symptom is actually reported in: **whole lines**. It compares completed lines rather than every possible character period, so it costs a handful of string comparisons per newline instead of per chunk — and it covers exactly the case the character scan abandons, a repeating block longer than 512 characters.

The character scan still runs first and is unchanged. This only fires where that scan returned nil, so no existing verdict moves.

### Guards, because a false positive is worse than the bug

- every line in the unit must be **≥24 characters trimmed AND contain a letter** — table rules (`|---|`), separators, blank lines and `    }` can never qualify
- the unit must be **primitive**, so `A A` is never reported as period 2
- **four** consecutive repeats required — at period 8 that is 32 identical substantial lines in a row
- **lines that vary never fire**: a real script whose lines differ by an index is doing useful work and must run to completion

`maximumLineCycle` is **12, not 4**. A unit longer than 512 characters necessarily spans several lines, and an earlier value of 4 could not see its own target case — an 8-line block went undetected until a test caught it. Recorded in the constant's doc comment so nobody re-tightens it.

### Tests

18 passing. New coverage: the >512-character block, four false-positive classes (table rules, blank lines, closers, short list items), varying lines, primitivity, and `VMLX_REPETITION_STOP=0` disabling the line path too.

### Scope

Does **not** cap context, lower `max_tokens`, or cap tool results — those would punish legitimate long work. It detects a pathology and stops it, which is what the existing detector already does; this just widens the class it can see.

Also does not address *near*-verbatim degeneration (a loop whose lines differ by a counter). That is genuinely ambiguous against legitimate output and is deliberately left out — the `varyingLinesDoNotFire` test pins that boundary.