### PR TITLE
Muse Glimmer: translate reasoning_effort into the reasoning_strength its template reads

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -1262,8 +1262,15 @@ private struct LLMUserInputProcessor: UserInputProcessor {
     }
 
     func prepare(input: UserInput) throws -> LMInput {
-        let additionalContext = Hy3ReasoningTemplateContext.apply(
-            additionalContext: try mergedAdditionalContext(input.additionalContext),
+        // Two per-family adapters, each translating the generic request
+        // surface into ITS template's contract. Both are no-ops for every
+        // other family (they gate on `modelType` first), so the order between
+        // them is irrelevant.
+        let additionalContext = MuseGlimmerReasoningTemplateContext.apply(
+            additionalContext: Hy3ReasoningTemplateContext.apply(
+                additionalContext: try mergedAdditionalContext(input.additionalContext),
+                modelType: modelType
+            ),
             modelType: modelType
         )
         let bailingMessages = BailingThinkingTemplateContext.apply(

--- a/Libraries/MLXLMCommon/MuseGlimmerReasoningTemplateContext.swift
+++ b/Libraries/MLXLMCommon/MuseGlimmerReasoningTemplateContext.swift
@@ -1,0 +1,92 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+
+/// Template-context adapter for Muse Glimmer (`model_type = muse_glimmer`).
+///
+/// Muse Glimmer keys reasoning on **`reasoning_strength`**, not the
+/// `reasoning_effort` every other family understands. Its `render_reasoning()`
+/// writes `Reasoning strength: <value>.` into the SYSTEM PREFIX and defaults to
+/// `high` when the variable is undefined:
+///
+/// ```jinja
+/// {%- set rs = reasoning_strength if reasoning_strength is defined and reasoning_strength else 'high' -%}
+/// {{- 'Reasoning strength: ' + rs + '.' -}}
+/// ```
+///
+/// Nothing in the library ever set that key. `reasoning_strength` appeared only
+/// in this repo's own docs and in `MediaSalt`, which merely READS it out of
+/// `additionalContext` for the cache scope salt — and, in osaurus, only in test
+/// files. So the shipping app sent `reasoning_effort`, the template ignored it,
+/// and **every Muse Glimmer request ran at `high`** regardless of what the user
+/// chose. The control was editable, saved, and inert.
+///
+/// `MuseGlimmer_PROOF_MATRIX.md:250` already predicted this in writing — "If
+/// osaurus sends `reasoning_effort`, the template never…" — which is why the
+/// translation belongs in code rather than in another comment.
+///
+/// **Four levels, not three.** The official contract is
+/// `low / medium / high / xhigh`, with `high`/`xhigh` intended for complex
+/// problem solving, coding and agentic work. A caller that models effort as
+/// low/medium/high only cannot express `xhigh`, so `max` maps there rather than
+/// being flattened into `high` and silently capping the model below its ceiling.
+///
+/// **There is no "off".** Reasoning is a system-prefix sentence, not a channel:
+/// there are no `<think>` tags to suppress. The lowest expressible setting is
+/// `low`, so a request to disable thinking maps to `low` rather than removing
+/// the key — removing it would fall through to the template's `high` default,
+/// i.e. the exact opposite of what was asked.
+public enum MuseGlimmerReasoningTemplateContext {
+
+    /// Accepted values, in the order the model card documents them.
+    public static let levels = ["low", "medium", "high", "xhigh"]
+
+    public static func applies(to modelType: String?) -> Bool {
+        guard let t = modelType?.lowercased() else { return false }
+        return t == "muse_glimmer" || t.hasPrefix("muse_glimmer") || t.hasPrefix("museglimmer")
+    }
+
+    public static func apply(
+        additionalContext: [String: any Sendable]?,
+        modelType: String?
+    ) -> [String: any Sendable]? {
+        guard applies(to: modelType) else { return additionalContext }
+        var context = additionalContext ?? [:]
+
+        // An explicit `reasoning_strength` from the caller is already in the
+        // template's own vocabulary — normalise it but never re-derive it from
+        // `reasoning_effort`, which would let a generic default override a
+        // deliberate per-model choice.
+        if let explicit = (context["reasoning_strength"] as? String)?.lowercased(),
+            !explicit.isEmpty
+        {
+            context["reasoning_strength"] = normalized(explicit)
+            return context
+        }
+
+        if let requested = (context["reasoning_effort"] as? String)?.lowercased(),
+            !requested.isEmpty
+        {
+            context["reasoning_strength"] = normalized(requested)
+        } else if let enable = context["enable_thinking"] as? Bool {
+            // No channel to switch off, so "off" is the floor, not absence.
+            context["reasoning_strength"] = enable ? "high" : "low"
+        }
+        // With neither present, leave the key unset and let the template's own
+        // `high` default apply — the documented behaviour for an undeclared
+        // request.
+        return context.isEmpty ? nil : context
+    }
+
+    /// Map the request surface onto the four documented levels.
+    static func normalized(_ raw: String) -> String {
+        switch raw {
+        case "low", "medium", "high", "xhigh": return raw
+        // OpenAI-style and internal synonyms.
+        case "minimal", "none", "off", "false", "no_think", "instruct": return "low"
+        case "max", "highest", "ultra": return "xhigh"
+        default: return "high"
+        }
+    }
+}

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -753,11 +753,15 @@ public final class VLMModelFactory: ModelFactory {
             processorType: processorType, tokenizer: tokenizer)
         let defaultAdditionalContext = VLMDefaultContextUserInputProcessor.defaultContext(
             capabilities: jangConfig?.capabilities)
+        let needsReasoningTranslation =
+            VLMDefaultContextUserInputProcessor.requiresReasoningTranslation(
+                modelType: baseConfig.modelType)
         let processor: any UserInputProcessor =
-            if defaultAdditionalContext != nil {
+            if defaultAdditionalContext != nil || needsReasoningTranslation {
                 VLMDefaultContextUserInputProcessor(
                     base: baseProcessor,
-                    defaultAdditionalContext: defaultAdditionalContext)
+                    defaultAdditionalContext: defaultAdditionalContext,
+                    modelType: baseConfig.modelType)
             } else {
                 baseProcessor
             }
@@ -859,10 +863,24 @@ private func loadProcessorConfig(from modelDirectory: URL) async throws -> (
 struct VLMDefaultContextUserInputProcessor: UserInputProcessor {
     let base: any UserInputProcessor
     let defaultAdditionalContext: [String: any Sendable]?
+    /// Needed by the per-family reasoning adapters, which gate on it.
+    let modelType: String?
 
-    init(base: any UserInputProcessor, defaultAdditionalContext: [String: any Sendable]?) {
+    init(
+        base: any UserInputProcessor,
+        defaultAdditionalContext: [String: any Sendable]?,
+        modelType: String? = nil
+    ) {
         self.base = base
         self.defaultAdditionalContext = defaultAdditionalContext
+        self.modelType = modelType
+    }
+
+    /// True when this model needs the wrapper even with no default context —
+    /// i.e. its template keys reasoning on a variable the request surface does
+    /// not use, so something has to translate.
+    static func requiresReasoningTranslation(modelType: String?) -> Bool {
+        MuseGlimmerReasoningTemplateContext.applies(to: modelType)
     }
 
     static func defaultContext(capabilities: JangCapabilities?) -> [String: any Sendable]? {
@@ -876,13 +894,22 @@ struct VLMDefaultContextUserInputProcessor: UserInputProcessor {
     }
 
     func prepare(input: UserInput) async throws -> LMInput {
-        guard let defaultAdditionalContext, !defaultAdditionalContext.isEmpty else {
-            return try await base.prepare(input: input)
-        }
-
-        var merged = defaultAdditionalContext
+        // The reasoning translation must run even when there is no default
+        // context to merge. Muse Glimmer declares `supports_thinking`, so
+        // `defaultContext` returns nil for it and the old early return skipped
+        // the wrapper entirely — the adapter would have been wired and still
+        // never reached.
+        var merged = defaultAdditionalContext ?? [:]
         for (key, value) in input.additionalContext ?? [:] {
             merged[key] = value
+        }
+        let translated = MuseGlimmerReasoningTemplateContext.apply(
+            additionalContext: merged.isEmpty ? nil : merged,
+            modelType: modelType
+        )
+        merged = translated ?? [:]
+        guard !merged.isEmpty else {
+            return try await base.prepare(input: input)
         }
 
         let rewritten = UserInput(

--- a/Tests/MLXLMTests/MuseGlimmerReasoningTemplateContextTests.swift
+++ b/Tests/MLXLMTests/MuseGlimmerReasoningTemplateContextTests.swift
@@ -1,0 +1,157 @@
+//
+//  MuseGlimmerReasoningTemplateContextTests.swift
+//  MLXLMTests
+//
+//  Muse Glimmer's template keys reasoning on `reasoning_strength`, not the
+//  `reasoning_effort` the request surface carries, and defaults to `high` when
+//  the variable is undefined. Nothing in the library ever set that key, so
+//  every request ran at `high` no matter what the caller chose — an editable,
+//  saved, inert control.
+//
+
+import Foundation
+import MLX
+import Testing
+
+@testable import MLXLMCommon
+@testable import MLXVLM
+
+@Suite("Muse Glimmer reasoning translation")
+struct MuseGlimmerReasoningTemplateContextTests {
+
+    private static func apply(
+        _ context: [String: any Sendable],
+        modelType: String = "muse_glimmer"
+    ) -> [String: any Sendable]? {
+        MuseGlimmerReasoningTemplateContext.apply(
+            additionalContext: context, modelType: modelType)
+    }
+
+    @Test("reasoning_effort becomes reasoning_strength")
+    func translatesEffort() throws {
+        for (effort, expected) in [
+            ("low", "low"), ("medium", "medium"), ("high", "high"), ("xhigh", "xhigh"),
+        ] {
+            let out = try #require(Self.apply(["reasoning_effort": effort]))
+            #expect(out["reasoning_strength"] as? String == expected, "effort \(effort)")
+        }
+    }
+
+    /// The level set is FOUR. A caller whose ceiling is `max` must reach
+    /// `xhigh`, not be flattened into `high` — that silently caps the model
+    /// below its intended ceiling for exactly the coding/agentic work the
+    /// model card says `xhigh` is for.
+    @Test("max reaches xhigh rather than capping at high")
+    func maxReachesXhigh() throws {
+        let out = try #require(Self.apply(["reasoning_effort": "max"]))
+        #expect(out["reasoning_strength"] as? String == "xhigh")
+    }
+
+    /// There is no reasoning channel — the strength is a system-prompt
+    /// sentence, so there are no think tags to suppress. "Off" must therefore
+    /// map to the floor. Removing the key instead would fall through to the
+    /// template's `high` default: the exact opposite of the request.
+    @Test("disabling maps to the floor, never to an absent key")
+    func offMapsToFloor() throws {
+        for off in ["none", "off", "minimal", "no_think"] {
+            let out = try #require(Self.apply(["reasoning_effort": off]))
+            #expect(out["reasoning_strength"] as? String == "low", "value \(off)")
+        }
+        let disabled = try #require(Self.apply(["enable_thinking": false]))
+        #expect(disabled["reasoning_strength"] as? String == "low")
+        let enabled = try #require(Self.apply(["enable_thinking": true]))
+        #expect(enabled["reasoning_strength"] as? String == "high")
+    }
+
+    /// An explicit `reasoning_strength` is already in the template's own
+    /// vocabulary and must win — re-deriving it from a generic
+    /// `reasoning_effort` would let a default override a deliberate choice.
+    @Test("an explicit reasoning_strength is not overridden by reasoning_effort")
+    func explicitStrengthWins() throws {
+        let out = try #require(
+            Self.apply(["reasoning_strength": "xhigh", "reasoning_effort": "low"]))
+        #expect(out["reasoning_strength"] as? String == "xhigh")
+    }
+
+    /// With nothing requested, leave the key unset so the template's own
+    /// documented `high` default applies. Injecting a value here would be this
+    /// adapter inventing a policy.
+    @Test("no request leaves the key unset for the template default")
+    func noRequestLeavesUnset() {
+        let out = MuseGlimmerReasoningTemplateContext.apply(
+            additionalContext: ["add_generation_prompt": true], modelType: "muse_glimmer")
+        #expect(out?["reasoning_strength"] == nil)
+    }
+
+    /// The gate is the whole safety story: every other family must pass
+    /// through byte-identical, or this adapter would corrupt their contracts.
+    @Test("other families are untouched")
+    func otherFamiliesUntouched() throws {
+        for other in ["hy_v3", "deepseek_v4", "gemma4", "qwen3_5", "gptoss", "apertus1p5"] {
+            let input: [String: any Sendable] = ["reasoning_effort": "low"]
+            let out = try #require(
+                MuseGlimmerReasoningTemplateContext.apply(
+                    additionalContext: input, modelType: other))
+            #expect(out["reasoning_strength"] == nil, "\(other) gained a Muse key")
+            #expect(out["reasoning_effort"] as? String == "low", "\(other) lost its effort")
+        }
+    }
+
+    @Test("the model-type gate accepts the shipped variants")
+    func gateMatchesVariants() {
+        #expect(MuseGlimmerReasoningTemplateContext.applies(to: "muse_glimmer"))
+        #expect(MuseGlimmerReasoningTemplateContext.applies(to: "muse_glimmer_text"))
+        #expect(MuseGlimmerReasoningTemplateContext.applies(to: "MUSE_GLIMMER"))
+        #expect(!MuseGlimmerReasoningTemplateContext.applies(to: "muse"))
+        #expect(!MuseGlimmerReasoningTemplateContext.applies(to: nil))
+    }
+
+    // MARK: - Reachability
+
+    /// Records the context that actually reached the underlying processor.
+    private final class SpyProcessor: UserInputProcessor, @unchecked Sendable {
+        var seen: [String: any Sendable]?
+        func prepare(input: UserInput) throws -> LMInput {
+            seen = input.additionalContext
+            return LMInput(text: .init(tokens: MLXArray([0])))
+        }
+    }
+
+    /// THE WIRING, not the adapter. Muse Glimmer declares `supports_thinking`,
+    /// so `VLMDefaultContextUserInputProcessor.defaultContext` returns nil for
+    /// it — and the wrapper's old `guard let defaultAdditionalContext` early
+    /// return meant a translation placed inside it would never run. A correct
+    /// adapter that is never reached is the failure mode this pins.
+    @Test("the translation reaches the processor even with no default context")
+    func translationIsReachedWithoutDefaults() async throws {
+        let spy = SpyProcessor()
+        let wrapper = VLMDefaultContextUserInputProcessor(
+            base: spy,
+            defaultAdditionalContext: nil,          // exactly Muse's situation
+            modelType: "muse_glimmer"
+        )
+        _ = try await wrapper.prepare(
+            input: UserInput(
+                prompt: .text("hi"), additionalContext: ["reasoning_effort": "low"]))
+        let seen = try #require(spy.seen, "the base processor was never called")
+        #expect(
+            seen["reasoning_strength"] as? String == "low",
+            "reasoning_strength never reached the template")
+    }
+
+    /// The same wrapper must leave a non-Muse model's context alone.
+    @Test("the wrapper does not inject a Muse key for other families")
+    func wrapperLeavesOtherFamiliesAlone() async throws {
+        let spy = SpyProcessor()
+        let wrapper = VLMDefaultContextUserInputProcessor(
+            base: spy, defaultAdditionalContext: nil, modelType: "gemma4")
+        _ = try await wrapper.prepare(
+            input: UserInput(
+                prompt: .text("hi"), additionalContext: ["reasoning_effort": "low"]))
+        // With no defaults and no translation there is nothing to merge, so the
+        // wrapper hands the ORIGINAL input straight through.
+        let seen = try #require(spy.seen)
+        #expect(seen["reasoning_strength"] == nil)
+        #expect(seen["reasoning_effort"] as? String == "low")
+    }
+}


### PR DESCRIPTION
Muse Glimmer keys reasoning on **`reasoning_strength`**, not the `reasoning_effort` every other family understands, and defaults to `high` when that variable is undefined:

```jinja
{%- set rs = reasoning_strength if reasoning_strength is defined and reasoning_strength else 'high' -%}
{{- 'Reasoning strength: ' + rs + '.' -}}
```

**Nothing in the library ever set that key.** `reasoning_strength` appears only in this repo's own docs and in `MediaSalt`, which merely *reads* it out of `additionalContext` for the cache scope salt — and in the host, only in test files. The tests pass the key explicitly and prove the *template* honours it, while the shipping app sends `reasoning_effort` and the template ignores it.

So every Muse Glimmer request ran at `high` regardless of what the user chose. The control was editable, saved, and inert.

`MuseGlimmer_PROOF_MATRIX.md:250` predicted this in writing — *"If osaurus sends `reasoning_effort`, the template never…"* — which is why the fix belongs in code rather than in another comment.

### Shape

Mirrors `Hy3ReasoningTemplateContext`, the existing adapter for the same class of problem (Hunyuan 3 keys thinking on its own closed set and `raise_exception`s on anything else). Both gate on `modelType` first, so each is a no-op for every other family.

**Four levels, not three.** The contract is `low / medium / high / xhigh`, with `high`/`xhigh` intended for complex problem solving, coding and agentic work. `max` therefore maps to `xhigh` rather than being flattened into `high` — flattening would silently cap the model below its ceiling for exactly the work `xhigh` exists for.

**No "off".** Reasoning is a system-prefix sentence, not a channel; there are no think tags to suppress. Disabling maps to `low`, the floor. *Removing* the key would fall through to the template's `high` default — the opposite of the request. With nothing requested the key stays unset so the template's own documented default applies, rather than this adapter inventing a policy.

### The part that nearly went wrong

`muse_glimmer` is registered in **both** factories — `LLMModelFactory` (`muse_glimmer`, `muse_glimmer_text`) and `VLMModelFactory`.

The VLM wrapper `VLMDefaultContextUserInputProcessor` early-returned when it had no default context. Muse declares `supports_thinking`, so `defaultContext` returns **nil** for it — meaning a translation placed inside that guard would have been perfectly correct and **never reached**. The wrapper now carries `modelType`, is constructed when a translation is needed even with no defaults, and applies the adapter before the early return. The type lives in `MLXLMCommon` so both factories can see it.

### Tests — 9 passing

Two of them exist specifically to pin reachability: they drive a spy processor through the wrapper with `defaultAdditionalContext: nil` (exactly Muse's situation) and assert `reasoning_strength` actually arrives, plus that a non-Muse family passes through untouched. The rest cover the four levels, `max → xhigh`, the four "off" synonyms, explicit `reasoning_strength` winning over `reasoning_effort`, the unset-by-default case, and the model-type gate.

### Note for #300

This is the small standalone fix I suggested splitting out of #300. It resolves the user-visible defect without depending on the `ReasoningEffortPolicy` design — @rcfa, if the policy lands later, `MuseGlimmerReasoningPolicy` can delegate its `normalize` to `MuseGlimmerReasoningTemplateContext.normalized(_:)` so the accepted set cannot drift from the code that enforces it, exactly as `DeepseekV4EffortPolicy`/`Hy3EffortPolicy` do.