### PR TITLE
Treat sustained filler as a collapse — volume, not just the unit

### DIFF
--- a/Libraries/MLXLMCommon/RepetitionCycleDetector.swift
+++ b/Libraries/MLXLMCommon/RepetitionCycleDetector.swift
@@ -85,6 +85,21 @@ public struct RepetitionCycleDetector: Sendable {
     /// separators, blank lines and `}` / `)` closers from ever qualifying.
     public static let minimumLineLength = 24
 
+    /// Consecutive characters of SHORT-PERIOD filler that count as a collapse.
+    ///
+    /// The primitivity rule below excludes `....`, `----`, `| | |` on purpose:
+    /// those are ordinary punctuation and formatting, and halting on them would
+    /// be far worse than the bug. But that rule looks only at the UNIT and never
+    /// at the VOLUME, so a model emitting `.` forever is indistinguishable from
+    /// an ellipsis and runs to the token cap — reported live as "looping `.`
+    /// output".
+    ///
+    /// Volume is what separates them. A horizontal rule is ~80 characters; a
+    /// markdown table rule is ~80; the longest legitimate run of a <32-character
+    /// unit in prose or code is far below this. 1024 consecutive characters of
+    /// the same short unit is not formatting, it is a collapsed decoder.
+    public static let fillerCollapseLength = 1024
+
     /// Rolling tail. Only the end of the stream can carry a cycle that is
     /// still running, and bounding this keeps `feed` O(1) in stream length.
     private static let tailCapacity = maximumUnitLength * (minimumRepeats + 1)
@@ -233,12 +248,42 @@ public struct RepetitionCycleDetector: Sendable {
             // something shorter than the floor, the real period is that
             // shorter thing and this is filler.
             let candidate = Array(buffer[(n - unit) ..< n])
-            guard minimalPeriod(of: candidate) >= minimumUnitLength else { continue }
+            let period = minimalPeriod(of: candidate)
+            guard period >= minimumUnitLength else {
+                // Filler by unit, but check VOLUME before dismissing it: past
+                // `fillerCollapseLength` characters of one short unit this is a
+                // collapsed decoder, not punctuation.
+                if let collapse = fillerCollapse(in: buffer, period: period) {
+                    return collapse
+                }
+                continue
+            }
             return Cycle(unit: String(candidate), repeats: repeats)
         }
         return nil
     }
 
+
+    /// How far back the buffer is an unbroken repetition of its last `period`
+    /// characters, reported as a cycle once it passes `fillerCollapseLength`.
+    ///
+    /// Deliberately measured in CHARACTERS rather than repeats: `.` repeated
+    /// 1024 times and a 4-character unit repeated 256 times are the same
+    /// pathology and the same wasted decode.
+    static func fillerCollapse(in buffer: [Character], period: Int) -> Cycle? {
+        guard period > 0, buffer.count >= fillerCollapseLength else { return nil }
+        let unit = Array(buffer.suffix(period))
+        var length = period
+        var index = buffer.count - period
+        while index >= period,
+            Array(buffer[(index - period) ..< index]) == unit
+        {
+            length += period
+            index -= period
+        }
+        guard length >= fillerCollapseLength else { return nil }
+        return Cycle(unit: String(unit), repeats: length / period)
+    }
 
     /// Length of the shortest string whose repetition builds `unit` exactly.
     /// Returns `unit.count` when the unit is primitive.

--- a/Tests/MLXLMTests/RepetitionCycleDetectorTests.swift
+++ b/Tests/MLXLMTests/RepetitionCycleDetectorTests.swift
@@ -255,4 +255,74 @@ extension String {
         }
         #expect(fired == nil)
     }
+
+    // MARK: - Filler collapse (volume, not unit)
+
+    /// The reported symptom: "looping `.` output". The primitivity rule
+    /// deliberately dismisses `.` as filler, and the line scan rejects it for
+    /// having no letter — so before this it ran to the token cap.
+    @Test("a dot loop is caught once it passes the volume threshold")
+    func dotLoopIsCaught() throws {
+        var detector = RepetitionCycleDetector()
+        var fired: RepetitionCycleDetector.Cycle?
+        for _ in 0 ..< 200 where fired == nil {
+            fired = detector.feed(String(repeating: ".", count: 32))
+        }
+        let cycle = try #require(fired, "a sustained '.' loop must be caught")
+        #expect(cycle.unit == ".")
+    }
+
+    /// Same pathology with a longer short-period unit.
+    @Test("a short repeating unit collapses on volume too")
+    func shortUnitCollapsesOnVolume() throws {
+        var detector = RepetitionCycleDetector()
+        var fired: RepetitionCycleDetector.Cycle?
+        // Enough iterations to clear fillerCollapseLength: the threshold is
+        // measured in CHARACTERS, and a 4-character unit needs 256+ of them.
+        let iterations = RepetitionCycleDetector.fillerCollapseLength  // 4 chars each
+        for _ in 0 ..< iterations where fired == nil {
+            fired = detector.feed(". . ")
+        }
+        #expect(fired != nil, "a sustained '. . ' loop must be caught")
+    }
+
+    /// FALSE POSITIVES ARE WORSE. Ordinary punctuation and formatting stay
+    /// well under the volume threshold and must never fire.
+    @Test("ordinary punctuation and rules never reach the threshold")
+    func ordinaryFillerNeverFires() {
+        let benign = [
+            "Wait for it...",                                   // ellipsis
+            "Section one\n" + String(repeating: "-", count: 80) + "\nBody text here.",
+            "| col | col |\n" + String(repeating: "|---", count: 20) + "|\n",
+            String(repeating: "=", count: 100) + "\nHeading\n",
+            "Loading" + String(repeating: ".", count: 60) + " done.",
+        ]
+        for text in benign {
+            var detector = RepetitionCycleDetector()
+            var fired: RepetitionCycleDetector.Cycle?
+            for _ in 0 ..< 3 where fired == nil { fired = detector.feed(text) }
+            #expect(fired == nil, "benign filler fired: \(text.prefix(30))")
+        }
+    }
+
+    /// The threshold is a real boundary, so pin both sides of it rather than
+    /// only the side that fires.
+    @Test("just under the threshold stays silent")
+    func belowThresholdStaysSilent() {
+        var detector = RepetitionCycleDetector()
+        var fired: RepetitionCycleDetector.Cycle?
+        let under = RepetitionCycleDetector.fillerCollapseLength - 64
+        fired = detector.feed("Reticulating splines" + String(repeating: ".", count: under))
+        #expect(fired == nil, "a run below fillerCollapseLength must not fire")
+    }
+
+    @Test("VMLX_REPETITION_STOP=0 disables the filler scan as well")
+    func disabledSkipsFillerScan() {
+        var detector = RepetitionCycleDetector.fromEnvironment(["VMLX_REPETITION_STOP": "0"])
+        var fired: RepetitionCycleDetector.Cycle?
+        for _ in 0 ..< 200 where fired == nil {
+            fired = detector.feed(String(repeating: ".", count: 32))
+        }
+        #expect(fired == nil)
+    }
 }


### PR DESCRIPTION
`RepetitionCycleDetector` dismisses short-period units as filler on purpose, and says so:

> `// A run of filler — `----`, `. . .`, `| | |\n` — also repeats at period 32, so unit length alone cannot separate a collapsed model from ordinary punctuation.`

That is right for punctuation and **wrong for collapse**, because the rule looks at the UNIT and never at the VOLUME. A model emitting `.` forever is indistinguishable from an ellipsis under it, so it runs to the token cap.

Reported on **Ornith 1.5-9B** as *"looping `.` output"*. Neither existing scan could catch it:

- the **character** scan rejects `.` — minimal period 1, below `minimumUnitLength`
- the **line** scan rejects a line of dots — no letter, fails the non-triviality guard

### The distinction

Volume separates formatting from collapse. An ellipsis is 3 characters, a horizontal rule ~80, a markdown table rule ~80. Past **1024** consecutive characters of one short unit it is not formatting, it is a collapsed decoder.

Measured in **characters, not repeats**, on purpose: `.` × 1024 and a 4-character unit × 256 are the same pathology and the same wasted decode.

Only reached where the primitivity rule has already decided "filler", so **no verdict that fires today changes**. `VMLX_REPETITION_STOP=0` disables it with the rest.

### Tests — 23 passing

Weighted deliberately to the false-positive side, because this now fires on punctuation and a wrong halt is worse than the bug it prevents. All of these stay silent:

- `"Wait for it..."` — ellipsis
- an 80-character `-----` rule under a heading
- a markdown table rule `|---|---|…`
- a 100-character `=====` separator
- `"Loading" + 60 dots + " done."`
- a run **just under** the threshold — the boundary is pinned from both directions, not only the side that fires

### Scope

This closes one of three symptoms in that report. The other two — empty final messages, and fabricated tool results at 30–45K context — are separate claims that need their own reproduction; I have not verified them and this PR does not address them.