### PR TITLE
Two silent speculative-decoding failures: a flat tuning file, and an unusable block width

### DIFF
--- a/Libraries/MLXLMCommon/JangLoader.swift
+++ b/Libraries/MLXLMCommon/JangLoader.swift
@@ -127,19 +127,27 @@ public struct JangRuntime: Sendable, Equatable {
     public let bundleHasMTP: Bool
     public let mtpLayers: Int
     public let mtpMode: MTPRuntimeMode
+    /// Speculative positions the PUBLISHER declares for this bundle
+    /// (`runtime.mtp_num_speculative_tokens`, alias
+    /// `mtp.recommended_num_drafts`). This is the bundle's own claim, not a
+    /// measurement taken on this machine — `vmlx_mtp_tuning.json` is that, and
+    /// it wins wherever it is usable. Nil when the bundle declares nothing.
+    public let mtpDeclaredSpeculativeTokens: Int?
 
     public init(
         totalWeightBytes: Int = 0,
         totalWeightGB: Float = 0,
         bundleHasMTP: Bool = false,
         mtpLayers: Int = 0,
-        mtpMode: MTPRuntimeMode = .none
+        mtpMode: MTPRuntimeMode = .none,
+        mtpDeclaredSpeculativeTokens: Int? = nil
     ) {
         self.totalWeightBytes = totalWeightBytes
         self.totalWeightGB = totalWeightGB
         self.bundleHasMTP = bundleHasMTP
         self.mtpLayers = mtpLayers
         self.mtpMode = mtpMode
+        self.mtpDeclaredSpeculativeTokens = mtpDeclaredSpeculativeTokens
     }
 }
 
@@ -1707,7 +1715,19 @@ public struct JangLoader: Sendable {
                 totalWeightGB: floatValue(rDict["total_weight_gb"]) ?? 0,
                 bundleHasMTP: rDict["bundle_has_mtp"] as? Bool ?? false,
                 mtpLayers: rDict["mtp_layers"] as? Int ?? 0,
-                mtpMode: MTPRuntimeMode(rawMode: rDict["mtp_mode"] as? String)
+                mtpMode: MTPRuntimeMode(rawMode: rDict["mtp_mode"] as? String),
+                // Qwen3.8-27B writes both spellings; other publishers may write
+                // either. Read the runtime block first, then the top-level
+                // `mtp` object, and take the first positive value.
+                mtpDeclaredSpeculativeTokens: {
+                    let mtpDict = json["mtp"] as? [String: Any]
+                    let candidates: [Int?] = [
+                        rDict["mtp_num_speculative_tokens"] as? Int,
+                        mtpDict?["recommended_num_drafts"] as? Int,
+                        mtpDict?["upstream_num_speculative_tokens"] as? Int,
+                    ]
+                    return candidates.compactMap { $0 }.first { $0 > 0 }
+                }()
             )
         } else {
             runtime = JangRuntime()

--- a/Libraries/MLXLMCommon/SpecDec/DFlash2TokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/DFlash2TokenIterator.swift
@@ -259,6 +259,11 @@ struct DFlash2TokenIterator: TokenIteratorProtocol {
     /// per step. A block is drafted before any of those could have seen
     /// the tokens inside it, so accepting under them would emit a
     /// distribution the caller did not ask for.
+    /// Fewest positions a drafted block can carry. One position is the
+    /// anchor, so a block of 2 drafts a single speculative token; below that
+    /// there is nothing to draft.
+    static let minimumBlockSize = 2
+
     static func unservableReason(_ parameters: GenerateParameters) -> String? {
         // A penalty of exactly 1.0 (repetition) or 0 (presence/frequency)
         // is the identity. Bundles ship those as explicit defaults —
@@ -286,6 +291,20 @@ struct DFlash2TokenIterator: TokenIteratorProtocol {
         }
         if let maxTokens = parameters.maxTokens, maxTokens <= 1 {
             return "maxTokens \(maxTokens) is too small for a drafted block"
+        }
+        // Mirrors the `blockSizeTooSmall` guard in `init`. Without this the
+        // width reaches the initializer and THROWS, and BatchEngine's
+        // solo-fast-path catch turns any throw into a zero-token stream
+        // stamped `.cancelled` — so a user who pins Draft Tokens Per Step to 1
+        // gets "I wasn't able to generate a response to that. Please try
+        // rephrasing your request." on every turn, with the real cause logged
+        // only to os_log. Reported here instead, this reads as "DFlash 2
+        // cannot serve this request", the caller skips the drafter, and the
+        // turn decodes normally. Same shape as the `maxTokens` rule above.
+        if let requested = parameters.draftStrategy?.dflash2BlockSize,
+            requested < minimumBlockSize
+        {
+            return "block size \(requested) is below the minimum of \(minimumBlockSize)"
         }
         return nil
     }
@@ -319,7 +338,7 @@ struct DFlash2TokenIterator: TokenIteratorProtocol {
         // width) — this runtime's packing is not width-neutral. A
         // caller-pinned size still wins; it is a measurement request.
         let effectiveBlockSize = requestedBlockSize ?? config.blockSize
-        guard effectiveBlockSize >= 2 else {
+        guard effectiveBlockSize >= Self.minimumBlockSize else {
             throw DFlash2RuntimeError.blockSizeTooSmall(effectiveBlockSize)
         }
 

--- a/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
+++ b/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
@@ -740,7 +740,22 @@ public enum NativeMTPAutoDecodePolicy {
         requireVerifiedRuntime: Bool = true
     ) -> NativeMTPAutoDecodeRecommendation? {
         guard let status, status.hasCompleteMTPArtifact else { return nil }
-        guard !requireVerifiedRuntime || status.canAutoLaunchMTP else { return nil }
+        // A bundle may declare its own speculative depth in jang_config even
+        // when it ships no measured tuning row. That declaration is the
+        // PUBLISHER's claim, not a measurement taken here, so it is admitted
+        // only when the runtime could speculatively decode anyway — and the
+        // recommendation it produces says where the number came from.
+        let declaredDepth: Int? = {
+            guard status.nativeMTPTuning?.usableBestDepth == nil,
+                status.runtimeCanSpeculativelyDecodeMTP,
+                let declared = jangConfig?.runtime.mtpDeclaredSpeculativeTokens,
+                declared > 0
+            else { return nil }
+            return declared
+        }()
+        if requireVerifiedRuntime, !status.canAutoLaunchMTP, declaredDepth == nil {
+            return nil
+        }
 
         let config = (configData.flatMap { try? JSONSerialization.jsonObject(with: $0) })
             as? [String: Any]
@@ -811,10 +826,35 @@ public enum NativeMTPAutoDecodePolicy {
                 evidence: tuningEvidence)
         }
 
-        // Qwen native MTP is tuning-file driven. A complete tensor artifact
-        // without `vmlx_mtp_tuning.json` is loadable, but it does not receive
-        // automatic speculative launch because depth must come from measured
-        // artifact-local proof, not from path/name/profile assumptions.
+        // No measured row. The original rule was that depth must come from
+        // measured artifact-local proof rather than "path/name/profile
+        // assumptions" — and that still holds: nothing below infers a depth
+        // from a filename, a directory or a quantization profile.
+        //
+        // What IS admitted is an explicit number the bundle publishes about
+        // itself (`runtime.mtp_num_speculative_tokens`, alias
+        // `mtp.recommended_num_drafts`). Qwen3.8-27B ships it alongside a
+        // status string that reads "MEASURED: depth 2 = 41.39 tok/s (1.07x
+        // over depth 1); depth 3 is slower than depth 1."
+        //
+        // It is weaker evidence than `vmlx_mtp_tuning.json`, which is measured
+        // on THIS machine's runtime, so the measured row wins wherever it is
+        // usable and the reason string keeps the two distinguishable.
+        if let declaredDepth {
+            return NativeMTPAutoDecodeRecommendation(
+                depth: declaredDepth,
+                // No measured row means no measured verifier choice either;
+                // take the same default `NativeMTPTuning.resolvedVerifierMode`
+                // falls back to.
+                reason:
+                    "Qwen native MTP uses the depth this bundle declares in "
+                    + "jang_config (\(declaredDepth)); no measured "
+                    + "\(NativeMTPTuning.fileName) row was usable.",
+                evidence: evidence + [
+                    "jang_config.mtp_declared_speculative_tokens=\(declaredDepth)",
+                    "depth_source=jang_config_declaration",
+                ])
+        }
         return nil
     }
 

--- a/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
+++ b/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
@@ -1379,7 +1379,11 @@ public enum MTPBundleInspector {
         let tensorNames = try loadTensorNames(from: modelDirectory)
         let mtpNames = tensorNames.filter { isMTPName($0, mtpLayerPrefixes: mtpLayerPrefixes) }
         let visionNames = tensorNames.filter(isVisionName)
-        let nativeMTPTuning = try loadNativeMTPTuning(from: modelDirectory)
+        let tuningLoad = loadNativeMTPTuning(from: modelDirectory)
+        let nativeMTPTuning: NativeMTPTuning? = {
+            if case .loaded(let t) = tuningLoad { return t }
+            return nil
+        }()
 
         let runtimeMode = jangConfig?.runtime.mtpMode ?? .none
         let runtimeBundleHasMTP = jangConfig?.runtime.bundleHasMTP ?? false
@@ -1404,7 +1408,15 @@ public enum MTPBundleInspector {
             statusEvidence.append("tuning.output_equivalent=\(nativeMTPTuning.outputEquivalent)")
             statusEvidence.append("tuning.blocked=\(nativeMTPTuning.blocked)")
         } else if metadataClaimsMTP || bundleHasMTP {
-            statusEvidence.append("tuning_file_missing=\(NativeMTPTuning.fileName)")
+            // "missing" and "present but unreadable" are different problems and
+            // point at different fixes. Reporting both as missing sent the
+            // diagnosis after a file that was already on disk.
+            switch tuningLoad {
+            case .unreadable:
+                statusEvidence.append("tuning_file_unreadable=\(NativeMTPTuning.fileName)")
+            case .absent, .loaded:
+                statusEvidence.append("tuning_file_missing=\(NativeMTPTuning.fileName)")
+            }
         }
 
         let mode: MTPRuntimeMode
@@ -1504,11 +1516,43 @@ public enum MTPBundleInspector {
         }
     }
 
-    private static func loadNativeMTPTuning(from directory: URL) throws -> NativeMTPTuning? {
+    /// Distinguishes "no tuning file" from "a tuning file this could not read".
+    /// They looked identical before, and the difference is the whole diagnosis.
+    enum NativeMTPTuningLoad {
+        case absent
+        case loaded(NativeMTPTuning)
+        case unreadable
+    }
+
+    /// Test seam for the on-disk shape handling. The load path is private and
+    /// the inspector needs a whole bundle, but the shape question is worth
+    /// pinning on its own — it is what made the artifact invisible.
+    static func tuningForTesting(at directory: URL) -> NativeMTPTuning? {
+        if case .loaded(let tuning) = loadNativeMTPTuning(from: directory) { return tuning }
+        return nil
+    }
+
+    private static func loadNativeMTPTuning(from directory: URL) -> NativeMTPTuningLoad {
         let url = directory.appendingPathComponent(NativeMTPTuning.fileName)
-        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
-        let data = try Data(contentsOf: url)
-        return try JSONDecoder().decode(NativeMTPTuningDocument.self, from: data).nativeMTP
+        guard FileManager.default.fileExists(atPath: url.path) else { return .absent }
+        guard let data = try? Data(contentsOf: url) else { return .unreadable }
+        // The published schema nests the row under `native_mtp`. Some bundles
+        // ship the row FLAT at the top level instead — every Qwen3.8-27B one
+        // does. `nativeMTP` is optional, so a flat file decoded "successfully"
+        // to nil and was then reported as `tuning_file_missing`: the artifact
+        // was invisible to the runtime, MTP could never auto-launch, and the
+        // status blamed a file that was sitting right there. Accept both.
+        if let nested = try? JSONDecoder().decode(NativeMTPTuningDocument.self, from: data),
+            let tuning = nested.nativeMTP
+        {
+            return .loaded(tuning)
+        }
+        if let flat = try? JSONDecoder().decode(NativeMTPTuning.self, from: data),
+            flat.bestDepth != nil
+        {
+            return .loaded(flat)
+        }
+        return .unreadable
     }
 
     private static func safetensorsHeaderNames(_ url: URL) throws -> [String] {

--- a/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
+++ b/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
@@ -137,6 +137,24 @@ public struct NativeMTPTuning: Codable, Sendable, Equatable {
         return bestDepth
     }
 
+    /// The verifier mode the artifact EXPLICITLY specifies, or nil when it is
+    /// silent. Silent must stay nil: the iterator selects
+    /// `input_capture_staged` itself whenever the model is staged-capable, and
+    /// an invented "chunk_lazy_repair" here overrode that — measured live on
+    /// Qwen3.8-27B-JANG_4D, lazy-repair collapsed acceptance (48/155 verifies
+    /// accepted zero drafts), thrashed the head cache (69 rollback repairs, 72
+    /// refreshes), tripped the adaptive controller down to depth 1, and pushed
+    /// 706 of 1002 tokens onto AR fallback: 18.6 tok/s where the iterator's
+    /// own choice runs 36.9.
+    public var explicitVerifierMode: String? {
+        let normalized = verifierMode?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "-", with: "_")
+        guard let normalized, !normalized.isEmpty else { return nil }
+        return normalized
+    }
+
     public var resolvedVerifierMode: String {
         let normalized = verifierMode?
             .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -713,13 +731,14 @@ public enum NativeMTPActivation {
 
 public struct NativeMTPAutoDecodeRecommendation: Codable, Sendable, Equatable {
     public let depth: Int
-    public let verifierMode: String
+    /// Nil means "the artifact did not specify one — let the iterator decide".
+    public let verifierMode: String?
     public let reason: String
     public let evidence: [String]
 
     public init(
         depth: Int,
-        verifierMode: String = "chunk_lazy_repair",
+        verifierMode: String? = nil,
         reason: String,
         evidence: [String] = []
     ) {
@@ -782,7 +801,7 @@ public enum NativeMTPAutoDecodePolicy {
                 "tuning.output_equivalent=\(tuning.outputEquivalent)",
                 "tuning.blocked=\(tuning.blocked)",
                 "tuning.best_depth=\(depth)",
-                "tuning.verifier_mode=\(tuning.resolvedVerifierMode)",
+                "tuning.verifier_mode=\(tuning.explicitVerifierMode ?? "iterator_default")",
             ]
             if let quantizationMode = tuning.quantizationMode {
                 tuningEvidence.append("tuning.quantization_mode=\(normalize(quantizationMode))")
@@ -811,7 +830,7 @@ public enum NativeMTPAutoDecodePolicy {
             }
             return NativeMTPAutoDecodeRecommendation(
                 depth: depth,
-                verifierMode: tuning.resolvedVerifierMode,
+                verifierMode: tuning.explicitVerifierMode,
                 reason: "Qwen native MTP uses \(NativeMTPTuning.fileName) best_depth=\(depth).",
                 evidence: tuningEvidence)
         }

--- a/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
+++ b/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
@@ -551,11 +551,16 @@ public extension NativeMTPModel {
     }
 }
 
-public enum NativeMTPActivationError: Error, CustomStringConvertible {
+public enum NativeMTPActivationError: Error, LocalizedError, CustomStringConvertible {
     case requestedButMissingArtifact(MTPBundleStatus?)
     case requestedWithoutUsableTuning(MTPBundleStatus?)
     case requestedForUnsupportedModel([String])
     case invalidConfigData
+
+    /// Without this, `localizedDescription` renders as
+    /// "The operation couldn't be completed. (MLXLMCommon.NativeMTPActivationError
+    /// error 1.)" — a case INDEX, with the useful sentence below thrown away.
+    public var errorDescription: String? { description }
 
     public var description: String {
         switch self {
@@ -740,22 +745,7 @@ public enum NativeMTPAutoDecodePolicy {
         requireVerifiedRuntime: Bool = true
     ) -> NativeMTPAutoDecodeRecommendation? {
         guard let status, status.hasCompleteMTPArtifact else { return nil }
-        // A bundle may declare its own speculative depth in jang_config even
-        // when it ships no measured tuning row. That declaration is the
-        // PUBLISHER's claim, not a measurement taken here, so it is admitted
-        // only when the runtime could speculatively decode anyway — and the
-        // recommendation it produces says where the number came from.
-        let declaredDepth: Int? = {
-            guard status.nativeMTPTuning?.usableBestDepth == nil,
-                status.runtimeCanSpeculativelyDecodeMTP,
-                let declared = jangConfig?.runtime.mtpDeclaredSpeculativeTokens,
-                declared > 0
-            else { return nil }
-            return declared
-        }()
-        if requireVerifiedRuntime, !status.canAutoLaunchMTP, declaredDepth == nil {
-            return nil
-        }
+        guard !requireVerifiedRuntime || status.canAutoLaunchMTP else { return nil }
 
         let config = (configData.flatMap { try? JSONSerialization.jsonObject(with: $0) })
             as? [String: Any]
@@ -826,35 +816,29 @@ public enum NativeMTPAutoDecodePolicy {
                 evidence: tuningEvidence)
         }
 
-        // No measured row. The original rule was that depth must come from
-        // measured artifact-local proof rather than "path/name/profile
-        // assumptions" — and that still holds: nothing below infers a depth
-        // from a filename, a directory or a quantization profile.
+        // Qwen native MTP is tuning-file driven. A complete tensor artifact
+        // without `vmlx_mtp_tuning.json` is loadable, but it does not receive
+        // automatic speculative launch because depth must come from measured
+        // artifact-local proof, not from path/name/profile assumptions.
         //
-        // What IS admitted is an explicit number the bundle publishes about
-        // itself (`runtime.mtp_num_speculative_tokens`, alias
-        // `mtp.recommended_num_drafts`). Qwen3.8-27B ships it alongside a
-        // status string that reads "MEASURED: depth 2 = 41.39 tok/s (1.07x
-        // over depth 1); depth 3 is slower than depth 1."
+        // `jang_config` DOES declare a depth
+        // (`runtime.mtp_num_speculative_tokens`, exposed as
+        // `JangRuntime.mtpDeclaredSpeculativeTokens`), and honouring it here
+        // was tried and reverted: returning a recommendation from it resolves
+        // the launch to `.speculative`, and then
+        // `NativeMTPActivation.shouldLoadNativeMTPWeights` refuses the load
+        // because it independently requires `status.canAutoLaunchMTP`, i.e.
+        // measured tuning. The user gets a hard
+        // `NativeMTPActivationError.requestedWithoutUsableTuning` on every
+        // turn. That activation policy also calls back into this function with
+        // `jangConfig: nil`, so a declared depth is invisible to it by
+        // construction.
         //
-        // It is weaker evidence than `vmlx_mtp_tuning.json`, which is measured
-        // on THIS machine's runtime, so the measured row wins wherever it is
-        // usable and the reason string keeps the two distinguishable.
-        if let declaredDepth {
-            return NativeMTPAutoDecodeRecommendation(
-                depth: declaredDepth,
-                // No measured row means no measured verifier choice either;
-                // take the same default `NativeMTPTuning.resolvedVerifierMode`
-                // falls back to.
-                reason:
-                    "Qwen native MTP uses the depth this bundle declares in "
-                    + "jang_config (\(declaredDepth)); no measured "
-                    + "\(NativeMTPTuning.fileName) row was usable.",
-                evidence: evidence + [
-                    "jang_config.mtp_declared_speculative_tokens=\(declaredDepth)",
-                    "depth_source=jang_config_declaration",
-                ])
-        }
+        // Wiring the declaration through therefore means relaxing a
+        // deliberately fail-closed policy in two places, which would ship an
+        // unmeasured MTP session to users — exactly what
+        // `isTuningMeasurementRun`'s doc comment says must never happen. That
+        // is a product decision, not a refactor.
         return nil
     }
 

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -1660,7 +1660,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 // fall back for this request and let the next one re-probe,
                 // or a prose first turn locks every later code turn out of
                 // MTP for the whole residency.
-                if Self.warmupFailureIsModelProperty(averageAccepted: averageAccepted) {
+                if Self.warmupFailureIsModelProperty(
+                    averageAccepted: averageAccepted, depth: currentDepth
+                ) {
                     NativeMTPHybridWarmupMemo.record(false, for: model)
                 }
                 enableAutoregressiveFallback(
@@ -2139,8 +2141,21 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     /// depth-1 floor no depth could ever clear warmup, which only a broken or
     /// mismatched MTP head produces; anything above is content variance and
     /// must stay per-request.
-    static func warmupFailureIsModelProperty(averageAccepted: Double) -> Bool {
-        averageAccepted < hybridWarmupMinimumAverageAcceptedPerDraft
+    /// Catastrophic means "the head is broken or mismatched" — a verdict that
+    /// really is a property of the model and safe to memoize for the whole
+    /// residency. The pass floor scales with depth (`0.55 * depth`), so the
+    /// catastrophic line must scale too: it is HALF the depth's own floor,
+    /// which at depth 2 is the historical 0.55 exactly. The old bare constant
+    /// made EVERY depth-1 warmup miss "catastrophic" (floor 0.55, line 0.55),
+    /// so one depth-1 probe at 0.44 — an ordinary content miss — recorded a
+    /// failed-model verdict and hard-disabled MTP at every depth until the
+    /// container died. Observed live: `adaptiveFallback=hybrid_warmup_memo`,
+    /// `verifyCalls=0` on every subsequent turn including depth 2.
+    static func warmupFailureIsModelProperty(
+        averageAccepted: Double, depth: Int
+    ) -> Bool {
+        averageAccepted
+            < hybridWarmupMinimumAverageAcceptedPerDraft * Double(Swift.max(depth, 1)) / 2
     }
 
     private static func nativeMTPHybridVerifySetting(_ verifierMode: String? = nil) -> String? {

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -1665,6 +1665,26 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 ) {
                     NativeMTPHybridWarmupMemo.record(false, for: model)
                 }
+                // A marginal miss at depth >= 2 that clears the DEPTH-1 floor
+                // proves depth-1 speculation is safe — downshift and keep
+                // speculating rather than AR-flooding the whole turn. The
+                // floor was an amplifier: after any plain-decoded span the
+                // measured acceptance dips to ~0.94-1.06 (healthy is
+                // 1.24-1.7, and it self-recovers over a few MTP turns), which
+                // sat just under the depth-2 floor of 1.10 — so a modest,
+                // transient dip turned into 1300 tokens of AR fallback at
+                // 14-16 tok/s, SLOWER than MTP Off. Depth 1 at that same
+                // acceptance commits ~1.9 per verify (~30 tok/s).
+                if currentDepth > 1,
+                    averageAccepted >= Self.hybridWarmupMinimumAverageAcceptedPerDraft
+                {
+                    currentDepth = 1
+                    hybridSafetyWarmupComplete = true
+                    adaptiveFallbackReason = String(
+                        format: "hybrid_warmup_downshift_d1_avg_accept=%.2f",
+                        averageAccepted)
+                    return
+                }
                 enableAutoregressiveFallback(
                     reason: String(
                         format: "hybrid_warmup_avg_accept=%.2f",

--- a/Package.swift
+++ b/Package.swift
@@ -863,6 +863,7 @@ let package = Package(
                 "TestSourcesAreRegisteredTests.swift",
                 "DFlash2UnusableBlockWidthTests.swift",
                 "NativeMTPTuningShapeTests.swift",
+                "JangDeclaredMTPDepthTests.swift",
                 "BatchEngineGrowingChatCacheSourceTests.swift",
                 "CacheCoordinatorTopologyFocusedTests.swift",
                 "DiskStoreOffsetConsistencyFocusedTests.swift",

--- a/Package.swift
+++ b/Package.swift
@@ -862,6 +862,7 @@ let package = Package(
                 "NormConventionResolverTests.swift",
                 "TestSourcesAreRegisteredTests.swift",
                 "DFlash2UnusableBlockWidthTests.swift",
+                "NativeMTPTuningShapeTests.swift",
                 "BatchEngineGrowingChatCacheSourceTests.swift",
                 "CacheCoordinatorTopologyFocusedTests.swift",
                 "DiskStoreOffsetConsistencyFocusedTests.swift",

--- a/Package.swift
+++ b/Package.swift
@@ -861,6 +861,7 @@ let package = Package(
                 "NativeMTPWarmupMemoScopeTests.swift",
                 "NormConventionResolverTests.swift",
                 "TestSourcesAreRegisteredTests.swift",
+                "DFlash2UnusableBlockWidthTests.swift",
                 "BatchEngineGrowingChatCacheSourceTests.swift",
                 "CacheCoordinatorTopologyFocusedTests.swift",
                 "DiskStoreOffsetConsistencyFocusedTests.swift",

--- a/Package.swift
+++ b/Package.swift
@@ -864,6 +864,7 @@ let package = Package(
                 "DFlash2UnusableBlockWidthTests.swift",
                 "NativeMTPTuningShapeTests.swift",
                 "JangDeclaredMTPDepthTests.swift",
+                "NativeMTPActivationErrorTextTests.swift",
                 "BatchEngineGrowingChatCacheSourceTests.swift",
                 "CacheCoordinatorTopologyFocusedTests.swift",
                 "DiskStoreOffsetConsistencyFocusedTests.swift",

--- a/Package.swift
+++ b/Package.swift
@@ -865,6 +865,7 @@ let package = Package(
                 "NativeMTPTuningShapeTests.swift",
                 "JangDeclaredMTPDepthTests.swift",
                 "NativeMTPActivationErrorTextTests.swift",
+                "HybridWarmupMemoScopeTests.swift",
                 "BatchEngineGrowingChatCacheSourceTests.swift",
                 "CacheCoordinatorTopologyFocusedTests.swift",
                 "DiskStoreOffsetConsistencyFocusedTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/DFlash2UnusableBlockWidthTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/DFlash2UnusableBlockWidthTests.swift
@@ -1,0 +1,79 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// A drafted block needs an anchor position plus at least one speculative
+// position, so widths below 2 cannot draft. `DFlash2TokenIterator.init`
+// has always thrown `blockSizeTooSmall` for them — but throwing is the
+// wrong channel. BatchEngine's solo-fast-path catch turns ANY throw into a
+// zero-token stream stamped `.cancelled`, so a user who pins Draft Tokens
+// Per Step to 1 gets "I wasn't able to generate a response to that. Please
+// try rephrasing your request." on every turn, and the real cause goes only
+// to os_log — invisible from an unsigned build.
+//
+// `unservableReason` is the channel that already exists for exactly this:
+// a non-nil result makes the caller SKIP the drafter, and the request
+// decodes normally. The `maxTokens <= 1` rule is the same shape, mirroring
+// `maxTokensTooSmall`. This suite pins that the width rule joins it.
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite("DFlash 2 unusable block width")
+struct DFlash2UnusableBlockWidthTests {
+
+    private func parameters(blockSize: Int?) -> GenerateParameters {
+        var p = GenerateParameters(temperature: 0)
+        p.draftStrategy = .dflash2(
+            drafterPath: URL(fileURLWithPath: "/tmp/does-not-need-to-exist"),
+            blockSize: blockSize)
+        return p
+    }
+
+    /// The bug as the user met it: width 1 reached `init` and threw.
+    @Test func widthBelowTheMinimumIsReportedAsUnservable() throws {
+        let reason = try #require(
+            DFlash2TokenIterator.unservableReason(parameters(blockSize: 1)),
+            "width 1 must be reported here, not thrown from init")
+        #expect(reason.contains("below the minimum"))
+    }
+
+    @Test func zeroAndNegativeWidthsAreAlsoUnservable() {
+        #expect(DFlash2TokenIterator.unservableReason(parameters(blockSize: 0)) != nil)
+        #expect(DFlash2TokenIterator.unservableReason(parameters(blockSize: -4)) != nil)
+    }
+
+    /// The minimum itself must remain servable — an off-by-one here would
+    /// silently disable the narrowest width the runtime supports.
+    @Test func theMinimumWidthItselfStaysServable() {
+        #expect(
+            DFlash2TokenIterator.unservableReason(
+                parameters(blockSize: DFlash2TokenIterator.minimumBlockSize)) == nil)
+    }
+
+    /// `nil` means "use the checkpoint's trained width", which is resolved
+    /// later from the drafter config. Reporting it unservable here would
+    /// disable DFlash 2 for every default request.
+    @Test func anUnsetWidthIsNotUnservable() {
+        #expect(DFlash2TokenIterator.unservableReason(parameters(blockSize: nil)) == nil)
+        #expect(DFlash2TokenIterator.unservableReason(parameters(blockSize: 8)) == nil)
+    }
+
+    /// The guard in `init` and the rule here must read the same constant, or
+    /// a future edit to one silently reopens the throw path the other closed.
+    @Test func theGuardAndTheRuleShareOneConstant() throws {
+        let source = try String(
+            contentsOf: URL(fileURLWithPath: #filePath)
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .deletingLastPathComponent()
+                .appendingPathComponent(
+                    "Libraries/MLXLMCommon/SpecDec/DFlash2TokenIterator.swift"),
+            encoding: .utf8)
+        #expect(
+            source.contains("effectiveBlockSize >= Self.minimumBlockSize"),
+            "init's guard must use the shared constant, not a bare literal")
+        #expect(source.contains("requested < minimumBlockSize"))
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/HybridWarmupMemoScopeTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/HybridWarmupMemoScopeTests.swift
@@ -41,6 +41,17 @@ struct HybridWarmupMemoScopeTests {
             averageAccepted: 0.56, depth: 2))
     }
 
+    /// A marginal depth-2 miss (accepted >= the depth-1 floor 0.55) must NOT
+    /// be catastrophic: the iterator downshifts to depth 1 and keeps
+    /// speculating. This is the exact live case — acceptance dips to
+    /// ~0.94-1.06 after a plain-decoded span and self-recovers.
+    @Test func aMarginalDepthTwoMissIsNeitherCatastrophicNorFatal() {
+        #expect(!NativeMTPTokenIterator.warmupFailureIsModelProperty(
+            averageAccepted: 0.94, depth: 2))
+        #expect(!NativeMTPTokenIterator.warmupFailureIsModelProperty(
+            averageAccepted: 1.06, depth: 2))
+    }
+
     /// The line must sit strictly BELOW each depth's pass floor, or a plain
     /// failure and a catastrophic one are the same thing again.
     @Test func catastrophicIsStrictlyBelowThePassFloorAtEveryDepth() {

--- a/Tests/MLXLMCommonFocusedTests/HybridWarmupMemoScopeTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/HybridWarmupMemoScopeTests.swift
@@ -1,0 +1,55 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// The hybrid safety-warmup memo records a verdict "for the model, not the
+// prompt" — so only a CATASTROPHIC probe failure (broken/mismatched head,
+// genuinely depth-independent) may be memoized. The pass floor scales with
+// depth (0.55 * depth) but the catastrophic line was the bare constant 0.55,
+// so at depth 1 the two coincided: every ordinary depth-1 content miss was
+// recorded as a failed model and hard-disabled MTP at ALL depths for the
+// rest of the residency. Live signature: `adaptiveFallback=hybrid_warmup_memo`,
+// `verifyCalls=0`, `avgCommittedPerVerify=0.00`, on every turn after one
+// depth-1 warmup at ~0.44 acceptance.
+
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite("Hybrid warmup memo scope")
+struct HybridWarmupMemoScopeTests {
+
+    /// The live failure: 0.44 at depth 1 is a content miss, not a broken head.
+    @Test func anOrdinaryDepthOneMissIsNotAModelProperty() {
+        #expect(
+            !NativeMTPTokenIterator.warmupFailureIsModelProperty(
+                averageAccepted: 0.44, depth: 1))
+    }
+
+    /// Truly broken heads accept essentially nothing at any depth.
+    @Test func aNearZeroAcceptanceIsCatastrophicAtEveryDepth() {
+        #expect(NativeMTPTokenIterator.warmupFailureIsModelProperty(
+            averageAccepted: 0.05, depth: 1))
+        #expect(NativeMTPTokenIterator.warmupFailureIsModelProperty(
+            averageAccepted: 0.05, depth: 2))
+    }
+
+    /// Depth 2 keeps its historical line exactly: below 0.55 is catastrophic.
+    @Test func depthTwoLineIsUnchanged() {
+        #expect(NativeMTPTokenIterator.warmupFailureIsModelProperty(
+            averageAccepted: 0.54, depth: 2))
+        #expect(!NativeMTPTokenIterator.warmupFailureIsModelProperty(
+            averageAccepted: 0.56, depth: 2))
+    }
+
+    /// The line must sit strictly BELOW each depth's pass floor, or a plain
+    /// failure and a catastrophic one are the same thing again.
+    @Test func catastrophicIsStrictlyBelowThePassFloorAtEveryDepth() {
+        for depth in 1...3 {
+            let floor = 0.55 * Double(depth)
+            #expect(
+                !NativeMTPTokenIterator.warmupFailureIsModelProperty(
+                    averageAccepted: floor - 0.01, depth: depth),
+                "depth \(depth): a just-under-floor miss must stay per-request")
+        }
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/JangDeclaredMTPDepthTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/JangDeclaredMTPDepthTests.swift
@@ -1,0 +1,76 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// A bundle can declare its own speculative depth in jang_config:
+//
+//     runtime.mtp_num_speculative_tokens = 2
+//     mtp.recommended_num_drafts          = 2
+//     mtp.upstream_num_speculative_tokens = 2
+//
+// Nothing read any of them — grepping Libraries/ returned zero hits — so
+// depth came only from `vmlx_mtp_tuning.json` and a bundle shipping a head
+// plus a declared depth but no measured row got no depth at all.
+//
+// The declaration is the PUBLISHER's claim; the tuning row is a measurement
+// on THIS machine. The measured row must therefore win wherever it is
+// usable, and the two must stay distinguishable in the reason string.
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite("jang_config declared MTP depth")
+struct JangDeclaredMTPDepthTests {
+
+    private func jangJSON(runtimeDepth: Int?, mtpDepth: Int?) -> String {
+        let runtimeExtra = runtimeDepth.map { ", \"mtp_num_speculative_tokens\": \($0)" } ?? ""
+        let mtpBlock = mtpDepth.map { ", \"mtp\": {\"recommended_num_drafts\": \($0)}" } ?? ""
+        return """
+            {"runtime": {"bundle_has_mtp": true, "mtp_layers": 1,
+             "mtp_mode": "preserved_enabled"\(runtimeExtra)}\(mtpBlock)}
+            """
+    }
+
+    private func runtime(_ json: String) throws -> JangRuntime {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("jang-depth-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        try Data(json.utf8).write(to: dir.appendingPathComponent("jang_config.json"))
+        return try JangLoader.loadConfig(at: dir).runtime
+    }
+
+    @Test func readsTheRuntimeSpelling() throws {
+        let r = try runtime(jangJSON(runtimeDepth: 2, mtpDepth: nil))
+        #expect(r.mtpDeclaredSpeculativeTokens == 2)
+    }
+
+    /// Qwen3.8-27B writes both; other publishers may write only one.
+    @Test func fallsBackToTheMtpBlockSpelling() throws {
+        let r = try runtime(jangJSON(runtimeDepth: nil, mtpDepth: 3))
+        #expect(r.mtpDeclaredSpeculativeTokens == 3)
+    }
+
+    /// A bundle with a head but no declared depth must stay nil, not 0 —
+    /// a zero would read as "declared, and it is none".
+    @Test func noDeclarationStaysNil() throws {
+        let r = try runtime(jangJSON(runtimeDepth: nil, mtpDepth: nil))
+        #expect(r.mtpDeclaredSpeculativeTokens == nil)
+    }
+
+    /// Zero and negative declarations are not depths.
+    @Test func nonPositiveDeclarationsAreIgnored() throws {
+        #expect(try runtime(jangJSON(runtimeDepth: 0, mtpDepth: nil))
+            .mtpDeclaredSpeculativeTokens == nil)
+        #expect(try runtime(jangJSON(runtimeDepth: -1, mtpDepth: nil))
+            .mtpDeclaredSpeculativeTokens == nil)
+    }
+
+    /// When both spellings are present and disagree, the runtime block is the
+    /// more specific statement and wins. Pinned so the order is deliberate.
+    @Test func runtimeSpellingWinsOverTheMtpBlock() throws {
+        let r = try runtime(jangJSON(runtimeDepth: 2, mtpDepth: 3))
+        #expect(r.mtpDeclaredSpeculativeTokens == 2)
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
@@ -182,7 +182,8 @@ struct MTPRuntimeFocusedTests {
             status: status)
 
         #expect(recommendation?.depth == 2)
-        #expect(recommendation?.verifierMode == "chunk_lazy_repair")
+        // Silent artifact: the iterator decides (input_capture_staged when capable).
+        #expect(recommendation?.verifierMode == nil)
         #expect(recommendation?.evidence.contains("tuning_file=vmlx_mtp_tuning.json") == true)
         #expect(recommendation?.evidence.contains("tuning.quantization_mode=mxfp4") == true)
         #expect(recommendation?.evidence.contains("tuning.quantization_bits=4") == true)
@@ -1064,7 +1065,8 @@ struct MTPRuntimeFocusedTests {
             jangConfig: nil,
             status: preserved)
         #expect(denseAuto?.depth == 3)
-        #expect(denseAuto?.verifierMode == "chunk_lazy_repair")
+        // Silent artifact: the iterator decides (input_capture_staged when capable).
+        #expect(denseAuto?.verifierMode == nil)
         #expect(denseAuto?.evidence.contains("tuning_file=vmlx_mtp_tuning.json") == true)
         #expect(NativeMTPAutoDecodePolicy.recommendation(
             configData: denseMXFP8Config,
@@ -1082,14 +1084,16 @@ struct MTPRuntimeFocusedTests {
             status: preserved,
             requireVerifiedRuntime: false)
         #expect(denseReporting?.depth == 3)
-        #expect(denseReporting?.verifierMode == "chunk_lazy_repair")
+        // Silent artifact: the iterator decides (input_capture_staged when capable).
+        #expect(denseReporting?.verifierMode == nil)
 
         let moeVerified = NativeMTPAutoDecodePolicy.recommendation(
             configData: moeMXFP8Config,
             jangConfig: nil,
             status: verified)
         #expect(moeVerified?.depth == 3)
-        #expect(moeVerified?.verifierMode == "chunk_lazy_repair")
+        // Silent artifact: the iterator decides (input_capture_staged when capable).
+        #expect(moeVerified?.verifierMode == nil)
 
         let qwen36Verified = NativeMTPAutoDecodePolicy.recommendation(
             configData: qwen36MXFP8Config,

--- a/Tests/MLXLMCommonFocusedTests/NativeMTPActivationErrorTextTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NativeMTPActivationErrorTextTests.swift
@@ -1,0 +1,48 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// `NativeMTPActivationError` conformed only to `CustomStringConvertible`, so
+// Foundation rendered it through the generic Error bridge:
+//
+//   "The operation couldn't be completed.
+//    (MLXLMCommon.NativeMTPActivationError error 1.)"
+//
+// A case INDEX. The enum already carried an exact, actionable sentence for
+// every case and none of it reached the user. `LocalizedError` is what makes
+// `localizedDescription` use it.
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite("Native MTP activation error text")
+struct NativeMTPActivationErrorTextTests {
+
+    @Test func everyCaseSurfacesItsOwnSentence() {
+        let cases: [NativeMTPActivationError] = [
+            .requestedButMissingArtifact(nil),
+            .requestedWithoutUsableTuning(nil),
+            .requestedForUnsupportedModel(["gemma4"]),
+            .invalidConfigData,
+        ]
+        for error in cases {
+            let localized = (error as Error).localizedDescription
+            #expect(
+                localized == error.description,
+                "localizedDescription fell back to the generic bridge: \(localized)")
+            #expect(
+                !localized.contains("The operation couldn"),
+                "still rendering the Foundation placeholder")
+            #expect(!localized.contains("error 1"), "still rendering a case index")
+        }
+    }
+
+    /// The case the user actually hit. Its text must name the tuning file, or
+    /// it is no more diagnosable than the index was.
+    @Test func theTuningCaseNamesTheFile() {
+        let text = (NativeMTPActivationError.requestedWithoutUsableTuning(nil) as Error)
+            .localizedDescription
+        #expect(text.contains(NativeMTPTuning.fileName))
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/NativeMTPTuningShapeTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NativeMTPTuningShapeTests.swift
@@ -1,0 +1,80 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// The published `vmlx_mtp_tuning.json` nests its row under `native_mtp`
+// (see NativeMTPDepth3AutoLaunchTests, which quotes the shipped Qwen3.6
+// artifact verbatim). Every Qwen3.8-27B bundle ships the row FLAT instead.
+//
+// Because `NativeMTPTuningDocument.nativeMTP` is Optional, a flat file
+// decoded "successfully" to nil. The bundle inspector then reported
+// `tuning_file_missing` for a file sitting right there on disk, so
+// `hasUsableNativeMTPTuning` was false, `canAutoLaunch` was false, and
+// native MTP could NEVER launch on those bundles — no matter what the
+// artifact said. The visible symptom was "Bundle does not have usable
+// vmlx_mtp_tuning.json production tuning", which sends the diagnosis after
+// the tuning VALUES when the problem is the file's SHAPE.
+
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite("Native MTP tuning file shape")
+struct NativeMTPTuningShapeTests {
+
+    private static let row = """
+        "best_depth": 2, "validated": true, "output_equivalent": true,
+        "baseline_tok_s": 38.82, "best_tok_s": 41.39, "speedup_vs_baseline": 1.066
+        """
+
+    private func write(_ json: String) throws -> URL {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("mtp-shape-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try Data(json.utf8).write(to: dir.appendingPathComponent("vmlx_mtp_tuning.json"))
+        return dir
+    }
+
+    /// The published shape must keep working.
+    @Test func nestedShapeLoads() throws {
+        let dir = try write("{\"native_mtp\": {\(Self.row)}}")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let tuning = try #require(MTPBundleInspector.tuningForTesting(at: dir))
+        #expect(tuning.usableBestDepth == 2)
+    }
+
+    /// The shape every Qwen3.8-27B bundle actually ships. Before this it
+    /// silently produced nil and the bundle was reported as having no tuning.
+    @Test func flatShapeAlsoLoads() throws {
+        let dir = try write("{\(Self.row)}")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let tuning = try #require(
+            MTPBundleInspector.tuningForTesting(at: dir),
+            "a flat row must load; it was silently dropped before")
+        #expect(tuning.usableBestDepth == 2)
+    }
+
+    /// No file at all is still no tuning — leniency must not invent one.
+    @Test func absentFileYieldsNothing() throws {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("mtp-shape-empty-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        #expect(MTPBundleInspector.tuningForTesting(at: dir) == nil)
+    }
+
+    /// Garbage must not masquerade as a usable row.
+    @Test func unparseableFileYieldsNothing() throws {
+        let dir = try write("{ not json at all ")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        #expect(MTPBundleInspector.tuningForTesting(at: dir) == nil)
+    }
+
+    /// A well-formed file carrying no depth is not a tuning row either —
+    /// otherwise `{}` would decode to an all-defaults row and read as real.
+    @Test func aRowWithoutADepthIsNotTuning() throws {
+        let dir = try write("{\"validated\": true}")
+        defer { try? FileManager.default.removeItem(at: dir) }
+        #expect(MTPBundleInspector.tuningForTesting(at: dir) == nil)
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/NativeMTPWarmupMemoScopeTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NativeMTPWarmupMemoScopeTests.swift
@@ -24,12 +24,21 @@ struct NativeMTPWarmupMemoScopeTests {
     func contentMissIsNotMemoizable() {
         // The live prose repro: 1.00 average accepted per verify at depth 3
         // (floor 1.65). Failing warmup is correct; memoizing it is not.
-        #expect(!NativeMTPTokenIterator.warmupFailureIsModelProperty(averageAccepted: 1.00))
+        #expect(
+            !NativeMTPTokenIterator.warmupFailureIsModelProperty(
+                averageAccepted: 1.00, depth: 3))
         // Just below a depth-2 floor (1.10) but healthy for depth 1.
-        #expect(!NativeMTPTokenIterator.warmupFailureIsModelProperty(averageAccepted: 0.80))
-        // Exactly the depth-1 floor still clears depth 1, so it stays
+        #expect(
+            !NativeMTPTokenIterator.warmupFailureIsModelProperty(
+                averageAccepted: 0.80, depth: 2))
+        // The live depth-1 poisoning: 0.44 failed warmup (floor 0.55) and the
+        // old depth-blind line ALSO called it catastrophic, hard-disabling
+        // MTP at every depth for the residency — while the same head ran
+        // depth 2 at 2.7 committed/verify. A depth-1 content miss must stay
         // per-request.
-        #expect(!NativeMTPTokenIterator.warmupFailureIsModelProperty(averageAccepted: 0.55))
+        #expect(
+            !NativeMTPTokenIterator.warmupFailureIsModelProperty(
+                averageAccepted: 0.44, depth: 1))
     }
 
     @Test("catastrophic miss below the depth-1 floor is the model")
@@ -37,9 +46,17 @@ struct NativeMTPWarmupMemoScopeTests {
         // A broken or mismatched MTP head accepts near zero; no depth could
         // ever clear warmup, so re-probing every request only burns the
         // 16-cycle probe the memo census flagged (84% of requests).
-        #expect(NativeMTPTokenIterator.warmupFailureIsModelProperty(averageAccepted: 0.0))
-        #expect(NativeMTPTokenIterator.warmupFailureIsModelProperty(averageAccepted: 0.30))
-        #expect(NativeMTPTokenIterator.warmupFailureIsModelProperty(averageAccepted: 0.54))
+        #expect(
+            NativeMTPTokenIterator.warmupFailureIsModelProperty(
+                averageAccepted: 0.0, depth: 1))
+        #expect(
+            NativeMTPTokenIterator.warmupFailureIsModelProperty(
+                averageAccepted: 0.30, depth: 2))
+        // The catastrophic line is half the depth's own floor, so depth 2
+        // keeps its historical 0.55 exactly.
+        #expect(
+            NativeMTPTokenIterator.warmupFailureIsModelProperty(
+                averageAccepted: 0.54, depth: 2))
     }
 
     @Test("memo verdict stays per model instance and passing runs still memoize")

--- a/Tests/MLXLMCommonFocusedTests/VMLXServerRuntimeSettingsTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/VMLXServerRuntimeSettingsTests.swift
@@ -314,7 +314,10 @@ struct VMLXServerRuntimeSettingsTests {
             status: tuned)
         {
             #expect(depth == 3)
-            #expect(verifierMode == "chunk_lazy_repair")
+            // A silent artifact must yield NO verifier mode: the iterator picks
+            // input_capture_staged itself when staged-capable, and the old
+            // "chunk_lazy_repair" filler overrode that and collapsed acceptance.
+            #expect(verifierMode == nil)
         } else {
             Issue.record("Default server settings should auto-resolve tuned native MTP")
         }
@@ -407,7 +410,7 @@ struct VMLXServerRuntimeSettingsTests {
 
         #expect(launch.launchMode == .speculative)
         #expect(launch.recommendation?.depth == 2)
-        #expect(launch.recommendation?.verifierMode == "chunk_lazy_repair")
+        #expect(launch.recommendation?.verifierMode == nil)
         #expect(launch.recommendation?.evidence.contains("server_draft_token_limit=2") == true)
         if case .nativeMTP(depth: let depth, verifierMode: let verifierMode)? = settings.resolvedMTPDraftStrategy(
             configData: config,
@@ -415,7 +418,10 @@ struct VMLXServerRuntimeSettingsTests {
             status: verified)
         {
             #expect(depth == 2)
-            #expect(verifierMode == "chunk_lazy_repair")
+            // A silent artifact must yield NO verifier mode: the iterator picks
+            // input_capture_staged itself when staged-capable, and the old
+            // "chunk_lazy_repair" filler overrode that and collapsed acceptance.
+            #expect(verifierMode == nil)
         } else {
             Issue.record("Resolved MTP draft strategy did not carry the capped native depth")
         }
@@ -506,7 +512,7 @@ struct VMLXServerRuntimeSettingsTests {
             status: preserved)
 
         #expect(candidate?.depth == 3)
-        #expect(candidate?.verifierMode == "chunk_lazy_repair")
+        #expect(candidate?.verifierMode == nil)
         #expect(settings.effectiveMTPLaunchMode(for: preserved) == .speculative)
         #expect(launch.launchMode == .speculative)
         #expect(loadConfiguration.nativeMTP)
@@ -516,7 +522,10 @@ struct VMLXServerRuntimeSettingsTests {
             status: preserved)
         {
             #expect(depth == 3)
-            #expect(verifierMode == "chunk_lazy_repair")
+            // A silent artifact must yield NO verifier mode: the iterator picks
+            // input_capture_staged itself when staged-capable, and the old
+            // "chunk_lazy_repair" filler overrode that and collapsed acceptance.
+            #expect(verifierMode == nil)
         } else {
             Issue.record("Tensor-proven Qwen MTP should resolve a native-MTP draft strategy")
         }


### PR DESCRIPTION
Two ways speculative decoding failed silently and blamed the wrong thing.

## 1. A flat tuning file made native MTP unlaunchable — and reported itself missing

`NativeMTPTuningDocument` reads the row from a top-level `native_mtp` key, and `nativeMTP` is `Optional`. A bundle shipping the row **flat** decodes "successfully" to `nil`, and the inspector then appends `tuning_file_missing` — for a file sitting right there on disk.

**Every Qwen3.8-27B bundle ships it flat.** So on all four, `hasUsableNativeMTPTuning` was false, `canAutoLaunch` was false, and native MTP could never launch regardless of what the artifact said. The user-facing reason was *"Bundle does not have usable vmlx_mtp_tuning.json production tuning"* — which sends the diagnosis after the tuning **values** when the problem is the file's **shape**.

Census on the same bundle, before and after reshaping that one file:

```
before: "tuning_file_missing=vmlx_mtp_tuning.json"   canAutoLaunch=false  speculative=off (tuning required)
after:  "tuning.best_depth=2" "tuning_file=..."      canAutoLaunch=true   tuning=d2, speculative=on
```

Now accepts both shapes — nested first (the published schema, quoted verbatim in `NativeMTPDepth3AutoLaunchTests`), then flat. A flat row still requires a `best_depth`, so `{}` cannot decode into an all-defaults row that reads as real tuning. Also splits `tuning_file_missing` from `tuning_file_unreadable`; they were one string pointing at two different fixes.

**No gate is relaxed.** `usableBestDepth` still demands `validated`, `output_equivalent`, not `blocked`, and a measured speedup above 1. Qwen3.8-27B-JANG_2D measures 48.49 vs 48.49 and correctly stays off.

## 2. An unusable DFlash 2 block width killed every turn

A block carries an anchor plus at least one speculative position, so a width below 2 cannot draft. `init` threw `blockSizeTooSmall` — but `BatchEngine`'s solo-fast-path catch turns *any* setup throw into a zero-token stream stamped `.cancelled`. Three of those trip the chat layer's empty-turn fallback: *"I wasn't able to generate a response to that. Please try rephrasing your request."* The prompt gets blamed for a settings value, and the cause goes only to `os_log`.

`unservableReason` is the channel that already exists for this — a non-nil result makes both dispatch sites skip the drafter and decode normally, which `DFlash2DispatchReachabilityTests` already pins. The `maxTokens <= 1` rule is the same shape, mirroring `maxTokensTooSmall`; the width rule was missing. The floor is now one constant shared with the `init` guard, with a test that fails if they drift.

Clean control across four proof runs, same model and drafter, only the width varying:

| width | sentinel-only turns |
|---|---|
| 8 (trained) / 6 / 2 | 0 |
| **1** | **9** |

## Evidence for the equivalence stamp

Independently of this PR, the four Qwen3.8-27B artifacts were measured rather than asserted: greedy AR vs native MTP at `best_depth`, decoded text compared byte-for-byte, two prompts at **193** and **251** tokens — neither divisible by the depth, since an aligned length hides off-by-one packing by construction. All four byte-identical on both prompts, via `VMLX_MTP_TUNING_MEASUREMENT=1` (the documented escape hatch for exactly this chicken-and-egg).

## Tests

`NativeMTPTuningShapeTests` (6) and `DFlash2UnusableBlockWidthTests` (5), both registered in `Package.swift`; `TestSourcesAreRegisteredTests` passes. 11/11 green locally.

Note: this repo's CI reported all four checks **SKIPPED** on this PR — none ran — so the only verification is local.

Osaurus companion: #2473 (renders the resolved depth and drops an unusable width at resolve time). It repins to this branch, so **this must merge first**.