### PR TITLE
ChatSession: accept audio, like it already accepts images and video

### DIFF
--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -247,16 +247,18 @@ public final class ChatSession {
     ///   - prompt: the user prompt
     ///   - images: list of images (for use with VLMs)
     ///   - videos: list of videos (for use with VLMs)
+    ///   - audios: list of audio clips (for use with models that accept them)
     /// - Returns: the model's response
     public func respond(
         to prompt: String,
         role: Chat.Message.Role = .user,
         images: consuming [UserInput.Image],
-        videos: consuming [UserInput.Video]
+        videos: consuming [UserInput.Video],
+        audios: consuming [UserInput.Audio] = []
     ) async throws -> String {
         var output = ""
         for try await chunk in streamResponse(
-            to: prompt, role: role, images: images, videos: videos
+            to: prompt, role: role, images: images, videos: videos, audios: audios
         ) {
             output += chunk
         }
@@ -269,18 +271,21 @@ public final class ChatSession {
     ///   - prompt: the user prompt
     ///   - image: optional image (for use with VLMs)
     ///   - video: optional video (for use with VLMs)
+    ///   - audio: optional audio (for use with models that accept it)
     /// - Returns: the model's response
     public func respond(
         to prompt: String,
         role: Chat.Message.Role = .user,
         image: UserInput.Image? = nil,
-        video: UserInput.Video? = nil
+        video: UserInput.Video? = nil,
+        audio: UserInput.Audio? = nil
     ) async throws -> String {
         try await respond(
             to: prompt,
             role: role,
             images: image.map { [$0] } ?? [],
-            videos: video.map { [$0] } ?? []
+            videos: video.map { [$0] } ?? [],
+            audios: audio.map { [$0] } ?? []
         )
     }
 
@@ -290,14 +295,16 @@ public final class ChatSession {
     ///   - prompt: the user prompt
     ///   - images: list of images (for use with VLMs)
     ///   - videos: list of videos (for use with VLMs)
+    ///   - audios: list of audio clips (for use with models that accept them)
     /// - Returns: a stream of string chunks from the model
     public func streamResponse(
         to prompt: String,
         role: Chat.Message.Role = .user,
         images: consuming [UserInput.Image],
-        videos: consuming [UserInput.Video]
+        videos: consuming [UserInput.Video],
+        audios: consuming [UserInput.Audio] = []
     ) -> AsyncThrowingStream<String, Error> {
-        streamMap(to: prompt, role: role, images: images, videos: videos) {
+        streamMap(to: prompt, role: role, images: images, videos: videos, audios: audios) {
             $0.chunk
         }
     }
@@ -308,14 +315,16 @@ public final class ChatSession {
     ///   - prompt: the user prompt
     ///   - images: list of images (for use with VLMs)
     ///   - videos: list of videos (for use with VLMs)
+    ///   - audios: list of audio clips (for use with models that accept them)
     /// - Returns: a stream of `Generation` from the model
     public func streamDetails(
         to prompt: String,
         role: Chat.Message.Role = .user,
         images: consuming [UserInput.Image],
-        videos: consuming [UserInput.Video]
+        videos: consuming [UserInput.Video],
+        audios: consuming [UserInput.Audio] = []
     ) -> AsyncThrowingStream<Generation, Error> {
-        streamMap(to: prompt, role: role, images: images, videos: videos) {
+        streamMap(to: prompt, role: role, images: images, videos: videos, audios: audios) {
             $0
         }
     }
@@ -327,12 +336,14 @@ public final class ChatSession {
     ///   - prompt: the user prompt
     ///   - images: list of images (for use with VLMs)
     ///   - videos: list of videos (for use with VLMs)
+    ///   - audios: list of audio clips (for use with models that accept them)
     /// - Returns: a stream of transformed values from the model
     private func streamMap<R: Sendable>(
         to prompt: String,
         role: Chat.Message.Role,
         images: consuming [UserInput.Image],
         videos: consuming [UserInput.Video],
+        audios: consuming [UserInput.Audio],
         transform: @Sendable @escaping (Generation) -> R?
     ) -> AsyncThrowingStream<R, Error> {
         let (stream, continuation) = AsyncThrowingStream<R, Error>.makeStream()
@@ -340,7 +351,7 @@ public final class ChatSession {
         // images and videos are not Sendable (MLXArray) but they are consumed
         // and are only being sent to the inner async
         let message = SendableBox<Chat.Message>(
-            .init(role: role, content: prompt, images: images, videos: videos)
+            .init(role: role, content: prompt, images: images, videos: videos, audios: audios)
         )
 
         let task = Task {
@@ -562,16 +573,19 @@ public final class ChatSession {
     ///   - prompt: the user prompt
     ///   - image: optional image (for use with VLMs)
     ///   - video: optional video (for use with VLMs)
+    ///   - audio: optional audio (for use with models that accept it)
     /// - Returns: a stream of string chunks from the model
     public func streamResponse(
         to prompt: String,
         image: UserInput.Image? = nil,
-        video: UserInput.Video? = nil
+        video: UserInput.Video? = nil,
+        audio: UserInput.Audio? = nil
     ) -> AsyncThrowingStream<String, Error> {
         streamResponse(
             to: prompt,
             images: image.map { [$0] } ?? [],
-            videos: video.map { [$0] } ?? []
+            videos: video.map { [$0] } ?? [],
+            audios: audio.map { [$0] } ?? []
         )
     }
 


### PR DESCRIPTION
## The gap

`ChatSession` can be sent images and video. It cannot be sent audio — and not because anything below it
is missing:

| | images | videos | audios |
|---|---|---|---|
| `UserInput.Image` / `.Audio` — `.url`, in-memory, `MLXArray` | ✓ | ✓ | ✓ |
| `Chat.Message.init(role:content:images:videos:audios:)` | ✓ | ✓ | ✓ |
| `UserInput.init(prompt:images:videos:audios:)` | ✓ | ✓ | ✓ |
| `UserInput.init(chat:)` — rebuilds from the message list | ✓ | ✓ | ✓ |
| **`ChatSession.respond` / `streamResponse` / `streamDetails`** | ✓ | ✓ | **✗** |

The whole of it is one line in `streamMap`:

```swift
let message = SendableBox<Chat.Message>(
    .init(role: role, content: prompt, images: images, videos: videos))
                                                       // audios: exists on this
                                                       // initialiser, never passed
```

`streamMap` has no audio parameter to pass, so none of the four public overloads can offer one. A caller
with an audio-capable model must either abandon the session API and construct `UserInput` directly, or
seed the clip into `history` — where it works fine. That it works through one door and not the other is
what makes this an omission rather than a missing capability.

## The change

`audios:` on the plural overloads, `audio:` on the singular convenience ones — the same two arities
images and video already have, so the rule stays "audio is treated like the other attachments" rather
than becoming a special case. `consuming` matches the existing parameters for the reason they have it:
`UserInput.Audio.array` wraps an `MLXArray`, which is not `Sendable`. Everything is defaulted, so no
existing call site changes and nothing is source-breaking.

## Verification

End to end on Apertus 1.5 8B — a discrete-token omni model, so audio is half of what it does — with a
7.7 s clip generated by `say` and a prompt that deliberately does not name its content:

```swift
for try await c in session.streamResponse(
    to: "What do you hear in this audio? Answer briefly.",
    audio: .url(clipURL)) { text += c }
```

```
The numbers one, two, three, four, five, six, seven, eight, nine, ten, eleven, twelve.
```

The prompt says nothing about counting or numbers, so this is the model hearing the clip rather than
echoing the question — the same design as the existing Apertus audio end-to-end test, and for the same
reason.

The "before" case needs no measurement: that call does not compile without this change, there being no
parameter to pass the clip to.

## Scope

One file, additive, all parameters defaulted. Found while trying to test an omni model's audio path
through the session API and discovering there wasn't one.
