### PR TITLE
ChatSession: stop handing the coordinator a cache it will always reject

### DIFF
--- a/Libraries/MLXLMCommon/ChatSession.swift
+++ b/Libraries/MLXLMCommon/ChatSession.swift
@@ -375,19 +375,24 @@ public final class ChatSession {
                     // are distinct.  In particular the KVCache cannot
                     // be shared and that is the lock that is held here.
 
-                    let cacheCoordinator = model.cacheCoordinator
+
+                    // Read from the CONTAINER before `model` is shadowed by the LanguageModel below.
+                    let containerCacheCoordinator = model.cacheCoordinator
 
                     let model = await model.perform { context in
                         SendableBox(context.model)
                     }.consume()
 
                     var kvCache: [KVCache]
+                    // Whether this session already carries conversation state the caller depends on.
+                    var kvCacheIsPopulated = false
                     switch cache {
                     case .empty:
                         kvCache = model.newCache(parameters: generateParameters)
                         cache = .kvcache(kvCache)
 
                     case .kvcache(let array):
+                        kvCacheIsPopulated = array.contains { $0.offset > 0 }
                         // Reuse the live cache across ChatSession turns.
                         // Bailing/Ling ArraysCache used to be reset here as
                         // a workaround for a Bailing MLA double-update bug.
@@ -402,6 +407,25 @@ public final class ChatSession {
                         cache = .kvcache(kvCache)
                         messages.append(contentsOf: history)
                     }
+
+                    // Hand the coordinator over only while the session's own cache is EMPTY.
+                    //
+                    // This session is append-only: after the first turn it submits just the new
+                    // message and relies on the live KV cache to carry the conversation. The
+                    // coordinator keys its lookup on the FULL prompt, so once that divergence starts
+                    // it can never match — and `populatedCacheRequiresResetAfterCoordinatorMiss`
+                    // reads a miss on a populated cache as proof the caller's state is unverified and
+                    // resets it, then "full-prefills" `input`. For an append-only caller `input` is
+                    // one message, so the reset does not restore what it discarded: the conversation
+                    // is gone. Observed as a model denying, one turn later, that it had ever been
+                    // shown an image or told a name — on two unrelated architectures.
+                    //
+                    // The reset itself is right, and the reasoning behind it (an Off→On reasoning
+                    // change made Ornith replay a stale tool call) still holds. What is wrong is
+                    // pairing it with a caller that cannot satisfy the re-prefill. So the coordinator
+                    // is offered the first turn, where its key IS the whole prompt and a disk hit can
+                    // seed the session, and withheld once the live cache is authoritative.
+                    let cacheCoordinator = kvCacheIsPopulated ? nil : containerCacheCoordinator
 
                     // prepare the input
                     messages.append(message.consume())


### PR DESCRIPTION
## A ChatSession with caching enabled has no conversation memory

Three turns — greeting with a name, an image, then a question about both:

| model | `enableCaching` off | `enableCaching` on |
|---|---|---|
| Apertus 1.5 8B | "Your name is Rudolf, and the main subject was an urban street scene with cars, trees, and lane markings" | "I don't have access to any image you may have shown me, nor do I know your name." |
| LFM2.5-VL-3B | "your name is Rudolf, and the main subject of the image is the city street scene" | "I don't have access to your personal information, so I can't tell you your name." |

Two unrelated architectures, one a discrete-token omni model and the other a continuous-embedding VLM.
The only difference between the working and broken column is the `enableCaching` call.

## Why

An interaction between two individually reasonable behaviours.

`ChatSession` is **append-only**. After the first turn it submits only the new message and relies on the
live KV cache to carry the conversation — visible in the token counts: turn 0 is 64 tokens, the image
turn is 1135, the text follow-up is 76, never the accumulated total.

The coordinator keys its lookup on the **full prompt**. From turn 2 onward it is therefore being asked
about a prompt it has never seen, and can never match. The fetch trace shows `MISS all tiers` on *every*
turn, not occasionally.

And a miss on a populated cache is treated as proof that the caller's state is unverified:

```swift
if populatedCacheRequiresResetAfterCoordinatorMiss(self.cache) {   // cache.contains { $0.offset > 0 }
    self.cache = self.model.newCache(parameters: effectiveParameters)
    inputForPrepare = input
}
```

For a caller that submits its whole prompt that is right — discard the unverified state, prefill
everything again. For an append-only caller it is destructive: `input` is one message, so the re-prefill
cannot restore what the reset just discarded. Every turn: miss, reset, forget.

## The fix

**The reset stays.** Its rationale is sound and documented in place — after an Off→On reasoning change,
Ornith reused the prior turn's `ArraysCache` state and replayed its old tool call. Reusing unverified
recurrent state really is incorrect.

What changes is that the session stops offering the coordinator a lookup it structurally cannot satisfy.
The coordinator is passed on the **first** turn, where its key IS the whole prompt and a disk hit can
legitimately seed the session, and withheld once the live cache is populated and authoritative — which is
also the case where the coordinator could not have helped, since the live cache is already the faster
path.

Non-session callers (`BatchEngine`, direct `TokenIterator`, `.history`-seeded sessions, which start at
offset 0) are unaffected.

## Verification

With the fix and caching **on**, both models answer exactly as they do with caching off:

```
Apertus:  "Your name is Rudolf. The main subject of the image was a street with cars
           parked along the road and trees lining the street."
LFM2.5-VL: "Your name is Rudolf, and the main subject of the image was a quiet city
           street with parked cars and a crosswalk."
```

`MLXLMCommonFocusedTests`: 599 tests in 67 suites pass.

## Scope

One file. Found while investigating why a media cache resume could never be demonstrated — the answer
being that the conversation it would resume was destroyed before it could be.
