### PR TITLE
Ling 3.0 (BailingMoeV3): KDA + MLA + V3-MoE runtime behind an architectures dispatch

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -218,7 +218,7 @@ public enum LLMTypeRegistry {
             "olmo2": create(Olmo2Configuration.self, Olmo2Model.init),
             "olmo3": create(Olmo3Configuration.self, Olmo3Model.init),
             "bailing_moe": create(BailingMoeConfiguration.self, BailingMoeModel.init),
-            "bailing_hybrid": create(BailingHybridConfiguration.self, BailingHybridModel.init),
+            "bailing_hybrid": dispatchBailingHybrid,
             "bailing_moe_v2_5": create(BailingHybridConfiguration.self, BailingHybridModel.init),
             "lfm2_moe": create(LFM2MoEConfiguration.self, LFM2MoEModel.init),
             "step": dispatchStep3p5,
@@ -383,6 +383,39 @@ public enum LLMTypeRegistry {
             context = nil
         }
         return ZayaModel(config, moe: context)
+    }
+
+    /// Ling 2.6 and Ling 3.0 both declare `model_type = "bailing_hybrid"`,
+    /// but they are different architectures: 2.6 is Lightning/GLA linear
+    /// attention (`BailingHybridModel`), 3.0 is KDA + MLA + V3 MoE
+    /// (`BailingMoeV3Model`, `architectures = ["BailingMoeV3ForCausalLM"]`).
+    /// The `architectures` list is the discriminator; a KDA marker key is the
+    /// fallback for configs that omit it.
+    private static func dispatchBailingHybrid(data: Data) throws -> any LanguageModel {
+        struct Probe: Decodable {
+            var architectures: [String]?
+            var linearAttention: String?
+            var kdaLowerBound: Float?
+
+            enum CodingKeys: String, CodingKey {
+                case architectures
+                case linearAttention = "linear_attention"
+                case kdaLowerBound = "kda_lower_bound"
+            }
+        }
+        let probe = try? JSONDecoder().decode(Probe.self, from: data)
+        let isV3 =
+            probe?.architectures?.contains(where: { $0.contains("MoeV3") }) == true
+            || probe?.linearAttention == "kda"
+            || probe?.kdaLowerBound != nil
+        if isV3 {
+            let configuration = try JSONDecoder().decode(
+                BailingMoeV3Configuration.self, from: data)
+            return BailingMoeV3Model(configuration)
+        }
+        let configuration = try JSONDecoder().decode(
+            BailingHybridConfiguration.self, from: data)
+        return BailingHybridModel(configuration)
     }
 
     private static func dispatchNemotronH(data: Data) throws -> any LanguageModel {

--- a/Libraries/MLXLLM/Models/BailingMoeV3.swift
+++ b/Libraries/MLXLLM/Models/BailingMoeV3.swift
@@ -330,7 +330,14 @@ final class BailingV3KDAAttention: Module {
             aLog: aLog, dtBias: dtBias,
             safeGate: safeGate, lowerBound: lowerBound,
             state: cache?[1], mask: mask)
-        if let cache { cache[1] = newState }
+        if let cache {
+            cache[1] = newState
+            // The disk-L2 eligibility gate requires every layer's offset to
+            // advance in step; a KDA layer stuck at 0 silently vetoed every
+            // store for the whole model (zero kv_v2 entries, measured live).
+            // Same contract as Qwen35's GatedDeltaNet (`cache.offset += S`).
+            cache.offset += T
+        }
 
         let gate: MLXArray
         if let gProj {

--- a/Libraries/MLXLLM/Models/BailingMoeV3.swift
+++ b/Libraries/MLXLLM/Models/BailingMoeV3.swift
@@ -1,0 +1,814 @@
+// Copyright © 2026 Apple Inc.
+
+// BailingMoeV3 — the Ling 3.0 family (e.g. Ling-3.0-tiny).
+//
+// Same `model_type` string ("bailing_hybrid") as Ling 2.6, but a DIFFERENT
+// architecture (`architectures = ["BailingMoeV3ForCausalLM"]`):
+//   * Linear layers are KDA (Kimi Delta Attention): per-stream short causal
+//     convolutions + a delta-rule recurrence with a PER-CHANNEL decay gate —
+//     not the Lightning/GLA recurrence `BailingHybrid.swift` implements.
+//   * Full-attention layers are MLA with interleaved RoPE and an optional
+//     head-wise sigmoid output gate (`g_proj`).
+//   * MoE is DeepSeek-V3-shaped: sigmoid scores, `expert_bias` added only for
+//     ROUTING (original scores are what get normalized), group-limited top-k,
+//     `routed_scaling_factor`, plus shared experts.
+// Layer rule: `(idx + 1) % layer_group_size == 0` (and any trailing partial
+// group) is MLA; everything else is KDA. Dense MLP below
+// `first_k_dense_replace`, MoE from there on.
+//
+// Reference: `modeling_bailing_moe_v3.py` shipped inside the upstream bundle
+// (inclusionAI/Ling-3.0-tiny) plus fla's `fused_recurrent_kda` for the exact
+// recurrence (see KDADelta.swift).
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+// MARK: - Configuration
+
+public struct BailingMoeV3Configuration: Codable, Sendable {
+    var hiddenSize: Int
+    var numHiddenLayers: Int
+    var intermediateSize: Int
+    var numAttentionHeads: Int
+    var numKeyValueHeads: Int
+    var vocabSize: Int
+    var rmsNormEps: Float
+    var ropeTheta: Float
+    var tieWordEmbeddings: Bool
+
+    // Layer typing
+    var layerGroupSize: Int
+    var firstKDenseReplace: Int
+
+    // KDA
+    var headDim: Int
+    var shortConvKernelSize: Int
+    var noKdaLora: Bool
+    var kdaSafeGate: Bool
+    var kdaLowerBound: Float
+
+    // MLA
+    var qLoraRank: Int?
+    var kvLoraRank: Int
+    var qkRopeHeadDim: Int
+    var qkNopeHeadDim: Int
+    var vHeadDim: Int
+    var ropeInterleave: Bool
+    var useQkvBias: Bool
+    var ropeScaling: [String: StringOrNumber]?
+    var gatedAttentionProjGranularityType: String?
+
+    // MoE
+    var numExperts: Int?
+    var numExpertsPerTok: Int
+    var numSharedExperts: Int
+    var moeIntermediateSize: Int
+    var moeSharedExpertIntermediateSize: Int
+    var nGroup: Int
+    var topkGroup: Int
+    var routedScalingFactor: Float
+    var normTopkProb: Bool
+    var scoreFunction: String
+
+    var qkHeadDim: Int { qkNopeHeadDim + qkRopeHeadDim }
+
+    /// Same rule as the reference `BailingMoeV3DecoderLayer`: the last layer
+    /// of each complete group is full attention, and every layer past the
+    /// last complete group is full attention too.
+    func isFullAttentionLayer(_ idx: Int) -> Bool {
+        (idx + 1) % layerGroupSize == 0
+            || idx >= (numHiddenLayers / layerGroupSize) * layerGroupSize
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case hiddenSize = "hidden_size"
+        case numHiddenLayers = "num_hidden_layers"
+        case intermediateSize = "intermediate_size"
+        case numAttentionHeads = "num_attention_heads"
+        case numKeyValueHeads = "num_key_value_heads"
+        case vocabSize = "vocab_size"
+        case rmsNormEps = "rms_norm_eps"
+        case ropeTheta = "rope_theta"
+        case tieWordEmbeddings = "tie_word_embeddings"
+        case layerGroupSize = "layer_group_size"
+        case firstKDenseReplace = "first_k_dense_replace"
+        case headDim = "head_dim"
+        case shortConvKernelSize = "short_conv_kernel_size"
+        case noKdaLora = "no_kda_lora"
+        case kdaSafeGate = "kda_safe_gate"
+        case kdaLowerBound = "kda_lower_bound"
+        case qLoraRank = "q_lora_rank"
+        case kvLoraRank = "kv_lora_rank"
+        case qkRopeHeadDim = "qk_rope_head_dim"
+        case qkNopeHeadDim = "qk_nope_head_dim"
+        case vHeadDim = "v_head_dim"
+        case ropeInterleave = "rope_interleave"
+        case useQkvBias = "use_qkv_bias"
+        case ropeScaling = "rope_scaling"
+        case gatedAttentionProjGranularityType = "gated_attention_proj_granularity_type"
+        case numExperts = "num_experts"
+        case numExpertsPerTok = "num_experts_per_tok"
+        case numSharedExperts = "num_shared_experts"
+        case moeIntermediateSize = "moe_intermediate_size"
+        case moeSharedExpertIntermediateSize = "moe_shared_expert_intermediate_size"
+        case nGroup = "n_group"
+        case topkGroup = "topk_group"
+        case routedScalingFactor = "routed_scaling_factor"
+        case normTopkProb = "norm_topk_prob"
+        case scoreFunction = "score_function"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        hiddenSize = try c.decode(Int.self, forKey: .hiddenSize)
+        numHiddenLayers = try c.decode(Int.self, forKey: .numHiddenLayers)
+        intermediateSize = try c.decode(Int.self, forKey: .intermediateSize)
+        numAttentionHeads = try c.decode(Int.self, forKey: .numAttentionHeads)
+        numKeyValueHeads =
+            try c.decodeIfPresent(Int.self, forKey: .numKeyValueHeads)
+            ?? numAttentionHeads
+        vocabSize = try c.decode(Int.self, forKey: .vocabSize)
+        rmsNormEps = try c.decodeIfPresent(Float.self, forKey: .rmsNormEps) ?? 1e-6
+        ropeTheta = try c.decodeIfPresent(Float.self, forKey: .ropeTheta) ?? 10000
+        tieWordEmbeddings =
+            try c.decodeIfPresent(Bool.self, forKey: .tieWordEmbeddings) ?? false
+        layerGroupSize = try c.decodeIfPresent(Int.self, forKey: .layerGroupSize) ?? 4
+        firstKDenseReplace =
+            try c.decodeIfPresent(Int.self, forKey: .firstKDenseReplace) ?? 0
+        headDim =
+            try c.decodeIfPresent(Int.self, forKey: .headDim)
+            ?? hiddenSize / numAttentionHeads
+        shortConvKernelSize =
+            try c.decodeIfPresent(Int.self, forKey: .shortConvKernelSize) ?? 4
+        noKdaLora = try c.decodeIfPresent(Bool.self, forKey: .noKdaLora) ?? true
+        kdaSafeGate = try c.decodeIfPresent(Bool.self, forKey: .kdaSafeGate) ?? true
+        kdaLowerBound =
+            try c.decodeIfPresent(Float.self, forKey: .kdaLowerBound) ?? -5
+        qLoraRank = try c.decodeIfPresent(Int.self, forKey: .qLoraRank)
+        kvLoraRank = try c.decodeIfPresent(Int.self, forKey: .kvLoraRank) ?? 512
+        qkRopeHeadDim = try c.decodeIfPresent(Int.self, forKey: .qkRopeHeadDim) ?? 64
+        qkNopeHeadDim = try c.decodeIfPresent(Int.self, forKey: .qkNopeHeadDim) ?? 128
+        vHeadDim = try c.decodeIfPresent(Int.self, forKey: .vHeadDim) ?? 128
+        ropeInterleave = try c.decodeIfPresent(Bool.self, forKey: .ropeInterleave) ?? true
+        useQkvBias = try c.decodeIfPresent(Bool.self, forKey: .useQkvBias) ?? false
+        ropeScaling = try c.decodeIfPresent(
+            [String: StringOrNumber].self, forKey: .ropeScaling)
+        gatedAttentionProjGranularityType = try c.decodeIfPresent(
+            String.self, forKey: .gatedAttentionProjGranularityType)
+        numExperts = try c.decodeIfPresent(Int.self, forKey: .numExperts)
+        numExpertsPerTok =
+            try c.decodeIfPresent(Int.self, forKey: .numExpertsPerTok) ?? 8
+        numSharedExperts =
+            try c.decodeIfPresent(Int.self, forKey: .numSharedExperts) ?? 0
+        moeIntermediateSize =
+            try c.decodeIfPresent(Int.self, forKey: .moeIntermediateSize) ?? 512
+        moeSharedExpertIntermediateSize =
+            try c.decodeIfPresent(Int.self, forKey: .moeSharedExpertIntermediateSize)
+            ?? moeIntermediateSize
+        nGroup = try c.decodeIfPresent(Int.self, forKey: .nGroup) ?? 1
+        topkGroup = try c.decodeIfPresent(Int.self, forKey: .topkGroup) ?? 1
+        routedScalingFactor =
+            try c.decodeIfPresent(Float.self, forKey: .routedScalingFactor) ?? 1
+        normTopkProb = try c.decodeIfPresent(Bool.self, forKey: .normTopkProb) ?? true
+        scoreFunction =
+            try c.decodeIfPresent(String.self, forKey: .scoreFunction) ?? "sigmoid"
+    }
+}
+
+// MARK: - Norms
+
+/// RMSNorm whose gate goes through SIGMOID — Ling 3.0's `o_norm` is fla's
+/// `FusedRMSNormGated(activation='sigmoid')`, unlike Qwen3Next's silu gate.
+final class BailingV3RMSNormGated: Module {
+    let weight: MLXArray
+    let eps: Float
+
+    init(dimensions: Int, eps: Float = 1e-6) {
+        self.weight = MLXArray.ones([dimensions])
+        self.eps = eps
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray, gate: MLXArray) -> MLXArray {
+        MLXFast.rmsNorm(x, weight: weight, eps: eps) * sigmoid(gate.asType(.float32))
+            .asType(x.dtype)
+    }
+}
+
+// MARK: - KDA linear attention
+
+final class BailingV3KDAAttention: Module {
+    let numHeads: Int
+    let headDim: Int
+    let projectionSize: Int
+    let convKernelSize: Int
+    let safeGate: Bool
+    let lowerBound: Float
+
+    @ModuleInfo(key: "q_proj") var qProj: Linear
+    @ModuleInfo(key: "k_proj") var kProj: Linear
+    @ModuleInfo(key: "v_proj") var vProj: Linear
+
+    @ModuleInfo(key: "q_conv1d") var qConv: Conv1d
+    @ModuleInfo(key: "k_conv1d") var kConv: Conv1d
+    @ModuleInfo(key: "v_conv1d") var vConv: Conv1d
+
+    @ParameterInfo(key: "A_log") var aLog: MLXArray
+    @ParameterInfo(key: "dt_bias") var dtBias: MLXArray
+
+    @ModuleInfo(key: "f_proj") var fProj: Linear?
+    @ModuleInfo(key: "f_a_proj") var fAProj: Linear?
+    @ModuleInfo(key: "f_b_proj") var fBProj: Linear?
+    @ModuleInfo(key: "b_proj") var bProj: Linear
+    @ModuleInfo(key: "g_proj") var gProj: Linear?
+    @ModuleInfo(key: "g_a_proj") var gAProj: Linear?
+    @ModuleInfo(key: "g_b_proj") var gBProj: Linear?
+
+    @ModuleInfo(key: "o_norm") var oNorm: BailingV3RMSNormGated
+    @ModuleInfo(key: "o_proj") var oProj: Linear
+
+    init(_ args: BailingMoeV3Configuration) {
+        self.numHeads = args.numAttentionHeads
+        self.headDim = args.headDim
+        self.projectionSize = numHeads * headDim
+        self.convKernelSize = args.shortConvKernelSize
+        self.safeGate = args.kdaSafeGate
+        self.lowerBound = args.kdaLowerBound
+
+        _qProj.wrappedValue = Linear(args.hiddenSize, projectionSize, bias: false)
+        _kProj.wrappedValue = Linear(args.hiddenSize, projectionSize, bias: false)
+        _vProj.wrappedValue = Linear(args.hiddenSize, projectionSize, bias: false)
+
+        let makeConv = { (channels: Int, kernel: Int) -> Conv1d in
+            Conv1d(
+                inputChannels: channels,
+                outputChannels: channels,
+                kernelSize: kernel,
+                stride: 1, padding: 0, dilation: 1,
+                groups: channels, bias: false)
+        }
+        _qConv.wrappedValue = makeConv(projectionSize, convKernelSize)
+        _kConv.wrappedValue = makeConv(projectionSize, convKernelSize)
+        _vConv.wrappedValue = makeConv(projectionSize, convKernelSize)
+
+        _aLog.wrappedValue = MLXArray.zeros([numHeads])
+        _dtBias.wrappedValue = MLXArray.zeros([projectionSize])
+
+        if args.noKdaLora {
+            _fProj.wrappedValue = Linear(args.hiddenSize, projectionSize, bias: false)
+            _gProj.wrappedValue = Linear(args.hiddenSize, projectionSize, bias: false)
+        } else {
+            _fAProj.wrappedValue = Linear(args.hiddenSize, headDim, bias: false)
+            _fBProj.wrappedValue = Linear(headDim, projectionSize, bias: false)
+            _gAProj.wrappedValue = Linear(args.hiddenSize, headDim, bias: false)
+            _gBProj.wrappedValue = Linear(headDim, projectionSize, bias: false)
+        }
+        _bProj.wrappedValue = Linear(args.hiddenSize, numHeads, bias: false)
+
+        _oNorm.wrappedValue = BailingV3RMSNormGated(
+            dimensions: headDim, eps: args.rmsNormEps)
+        _oProj.wrappedValue = Linear(projectionSize, args.hiddenSize, bias: false)
+        super.init()
+    }
+
+    func callAsFunction(
+        _ x: MLXArray, mask: MLXArray? = nil, cache: MambaCache? = nil
+    ) -> MLXArray {
+        let B = x.dim(0)
+        let T = x.dim(1)
+        let dtype = x.dtype
+        let proj = projectionSize
+
+        var mixed = concatenated([qProj(x), kProj(x), vProj(x)], axis: -1)
+        if let mask {
+            mixed = MLX.where(
+                expandedDimensions(mask, axis: -1), mixed, MLXArray.zeros(like: mixed))
+        }
+
+        let convState: MLXArray
+        if let s = cache?[0] {
+            convState = s
+        } else {
+            convState = MLXArray.zeros(
+                [B, convKernelSize - 1, 3 * proj], dtype: dtype)
+        }
+        let convInput = concatenated([convState, mixed], axis: 1)
+        if let cache {
+            cache[0] = convInput[0..., (1 - convKernelSize)..., 0...]
+        }
+
+        var q = silu(qConv(convInput[0..., 0..., 0 ..< proj]))
+        var k = silu(kConv(convInput[0..., 0..., proj ..< (2 * proj)]))
+        let v = silu(vConv(convInput[0..., 0..., (2 * proj) ..< (3 * proj)]))
+            .reshaped(B, T, numHeads, headDim)
+
+        q = q.reshaped(B, T, numHeads, headDim)
+        k = k.reshaped(B, T, numHeads, headDim)
+
+        // fla applies true per-head L2 norm and scales q by Dk^-0.5. An
+        // unweighted rmsNorm is l2norm * sqrt(D), so multiplying by
+        // invScale^2 / invScale reproduces l2(q)*Dk^-0.5 and l2(k) exactly —
+        // the same identity Qwen3Next uses.
+        let invScale = pow(Float(headDim), -0.5)
+        q = MLXArray(invScale * invScale, dtype: q.dtype)
+            * MLXFast.rmsNorm(q, weight: MLXArray.mlxNone, eps: 1e-6)
+        k = MLXArray(invScale, dtype: k.dtype)
+            * MLXFast.rmsNorm(k, weight: MLXArray.mlxNone, eps: 1e-6)
+
+        let fRaw: MLXArray
+        if let fProj {
+            fRaw = fProj(x).reshaped(B, T, numHeads, headDim)
+        } else {
+            fRaw = fBProj!(fAProj!(x)).reshaped(B, T, numHeads, headDim)
+        }
+        let beta = sigmoid(bProj(x).asType(.float32))
+
+        let (y, newState) = kdaUpdate(
+            q: q, k: k, v: v, fRaw: fRaw, beta: beta,
+            aLog: aLog, dtBias: dtBias,
+            safeGate: safeGate, lowerBound: lowerBound,
+            state: cache?[1], mask: mask)
+        if let cache { cache[1] = newState }
+
+        let gate: MLXArray
+        if let gProj {
+            gate = gProj(x).reshaped(B, T, numHeads, headDim)
+        } else {
+            gate = gBProj!(gAProj!(x)).reshaped(B, T, numHeads, headDim)
+        }
+        let out = oNorm(y.asType(dtype), gate: gate)
+        return oProj(out.reshaped(B, T, -1))
+    }
+}
+
+// MARK: - MLA full attention
+
+final class BailingV3MLAAttention: Module {
+    let numHeads: Int
+    let qLoraRank: Int?
+    let qkRopeHeadDim: Int
+    let kvLoraRank: Int
+    let vHeadDim: Int
+    let qkNopeHeadDim: Int
+    let qHeadDim: Int
+    let gateGranularity: String?
+    var scale: Float
+
+    @ModuleInfo(key: "q_proj") var qProj: Linear?
+    @ModuleInfo(key: "q_a_proj") var qAProj: Linear?
+    @ModuleInfo(key: "q_a_layernorm") var qALayerNorm: RMSNorm?
+    @ModuleInfo(key: "q_b_proj") var qBProj: Linear?
+    @ModuleInfo(key: "kv_a_proj_with_mqa") var kvAProjWithMqa: Linear
+    @ModuleInfo(key: "kv_a_layernorm") var kvALayerNorm: RMSNorm
+    @ModuleInfo(key: "kv_b_proj") var kvBProj: Linear
+    @ModuleInfo(key: "g_proj") var gProj: Linear?
+    @ModuleInfo(key: "dense") var dense: Linear
+
+    let rope: RoPE
+
+    init(_ args: BailingMoeV3Configuration) {
+        self.numHeads = args.numAttentionHeads
+        self.qLoraRank = args.qLoraRank
+        self.qkRopeHeadDim = args.qkRopeHeadDim
+        self.kvLoraRank = args.kvLoraRank
+        self.vHeadDim = args.vHeadDim
+        self.qkNopeHeadDim = args.qkNopeHeadDim
+        self.qHeadDim = args.qkHeadDim
+        self.gateGranularity = args.gatedAttentionProjGranularityType
+        self.scale = pow(Float(qHeadDim), -0.5)
+
+        if let q = args.qLoraRank {
+            _qAProj.wrappedValue = Linear(args.hiddenSize, q, bias: args.useQkvBias)
+            _qALayerNorm.wrappedValue = RMSNorm(dimensions: q, eps: args.rmsNormEps)
+            _qBProj.wrappedValue = Linear(q, numHeads * qHeadDim, bias: false)
+        } else {
+            _qProj.wrappedValue = Linear(
+                args.hiddenSize, numHeads * qHeadDim, bias: false)
+        }
+        _kvAProjWithMqa.wrappedValue = Linear(
+            args.hiddenSize, kvLoraRank + qkRopeHeadDim, bias: args.useQkvBias)
+        _kvALayerNorm.wrappedValue = RMSNorm(
+            dimensions: kvLoraRank, eps: args.rmsNormEps)
+        _kvBProj.wrappedValue = Linear(
+            kvLoraRank, numHeads * (qkNopeHeadDim + vHeadDim), bias: false)
+        switch gateGranularity {
+        case "head_wise":
+            _gProj.wrappedValue = Linear(args.hiddenSize, numHeads, bias: false)
+        case "element_wise":
+            _gProj.wrappedValue = Linear(
+                args.hiddenSize, numHeads * vHeadDim, bias: false)
+        default:
+            break
+        }
+        _dense.wrappedValue = Linear(
+            numHeads * vHeadDim, args.hiddenSize, bias: args.useQkvBias)
+
+        // YaRN mscale correction, matching the reference (rope_scaling is
+        // nil on Ling-3.0-tiny so this is a no-op there).
+        if let ropeScaling = args.ropeScaling {
+            let mScaleAllDim = ropeScaling["mscale_all_dim"]?.asFloat() ?? 0.0
+            let scalingFactor = ropeScaling["factor"]?.asFloat() ?? 1.0
+            if mScaleAllDim != 0, scalingFactor > 1 {
+                let s = 0.1 * mScaleAllDim * log(scalingFactor) + 1.0
+                self.scale = self.scale * s * s
+            }
+        }
+
+        // rope_interleave = true → traditional (interleaved-pair) RoPE.
+        self.rope = RoPE(
+            dimensions: qkRopeHeadDim, traditional: args.ropeInterleave,
+            base: args.ropeTheta)
+        super.init()
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        mask: MLXFast.ScaledDotProductAttentionMaskMode,
+        cache: KVCache?
+    ) -> MLXArray {
+        let B = x.dim(0)
+        let L = x.dim(1)
+
+        var q: MLXArray
+        if qLoraRank == nil {
+            q = qProj!(x)
+        } else {
+            q = qBProj!(qALayerNorm!(qAProj!(x)))
+        }
+        q = q.reshaped(B, L, numHeads, qHeadDim).transposed(0, 2, 1, 3)
+        let qSplit = split(q, indices: [qkNopeHeadDim], axis: -1)
+        let qNope = qSplit[0]
+        var qPe = qSplit[1]
+
+        var compressedKv = kvAProjWithMqa(x)
+        let kvSplit = split(compressedKv, indices: [kvLoraRank], axis: -1)
+        compressedKv = kvSplit[0]
+        var kPe = kvSplit[1]
+        kPe = kPe.reshaped(B, L, 1, qkRopeHeadDim).transposed(0, 2, 1, 3)
+
+        var kv = kvBProj(kvALayerNorm(compressedKv))
+        kv = kv.reshaped(B, L, numHeads, qkNopeHeadDim + vHeadDim)
+            .transposed(0, 2, 1, 3)
+        let kvPartSplit = split(kv, indices: [qkNopeHeadDim], axis: -1)
+        let kNope = kvPartSplit[0]
+        var values = kvPartSplit[1]
+
+        qPe = applyRotaryPosition(rope, to: qPe, cache: cache)
+        kPe = applyRotaryPosition(rope, to: kPe, cache: cache)
+        kPe = repeated(kPe, count: numHeads, axis: 1)
+
+        let queries = concatenated([qNope, qPe], axis: -1)
+        var keys = concatenated([kNope, kPe], axis: -1)
+
+        if let cache {
+            (keys, values) = cache.update(keys: keys, values: values)
+        }
+
+        var output = mlaScaledDotProductAttention(
+            queries: queries, keys: keys, values: values,
+            scale: scale, mask: mask
+        )
+        .transposed(0, 2, 1, 3)  // [B, L, H, Dv]
+
+        if let gProj {
+            let gate = sigmoid(gProj(x).asType(.float32)).asType(output.dtype)
+            if gateGranularity == "head_wise" {
+                output = output * gate.reshaped(B, L, numHeads, 1)
+            } else {
+                output = output * gate.reshaped(B, L, numHeads, vHeadDim)
+            }
+        }
+        return dense(output.reshaped(B, L, -1))
+    }
+}
+
+// MARK: - MLP / MoE
+
+final class BailingV3MLP: Module, UnaryLayer {
+    @ModuleInfo(key: "gate_proj") var gateProj: Linear
+    @ModuleInfo(key: "up_proj") var upProj: Linear
+    @ModuleInfo(key: "down_proj") var downProj: Linear
+
+    init(_ args: BailingMoeV3Configuration, intermediateSize: Int? = nil) {
+        let inter = intermediateSize ?? args.intermediateSize
+        _gateProj.wrappedValue = Linear(args.hiddenSize, inter, bias: false)
+        _upProj.wrappedValue = Linear(args.hiddenSize, inter, bias: false)
+        _downProj.wrappedValue = Linear(inter, args.hiddenSize, bias: false)
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        downProj(silu(gateProj(x)) * upProj(x))
+    }
+}
+
+final class BailingV3MoEGate: Module {
+    let topK: Int
+    let nGroup: Int
+    let topkGroup: Int
+    let routedScalingFactor: Float
+    let normTopkProb: Bool
+    let scoreFunction: String
+
+    @ParameterInfo(key: "weight") var weight: MLXArray
+    @ParameterInfo(key: "expert_bias") var expertBias: MLXArray
+
+    init(_ args: BailingMoeV3Configuration) {
+        guard let numExperts = args.numExperts else {
+            fatalError("BailingV3MoEGate requires num_experts")
+        }
+        self.topK = args.numExpertsPerTok
+        self.nGroup = args.nGroup
+        self.topkGroup = args.topkGroup
+        self.routedScalingFactor = args.routedScalingFactor
+        self.normTopkProb = args.normTopkProb
+        self.scoreFunction = args.scoreFunction
+        _weight.wrappedValue = MLXArray.zeros([numExperts, args.hiddenSize])
+        _expertBias.wrappedValue = MLXArray.zeros([numExperts])
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> (MLXArray, MLXArray) {
+        // Router in float32, as `router_dtype = "fp32"` demands.
+        let logits = x.asType(.float32).matmul(weight.asType(.float32).T)
+        let scores =
+            scoreFunction == "sigmoid"
+            ? sigmoid(logits) : softmax(logits, axis: -1, precise: true)
+
+        // expert_bias participates in SELECTION only; the returned weights
+        // come from the un-biased scores (reference lines 398-404).
+        var selection = scores + expertBias.asType(.float32)
+
+        if nGroup > 1 {
+            // Group score = sum of the top-2 experts in the group; keep the
+            // best `topk_group` groups, drop the rest to -inf so a negative
+            // expert_bias cannot resurrect a dropped group.
+            var grouped = unflatten(selection, axis: -1, shape: [nGroup, -1])
+            let groupScores = top(grouped, k: 2, axis: -1).sum(axis: -1, keepDims: true)
+            let dropCount = nGroup - topkGroup
+            let dropIdx = argPartition(groupScores, kth: dropCount - 1, axis: -2)[
+                .ellipsis, ..<dropCount, 0...]
+            grouped = putAlong(
+                grouped, stopGradient(dropIdx),
+                values: MLXArray(-Float.infinity, dtype: grouped.dtype), axis: -2)
+            selection = flattened(grouped, start: -2, end: -1)
+        }
+
+        let inds = argPartition(-selection, kth: topK - 1, axis: -1)[.ellipsis, ..<topK]
+        var selectedScores = takeAlong(scores, inds, axis: -1)
+
+        if topK > 1, normTopkProb {
+            selectedScores =
+                selectedScores / (selectedScores.sum(axis: -1, keepDims: true) + 1e-20)
+        }
+        selectedScores = selectedScores * routedScalingFactor
+        return (inds, selectedScores)
+    }
+}
+
+final class BailingV3SparseMoE: Module, UnaryLayer {
+    let gate: BailingV3MoEGate
+
+    @ModuleInfo(key: "switch_mlp") var switchMLP: SwitchGLU
+    @ModuleInfo(key: "shared_experts") var sharedExperts: BailingV3MLP?
+
+    init(_ args: BailingMoeV3Configuration) {
+        guard let numExperts = args.numExperts else {
+            fatalError("BailingV3SparseMoE requires num_experts")
+        }
+        self.gate = BailingV3MoEGate(args)
+        _switchMLP.wrappedValue = SwitchGLU(
+            inputDims: args.hiddenSize,
+            hiddenDims: args.moeIntermediateSize,
+            numExperts: numExperts)
+        if args.numSharedExperts > 0 {
+            _sharedExperts.wrappedValue = BailingV3MLP(
+                args,
+                intermediateSize: args.moeSharedExpertIntermediateSize
+                    * args.numSharedExperts)
+        }
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let (inds, scores) = gate(x)
+        var y = switchMLP(x, inds)
+        y = (y * scores[.ellipsis, .newAxis].asType(y.dtype)).sum(axis: -2)
+        if let sharedExperts {
+            y = y + sharedExperts(x)
+        }
+        return y
+    }
+}
+
+// MARK: - Decoder layer / model
+
+/// Both layer kinds load from the same `attention` bundle key (the Python
+/// class has a single `self.attention` attribute), so the decoder layer keeps
+/// one existential property — the same trick as BailingHybrid.
+protocol BailingV3Attention: Module {
+    func callAsV3Attention(
+        _ x: MLXArray,
+        attnMask: MLXFast.ScaledDotProductAttentionMaskMode,
+        ssmMask: MLXArray?,
+        cache: KVCache?
+    ) -> MLXArray
+}
+
+extension BailingV3MLAAttention: BailingV3Attention {
+    func callAsV3Attention(
+        _ x: MLXArray,
+        attnMask: MLXFast.ScaledDotProductAttentionMaskMode,
+        ssmMask: MLXArray?,
+        cache: KVCache?
+    ) -> MLXArray {
+        callAsFunction(x, mask: attnMask, cache: cache)
+    }
+}
+
+extension BailingV3KDAAttention: BailingV3Attention {
+    func callAsV3Attention(
+        _ x: MLXArray,
+        attnMask: MLXFast.ScaledDotProductAttentionMaskMode,
+        ssmMask: MLXArray?,
+        cache: KVCache?
+    ) -> MLXArray {
+        // The recurrence is implicitly causal; only the SSM padding mask
+        // applies here.
+        callAsFunction(x, mask: ssmMask, cache: cache as? MambaCache)
+    }
+}
+
+final class BailingV3DecoderLayer: Module {
+    let isFullAttention: Bool
+
+    @ModuleInfo(key: "input_layernorm") var inputLayerNorm: RMSNorm
+    @ModuleInfo(key: "post_attention_layernorm") var postAttentionLayerNorm: RMSNorm
+
+    @ModuleInfo(key: "attention") var attention: any BailingV3Attention
+    let mlp: UnaryLayer
+
+    init(_ args: BailingMoeV3Configuration, layerIdx: Int) {
+        self.isFullAttention = args.isFullAttentionLayer(layerIdx)
+        if isFullAttention {
+            _attention.wrappedValue = BailingV3MLAAttention(args)
+        } else {
+            _attention.wrappedValue = BailingV3KDAAttention(args)
+        }
+        if args.numExperts != nil, layerIdx >= args.firstKDenseReplace {
+            self.mlp = BailingV3SparseMoE(args)
+        } else {
+            self.mlp = BailingV3MLP(args)
+        }
+        _inputLayerNorm.wrappedValue = RMSNorm(
+            dimensions: args.hiddenSize, eps: args.rmsNormEps)
+        _postAttentionLayerNorm.wrappedValue = RMSNorm(
+            dimensions: args.hiddenSize, eps: args.rmsNormEps)
+        super.init()
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        attnMask: MLXFast.ScaledDotProductAttentionMaskMode,
+        ssmMask: MLXArray?,
+        cache: KVCache?
+    ) -> MLXArray {
+        let r = attention.callAsV3Attention(
+            inputLayerNorm(x), attnMask: attnMask, ssmMask: ssmMask, cache: cache)
+        let h = x + r
+        let r2 = mlp(postAttentionLayerNorm(h))
+        return h + r2
+    }
+}
+
+public class BailingMoeV3LanguageModel: Module {
+    let args: BailingMoeV3Configuration
+
+    @ModuleInfo(key: "word_embeddings") var wordEmbeddings: Embedding
+    var layers: [BailingV3DecoderLayer]
+    @ModuleInfo(key: "norm") var norm: RMSNorm
+
+    let firstFullIdx: Int
+    let firstLinearIdx: Int
+
+    init(_ args: BailingMoeV3Configuration) {
+        self.args = args
+        self._wordEmbeddings.wrappedValue = Embedding(
+            embeddingCount: args.vocabSize, dimensions: args.hiddenSize)
+        self.layers = (0 ..< args.numHiddenLayers).map {
+            BailingV3DecoderLayer(args, layerIdx: $0)
+        }
+        self._norm.wrappedValue = RMSNorm(
+            dimensions: args.hiddenSize, eps: args.rmsNormEps)
+        self.firstFullIdx =
+            (0 ..< args.numHiddenLayers).first(where: { args.isFullAttentionLayer($0) })
+            ?? 0
+        self.firstLinearIdx =
+            (0 ..< args.numHiddenLayers).first(where: { !args.isFullAttentionLayer($0) })
+            ?? 0
+        super.init()
+    }
+
+    public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]? = nil) -> MLXArray {
+        var h = wordEmbeddings(inputs)
+
+        let fullCache = cache?[firstFullIdx]
+        let attnMask = createAttentionMask(h: h, cache: fullCache)
+        let ssmMask = createSSMMask(h: h, cache: cache?[firstLinearIdx] as? MambaCache)
+
+        for (i, layer) in layers.enumerated() {
+            let layerCache = (cache != nil && i < cache!.count) ? cache![i] : nil
+            h = layer(h, attnMask: attnMask, ssmMask: ssmMask, cache: layerCache)
+        }
+        return norm(h)
+    }
+}
+
+public class BailingMoeV3Model: Module, LLMModel, KVCacheDimensionProvider {
+    public var kvHeads: [Int]
+    let args: BailingMoeV3Configuration
+
+    @ModuleInfo(key: "model") var model: BailingMoeV3LanguageModel
+    @ModuleInfo(key: "lm_head") var lmHead: Linear?
+
+    public init(_ args: BailingMoeV3Configuration) {
+        self.args = args
+        self._model.wrappedValue = BailingMoeV3LanguageModel(args)
+        if !args.tieWordEmbeddings {
+            self._lmHead.wrappedValue = Linear(
+                args.hiddenSize, args.vocabSize, bias: false)
+        }
+        // Only the full-attention (MLA) layers hold a KV cache.
+        self.kvHeads = (0 ..< args.numHiddenLayers).map {
+            args.isFullAttentionLayer($0) ? args.numAttentionHeads : 0
+        }
+        super.init()
+    }
+
+    public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        let out = model(inputs, cache: cache)
+        if let lmHead {
+            return lmHead(out)
+        }
+        return model.wordEmbeddings.asLinear(out)
+    }
+
+    public func newCache(parameters: GenerateParameters?) -> [KVCache] {
+        (0 ..< args.numHiddenLayers).map { i in
+            if args.isFullAttentionLayer(i) {
+                if let maxKVSize = parameters?.maxKVSize {
+                    return RotatingKVCache(maxSize: maxKVSize, keep: 4)
+                }
+                return KVCacheSimple()
+            }
+            // Slot 0: concatenated q/k/v conv tail. Slot 1: recurrent state.
+            return MambaCache()
+        }
+    }
+
+    public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        var out = weights
+
+        if args.tieWordEmbeddings {
+            out.removeValue(forKey: "lm_head.weight")
+        }
+
+        // MTP head weights (num_nextn_predict_layers > 0 bundles) are not
+        // part of the standard forward.
+        for key in out.keys.filter({ $0.contains("mtp.") }) {
+            out.removeValue(forKey: key)
+        }
+
+        // Torch conv layout [C, 1, k] → MLX [C, k, 1].
+        for (key, value) in out {
+            if key.contains("conv1d.weight"), value.ndim == 3, value.dim(-1) != 1 {
+                out[key] = value.movedAxis(source: 2, destination: 1)
+            }
+        }
+
+        // Upstream (unstamped) bundles ship loose per-expert weights; JANG
+        // bundles are already stacked under `switch_mlp`.
+        if out["model.layers.1.mlp.experts.0.up_proj.weight"] != nil {
+            for l in 0 ..< args.numHiddenLayers {
+                let prefix = "model.layers.\(l).mlp"
+                guard out["\(prefix).experts.0.up_proj.weight"] != nil else { continue }
+                for n in ["gate_proj", "up_proj", "down_proj"] {
+                    let joined = (0 ..< (args.numExperts ?? 0)).compactMap {
+                        out.removeValue(forKey: "\(prefix).experts.\($0).\(n).weight")
+                    }
+                    if !joined.isEmpty {
+                        out["\(prefix).switch_mlp.\(n).weight"] = MLX.stacked(joined)
+                    }
+                }
+            }
+        }
+        return out
+    }
+}
+
+extension BailingMoeV3Model: LoRAModel {
+    public var loraLayers: [Module] { model.layers }
+    public var loraDefaultKeys: [String] { ["attention.kv_a_proj_with_mqa"] }
+}

--- a/Libraries/MLXLLM/Models/KDADelta.swift
+++ b/Libraries/MLXLLM/Models/KDADelta.swift
@@ -1,0 +1,229 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+// KDA (Kimi Delta Attention) recurrence — the linear-attention path of
+// BailingMoeV3 / Ling 3.0. Structurally the GatedDelta recurrence with one
+// difference that forces a separate kernel: the decay gate is PER K-CHANNEL
+// ([B, T, H, Dk]), not per head ([B, T, H]). The state update per step is
+//
+//     S     ← S ⊙ g_t            (g_t broadcast over the Dv axis)
+//     v'_t  = β_t (v_t − Sᵀ k_t)
+//     S     ← S + k_t ⊗ v'_t
+//     o_t   = Sᵀ q_t
+//
+// with g_t already the multiplicative decay (exp applied on the host side).
+// Reference: fla `fused_recurrent_kda` (USE_GATE_IN_KERNEL branch) as invoked
+// by `modeling_bailing_moe_v3.BailingMoeV3KimiDeltaAttention`.
+
+/// Multiplicative per-channel decay from the raw f-projection.
+///
+/// `safe_gate` (Ling 3.0 ships `kda_safe_gate = true`): the log-decay is
+/// `lower_bound * sigmoid(exp(A_log) * (f + dt_bias))`, bounded to
+/// `(lower_bound, 0)`. The unsafe branch is `-exp(A_log) * softplus(f + dt_bias)`.
+func computeKDADecay(
+    fRaw: MLXArray,  // [B, T, H, Dk] — f_proj output + nothing else
+    aLog: MLXArray,  // [H]
+    dtBias: MLXArray,  // [H * Dk]
+    safeGate: Bool,
+    lowerBound: Float
+) -> MLXArray {
+    let H = aLog.dim(0)
+    let dk = fRaw.dim(-1)
+    let bias = dtBias.reshaped(H, dk).asType(.float32)
+    let x = fRaw.asType(.float32) + bias
+    let aExp = exp(aLog.asType(.float32)).reshaped(1, 1, H, 1)
+    let logDecay: MLXArray
+    if safeGate {
+        logDecay = MLXArray(lowerBound) * sigmoid(aExp * x)
+    } else {
+        logDecay = -aExp * logAddExp(x, MLXArray(Float(0)))  // softplus
+    }
+    return exp(logDecay)
+}
+
+// MARK: - Metal kernel (whole-sequence, one dispatch per layer)
+
+private func makeKDAKernel(hasMask: Bool) -> MLXFast.MLXFastKernel? {
+    let maskSource = hasMask ? "mask[b_idx * T + t]" : "true"
+
+    // Identical loop structure to `gated_delta_step`, but `g` is indexed per
+    // K channel: g[b, t, hv, dk] with stride Hv * Dk per step.
+    let source = """
+            auto n = thread_position_in_grid.z;
+            auto b_idx = n / Hv;
+            auto hv_idx = n % Hv;
+            auto hk_idx = hv_idx / (Hv / Hk);
+            constexpr int n_per_t = Dk / 32;
+
+            // q, k: [B, T, Hk, Dk]
+            auto q_ = q + b_idx * T * Hk * Dk + hk_idx * Dk;
+            auto k_ = k + b_idx * T * Hk * Dk + hk_idx * Dk;
+
+            // v, y: [B, T, Hv, Dv]
+            auto v_ = v + b_idx * T * Hv * Dv + hv_idx * Dv;
+            y += b_idx * T * Hv * Dv + hv_idx * Dv;
+
+            auto dk_idx = thread_position_in_threadgroup.x;
+            auto dv_idx = thread_position_in_grid.y;
+
+            // g: [B, T, Hv, Dk] — per-channel decay
+            auto g_ = g + b_idx * T * Hv * Dk + hv_idx * Dk;
+            // beta: [B, T, Hv]
+            auto beta_ = beta + b_idx * T * Hv;
+
+            // state_in, state_out: [B, Hv, Dv, Dk]
+            auto i_state = state_in + (n * Dv + dv_idx) * Dk;
+            auto o_state = state_out + (n * Dv + dv_idx) * Dk;
+
+            float state[n_per_t];
+            for (int i = 0; i < n_per_t; ++i) {
+              auto s_idx = n_per_t * dk_idx + i;
+              state[i] = static_cast<float>(i_state[s_idx]);
+            }
+
+            for (int t = 0; t < T; ++t) {
+              if (\(maskSource)) {
+                float kv_mem = 0.0f;
+                for (int i = 0; i < n_per_t; ++i) {
+                  auto s_idx = n_per_t * dk_idx + i;
+                  state[i] = state[i] * static_cast<float>(g_[s_idx]);
+                  kv_mem += state[i] * k_[s_idx];
+                }
+                kv_mem = simd_sum(kv_mem);
+
+                auto delta = (v_[dv_idx] - kv_mem) * beta_[hv_idx];
+
+                float out = 0.0f;
+                for (int i = 0; i < n_per_t; ++i) {
+                  auto s_idx = n_per_t * dk_idx + i;
+                  state[i] = state[i] + k_[s_idx] * delta;
+                  out += state[i] * q_[s_idx];
+                }
+                out = simd_sum(out);
+                if (thread_index_in_simdgroup == 0) {
+                  y[dv_idx] = static_cast<InT>(out);
+                }
+              } else {
+                y[dv_idx] = static_cast<InT>(0);
+              }
+              q_ += Hk * Dk;
+              k_ += Hk * Dk;
+              v_ += Hv * Dv;
+              y += Hv * Dv;
+              g_ += Hv * Dk;
+              beta_ += Hv;
+            }
+            for (int i = 0; i < n_per_t; ++i) {
+              auto s_idx = n_per_t * dk_idx + i;
+              o_state[s_idx] = static_cast<StT>(state[i]);
+            }
+        """
+
+    var inputNames = ["q", "k", "v", "g", "beta", "state_in", "T"]
+    if hasMask { inputNames.append("mask") }
+
+    return MLXFast.metalKernel(
+        name: "kda_delta_step" + (hasMask ? "_mask" : ""),
+        inputNames: inputNames,
+        outputNames: ["y", "state_out"],
+        source: source
+    )
+}
+
+private final class KDAKernelManager: Sendable {
+    static let shared = KDAKernelManager()
+    let kernel: MLXFast.MLXFastKernel?
+    let kernelMasked: MLXFast.MLXFastKernel?
+    private init() {
+        kernel = makeKDAKernel(hasMask: false)
+        kernelMasked = makeKDAKernel(hasMask: true)
+    }
+}
+
+private func kdaKernel(
+    q: MLXArray, k: MLXArray, v: MLXArray,
+    g: MLXArray, beta: MLXArray, state: MLXArray,
+    mask: MLXArray?
+) -> (MLXArray, MLXArray) {
+    let B = k.dim(0)
+    let T = k.dim(1)
+    let Hk = k.dim(2)
+    let Dk = k.dim(3)
+    let Hv = v.dim(2)
+    let Dv = v.dim(3)
+
+    let selected =
+        mask != nil ? KDAKernelManager.shared.kernelMasked : KDAKernelManager.shared.kernel
+    guard let kernel = selected else { fatalError("KDA kernel not available") }
+
+    var inputs: [MLXArray] = [q, k, v, g.asType(q.dtype), beta, state, MLXArray(T)]
+    if let mask { inputs.append(mask) }
+
+    let outputs = kernel(
+        inputs,
+        template: [
+            ("InT", q.dtype),
+            ("StT", state.dtype),
+            ("Dk", Dk),
+            ("Dv", Dv),
+            ("Hk", Hk),
+            ("Hv", Hv),
+        ],
+        grid: (32, Dv, B * Hv),
+        threadGroup: (32, 4, 1),
+        outputShapes: [[B, T, Hv, Dv], state.shape],
+        outputDTypes: [q.dtype, state.dtype]
+    )
+    return (outputs[0], outputs[1])
+}
+
+// MARK: - Public entry
+
+/// KDA recurrence over a full segment. `fRaw` is the raw f-projection output
+/// (decay computed here); `beta` must already be `sigmoid(b_proj(x))`.
+func kdaUpdate(
+    q: MLXArray,  // [B, T, H, Dk] — L2-normalized, scaled
+    k: MLXArray,  // [B, T, H, Dk] — L2-normalized
+    v: MLXArray,  // [B, T, H, Dv]
+    fRaw: MLXArray,  // [B, T, H, Dk]
+    beta: MLXArray,  // [B, T, H]
+    aLog: MLXArray,  // [H]
+    dtBias: MLXArray,  // [H * Dk]
+    safeGate: Bool,
+    lowerBound: Float,
+    state: MLXArray? = nil,
+    mask: MLXArray? = nil
+) -> (MLXArray, MLXArray) {
+    let B = q.dim(0)
+    let Dk = q.dim(3)
+    let Hv = v.dim(2)
+    let Dv = v.dim(3)
+
+    let g = computeKDADecay(
+        fRaw: fRaw, aLog: aLog, dtBias: dtBias,
+        safeGate: safeGate, lowerBound: lowerBound)
+
+    // Recurrent state stays float32 for the same cached-prefix-boundary
+    // rounding reason as GatedDelta (see gatedDeltaUpdate).
+    var state = state ?? MLXArray.zeros([B, Hv, Dv, Dk], dtype: .float32)
+    if state.dtype != .float32 { state = state.asType(.float32) }
+
+    // Same SIMD tile constraint as the GatedDelta kernel: Dk must be a
+    // multiple of 32 (Ling 3.0 ships Dk = 128). Narrow synthetic configs
+    // take the ops fallback, whose per-step decay branch broadcasts a
+    // 3-D per-channel gate.
+    let manager = KDAKernelManager.shared
+    let available = (mask != nil ? manager.kernelMasked : manager.kernel) != nil
+    if available && Dk >= 32 && Dk % 32 == 0 {
+        return kdaKernel(
+            q: q, k: k, v: v, g: g, beta: beta.asType(q.dtype),
+            state: state, mask: mask)
+    }
+    return gatedDeltaOps(
+        q: q, k: k, v: v, g: g, beta: beta.asType(.float32),
+        state: state, mask: mask)
+}

--- a/Libraries/MLXLMCommon/BaseConfiguration.swift
+++ b/Libraries/MLXLMCommon/BaseConfiguration.swift
@@ -286,6 +286,26 @@ public struct BaseConfiguration: Codable, Sendable {
                     "norms_residual_bits":
                     continue
 
+                // 2026-08-26 (Ling 3.0 tiny): JANG stampers can write the
+                // per-tensor overrides as one `per_tensor` MAP
+                // ({tensor: {mode, bits, group_size}}) instead of loose
+                // sibling keys. Left unlisted, the override decoder parsed
+                // the map itself as a single Quantization and threw
+                // "Missing field 'quantization.per_tensor.bits'", blocking
+                // every load of the bundle. Decode its ENTRIES as the
+                // per-layer overrides they are.
+                case "per_tensor":
+                    let nested = try container.nestedContainer(
+                        keyedBy: _DictionaryCodingKey.self, forKey: key)
+                    for layerKey in nested.allKeys {
+                        perLayerQuantization[layerKey.stringValue] = .quantize(
+                            try Self.decodeLayerQuantization(
+                                from: nested,
+                                key: layerKey,
+                                defaultGroupSize: quantization.groupSize))
+                    }
+                    continue
+
                 default:
                     if let f = try? container.decode(Bool.self, forKey: key) {
                         if !f {

--- a/Tests/MLXLMTests/BailingMoeV3Tests.swift
+++ b/Tests/MLXLMTests/BailingMoeV3Tests.swift
@@ -206,3 +206,34 @@ struct BailingMoeV3Tests {
         }
     }
 }
+
+@Suite("per_tensor quantization map decode")
+struct PerTensorQuantizationDecodeTests {
+    /// The JANG stamper writes per-tensor overrides as ONE `per_tensor` map.
+    /// The dynamic key scan used to parse the map itself as a single
+    /// Quantization and threw "Missing field 'quantization.per_tensor.bits'",
+    /// blocking every load of Ling-3.0-tiny-JANG_6M.
+    @Test("Ling 6M quantization dict decodes; entries become per-layer overrides")
+    func perTensorMapDecodes() throws {
+        let json = """
+            {
+              "model_type": "bailing_hybrid",
+              "quantization": {
+                "group_size": 64,
+                "bits": 8,
+                "per_tensor": {
+                  "lm_head": {"mode": "affine", "bits": 8, "group_size": 64},
+                  "model.layers.0.attention.k_proj": {"mode": "affine", "bits": 6, "group_size": 64}
+                }
+              }
+            }
+            """.data(using: .utf8)!
+        let config = try JSONDecoder().decode(BaseConfiguration.self, from: json)
+        #expect(config.quantization?.bits == 8)
+        let lmHead = config.perLayerQuantization?.quantization(layer: "lm_head")
+        #expect(lmHead?.bits == 8)
+        let kProj = config.perLayerQuantization?.quantization(
+            layer: "model.layers.0.attention.k_proj")
+        #expect(kProj?.bits == 6)
+    }
+}

--- a/Tests/MLXLMTests/BailingMoeV3Tests.swift
+++ b/Tests/MLXLMTests/BailingMoeV3Tests.swift
@@ -237,3 +237,26 @@ struct PerTensorQuantizationDecodeTests {
         #expect(kProj?.bits == 6)
     }
 }
+
+extension BailingMoeV3Tests {
+    /// Zero disk-cache stores, measured live: the eligibility gate requires
+    /// every layer's offset to advance, and the KDA layers stayed at 0.
+    @Test("KDA forward advances the MambaCache offset by the segment length")
+    func kdaAdvancesOffset() throws {
+        try MLXMetalTestLock.withLock {
+            let config = try JSONDecoder().decode(
+                BailingMoeV3Configuration.self, from: Self.v3ConfigJSON)
+            let model = BailingMoeV3Model(config)
+            MLX.eval(model.parameters())
+            let cache = model.newCache(parameters: nil)
+            _ = model(MLXArray([1, 2, 3, 4, 5].map(Int32.init)).reshaped(1, 5), cache: cache)
+            for (i, c) in cache.enumerated() {
+                #expect(c.offset == 5, "layer \(i) offset \(c.offset) != 5")
+            }
+            _ = model(MLXArray([7].map(Int32.init)).reshaped(1, 1), cache: cache)
+            for (i, c) in cache.enumerated() {
+                #expect(c.offset == 6, "layer \(i) offset \(c.offset) != 6 after decode step")
+            }
+        }
+    }
+}

--- a/Tests/MLXLMTests/BailingMoeV3Tests.swift
+++ b/Tests/MLXLMTests/BailingMoeV3Tests.swift
@@ -1,0 +1,208 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import Testing
+
+@testable import MLXLLM
+
+/// Ling 3.0 (BailingMoeV3): the same `model_type` string as Ling 2.6 resolves
+/// to a DIFFERENT architecture. These tests pin the dispatch, the layer
+/// typing rule, the KDA kernel/ops numeric parity, and cached-decode parity
+/// on a tiny synthetic model.
+@Suite("BailingMoeV3 (Ling 3.0)", .serialized)
+struct BailingMoeV3Tests {
+
+    /// Field set copied from the real Ling-3.0-tiny `config.json` (values
+    /// reduced only where irrelevant to dispatch). Schema-shaped on purpose:
+    /// a hand-invented fixture once hid a decode bug behind defaults.
+    static let v3ConfigJSON = """
+        {
+          "model_type": "bailing_hybrid",
+          "architectures": ["BailingMoeV3ForCausalLM"],
+          "hidden_size": 64,
+          "num_hidden_layers": 8,
+          "intermediate_size": 128,
+          "num_attention_heads": 2,
+          "num_key_value_heads": 2,
+          "head_dim": 32,
+          "vocab_size": 128,
+          "rms_norm_eps": 1e-6,
+          "rope_theta": 6000000,
+          "tie_word_embeddings": false,
+          "layer_group_size": 4,
+          "first_k_dense_replace": 1,
+          "short_conv_kernel_size": 4,
+          "no_kda_lora": true,
+          "kda_safe_gate": true,
+          "kda_lower_bound": -5,
+          "linear_attention": "kda",
+          "q_lora_rank": 32,
+          "kv_lora_rank": 32,
+          "qk_rope_head_dim": 16,
+          "qk_nope_head_dim": 32,
+          "v_head_dim": 32,
+          "rope_interleave": true,
+          "use_qkv_bias": false,
+          "gated_attention_proj_granularity_type": "head_wise",
+          "num_experts": 8,
+          "num_experts_per_tok": 2,
+          "num_shared_experts": 1,
+          "moe_intermediate_size": 32,
+          "moe_shared_expert_intermediate_size": 32,
+          "n_group": 2,
+          "topk_group": 1,
+          "routed_scaling_factor": 2.5,
+          "norm_topk_prob": true,
+          "score_function": "sigmoid",
+          "moe_router_enable_expert_bias": true
+        }
+        """.data(using: .utf8)!
+
+    /// Ling 2.6 (GLA) still resolves to the legacy runtime — a minimal
+    /// field set the legacy configuration accepts, with NO V3 markers.
+    static let legacyConfigJSON = """
+        {
+          "model_type": "bailing_hybrid",
+          "architectures": ["BailingMoeV2ForCausalLM"],
+          "max_position_embeddings": 32768,
+          "hidden_size": 64,
+          "num_hidden_layers": 4,
+          "intermediate_size": 128,
+          "num_attention_heads": 2,
+          "num_key_value_heads": 2,
+          "head_dim": 32,
+          "vocab_size": 128,
+          "rms_norm_eps": 1e-6,
+          "rope_theta": 600000,
+          "tie_word_embeddings": true,
+          "num_experts": 8,
+          "num_experts_per_tok": 2,
+          "num_shared_experts": 1,
+          "moe_intermediate_size": 32,
+          "first_k_dense_replace": 1,
+          "q_lora_rank": 32,
+          "kv_lora_rank": 32,
+          "qk_rope_head_dim": 16,
+          "qk_nope_head_dim": 32,
+          "v_head_dim": 32
+        }
+        """.data(using: .utf8)!
+
+    @Test("architectures=BailingMoeV3ForCausalLM dispatches to the V3 runtime")
+    func v3Dispatch() async throws {
+        let name = try await MLXMetalTestLock.withLock {
+            let model = try await LLMTypeRegistry.shared.createModel(
+                configuration: Self.v3ConfigJSON, modelType: "bailing_hybrid")
+            return String(describing: type(of: model))
+        }
+        #expect(name.contains("BailingMoeV3"))
+    }
+
+    @Test("a V2 config keeps resolving to the legacy GLA runtime")
+    func legacyDispatch() async throws {
+        let name = try await MLXMetalTestLock.withLock {
+            let model = try await LLMTypeRegistry.shared.createModel(
+                configuration: Self.legacyConfigJSON, modelType: "bailing_hybrid")
+            return String(describing: type(of: model))
+        }
+        #expect(name.contains("BailingHybridModel"))
+        #expect(!name.contains("V3"))
+    }
+
+    @Test("layer typing matches the reference rule for 24 layers / group 4")
+    func layerTyping() throws {
+        var config = try JSONDecoder().decode(
+            BailingMoeV3Configuration.self, from: Self.v3ConfigJSON)
+        config.numHiddenLayers = 24
+        config.layerGroupSize = 4
+        let full = (0 ..< 24).filter { config.isFullAttentionLayer($0) }
+        #expect(full == [3, 7, 11, 15, 19, 23])
+
+        // Trailing partial group is full attention (reference line 1006-1008).
+        config.numHiddenLayers = 26
+        let fullTail = (0 ..< 26).filter { config.isFullAttentionLayer($0) }
+        #expect(fullTail == [3, 7, 11, 15, 19, 23, 24, 25])
+    }
+
+    @Test("KDA Metal kernel matches the ops fallback numerically")
+    func kdaKernelOpsParity() throws {
+        try MLXMetalTestLock.withLock {
+            MLXRandom.seed(7)
+            let (B, T, H, Dk, Dv) = (1, 9, 2, 32, 32)
+            let q = MLXRandom.normal([B, T, H, Dk]) * 0.3
+            let k = MLXRandom.normal([B, T, H, Dk]) * 0.3
+            let v = MLXRandom.normal([B, T, H, Dv]) * 0.3
+            let fRaw = MLXRandom.normal([B, T, H, Dk])
+            let beta = sigmoid(MLXRandom.normal([B, T, H]))
+            let aLog = MLXRandom.normal([H]) * 0.5
+            let dtBias = MLXRandom.normal([H * Dk]) * 0.1
+
+            // Dk = 32 → kernel path.
+            let (yKernel, sKernel) = kdaUpdate(
+                q: q, k: k, v: v, fRaw: fRaw, beta: beta,
+                aLog: aLog, dtBias: dtBias, safeGate: true, lowerBound: -5)
+
+            // Same math through the ops fallback: precompute the decay and
+            // call gatedDeltaOps directly, exactly as kdaUpdate's fallback
+            // branch does.
+            let g = computeKDADecay(
+                fRaw: fRaw, aLog: aLog, dtBias: dtBias,
+                safeGate: true, lowerBound: -5)
+            let state = MLXArray.zeros([B, H, Dv, Dk], dtype: .float32)
+            let (yOps, sOps) = gatedDeltaOps(
+                q: q, k: k, v: v, g: g, beta: beta.asType(.float32), state: state)
+
+            let yDiff = abs(yKernel.asType(.float32) - yOps.asType(.float32)).max()
+                .item(Float.self)
+            let sDiff = abs(sKernel.asType(.float32) - sOps.asType(.float32)).max()
+                .item(Float.self)
+            #expect(yDiff < 2e-3, "kernel/ops output diverge: \(yDiff)")
+            #expect(sDiff < 2e-3, "kernel/ops state diverge: \(sDiff)")
+        }
+    }
+
+    @Test("safe-gate decay is bounded to (exp(lower_bound), 1)")
+    func safeGateBounds() throws {
+        try MLXMetalTestLock.withLock {
+            let fRaw = MLXRandom.normal([1, 4, 2, 8]) * 10  // extreme inputs
+            let aLog = MLXArray(converting: [0.5, -0.5])
+            let dtBias = MLXArray.zeros([16])
+            let g = computeKDADecay(
+                fRaw: fRaw, aLog: aLog, dtBias: dtBias, safeGate: true, lowerBound: -5)
+            let mn = g.min().item(Float.self)
+            let mx = g.max().item(Float.self)
+            #expect(mn >= exp(Float(-5)) - 1e-6)
+            #expect(mx <= 1.0 + 1e-6)
+        }
+    }
+
+    @Test("tiny model: one-shot prefill equals cached prefill + decode step")
+    func cachedDecodeParity() throws {
+        try MLXMetalTestLock.withLock {
+            MLXRandom.seed(11)
+            let config = try JSONDecoder().decode(
+                BailingMoeV3Configuration.self, from: Self.v3ConfigJSON)
+            let model = BailingMoeV3Model(config)
+            MLX.eval(model.parameters())
+
+            let tokens = MLXArray([3, 17, 42, 5, 99, 7].map(Int32.init))
+
+            // One shot, no cache.
+            let full = model(tokens.reshaped(1, 6), cache: nil)
+            let fullLast = full[0, 5]
+
+            // Prefill 5, then decode token 6 through the cache.
+            let cache = model.newCache(parameters: nil)
+            _ = model(tokens[0 ..< 5].reshaped(1, 5), cache: cache)
+            let step = model(tokens[5 ..< 6].reshaped(1, 1), cache: cache)
+            let stepLast = step[0, 0]
+
+            let diff = abs(
+                fullLast.asType(.float32) - stepLast.asType(.float32)
+            ).max().item(Float.self)
+            #expect(diff < 2e-2, "cached decode diverged from one-shot: \(diff)")
+        }
+    }
+}


### PR DESCRIPTION
model_type `bailing_hybrid` names two different architectures: Ling 2.6 (Lightning/GLA) and Ling 3.0 (KDA + MLA + DeepSeek-V3-style MoE). Every bailing_hybrid config decoded as 2.6, so a Ling-3.0-tiny bundle could not bind its KDA tensors at all — the family was unrunnable.

- **KDADelta.swift** — the KDA recurrence: per-K-CHANNEL decay (what keeps it out of the GatedDelta kernel), safe-gate `g = lower_bound * sigmoid(exp(A_log) * (f + dt_bias))`, delta rule, whole-sequence Metal kernel (same SIMD tiling as `gated_delta_step`), ops fallback via `gatedDeltaOps`'s 3-D gate branch.
- **BailingMoeV3.swift** — config; KDA layer (three cached short convs in one MambaCache slot, L2-norm-via-rmsNorm identity, sigmoid-gated `o_norm`); MLA with interleaved RoPE + head-wise sigmoid output gate; V3 MoE gate (sigmoid scores, `expert_bias` routing-only, group top-2-sum limited top-k with -inf masking, routed scaling) + SwitchGLU + shared experts; hybrid cache layout (KVCacheSimple on MLA, MambaCache on KDA) so the shipped hybrid disk-L2 strip-boundary path and compiled-decode promotion attach by construction.
- **Factory** — `dispatchBailingHybrid` keys on `architectures`/KDA markers; V2 configs keep the legacy runtime (pinned by test).

Tool calls: the bundle stamps `tool_parser = bailing_v3_xml_arg`, which resolves through the existing `bailing*` alias to the GLM4 arg_key/arg_value parser — the exact declared dialect. Reasoning falls to the bailing family think-tag parser.

Tests (6/6): dispatch both ways, the 24-layer typing rule incl. trailing partial group, KDA kernel-vs-ops numeric parity, safe-gate bounds, one-shot vs cached-decode parity on a tiny model. Registry-neighbor suites (Hy3, KimiK25, Bailing thinking template, reasoning stamps, MoE topK wiring) green.

**DRAFT until the live gate passes:** real Ling-3.0-tiny-JANG_6M load + coherence, multiturn + tools + cache reuse + speeds proven in the dev-built app via the clicked visual harness. The box currently runs a training job, so the GPU legs are queued behind it.