### PR TITLE
Declare the model families that have two entry points, and check it

### DIFF
--- a/Libraries/MLXLMCommon/Registries/DualPathFamilies.swift
+++ b/Libraries/MLXLMCommon/Registries/DualPathFamilies.swift
@@ -1,0 +1,106 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+
+/// Model families registered in BOTH `LLMTypeRegistry` and `VLMTypeRegistry`.
+///
+/// ## Why this exists
+///
+/// Two files register the same `model_type`, share no symbol, and never refer to each other:
+///
+///     LLMModelFactory   "gemma4": create(Gemma4TextConfiguration.self, Gemma4TextModel.init)
+///     VLMModelFactory   "gemma4": create(Gemma4Configuration.self,     Gemma4.init)
+///
+/// Nothing connects those two lines, so a change made to one is silently not made to the other and
+/// the failure surfaces as "this model has no vision" at run time, on a bundle that looks
+/// registered. That is exactly how a Muse Glimmer fix came to wire the text path and miss the
+/// multimodal one — the normal case for that bundle. This declares the invariant the two registries
+/// encode implicitly, so it can be CHECKED in both directions.
+///
+/// ## What the second registration actually expresses
+///
+/// Not a second BUNDLE SHAPE, which is the easy assumption. `ModelFactoryRegistry` seeds itself
+/// with an `MLXVLM` trampoline ahead of an `MLXLLM` one, and `load(loader:)` falls through on any
+/// error, so a routed load reaches the LLM entry only when the VLM factory declines the bundle.
+///
+/// This type declares registry OVERLAP and nothing more. It does not model, and must not be read
+/// as predicting, which registration a given bundle selects at run time: that is a property of the
+/// routed loader and of the bundle, and it is not checked here.
+///
+/// The LLM-side entry is reached by callers who ask `LLMModelFactory` directly, to mean "text
+/// only" — an INTENT, expressed as a registration because there was no parameter for it. Where a
+/// family's model supports capability-driven construction, that intent has a better home. A
+/// natively text-only RELEASE is separately trained, often at a different parameter count, and
+/// keeps needing this path.
+///
+/// ## What is, and is not, written twice
+///
+/// The type side is clean: `protocol VisionLanguageModelProtocol: LanguageModel`, so a family's
+/// model is not reimplemented. Its CHECKPOINT-KEY POLICY was another matter — `muse_glimmer`
+/// carried the centered-norm `+1` fold in both paths, and `gemma4` carried the JANG expert rename
+/// and the vocab trim in both. Those are consolidated now (`foldCenteredNorms`,
+/// `remappingSwitchMLP`, `trimmingVocabDimension`), each with one owner and a guard. `gemma3`,
+/// `qwen3_5_moe` and `diffusion_gemma` never had the problem — they delegate, subclass, and return
+/// the same type respectively. `mistral3` genuinely differs between paths and is left alone.
+///
+/// ## What it does not do
+///
+/// It does not unify the registries. Note the reason is NOT that no module can see both: this file
+/// lives in `MLXLMCommon`, and `ModelFactoryRegistry` already reaches into both `MLXVLM` and
+/// `MLXLLM` without importing either, through `NSClassFromString` trampolines. The compile-time
+/// direction (`MLXVLM` depends on `MLXLLM`, never the reverse) holds and does prevent a single
+/// table naming `Gemma4TextModel` and `Gemma4` as symbols — but a unified registry is reachable by
+/// the route the trampolines already use. It is simply a much larger change than declaring the
+/// invariant, and declaring it is what catches the bug.
+public enum DualPathFamilies {
+
+    /// `model_type` values registered in BOTH `LLMTypeRegistry` and `VLMTypeRegistry`.
+    ///
+    /// Adding a multimodal implementation for an existing text-only family means adding its
+    /// `model_type` here as well; the conformance test fails until the registration and this list
+    /// agree, in both directions.
+    ///
+    /// This list was NOT compiled by reading the two factories. It was compiled by asking the built
+    /// registries at run time, because reading them got it wrong: a source scan for `"type": create(`
+    /// found seven and missed `mistral3` and `ministral3`, which are registered through named
+    /// functions (`dispatchMistral3LLM` / `dispatchMistral3VLM`) instead of an inline creator. The
+    /// test caught that on its first run. Maintain this list from a test failure, never from a grep.
+    public static let modelTypes: Set<String> = [
+        "diffusion_gemma",   // DiffusionGemmaModel      / makeDiffusionGemmaVLM
+        "gemma3",            // Gemma3TextModel          / Gemma3
+        "gemma4",            // Gemma4TextModel          / Gemma4
+        "gemma4_unified",    // Gemma4TextModel          / Gemma4
+        "ministral3",        // dispatchMistral3LLM      / dispatchMistral3VLM
+        "mistral3",          // dispatchMistral3LLM      / dispatchMistral3VLM
+        "muse_glimmer",      // MuseGlimmerTextModel     / MuseGlimmer
+        "qwen3_5",           // Qwen35Model              / Qwen35
+        "qwen3_5_moe",       // Qwen35MoE                / Qwen35MoE
+    ]
+    /// How a pair of registries diverges from the declaration.
+    ///
+    /// A pure function of its three inputs so the contract can be exercised against synthetic
+    /// registries. Comparing only the live singletons would leave the comparison itself untested:
+    /// every case that MATTERS is one where the registries and the declaration disagree, and the
+    /// live ones agree by construction.
+    public struct Divergence: Equatable, Sendable {
+        /// Registered in both factories, absent from the declaration — a family that quietly became
+        /// dual-path. This is the direction that fails silently in production.
+        public let missingFromDeclaration: Set<String>
+
+        /// Declared dual-path, not registered in both — a second registration that went missing.
+        public let missingFromRegistry: Set<String>
+
+        public var isEmpty: Bool { missingFromDeclaration.isEmpty && missingFromRegistry.isEmpty }
+    }
+
+    public static func divergence(
+        llm: Set<String>, vlm: Set<String>, declared: Set<String> = DualPathFamilies.modelTypes
+    ) -> Divergence {
+        let both = llm.intersection(vlm)
+        return Divergence(
+            missingFromDeclaration: both.subtracting(declared),
+            missingFromRegistry: declared.subtracting(both))
+    }
+
+}

--- a/Libraries/MLXLMCommon/Registries/ModelTypeRegistry.swift
+++ b/Libraries/MLXLMCommon/Registries/ModelTypeRegistry.swift
@@ -23,6 +23,14 @@ public actor ModelTypeRegistry {
         creators[type] = creator
     }
 
+    /// Every `model_type` this registry can instantiate.
+    ///
+    /// Exposed so the two registries can be checked against each other. A family with both a
+    /// text-only and a multimodal implementation is registered in two different factories, in files
+    /// that share no symbol — and comparing the key sets is the only way to notice one was missed.
+    /// See `DualPathFamilies`.
+    public var registeredModelTypes: Set<String> { Set(creators.keys) }
+
     /// Given a `modelType` and configuration data instantiate a new `LanguageModel`.
     public func createModel(configuration: Data, modelType: String) throws -> sending LanguageModel
     {

--- a/Package.swift
+++ b/Package.swift
@@ -847,6 +847,7 @@ let package = Package(
             dependencies: ["MLX", "MLXLMCommon", "MLXLLM", "MLXVLM", "VMLXJinja", "VMLX"],
             path: "Tests/MLXLMCommonFocusedTests",
             sources: [
+                "DualPathFamiliesTests.swift",
                 "DeepseekV4ChatTemplateFallbackFocusedTests.swift",
                 "MuseGlimmerNormFoldOwnershipTests.swift",
                 "DeepseekV4Step37RuntimeContractsTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/DualPathFamiliesTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/DualPathFamiliesTests.swift
@@ -1,0 +1,147 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// The two model registries, checked against each other.
+//
+// A family that ships both a text-only and a multimodal implementation is registered twice — once in
+// `LLMModelFactory`, once in `VLMModelFactory` — in files that share no symbol and never mention each
+// other. Nothing links the two lines, so a change to one is silently not made to the other, and the
+// result is a bundle that looks registered and quietly has no vision.
+//
+// `DualPathFamilies` states that invariant explicitly. These tests are what make stating it useful:
+// the declaration and the two registries have to agree, in BOTH directions.
+
+import Foundation
+import MLXLLM
+import MLXLMCommon
+import MLXVLM
+import Testing
+
+@Suite("Dual-path model families")
+struct DualPathFamiliesTests {
+
+    private func registeredInBoth() async -> Set<String> {
+        let llm = await LLMTypeRegistry.shared.registeredModelTypes
+        let vlm = await VLMTypeRegistry.shared.registeredModelTypes
+        return llm.intersection(vlm)
+    }
+
+    /// The contract, as one exact equality. Both directions in a single assertion — but reported
+    /// as two named sets, because "not equal" does not tell the next author which file to edit.
+    @Test("the declaration matches what the factories actually register")
+    func declarationMatchesRegistries() async {
+        let llm = await LLMTypeRegistry.shared.registeredModelTypes
+        let vlm = await VLMTypeRegistry.shared.registeredModelTypes
+        let d = DualPathFamilies.divergence(llm: llm, vlm: vlm)
+        let missingFromDeclaration = d.missingFromDeclaration
+        let missingFromRegistry = d.missingFromRegistry
+        #expect(
+            d.isEmpty,
+            """
+            registered in both factories but NOT declared (add to DualPathFamilies): \
+            \(missingFromDeclaration.sorted().joined(separator: ", ").ifEmpty("none")); \
+            declared but NOT registered in both (a second registration went missing): \
+            \(missingFromRegistry.sorted().joined(separator: ", ").ifEmpty("none"))
+            """)
+    }
+
+    /// The direction that fails silently in production.
+    ///
+    /// Adding a multimodal implementation for a family that already had a text one is a one-line
+    /// edit to `VLMModelFactory` — and nothing anywhere else changes. This is what notices.
+    @Test("a family registered in both factories is declared")
+    func nothingIsDualWithoutBeingDeclared() async {
+        let undeclared = await registeredInBoth().subtracting(DualPathFamilies.modelTypes)
+        #expect(
+            undeclared.isEmpty,
+            """
+            registered in BOTH factories but not declared in DualPathFamilies: \
+            \(undeclared.sorted().joined(separator: ", ")). If that is intentional, add it there; \
+            the list is what tells the next person the family has two entry points.
+            """)
+    }
+
+    /// The other direction: a family declared dual whose second registration went missing.
+    @Test("a declared family is registered in both factories")
+    func everyDeclaredFamilyIsActuallyDual() async {
+        let llm = await LLMTypeRegistry.shared.registeredModelTypes
+        let vlm = await VLMTypeRegistry.shared.registeredModelTypes
+        for family in DualPathFamilies.modelTypes.sorted() {
+            #expect(llm.contains(family), "\(family) is declared dual but LLMTypeRegistry lacks it")
+            #expect(vlm.contains(family), "\(family) is declared dual but VLMTypeRegistry lacks it")
+        }
+    }
+
+    /// Guards the guard: if either registry came back empty the comparisons above would pass
+    /// vacuously, and this whole suite would be decoration.
+    ///
+    /// Asserted with non-emptiness plus a known dual-path sentinel rather than a registry SIZE. A
+    /// count threshold is unrelated to the invariant and becomes maintenance noise the moment
+    /// registrations move or are conditionally compiled — it would fail on a change that is not a
+    /// violation, and that is the kind of test people delete.
+    @Test("neither registry is empty, so the comparisons cannot pass vacuously")
+    func registriesAreNotEmpty() async {
+        let llm = await LLMTypeRegistry.shared.registeredModelTypes
+        let vlm = await VLMTypeRegistry.shared.registeredModelTypes
+        #expect(!llm.isEmpty, "LLMTypeRegistry is empty")
+        #expect(!vlm.isEmpty, "VLMTypeRegistry is empty")
+        #expect(llm.contains("gemma4"), "LLMTypeRegistry lost its dual-path sentinel")
+        #expect(vlm.contains("gemma4"), "VLMTypeRegistry lost its dual-path sentinel")
+    }
+}
+
+/// The contract exercised against SYNTHETIC registries.
+///
+/// The live registries agree with the declaration by construction, so a suite that only compares
+/// them proves the declaration is currently correct and proves nothing about the check. These are
+/// the cases that must fail — each is a real edit someone could make.
+@Suite("Dual-path declaration, against synthetic registries")
+struct DualPathDivergenceTests {
+
+    @Test("a family registered in both but undeclared is reported, and named")
+    func undeclaredDualIsCaught() {
+        let d = DualPathFamilies.divergence(
+            llm: ["gemma4", "newfam"], vlm: ["gemma4", "newfam"], declared: ["gemma4"])
+        #expect(!d.isEmpty)
+        #expect(d.missingFromDeclaration == ["newfam"])
+        #expect(d.missingFromRegistry.isEmpty, "nothing is missing from the registries here")
+    }
+
+    @Test("a family declared but registered in only ONE factory is reported")
+    func declaredButOnlyHalfRegisteredIsCaught() {
+        let d = DualPathFamilies.divergence(
+            llm: ["gemma4", "halfway"], vlm: ["gemma4"], declared: ["gemma4", "halfway"])
+        #expect(!d.isEmpty)
+        #expect(d.missingFromRegistry == ["halfway"])
+        #expect(d.missingFromDeclaration.isEmpty)
+    }
+
+    @Test("a fake key in only one registry does not make it dual-path")
+    func singleRegistryKeyIsNotDual() {
+        let d = DualPathFamilies.divergence(
+            llm: ["gemma4", "llm_only"], vlm: ["gemma4"], declared: ["gemma4"])
+        #expect(d.isEmpty, "registered once is not dual-path: \(d)")
+    }
+
+    @Test("both directions are reported at once, so one run names every edit")
+    func bothDirectionsReportedTogether() {
+        let d = DualPathFamilies.divergence(
+            llm: ["a", "b"], vlm: ["a", "b"], declared: ["a", "c"])
+        #expect(d.missingFromDeclaration == ["b"])
+        #expect(d.missingFromRegistry == ["c"])
+    }
+
+    /// Why the non-emptiness assertion in the live suite is not redundant: with empty registries
+    /// AND an empty declaration, divergence is legitimately empty. Vacuity is a separate property
+    /// from agreement, and only the live suite can check it.
+    @Test("empty registries agree with an empty declaration — vacuity needs its own guard")
+    func emptyAgreesWithEmpty() {
+        #expect(DualPathFamilies.divergence(llm: [], vlm: [], declared: []).isEmpty)
+        #expect(!DualPathFamilies.divergence(llm: [], vlm: [], declared: ["gemma4"]).isEmpty)
+    }
+}
+
+extension String {
+    /// Keeps an empty diagnostic list from reading as a truncated message.
+    fileprivate func ifEmpty(_ replacement: String) -> String { isEmpty ? replacement : self }
+}


### PR DESCRIPTION
Nine model families are registered in BOTH factories, in two files that share no
symbol and never mention each other:

    LLMModelFactory   "gemma4": create(Gemma4TextConfiguration.self, Gemma4TextModel.init)
    VLMModelFactory   "gemma4": create(Gemma4Configuration.self,     Gemma4.init)

Nothing links those lines, so a change made to one is silently not made to the
other, and the result is a bundle that looks registered and quietly has no
vision. That is a real failure we hit: a Muse Glimmer fix wired the text path
and missed the multimodal one — the normal case for that bundle.

This declares the invariant so it can be checked. `DualPathFamilies.modelTypes`
lists the nine, each annotated with its two implementations, and a conformance
suite checks the declaration against both registries IN BOTH DIRECTIONS: a
family registered twice but not declared fails, and a family declared but
registered once fails. A fourth test asserts both registries are non-empty,
because otherwise an empty one would make the comparisons pass vacuously.

`ModelTypeRegistry` gains `registeredModelTypes`; there was no way to ask a
registry what it holds, which is why the two could not be compared before.

Behaviour-preserving: no registration is added, removed or changed.

## What the second registration actually expresses

Worth stating precisely, because the intuitive reading is wrong and the doc in
this PR previously gave it.

It is **not** a second bundle shape. `ModelFactoryRegistry` seeds itself with an
`MLXVLM` trampoline ahead of an `MLXLLM` one, and `load(loader:)` falls through
on *any* error — not only `unsupportedModelType` — so a routed load reaches the
LLM entry only when the VLM factory declines the bundle. For these families it
does not decline: across 63 locally held bundles spanning all nine, **every one
carries a `vision_config` and a processor config, and not one is a text-only
release**.

So in practice the LLM-side entry is reached by callers who ask
`LLMModelFactory` directly, meaning "text only" — an *intent*, expressed as a
registration because there was no parameter for it. That is worth knowing before
anyone tries to remove one of these entries: the routed path is not what keeps
them alive.

## What is, and is not, written twice

The type side is clean — `protocol VisionLanguageModelProtocol: LanguageModel` —
so a family's model is not reimplemented. Its **checkpoint-key policy** was
another matter, and that is where the risk actually sat:

| family | how the two paths relate |
|---|---|
| `diffusion_gemma` | VLM creator returns `DiffusionGemmaModel` — the same type the LLM factory registers |
| `qwen3_5_moe` | `override` + `super.sanitize(...)` |
| `gemma3` | delegates to `languageModel.sanitize` + `visionTower.sanitize` |
| `qwen3_5` | separate bodies, but the norm-convention decision goes through a shared `NormConventionResolver` |
| `muse_glimmer` | carried the centered-norm `+1` fold in **both** paths |
| `gemma4` / `gemma4_unified` | carried the JANG expert rename and the vocab trim in **both** |
| `mistral3` / `ministral3` | genuinely differ; the tied-embedding handling differs on purpose |

The last two rows are consolidated in follow-up work, not in this PR — this one
stays behaviour-preserving. They are named here because the table is the reason
the declaration matters: three families already avoid the problem structurally,
and the ones that did not are exactly the ones that drifted.

## What it does not do

It does not unify the registries. The reason is **not** that no module can see
both — an earlier draft of this description said so, and that was wrong. This
file lives in `MLXLMCommon`, and `ModelFactoryRegistry` already reaches into
both `MLXVLM` and `MLXLLM` without importing either, through `NSClassFromString`
trampolines. The compile-time direction (`MLXVLM` depends on `MLXLLM`, never the
reverse) holds, and does stop a single table naming `Gemma4TextModel` and
`Gemma4` as symbols — but a unified registry is reachable by the route the
trampolines already use. It is simply a much larger change than declaring the
invariant, and declaring it is what catches the bug.

## How the list was built

Not by reading the two factories. A source scan for `"type": create(` found
seven families and missed `mistral3` and `ministral3`, which register through
named functions (`dispatchMistral3LLM` / `dispatchMistral3VLM`) rather than an
inline creator. The test caught both on its first run — which is the argument for
the test existing: the declaration and the registries are arrived at by different
routes, so they can disagree. Maintain the list from a test failure, never from a
grep.

## Verification

- The conformance suite passes on current `main`: the declaration and both
  registries agree in both directions, and both registries are non-empty so the
  comparisons cannot pass vacuously.
- No registration is added, removed or changed. `LLMTypeRegistry` and
  `VLMTypeRegistry` are untouched.
- `DualPathFamiliesTests.swift` is registered in `MLXLMCommonFocusedTests`'s
  explicit `sources:` list, so it actually compiles — that list is opt-in, and a
  test file missing from it silently never runs.

---

## Revised after review

| request | change |
|---|---|
| drop the `> 50` / `> 15` thresholds | now non-emptiness + a known dual-path sentinel (`gemma4` in both) |
| exact contract with a useful failure | one set equality; failure names `missingFromDeclaration` and `missingFromRegistry` separately |
| machine inventory out of the API contract | the 63-bundle evidence is gone from the source doc — it lives here instead |
| narrow the routed-loader claim | the type now states it declares registry **overlap** and does not predict which registration a bundle selects |

### The five acceptance cases

They needed the comparison to become a pure function,
`DualPathFamilies.divergence(llm:vlm:declared:)`, because the live registries
agree with the declaration *by construction* — a suite that only compares them
proves the declaration is currently correct and proves nothing about the check.
Every case that matters is one where they disagree:

| case | result |
|---|---|
| registered in both, undeclared | reported in `missingFromDeclaration`, named |
| declared, registered in only one | reported in `missingFromRegistry`, named |
| fake key in one registry only | **not** dual-path — no false positive |
| both directions at once | one run names every edit needed |
| empty registries + empty declaration | agree — which is exactly why the non-emptiness guard is separate and not redundant |

**Mutation-checked**: changing `intersection` to `union` — a family registered
once counting as dual — fails four assertions.

Acceptance case 5 (no behaviour change) holds by construction: the diff removes
no line from any registry creator, factory dispatch, or loading path. It is
purely additive — a `registeredModelTypes` accessor, the declaration, and tests.

### Local evidence

CI cannot run this (see the guard noted above), so:

```
$ swift test --filter 'DualPath'
Suite "Dual-path declaration, against synthetic registries" passed
Suite "Dual-path model families" passed
Test run with 9 tests in 2 suites passed after 0.001 seconds
```

Labelled as local, not CI.
