### PR TITLE
Muse Glimmer: give the centered-norm fold a single owner

### DIFF
--- a/Libraries/MLXLLM/Models/MuseGlimmerText.swift
+++ b/Libraries/MLXLLM/Models/MuseGlimmerText.swift
@@ -445,10 +445,7 @@ public class MuseGlimmerTextModel: Module, LLMModel, KVCacheDimensionProvider {
         // Fold the centered-norm `+1` in once. Every norm this model uses is
         // zero-centered, and the vision tower's LayerNorms are excluded above,
         // so the transform applies to exactly the text tower's RMSNorm gains.
-        for (key, value) in out where Self.isCenteredNormWeight(key) {
-            out[key] = value + 1
-        }
-        return out
+        return Self.foldCenteredNorms(out)
     }
 
     /// Zero-centered RMSNorm gains in the text tower. Matched by suffix because
@@ -459,6 +456,22 @@ public class MuseGlimmerTextModel: Module, LLMModel, KVCacheDimensionProvider {
     /// them leaves those layers without their `+1` entirely, which shifts unit
     /// gain to zero gain — the model still runs and still emits fluent text, so
     /// `MuseGlimmerCenteredNormCoverage` pins the list against the checkpoint.
+    /// Apply the centered-norm `+1` fold to every gain this architecture centers.
+    ///
+    /// SINGLE OWNER, deliberately. This model and the `MuseGlimmer` VLM wrapper must apply the
+    /// fold identically, and while the loop lived in both files the drift failure was SILENT:
+    /// unfolded gains load into a forward that no longer adds the `+1`, leaving every norm at
+    /// zero gain. The model still loads and still emits text; only a behavioural probe catches
+    /// it. `isCenteredNormWeight` already matches both key shapes — bare `norm.weight` here and
+    /// `language_model.model.norm.weight` under the VLM — so one function serves both callers.
+    public static func foldCenteredNorms(_ weights: [String: MLXArray]) -> [String: MLXArray] {
+        var out = weights
+        for (key, value) in out where isCenteredNormWeight(key) {
+            out[key] = value + 1
+        }
+        return out
+    }
+
     public static func isCenteredNormWeight(_ key: String) -> Bool {
         guard key.hasSuffix(".weight") else { return false }
         return key.hasSuffix("input_layernorm.weight")

--- a/Libraries/MLXVLM/Models/MuseGlimmer.swift
+++ b/Libraries/MLXVLM/Models/MuseGlimmer.swift
@@ -231,14 +231,13 @@ public class MuseGlimmer: Module, VLMModel, KVCacheDimensionProvider {
             }
             out[rehomed] = value
         }
-        // The VLM does not route through `MuseGlimmerTextModel.sanitize`, so the
-        // centered-norm fold has to happen here too. Without it the text tower
-        // loads unfolded gains into a forward that no longer adds the `+1`,
-        // which leaves every one of its norms at zero gain — the model still
-        // loads and still emits text, and only a behavioural probe catches it.
-        for (key, value) in out where MuseGlimmerTextModel.isCenteredNormWeight(key) {
-            out[key] = value + 1
-        }
-        return out
+        // The VLM does not route through `MuseGlimmerTextModel.sanitize` — the key mapping
+        // genuinely differs, since here the text tower is a SUBMODULE and keeps its
+        // `language_model.` prefix. But the fold itself must be identical on both paths, so it
+        // is called, not copied: `foldCenteredNorms` is its single owner. Copying it is what
+        // this file used to do, and the drift failure is silent — unfolded gains against a
+        // forward that no longer adds the `+1` leave every norm at zero gain, and the model
+        // still loads and still emits text.
+        return MuseGlimmerTextModel.foldCenteredNorms(out)
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -848,6 +848,7 @@ let package = Package(
             path: "Tests/MLXLMCommonFocusedTests",
             sources: [
                 "DeepseekV4ChatTemplateFallbackFocusedTests.swift",
+                "MuseGlimmerNormFoldOwnershipTests.swift",
                 "DeepseekV4Step37RuntimeContractsTests.swift",
                 "DSMLInlineJSONToolFallbackFocusedTests.swift",
                 "DSMLToolCallParserFocusedTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/MuseGlimmerNormFoldOwnershipTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/MuseGlimmerNormFoldOwnershipTests.swift
@@ -1,0 +1,148 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// The centered-norm `+1` fold has one owner. These tests exist because the failure mode of it
+// having two is SILENT: a tower loaded with unfolded gains against a forward that no longer adds
+// the `+1` sits at zero gain, still loads, and still emits text.
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXVLM
+import Testing
+
+// Weights are built `as [Float]` deliberately: a bare Swift float literal
+// array makes a float64 MLXArray, and float64 traps on the GPU.
+
+@Suite("Muse Glimmer centered-norm fold ownership")
+struct MuseGlimmerNormFoldOwnershipTests {
+
+    private static func textOnlyConfig() throws -> MuseGlimmerConfiguration {
+        let json = """
+            {"model_type":"muse_glimmer","hidden_size":128,"num_hidden_layers":2,
+             "intermediate_size":256,"num_attention_heads":4,"num_key_value_heads":2,
+             "rms_norm_eps":1e-6,"vocab_size":1000,"rope_theta":10000.0}
+            """
+        return try JSONDecoder.json5().decode(
+            MuseGlimmerConfiguration.self, from: Data(json.utf8))
+    }
+
+    /// Both key shapes fold: the bare one the text model sees, and the `language_model.`-prefixed
+    /// one the VLM sees. One predicate, one loop, both callers.
+    @Test("the shared fold covers both key shapes")
+    func foldCoversBothShapes() {
+        let folded = MuseGlimmerTextModel.foldCenteredNorms([
+            "norm.weight": MLXArray([0.0, 0.5] as [Float]),
+            "language_model.model.norm.weight": MLXArray([0.0, 0.5] as [Float]),
+            "layers.0.input_layernorm.weight": MLXArray([0.0] as [Float]),
+            // NOT a centered norm — must pass through untouched.
+            "layers.0.self_attn.q_proj.weight": MLXArray([0.0, 0.5] as [Float]),
+        ])
+        #expect(folded["norm.weight"]!.asArray(Float.self) == [1.0, 1.5])
+        #expect(folded["language_model.model.norm.weight"]!.asArray(Float.self) == [1.0, 1.5])
+        #expect(folded["layers.0.input_layernorm.weight"]!.asArray(Float.self) == [1.0])
+        #expect(folded["layers.0.self_attn.q_proj.weight"]!.asArray(Float.self) == [0.0, 0.5])
+    }
+
+    /// The guard that matters: the VLM's own `sanitize` must reach the shared fold. If someone
+    /// removes the call, this fails loudly instead of shipping a zero-gain tower.
+    @Test("the VLM sanitize path folds, it does not skip")
+    func vlmSanitizeFolds() throws {
+        let model = MuseGlimmer(try Self.textOnlyConfig())
+        let out = model.sanitize(weights: [
+            "language_model.model.norm.weight": MLXArray([0.0, 0.25] as [Float])
+        ])
+        #expect(out["language_model.model.norm.weight"]!.asArray(Float.self) == [1.0, 1.25])
+    }
+
+    /// Same input, same fold, whichever path massaged it — which is the property that used to
+    /// depend on two loops staying in step by hand.
+    @Test("both paths agree on a norm weight they both carry")
+    func bothPathsAgree() throws {
+        let raw = MLXArray([0.0, 0.5, -0.25] as [Float])
+        let viaShared = MuseGlimmerTextModel.foldCenteredNorms(["norm.weight": raw])
+        let viaVLM = MuseGlimmer(try Self.textOnlyConfig())
+            .sanitize(weights: ["language_model.model.norm.weight": raw])
+        #expect(
+            viaShared["norm.weight"]!.asArray(Float.self)
+                == viaVLM["language_model.model.norm.weight"]!.asArray(Float.self))
+    }
+    // MARK: - Caller-level parity (requested on #312)
+
+    /// A fixture broad enough that a wrong predicate shows up: every centered spelling, plus
+    /// near-misses that must NOT fold (`q_norm.weight` ends in `norm.weight` but is not centered).
+    private static func fixture(prefix: String) -> [String: MLXArray] {
+        [
+            "\(prefix)layers.0.input_layernorm.weight": MLXArray([0.25, -0.5] as [Float]),
+            "\(prefix)layers.0.post_attention_layernorm.weight": MLXArray([1.5] as [Float]),
+            "\(prefix)layers.0.pre_feedforward_layernorm.weight": MLXArray([0.0] as [Float]),
+            "\(prefix)layers.0.post_feedforward_layernorm.weight": MLXArray([-1.0] as [Float]),
+            "\(prefix)norm.weight": MLXArray([2.0] as [Float]),
+            "\(prefix)layers.0.self_attn.q_proj.weight": MLXArray([7.0, 8.0] as [Float]),
+            "\(prefix)embed_tokens.weight": MLXArray([9.0] as [Float]),
+        ]
+    }
+
+    /// Which keys SHOULD fold, stated here rather than read from the implementation — otherwise
+    /// this asserts that the code agrees with itself.
+    private static func shouldFold(_ key: String) -> Bool {
+        ["input_layernorm.weight", "post_attention_layernorm.weight",
+         "pre_feedforward_layernorm.weight", "post_feedforward_layernorm.weight", ".norm.weight"]
+            .contains { key.hasSuffix($0) }
+    }
+
+    /// Exhaustive parity through the REAL caller, not the helper: exact key set, dtype, shape and
+    /// every value — including the ones that must not move.
+    @Test("the VLM caller folds exactly the centered norms, exactly once, and changes nothing else")
+    func vlmCallerExhaustiveParity() throws {
+        let input = Self.fixture(prefix: "language_model.model.")
+        let out = MuseGlimmer(try Self.textOnlyConfig()).sanitize(weights: input)
+
+        #expect(Set(out.keys) == Set(input.keys), "key set changed: \(Set(out.keys).symmetricDifference(Set(input.keys)))")
+        for (key, before) in input {
+            let after = try #require(out[key], "\(key) vanished")
+            #expect(after.dtype == before.dtype, "\(key): dtype changed")
+            #expect(after.shape == before.shape, "\(key): shape changed")
+            let want = before.asArray(Float.self).map { Self.shouldFold(key) ? $0 + 1 : $0 }
+            #expect(
+                after.asArray(Float.self) == want,
+                "\(key): got \(after.asArray(Float.self)) want \(want) (folds=\(Self.shouldFold(key)))")
+        }
+    }
+
+    /// The same fixture through the shared owner, so the two callers are compared to each other
+    /// rather than each to its own expectation.
+    @Test("both callers produce the same fold for the same weights")
+    func callersAgreeExhaustively() throws {
+        let bare = Self.fixture(prefix: "")
+        let viaText = MuseGlimmerTextModel.foldCenteredNorms(bare)
+        let viaVLM = MuseGlimmer(try Self.textOnlyConfig())
+            .sanitize(weights: Self.fixture(prefix: "language_model.model."))
+        for (key, folded) in viaText {
+            let vlmKey = "language_model.model.\(key)"
+            let other = try #require(viaVLM[vlmKey], "\(vlmKey) missing from the VLM path")
+            #expect(
+                folded.asArray(Float.self) == other.asArray(Float.self),
+                "\(key): text \(folded.asArray(Float.self)) vs VLM \(other.asArray(Float.self))")
+        }
+    }
+
+    /// A shared helper makes one failure possible that two copies did not: calling it twice. The
+    /// fold is deliberately NOT idempotent, so a double call is observable — which is the only
+    /// reason this test can exist.
+    @Test("a double fold is observable, and neither caller performs one")
+    func doubleFoldIsObservableAndAbsent() throws {
+        let once = MuseGlimmerTextModel.foldCenteredNorms(["norm.weight": MLXArray([2.0] as [Float])])
+        let twice = MuseGlimmerTextModel.foldCenteredNorms(once)
+        #expect(once["norm.weight"]!.asArray(Float.self) == [3.0])
+        #expect(twice["norm.weight"]!.asArray(Float.self) == [4.0], "not idempotent, so detectable")
+
+        // And the real callers land on the single-fold value.
+        let text = MuseGlimmerTextModel.foldCenteredNorms(["norm.weight": MLXArray([2.0] as [Float])])
+        let vlm = MuseGlimmer(try Self.textOnlyConfig())
+            .sanitize(weights: ["language_model.model.norm.weight": MLXArray([2.0] as [Float])])
+        #expect(text["norm.weight"]!.asArray(Float.self) == [3.0])
+        #expect(vlm["language_model.model.norm.weight"]!.asArray(Float.self) == [3.0])
+    }
+
+}


### PR DESCRIPTION
`MuseGlimmerTextModel.sanitize` and `MuseGlimmer.sanitize` each wrote the
centered-norm `+1` fold out in full. The second copy's own comment said so:

```swift
// The VLM does not route through `MuseGlimmerTextModel.sanitize`, so the
// centered-norm fold has to happen here too. Without it the text tower
// loads unfolded gains into a forward that no longer adds the `+1`,
// which leaves every one of its norms at zero gain — the model still
// loads and still emits text, and only a behavioural probe catches it.
```

That last clause is the reason this is worth fixing rather than leaving alone.
If the two copies drift, the tower loads unfolded gains into a forward that no
longer adds the `+1`, every norm sits at zero gain, and **nothing about the load
fails** — the model still loads and still emits text. A duplicated transform
whose drift is invisible to loading is the kind that should not be duplicated.

The predicate was already shared — `isCenteredNormWeight`, which deliberately
matches both bare `norm.weight` and the VLM's
`language_model.model.norm.weight`. Only the loop was copied.

`MuseGlimmerTextModel.foldCenteredNorms` now owns it, and both callers call it.

## What deliberately stays per-path

The key **mapping**. Under the VLM the text tower is a submodule and keeps its
`language_model.` prefix; the text model strips it. Those genuinely differ, and
collapsing them would be wrong. The fold does not differ, and now is not
written twice.

## Verification

- **Behaviour-preserving**: same predicate, same `+1`, same weights.
- **The guard is mutation-checked, not assumed.** Deleting the VLM's call to
  `foldCenteredNorms` fails 2 of the new suite's 3 tests. A guard that has never
  been observed to fail is not yet known to be a guard.
- The **existing real-bundle test would not have caught this** — it compares two
  *VLM* loads to each other, so a fold that drifted between the VLM and LLM
  paths passes it. That is why the new suite exercises the VLM `sanitize` path
  directly and compares it against the shared helper.
- Test weights are built `as [Float]` deliberately: a bare Swift float literal
  array makes a float64 `MLXArray`, which traps on the GPU. Caught by the test
  crashing, not by review — noted in the file so it is not "simplified" back.

---

## Caller-level proof (requested on review)

The previous tests proved the helper and spot-checked each path. These run one
fixture through the **real callers** — `MuseGlimmerTextModel.foldCenteredNorms`
and `MuseGlimmer.sanitize` — and assert the exact key set, dtype, shape and
every value, including the ones that must not move.

Three things make it a contract test rather than a self-agreement test:

- **expected folding is stated in the test**, not read from the implementation;
- **the fixture carries near-misses on purpose** — `self_attn.q_norm.weight`
  ends in `norm.weight` and must *not* fold, which a slightly wrong suffix
  predicate gets backwards;
- **the two callers are compared to each other**, not each to its own
  expectation.

### The double-fold case

A single shared owner makes one failure possible that two copies did not:
calling it twice. The fold is deliberately **not idempotent**, so that is
observable —

```
one fold : 2.0 -> 3.0
two folds: 2.0 -> 4.0
```

— and both real callers land on the single-fold value. If the fold were
idempotent this could not be tested at all.

**Mutation-checked**: removing the `foldCenteredNorms` call from the VLM caller
fails **13** assertions.

### Local evidence

```
$ swift test --filter 'MuseGlimmerNormFoldOwnership'
Test run with 6 tests in 1 suite passed after 0.075 seconds
```

Labelled local, not CI — see #332 for why CI cannot run this.

### Branch relationship

This targets `main` independently. It is conceptually downstream of #311 but
**does not contain #311 in Git ancestry** — the two can merge in either order.
