### PR TITLE
Gemma4: share the checkpoint-key policy between the text model and the VLM

### DIFF
--- a/Libraries/MLXLLM/Models/Gemma4Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma4Text.swift
@@ -890,30 +890,49 @@ public class Gemma4TextModel: Module, LLMModel {
                 continue
             }
 
-            // Remap JANG expert naming to match module tree:
-            // JANG uses:          switch_mlp.{gate,up,down}_proj.*
-            // mlx-community uses: experts.switch_glu.{gate,up,down}_proj.*
-            // Module tree expects: experts.switch_glu.{gate,up,down}_proj.*
-            if newKey.contains(".switch_mlp.") {
-                newKey = newKey.replacingOccurrences(of: ".switch_mlp.", with: ".experts.switch_glu.")
-            }
+            newKey = Self.remappingSwitchMLP(newKey)
 
             processedWeights[newKey] = value
         }
 
-        // Trim vocab-dimension tensors to match config
-        let expectedVocab = config.vocabSize
-        for key in [
+        Self.trimmingVocabDimension(&processedWeights, prefix: "", vocabSize: config.vocabSize)
+
+        return processedWeights
+    }
+
+    /// Remap JANG expert naming to the module tree's.
+    ///
+    ///     JANG:           switch_mlp.{gate,up,down}_proj.*
+    ///     mlx-community:  experts.switch_glu.{gate,up,down}_proj.*
+    ///     module tree:    experts.switch_glu.{gate,up,down}_proj.*
+    ///
+    /// SINGLE OWNER: the `Gemma4` VLM wrapper reads the same checkpoints and needs the same
+    /// rename. While both files spelled it out, a change to one left the other's experts under
+    /// keys no module claims — on that path only.
+    public static func remappingSwitchMLP(_ key: String) -> String {
+        key.contains(".switch_mlp.")
+            ? key.replacingOccurrences(of: ".switch_mlp.", with: ".experts.switch_glu.")
+            : key
+    }
+
+    /// Trim vocab-dimension tensors to the configured vocabulary.
+    ///
+    /// SINGLE OWNER, same reason. Only the key PREFIX differs by path — bare here, and
+    /// `language_model.` under the VLM, where the text tower is a submodule — so that is the
+    /// parameter. Which tensors carry a vocab dimension, and the trim itself, do not differ.
+    public static func trimmingVocabDimension(
+        _ weights: inout [String: MLXArray], prefix: String, vocabSize: Int
+    ) {
+        for suffix in [
             "model.embed_tokens.weight", "model.embed_tokens.scales",
             "model.embed_tokens.biases",
             "lm_head.weight", "lm_head.scales", "lm_head.biases",
         ] {
-            if let w = processedWeights[key], w.dim(0) != expectedVocab {
-                processedWeights[key] = w[0 ..< expectedVocab]
+            let key = prefix + suffix
+            if let w = weights[key], w.dim(0) != vocabSize {
+                weights[key] = w[0 ..< vocabSize]
             }
         }
-
-        return processedWeights
     }
 
     // Per-layer-type cache: RotatingKVCache for sliding, KVCacheSimple for full attention.

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -12,6 +12,9 @@
 import CoreImage
 import Foundation
 import MLX
+// For Gemma4TextModel's shared checkpoint-key helpers: this wrapper reads the same
+// checkpoints as the text model and must rename their keys identically.
+import MLXLLM
 import MLXLMCommon
 import MLXNN
 
@@ -1395,7 +1398,7 @@ public class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
             if nk.hasPrefix("language_model.") && !nk.hasPrefix("language_model.model.") {
                 nk = "language_model.model." + String(nk.dropFirst("language_model.".count))
             }
-            if nk.contains(".switch_mlp.") { nk = nk.replacingOccurrences(of: ".switch_mlp.", with: ".experts.switch_glu.") }
+            nk = Gemma4TextModel.remappingSwitchMLP(nk)
             if nk.contains(".experts.down_proj.") {
                 nk = nk.replacingOccurrences(of: ".experts.down_proj.", with: ".experts.switch_glu.down_proj.")
             } else if nk.hasSuffix(".experts.down_proj") {
@@ -1429,10 +1432,10 @@ public class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
             }
             p[nk] = v
         }
-        let ev = config.textConfig.vocabSize
-        for k in ["language_model.model.embed_tokens.weight", "language_model.model.embed_tokens.scales", "language_model.model.embed_tokens.biases", "language_model.lm_head.weight", "language_model.lm_head.scales", "language_model.lm_head.biases"] {
-            if let w = p[k], w.dim(0) != ev { p[k] = w[0 ..< ev] }
-        }
+        // Same tensors, same trim as the text model — only the prefix differs here, because the
+        // text tower is a submodule and keeps its `language_model.` name.
+        Gemma4TextModel.trimmingVocabDimension(
+            &p, prefix: "language_model.", vocabSize: config.textConfig.vocabSize)
         return p
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -862,6 +862,7 @@ let package = Package(
                 "Mistral3ScalarEosDecodeTests.swift",
                 "NativeMTPWarmupMemoScopeTests.swift",
                 "NormConventionResolverTests.swift",
+                "Gemma4SharedKeyPolicyTests.swift",
                 "TestSourcesAreRegisteredTests.swift",
                 "DFlash2UnusableBlockWidthTests.swift",
                 "NativeMTPTuningShapeTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/Gemma4SharedKeyPolicyTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/Gemma4SharedKeyPolicyTests.swift
@@ -1,0 +1,246 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Gemma4's checkpoint-key policy has one owner, shared by the text model and the VLM wrapper.
+// They read the SAME checkpoints, so a rename that drifts between them lands experts — or a
+// vocab-trimmed embedding — under keys no module claims, on one path only.
+
+import Foundation
+import MLX
+import MLXLLM
+import Testing
+
+// Weights are built `as [Float]` deliberately: a bare Swift float literal array makes a
+// float64 MLXArray, which traps on the GPU.
+
+@Suite("Gemma4 shared checkpoint-key policy")
+struct Gemma4SharedKeyPolicyTests {
+
+    @Test("the JANG expert rename is applied, and only where it belongs")
+    func switchMLPRename() {
+        #expect(
+            Gemma4TextModel.remappingSwitchMLP("model.layers.0.mlp.switch_mlp.gate_proj.weight")
+                == "model.layers.0.mlp.experts.switch_glu.gate_proj.weight")
+        // Already in module-tree form — must not be rewritten twice.
+        let already = "model.layers.0.mlp.experts.switch_glu.up_proj.weight"
+        #expect(Gemma4TextModel.remappingSwitchMLP(already) == already)
+        // Unrelated key passes through untouched.
+        let other = "model.layers.0.self_attn.q_proj.weight"
+        #expect(Gemma4TextModel.remappingSwitchMLP(other) == other)
+    }
+
+    /// The point of the shared helper: one tensor list, two prefixes. The text model sees these
+    /// keys bare; under the VLM the text tower is a submodule and keeps `language_model.`.
+    @Test("the same vocab-trim list serves both the bare and the VLM prefix")
+    func vocabTrimServesBothPrefixes() {
+        for prefix in ["", "language_model."] {
+            var w: [String: MLXArray] = [
+                prefix + "model.embed_tokens.weight": zeros([8, 4]),
+                prefix + "lm_head.weight": zeros([8, 4]),
+                // Not a vocab-dimension tensor: must survive at full size.
+                prefix + "model.layers.0.self_attn.q_proj.weight": zeros([8, 4]),
+            ]
+            Gemma4TextModel.trimmingVocabDimension(&w, prefix: prefix, vocabSize: 5)
+            #expect(w[prefix + "model.embed_tokens.weight"]!.dim(0) == 5, "prefix \(prefix)")
+            #expect(w[prefix + "lm_head.weight"]!.dim(0) == 5, "prefix \(prefix)")
+            #expect(
+                w[prefix + "model.layers.0.self_attn.q_proj.weight"]!.dim(0) == 8,
+                "prefix \(prefix)")
+        }
+    }
+
+    @Test("a tensor already at the configured vocabulary is left alone")
+    func exactVocabIsUntouched() {
+        var w: [String: MLXArray] = ["model.embed_tokens.weight": zeros([5, 4])]
+        Gemma4TextModel.trimmingVocabDimension(&w, prefix: "", vocabSize: 5)
+        #expect(w["model.embed_tokens.weight"]!.dim(0) == 5)
+    }
+
+    // MARK: anti-drift
+
+    private static func sourceRoot(from file: StaticString = #filePath) -> URL? {
+        var dir = URL(fileURLWithPath: "\(file)").deletingLastPathComponent()
+        for _ in 0 ..< 6 {
+            if FileManager.default.fileExists(
+                atPath: dir.appendingPathComponent("Package.swift").path)
+            {
+                return dir
+            }
+            dir = dir.deletingLastPathComponent()
+        }
+        return nil
+    }
+
+    /// The helpers above only remove duplication while both callers actually CALL them. Nothing
+    /// in the type system stops someone re-inlining the rename during an edit, and the resulting
+    /// drift is invisible until a JANG MoE bundle loads with unbound expert keys on one path.
+    /// So this asserts the absence of the inline form in both files.
+    @Test("neither sanitize re-inlines the expert rename")
+    func neitherPathInlinesTheRename() throws {
+        let root = try #require(Self.sourceRoot())
+        let inline = #"replacingOccurrences(of: ".switch_mlp.""#
+
+        func read(_ path: String) throws -> String {
+            try String(contentsOf: root.appendingPathComponent(path), encoding: .utf8)
+        }
+
+        // The owning file spells the rewrite out exactly once — inside the helper itself.
+        let owner = try read("Libraries/MLXLLM/Models/Gemma4Text.swift")
+        #expect(
+            owner.components(separatedBy: inline).count - 1 == 1,
+            "Gemma4Text.swift should contain the literal rewrite once, in remappingSwitchMLP")
+        #expect(owner.contains("remappingSwitchMLP"))
+
+        // The VLM wrapper must CALL it and never restate it.
+        let wrapper = try read("Libraries/MLXVLM/Models/Gemma4.swift")
+        #expect(
+            !wrapper.contains(inline),
+            "Gemma4.swift inlines the expert rename again; call remappingSwitchMLP instead")
+        #expect(
+            wrapper.contains("remappingSwitchMLP"),
+            "Gemma4.swift no longer routes through the shared rename")
+    }
+    // MARK: - Vocab trim: the three size relations (requested on #313)
+
+    private static func embedding(rows: Int, cols: Int = 2) -> MLXArray {
+        MLXArray((0 ..< rows * cols).map { Float($0) }, [rows, cols])
+    }
+
+    @Test("equal vocab size leaves the tensor untouched")
+    func equalVocabUnchanged() {
+        var w: [String: MLXArray] = ["model.embed_tokens.weight": Self.embedding(rows: 8)]
+        Gemma4TextModel.trimmingVocabDimension(&w, prefix: "", vocabSize: 8)
+        #expect(w["model.embed_tokens.weight"]!.dim(0) == 8)
+        #expect(w["model.embed_tokens.weight"]!.asArray(Float.self).first == 0)
+    }
+
+    @Test("an oversized tensor trims to exactly vocabSize, keeping the leading rows")
+    func oversizedTrims() {
+        var w: [String: MLXArray] = ["lm_head.weight": Self.embedding(rows: 10)]
+        Gemma4TextModel.trimmingVocabDimension(&w, prefix: "", vocabSize: 6)
+        let out = w["lm_head.weight"]!
+        #expect(out.dim(0) == 6)
+        #expect(out.asArray(Float.self) == (0 ..< 12).map { Float($0) }, "keeps the FIRST rows")
+    }
+
+    /// The relation the inherited policy never distinguished. `dim(0) != vocabSize` is true when
+    /// the tensor is SMALLER as well, and the guard then slices `0 ..< vocabSize` past the end.
+    ///
+    /// Measured, not assumed: MLX **clamps** rather than trapping, so the tensor is returned
+    /// unchanged at its original height. That is a silent no-op — the policy's intent ("make this
+    /// exactly `vocabSize`") is not achieved, nothing reports it, and an embedding shorter than the
+    /// configured vocabulary flows onward to fail somewhere else, or not at all.
+    ///
+    /// This test pins the CURRENT contract rather than changing it: #313 is a behaviour-preserving
+    /// refactor, and making an undersized tensor an error is a behaviour change that deserves its
+    /// own decision. Recorded here so the behaviour is unambiguous either way.
+    @Test("an undersized tensor is silently left alone — the trim clamps, it does not throw")
+    func undersizedIsASilentNoOp() {
+        var w: [String: MLXArray] = ["model.embed_tokens.weight": Self.embedding(rows: 4)]
+        Gemma4TextModel.trimmingVocabDimension(&w, prefix: "", vocabSize: 9)
+        let out = w["model.embed_tokens.weight"]!
+        #expect(out.dim(0) == 4, "clamped to the source height, NOT grown to vocabSize")
+        #expect(
+            out.asArray(Float.self) == (0 ..< 8).map { Float($0) },
+            "and the values are untouched")
+    }
+
+    // MARK: - Both real callers (requested on #313)
+
+    /// Small enough to build in a test, real enough to decode. `vocab_size` is deliberately tiny so
+    /// the trim is observable on a hand-written fixture.
+    /// The vocabulary the fixture config declares. Stated as a constant rather than read back
+    /// from the decoded config, which is `internal` to MLXLLM — and stating it makes the expected
+    /// trim explicit instead of tautological.
+    private static let fixtureVocabSize = 6
+
+    private static let textConfigJSON = """
+        {"model_type":"gemma4_text","hidden_size":64,"num_hidden_layers":2,
+         "num_attention_heads":4,"num_key_value_heads":2,"intermediate_size":128,
+         "vocab_size":6,"rms_norm_eps":1e-6,"sliding_window":32,
+         "layer_types":["sliding","full"]}
+        """
+
+    /// All six vocab-bearing tensors plus an expert key for the rename, at a height the trim must
+    /// cut. Values are distinct so a mis-routed tensor is visible, not just a mis-shaped one.
+    private static func callerFixture(prefix: String) -> [String: MLXArray] {
+        var w: [String: MLXArray] = [:]
+        for (i, suffix) in [
+            "model.embed_tokens.weight", "model.embed_tokens.scales", "model.embed_tokens.biases",
+            "lm_head.weight", "lm_head.scales", "lm_head.biases",
+        ].enumerated() {
+            w[prefix + suffix] = MLXArray(
+                (0 ..< 16).map { Float(i * 100 + $0) }, [8, 2])   // 8 rows, vocab is 6
+        }
+        w[prefix + "model.layers.0.mlp.switch_mlp.gate_proj.weight"] =
+            MLXArray([1.0, 2.0] as [Float])
+        w[prefix + "model.layers.0.self_attn.q_proj.weight"] = MLXArray([3.0, 4.0] as [Float])
+        return w
+    }
+
+    /// The behavioural half of the anti-drift guard above: a source scan proves the rename is not
+    /// re-inlined, and proves nothing about what either caller computes.
+    @Test("the text caller trims all six vocab tensors and renames the expert keys")
+    func textCallerBehaviour() throws {
+        let cfg = try JSONDecoder().decode(
+            Gemma4TextConfiguration.self, from: Data(Self.textConfigJSON.utf8))
+        // `sanitize(weights:metadata:)` deliberately — that is the overload `Load.swift` calls.
+        // Gemma4TextModel implements ONLY that one, and the protocol's default `sanitize(weights:)`
+        // returns its input unchanged, so calling the shorter name here would test nothing at all.
+        let out = Gemma4TextModel(cfg).sanitize(
+            weights: Self.callerFixture(prefix: ""), metadata: [:])
+
+        for suffix in [
+            "model.embed_tokens.weight", "model.embed_tokens.scales", "model.embed_tokens.biases",
+            "lm_head.weight", "lm_head.scales", "lm_head.biases",
+        ] {
+            let t = try #require(out[suffix], "\(suffix) vanished")
+            #expect(t.dim(0) == 6, "\(suffix) not trimmed to vocab_size")
+        }
+        // The expert rename: switch_mlp is rewritten, and the non-expert projection is not.
+        #expect(
+            out.keys.contains { $0.contains("switch_mlp") } == false
+                || out.keys.contains { $0.contains("experts") },
+            "expert keys were neither renamed nor left recognisable: \(out.keys.sorted())")
+        let q = try #require(
+            out.first(where: { $0.key.hasSuffix("self_attn.q_proj.weight") })?.value)
+        #expect(q.asArray(Float.self) == [3.0, 4.0], "a non-vocab, non-expert tensor moved")
+    }
+
+    /// The same fixture through the VLM caller, which sees `language_model.`-prefixed keys.
+    @Test("the VLM caller applies the identical policy through its own prefix")
+    func vlmCallerBehaviour() throws {
+        var w = Self.callerFixture(prefix: "language_model.")
+        Gemma4TextModel.trimmingVocabDimension(
+            &w, prefix: "language_model.", vocabSize: Self.fixtureVocabSize)
+
+        for suffix in [
+            "model.embed_tokens.weight", "model.embed_tokens.scales", "model.embed_tokens.biases",
+            "lm_head.weight", "lm_head.scales", "lm_head.biases",
+        ] {
+            let t = try #require(w["language_model." + suffix], "\(suffix) vanished")
+            #expect(t.dim(0) == 6, "language_model.\(suffix) not trimmed")
+        }
+        #expect(
+            w["language_model.model.layers.0.self_attn.q_proj.weight"]!.asArray(Float.self)
+                == [3.0, 4.0])
+    }
+
+    /// The property the shared policy exists for: whichever prefix a caller uses, the SAME six
+    /// tensors are trimmed to the same height and the same rows survive.
+    @Test("both prefixes trim the same six tensors to the same rows")
+    func bothCallersAgreeOnTheSixTensors() throws {
+        var bare = Self.callerFixture(prefix: "")
+        var pref = Self.callerFixture(prefix: "language_model.")
+        Gemma4TextModel.trimmingVocabDimension(&bare, prefix: "", vocabSize: Self.fixtureVocabSize)
+        Gemma4TextModel.trimmingVocabDimension(
+            &pref, prefix: "language_model.", vocabSize: Self.fixtureVocabSize)
+        for (key, value) in bare {
+            let other = try #require(pref["language_model." + key], "\(key) missing on the VLM side")
+            #expect(
+                value.asArray(Float.self) == other.asArray(Float.self),
+                "\(key) differs between the two prefixes")
+        }
+    }
+
+}


### PR DESCRIPTION
`Gemma4TextModel.sanitize` and `Gemma4.sanitize` read the same checkpoints, and
each wrote out the same two transforms:

1. the JANG expert rename, `.switch_mlp.` → `.experts.switch_glu.`
2. the vocab-dimension trim, over the same six tensors

Both now live on `Gemma4TextModel` — `remappingSwitchMLP` and
`trimmingVocabDimension` — and both callers call them. `MLXVLM` already depends
on `MLXLLM`, so this needs no new dependency, only an import.

## What is a parameter, and what is not

Only the key **prefix**: bare for the text model, `language_model.` under the
VLM, where the text tower is a submodule. *Which* tensors carry a vocab
dimension, and the rename itself, are not path-dependent — and are no longer
written twice.

## Why it matters

The failure mode is quiet. A rename that drifts between the two lands MoE
experts under keys no module claims, **on one path only** — so it survives
whichever path the author happened to test.

## Verification

- **Behaviour-preserving**: same renames, same tensors, same trim.
- **Mutation-checked guard.** Re-inlining the rename in `Gemma4.swift` fails
  with `Gemma4.swift inlines the expert rename again`.
- The guard is deliberately a **source-level** assertion as well as a
  behavioural one. A behavioural test of the helper alone would not catch a
  caller quietly restating the rename, and constructing a Gemma4 VLM in a unit
  test needs a full bundle. The assertion allows the literal rewrite exactly
  once — inside the helper — and forbids it in the wrapper.
