### PR TITLE
Capability-driven construction: build the towers the caller asked for

### DIFF
--- a/Libraries/MLXLLM/Models/DiffusionGemma.swift
+++ b/Libraries/MLXLLM/Models/DiffusionGemma.swift
@@ -579,7 +579,15 @@ class DiffusionGemmaInnerModel: Module {
 
 // MARK: - Top-level model
 
-public class DiffusionGemmaModel: Module, LLMModel {
+public class DiffusionGemmaModel: Module, LLMModel, ModalityBearing {
+    /// What this instance actually carries.
+    ///
+    /// Unlike the other converted families this is a `var`, and honestly so: this type is built
+    /// as the text engine and GAINS its vision lane later, when `installVision` attaches a tower.
+    /// Its VLM creator returns this same type — there is no separate multimodal class — so the
+    /// modality set has to follow the installation rather than the initialiser.
+    public private(set) var modalities: Set<ModelRuntimeRequestModality> = [.text]
+
 
     @ModuleInfo var model: DiffusionGemmaInnerModel
 
@@ -746,6 +754,7 @@ public class DiffusionGemmaModel: Module, LLMModel {
             @escaping (LMInput, DiffusionGemmaModel) throws
                 -> (embeddings: MLXArray, visionBlockIds: MLXArray)?
     ) {
+        modalities.insert(.vision)
         model.encoder.visionTower = tower
         model.encoder.embedVision = embedder
         visionPromptEmbedder = promptEmbedder

--- a/Libraries/MLXLMCommon/ModelConstructionModalities.swift
+++ b/Libraries/MLXLMCommon/ModelConstructionModalities.swift
@@ -1,0 +1,124 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+
+/// Construction-time counterpart to `ModelRuntimeCapabilitySnapshot.validate(request:)`.
+///
+/// Two different questions are being asked about the same bundle, and they are deliberately not
+/// merged:
+///
+/// - `ModelRuntimeCapabilitySnapshot` answers *"is this model trained for a modality"*. It merges
+///   an explicit stamp, a structural probe, and coarse `modality` tokens, and it is honest about
+///   the gap between them — hence `.unknown`. It gates a generation request.
+/// - This file answers *"which towers can this configuration instantiate, and which of those does
+///   the caller want built"*. It is structural, local to the config, and has no third state: a
+///   config either carries a vision section or it does not.
+///
+/// The two can legitimately disagree — a bundle may declare `supportsVision` while shipping a
+/// config with no vision section, which is a broken conversion rather than a policy question — so
+/// keeping them separate preserves that signal instead of averaging it away. They share the
+/// `ModelRuntimeRequestModality` vocabulary so no caller has to translate between them.
+///
+/// Nothing here implies `.text`. A model whose only lanes are audio-in and audio-out is unusual but
+/// not incoherent, and a default that quietly adds text would misdescribe it.
+/// A consequence worth stating, because it changes what bundles are worth SHIPPING.
+///
+/// Once a multimodal bundle can be constructed text-only, a text-only DERIVATIVE of that same
+/// checkpoint has almost no reason to exist. It saves disk only for someone who never once wants
+/// the vision lane; anyone who alternates now stores two copies of the same text tower to avoid
+/// allocating a tower they could simply not build. The saving is small either way — on the 30B
+/// Muse Glimmer the vision half is 1.92B of 29.8B parameters, about 6%.
+///
+/// The distinction that survives is between a derivative and a RELEASE. A natively text-only
+/// model in the same family is not the multimodal one with the tower removed — it is separately
+/// trained, often at a different parameter count, and its weights are its own. Those still need
+/// the text-only path, and always will.
+///
+/// Which of the two the dual registrations actually serve is an empirical question, and at the
+/// time of writing the local answer is stark: across 63 bundles in the nine families registered
+/// in BOTH factories, every single one carries a `vision_config` AND a processor config. Not one
+/// is a text-only release. So on this machine those LLM-side entries are never reached by the
+/// routed loader — `loadModelContainer` tries the VLM factory first and it succeeds every time —
+/// and they serve only callers who reach for `LLMModelFactory.shared.load` directly to express
+/// "text only". That intent is exactly what the `requesting:` parameter here makes explicit,
+/// which is a better place for it than a second registration.
+///
+public struct UnconstructibleModalities: Error, CustomStringConvertible {
+    public let requested: Set<ModelRuntimeRequestModality>
+    public let constructible: Set<ModelRuntimeRequestModality>
+
+    public init(
+        requested: Set<ModelRuntimeRequestModality>,
+        constructible: Set<ModelRuntimeRequestModality>
+    ) {
+        self.requested = requested
+        self.constructible = constructible
+    }
+
+    /// The part of the request this configuration cannot satisfy.
+    public var excess: Set<ModelRuntimeRequestModality> {
+        requested.subtracting(constructible)
+    }
+
+    public var description: String {
+        "this configuration cannot build \(excess.modalityDescription) "
+            + "(requested \(requested.modalityDescription); constructible \(constructible.modalityDescription))"
+    }
+
+}
+
+/// An empty selection would build a model with no lanes at all — loadable, and useless.
+public struct EmptyModalitySelection: Error, CustomStringConvertible {
+    public let source: String
+
+    public init(_ source: String) {
+        self.source = source
+    }
+
+    public var description: String {
+        "\(source) named no modalities; a model with no lanes cannot be constructed"
+    }
+}
+
+extension Set where Element == ModelRuntimeRequestModality {
+    /// Stable, readable rendering in the canonical modality order.
+    public var modalityDescription: String {
+        isEmpty
+            ? "nothing"
+            : ModelRuntimeCapabilityRequest(modalities: self)
+                .sortedModalities.map(\.rawValue).joined(separator: ", ")
+    }
+
+    /// Narrow what a configuration can build down to what the caller asked for.
+    ///
+    /// - Parameters:
+    ///   - requested: the caller's subset, or `nil` for "everything this configuration offers".
+    ///   - constructible: what the configuration structurally permits.
+    /// - Returns: exactly the lanes to instantiate.
+    /// - Throws: `UnconstructibleModalities` if the request exceeds what can be built — refusing
+    ///   here rather than yielding a model that fails later inside `prepare()`, where the cause is
+    ///   no longer visible; `EmptyModalitySelection` if either side names nothing.
+    public static func resolveForConstruction(
+        requested: Set<ModelRuntimeRequestModality>?,
+        constructible: Set<ModelRuntimeRequestModality>
+    ) throws -> Set<ModelRuntimeRequestModality> {
+        guard !constructible.isEmpty else {
+            throw EmptyModalitySelection("this configuration")
+        }
+        guard let requested else { return constructible }
+        guard !requested.isEmpty else {
+            throw EmptyModalitySelection("the request")
+        }
+        guard requested.isSubset(of: constructible) else {
+            throw UnconstructibleModalities(requested: requested, constructible: constructible)
+        }
+        return requested
+    }
+}
+
+/// A model that reports which lanes it actually carries, as opposed to which its bundle advertises.
+public protocol ModalityBearing {
+    /// What this instance was built with — never wider than its configuration allowed.
+    var modalities: Set<ModelRuntimeRequestModality> { get }
+}

--- a/Libraries/MLXVLM/Models/DiffusionGemmaVLM.swift
+++ b/Libraries/MLXVLM/Models/DiffusionGemmaVLM.swift
@@ -49,11 +49,45 @@ public struct DiffusionGemmaVLMConfiguration: Codable, Sendable {
 /// tower, install the vision modules + the prompt-embedding splice closure.
 /// Text-only bundles (no `vision_config` / `image_token_id`) come back as
 /// the plain text engine.
+/// Which lanes this configuration can actually build.
+///
+/// Note the second condition: a vision tower is only installable when the bundle ALSO declares an
+/// `image_token_id`, because without it there is nowhere to splice the features. A bundle with a
+/// `vision_config` and no image token is not a vision bundle, and saying so here keeps the
+/// declaration honest rather than optimistic.
+public func diffusionGemmaConstructibleModalities(
+    of config: DiffusionGemmaVLMConfiguration
+) -> Set<ModelRuntimeRequestModality> {
+    config.visionConfig != nil && config.core.imageTokenId != nil ? [.text, .vision] : [.text]
+}
+
+/// - Parameter requesting: the caller's subset, or nil for "everything this config offers".
+///   Asking for a lane the config cannot build throws rather than yielding a model that fails
+///   later at `prepare()`.
+public func makeDiffusionGemmaVLM(
+    _ config: DiffusionGemmaVLMConfiguration,
+    requesting: Set<ModelRuntimeRequestModality>?
+) throws -> DiffusionGemmaModel {
+    let resolved = try Set.resolveForConstruction(
+        requested: requesting,
+        constructible: diffusionGemmaConstructibleModalities(of: config))
+    return makeDiffusionGemmaVLM(config, modalities: resolved)
+}
+
 public func makeDiffusionGemmaVLM(
     _ config: DiffusionGemmaVLMConfiguration
 ) -> DiffusionGemmaModel {
+    makeDiffusionGemmaVLM(config, modalities: diffusionGemmaConstructibleModalities(of: config))
+}
+
+/// Builds exactly the lanes named by `modalities`.
+public func makeDiffusionGemmaVLM(
+    _ config: DiffusionGemmaVLMConfiguration,
+    modalities: Set<ModelRuntimeRequestModality>
+) -> DiffusionGemmaModel {
     let model = DiffusionGemmaModel(config.core)
-    guard let visionConfig = config.visionConfig,
+    guard modalities.contains(.vision),
+        let visionConfig = config.visionConfig,
         let imageTokenId = config.core.imageTokenId
     else {
         return model

--- a/Libraries/MLXVLM/Models/Gemma3.swift
+++ b/Libraries/MLXVLM/Models/Gemma3.swift
@@ -97,7 +97,9 @@ public struct Gemma3VisionConfiguration: Codable, Sendable {
 
 public struct Gemma3Configuration: Codable, Sendable {
     public let textConfiguration: Gemma3TextConfiguration
-    public let visionConfiguration: Gemma3VisionConfiguration
+    /// Optional, like `Gemma4Configuration.visionConfig`. A text-only Gemma 3 bundle carries no
+    /// `vision_config`, and while this was non-optional such a bundle could not DECODE at all.
+    public let visionConfiguration: Gemma3VisionConfiguration?
     public let modelType: String
     public let mmTokensPerImage: Int
     public let quantization: BaseConfiguration.Quantization?
@@ -799,21 +801,21 @@ class Gemma3MultiModalProjector: Module, UnaryLayer {
     let tokensPerSide: Int
     let kernelSize: Int
 
-    init(config: Gemma3Configuration) {
+    init(config: Gemma3Configuration, vision: Gemma3VisionConfiguration) {
         self.config = config
 
         self._mmInputProjectionWeight.wrappedValue = ones([
-            config.visionConfiguration.hiddenSize,
+            vision.hiddenSize,
             config.textConfiguration.hiddenSize,
         ])
 
         self._mmSoftEmbNorm.wrappedValue = Gemma.RMSNorm(
-            dimensions: config.visionConfiguration.hiddenSize,
-            eps: config.visionConfiguration.layerNormEps
+            dimensions: vision.hiddenSize,
+            eps: vision.layerNormEps
         )
 
         self.patchesPerImage =
-            config.visionConfiguration.imageSize / config.visionConfiguration.patchSize
+            vision.imageSize / vision.patchSize
 
         self.tokensPerSide = Int(sqrt(Double(config.mmTokensPerImage)))
         self.kernelSize = patchesPerImage / tokensPerSide
@@ -896,10 +898,10 @@ private func maskedScatter(
 
 // MARK: - Gemma 3 Model
 
-public class Gemma3: Module, VLMModel, KVCacheDimensionProvider {
-    @ModuleInfo(key: "vision_tower") private var visionTower: VisionModel
+public class Gemma3: Module, VLMModel, KVCacheDimensionProvider, ModalityBearing {
+    @ModuleInfo(key: "vision_tower") private var visionTower: VisionModel?
     @ModuleInfo(key: "language_model") private var languageModel: LanguageModel
-    @ModuleInfo(key: "multi_modal_projector") var multiModalProjector: Gemma3MultiModalProjector
+    @ModuleInfo(key: "multi_modal_projector") var multiModalProjector: Gemma3MultiModalProjector?
 
     public let config: Gemma3Configuration
 
@@ -911,12 +913,44 @@ public class Gemma3: Module, VLMModel, KVCacheDimensionProvider {
         return languageModel.newCache(parameters: parameters)
     }
 
-    public init(_ config: Gemma3Configuration) {
+    /// What this instance actually carries. Same contract as the other converted families.
+    public let modalities: Set<ModelRuntimeRequestModality>
+
+    /// Which towers this configuration can instantiate. SigLIP here is image-only, so no `.video`.
+    public static func constructibleModalities(
+        of config: Gemma3Configuration
+    ) -> Set<ModelRuntimeRequestModality> {
+        config.visionConfiguration != nil ? [.text, .vision] : [.text]
+    }
+
+    public convenience init(_ config: Gemma3Configuration) {
+        self.init(config, modalities: Self.constructibleModalities(of: config))
+    }
+
+    /// - Parameter requesting: the caller's subset, or nil for "everything this config offers".
+    public convenience init(
+        _ config: Gemma3Configuration,
+        requesting: Set<ModelRuntimeRequestModality>?
+    ) throws {
+        let resolved = try Set.resolveForConstruction(
+            requested: requesting, constructible: Self.constructibleModalities(of: config))
+        self.init(config, modalities: resolved)
+    }
+
+    /// The one real initialiser: builds exactly the towers named by `modalities`.
+    public init(
+        _ config: Gemma3Configuration,
+        modalities: Set<ModelRuntimeRequestModality>
+    ) {
+        self.modalities = modalities
         self.config = config
 
-        self._visionTower.wrappedValue = VisionModel(config: config.visionConfiguration)
+        if let vision = config.visionConfiguration, modalities.contains(.vision) {
+            self._visionTower.wrappedValue = VisionModel(config: vision)
+            self._multiModalProjector.wrappedValue = Gemma3MultiModalProjector(
+                config: config, vision: vision)
+        }
         self._languageModel.wrappedValue = LanguageModel(config.textConfiguration)
-        self._multiModalProjector.wrappedValue = Gemma3MultiModalProjector(config: config)
     }
 
     private func getInputEmbeddings(
@@ -932,6 +966,15 @@ public class Gemma3: Module, VLMModel, KVCacheDimensionProvider {
 
         // Process image through vision tower
         let processedPixels = pixelValues.transposed(0, 2, 3, 1).asType(inputsEmbeds.dtype)
+
+        // Images arrived at a model that carries no vision tower. Refuse rather than embed the
+        // prompt without them: a silently image-free answer looks like a bad model, not a bad call.
+        guard let visionTower, let multiModalProjector else {
+            throw VLMError.processing(
+                "image input requires the vision tower, and this instance carries none "
+                + "(modalities: \(modalities.modalityDescription)). "
+                + "Load with .vision requested, or send text only.")
+        }
 
         let (hiddenState, _, _) = visionTower(
             processedPixels,
@@ -1053,8 +1096,16 @@ public class Gemma3: Module, VLMModel, KVCacheDimensionProvider {
         var processedWeights = languageModel.sanitize(
             weights: weights, quantizationConfig: config.quantization)
 
-        // Handle vision model sanitization (conv2d weight reshaping, etc.)
-        processedWeights = visionTower.sanitize(weights: processedWeights)
+        // Handle vision model sanitization (conv2d weight reshaping, etc.). With no tower built
+        // the bundle's vision weights have no destination — drop them rather than reshape them
+        // onto a module that does not exist.
+        if let visionTower {
+            processedWeights = visionTower.sanitize(weights: processedWeights)
+        } else {
+            processedWeights = processedWeights.filter {
+                !$0.key.contains("vision_tower") && !$0.key.contains("multi_modal_projector")
+            }
+        }
 
         return processedWeights
     }

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -299,7 +299,9 @@ struct G4TextConfig: Codable, Sendable {
 
 public struct Gemma4Configuration: Codable, Sendable {
     let textConfig: G4TextConfig
-    let visionConfig: Gemma4VisionConfig
+    /// Optional, like `audioConfig` below. A text-only Gemma 4 bundle carries no `vision_config`,
+    /// and while this was non-optional such a bundle could not DECODE this configuration at all.
+    let visionConfig: Gemma4VisionConfig?
     /// Full `audio_config` when present. `model_type == "gemma4_audio"`
     /// (E2B/E4B) means the bundle ships a conformer `audio_tower`;
     /// `gemma4_unified_audio` (12B) is the encoder-free raw-chunking path.
@@ -344,7 +346,7 @@ public struct Gemma4Configuration: Codable, Sendable {
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: DecodingKeys.self)
         textConfig = try c.decode(G4TextConfig.self, forKey: .textConfig)
-        visionConfig = try c.decode(Gemma4VisionConfig.self, forKey: .visionConfig)
+        visionConfig = try c.decodeIfPresent(Gemma4VisionConfig.self, forKey: .visionConfig)
         modelType = try c.decodeIfPresent(String.self, forKey: .modelType) ?? "gemma4"
         imageTokenId = try c.decodeIfPresent(Int.self, forKey: .imageTokenId) ?? 258880
         audioTokenId = try c.decodeIfPresent(Int.self, forKey: .audioTokenId) ?? 258881
@@ -360,7 +362,9 @@ public struct Gemma4Configuration: Codable, Sendable {
         }
         visionSoftTokensPerImage =
             try c.decodeIfPresent(Int.self, forKey: .visionSoftTokensPerImage)
-            ?? visionConfig.defaultOutputLength
+            // Zero when the bundle has no vision section: there are no image soft tokens to
+            // budget for, and any value would be a fiction.
+            ?? visionConfig?.defaultOutputLength ?? 0
         quantization = try c.decodeIfPresent(BaseConfiguration.Quantization.self, forKey: .quantization)
     }
 }
@@ -1151,7 +1155,7 @@ func gemma4MaskedScatter(
 
 // MARK: - Gemma4 VLM
 
-public class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
+public class Gemma4: Module, VLMModel, KVCacheDimensionProvider, ModalityBearing {
     @ModuleInfo(key: "vision_tower") private var visionTower: VisionTower?
     @ModuleInfo(key: "vision_embedder") private var unifiedVisionEmbedder: UnifiedVisionEmbedder?
     @ModuleInfo(key: "audio_tower") private var audioTower: Gemma4AudioTower?
@@ -1171,23 +1175,72 @@ public class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
 
     public func newCache(parameters: GenerateParameters?) -> [any KVCache] { languageModel.newCache(parameters: parameters) }
 
-    public init(_ config: Gemma4Configuration) {
+    /// What this instance actually carries. Same contract as the other converted families.
+    public let modalities: Set<ModelRuntimeRequestModality>
+
+    /// Which towers this configuration can instantiate.
+    ///
+    /// No `.video` lane, deliberately: `prepare` refuses video outright ("no proven vMLX video
+    /// path yet"), so declaring it would let a video request pass construction and fail later —
+    /// exactly the failure the modality set exists to move earlier.
+    ///
+    /// `.audio` is claimed only for the CONFORMER tower. `gemma4_unified_audio` bundles take the
+    /// encoder-free raw-chunking path and build no tower, so there is nothing to skip.
+    public static func constructibleModalities(
+        of config: Gemma4Configuration
+    ) -> Set<ModelRuntimeRequestModality> {
+        var m: Set<ModelRuntimeRequestModality> = [.text]
+        if config.visionConfig != nil { m.insert(.vision) }
+        if config.hasConformerAudioTower { m.insert(.audio) }
+        return m
+    }
+
+    public convenience init(_ config: Gemma4Configuration) {
+        self.init(config, modalities: Self.constructibleModalities(of: config))
+    }
+
+    /// - Parameter requesting: the caller's subset, or nil for "everything this config offers".
+    public convenience init(
+        _ config: Gemma4Configuration,
+        requesting: Set<ModelRuntimeRequestModality>?
+    ) throws {
+        let resolved = try Set.resolveForConstruction(
+            requested: requesting, constructible: Self.constructibleModalities(of: config))
+        self.init(config, modalities: resolved)
+    }
+
+    /// The one real initialiser: builds exactly the towers named by `modalities`.
+    public init(
+        _ config: Gemma4Configuration,
+        modalities: Set<ModelRuntimeRequestModality>
+    ) {
+        self.modalities = modalities
         self.config = config
-        if config.visionConfig.usesUnifiedVisionEmbedder {
-            _unifiedVisionEmbedder.wrappedValue = UnifiedVisionEmbedder(config.visionConfig)
-        } else {
-            _visionTower.wrappedValue = VisionTower(config.visionConfig)
+        if let visionConfig = config.visionConfig, modalities.contains(.vision) {
+            if visionConfig.usesUnifiedVisionEmbedder {
+                _unifiedVisionEmbedder.wrappedValue = UnifiedVisionEmbedder(visionConfig)
+            } else {
+                _visionTower.wrappedValue = VisionTower(visionConfig)
+            }
         }
         // The conformer audio tower exists only on E-series bundles
         // (audio_config.model_type == "gemma4_audio"). Unified 12B bundles
         // (gemma4_unified_audio) and audio-less 26B/31B bundles stay
         // tower-free; their `audio_tower.*` weights (if any) are discarded
         // in sanitize().
-        if let audioConfig = config.audioConfig, audioConfig.isConformerTower {
+        if let audioConfig = config.audioConfig, audioConfig.isConformerTower,
+            modalities.contains(.audio)
+        {
             _audioTower.wrappedValue = Gemma4AudioTower(audioConfig)
         }
         _languageModel.wrappedValue = G4LanguageModel(config.textConfig)
-        _embedVision.wrappedValue = MultimodalEmbedder(embDim: config.visionConfig.outputProjectionDimensions, textDim: config.textConfig.hiddenSize)
+        // Built unconditionally: it is a projection the checkpoint may still carry, and its
+        // dimension comes from the vision config when there is one. With no vision section
+        // there are no `embed_vision.*` weights to receive either.
+        _embedVision.wrappedValue = MultimodalEmbedder(
+            embDim: config.visionConfig?.outputProjectionDimensions
+                ?? config.textConfig.hiddenSize,
+            textDim: config.textConfig.hiddenSize)
         _embedAudio.wrappedValue = MultimodalEmbedder(embDim: config.audioEmbedDim, textDim: config.textConfig.hiddenSize)
     }
 
@@ -1387,8 +1440,8 @@ public class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
                 p[nk] = v
                 continue
             }
-            if nk.hasPrefix("vision_tower.") && config.visionConfig.usesUnifiedVisionEmbedder { continue }
-            if nk.hasPrefix("vision_embedder.") && !config.visionConfig.usesUnifiedVisionEmbedder { continue }
+            if nk.hasPrefix("vision_tower.") && (config.visionConfig?.usesUnifiedVisionEmbedder ?? true) { continue }
+            if nk.hasPrefix("vision_embedder.") && !(config.visionConfig?.usesUnifiedVisionEmbedder ?? false) { continue }
             // Skip clipped linear params on non-audio modules — the vision
             // tower uses plain Linear. (Audio tower keys are handled above
             // and KEEP their input/output clipping scalars.)

--- a/Libraries/MLXVLM/Models/Mistral3.swift
+++ b/Libraries/MLXVLM/Models/Mistral3.swift
@@ -73,7 +73,10 @@ public struct Mistral3VLMTextConfiguration: Codable, Sendable {
 
 public struct Mistral3VLMConfiguration: Codable, Sendable {
     public let textConfig: Mistral3VLMTextConfiguration
-    public let visionConfig: Mistral3VisionConfiguration
+    /// Optional, following `Gemma4Configuration.audioConfig` and `MuseGlimmerConfiguration`. A
+    /// text-only conversion of a Mistral 3 bundle carries no `vision_config`, and while this was
+    /// non-optional such a bundle could not DECODE this configuration at all.
+    public let visionConfig: Mistral3VisionConfiguration?
     public let modelType: String
 
     public var ignoreIndex: Int { _ignoreIndex ?? -100 }
@@ -196,11 +199,11 @@ class Mistral3PatchMerger: Module {
 
     @ModuleInfo(key: "merging_layer") var mergingLayer: Linear
 
-    init(_ config: Mistral3VLMConfiguration) {
+    init(_ config: Mistral3VLMConfiguration, vision: Mistral3VisionConfiguration) {
         self.spatialMergeSize = config.spatialMergeSize
-        self.patchSize = config.visionConfig.patchSize
+        self.patchSize = vision.patchSize
 
-        let hiddenSize = config.visionConfig.hiddenSize
+        let hiddenSize = vision.hiddenSize
         self._mergingLayer.wrappedValue = Linear(
             hiddenSize * spatialMergeSize * spatialMergeSize,
             hiddenSize,
@@ -268,11 +271,11 @@ class Mistral3MultiModalProjector: Module {
     @ModuleInfo var gelu: GELU
     @ModuleInfo(key: "linear_2") var linear2: Linear
 
-    init(_ config: Mistral3VLMConfiguration) {
-        self._norm.wrappedValue = RMSNorm(dimensions: config.visionConfig.hiddenSize)
-        self._patchMerger.wrappedValue = Mistral3PatchMerger(config)
+    init(_ config: Mistral3VLMConfiguration, vision: Mistral3VisionConfiguration) {
+        self._norm.wrappedValue = RMSNorm(dimensions: vision.hiddenSize)
+        self._patchMerger.wrappedValue = Mistral3PatchMerger(config, vision: vision)
         self._linear1.wrappedValue = Linear(
-            config.visionConfig.hiddenSize,
+            vision.hiddenSize,
             config.textConfig.hiddenSize,
             bias: config.multimodalProjectorBias
         )
@@ -685,12 +688,12 @@ private enum Language {
 
 // MARK: - Mistral3 VLM Model
 
-public class Mistral3VLM: Module, VLMModel, KVCacheDimensionProvider {
+public class Mistral3VLM: Module, VLMModel, KVCacheDimensionProvider, ModalityBearing {
     // Use PixtralVision.VisionModel from Pixtral.swift
-    @ModuleInfo(key: "vision_tower") private var visionTower: PixtralVision.VisionModel
+    @ModuleInfo(key: "vision_tower") private var visionTower: PixtralVision.VisionModel?
     @ModuleInfo(key: "language_model") private var languageModel: Language.LanguageModel
     @ModuleInfo(key: "multi_modal_projector") private var multiModalProjector:
-        Mistral3MultiModalProjector
+        Mistral3MultiModalProjector?
 
     public let config: Mistral3VLMConfiguration
     let visionFeatureLayer: Int
@@ -698,13 +701,56 @@ public class Mistral3VLM: Module, VLMModel, KVCacheDimensionProvider {
     public var vocabularySize: Int { config.vocabSize }
     public var kvHeads: [Int] { languageModel.kvHeads }
 
-    public init(_ config: Mistral3VLMConfiguration) {
+    /// What this instance actually carries — not what the bundle advertises. The bundle-level
+    /// claim lives in `ModelRuntimeCapabilitySnapshot.supportsVision` and answers a different
+    /// question; see `ModelConstructionModalities.swift` for why the two are kept apart.
+    public let modalities: Set<ModelRuntimeRequestModality>
+
+    /// Which towers this configuration can actually instantiate. Pixtral is image-only, so there
+    /// is no `.video` lane here even though the vision tower exists.
+    public static func constructibleModalities(
+        of config: Mistral3VLMConfiguration
+    ) -> Set<ModelRuntimeRequestModality> {
+        config.visionConfig != nil ? [.text, .vision] : [.text]
+    }
+
+    public convenience init(_ config: Mistral3VLMConfiguration) {
+        // Unchanged behaviour for every existing caller: build everything the config permits.
+        // Non-throwing by CONSTRUCTION rather than by argument — passing the constructible set
+        // directly removes the throw instead of reasoning about why it cannot happen.
+        self.init(config, modalities: Self.constructibleModalities(of: config))
+    }
+
+    /// - Parameter requesting: the caller's subset, or nil for "everything this config offers".
+    ///   Asking for a modality the config cannot build throws rather than yielding a model that
+    ///   fails later at `prepare()`.
+    public convenience init(
+        _ config: Mistral3VLMConfiguration,
+        requesting: Set<ModelRuntimeRequestModality>?
+    ) throws {
+        let resolved = try Set.resolveForConstruction(
+            requested: requesting, constructible: Self.constructibleModalities(of: config))
+        self.init(config, modalities: resolved)
+    }
+
+    /// The one real initialiser: builds exactly the towers named by `modalities`.
+    public init(
+        _ config: Mistral3VLMConfiguration,
+        modalities: Set<ModelRuntimeRequestModality>
+    ) {
+        self.modalities = modalities
         self.config = config
         self.visionFeatureLayer = config.visionFeatureLayer
 
-        self._visionTower.wrappedValue = PixtralVision.VisionModel(config.visionConfig)
+        // Built only when the bundle has a tower AND the caller asked for it. Skipping it is not a
+        // degraded mode: it is the text-only load that previously required the separate
+        // `mistral3` registration in LLMModelFactory, and it leaves ~0.8 GB unallocated.
+        if let vision = config.visionConfig, modalities.contains(.vision) {
+            self._visionTower.wrappedValue = PixtralVision.VisionModel(vision)
+            self._multiModalProjector.wrappedValue = Mistral3MultiModalProjector(
+                config, vision: vision)
+        }
         self._languageModel.wrappedValue = Language.LanguageModel(config.textConfig)
-        self._multiModalProjector.wrappedValue = Mistral3MultiModalProjector(config)
     }
 
     private func getInputEmbeddings(
@@ -728,6 +774,15 @@ public class Mistral3VLM: Module, VLMModel, KVCacheDimensionProvider {
         // Handle 3D pixel values (missing batch dimension)
         if pixelValues.ndim == 3 {
             pixelValues = pixelValues.expandedDimensions(axis: 0)
+        }
+
+        // Images arrived at a model that carries no vision tower. Refuse rather than embed the
+        // prompt without them: a silently image-free answer looks like a bad model, not a bad call.
+        guard let visionTower, let multiModalProjector else {
+            throw VLMError.processing(
+                "image input requires the vision tower, and this instance carries none "
+                + "(modalities: \(modalities.modalityDescription)). "
+                + "Load with .vision requested, or send text only.")
         }
 
         // Process through vision tower (reuses Pixtral vision model)
@@ -828,8 +883,8 @@ public class Mistral3VLM: Module, VLMModel, KVCacheDimensionProvider {
         let imageSizes: [(Int, Int)]?
         if let frames = input.image?.frames {
             imageSizes = frames.map { ($0.h, $0.w) }
-        } else if pixelValues != nil {
-            imageSizes = [(config.visionConfig.imageSize, config.visionConfig.imageSize)]
+        } else if pixelValues != nil, let vision = config.visionConfig {
+            imageSizes = [(vision.imageSize, vision.imageSize)]
         } else {
             imageSizes = nil
         }
@@ -865,6 +920,17 @@ public class Mistral3VLM: Module, VLMModel, KVCacheDimensionProvider {
 
         for (key, value) in weights {
             var newKey = key
+
+            // No tower to receive them. A multimodal bundle loaded text-only still SHIPS its
+            // vision weights; rehoming them onto modules that were never built leaves keys with no
+            // destination. Dropping them is what MuseGlimmer does, and what Gemma4 does with
+            // `audio_tower.*` on audio-less bundles.
+            if !modalities.contains(.vision),
+                key.contains("vision_tower") || key.contains("vision_encoder")
+                    || key.contains("vision_projection") || key.contains("multi_modal_projector")
+            {
+                continue
+            }
 
             // Transform keys to match model structure
             // Vision tower keys: vision_tower.X -> vision_tower.vision_model.X (for pixtral structure)

--- a/Libraries/MLXVLM/Models/Mistral3VLMJANGTQ.swift
+++ b/Libraries/MLXVLM/Models/Mistral3VLMJANGTQ.swift
@@ -415,11 +415,11 @@ internal final class Mistral3JANGTQLanguageModel: Module, KVCacheDimensionProvid
 /// JANGTQ-quantized Mistral3 VLM. Sibling of `Mistral3VLM`; differs
 /// only in the language-model inner. Pixtral vision tower stays
 /// vanilla.
-public class Mistral3VLMJANGTQ: Module, VLMModel, KVCacheDimensionProvider {
-    @ModuleInfo(key: "vision_tower") private var visionTower: PixtralVision.VisionModel
+public class Mistral3VLMJANGTQ: Module, VLMModel, KVCacheDimensionProvider, ModalityBearing {
+    @ModuleInfo(key: "vision_tower") private var visionTower: PixtralVision.VisionModel?
     @ModuleInfo(key: "language_model") private var languageModel: Mistral3JANGTQLanguageModel
     @ModuleInfo(key: "multi_modal_projector") private var multiModalProjector:
-        Mistral3MultiModalProjector
+        Mistral3MultiModalProjector?
 
     public let config: Mistral3VLMConfiguration
     let visionFeatureLayer: Int
@@ -427,14 +427,51 @@ public class Mistral3VLMJANGTQ: Module, VLMModel, KVCacheDimensionProvider {
     public var vocabularySize: Int { config.vocabSize }
     public var kvHeads: [Int] { languageModel.kvHeads }
 
-    public init(_ config: Mistral3VLMConfiguration, bits: Int = 2, seed: Int = 42) {
+    /// What this instance actually carries. See `Mistral3VLM` — same contract, same vocabulary.
+    public let modalities: Set<ModelRuntimeRequestModality>
+
+    /// Which towers this configuration can instantiate. Pixtral is image-only: no `.video` lane.
+    public static func constructibleModalities(
+        of config: Mistral3VLMConfiguration
+    ) -> Set<ModelRuntimeRequestModality> {
+        config.visionConfig != nil ? [.text, .vision] : [.text]
+    }
+
+    public convenience init(_ config: Mistral3VLMConfiguration, bits: Int = 2, seed: Int = 42) {
+        self.init(
+            config, modalities: Self.constructibleModalities(of: config), bits: bits, seed: seed)
+    }
+
+    /// - Parameter requesting: the caller's subset, or nil for "everything this config offers".
+    public convenience init(
+        _ config: Mistral3VLMConfiguration,
+        requesting: Set<ModelRuntimeRequestModality>?,
+        bits: Int = 2,
+        seed: Int = 42
+    ) throws {
+        let resolved = try Set.resolveForConstruction(
+            requested: requesting, constructible: Self.constructibleModalities(of: config))
+        self.init(config, modalities: resolved, bits: bits, seed: seed)
+    }
+
+    /// The one real initialiser: builds exactly the towers named by `modalities`.
+    public init(
+        _ config: Mistral3VLMConfiguration,
+        modalities: Set<ModelRuntimeRequestModality>,
+        bits: Int = 2,
+        seed: Int = 42
+    ) {
+        self.modalities = modalities
         self.config = config
         self.visionFeatureLayer = config.visionFeatureLayer
 
-        self._visionTower.wrappedValue = PixtralVision.VisionModel(config.visionConfig)
+        if let vision = config.visionConfig, modalities.contains(.vision) {
+            self._visionTower.wrappedValue = PixtralVision.VisionModel(vision)
+            self._multiModalProjector.wrappedValue = Mistral3MultiModalProjector(
+                config, vision: vision)
+        }
         self._languageModel.wrappedValue = Mistral3JANGTQLanguageModel(
             config.textConfig, bits: bits, seed: seed)
-        self._multiModalProjector.wrappedValue = Mistral3MultiModalProjector(config)
     }
 
     private func getInputEmbeddings(
@@ -457,6 +494,13 @@ public class Mistral3VLMJANGTQ: Module, VLMModel, KVCacheDimensionProvider {
 
         if pixelValues.ndim == 3 {
             pixelValues = pixelValues.expandedDimensions(axis: 0)
+        }
+
+        guard let visionTower, let multiModalProjector else {
+            throw VLMError.processing(
+                "image input requires the vision tower, and this instance carries none "
+                + "(modalities: \(modalities.modalityDescription)). "
+                + "Load with .vision requested, or send text only.")
         }
 
         let (_, _, hiddenStates) = visionTower(
@@ -530,8 +574,8 @@ public class Mistral3VLMJANGTQ: Module, VLMModel, KVCacheDimensionProvider {
         let imageSizes: [(Int, Int)]?
         if let frames = input.image?.frames {
             imageSizes = frames.map { ($0.h, $0.w) }
-        } else if pixelValues != nil {
-            imageSizes = [(config.visionConfig.imageSize, config.visionConfig.imageSize)]
+        } else if pixelValues != nil, let vision = config.visionConfig {
+            imageSizes = [(vision.imageSize, vision.imageSize)]
         } else {
             imageSizes = nil
         }

--- a/Libraries/MLXVLM/Models/Mistral4VLM.swift
+++ b/Libraries/MLXVLM/Models/Mistral4VLM.swift
@@ -16,7 +16,8 @@ import MLXNN
 /// Mistral4 VLM top-level configuration (wraps text + vision)
 public struct Mistral4VLMConfiguration: Codable, Sendable {
     public let textConfig: Mistral3VLMTextConfiguration  // Reuses Mistral3's text config structure
-    public let visionConfig: Mistral3VisionConfiguration  // Same Pixtral vision
+    /// Optional, matching `Mistral3VLMConfiguration`: a text-only conversion carries none.
+    public let visionConfig: Mistral3VisionConfiguration?  // Same Pixtral vision
     public let modelType: String
 
     public var imageTokenIndex: Int { _imageTokenIndex ?? _imageTokenId ?? 10 }
@@ -75,7 +76,8 @@ public struct Mistral4VLMConfiguration: Codable, Sendable {
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         textConfig = try c.decode(Mistral3VLMTextConfiguration.self, forKey: .textConfig)
-        visionConfig = try c.decode(Mistral3VisionConfiguration.self, forKey: .visionConfig)
+        visionConfig = try c.decodeIfPresent(
+            Mistral3VisionConfiguration.self, forKey: .visionConfig)
         modelType = try c.decodeIfPresent(String.self, forKey: .modelType) ?? "mistral3"
         _imageTokenIndex = try c.decodeIfPresent(Int.self, forKey: ._imageTokenIndex)
         _imageTokenId = try c.decodeIfPresent(Int.self, forKey: ._imageTokenId)
@@ -327,22 +329,54 @@ private class M4LanguageModel: Module, KVCacheDimensionProvider {
 
 // MARK: - Mistral4 VLM Model
 
-public class Mistral4VLM: Module, VLMModel, KVCacheDimensionProvider {
-    @ModuleInfo(key: "vision_tower") private var visionTower: PixtralVision.VisionModel
+public class Mistral4VLM: Module, VLMModel, KVCacheDimensionProvider, ModalityBearing {
+    @ModuleInfo(key: "vision_tower") private var visionTower: PixtralVision.VisionModel?
     @ModuleInfo(key: "language_model") private var languageModel: M4LanguageModel
-    @ModuleInfo(key: "multi_modal_projector") private var multiModalProjector: Mistral3MultiModalProjector
+    @ModuleInfo(key: "multi_modal_projector") private var multiModalProjector:
+        Mistral3MultiModalProjector?
 
     public let config: Mistral4VLMConfiguration
 
     public var vocabularySize: Int { config.vocabSize }
     public var kvHeads: [Int] { languageModel.kvHeads }
 
-    public init(_ config: Mistral4VLMConfiguration) {
+    /// What this instance actually carries. Same contract as `Mistral3VLM`.
+    public let modalities: Set<ModelRuntimeRequestModality>
+
+    /// Which towers this configuration can instantiate. Pixtral is image-only: no `.video` lane.
+    public static func constructibleModalities(
+        of config: Mistral4VLMConfiguration
+    ) -> Set<ModelRuntimeRequestModality> {
+        config.visionConfig != nil ? [.text, .vision] : [.text]
+    }
+
+    public convenience init(_ config: Mistral4VLMConfiguration) {
+        self.init(config, modalities: Self.constructibleModalities(of: config))
+    }
+
+    /// - Parameter requesting: the caller's subset, or nil for "everything this config offers".
+    public convenience init(
+        _ config: Mistral4VLMConfiguration,
+        requesting: Set<ModelRuntimeRequestModality>?
+    ) throws {
+        let resolved = try Set.resolveForConstruction(
+            requested: requesting, constructible: Self.constructibleModalities(of: config))
+        self.init(config, modalities: resolved)
+    }
+
+    /// The one real initialiser: builds exactly the towers named by `modalities`.
+    public init(
+        _ config: Mistral4VLMConfiguration,
+        modalities: Set<ModelRuntimeRequestModality>
+    ) {
+        self.modalities = modalities
         self.config = config
-        _visionTower.wrappedValue = PixtralVision.VisionModel(config.visionConfig)
+        if let vision = config.visionConfig, modalities.contains(.vision) {
+            _visionTower.wrappedValue = PixtralVision.VisionModel(vision)
+            _multiModalProjector.wrappedValue = Mistral3MultiModalProjector(
+                Mistral3VLMConfiguration(from: config, vision: vision), vision: vision)
+        }
         _languageModel.wrappedValue = M4LanguageModel(config)
-        _multiModalProjector.wrappedValue = Mistral3MultiModalProjector(
-            Mistral3VLMConfiguration(from: config))
     }
 
     public func newCache(parameters: GenerateParameters?) -> [any KVCache] {
@@ -356,8 +390,8 @@ public class Mistral4VLM: Module, VLMModel, KVCacheDimensionProvider {
         let imageSizes: [(Int, Int)]?
         if let frames = input.image?.frames {
             imageSizes = frames.map { ($0.h, $0.w) }
-        } else if pixelValues != nil {
-            imageSizes = [(config.visionConfig.imageSize, config.visionConfig.imageSize)]
+        } else if pixelValues != nil, let vision = config.visionConfig {
+            imageSizes = [(vision.imageSize, vision.imageSize)]
         } else {
             imageSizes = nil
         }
@@ -374,6 +408,13 @@ public class Mistral4VLM: Module, VLMModel, KVCacheDimensionProvider {
 
         let inputsEmbeds = languageModel.embedTokens(inputIds)
         if pixelValues.ndim == 3 { pixelValues = pixelValues.expandedDimensions(axis: 0) }
+
+        guard let visionTower, let multiModalProjector else {
+            throw VLMError.processing(
+                "image input requires the vision tower, and this instance carries none "
+                + "(modalities: \(modalities.modalityDescription)). "
+                + "Load with .vision requested, or send text only.")
+        }
 
         let (_, _, hiddenStates) = visionTower(pixelValues.transposed(0, 2, 3, 1), outputHiddenStates: true)
         guard let hiddenStates else {
@@ -450,11 +491,13 @@ extension Mistral4VLM: LoRAModel {
 
 // Helper to create Mistral3VLMConfiguration from Mistral4VLMConfiguration (for projector reuse)
 private extension Mistral3VLMConfiguration {
-    init(from m4: Mistral4VLMConfiguration) {
+    /// The vision config is passed in rather than read from `m4`, because it is optional there
+    /// and this bridge is only reached once the caller has unwrapped it to build the tower.
+    init(from m4: Mistral4VLMConfiguration, vision: Mistral3VisionConfiguration) {
         // Create a minimal Mistral3VLMConfiguration for the projector
         self.init(
             textConfig: m4.textConfig,
-            visionConfig: m4.visionConfig,
+            visionConfig: vision,
             modelType: m4.modelType
         )
     }

--- a/Libraries/MLXVLM/Models/MuseGlimmer.swift
+++ b/Libraries/MLXVLM/Models/MuseGlimmer.swift
@@ -16,7 +16,27 @@ import MLXNN
 
 public struct MuseGlimmerConfiguration: Codable, Sendable {
     public let textConfiguration: MuseGlimmerTextConfiguration
-    public let visionConfiguration: MuseGlimmerVisionConfiguration
+    /// Optional, following `Gemma4Configuration.audioConfig`. A text-only Muse Glimmer bundle has
+    /// no `vision_config`, and until this was optional such a bundle could not DECODE this
+    /// configuration at all — the first of the reasons a second `muse_glimmer` registration
+    /// (`MuseGlimmerTextConfiguration` / `MuseGlimmerTextModel`) exists in LLMModelFactory.
+    ///
+    /// It is NOT the only reason, and this change does not retire that entry — because the entry
+    /// is not in fact a duplicate. `muse_glimmer` names two different BUNDLE SHAPES: one with a
+    /// vision section, one without. The two registrations serve one each, and `ModelFactory`'s
+    /// `load(loader:)` already routes between them by content: `ModelFactoryRegistry` seeds
+    /// itself with an `MLXVLM` trampoline ahead of an `MLXLLM` one, and the loop falls through on
+    /// ANY error, not only `unsupportedModelType`. So a text-only bundle is tried against the VLM
+    /// factory, fails there when `loadProcessorConfig` finds no `preprocessor_config.json`
+    /// (surfacing as `ModelFactoryError.configurationFileError`), and is then served by the LLM
+    /// factory. That is content-based dispatch, not redundancy.
+    ///
+    /// What THIS change buys is orthogonal to that routing, and is the actual point: a bundle
+    /// that does carry a vision section can now be constructed text-only, leaving the tower
+    /// unallocated. On a 30B Muse Glimmer that spares 3.84 GB. Nothing about the two-entry
+    /// routing needs to change for it, and retiring either entry would remove a bundle shape's
+    /// only route.
+    public let visionConfiguration: MuseGlimmerVisionConfiguration?
     public let imageTokenId: Int
     public let videoTokenId: Int
     /// Width of a merged vision token before the adapter — `hidden * merge²`.
@@ -39,16 +59,18 @@ public struct MuseGlimmerConfiguration: Codable, Sendable {
         // The text config decoder accepts either the nested or flat shape, so
         // hand it the whole document.
         textConfiguration = try MuseGlimmerTextConfiguration(from: decoder)
-        visionConfiguration = try c.decode(
+        visionConfiguration = try c.decodeIfPresent(
             MuseGlimmerVisionConfiguration.self, forKey: .visionConfig)
         imageTokenId = try c.decodeIfPresent(Int.self, forKey: .imageTokenId) ?? 200_092
         videoTokenId = try c.decodeIfPresent(Int.self, forKey: .videoTokenId) ?? 200_091
         projectorHiddenSize =
             try c.decodeIfPresent(Int.self, forKey: .projectorHiddenSize) ?? 4096
-        let merged =
-            visionConfiguration.hiddenSize * visionConfiguration.mergeSize
-            * visionConfiguration.mergeSize
-        outHiddenSize = try c.decodeIfPresent(Int.self, forKey: .outHiddenSize) ?? merged
+        // Derived from the tower when there is one; a declared value still wins. With no tower the
+        // adapter is never built, so the value is unused rather than wrong — 0 is honest here.
+        let merged = visionConfiguration.map {
+            $0.hiddenSize * $0.mergeSize * $0.mergeSize
+        }
+        outHiddenSize = try c.decodeIfPresent(Int.self, forKey: .outHiddenSize) ?? merged ?? 0
     }
 
     /// Written by hand because the `CodingKeys` case names deliberately differ
@@ -57,7 +79,7 @@ public struct MuseGlimmerConfiguration: Codable, Sendable {
     public func encode(to encoder: Encoder) throws {
         var c = encoder.container(keyedBy: CodingKeys.self)
         try c.encode(textConfiguration, forKey: .textConfig)
-        try c.encode(visionConfiguration, forKey: .visionConfig)
+        try c.encodeIfPresent(visionConfiguration, forKey: .visionConfig)
         try c.encode(imageTokenId, forKey: .imageTokenId)
         try c.encode(videoTokenId, forKey: .videoTokenId)
         try c.encode(outHiddenSize, forKey: .outHiddenSize)
@@ -67,11 +89,11 @@ public struct MuseGlimmerConfiguration: Codable, Sendable {
 
 // MARK: - Model
 
-public class MuseGlimmer: Module, VLMModel, KVCacheDimensionProvider {
+public class MuseGlimmer: Module, VLMModel, KVCacheDimensionProvider, ModalityBearing {
 
-    @ModuleInfo(key: "vision_tower") private var visionTower: MuseGlimmerVisionModel
-    @ModuleInfo(key: "vision_adapter") private var visionAdapter: MuseGlimmerVisionProjector
-    @ModuleInfo(key: "vision_projection") private var visionProjection: Linear
+    @ModuleInfo(key: "vision_tower") private var visionTower: MuseGlimmerVisionModel?
+    @ModuleInfo(key: "vision_adapter") private var visionAdapter: MuseGlimmerVisionProjector?
+    @ModuleInfo(key: "vision_projection") private var visionProjection: Linear?
     @ModuleInfo(key: "language_model") private var languageModel: MuseGlimmerTextModel
 
     /// `RotatingKVCache`'s stock allocation step. Prefill chunks must not
@@ -84,27 +106,80 @@ public class MuseGlimmer: Module, VLMModel, KVCacheDimensionProvider {
     public var kvHeads: [Int] { languageModel.kvHeads }
     public var loraLayers: [Module] { languageModel.loraLayers }
 
-    public init(_ config: MuseGlimmerConfiguration) {
+    /// What this instance actually carries — not what the bundle advertises. The bundle-level
+    /// claim lives in `ModelRuntimeCapabilitySnapshot.supportsVision` and answers a different
+    /// question; see `ModelConstructionModalities.swift` for why the two are kept apart.
+    public let modalities: Set<ModelRuntimeRequestModality>
+
+    public convenience init(_ config: MuseGlimmerConfiguration) {
+        // Unchanged behaviour for every existing caller: build everything the config permits.
+        //
+        // Non-throwing by CONSTRUCTION, not by argument. `resolveForConstruction` can only throw
+        // when a request exceeds what is constructible, and this path makes no request — but
+        // "provably unreachable" is a property of the function above it, and that function can be
+        // edited. Passing the constructible set directly removes the possibility instead of
+        // reasoning about it.
+        self.init(config, modalities: Self.constructibleModalities(of: config))
+    }
+
+    /// Which towers this configuration can actually instantiate.
+    ///
+    /// Structural, and deliberately not read from the bundle's `supports_vision` stamp: a config
+    /// with no vision section cannot build a vision tower no matter what the stamp claims, and a
+    /// mismatch between the two is a broken conversion worth surfacing rather than smoothing over.
+    public static func constructibleModalities(
+        of config: MuseGlimmerConfiguration
+    ) -> Set<ModelRuntimeRequestModality> {
+        config.visionConfiguration != nil ? [.text, .vision, .video] : [.text]
+    }
+
+    /// - Parameter requesting: the caller's subset, or nil for "everything this config offers".
+    ///   Asking for a modality the config cannot build throws rather than yielding a model that
+    ///   fails later at `prepare()`.
+    public convenience init(
+        _ config: MuseGlimmerConfiguration,
+        requesting: Set<ModelRuntimeRequestModality>?
+    ) throws {
+        let resolved = try Set.resolveForConstruction(
+            requested: requesting, constructible: Self.constructibleModalities(of: config))
+        self.init(config, modalities: resolved)
+    }
+
+    /// The one real initialiser: builds exactly the towers named by `modalities`.
+    public init(
+        _ config: MuseGlimmerConfiguration,
+        modalities: Set<ModelRuntimeRequestModality>
+    ) {
+        self.modalities = modalities
         self.config = config
-        self._visionTower.wrappedValue = MuseGlimmerVisionModel(config.visionConfiguration)
-        self._visionAdapter.wrappedValue = MuseGlimmerVisionProjector(
-            inputDimensions: config.outHiddenSize,
-            hiddenDimensions: config.projectorHiddenSize)
-        self._visionProjection.wrappedValue = Linear(
-            config.projectorHiddenSize, config.textConfiguration.hiddenSize, bias: false)
+        // Built only when the bundle has a tower AND the caller asked for it. Skipping it is not a
+        // degraded mode: it is the text-only load that previously required a separate registration,
+        // and on a 30B bundle it leaves 3.84 GB of vision weights unallocated.
+        if config.visionConfiguration != nil, modalities.contains(.vision) {
+            self._visionTower.wrappedValue = MuseGlimmerVisionModel(config.visionConfiguration!)
+            self._visionAdapter.wrappedValue = MuseGlimmerVisionProjector(
+                inputDimensions: config.outHiddenSize,
+                hiddenDimensions: config.projectorHiddenSize)
+            self._visionProjection.wrappedValue = Linear(
+                config.projectorHiddenSize, config.textConfiguration.hiddenSize, bias: false)
+        }
         self._languageModel.wrappedValue = MuseGlimmerTextModel(config.textConfiguration)
         super.init()
     }
 
     /// Vision tower → 2×2-merged tokens → adapter → projection into the text
     /// width, then scattered over the `<|patch|>` / `<|video|>` placeholders.
-    private func visionFeatures(_ pixels: MLXArray, frames: [THW]) -> MLXArray {
-        visionProjection(visionAdapter(visionTower(pixels, frames: frames)))
+    /// Nil when this instance carries no vision tower — either the bundle has none, or the caller
+    /// asked for text only. Callers must already handle "no image embeddings"; that path exists for
+    /// text-only prompts to a multimodal model.
+    private func visionFeatures(_ pixels: MLXArray, frames: [THW]) -> MLXArray? {
+        guard let visionTower, let visionAdapter, let visionProjection else { return nil }
+        return visionProjection(visionAdapter(visionTower(pixels, frames: frames)))
     }
 
     private func inputEmbeddings(
         inputIds: MLXArray, pixelValues: MLXArray?, frames: [THW]?
-    ) -> MLXArray {
+    ) throws -> MLXArray {
         guard let pixelValues, let frames, !frames.isEmpty else {
             // `input.text.tokens` already arrives as `(1, T)` on this path.
             // Adding `.newAxis` unconditionally (as the Qwen VLMs do, where the
@@ -118,7 +193,15 @@ public class MuseGlimmer: Module, VLMModel, KVCacheDimensionProvider {
         }
 
         let inputEmbeds = languageModel.model.embed(inputIds)
-        var features = visionFeatures(pixelValues, frames: frames)
+        // Images arrived at a model that carries no vision tower. Refuse rather than embed the
+        // prompt without them: a silently image-free answer looks like a bad model, not a bad call.
+        // Same stance as Gemma4's video guard — "do not silently generate over missing embeddings".
+        guard var features = visionFeatures(pixelValues, frames: frames) else {
+            throw VLMError.processing(
+                "image input requires the vision tower, and this instance carries none "
+                + "(modalities: \(modalities.modalityDescription)). "
+                + "Load with .vision requested, or send text only.")
+        }
         if features.ndim == 2 {
             features = features[.newAxis, 0..., 0...]
         }
@@ -135,7 +218,8 @@ public class MuseGlimmer: Module, VLMModel, KVCacheDimensionProvider {
         // The vision tower is unquantized F16 even in the JANG bundles, so the
         // dtype comes from the tower rather than being assumed to match the
         // quantized text tower.
-        let dtype = visionTower.lnPre.weight?.dtype ?? .float16
+        // With no tower there is nothing to convert — the fallback was already the default here.
+        let dtype = visionTower?.lnPre.weight?.dtype ?? .float16
 
         var allPixels: MLXArray?
         var allFrames: [THW] = []
@@ -150,7 +234,7 @@ public class MuseGlimmer: Module, VLMModel, KVCacheDimensionProvider {
             allFrames.append(contentsOf: frames)
         }
 
-        let embeddings = inputEmbeddings(
+        let embeddings = try inputEmbeddings(
             inputIds: input.text.tokens, pixelValues: allPixels,
             frames: allFrames.isEmpty ? nil : allFrames)
 
@@ -227,6 +311,11 @@ public class MuseGlimmer: Module, VLMModel, KVCacheDimensionProvider {
         for (key, value) in weights {
             var rehomed = key
             if rehomed.hasPrefix("model.vision_") {
+                // No tower to receive them. A multimodal bundle loaded text-only still SHIPS its
+                // vision weights; rehoming them onto a module that was never built leaves keys with
+                // no destination. Dropping them is what MuseGlimmerTextModel.sanitize already does,
+                // and what Gemma4 does with `audio_tower.*` on audio-less bundles.
+                guard modalities.contains(.vision) else { continue }
                 rehomed = String(rehomed.dropFirst("model.".count))
             }
             out[rehomed] = value

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -1074,7 +1074,9 @@ public struct Qwen35Configuration: Codable, Sendable {
     public typealias VisionConfiguration = Qwen3VLConfiguration.VisionConfiguration
 
     public let textConfiguration: TextConfiguration
-    public let visionConfiguration: VisionConfiguration
+    /// Optional, like `Gemma4Configuration.visionConfig`. A text-only Qwen 3.5 bundle carries no
+    /// `vision_config`, and while this was non-optional such a bundle could not DECODE at all.
+    public let visionConfiguration: VisionConfiguration?
     public let modelType: String
     private let _ignoreIndex: Int?
     public var ignoreIndex: Int { _ignoreIndex ?? -100 }
@@ -2654,7 +2656,7 @@ enum Qwen35Language {
                             inputIds: inputs,
                             imageGridTHW: imageGridTHW,
                             videoGridTHW: videoGridTHW,
-                            spatialMergeSize: config.visionConfiguration.spatialMergeSize,
+                            spatialMergeSize: config.visionConfiguration?.spatialMergeSize ?? 1,
                             imageTokenId: config.imageTokenId,
                             videoTokenId: config.videoTokenId,
                             visionStartTokenId: config.visionStartTokenId,
@@ -2895,14 +2897,50 @@ enum Qwen35Language {
 public class Qwen35: Module, VLMModel, HiddenStateCaptureModel, TokenEmbedderModel, NativeMTPModel,
     DFlash2StagedVerifyRollbackModel
 {
-    @ModuleInfo(key: "vision_tower") private var visionModel: Qwen3VLVision.VisionModel
+    @ModuleInfo(key: "vision_tower") private var visionModel: Qwen3VLVision.VisionModel?
     @ModuleInfo(key: "language_model") fileprivate var languageModel: Qwen35Language.LanguageModel
 
     public let config: Qwen35Configuration
 
-    public init(_ config: Qwen35Configuration) {
+    /// What this instance actually carries. Same contract as the other converted families.
+    public let modalities: Set<ModelRuntimeRequestModality>
+
+    /// Which towers this configuration can instantiate.
+    ///
+    /// `.video` IS claimed here, unlike the Gemma and Mistral families: `prepare` consumes
+    /// `input.video` and the vision tower takes a `videoGridTHW`, so the lane is real rather than
+    /// nominal. The image/video split earns its keep exactly here — one flag would have made this
+    /// family and Pixtral indistinguishable.
+    public static func constructibleModalities(
+        of config: Qwen35Configuration
+    ) -> Set<ModelRuntimeRequestModality> {
+        config.visionConfiguration != nil ? [.text, .vision, .video] : [.text]
+    }
+
+    public convenience init(_ config: Qwen35Configuration) {
+        self.init(config, modalities: Self.constructibleModalities(of: config))
+    }
+
+    /// - Parameter requesting: the caller's subset, or nil for "everything this config offers".
+    public convenience init(
+        _ config: Qwen35Configuration,
+        requesting: Set<ModelRuntimeRequestModality>?
+    ) throws {
+        let resolved = try Set.resolveForConstruction(
+            requested: requesting, constructible: Self.constructibleModalities(of: config))
+        self.init(config, modalities: resolved)
+    }
+
+    /// The one real initialiser: builds exactly the towers named by `modalities`.
+    public init(
+        _ config: Qwen35Configuration,
+        modalities: Set<ModelRuntimeRequestModality>
+    ) {
+        self.modalities = modalities
         self.config = config
-        _visionModel.wrappedValue = Qwen3VLVision.VisionModel(config.visionConfiguration)
+        if let vision = config.visionConfiguration, modalities.contains(.vision) {
+            _visionModel.wrappedValue = Qwen3VLVision.VisionModel(vision)
+        }
         _languageModel.wrappedValue = Qwen35Language.LanguageModel(config)
         super.init()
     }
@@ -3008,8 +3046,8 @@ public class Qwen35: Module, VLMModel, HiddenStateCaptureModel, TokenEmbedderMod
     /// vision tower's output rows: each `THW` frame yields
     /// `t*h*w / spatialMergeSize^2` rows.
     private func mergedRowCount(for frames: [THW]?) -> Int {
-        guard let frames else { return 0 }
-        let merge = config.visionConfiguration.spatialMergeSize
+        guard let frames, let vision = config.visionConfiguration else { return 0 }
+        let merge = vision.spatialMergeSize
         let divisor = max(1, merge * merge)
         return frames.reduce(0) { $0 + $1.product / divisor }
     }
@@ -3042,7 +3080,16 @@ public class Qwen35: Module, VLMModel, HiddenStateCaptureModel, TokenEmbedderMod
         var imageFrames: [THW]?
         var videoFrames: [THW]?
 
-        let visionDType = visionModel.patchEmbed.proj.weight.dtype
+        // Media arrived at a model that carries no vision tower. Refuse rather than embed the
+        // prompt without it: a silently media-free answer looks like a bad model, not a bad call.
+        if input.image != nil || input.video != nil, visionModel == nil {
+            throw VLMError.processing(
+                "image or video input requires the vision tower, and this instance carries none "
+                + "(modalities: \(modalities.modalityDescription)). "
+                + "Load with .vision requested, or send text only.")
+        }
+        let visionDType =
+            visionModel?.patchEmbed.proj.weight.dtype ?? languageModel.model.embedTokens.weight.dtype
         var pixelParts: [MLXArray] = []
 
         if let image = input.image {
@@ -3059,7 +3106,7 @@ public class Qwen35: Module, VLMModel, HiddenStateCaptureModel, TokenEmbedderMod
 
         var inputEmbeddings: MLXArray?
 
-        if let pixelValues,
+        if let pixelValues, let visionModel,
             let frames = combinedFrames(imageFrames: imageFrames, videoFrames: videoFrames)
                 .nilIfEmpty
         {
@@ -3386,6 +3433,11 @@ public class Qwen35: Module, VLMModel, HiddenStateCaptureModel, TokenEmbedderMod
             sanitized[key] = value
         }
 
+        // With no tower built, the bundle's vision weights have no destination — drop them
+        // rather than hand them to a module that does not exist.
+        guard let visionModel else {
+            return sanitized.filter { !$0.key.contains("visual") && !$0.key.contains("vision_tower") }
+        }
         return visionModel.sanitize(weights: sanitized)
     }
 

--- a/Libraries/MLXVLM/Models/Qwen4Exp.swift
+++ b/Libraries/MLXVLM/Models/Qwen4Exp.swift
@@ -1377,7 +1377,7 @@ protocol Qwen4ExpModelDirectoryConfigurable: AnyObject {
 
 public final class Qwen4Exp: Module, VLMModel, Qwen4ExpModelDirectoryConfigurable,
     SafetensorsLoadKeyExcluding, NativeMTPModel, DFlash2StagedVerifyRollbackModel,
-    CompiledDecodeExternalInputModel
+    CompiledDecodeExternalInputModel, ModalityBearing
 {
     /// QSA index selection and its path-dependent cache currently require a
     /// single sequence. Keep concurrent requests queued until a B-wide QSA
@@ -1388,7 +1388,7 @@ public final class Qwen4Exp: Module, VLMModel, Qwen4ExpModelDirectoryConfigurabl
     @ModuleInfo(key: "language_model") private var textModel: Qwen4ExpTextModel
     @ModuleInfo(key: "lm_head") private var head: Linear
     @ModuleInfo(key: "mtp") private var mtp: Qwen4ExpMTPModule?
-    @ModuleInfo(key: "visual") private var visionModel: Qwen3VLVision.VisionModel
+    @ModuleInfo(key: "visual") private var visionModel: Qwen3VLVision.VisionModel?
 
     /// M-RoPE delta established by the most recent media prefill, keyed by the
     /// conversation's cache identity so concurrent sessions do not cross.
@@ -1398,7 +1398,40 @@ public final class Qwen4Exp: Module, VLMModel, Qwen4ExpModelDirectoryConfigurabl
     private let ropeDeltaLock = NSLock()
     nonisolated(unsafe) private var ropeDeltas: [ObjectIdentifier: Int] = [:]
 
-    public init(_ config: Qwen4ExpConfiguration) {
+    /// What this instance actually carries. Same contract as every other multimodal family here.
+    public let modalities: Set<ModelRuntimeRequestModality>
+
+    /// Which towers this configuration can instantiate.
+    ///
+    /// `.video` IS claimed: `prepare` consumes `input.video` and threads real video frames into
+    /// the tower, so the lane is genuine rather than nominal — the same shape as `qwen3_5`, and
+    /// unlike the Gemma and Pixtral families which are image-only.
+    public static func constructibleModalities(
+        of config: Qwen4ExpConfiguration
+    ) -> Set<ModelRuntimeRequestModality> {
+        config.base.visionConfiguration != nil ? [.text, .vision, .video] : [.text]
+    }
+
+    public convenience init(_ config: Qwen4ExpConfiguration) {
+        self.init(config, modalities: Self.constructibleModalities(of: config))
+    }
+
+    /// - Parameter requesting: the caller's subset, or nil for "everything this config offers".
+    public convenience init(
+        _ config: Qwen4ExpConfiguration,
+        requesting: Set<ModelRuntimeRequestModality>?
+    ) throws {
+        let resolved = try Set.resolveForConstruction(
+            requested: requesting, constructible: Self.constructibleModalities(of: config))
+        self.init(config, modalities: resolved)
+    }
+
+    /// The one real initialiser: builds exactly the towers named by `modalities`.
+    public init(
+        _ config: Qwen4ExpConfiguration,
+        modalities: Set<ModelRuntimeRequestModality>
+    ) {
+        self.modalities = modalities
         self.config = config
         _textModel.wrappedValue = Qwen4ExpTextModel(config)
         _head.wrappedValue = Linear(
@@ -1407,7 +1440,9 @@ public final class Qwen4Exp: Module, VLMModel, Qwen4ExpModelDirectoryConfigurabl
         if config.extras.mtpNumHiddenLayers > 0 {
             _mtp.wrappedValue = Qwen4ExpMTPModule(config)
         }
-        _visionModel.wrappedValue = Qwen3VLVision.VisionModel(config.base.visionConfiguration)
+        if let vision = config.base.visionConfiguration, modalities.contains(.vision) {
+            _visionModel.wrappedValue = Qwen3VLVision.VisionModel(vision)
+        }
         super.init()
     }
 
@@ -1457,6 +1492,15 @@ public final class Qwen4Exp: Module, VLMModel, Qwen4ExpModelDirectoryConfigurabl
             return .logits(LMOutput(logits: callAsFunction(inputIds, cache: cache)))
         }
 
+        // Media arrived at a model that carries no vision tower. Refuse rather than embed the
+        // prompt without it: a silently media-free answer looks like a bad model, not a bad call.
+        guard let visionModel else {
+            throw VLMError.processing(
+                "image or video input requires the vision tower, and this instance carries none "
+                + "(modalities: \(modalities.modalityDescription)). "
+                + "Load with .vision requested, or send text only.")
+        }
+
         // Media prefill: encode pixels through the bundled quantized vision
         // tower, scatter image rows onto image placeholders and video rows
         // onto video placeholders (never interleaved), and derive 3-channel
@@ -1485,7 +1529,7 @@ public final class Qwen4Exp: Module, VLMModel, Qwen4ExpModelDirectoryConfigurabl
         let (visionHidden, _) = visionModel(concatenated(pixelParts), gridTHW: frames)
         let features = visionHidden.asType(textEmbeds.dtype)
 
-        let mergeSize = config.base.visionConfiguration.spatialMergeSize
+        let mergeSize = config.base.visionConfiguration?.spatialMergeSize ?? 1
         let divisor = max(1, mergeSize * mergeSize)
         let imageRowCount = (imageFrames ?? []).reduce(0) { $0 + $1.product / divisor }
         let mergedEmbeddings = try Self.scatterMediaFeatures(
@@ -1711,6 +1755,11 @@ public final class Qwen4Exp: Module, VLMModel, Qwen4ExpModelDirectoryConfigurabl
                 || originalKey.contains("ngram_embedding.shards")
                 || originalKey.contains("ngram_heads_") || originalKey.contains("layer_multipliers")
             { continue }
+            // No tower to receive them. A multimodal bundle loaded text-only still SHIPS its
+            // vision weights; handing them to a module that was never built leaves keys with no
+            // destination. Dropping them is what every other converted family does here, and it
+            // mirrors the `mtp.` guard directly above — same idea, different lane.
+            if !modalities.contains(.vision), originalKey.hasPrefix("visual.") { continue }
             var key = originalKey
             var value = originalValue
             if key.hasPrefix("model.language_model.") {
@@ -1745,7 +1794,7 @@ public final class Qwen4Exp: Module, VLMModel, Qwen4ExpModelDirectoryConfigurabl
             // already-MLX-format tensor passes through untouched.
             if key == "visual.patch_embed.proj.weight",
                 value.ndim == 5,
-                value.dim(-1) != config.base.visionConfiguration.inChannels
+                value.dim(-1) != (config.base.visionConfiguration?.inChannels ?? -1)
             {
                 value = value.transposed(0, 2, 3, 4, 1)
             }

--- a/Package.swift
+++ b/Package.swift
@@ -852,6 +852,8 @@ let package = Package(
                 "MuseGlimmerNormFoldOwnershipTests.swift",
                 "DeepseekV4Step37RuntimeContractsTests.swift",
                 "DSMLInlineJSONToolFallbackFocusedTests.swift",
+                "MuseGlimmerCapabilityLoadTests.swift",
+                "ModelConstructionModalitiesTests.swift",
                 "DSMLToolCallParserFocusedTests.swift",
                 "DeepseekV4ToolHistoryPrefixBoundaryTests.swift",
                 "DeepseekV4DropThinkingCacheTests.swift",

--- a/Package.swift
+++ b/Package.swift
@@ -856,6 +856,7 @@ let package = Package(
                 "ModelConstructionModalitiesTests.swift",
                 "DSMLToolCallParserFocusedTests.swift",
                 "DeepseekV4ToolHistoryPrefixBoundaryTests.swift",
+                "Mistral3CapabilityConstructionTests.swift",
                 "DeepseekV4DropThinkingCacheTests.swift",
                 "DeepseekV4AgentLoopBoundaryTests.swift",
                 "EarlyCompletionBeforeCachePersistTests.swift",

--- a/Package.swift
+++ b/Package.swift
@@ -863,6 +863,7 @@ let package = Package(
                 "ToolCallProgressRoutingTests.swift",
                 "FocusedMLXTestSupport.swift",
                 "CanonicalChatCacheBoundariesTests.swift",
+                "UniversalCapabilityConstructionTests.swift",
                 "RotatingKVCachePhysicalGrowthTests.swift",
                 "Mistral3ScalarEosDecodeTests.swift",
                 "NativeMTPWarmupMemoScopeTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/Mistral3CapabilityConstructionTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/Mistral3CapabilityConstructionTests.swift
@@ -1,0 +1,160 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Capability-driven construction for the mistral3 family, checked without a GPU where possible and
+// against a real bundle where one is present. Same contract as Muse Glimmer — deliberately, since
+// a convention that only one family follows is a proposal rather than an architecture.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXVLM
+import Testing
+
+@Suite("Mistral3 capability-driven construction")
+struct Mistral3CapabilityConstructionTests {
+
+    typealias Modalities = Set<ModelRuntimeRequestModality>
+
+    /// A text-only Mistral 3 conversion: the same document minus its vision section. Until
+    /// `visionConfig` became optional this could not DECODE at all.
+    private static let textOnlyJSON = """
+        {"model_type":"mistral3",
+         "text_config":{"model_type":"mistral","hidden_size":128,"num_hidden_layers":2,
+           "intermediate_size":256,"num_attention_heads":4,"num_key_value_heads":2,
+           "rms_norm_eps":1e-6,"vocab_size":1000,"rope_theta":10000.0,"head_dim":32,
+           "max_position_embeddings":4096}}
+        """
+
+    private func textOnlyConfig() throws -> Mistral3VLMConfiguration {
+        try JSONDecoder.json5().decode(
+            Mistral3VLMConfiguration.self, from: Data(Self.textOnlyJSON.utf8))
+    }
+
+    @Test("a config with no vision_config decodes, and builds text only")
+    func textOnlyDecodes() throws {
+        let cfg = try textOnlyConfig()
+        #expect(cfg.visionConfig == nil)
+        #expect(Mistral3VLM.constructibleModalities(of: cfg) == [.text])
+        #expect(Mistral3VLM(cfg).modalities == [.text])
+    }
+
+    /// Pixtral is image-only. Declaring `.video` here would let a video request pass construction
+    /// and fail later at `prepare()`, which is exactly the failure the modality set exists to move
+    /// earlier.
+    @Test("the vision lane is image-only — no video is claimed")
+    func noVideoLaneIsClaimed() throws {
+        guard let cfg = try Self.realBundleConfig() else { return }
+        #expect(Mistral3VLM.constructibleModalities(of: cfg) == [.text, .vision])
+        #expect(!Mistral3VLM.constructibleModalities(of: cfg).contains(.video))
+    }
+
+    @Test("asking a text-only config for vision fails at construction, not at prepare()")
+    func visionRequestOnTextOnlyThrows() throws {
+        let cfg = try textOnlyConfig()
+        #expect(throws: UnconstructibleModalities.self) {
+            _ = try Mistral3VLM(cfg, requesting: [.text, .vision])
+        }
+    }
+
+    @Test("a caller may ask for less than the bundle offers")
+    func narrowerRequestIsHonoured() throws {
+        guard let cfg = try Self.realBundleConfig() else { return }
+        let narrowed = try Mistral3VLM(cfg, requesting: [.text])
+        #expect(narrowed.modalities == [.text])
+        let full = Mistral3VLM(cfg)
+        #expect(full.modalities == [.text, .vision])
+    }
+
+    // MARK: the real bundle
+
+    /// The SMALLEST locally held mistral3 bundle, if any. Absent on a machine without one, so
+    /// these skip.
+    ///
+    /// Smallest rather than first-found: these tests construct the model, and the qualifying
+    /// bundles here span 2.6 GB to 91 GB. Any of them proves the same thing about construction,
+    /// so there is no reason to pay for the largest — and "first alphabetically" was picking a
+    /// 119B purely by accident of the org name.
+    static func realBundleConfig() throws -> Mistral3VLMConfiguration? {
+        guard let dir = smallestBundleDirectory(modelType: "mistral3") else { return nil }
+        let url = dir.appendingPathComponent("config.json")
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? JSONDecoder.json5().decode(Mistral3VLMConfiguration.self, from: data)
+    }
+
+    /// Bundle directories are ranked by total `.safetensors` bytes, which is the cost that
+    /// actually matters here — config decoding is free either way.
+    static func smallestBundleDirectory(modelType: String) -> URL? {
+        let root = URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library/MLModels")
+        let fm = FileManager.default
+        guard let orgs = try? fm.contentsOfDirectory(atPath: root.path) else { return nil }
+        var best: (url: URL, bytes: UInt64)? = nil
+        for org in orgs.sorted() {
+            let orgDir = root.appendingPathComponent(org)
+            guard let kids = try? fm.contentsOfDirectory(atPath: orgDir.path) else { continue }
+            for kid in kids.sorted() {
+                let dir = orgDir.appendingPathComponent(kid)
+                guard let data = try? Data(contentsOf: dir.appendingPathComponent("config.json")),
+                    let obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+                    obj["model_type"] as? String == modelType,
+                    obj["vision_config"] != nil,
+                    let files = try? fm.contentsOfDirectory(atPath: dir.path)
+                else { continue }
+                var bytes: UInt64 = 0
+                for f in files where f.hasSuffix(".safetensors") {
+                    let attrs = try? fm.attributesOfItem(atPath: dir.appendingPathComponent(f).path)
+                    bytes += (attrs?[.size] as? UInt64) ?? 0
+                }
+                if best == nil || bytes < best!.bytes { best = (dir, bytes) }
+            }
+        }
+        return best?.url
+    }
+
+    /// The payoff, on a real bundle: a text-only load allocates no vision tower and no projector.
+    /// Pixtral's tower is a flat ~0.75 GiB whatever the text model's size, so this is a smaller
+    /// win than Muse Glimmer's 3.84 GB — but it is the same win, and it is measured.
+    @Test("text-only construction omits the vision tower entirely")
+    func textOnlyOmitsTheTower() throws {
+        guard let cfg = try Self.realBundleConfig() else { return }
+        func count(_ m: Mistral3VLM) -> Int {
+            m.parameters().flattened().reduce(0) { $0 + $1.1.size }
+        }
+        let full = count(Mistral3VLM(cfg))
+        let text = count(try Mistral3VLM(cfg, requesting: [.text]))
+        #expect(text < full)
+        print("full  : \(full) params")
+        print("text  : \(text) params")
+        print("spared: \(full - text) params")
+    }
+
+    /// A text-only instance must expose no vision parameters at all — not merely fewer.
+    @Test("a text-only instance exposes no vision keys")
+    func textOnlyHasNoVisionKeys() throws {
+        guard let cfg = try Self.realBundleConfig() else { return }
+        let text = try Mistral3VLM(cfg, requesting: [.text])
+        let keys = text.parameters().flattened().map(\.0)
+        #expect(!keys.isEmpty)
+        for k in keys {
+            #expect(!k.contains("vision_tower"), "vision parameter present: \(k)")
+            #expect(!k.contains("multi_modal_projector"), "projector parameter present: \(k)")
+        }
+    }
+
+    /// The bundle still SHIPS its vision weights. Sanitize must drop them rather than rehome them
+    /// onto modules that were never built, which would leave keys with no destination.
+    @Test("sanitize drops the vision weights a text-only instance cannot receive")
+    func sanitizeDropsVisionWeights() throws {
+        guard let cfg = try Self.realBundleConfig() else { return }
+        let text = try Mistral3VLM(cfg, requesting: [.text])
+        let out = text.sanitize(weights: [
+            "vision_tower.transformer.layers.0.attention.wq.weight": MLXArray([0.0] as [Float]),
+            "model.multi_modal_projector.linear_1.weight": MLXArray([0.0] as [Float]),
+            "model.language_model.layers.0.self_attn.q_proj.weight": MLXArray([0.0] as [Float]),
+        ])
+        #expect(out.keys.first { $0.contains("vision_tower") } == nil)
+        #expect(out.keys.first { $0.contains("multi_modal_projector") } == nil)
+        // The language weight survives, so the drop is targeted rather than wholesale.
+        #expect(out.count == 1)
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/ModelConstructionModalitiesTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/ModelConstructionModalitiesTests.swift
@@ -1,0 +1,145 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Construction-time modality selection, checked without a GPU or a bundle.
+
+import Foundation
+import MLXLMCommon
+import MLXVLM
+import Testing
+
+@Suite("Model construction modalities")
+struct ModelConstructionModalitiesTests {
+
+    typealias Modalities = Set<ModelRuntimeRequestModality>
+
+    // MARK: the subset rule
+
+    @Test("no request means everything the configuration can build")
+    func nilRequestTakesAll() throws {
+        let constructible: Modalities = [.text, .vision, .video]
+        #expect(
+            try Modalities.resolveForConstruction(requested: nil, constructible: constructible)
+                == constructible)
+    }
+
+    @Test("a caller may ask for LESS — that is the point")
+    func narrowerRequestIsHonoured() throws {
+        // This is the load that is impossible today for any family nobody hand-registered twice:
+        // a vision bundle opened text-only, leaving its tower unallocated.
+        let got = try Modalities.resolveForConstruction(
+            requested: [.text], constructible: [.text, .vision, .video])
+        #expect(got == [.text])
+        #expect(!got.contains(.vision))
+    }
+
+    @Test("asking for MORE than can be built is an error, and an early one")
+    func widerRequestThrows() {
+        #expect(throws: UnconstructibleModalities.self) {
+            try Modalities.resolveForConstruction(requested: [.text, .vision], constructible: [.text])
+        }
+    }
+
+    @Test("text is NOT implied — a speech-to-speech model must be expressible")
+    func textIsNotImplied() throws {
+        // audio in, audio out, no text anywhere. Unlikely, not impossible; implying text would make
+        // it inexpressible, and the cost of not implying is that callers say what they mean.
+        let got = try Modalities.resolveForConstruction(requested: [.audio], constructible: [.audio])
+        #expect(got == [.audio])
+        #expect(!got.contains(.text))
+    }
+
+    @Test("an empty configuration or request is rejected, not silently accepted")
+    func emptyIsRejected() {
+        // With every component optional, "nothing" is reachable by a config that merely failed to
+        // parse. A model that can do nothing is a bug far more often than an intent.
+        #expect(throws: EmptyModalitySelection.self) {
+            try Modalities.resolveForConstruction(requested: nil, constructible: [])
+        }
+        #expect(throws: EmptyModalitySelection.self) {
+            try Modalities.resolveForConstruction(requested: [], constructible: [.text])
+        }
+    }
+
+    /// The vocabulary is `ModelRuntimeRequestModality` — shared with
+    /// `ModelRuntimeCapabilitySnapshot.validate`, and CLOSED. A downstream package cannot mint a
+    /// modality; a new one is a case added upstream, which is deliberate: the exhaustive switch in
+    /// `support(for:)` then forces it to be wired through everywhere before it can be requested.
+    /// What this test pins is that the resolver itself is modality-agnostic — it hardcodes no
+    /// subset, so a new case costs nothing here.
+    @Test("the resolver covers the whole vocabulary, with no lane special-cased")
+    func resolverIsModalityAgnostic() throws {
+        for modality in ModelRuntimeRequestModality.allCases {
+            let got = try Modalities.resolveForConstruction(
+                requested: [modality], constructible: Set(ModelRuntimeRequestModality.allCases))
+            #expect(got == [modality])
+        }
+    }
+
+    @Test("vision and video are separate, because bundles differ on exactly that")
+    func visionAndVideoAreDistinct() {
+        // JangLoader's own comment: "many VLMs accept images but not videos", and Gemma4 throws on
+        // video input. One vision flag would let such a request pass here and fail at prepare().
+        #expect(ModelRuntimeRequestModality.vision != ModelRuntimeRequestModality.video)
+        #expect(throws: UnconstructibleModalities.self) {
+            try Modalities.resolveForConstruction(
+                requested: [.video], constructible: [.text, .vision])
+        }
+    }
+
+    @Test("the error names what is missing, not just that something is")
+    func errorIsActionable() {
+        let e = UnconstructibleModalities(
+            requested: [.text, .audio], constructible: [.text, .vision])
+        #expect(e.excess == [.audio])
+        #expect(e.description.contains("audio"))
+    }
+
+    // MARK: the two questions are deliberately distinct
+
+    /// `ModelRuntimeCapabilitySnapshot` says what a bundle was TRAINED for; this says what a config
+    /// can BUILD. Keeping them apart is what lets a broken conversion — a `supports_vision` stamp
+    /// over a config with no vision section — stay visible instead of being averaged away.
+    @Test("a bundle may declare vision while its config cannot build it")
+    func declarationAndConstructibilityCanDisagree() throws {
+        let json = """
+            {"model_type":"muse_glimmer","hidden_size":128,"num_hidden_layers":2,
+             "intermediate_size":256,"num_attention_heads":4,"num_key_value_heads":2,
+             "rms_norm_eps":1e-6,"vocab_size":1000,"rope_theta":10000.0}
+            """
+        let cfg = try JSONDecoder.json5().decode(
+            MuseGlimmerConfiguration.self, from: Data(json.utf8))
+
+        // The config cannot build a vision tower...
+        #expect(MuseGlimmer.constructibleModalities(of: cfg) == [.text])
+        // ...and construction refuses, regardless of what any stamp elsewhere claims.
+        #expect(throws: UnconstructibleModalities.self) {
+            _ = try MuseGlimmer(cfg, requesting: [.text, .vision])
+        }
+    }
+
+    // MARK: the change that removes the need for a second registration
+
+    /// A text-only Muse Glimmer bundle has no `vision_config`, and until it became optional this
+    /// configuration could not DECODE such a bundle at all.
+    ///
+    /// That does NOT make the LLM-side `muse_glimmer` entry redundant. `muse_glimmer` names two
+    /// bundle shapes, and the two registrations serve one each — `ModelFactory` routes between
+    /// them by trying the VLM factory first and falling through on any error. See
+    /// `MuseGlimmerConfiguration.visionConfiguration`. What this test pins is only that a
+    /// vision-less config decodes and builds nothing but text.
+    @Test("a config with no vision_config decodes, and builds text only")
+    func textOnlyBundleDecodes() throws {
+        let json = """
+            {"model_type":"muse_glimmer","hidden_size":128,"num_hidden_layers":2,
+             "intermediate_size":256,"num_attention_heads":4,"num_key_value_heads":2,
+             "rms_norm_eps":1e-6,"vocab_size":1000,"rope_theta":10000.0}
+            """
+        let cfg = try JSONDecoder.json5().decode(
+            MuseGlimmerConfiguration.self, from: Data(json.utf8))
+        #expect(cfg.visionConfiguration == nil)
+
+        let model = MuseGlimmer(cfg)
+        #expect(model.modalities == [.text])
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/MuseGlimmerCapabilityLoadTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/MuseGlimmerCapabilityLoadTests.swift
@@ -1,0 +1,99 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// The claim, against a real bundle: a multimodal Muse Glimmer loaded text-only builds no vision
+// tower, and its language tower is unchanged.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import MLXVLM
+import Testing
+
+@Suite("Muse Glimmer capability-driven load (real bundle)")
+struct MuseGlimmerCapabilityLoadTests {
+
+    /// The real converted bundle. Absent on a machine without it, so every test here skips rather
+    /// than fails — a missing 26 GB model is not a defect in this code.
+    static var bundleConfig: URL? {
+        let root = URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent("Library/MLModels")
+        for org in ["OsaurusAI", "cubiculum", "JANGQ-AI"] {
+            let d = root.appendingPathComponent(org)
+            guard let kids = try? FileManager.default.contentsOfDirectory(atPath: d.path) else { continue }
+            for k in kids where k.hasPrefix("Muse-Glimmer") {
+                let c = d.appendingPathComponent(k).appendingPathComponent("config.json")
+                if FileManager.default.fileExists(atPath: c.path) { return c }
+            }
+        }
+        return nil
+    }
+
+    private func config() throws -> MuseGlimmerConfiguration? {
+        guard let url = Self.bundleConfig else { return nil }
+        return try JSONDecoder.json5().decode(
+            MuseGlimmerConfiguration.self, from: Data(contentsOf: url))
+    }
+
+    @Test("the real bundle declares text, image and video")
+    func realBundleDeclares() throws {
+        guard let cfg = try config() else { return }
+        #expect(cfg.visionConfiguration != nil)
+        #expect(MuseGlimmer.constructibleModalities(of: cfg) == [.text, .vision, .video])
+    }
+
+    /// The measurement that matters: same bundle, two loads, and the text-only one must not carry
+    /// the tower. Parameter COUNT is the observable — it is what allocation follows from.
+    @Test("text-only construction omits the vision tower entirely")
+    func textOnlyOmitsTower() throws {
+        guard let cfg = try config() else { return }
+
+        let full = MuseGlimmer(cfg)                                   // everything declared
+        let text = try MuseGlimmer(cfg, requesting: [.text])          // narrowed
+
+        func params(_ m: Module) -> Int {
+            m.parameters().flattened().reduce(0) { $0 + $1.1.size }
+        }
+        let pFull = params(full), pText = params(text)
+
+        #expect(text.modalities == [.text])
+        #expect(full.modalities == [.text, .vision, .video])
+        #expect(pText < pFull, "text-only must allocate strictly less")
+
+        let savedGB = Double(pFull - pText) * 2.0 / 1e9   // fp16 lower bound on the tower
+        print("""
+              full  : \(pFull) params
+              text  : \(pText) params
+              spared: \(pFull - pText) params (>= \(String(format: "%.2f", savedGB)) GB at fp16)
+              """)
+    }
+
+    /// The language tower must be untouched by narrowing — otherwise this changes answers rather
+    /// than packaging, and every banked Muse Glimmer row would be invalidated.
+    @Test("the language tower is identical in both loads")
+    func languageTowerUnchanged() throws {
+        guard let cfg = try config() else { return }
+        let full = MuseGlimmer(cfg)
+        let text = try MuseGlimmer(cfg, requesting: [.text])
+
+        func languageKeys(_ m: Module) -> [String] {
+            m.parameters().flattened().map(\.0).filter { $0.hasPrefix("language_model") }.sorted()
+        }
+        func languageSize(_ m: Module) -> Int {
+            m.parameters().flattened().filter { $0.0.hasPrefix("language_model") }
+                .reduce(0) { $0 + $1.1.size }
+        }
+        #expect(languageKeys(full) == languageKeys(text), "the text tower's shape must not change")
+        #expect(languageSize(full) == languageSize(text), "…nor its parameter count")
+    }
+
+    @Test("a text-only instance exposes no vision keys at all")
+    func noVisionKeysWhenNarrowed() throws {
+        guard let cfg = try config() else { return }
+        let text = try MuseGlimmer(cfg, requesting: [.text])
+        let visionish = text.parameters().flattened().map(\.0)
+            .filter { $0.contains("vision") }
+        #expect(visionish.isEmpty, "leftover vision parameters: \(visionish.prefix(3))")
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/UniversalCapabilityConstructionTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/UniversalCapabilityConstructionTests.swift
@@ -89,9 +89,12 @@ struct UniversalCapabilityConstructionTests {
     /// factory, so they are not this suite's subject at all.
     @Test("report which families this machine can actually exercise")
     func coverageIsLegible() {
+        // The nine dual-path families PLUS qwen4_exp, which is VLM-only and therefore not in
+        // DualPathFamilies — but the modality convention is about multimodal construction, not
+        // about dual registration, so it belongs in this suite's scope.
         let families = [
             "gemma3", "gemma4", "gemma4_unified", "qwen3_5", "qwen3_5_moe",
-            "mistral3", "ministral3", "muse_glimmer", "diffusion_gemma",
+            "mistral3", "ministral3", "muse_glimmer", "diffusion_gemma", "qwen4_exp",
         ]
         var withVision: [String] = []
         var textOnlyOnly: [String] = []
@@ -152,6 +155,33 @@ struct UniversalCapabilityConstructionTests {
         // Audio is claimed only for the conformer tower; whether THIS bundle has one is a
         // property of the bundle, so pin only that the claim is one of the two coherent answers.
         #expect(lanes.isSubset(of: [.text, .vision, .audio]))
+    }
+
+    /// qwen4_exp is the first family to ARRIVE after the convention existed, which makes it the
+    /// real test of whether the convention is one. Like qwen3_5 it genuinely consumes video —
+    /// `prepare` reads `input.video` and threads video frames into the tower — so it claims the
+    /// video lane rather than the image-only shape the Gemma and Pixtral families use.
+    @Test("qwen4_exp declares text, vision and video, and narrows like the rest")
+    func qwen4ExpFollowsTheConvention() throws {
+        guard let raw = Self.rawConfig(modelType: "qwen4_exp") else { return }
+        let cfg = try JSONDecoder.json5().decode(Qwen4ExpConfiguration.self, from: Self.asData(raw))
+        #expect(Qwen4Exp.constructibleModalities(of: cfg) == [.text, .vision, .video])
+
+        let narrowed = try Qwen4Exp(cfg, requesting: [.text])
+        #expect(narrowed.modalities == [.text])
+        #expect(Qwen4Exp(cfg).modalities == [.text, .vision, .video])
+
+        // Narrowing must SKIP the tower, not merely declare a smaller set.
+        let visionKeys = narrowed.parameters().flattened().map(\.0).filter { $0.contains("visual") }
+        #expect(visionKeys.isEmpty)
+
+        // And the weights it cannot receive are dropped rather than handed to nothing.
+        let out = narrowed.sanitize(weights: [
+            "visual.patch_embed.proj.weight": MLXArray([0.0] as [Float]),
+            "model.language_model.layers.0.self_attn.q_proj.weight": MLXArray([0.0] as [Float]),
+        ])
+        #expect(out.keys.first { $0.contains("visual") } == nil)
+        #expect(out.count == 1)
     }
 
     // MARK: a vision-less config decodes, and builds text only

--- a/Tests/MLXLMCommonFocusedTests/UniversalCapabilityConstructionTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/UniversalCapabilityConstructionTests.swift
@@ -1,0 +1,291 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Every dual-path family now answers the same question the same way. The point of this suite is
+// UNIVERSALITY: a convention a few families follow is a proposal, and the next person adding a
+// multimodal model should find a pattern rather than a special case. So these tests assert the
+// SHAPE across families rather than one family's behaviour.
+//
+// Configurations come from real local bundles, with `vision_config` removed where a text-only case
+// is needed — which is what a text-only conversion of that bundle would look like. Hand-written
+// fixtures were tried first and drifted from the real schemas immediately; deriving from the
+// bundles keeps the test honest and removes a whole class of maintenance.
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import MLXNN
+import MLXVLM
+import Testing
+
+@Suite("Capability-driven construction across the dual-path families")
+struct UniversalCapabilityConstructionTests {
+
+    typealias Modalities = Set<ModelRuntimeRequestModality>
+
+    /// The raw `config.json` of the SMALLEST local bundle with this `model_type`, if any.
+    ///
+    /// Smallest rather than first-found: several of these tests construct the model, and the
+    /// qualifying bundles span 2.6 GB to 91 GB. Any of them proves the same thing, so ranking by
+    /// weight size keeps the suite cheap — "first alphabetically" was selecting a 119B by accident
+    /// of the org name.
+    static func rawConfig(modelType: String, needsVision: Bool = true) -> [String: Any]? {
+        let root = URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library/MLModels")
+        let fm = FileManager.default
+        guard let orgs = try? fm.contentsOfDirectory(atPath: root.path) else { return nil }
+        var best: (obj: [String: Any], bytes: UInt64)? = nil
+        for org in orgs.sorted() {
+            let orgDir = root.appendingPathComponent(org)
+            guard let kids = try? fm.contentsOfDirectory(atPath: orgDir.path) else { continue }
+            for kid in kids.sorted() {
+                let dir = orgDir.appendingPathComponent(kid)
+                guard let data = try? Data(contentsOf: dir.appendingPathComponent("config.json")),
+                    let obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+                    obj["model_type"] as? String == modelType,
+                    !needsVision || obj["vision_config"] != nil,
+                    let files = try? fm.contentsOfDirectory(atPath: dir.path)
+                else { continue }
+                var bytes: UInt64 = 0
+                for f in files where f.hasSuffix(".safetensors") {
+                    let attrs = try? fm.attributesOfItem(atPath: dir.appendingPathComponent(f).path)
+                    bytes += (attrs?[.size] as? UInt64) ?? 0
+                }
+                if best == nil || bytes < best!.bytes { best = (obj, bytes) }
+            }
+        }
+        return best?.obj
+    }
+
+    /// The same document with its vision section removed.
+    static func visionStripped(_ cfg: [String: Any]) -> Data {
+        var c = cfg
+        c.removeValue(forKey: "vision_config")
+        if var t = c["text_config"] as? [String: Any] {
+            t.removeValue(forKey: "vision_config")
+            c["text_config"] = t
+        }
+        return try! JSONSerialization.data(withJSONObject: c)
+    }
+
+    private static func asData(_ cfg: [String: Any]) -> Data {
+        try! JSONSerialization.data(withJSONObject: cfg)
+    }
+
+    /// Which families this run actually exercised.
+    ///
+    /// Every test here is bundle-gated, and a gate that closes silently is indistinguishable from a
+    /// passing test — not hypothetical: a mutation to Gemma3's construction passed the whole suite
+    /// because no `gemma3` bundle exists on this machine, so its assertions never ran.
+    ///
+    /// The report distinguishes THREE states, because two of them look alike and are not. The
+    /// vision-bearing tests need a bundle WITH a `vision_config`; a text-only bundle of the same
+    /// family satisfies neither. An earlier version of this test asked only whether any bundle
+    /// existed, which would have reported a family as exercised while every one of its assertions
+    /// skipped — the precise failure this test exists to prevent, in the test itself.
+    ///
+    /// Note also that a family's text-only bundles often carry a DIFFERENT `model_type` entirely
+    /// (`gemma3_text` rather than `gemma3`, `mistral` rather than `mistral3`) and route to the LLM
+    /// factory, so they are not this suite's subject at all.
+    @Test("report which families this machine can actually exercise")
+    func coverageIsLegible() {
+        let families = [
+            "gemma3", "gemma4", "gemma4_unified", "qwen3_5", "qwen3_5_moe",
+            "mistral3", "ministral3", "muse_glimmer", "diffusion_gemma",
+        ]
+        var withVision: [String] = []
+        var textOnlyOnly: [String] = []
+        var absent: [String] = []
+        for f in families {
+            if Self.rawConfig(modelType: f) != nil {
+                withVision.append(f)
+            } else if Self.rawConfig(modelType: f, needsVision: false) != nil {
+                textOnlyOnly.append(f)
+            } else {
+                absent.append(f)
+            }
+        }
+        print("exercised          : \(withVision.sorted().joined(separator: ", "))")
+        if !textOnlyOnly.isEmpty {
+            print("NOT exercised      : \(textOnlyOnly.sorted().joined(separator: ", "))"
+                + "  — a bundle exists but carries no vision_config, so the assertions skip")
+        }
+        print("no bundle at all   : \(absent.sorted().joined(separator: ", "))")
+        #expect(!withVision.isEmpty, "no vision bundle for any dual-path family; this suite tested nothing")
+    }
+
+    // MARK: the lanes each family declares
+
+    /// The declared set must describe what `prepare` will actually accept, and the families DIFFER.
+    /// That difference is the evidence the image/video split earns its keep: one "vision" flag
+    /// could not tell Qwen 3.5 from Pixtral, and would let a video request pass construction on a
+    /// family that refuses video outright.
+    @Test("Qwen 3.5 claims video, because it actually consumes it")
+    func qwenClaimsVideo() throws {
+        guard let raw = Self.rawConfig(modelType: "qwen3_5") else { return }
+        let cfg = try JSONDecoder.json5().decode(
+            MLXVLM.Qwen35Configuration.self, from: Self.asData(raw))
+        #expect(Qwen35.constructibleModalities(of: cfg) == [.text, .vision, .video])
+    }
+
+    @Test("Mistral 3 claims vision without video, because Pixtral is image-only")
+    func mistralClaimsVisionNotVideo() throws {
+        guard let raw = Self.rawConfig(modelType: "mistral3") else { return }
+        let cfg = try JSONDecoder.json5().decode(
+            Mistral3VLMConfiguration.self, from: Self.asData(raw))
+        #expect(Mistral3VLM.constructibleModalities(of: cfg) == [.text, .vision])
+        #expect(!Mistral3VLM.constructibleModalities(of: cfg).contains(.video))
+    }
+
+    /// Gemma 4 refuses video in `prepare` ("no proven vMLX video path yet"), so it must not claim
+    /// the lane — and it may claim `.audio`, but only for the conformer tower.
+    @Test("Gemma 4 never claims video, and claims audio only for a conformer tower")
+    func gemma4LanesAreHonest() throws {
+        guard let raw = Self.rawConfig(modelType: "gemma4") else { return }
+        let cfg = try JSONDecoder.json5().decode(Gemma4Configuration.self, from: Self.asData(raw))
+        // Asserted through the public surface only: Gemma4Configuration's own fields are
+        // internal, and `constructibleModalities` is the thing callers actually consult.
+        let lanes = Gemma4.constructibleModalities(of: cfg)
+        #expect(lanes.contains(.text))
+        #expect(lanes.contains(.vision))
+        #expect(!lanes.contains(.video))
+        // Audio is claimed only for the conformer tower; whether THIS bundle has one is a
+        // property of the bundle, so pin only that the claim is one of the two coherent answers.
+        #expect(lanes.isSubset(of: [.text, .vision, .audio]))
+    }
+
+    // MARK: a vision-less config decodes, and builds text only
+
+    /// Before this work a text-only bundle of any of these families could not DECODE at all — the
+    /// vision section was non-optional. That, not the tower, was the original reason each family
+    /// needed a second registration.
+    @Test("a vision-stripped config decodes and builds text only, in every family")
+    func textOnlyEverywhere() throws {
+        if let raw = Self.rawConfig(modelType: "gemma3") {
+            let cfg = try JSONDecoder.json5().decode(
+                Gemma3Configuration.self, from: Self.visionStripped(raw))
+            #expect(cfg.visionConfiguration == nil)
+            #expect(Gemma3.constructibleModalities(of: cfg) == [.text])
+            #expect(Gemma3(cfg).modalities == [.text])
+        }
+        if let raw = Self.rawConfig(modelType: "mistral3") {
+            let cfg = try JSONDecoder.json5().decode(
+                Mistral3VLMConfiguration.self, from: Self.visionStripped(raw))
+            #expect(cfg.visionConfig == nil)
+            #expect(Mistral3VLM(cfg).modalities == [.text])
+        }
+        if let raw = Self.rawConfig(modelType: "gemma4") {
+            let cfg = try JSONDecoder.json5().decode(
+                Gemma4Configuration.self, from: Self.visionStripped(raw))
+            #expect(!Gemma4.constructibleModalities(of: cfg).contains(.vision))
+        }
+        if let raw = Self.rawConfig(modelType: "qwen3_5") {
+            let cfg = try JSONDecoder.json5().decode(
+                MLXVLM.Qwen35Configuration.self, from: Self.visionStripped(raw))
+            #expect(cfg.visionConfiguration == nil)
+            #expect(Qwen35.constructibleModalities(of: cfg) == [.text])
+        }
+    }
+
+    // MARK: the subset rule holds everywhere
+
+    @Test("asking a vision-stripped config for vision throws, in every family")
+    func overRequestThrowsEverywhere() throws {
+        if let raw = Self.rawConfig(modelType: "gemma3") {
+            let cfg = try JSONDecoder.json5().decode(
+                Gemma3Configuration.self, from: Self.visionStripped(raw))
+            #expect(throws: UnconstructibleModalities.self) {
+                _ = try Gemma3(cfg, requesting: [.text, .vision])
+            }
+        }
+        if let raw = Self.rawConfig(modelType: "mistral3") {
+            let cfg = try JSONDecoder.json5().decode(
+                Mistral3VLMConfiguration.self, from: Self.visionStripped(raw))
+            #expect(throws: UnconstructibleModalities.self) {
+                _ = try Mistral3VLM(cfg, requesting: [.text, .vision])
+            }
+        }
+        if let raw = Self.rawConfig(modelType: "qwen3_5") {
+            let cfg = try JSONDecoder.json5().decode(
+                MLXVLM.Qwen35Configuration.self, from: Self.visionStripped(raw))
+            #expect(throws: UnconstructibleModalities.self) {
+                _ = try Qwen35(cfg, requesting: [.text, .vision])
+            }
+        }
+    }
+
+    /// A caller may narrow, which is the whole point — and the narrowed instance must SAY so.
+    @Test("a narrowed instance reports the narrower set, in every family")
+    func narrowingIsReportedEverywhere() throws {
+        if let raw = Self.rawConfig(modelType: "mistral3") {
+            let cfg = try JSONDecoder.json5().decode(
+                Mistral3VLMConfiguration.self, from: Self.asData(raw))
+            #expect(try Mistral3VLM(cfg, requesting: [.text]).modalities == [.text])
+            #expect(Mistral3VLM(cfg).modalities == [.text, .vision])
+        }
+        if let raw = Self.rawConfig(modelType: "gemma3") {
+            let cfg = try JSONDecoder.json5().decode(
+                Gemma3Configuration.self, from: Self.asData(raw))
+            #expect(try Gemma3(cfg, requesting: [.text]).modalities == [.text])
+        }
+    }
+
+    /// Declaring a narrower set and BUILDING a narrower model are different claims, and only the
+    /// second one saves anything. A mutation that built the tower regardless of the request passed
+    /// every other test in this suite, which is exactly why this one exists: assert the parameters,
+    /// not the declaration.
+    @Test("a narrowed instance allocates no vision parameters, in every family")
+    func narrowingActuallySkipsTheTower() throws {
+        func visionKeys(_ m: Module) -> [String] {
+            m.parameters().flattened().map(\.0).filter {
+                $0.contains("vision_tower") || $0.contains("vision_model")
+                    || $0.contains("multi_modal_projector") || $0.contains("vision_embedder")
+            }
+        }
+
+        if let raw = Self.rawConfig(modelType: "gemma3") {
+            let cfg = try JSONDecoder.json5().decode(
+                Gemma3Configuration.self, from: Self.asData(raw))
+            #expect(!visionKeys(Gemma3(cfg)).isEmpty, "the full load should carry vision")
+            #expect(visionKeys(try Gemma3(cfg, requesting: [.text])).isEmpty)
+        }
+        if let raw = Self.rawConfig(modelType: "mistral3") {
+            let cfg = try JSONDecoder.json5().decode(
+                Mistral3VLMConfiguration.self, from: Self.asData(raw))
+            #expect(!visionKeys(Mistral3VLM(cfg)).isEmpty, "the full load should carry vision")
+            #expect(visionKeys(try Mistral3VLM(cfg, requesting: [.text])).isEmpty)
+        }
+        if let raw = Self.rawConfig(modelType: "gemma4") {
+            let cfg = try JSONDecoder.json5().decode(
+                Gemma4Configuration.self, from: Self.asData(raw))
+            #expect(!visionKeys(Gemma4(cfg)).isEmpty, "the full load should carry vision")
+            #expect(visionKeys(try Gemma4(cfg, requesting: [.text])).isEmpty)
+        }
+        if let raw = Self.rawConfig(modelType: "qwen3_5") {
+            let cfg = try JSONDecoder.json5().decode(
+                MLXVLM.Qwen35Configuration.self, from: Self.asData(raw))
+            #expect(!visionKeys(Qwen35(cfg)).isEmpty, "the full load should carry vision")
+            #expect(visionKeys(try Qwen35(cfg, requesting: [.text])).isEmpty)
+        }
+    }
+
+    /// diffusion_gemma was already closest to the target: its VLM creator returns the SAME type the
+    /// LLM factory registers, gaining a vision lane only when a tower is installed. So its modality
+    /// set is a `var` — and it still refuses an impossible request.
+    @Test("diffusion_gemma declares and refuses like the rest")
+    func diffusionGemmaFollowsTheConvention() throws {
+        guard let raw = Self.rawConfig(modelType: "diffusion_gemma") else { return }
+        let full = try JSONDecoder.json5().decode(
+            DiffusionGemmaVLMConfiguration.self, from: Self.asData(raw))
+        #expect(diffusionGemmaConstructibleModalities(of: full).contains(.vision))
+        #expect(makeDiffusionGemmaVLM(full).modalities.contains(.vision))
+
+        let stripped = try JSONDecoder.json5().decode(
+            DiffusionGemmaVLMConfiguration.self, from: Self.visionStripped(raw))
+        #expect(diffusionGemmaConstructibleModalities(of: stripped) == [.text])
+        #expect(makeDiffusionGemmaVLM(stripped).modalities == [.text])
+        #expect(throws: UnconstructibleModalities.self) {
+            _ = try makeDiffusionGemmaVLM(stripped, requesting: [.text, .vision])
+        }
+    }
+}

--- a/Tests/MLXLMTests/Gemma4VLMTests.swift
+++ b/Tests/MLXLMTests/Gemma4VLMTests.swift
@@ -155,9 +155,9 @@ private func maskedScatter(input: MLXArray, mask: MLXArray, source: MLXArray) ->
     let config = try JSONDecoder().decode(Gemma4Configuration.self, from: data)
 
     #expect(config.imageTokenId == 258880)
-    #expect(config.visionConfig.defaultOutputLength == 280)
-    #expect(config.visionConfig.poolingKernelSize == 3)
-    #expect(config.visionConfig.patchSize == 16)
+    #expect(config.visionConfig?.defaultOutputLength == 280)
+    #expect(config.visionConfig?.poolingKernelSize == 3)
+    #expect(config.visionConfig?.patchSize == 16)
     #expect(config.textConfig.numHiddenLayers == 35)
     #expect(config.textConfig.numKvSharedLayers == 20)
     #expect(config.textConfig.slidingWindow == 512)
@@ -270,12 +270,12 @@ private func maskedScatter(input: MLXArray, mask: MLXArray, source: MLXArray) ->
     #expect(config.textConfig.slidingWindow == 1024)
     #expect(config.textConfig.layerTypes.filter { $0 == "full_attention" }.count == 8)
     #expect(config.textConfig.layerTypes.filter { $0 == "sliding_attention" }.count == 40)
-    #expect(config.visionConfig.usesUnifiedVisionEmbedder)
-    #expect(config.visionConfig.hiddenSize == 3840)
-    #expect(config.visionConfig.outputProjectionDimensions == 3840)
-    #expect(config.visionConfig.modelPatchSize == 48)
-    #expect(config.visionConfig.positionEmbeddingSize == 1120)
-    #expect(config.visionConfig.defaultOutputLength == 280)
+    #expect(config.visionConfig?.usesUnifiedVisionEmbedder == true)
+    #expect(config.visionConfig?.hiddenSize == 3840)
+    #expect(config.visionConfig?.outputProjectionDimensions == 3840)
+    #expect(config.visionConfig?.modelPatchSize == 48)
+    #expect(config.visionConfig?.positionEmbeddingSize == 1120)
+    #expect(config.visionConfig?.defaultOutputLength == 280)
 }
 
 @Test func gemma4ProportionalRoPEHandlesAsymmetricGlobalKeyWidth() {
@@ -540,8 +540,8 @@ private func maskedScatter(input: MLXArray, mask: MLXArray, source: MLXArray) ->
 
     // This is the root invariant: processor token count must match vision feature count
     #expect(
-        procConfig.imageSeqLength == modelConfig.visionConfig.defaultOutputLength,
-        "Processor imageSeqLength (\(procConfig.imageSeqLength)) must equal vision defaultOutputLength (\(modelConfig.visionConfig.defaultOutputLength))")
+        procConfig.imageSeqLength == modelConfig.visionConfig?.defaultOutputLength,
+        "Processor imageSeqLength (\(procConfig.imageSeqLength)) must equal vision defaultOutputLength (\(modelConfig.visionConfig?.defaultOutputLength))")
 }
 
 @Test func gemma4E4BConfigDecode() throws {
@@ -556,6 +556,6 @@ private func maskedScatter(input: MLXArray, mask: MLXArray, source: MLXArray) ->
     let config = try JSONDecoder().decode(Gemma4Configuration.self, from: data)
 
     #expect(config.imageTokenId == 258880)
-    #expect(config.visionConfig.defaultOutputLength == 280)
-    #expect(config.visionConfig.poolingKernelSize == 3)
+    #expect(config.visionConfig?.defaultOutputLength == 280)
+    #expect(config.visionConfig?.poolingKernelSize == 3)
 }


### PR DESCRIPTION
A VLM bundle can only be loaded one way today: with every tower its config
declares. A caller who wants text out of a multimodal bundle either allocates a
vision tower it will never use, or reaches for a second registration in
`LLMModelFactory` that exists only to say "text only".

This makes that intent a parameter.

```swift
let full = MuseGlimmer(config)                        // everything the config offers
let text = try MuseGlimmer(config, requesting: [.text])  // no vision tower allocated
text.modalities        // [.text] — what this instance CARRIES
```

A request that exceeds what the config can build throws at construction, not
later inside `prepare()` where the cause is no longer visible.

## It reuses the vocabulary that already exists

The modality names are `MLXLMCommon`'s own `ModelRuntimeRequestModality` — the
type `ModelRuntimeCapabilitySnapshot.validate(request:)` already speaks — so
nothing translates between the two. `ModelConstructionModalities.swift` adds only
what was genuinely absent: construction-time resolution and its two errors.

The snapshot and this answer **different questions**, and are deliberately not
merged:

| | question | shape |
|---|---|---|
| `ModelRuntimeCapabilitySnapshot` | what was this bundle **trained** for? | tri-state, incl. `.unknown` |
| `constructibleModalities(of:)` | which towers can this **config** instantiate? | structural, no third state |

A `supports_vision` stamp over a config with no vision section is a broken
conversion. Keeping the two apart leaves that visible instead of averaging it
away.

## Two properties that are load-bearing

- **`.text` is never implied.** A model whose only lanes are audio-in and
  audio-out is unusual but not incoherent; a default that quietly added text
  would misdescribe it.
- **An empty selection is refused on both sides.** With every component optional,
  "nothing" is reachable by a config that merely failed to parse, and a model
  that can do nothing is a bug far more often than an intent.

## Applied to EVERY dual-path family

A convention a few families follow is a proposal, not an architecture — the next
person adding a multimodal model should find a pattern rather than a special
case. So all nine are converted.

They started in different places, and two were already most of the way there:

| family | starting point |
|---|---|
| `muse_glimmer` | full conversion |
| `mistral3` / `ministral3` | full conversion, across all three classes sharing the config — `Mistral3VLM`, `Mistral3VLMJANGTQ`, `Mistral4VLM` |
| `gemma3` | full conversion |
| `qwen3_5` / `qwen3_5_moe` | full conversion; the MoE variant inherits it by subclassing |
| `gemma4` / `gemma4_unified` | towers and `audioConfig` were **already** optional; needed the config section and the API |
| `diffusion_gemma` | already returned the **same type** from both factories and already attached the tower conditionally; needed only the API |

## The declared lanes differ, and that is the substance

| family | declares | why |
|---|---|---|
| `qwen3_5` | `.text .vision .video` | `prepare` consumes `input.video`; the tower takes a `videoGridTHW` |
| `mistral3` | `.text .vision` | Pixtral is image-only |
| `gemma3` | `.text .vision` | SigLIP is image-only |
| `gemma4` | `.text .vision` (+`.audio`) | `.audio` only for the **conformer** tower; never `.video` — `prepare` refuses it outright |

One "vision" flag could not express that. Declaring `.video` on Gemma 4 would let
a video request pass construction and fail at `prepare()` — precisely the failure
this design moves earlier.

`diffusion_gemma` is the interesting case: its modality set is a `var`, not a
`let`, and honestly so. The type is built as the text engine and *gains* its
vision lane when `installVision` attaches a tower — there is no separate
multimodal class to carry a fixed set.

## Measured, not asserted

| bundle | spared by a text-only load |
|---|---|
| Muse Glimmer 30B | 1,921,845,760 params — ≥3.84 GB at fp16 |
| Mistral 3 (real bundle) | 428,472,320 params — ~0.80 GiB |

Mistral's is smaller because Pixtral's tower is a flat ~0.75 GiB whatever the
text model's size. Same win, honestly smaller.

For Muse Glimmer the language tower is verified **identical** in both loads, so
the narrowing removes the vision tower and nothing else.

## Verification

- Real-bundle tests for both families; they skip rather than fail where the
  bundle is absent.
- **Mutation-checked.** Building the tower regardless of requested modalities,
  and not dropping vision weights in `sanitize`, each fail the suite.
- **A mutation that did NOT fail, and what it exposed.** Building Gemma 3's tower
  regardless of the request passed the entire suite — not because the assertion
  was weak, but because no `gemma3` bundle exists on the machine, so every
  `gemma3` assertion silently skipped. Every test here is bundle-gated, and a
  gate that closes quietly is indistinguishable from a passing test. There is now
  a test that **prints which families were exercised** and fails if none were;
  the same mutation re-run against `gemma4` (11 bundles) and `qwen3_5` (21) fails
  as it should. **The loop is now closed on `gemma3` itself**: with a multimodal
  `gemma-3-4b` present, that original mutation fails on *"a narrowed instance
  allocates no vision parameters, in every family"* — the very test it had slipped
  past. Exercised: `diffusion_gemma`, `gemma3`, `gemma4`, `gemma4_unified`,
  `mistral3`, `muse_glimmer`, `qwen3_5`, `qwen3_5_moe`. Only `ministral3` lacks a
  bundle, and it shares `mistral3`'s code paths entirely.
- **Declaring a narrower set and building a narrower model are different claims**,
  and only the second saves anything, so the suite asserts the parameter set and
  not merely the declaration.
- `sanitize` drops vision weights a text-only instance cannot receive, rather
  than rehoming them onto modules that were never built — the same stance Gemma4
  already takes with `audio_tower.*` on audio-less bundles.
- Existing callers are untouched: the plain `init(_ config:)` still builds
  everything the config offers, and is non-throwing by construction rather than
  by argument.

---

**Now includes the Qwen4Exp adoption (previously proposed separately as #321).**

They were split so the API and each adopter could be reviewed apart. That split does not survive as a
MERGE order: with the capability API in place and `Qwen4Exp` still on the old construction path, the
tree does not compile —

```
Qwen4Exp.swift: error: value of optional type 'Qwen35Configuration.VisionConfiguration?'
```

— so landing the API first would break `main` for however long the follow-up took. Folding the
adoption in keeps every commit on `main` buildable, which is the property that actually matters here.

Verified on current `main`: the package builds, and all five suites these patches add or touch pass —
`ModelConstructionModalities` (10), `UniversalCapabilityConstruction` (10),
`Mistral3CapabilityConstruction` (7), `MuseGlimmerCapabilityLoad` (4) and `Gemma4VLM` (5).
