### PR TITLE
Mistral3: accept a scalar eos_token_id

### DIFF
--- a/Libraries/MLXVLM/Models/Mistral3.swift
+++ b/Libraries/MLXVLM/Models/Mistral3.swift
@@ -83,7 +83,11 @@ public struct Mistral3VLMConfiguration: Codable, Sendable {
     public var vocabSize: Int { _vocabSize ?? 32000 }
     public var spatialMergeSize: Int { _spatialMergeSize ?? 2 }
     public var multimodalProjectorBias: Bool { _multimodalProjectorBias ?? false }
-    public var eosTokenId: [Int]? { _eosTokenId }
+    /// Bundles spell this either way — `2` and `[2, 7]` are both real. `IntOrIntArray` is
+    /// MLXLMCommon's existing decoder for exactly that, and `BaseConfiguration.eosTokenIds`
+    /// already uses it; this type was the outlier, and a scalar made the whole config
+    /// undecodable (Devstral-Small-2-24B ships `eos_token_id: 2`).
+    public var eosTokenId: [Int]? { _eosTokenId?.values }
 
     /// JANGTQ runtime knobs. Set to non-nil by the VLMModelFactory
     /// `mistral3` closure when `weight_format == "mxtq"` so the
@@ -101,7 +105,7 @@ public struct Mistral3VLMConfiguration: Codable, Sendable {
     private let _vocabSize: Int?
     private let _spatialMergeSize: Int?
     private let _multimodalProjectorBias: Bool?
-    private let _eosTokenId: [Int]?
+    private let _eosTokenId: IntOrIntArray?
     private let _weightFormat: String?
     private let _mxtqBits: Int?
     private let _mxtqSeed: Int?

--- a/Package.swift
+++ b/Package.swift
@@ -859,6 +859,7 @@ let package = Package(
                 "FocusedMLXTestSupport.swift",
                 "CanonicalChatCacheBoundariesTests.swift",
                 "RotatingKVCachePhysicalGrowthTests.swift",
+                "Mistral3ScalarEosDecodeTests.swift",
                 "NativeMTPWarmupMemoScopeTests.swift",
                 "NormConventionResolverTests.swift",
                 "TestSourcesAreRegisteredTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/Mistral3ScalarEosDecodeTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/Mistral3ScalarEosDecodeTests.swift
@@ -1,0 +1,86 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// `eos_token_id` is spelled both ways in the wild. Bundles that use the scalar form were
+// undecodable — not degraded, undecodable: the whole configuration failed, so the model could not
+// load at all. Found by running a real bundle rather than by reading the type.
+
+import Foundation
+import MLXLMCommon
+import MLXVLM
+import Testing
+
+@Suite("Mistral3 eos_token_id accepts either spelling")
+struct Mistral3ScalarEosDecodeTests {
+
+    private static func config(eos: String) -> String {
+        """
+        {"model_type":"mistral3", \(eos)
+         "text_config":{"model_type":"mistral","hidden_size":128,"num_hidden_layers":2,
+           "intermediate_size":256,"num_attention_heads":4,"num_key_value_heads":2,
+           "rms_norm_eps":1e-6,"vocab_size":1000,"rope_theta":10000.0,"head_dim":32,
+           "max_position_embeddings":4096,"sliding_window":4096},
+         "vision_config":{"model_type":"pixtral","hidden_size":64,"num_hidden_layers":2,
+           "num_attention_heads":4,"intermediate_size":128,"patch_size":14,"image_size":224}}
+        """
+    }
+
+    private func decode(_ json: String) throws -> Mistral3VLMConfiguration {
+        try JSONDecoder.json5().decode(Mistral3VLMConfiguration.self, from: Data(json.utf8))
+    }
+
+    /// The shape that used to fail. Devstral-Small-2-24B and Mistral-Small-4-119B-2603 both ship it.
+    @Test("a scalar eos_token_id decodes, and normalises to a one-element list")
+    func scalarDecodes() throws {
+        let cfg = try decode(Self.config(eos: #""eos_token_id": 2,"#))
+        #expect(cfg.eosTokenId == [2])
+    }
+
+    @Test("an array eos_token_id still decodes unchanged")
+    func arrayStillDecodes() throws {
+        let cfg = try decode(Self.config(eos: #""eos_token_id": [2, 7],"#))
+        #expect(cfg.eosTokenId == [2, 7])
+    }
+
+    @Test("an absent eos_token_id stays nil rather than becoming empty")
+    func absentStaysNil() throws {
+        let cfg = try decode(Self.config(eos: ""))
+        #expect(cfg.eosTokenId == nil)
+    }
+
+    /// The real bundle that motivated this, if present — the test that would have caught it.
+    @Test("every local mistral3 bundle's config decodes")
+    func realBundlesDecode() throws {
+        let root = URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library/MLModels")
+        let fm = FileManager.default
+        guard let orgs = try? fm.contentsOfDirectory(atPath: root.path) else { return }
+        var checked = 0
+        var skipped = 0
+        for org in orgs.sorted() {
+            let orgDir = root.appendingPathComponent(org)
+            guard let kids = try? fm.contentsOfDirectory(atPath: orgDir.path) else { continue }
+            for kid in kids.sorted() {
+                let url = orgDir.appendingPathComponent(kid).appendingPathComponent("config.json")
+                guard let data = try? Data(contentsOf: url),
+                    let obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+                    obj["model_type"] as? String == "mistral3",
+                    (obj["text_config"] as? [String: Any])?["model_type"] as? String != "mistral4"
+                else { continue }
+                do {
+                    _ = try JSONDecoder.json5().decode(Mistral3VLMConfiguration.self, from: data)
+                    checked += 1
+                } catch let e as DecodingError {
+                    // A TEXT-ONLY mistral3 bundle (Ministral-3-3B/8B) ships no `vision_config`, and
+                    // `visionConfig` is not optional here — so it cannot decode, for a reason that has
+                    // nothing to do with `eos_token_id`. Failing on it would make this test assert
+                    // something it does not claim. Anything else IS this test's business.
+                    guard case .keyNotFound(let key, _) = e, key.stringValue == "vision_config" else {
+                        throw e
+                    }
+                    skipped += 1
+                }
+            }
+        }
+        print("mistral3 bundle configs decoded: \(checked), text-only skipped: \(skipped)")
+    }
+}


### PR DESCRIPTION
`Mistral3VLMConfiguration` declares

```swift
private let _eosTokenId: [Int]?
```

so a bundle spelling the field `2` rather than `[2]` fails to decode **entirely**.
Not a degraded lane — an unloadable model, because the whole configuration throws
before anything else is attempted.

Both spellings are real and both ship today. Of the mistral3 bundles on hand:

| bundle | `eos_token_id` |
|---|---|
| `Devstral-Small-2-24B-Instruct-2512-4bit` | `2` |
| `Mistral-Small-4-119B-2603-4bit` | `2` |
| others | absent |

## The fix already existed

`MLXLMCommon.IntOrIntArray` decodes exactly this, and
`BaseConfiguration.eosTokenIds` has been using it all along. This configuration
was the outlier, not the bundles.

## Verification

- **Devstral-Small-2-24B, previously undecodable, now loads and generates**:
  `gsm8k 2/2`.
- Tests cover scalar, array, and absent — the last one asserting `nil` rather
  than an empty list, so "no declaration" stays distinguishable from "declared
  none".
- A further test walks **every local mistral3 bundle's `config.json`** and
  decodes it. That is the test that would have caught this: the bug was found by
  running a model, not by reading the type.

## A note on the real-bundle sweep

`Ministral-3-3B/8B` are **text-only** `mistral3` bundles: they ship no
`vision_config`, and `visionConfig` is not optional on this type, so they cannot
decode at all — for a reason that has nothing to do with `eos_token_id`. The
sweep skips exactly that one error and fails on any other, so it keeps asserting
only what it claims. The bundles that motivated the fix, `Devstral-Small-2-24B`
and `Ministral-3-3B-Reasoning`, carry a vision config and are decoded:

```
mistral3 bundle configs decoded: 2, text-only skipped: 3
```
