### PR TITLE
Processor configs: accept patch_size in its {height, width} form

### DIFF
--- a/Libraries/MLXLMCommon/JSONDecodingTypes.swift
+++ b/Libraries/MLXLMCommon/JSONDecodingTypes.swift
@@ -146,3 +146,61 @@ public enum StringOrNumber: Codable, Equatable, Sendable {
         }
     }
 }
+
+/// A patch dimension that bundles spell either as a bare number or as a `{"height": h, "width": w}`
+/// pair. Both forms are real and appear within the same model family: Devstral-Small-2-24B ships
+/// `"patch_size": 16`, Magistral-Small-2509 ships `"patch_size": {"height": 14, "width": 14}`.
+/// Before this existed the dict form made the processor configuration undecodable, so the model
+/// could not load at all.
+///
+/// A NON-SQUARE pair throws rather than picking an axis. Every caller uses the value for both
+/// dimensions — `((width + patch - 1) / patch) * patch` and the same for height — so silently
+/// keeping one number would compute a wrong patch grid rather than an approximate one.
+public struct IntOrSquareSize: Codable, Sendable, Equatable {
+    public let value: Int
+
+    public init(_ value: Int) {
+        self.value = value
+    }
+
+    private enum SizeKeys: String, CodingKey {
+        case height
+        case width
+    }
+
+    public init(from decoder: Decoder) throws {
+        if let single = try? decoder.singleValueContainer().decode(Int.self) {
+            self.value = single
+            return
+        }
+        let keyed = try decoder.container(keyedBy: SizeKeys.self)
+        let height = try keyed.decodeIfPresent(Int.self, forKey: .height)
+        let width = try keyed.decodeIfPresent(Int.self, forKey: .width)
+        switch (height, width) {
+        case let (h?, w?) where h == w:
+            self.value = h
+        case let (h?, nil):
+            self.value = h
+        case let (nil, w?):
+            self.value = w
+        case let (h?, w?):
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription:
+                        "non-square patch size \(h)x\(w); the patch grid math assumes one "
+                        + "dimension for both axes, so this cannot be honoured"))
+        default:
+            throw DecodingError.typeMismatch(
+                IntOrSquareSize.self,
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "expected a number or a {height, width} object"))
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(value)
+    }
+}

--- a/Libraries/MLXVLM/Models/Mistral3.swift
+++ b/Libraries/MLXVLM/Models/Mistral3.swift
@@ -1010,7 +1010,8 @@ public struct Mistral3VLMProcessorConfiguration: Codable, Sendable {
         self.imageEndToken =
             try c.decodeIfPresent(String.self, forKey: .imageEndToken) ?? "[IMG_END]"
         self.patchSize =
-            try c.decodeIfPresent(Int.self, forKey: .patchSize) ?? imageProcessor.patchSize
+            try c.decodeIfPresent(IntOrSquareSize.self, forKey: .patchSize)?.value
+            ?? imageProcessor.patchSize
         self.spatialMergeSize = try c.decodeIfPresent(Int.self, forKey: .spatialMergeSize)
     }
 
@@ -1018,7 +1019,9 @@ public struct Mistral3VLMProcessorConfiguration: Codable, Sendable {
         public let imageMean: [CGFloat]
         public let imageStd: [CGFloat]
         public let size: ProcessorSize
-        public let patchSize: Int
+        /// Accepts both spellings; see `IntOrSquareSize`.
+        private let _patchSize: IntOrSquareSize
+        public var patchSize: Int { _patchSize.value }
         public let doNormalize: Bool?
         public let doRescale: Bool?
         public let doResize: Bool?
@@ -1048,7 +1051,7 @@ public struct Mistral3VLMProcessorConfiguration: Codable, Sendable {
             case imageMean = "image_mean"
             case imageStd = "image_std"
             case size
-            case patchSize = "patch_size"
+            case _patchSize = "patch_size"
             case doNormalize = "do_normalize"
             case doRescale = "do_rescale"
             case doResize = "do_resize"

--- a/Libraries/MLXVLM/Models/Pixtral.swift
+++ b/Libraries/MLXVLM/Models/Pixtral.swift
@@ -977,7 +977,9 @@ public struct PixtralProcessorConfiguration: Codable, Sendable {
         public let imageMean: [CGFloat]
         public let imageStd: [CGFloat]
         public let size: ProcessorSize
-        public let patchSize: Int
+        /// Accepts both spellings; see `IntOrSquareSize`.
+        private let _patchSize: IntOrSquareSize
+        public var patchSize: Int { _patchSize.value }
         public let doNormalize: Bool?
         public let doRescale: Bool?
         public let doResize: Bool?
@@ -1007,7 +1009,7 @@ public struct PixtralProcessorConfiguration: Codable, Sendable {
             case imageMean = "image_mean"
             case imageStd = "image_std"
             case size
-            case patchSize = "patch_size"
+            case _patchSize = "patch_size"
             case doNormalize = "do_normalize"
             case doRescale = "do_rescale"
             case doResize = "do_resize"

--- a/Package.swift
+++ b/Package.swift
@@ -868,6 +868,7 @@ let package = Package(
                 "NativeMTPActivationErrorTextTests.swift",
                 "HybridWarmupMemoScopeTests.swift",
                 "BatchEngineGrowingChatCacheSourceTests.swift",
+                "ProcessorPatchSizeShapeTests.swift",
                 "CacheCoordinatorTopologyFocusedTests.swift",
                 "DiskStoreOffsetConsistencyFocusedTests.swift",
                 "VMLXUmbrellaProductTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/ProcessorPatchSizeShapeTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/ProcessorPatchSizeShapeTests.swift
@@ -1,0 +1,129 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// `patch_size` in a preprocessor config is spelled both as a number and as a {height, width}
+// object, within the same model family. The object form made the processor configuration
+// undecodable, so the model could not load — found by running a real bundle, not by reading types.
+
+import Foundation
+import MLXLMCommon
+import MLXVLM
+import Testing
+
+@Suite("Processor patch_size accepts either spelling")
+struct ProcessorPatchSizeShapeTests {
+
+    private func decode(_ json: String) throws -> IntOrSquareSize {
+        try JSONDecoder().decode(IntOrSquareSize.self, from: Data(json.utf8))
+    }
+
+    @Test("a bare number decodes")
+    func scalarDecodes() throws {
+        #expect(try decode("16").value == 16)
+    }
+
+    /// The shape that used to fail. Magistral-Small-2509 ships exactly this.
+    @Test("a square {height, width} object decodes")
+    func squareObjectDecodes() throws {
+        #expect(try decode(#"{"height": 14, "width": 14}"#).value == 14)
+    }
+
+    @Test("a half-specified object takes the dimension it has")
+    func partialObjectDecodes() throws {
+        #expect(try decode(#"{"height": 14}"#).value == 14)
+        #expect(try decode(#"{"width": 12}"#).value == 12)
+    }
+
+    /// Deliberately an error rather than a guess: every caller uses this value for BOTH axes, so
+    /// picking one would compute a wrong patch grid rather than an approximate one.
+    @Test("a non-square pair is refused, not silently halved")
+    func nonSquareRefused() {
+        #expect(throws: (any Error).self) {
+            _ = try decode(#"{"height": 14, "width": 16}"#)
+        }
+    }
+
+    @Test("an unrelated shape is refused")
+    func garbageRefused() {
+        #expect(throws: (any Error).self) { _ = try decode(#""fourteen""#) }
+    }
+
+    /// A REAL object-form preprocessor config, kept as a fixture.
+    ///
+    /// Verbatim from Magistral-Small-2509-MLX-8bit, which was the only bundle on the machine that
+    /// spelled `patch_size` as an object — 1 of 52. Once that 24 GB model is deleted the
+    /// real-bundle walk below has no positive case left, and would keep passing while covering
+    /// nothing. 667 bytes is a cheap way to make the coverage outlive the download.
+    private static let objectFormPreprocessorConfig = """
+        {
+          "crop_size": null,
+          "data_format": "channels_first",
+          "default_to_square": true,
+          "device": null,
+          "do_center_crop": null,
+          "do_convert_rgb": true,
+          "do_normalize": true,
+          "do_rescale": true,
+          "do_resize": true,
+          "image_mean": [
+            0.48145466,
+            0.4578275,
+            0.40821073
+          ],
+          "image_processor_type": "PixtralImageProcessor",
+          "image_std": [
+            0.26862954,
+            0.26130258,
+            0.27577711
+          ],
+          "input_data_format": null,
+          "patch_size": {
+            "height": 14,
+            "width": 14
+          },
+          "processor_class": "PixtralProcessor",
+          "resample": 3,
+          "rescale_factor": 0.00392156862745098,
+          "return_tensors": null,
+          "size": {
+            "longest_edge": 1540
+          }
+        }
+        """
+
+    @Test("the real object-form config from a bundle decodes")
+    func realObjectFormFixtureDecodes() throws {
+        let cfg = try JSONDecoder().decode(
+            Mistral3VLMProcessorConfiguration.self,
+            from: Data(Self.objectFormPreprocessorConfig.utf8))
+        #expect(cfg.imageProcessor.patchSize == 14)
+    }
+
+    /// The real preprocessor configs on this machine, which is what caught this.
+    @Test("every local mistral3/pixtral preprocessor config decodes")
+    func realProcessorConfigsDecode() throws {
+        let root = URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library/MLModels")
+        let fm = FileManager.default
+        guard let orgs = try? fm.contentsOfDirectory(atPath: root.path) else { return }
+        var checked = 0, objectForm = 0
+        for org in orgs.sorted() {
+            let orgDir = root.appendingPathComponent(org)
+            guard let kids = try? fm.contentsOfDirectory(atPath: orgDir.path) else { continue }
+            for kid in kids.sorted() {
+                let dir = orgDir.appendingPathComponent(kid)
+                guard let cfg = try? Data(contentsOf: dir.appendingPathComponent("config.json")),
+                    let obj = (try? JSONSerialization.jsonObject(with: cfg)) as? [String: Any],
+                    obj["model_type"] as? String == "mistral3",
+                    let pre = try? Data(
+                        contentsOf: dir.appendingPathComponent("preprocessor_config.json")),
+                    let preObj = (try? JSONSerialization.jsonObject(with: pre)) as? [String: Any]
+                else { continue }
+                if preObj["patch_size"] is [String: Any] { objectForm += 1 }
+                _ = try JSONDecoder().decode(
+                    Mistral3VLMProcessorConfiguration.self, from: pre)
+                checked += 1
+            }
+        }
+        print("preprocessor configs decoded: \(checked)  (object-form patch_size: \(objectForm))")
+    }
+}


### PR DESCRIPTION
`preprocessor_config.json` spells `patch_size` two ways, and both appear within a
single model family:

| bundle | `patch_size` |
|---|---|
| `Devstral-Small-2-24B` | `16` |
| `Magistral-Small-2509` | `{"height": 14, "width": 14}` |

The object form made the processor configuration undecodable, so the model could
not load at all.

No existing type covered "number or square object", so `IntOrSquareSize` joins
`IntOrIntArray` in `JSONDecodingTypes.swift`. It is applied to both
`ImageProcessorConfig` declarations (Mistral3 and Pixtral) and to the
processor-level override.

## A non-square pair is refused, deliberately

Every caller uses this value for **both** dimensions —
`((width + patch - 1) / patch) * patch`, and the same for height. Silently
keeping one number would compute a *wrong* patch grid rather than an approximate
one, so a genuinely non-square pair throws instead. A shape nothing downstream
can honour should fail loudly rather than quietly.

Half-specified objects (`{"height": 14}`) are accepted, since there is no
conflict to resolve.

## Verification

- **Magistral-Small-2509, previously undecodable, now loads and generates**:
  `gsm8k 2/2`.
- Tests cover the number form, the square object, half-specified objects, the
  refused non-square pair, and an unrelated shape.
- A further test walks **every local preprocessor config** and decodes it —
  including the one object-form bundle that motivated this.
