### PR TITLE
JangLoader: derive expert down-projection quantization before consulting the declaration

### DIFF
--- a/Libraries/MLXLMCommon/JangLoader.swift
+++ b/Libraries/MLXLMCommon/JangLoader.swift
@@ -2455,6 +2455,30 @@ public struct JangLoader: Sendable {
                       let exact = inferExactQuantization(expectedInDim: hiddenSize)
             {
                 (bits, inferredGroupSize) = exact
+            } else if isExpertDownProjection,
+                      let expertIntermediateSize = expertIntermediateSizeHint,
+                      expertIntermediateSize > 0
+            {
+                // MOVED above the declaration fallback below, deliberately.
+                //
+                // A MoE expert's down projection takes the INTERMEDIATE width as input, so
+                // `hiddenSizeHint` cannot validate it the way it validates the gate/up siblings —
+                // which is why those two resolve correctly and this one did not. The packed width
+                // is frequently ambiguous: on Mistral-Small-4-119B, packed=256 with numGroups=32
+                // satisfies BOTH (bits=4, gs=64) and (bits=8, gs=32).
+                //
+                // While this sat BELOW the declaration branch, a self-consistent-but-WRONG
+                // declaration won every time, because self-consistency is exactly what an
+                // ambiguous width guarantees. The bundle declared 8-bit, the tensors were 4-bit,
+                // and gather_qmm died on a 1024-wide matrix fed a 2048-wide input. Every other
+                // tensor-derived hint already sits above the declaration; this one was on the
+                // wrong side of that line.
+                (bits, inferredGroupSize) = inferBitWidthAndGroupSize(
+                    packedDim: packedDim,
+                    numGroups: numGroups,
+                    knownGroupSize: moduleGroupSize,
+                    bitWidthsUsed: bitWidthsUsed,
+                    expectedInDim: expertIntermediateSize)
             } else if let dq = explicitForLayer,
                dq.bits > 0, numGroups > 0, (packedDim * 32) % dq.bits == 0,
                case let declaredInputDim = (packedDim * 32) / dq.bits,
@@ -2542,16 +2566,6 @@ public struct JangLoader: Sendable {
                     knownGroupSize: moduleGroupSize,
                     bitWidthsUsed: bitWidthsUsed,
                     expectedInDim: hiddenSize)
-            } else if isExpertDownProjection,
-                      let expertIntermediateSize = expertIntermediateSizeHint,
-                      expertIntermediateSize > 0
-            {
-                (bits, inferredGroupSize) = inferBitWidthAndGroupSize(
-                    packedDim: packedDim,
-                    numGroups: numGroups,
-                    knownGroupSize: moduleGroupSize,
-                    bitWidthsUsed: bitWidthsUsed,
-                    expectedInDim: expertIntermediateSize)
             } else if let picked = inferFromUniqueValidInDim() {
                 (bits, inferredGroupSize) = picked
             } else if isExpertDownProjection && !validInDims.isEmpty {

--- a/Package.swift
+++ b/Package.swift
@@ -870,6 +870,7 @@ let package = Package(
                 "BatchEngineGrowingChatCacheSourceTests.swift",
                 "CacheCoordinatorTopologyFocusedTests.swift",
                 "DiskStoreOffsetConsistencyFocusedTests.swift",
+                "ExpertDownProjectionQuantOrderTests.swift",
                 "VMLXUmbrellaProductTests.swift",
                 "ZayaConfigDecodeFocusedTests.swift",
                 "VLShapeGuardFocusedTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/ExpertDownProjectionQuantOrderTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/ExpertDownProjectionQuantOrderTests.swift
@@ -1,0 +1,71 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// A MoE expert's down projection must resolve its quantization from TENSOR GEOMETRY, not from the
+// bundle's declaration — because on an ambiguous packed width the declaration is self-consistent
+// even when it is wrong, so consulting it first cannot fail loudly.
+//
+// This is a source-ordering assertion. The behaviour it guards needs a 119B bundle to observe, and
+// the failure it prevents is a hard crash inside gather_qmm rather than a bad number, so there is
+// nothing subtler to assert against.
+
+import Foundation
+import Testing
+
+@Suite("Expert down-projection quantization is derived before it is declared")
+struct ExpertDownProjectionQuantOrderTests {
+
+    private static func loaderSource(from file: StaticString = #filePath) throws -> String {
+        var dir = URL(fileURLWithPath: "\(file)").deletingLastPathComponent()
+        for _ in 0 ..< 6 {
+            let candidate = dir.appendingPathComponent("Libraries/MLXLMCommon/JangLoader.swift")
+            if FileManager.default.fileExists(atPath: candidate.path) {
+                return try String(contentsOf: candidate, encoding: .utf8)
+            }
+            dir = dir.deletingLastPathComponent()
+        }
+        throw CocoaError(.fileNoSuchFile)
+    }
+
+    /// The whole bug, in one assertion.
+    ///
+    /// `packedDim = 256` with `numGroups = 32` satisfies BOTH `(bits=4, gs=64)` and
+    /// `(bits=8, gs=32)`. Mistral-Small-4-119B declares 8-bit and ships 4-bit tensors. While the
+    /// declaration was consulted first, it won — and `gather_qmm` died on a 1024-wide matrix fed a
+    /// 2048-wide input. The sibling-derived intermediate width settles it correctly.
+    @Test("the expert-intermediate hint is consulted before the declared per-layer option")
+    func hintPrecedesDeclaration() throws {
+        let src = try Self.loaderSource()
+        guard let hint = src.range(
+            of: "} else if isExpertDownProjection,\n                      let expertIntermediateSize")
+        else {
+            Issue.record("the expert down-projection hint branch is gone"); return
+        }
+        guard let declaration = src.range(of: "} else if let dq = explicitForLayer,") else {
+            Issue.record("the declared per-layer fallback is gone"); return
+        }
+        // Below the declaration, a self-consistent-but-wrong declaration wins on every
+        // ambiguous packed width — which is how the 8-bit stamp beat 4-bit tensors.
+        #expect(hint.lowerBound < declaration.lowerBound)
+    }
+
+    /// Both other tensor-derived hints already sit above the declaration. The expert hint was the
+    /// odd one out, and this pins the general rule rather than the single case.
+    @Test("every tensor-derived hint precedes the declared fallback")
+    func allDerivedHintsPrecedeDeclaration() throws {
+        let src = try Self.loaderSource()
+        guard let declaration = src.range(of: "} else if let dq = explicitForLayer,") else {
+            Issue.record("the declared per-layer fallback is gone"); return
+        }
+        for derived in [
+            "} else if isLanguageHiddenAnchor,",
+            "} else if isHiddenInputProjection,",
+            "} else if isExpertDownProjection,",
+        ] {
+            guard let r = src.range(of: derived) else {
+                Issue.record("missing branch: \(derived)"); continue
+            }
+            #expect(r.lowerBound < declaration.lowerBound, "\(derived)")
+        }
+    }
+}


### PR DESCRIPTION
A MoE expert's down projection could be quantized at the wrong bit width, and the
model then died inside `gather_qmm`:

```
[gather_qmm] Last dimension of first input with shape (..., 2048) does not match
the expanded quantized matrix (1024, 4096) computed from shape (128,4096,256)
with group_size=32, bits=8
```

## What the resolved widths show

Probing the merged per-layer table for the failing key names the bug in one shot:

```
layers.0.mlp.switch_mlp.down_proj -> b=8 gs=32   WRONG
layers.0.mlp.switch_mlp.gate_proj -> b=4 gs=64   right
layers.0.mlp.switch_mlp.up_proj   -> b=4 gs=64   right
```

Only `down_proj`, and the reason is geometric. `gate`/`up` take the **hidden**
width as input, so `hiddenSizeHint` validates them. `down` takes the
**intermediate** width, which that hint cannot check — so it fell through to the
declared per-layer option, and the declaration is exactly what is in doubt.

## Why the existing consistency check could not catch it

The packed width is frequently ambiguous. For this tensor, `packed = 256` with
`numGroups = 32` satisfies **both**:

| bits | inputDim | groupSize | valid? |
|---|---|---|---|
| 4 | `256 × 32/4 = 2048` | 64 | ✅ |
| 8 | `256 × 32/8 = 1024` | 32 | ✅ |

An ambiguous width *guarantees* the declaration is self-consistent, so the
"is the declaration shape-consistent?" test cannot discriminate. The bundle
stamps 8-bit, the tensors are 4-bit, and the declaration wins. `gather_qmm` then
builds a 1024-wide matrix and is handed a 2048-wide input.

## The fix is not new code

`isExpertDownProjection` and `expertIntermediateSizeHint` already exist, and the
branch using them was already written. It simply sat **below** the declaration
fallback, so it was unreachable on exactly the bundles that need it.

Moving it above restores the rule every other tensor-derived hint already
follows: **geometry decides, the declaration is the fallback.** The expert hint
was the only one on the wrong side of that line.

## Verification

| bundle | before | after |
|---|---|---|
| `Mistral-Small-4-119B-JANG_4M-CRACK` | `gather_qmm` fatal | `gsm8k 1/1` |
| `Mistral-Small-4-119B-A6B-JANG_2L` | `gather_qmm` fatal | `gsm8k 1/1` |

No regression on models that already loaded: `Ornith-1.0-35B-JANG_4M` 2/2,
`Holo3-35B-A3B-mxfp4` 2/2, `Ornith-1.5-9B-JANG_4D` 2/2. Two bundles at different
quantizations (2-bit and 4-bit) both went from fatal to generating.

Guarded by a source-ordering test, **mutation-checked**: moving the branch back
below the declaration fails it. The assertion is on source order rather than
behaviour because observing the behaviour needs a 119B bundle, and the failure is
a hard crash rather than a wrong number — there is nothing subtler to assert
against.

## Scope beyond one model

Any bundle whose declared quantization is wrong *and* lands on an ambiguous
packed width was exposed the same way. Agreement between declaration and geometry
is what keeps other JANG MoE models working, and that is a property of how they
were converted rather than of the loader.
