### PR TITLE
Qwen35: split an oversized diagnostic so the file type-checks

### DIFF
--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -187,14 +187,19 @@ enum Qwen4ExpCompiledGDNInputs {
             lock.lock()
             if !didReportFrontRejection {
                 didReportFrontRejection = true
-                FileHandle.standardError.write(
-                    Data(
-                        ("[Qwen4Exp] compiled_gdn_front=rejected"
-                            + " enabled=\(enabled) trace=\(CompiledDecodeTrace.isActive)"
-                            + " input=\(input.shape):\(input.dtype)"
-                            + " conv_state=\(convState.shape):\(convState.dtype)"
-                            + " scales=\(metadataDType) biases=\(biases.dtype)"
-                            + " conv_weight=\(convWeight.dtype)\n").utf8))
+                // Built piecewise on purpose. As a single `+` chain with eight interpolations
+                // wrapped in `Data(...).utf8`, this expression exceeds the type checker's budget and
+                // the file does not compile: "unable to type-check this expression in reasonable
+                // time" (Swift 6.4, swiftlang-6.4.0.33.1). Reproduced with trivial stand-in types,
+                // so it is the shape of the expression rather than anything about MLXArray. Same
+                // output; 11s-then-failure becomes 0.15s.
+                var diag = "[Qwen4Exp] compiled_gdn_front=rejected"
+                diag += " enabled=\(enabled) trace=\(CompiledDecodeTrace.isActive)"
+                diag += " input=\(input.shape):\(input.dtype)"
+                diag += " conv_state=\(convState.shape):\(convState.dtype)"
+                diag += " scales=\(metadataDType) biases=\(biases.dtype)"
+                diag += " conv_weight=\(convWeight.dtype)\n"
+                FileHandle.standardError.write(Data(diag.utf8))
             }
             lock.unlock()
             return nil


### PR DESCRIPTION
`Libraries/MLXVLM/Models/Qwen35.swift` does not compile on Swift 6.4
(`swiftlang-6.4.0.33.1`):

```
Qwen35.swift:183:36: error: the compiler is unable to type-check this expression
in reasonable time; try breaking up the expression into distinct sub-expressions
```

`MLXVLM` is a core target, so this blocks **any** build of the package, not a
rare configuration.

## The expression

The `compiled_gdn_front=rejected` diagnostic in `callFront` — a single `+` chain
with eight interpolations, wrapped in `Data(...).utf8` inside a call. The
constraint solver has to consider the `+` overloads combinatorially across the
whole chain.

## It is the expression, not the surrounding types

Reproduced standalone with trivial stand-ins — no MLXArray involved:

```swift
struct DType: CustomStringConvertible { var description: String { "f16" } }
struct Arr { var shape: [Int] { [1,2,3] }; var dtype: DType { DType() } }
```

| form | result |
|---|---|
| one `+` chain, as shipped | **11.1 s**, then `unable to type-check` |
| `var` + `+=`, same output | **0.15 s**, compiles |

So the fix is mechanical and behaviour-preserving: same string, same
`FileHandle.standardError.write`, assembled in steps.

## Note on how this landed

The block was introduced by the current `main` HEAD, so it looks simply
un-built-yet on this toolchain rather than a long-standing problem. It is also
possible a different Swift release has a larger solver budget and squeaks it
through — I could not test other toolchains, so I am flagging that as a
possibility rather than asserting it.

## Verification

No test accompanies this, deliberately: **the build is the test.** It either
compiles or it does not, and before this change it does not. With the change,
`swift build --target MLXVLM` succeeds.
