### PR TITLE
Load HuggingFace PEFT LoRA adapters, which is what published adapters are

### DIFF
--- a/Libraries/MLXLMCommon/Adapters/LoRA/LoRAContainer.swift
+++ b/Libraries/MLXLMCommon/Adapters/LoRA/LoRAContainer.swift
@@ -117,19 +117,41 @@ public struct LoRAContainer: ModelAdapter, @unchecked Sendable {
     }
 
     /// Loads a `LoRAContainer` from a directory containing adapter weights and configuration.
+    ///
+    /// Accepts BOTH layouts: MLX's own (`fine_tune_type` + `adapters.safetensors`) and
+    /// HuggingFace PEFT's (`peft_type` + `adapter_model.safetensors`), which is what essentially
+    /// every published adapter is. PEFT weights are translated on load rather than by an offline
+    /// converter, so an adapter downloaded from the Hub works directly — see `PEFTAdapter`.
     public static func from(directory: URL) throws -> LoRAContainer {
         let configurationURL = directory.appending(component: "adapter_config.json")
         let configurationData = try Data(contentsOf: configurationURL)
-        let configuration = try JSONDecoder()
-            .decode(LoRAConfiguration.self, from: configurationData)
 
-        let weightsURL = directory.appending(component: "adapters.safetensors")
-        let weights = try MLX.loadArrays(url: weightsURL)
-        let parameters = ModuleParameters.unflattened(weights)
+        func loadWeights() throws -> [String: MLXArray] {
+            for name in PEFTAdapter.weightsFilenames {
+                let url = directory.appending(component: name)
+                if FileManager.default.fileExists(atPath: url.path) {
+                    return try MLX.loadArrays(url: url)
+                }
+            }
+            // Preserve the original error surface when neither spelling is present.
+            return try MLX.loadArrays(url: directory.appending(component: "adapters.safetensors"))
+        }
+
+        let raw = try loadWeights()
+        let configuration: LoRAConfiguration
+        let weights: [String: MLXArray]
+        if let peft = PEFTAdapter.detect(configuration: configurationData) {
+            weights = PEFTAdapter.translate(weights: raw)
+            configuration = PEFTAdapter.configuration(from: peft, weights: weights)
+        } else {
+            configuration = try JSONDecoder()
+                .decode(LoRAConfiguration.self, from: configurationData)
+            weights = raw
+        }
 
         return LoRAContainer(
             configuration: configuration,
-            parameters: parameters
+            parameters: ModuleParameters.unflattened(weights)
         )
     }
 
@@ -144,13 +166,22 @@ public struct LoRAContainer: ModelAdapter, @unchecked Sendable {
         }
 
         let layers = lora.loraLayers.suffix(configuration.numLayers)
-        let keys = configuration.loraParameters.keys ?? lora.loraDefaultKeys
+        // PEFT names LEAVES ("out_proj"); replaceLayers matches full child keys
+        // ("linear_attn.out_proj"). Expand against the live layers, or nothing is replaced.
+        let keys = PEFTAdapter.expandTargetKeys(
+            configuration.loraParameters.keys ?? lora.loraDefaultKeys, in: layers)
         replaceLayers(layers: layers, keys: keys) { (layer: Module) in
             createReplacementLayer(target: layer, configuration: configuration)
         }
 
+        // The adapter records CHECKPOINT paths; the tree uses MODULE paths. Re-key against the
+        // live tree — after `replaceLayers`, so the lora_a/lora_b slots exist to match against.
+        let modelKeys = model.parameters().flattened().map(\.0)
+        let rekeyed = try PEFTAdapter.rekey(
+            Dictionary(uniqueKeysWithValues: parameters.flattened()), toModelKeys: modelKeys)
+
         try model.update(
-            parameters: parameters,
+            parameters: ModuleParameters.unflattened(rekeyed),
             verify: .noUnusedKeys
         )
     }

--- a/Libraries/MLXLMCommon/Adapters/LoRA/PEFTAdapter.swift
+++ b/Libraries/MLXLMCommon/Adapters/LoRA/PEFTAdapter.swift
@@ -1,0 +1,231 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Reading HuggingFace PEFT LoRA adapters, which is what essentially every published adapter is.
+//
+// This is the adapter-side equivalent of a model's `sanitize(weights:)`. Base models load from HF
+// unchanged only because 85 model files each carry a hand-written translator from checkpoint
+// naming to module naming; the adapter path had none, so PEFT adapters failed at the first
+// missing key. The gap is not specific to this port — `mlx-lm` has no mention of PEFT either, and
+// its loader validates leaf names against exactly `{lora_a, lora_b, m}`.
+
+import Foundation
+import MLX
+import MLXNN
+
+/// A PEFT `adapter_config.json`, in the fields that matter for loading one.
+struct PEFTConfiguration: Decodable {
+    let peftType: String
+    let r: Int
+    let loraAlpha: Float
+    let targetModules: [String]?
+    let useDora: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case peftType = "peft_type"
+        case r
+        case loraAlpha = "lora_alpha"
+        case targetModules = "target_modules"
+        case useDora = "use_dora"
+    }
+}
+
+enum PEFTAdapter {
+    /// PEFT names its weights file differently from MLX, so both spellings are accepted.
+    static let weightsFilenames = ["adapter_model.safetensors", "adapters.safetensors"]
+
+    /// Is this directory a PEFT adapter rather than an MLX one?
+    ///
+    /// Keyed on `peft_type` being present while `fine_tune_type` is absent, so an MLX adapter is
+    /// never mistaken for a PEFT one even if a converter later writes both.
+    static func detect(configuration: Data) -> PEFTConfiguration? {
+        guard let obj = try? JSONSerialization.jsonObject(with: configuration) as? [String: Any],
+            obj["peft_type"] != nil, obj["fine_tune_type"] == nil
+        else { return nil }
+        return try? JSONDecoder().decode(PEFTConfiguration.self, from: configuration)
+    }
+
+    /// Translate PEFT weights into the naming and ORIENTATION MLX expects.
+    ///
+    /// Three things change, and the last is the one that fails silently if it is wrong:
+    ///
+    ///   1. the `base_model.model.` wrapper PEFT adds is stripped;
+    ///   2. `…lora_A.weight` / `…lora_B.weight` become `…lora_a` / `…lora_b`;
+    ///   3. BOTH factors are TRANSPOSED.
+    ///
+    /// On (3): `LoRALinear` stores `loraA` as `[in, rank]` and `loraB` as `[rank, out]`, and its
+    /// forward is `y + scale * (x @ loraA @ loraB)`. PEFT stores the transpose of each — verified
+    /// against this adapter rather than assumed, where `out_proj` gives A=(32, 6144) and
+    /// B=(5120, 32) against a 5120-wide model. Loading those un-transposed would either throw on
+    /// a shape mismatch or, where dimensions happen to agree, quietly compute a different function
+    /// — which is why the round trip is checked numerically in the tests rather than by loading
+    /// successfully.
+    static func translate(weights: [String: MLXArray]) -> [String: MLXArray] {
+        var out: [String: MLXArray] = [:]
+        out.reserveCapacity(weights.count)
+        for (key, value) in weights {
+            var k = key
+            if k.hasPrefix("base_model.model.") {
+                k = String(k.dropFirst("base_model.model.".count))
+            }
+            if k.hasSuffix(".lora_A.weight") {
+                k = String(k.dropLast(".lora_A.weight".count)) + ".lora_a"
+            } else if k.hasSuffix(".lora_B.weight") {
+                k = String(k.dropLast(".lora_B.weight".count)) + ".lora_b"
+            } else {
+                continue                       // biases, magnitudes, anything else: not ours
+            }
+            out[k] = value.ndim == 2 ? value.transposed(1, 0) : value
+        }
+        return out
+    }
+
+    /// The MLX configuration a PEFT one implies.
+    ///
+    /// `scale` is `lora_alpha / r`, which is PEFT's own convention and NOT interchangeable with
+    /// MLX's default of 10–20. For this adapter alpha and r are both 32, so the scale is 1.0 —
+    /// taking the MLX default instead would apply the update at ten to twenty times its intended
+    /// strength, and the model would still load and still generate.
+    ///
+    /// `numLayers` is counted from the weights rather than declared, because PEFT does not record
+    /// it: it is the number of distinct `layers.N` indices the adapter actually touches.
+    static func configuration(
+        from peft: PEFTConfiguration, weights: [String: MLXArray]
+    ) -> LoRAConfiguration {
+        var layerIndices = Set<Int>()
+        for key in weights.keys {
+            let parts = key.split(separator: ".")
+            for (i, p) in parts.enumerated() where p == "layers" && i + 1 < parts.count {
+                if let n = Int(parts[i + 1]) { layerIndices.insert(n) }
+            }
+        }
+        // `keys` is carried through verbatim; `expandTargetKeys` is what reconciles PEFT's two
+        // spellings of target_modules with this model's actual module paths.
+        return LoRAConfiguration(
+            numLayers: max(layerIndices.count, 1),
+            fineTuneType: (peft.useDora ?? false) ? .dora : .lora,
+            loraParameters: .init(
+                rank: peft.r,
+                scale: peft.loraAlpha / Float(peft.r),
+                keys: peft.targetModules))
+    }
+
+    /// Expand PEFT's LEAF target names into the child keys this model actually uses.
+    ///
+    /// `target_modules: ["o_proj", "out_proj", "down_proj"]` names leaves. `replaceLayers` matches
+    /// `namedModules()` keys EXACTLY, and in a model where the projection sits under a submodule
+    /// that key is `linear_attn.out_proj`, not `out_proj` — so nothing matches and no LoRA slots
+    /// are created. The failure is silent in the worst way: the adapter then reports every one of
+    /// its parameters as unmatched, which reads like a bad adapter rather than an unexpanded key.
+    ///
+    /// Resolving against the live layers keeps this family-agnostic, for the same reason `rekey`
+    /// does.
+    static func expandTargetKeys(_ targets: [String], in layers: ArraySlice<Module>) -> [String] {
+        // PEFT writes target_modules EITHER as leaf names ("o_proj") or as full checkpoint paths
+        // ("model.language_model.layers.16.mlp.down_proj") — both are valid and both appear in
+        // the wild, in two adapters from the same author. Reduce to leaves so one rule covers both;
+        // the layer selection is carried by `numLayers` and by which weights the adapter ships,
+        // not by these strings.
+        let wanted = Set(targets.map { $0.split(separator: ".").last.map(String.init) ?? $0 })
+        var expanded = Set<String>()
+        // EVERY layer, not just the first. Qwen 3.8 is hybrid: early layers carry
+        // `linear_attn.out_proj` and later ones `self_attn.o_proj`, and this adapter targets both.
+        // Sampling layer 0 alone found 112 of 144 slots and left 32 parameters unmatched — a
+        // failure that reads like a bad adapter rather than an unrepresentative sample.
+        for layer in layers {
+            for (key, _) in layer.namedModules() {
+                let leaf = key.split(separator: ".").last.map(String.init) ?? key
+                if wanted.contains(leaf) { expanded.insert(key) }
+            }
+        }
+        return expanded.isEmpty ? targets : expanded.sorted()
+    }
+
+    /// Re-key adapter parameters onto the paths the LIVE MODULE TREE actually uses.
+    ///
+    /// PEFT records checkpoint paths, which are not module paths. Qwen 3.5 is the plain case: the
+    /// adapter says `model.language_model.layers.0.…` while the module tree says
+    /// `language_model.model.layers.0.…` — the same swap a base model's `sanitize` performs, and
+    /// the reason `update(parameters:)` reports `Unhandled keys ["model"]`.
+    ///
+    /// Matching by SUFFIX against the model rather than hardcoding per family is deliberate. The
+    /// 85 `sanitize` implementations exist because every family spells its checkpoint differently;
+    /// requiring an 86th for adapters would repeat that cost and leave the next family broken
+    /// again. A LoRA target is identified by its tail — `layers.N.<module>.<proj>.lora_a` — and
+    /// that tail is stable across the prefixes families disagree about.
+    ///
+    /// An unmatched or ambiguous key is an ERROR, never a silent drop: an adapter that loads with
+    /// half its factors missing still generates fluent text, and nothing downstream would say so.
+    static func rekey(
+        _ parameters: [String: MLXArray], toModelKeys modelKeys: [String]
+    ) throws -> [String: MLXArray] {
+        func tail(_ key: String) -> String {
+            let parts = key.split(separator: ".")
+            if let i = parts.lastIndex(where: { $0 == "layers" }), i + 1 < parts.count {
+                return parts[i...].joined(separator: ".")
+            }
+            return key
+        }
+        var byTail: [String: [String]] = [:]
+        for k in modelKeys { byTail[tail(k), default: []].append(k) }
+
+        var out: [String: MLXArray] = [:]
+        var unmatched: [String] = []
+        for (key, value) in parameters {
+            if modelKeys.contains(key) {            // already correct — MLX-native adapter
+                out[key] = value
+                continue
+            }
+            let candidates = byTail[tail(key)] ?? []
+            guard candidates.count == 1 else {
+                unmatched.append(candidates.isEmpty ? key : "\(key) [ambiguous: \(candidates.count)]")
+                continue
+            }
+            out[candidates[0]] = value
+        }
+        guard unmatched.isEmpty else {
+            // Report BOTH sides. "does not correspond" alone cannot distinguish a wrong prefix
+            // from a target module the model never LoRA-ised, and those need opposite fixes.
+            let offered = modelKeys.filter { $0.hasSuffix(".lora_a") }.sorted()
+            throw ModelAdapterError.unsupportedAdapterType(
+                "\(unmatched.count) adapter parameter(s) match no module. "
+                + "adapter wants: \(unmatched.sorted().prefix(2).joined(separator: ", ")). "
+                + "model offers \(offered.count) lora slot(s)"
+                + (offered.isEmpty
+                    ? " — none, so the target modules were never replaced (check target_modules "
+                      + "against this model's layer names)"
+                    : ": \(offered.prefix(2).joined(separator: ", "))"))
+        }
+        return out
+    }
+}
+
+/// Test seam.
+///
+/// `PEFTAdapter` is internal because nothing outside the loader should call it, but the
+/// orientation of the translated factors is precisely the thing that must be checked numerically
+/// rather than by a successful load. This exposes the three pure functions and nothing else.
+public enum PEFTAdapterTestBridge {
+    public static func translate(_ weights: [String: MLXArray]) -> [String: MLXArray] {
+        PEFTAdapter.translate(weights: weights)
+    }
+
+    public static func detect(_ configuration: Data) -> PEFTConfigurationBox? {
+        PEFTAdapter.detect(configuration: configuration).map(PEFTConfigurationBox.init)
+    }
+
+    public static func configuration(
+        _ box: PEFTConfigurationBox, _ weights: [String: MLXArray]
+    ) -> LoRAConfiguration {
+        PEFTAdapter.configuration(from: box.value, weights: weights)
+    }
+
+    public static func expandTargetKeys(_ targets: [String], in layers: [Module]) -> [String] {
+        PEFTAdapter.expandTargetKeys(targets, in: layers[...])
+    }
+}
+
+public struct PEFTConfigurationBox {
+    let value: PEFTConfiguration
+    init(_ value: PEFTConfiguration) { self.value = value }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -871,6 +871,7 @@ let package = Package(
                 "CacheCoordinatorTopologyFocusedTests.swift",
                 "DiskStoreOffsetConsistencyFocusedTests.swift",
                 "VMLXUmbrellaProductTests.swift",
+                "PEFTAdapterTranslationTests.swift",
                 "ZayaConfigDecodeFocusedTests.swift",
                 "VLShapeGuardFocusedTests.swift",
                 "JANGTQStreamingExpertDescriptorTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/PEFTAdapterTranslationTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/PEFTAdapterTranslationTests.swift
@@ -1,0 +1,156 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// The orientation of a translated LoRA factor cannot be checked by loading successfully. Where the
+// dimensions happen to agree, a transposed factor loads fine and computes a DIFFERENT function —
+// the model generates fluent, plausible, wrong text. So the round trip is checked numerically
+// against the reference PEFT formula.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import Testing
+
+@Suite("PEFT adapter translation")
+struct PEFTAdapterTranslationTests {
+
+    /// The claim, stated as arithmetic.
+    ///
+    ///   PEFT  : y = (alpha/r) * (x @ Aᵀ @ Bᵀ)      A=(r, in)  B=(out, r)
+    ///   MLX   : y = scale     * (x @ a  @ b )      a=(in, r)  b=(r, out)
+    ///
+    /// so `a = Aᵀ`, `b = Bᵀ`, `scale = alpha/r`. If either transpose is dropped the two disagree.
+    @Test("the translated factors compute the same update as the PEFT reference")
+    func roundTripMatchesReference() {
+        let (inDim, outDim, rank) = (16, 12, 4)
+        MLXRandom.seed(7)
+        let A = MLXRandom.normal([rank, inDim])      // PEFT orientation
+        let B = MLXRandom.normal([outDim, rank])
+        let x = MLXRandom.normal([3, inDim])
+        let alpha: Float = 8
+        let scale = alpha / Float(rank)
+
+        // Reference: exactly what PEFT computes.
+        let reference = scale * matmul(matmul(x, A.transposed(1, 0)), B.transposed(1, 0))
+
+        // Translated, then fed through MLX's own forward shape.
+        let t = PEFTAdapterTestBridge.translate([
+            "base_model.model.model.layers.0.mlp.down_proj.lora_A.weight": A,
+            "base_model.model.model.layers.0.mlp.down_proj.lora_B.weight": B,
+        ])
+        let a = t["model.layers.0.mlp.down_proj.lora_a"]!
+        let b = t["model.layers.0.mlp.down_proj.lora_b"]!
+        #expect(a.shape == [inDim, rank], "lora_a must be (in, rank)")
+        #expect(b.shape == [rank, outDim], "lora_b must be (rank, out)")
+
+        let got = scale * matmul(matmul(x, a), b)
+        let maxDiff = abs(got - reference).max().item(Float.self)
+        #expect(maxDiff < 1e-4, "translated update differs from the PEFT reference by \(maxDiff)")
+    }
+
+    /// The negative control. Without it the test above proves only that some arrangement works,
+    /// not that THIS one is required — and a test that passes for the wrong reason is the failure
+    /// mode this whole exercise keeps hitting.
+    @Test("skipping either transpose gives a DIFFERENT function")
+    func untransposedDisagrees() {
+        let (inDim, outDim, rank) = (16, 12, 4)
+        MLXRandom.seed(11)
+        let A = MLXRandom.normal([rank, inDim])
+        let B = MLXRandom.normal([outDim, rank])
+        let x = MLXRandom.normal([3, inDim])
+        let reference = matmul(matmul(x, A.transposed(1, 0)), B.transposed(1, 0))
+
+        // A left un-transposed is (r, in): x @ A is not even conformable, so the wrong-ness shows
+        // as a shape error rather than a number. Assert the shapes differ, which is the same claim.
+        #expect(A.shape != [inDim, rank])
+        #expect(B.shape != [rank, outDim])
+
+        // Both transposed the WRONG way round (a=Bᵀ, b=Aᵀ) is conformable here only if in == out,
+        // so use the square case to make the numerical disagreement visible.
+        let sq = 8
+        MLXRandom.seed(13)
+        let A2 = MLXRandom.normal([rank, sq])
+        let B2 = MLXRandom.normal([sq, rank])
+        let x2 = MLXRandom.normal([3, sq])
+        let right = matmul(matmul(x2, A2.transposed(1, 0)), B2.transposed(1, 0))
+        let swapped = matmul(matmul(x2, B2), A2)      // factors exchanged
+        let diff = abs(right - swapped).max().item(Float.self)
+        #expect(diff > 1e-3, "swapping the factors should NOT agree, but differed by only \(diff)")
+    }
+
+    /// Scale is as easy to get wrong as orientation, and fails just as quietly: the model loads,
+    /// generates, and applies the adaptation at the wrong strength.
+    @Test("scale is alpha/r, not MLX's default")
+    func scaleFollowsPEFT() throws {
+        let json = #"{"peft_type":"LORA","r":32,"lora_alpha":32,"target_modules":["down_proj"]}"#
+        let cfg = try #require(PEFTAdapterTestBridge.detect(Data(json.utf8)))
+        let weights = ["model.layers.0.mlp.down_proj.lora_a": MLXArray.zeros([4, 2])]
+        let lora = PEFTAdapterTestBridge.configuration(cfg, weights)
+        #expect(lora.loraParameters.rank == 32)
+        #expect(lora.loraParameters.scale == 1.0)     // 32/32 — NOT the 10–20 MLX defaults to
+        #expect(lora.loraParameters.keys == ["down_proj"])
+        #expect(lora.numLayers == 1)
+    }
+
+    /// PEFT writes `target_modules` two different ways, and both appear in the wild — in two
+    /// adapters from the SAME author. Qwen3.8-absolute-heresy uses leaf names; gemma-4-SOMPOA uses
+    /// full checkpoint paths, all 60 of them. Whichever way it is spelled, what has to come out is
+    /// the MODULE path, because that is what `replaceLayers` matches against.
+    ///
+    /// Asserted against a live module tree rather than against string handling, so the test fails
+    /// if the expansion stops resolving real modules — not merely if the parsing changes.
+    @Test("target_modules resolves to module paths from leaf names OR from full paths")
+    func targetModulesBothConventions() {
+        let layers: [Module] = [ProbeLayer(), ProbeLayer()]
+        let expected = ["mlp.down_proj", "self_attn.o_proj"]
+
+        let fromLeaves = PEFTAdapterTestBridge.expandTargetKeys(["o_proj", "down_proj"], in: layers)
+        #expect(fromLeaves == expected)
+
+        // The same two projections, spelled as checkpoint paths from a DIFFERENT model's naming.
+        // The layer indices in them are noise: which layers get LoRA is carried by `numLayers` and
+        // by which weights the adapter ships, never by these strings.
+        let fromPaths = PEFTAdapterTestBridge.expandTargetKeys(
+            [
+                "model.language_model.layers.16.mlp.down_proj",
+                "model.language_model.layers.7.self_attn.o_proj",
+            ], in: layers)
+        #expect(fromPaths == expected, "full-path targets resolved to \(fromPaths)")
+        #expect(fromPaths == fromLeaves, "the two spellings must be interchangeable")
+    }
+
+    /// A target the model does not have must NOT silently become a module path.
+    @Test("an unknown target expands to nothing invented")
+    func unknownTargetIsNotInvented() {
+        let expanded = PEFTAdapterTestBridge.expandTargetKeys(["not_a_projection"], in: [ProbeLayer()])
+        #expect(!expanded.contains { $0.hasPrefix("mlp.") || $0.hasPrefix("self_attn.") })
+    }
+
+    /// An MLX-native adapter must keep loading exactly as before.
+    @Test("an MLX adapter is not mistaken for a PEFT one")
+    func mlxAdapterUnaffected() {
+        let json = #"{"fine_tune_type":"lora","num_layers":28,"lora_parameters":{"rank":16,"scale":20.0}}"#
+        #expect(PEFTAdapterTestBridge.detect(Data(json.utf8)) == nil)
+    }
+}
+
+/// A two-deep stand-in for a decoder layer: the projections PEFT targets do not sit at the top of a
+/// layer, they sit under `self_attn` / `mlp`, which is the whole reason leaf names need expanding.
+private class ProbeLayer: Module {
+    private class Attention: Module {
+        @ModuleInfo(key: "o_proj") var oProj: Linear
+        override init() { self._oProj.wrappedValue = Linear(4, 4); super.init() }
+    }
+    private class Feedforward: Module {
+        @ModuleInfo(key: "down_proj") var downProj: Linear
+        override init() { self._downProj.wrappedValue = Linear(4, 4); super.init() }
+    }
+    @ModuleInfo(key: "self_attn") private var attention: Attention
+    @ModuleInfo(key: "mlp") private var feedforward: Feedforward
+    override init() {
+        self._attention.wrappedValue = Attention()
+        self._feedforward.wrappedValue = Feedforward()
+        super.init()
+    }
+}


### PR DESCRIPTION
A published LoRA adapter cannot currently be loaded. Every adapter on the Hub is
in **PEFT** format, and `LoRAContainer.from(directory:)` reads only MLX's own
layout, so it fails on the first field:

```
keyNotFound(CodingKeys(stringValue: "num_layers"))
```

Fixing that alone produces three more errors, each further in. This adds the
adapter-side equivalent of a model's `sanitize(weights:)`.

## The four mismatches

| # | Symptom | Cause |
|---|---|---|
| 1 | `keyNotFound "num_layers"` | PEFT does not record it |
| 2 | `Unhandled keys ["model"]` | adapter has **checkpoint** paths, tree has **module** paths |
| 3 | `0 lora slot(s)` | `target_modules` names **leaves**, `replaceLayers` matches full child keys |
| 4 | *nothing* | both factors are **transposed** relative to MLX |

`num_layers` is counted from the weights — the number of distinct `layers.N`
indices the adapter actually touches.

## Why (4) is the dangerous one

`LoRALinear` computes `y + scale * (x @ a @ b)` with `a = (in, rank)` and
`b = (rank, out)`. PEFT stores `A = (rank, in)` and `B = (out, rank)`:

```
PEFT : y = (alpha/r) * (x @ Aᵀ @ Bᵀ)
MLX  : y = scale     * (x @ a  @ b )     so  a = Aᵀ,  b = Bᵀ
```

Where the dimensions happen to agree, an un-transposed factor **loads fine and
computes a different function** — the model generates fluent, plausible, wrong
text, and nothing downstream reports it.

`scale` is the same kind of trap: PEFT's is `lora_alpha / r`. For both adapters
tested, alpha and r are 32, so the scale is 1.0 — taking MLX's default of 10–20
instead would apply the update at ten to twenty times its intended strength,
and the model would still load and still generate.

So the round trip is asserted **numerically against the reference formula**,
with a negative control that drops each transpose and requires the result to
disagree. Loading successfully is not treated as evidence.

## Re-keying by suffix, not per family

PEFT records checkpoint paths, which are not module paths — the adapter says
`model.language_model.layers.0.…` while the tree says
`language_model.model.layers.0.…`. That is exactly the swap a base model's
`sanitize` performs.

Matching by **suffix against the live module tree** is deliberate. The 85
`sanitize` implementations exist because every family spells its checkpoint
differently; requiring an 86th for adapters would repeat that cost and leave
the next family broken again. A LoRA target is identified by its tail —
`layers.N.<module>.<proj>.lora_a` — and that tail is stable across the prefixes
families disagree about.

An unmatched or ambiguous key is an **error**, never a silent drop: an adapter
that loads with half its factors missing still generates fluent text.

## target_modules has two spellings, and both are real

```
Qwen3.8-absolute-heresy : ["o_proj", "out_proj", "down_proj"]              leaves
gemma-4-SOMPOA-heresy   : ["model.language_model.layers.16.mlp.down_proj", …]  full paths
```

Two adapters, same author, opposite conventions. Both are reduced to leaves so
one rule covers both, then expanded against the live layers — **every** layer,
not a sample: Qwen 3.8 is hybrid, with `linear_attn.out_proj` early and
`self_attn.o_proj` later, and this adapter targets both. Sampling layer 0 alone
found 112 of 144 slots and left 32 parameters unmatched.

Mutation-checked: removing the leaf reduction makes the full-path adapter
resolve to zero modules, which is the original silent failure.

## MLX-native adapters are unaffected

PEFT is detected by `peft_type` present **and** `fine_tune_type` absent, so an
MLX adapter is never mistaken for a PEFT one even if a converter later writes
both. A key that already matches the model passes through untouched. Covered by
a test.

## Verification

Two published adapters, each on its own base, at temperature 0:

| adapter | base | result |
|---|---|---|
| `MuXodious/Qwen3.8-27B-absolute-heresy-LoRA` | `Qwen3.8-27B-MLX-4bit` | loads, coherent, output changes |
| `MuXodious/gemma-4-26B-A4B-it-SOMPOA-heresy-LoRA` | `gemma-4-26B-A4B-it-QAT-MLX-4bit` | loads, coherent, output changes |

Same prompt, adapter off then on:

```
without : The salt had long ago etched itself into the deep lines of Elias's face,
          a permanent map of a life spent watching the horizon for things that
          never quite arrived.
with    : The salt had long since become a part of Elias's skin, a permanent crust
          that felt less like residue and more like a second, harder layer of soul.
```

Both halves matter. Coherence alone would be satisfied by an adapter that failed
to apply; a changed output alone would be satisfied by one applied wrongly.

## Scope

The gap is not specific to this port — `mlx-lm` has no mention of PEFT either,
and its loader validates leaf names against exactly `{lora_a, lora_b, m}`. Base
models load from HF unchanged only because 85 model files each carry a
hand-written translator; the adapter path had none.

## Building this branch

Independent of this change, upstream `main` does not currently compile on Swift
6.4 — `Libraries/MLXVLM/Models/Qwen35.swift:183` fails with *"the compiler is
unable to type-check this expression in reasonable time"*, which is what #319
fixes. It will stop you building this branch as-is.

Verified on `upstream main + #319 + this PR` and nothing else: clean build, all
six tests pass. This PR shares no code with #319 and does not otherwise depend
on it.
