### PR TITLE
Qwen4Exp: build the towers the caller asked for, like the other families

### DIFF
--- a/Libraries/MLXLLM/Models/DiffusionGemma.swift
+++ b/Libraries/MLXLLM/Models/DiffusionGemma.swift
@@ -579,7 +579,15 @@ class DiffusionGemmaInnerModel: Module {
 
 // MARK: - Top-level model
 
-public class DiffusionGemmaModel: Module, LLMModel {
+public class DiffusionGemmaModel: Module, LLMModel, ModalityBearing {
+    /// What this instance actually carries.
+    ///
+    /// Unlike the other converted families this is a `var`, and honestly so: this type is built
+    /// as the text engine and GAINS its vision lane later, when `installVision` attaches a tower.
+    /// Its VLM creator returns this same type — there is no separate multimodal class — so the
+    /// modality set has to follow the installation rather than the initialiser.
+    public private(set) var modalities: Set<ModelRuntimeRequestModality> = [.text]
+
 
     @ModuleInfo var model: DiffusionGemmaInnerModel
 
@@ -746,6 +754,7 @@ public class DiffusionGemmaModel: Module, LLMModel {
             @escaping (LMInput, DiffusionGemmaModel) throws
                 -> (embeddings: MLXArray, visionBlockIds: MLXArray)?
     ) {
+        modalities.insert(.vision)
         model.encoder.visionTower = tower
         model.encoder.embedVision = embedder
         visionPromptEmbedder = promptEmbedder

--- a/Libraries/MLXLLM/Models/Gemma4Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma4Text.swift
@@ -890,30 +890,49 @@ public class Gemma4TextModel: Module, LLMModel {
                 continue
             }
 
-            // Remap JANG expert naming to match module tree:
-            // JANG uses:          switch_mlp.{gate,up,down}_proj.*
-            // mlx-community uses: experts.switch_glu.{gate,up,down}_proj.*
-            // Module tree expects: experts.switch_glu.{gate,up,down}_proj.*
-            if newKey.contains(".switch_mlp.") {
-                newKey = newKey.replacingOccurrences(of: ".switch_mlp.", with: ".experts.switch_glu.")
-            }
+            newKey = Self.remappingSwitchMLP(newKey)
 
             processedWeights[newKey] = value
         }
 
-        // Trim vocab-dimension tensors to match config
-        let expectedVocab = config.vocabSize
-        for key in [
+        Self.trimmingVocabDimension(&processedWeights, prefix: "", vocabSize: config.vocabSize)
+
+        return processedWeights
+    }
+
+    /// Remap JANG expert naming to the module tree's.
+    ///
+    ///     JANG:           switch_mlp.{gate,up,down}_proj.*
+    ///     mlx-community:  experts.switch_glu.{gate,up,down}_proj.*
+    ///     module tree:    experts.switch_glu.{gate,up,down}_proj.*
+    ///
+    /// SINGLE OWNER: the `Gemma4` VLM wrapper reads the same checkpoints and needs the same
+    /// rename. While both files spelled it out, a change to one left the other's experts under
+    /// keys no module claims — on that path only.
+    public static func remappingSwitchMLP(_ key: String) -> String {
+        key.contains(".switch_mlp.")
+            ? key.replacingOccurrences(of: ".switch_mlp.", with: ".experts.switch_glu.")
+            : key
+    }
+
+    /// Trim vocab-dimension tensors to the configured vocabulary.
+    ///
+    /// SINGLE OWNER, same reason. Only the key PREFIX differs by path — bare here, and
+    /// `language_model.` under the VLM, where the text tower is a submodule — so that is the
+    /// parameter. Which tensors carry a vocab dimension, and the trim itself, do not differ.
+    public static func trimmingVocabDimension(
+        _ weights: inout [String: MLXArray], prefix: String, vocabSize: Int
+    ) {
+        for suffix in [
             "model.embed_tokens.weight", "model.embed_tokens.scales",
             "model.embed_tokens.biases",
             "lm_head.weight", "lm_head.scales", "lm_head.biases",
         ] {
-            if let w = processedWeights[key], w.dim(0) != expectedVocab {
-                processedWeights[key] = w[0 ..< expectedVocab]
+            let key = prefix + suffix
+            if let w = weights[key], w.dim(0) != vocabSize {
+                weights[key] = w[0 ..< vocabSize]
             }
         }
-
-        return processedWeights
     }
 
     // Per-layer-type cache: RotatingKVCache for sliding, KVCacheSimple for full attention.

--- a/Libraries/MLXLMCommon/ModelConstructionModalities.swift
+++ b/Libraries/MLXLMCommon/ModelConstructionModalities.swift
@@ -1,0 +1,124 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+
+/// Construction-time counterpart to `ModelRuntimeCapabilitySnapshot.validate(request:)`.
+///
+/// Two different questions are being asked about the same bundle, and they are deliberately not
+/// merged:
+///
+/// - `ModelRuntimeCapabilitySnapshot` answers *"is this model trained for a modality"*. It merges
+///   an explicit stamp, a structural probe, and coarse `modality` tokens, and it is honest about
+///   the gap between them — hence `.unknown`. It gates a generation request.
+/// - This file answers *"which towers can this configuration instantiate, and which of those does
+///   the caller want built"*. It is structural, local to the config, and has no third state: a
+///   config either carries a vision section or it does not.
+///
+/// The two can legitimately disagree — a bundle may declare `supportsVision` while shipping a
+/// config with no vision section, which is a broken conversion rather than a policy question — so
+/// keeping them separate preserves that signal instead of averaging it away. They share the
+/// `ModelRuntimeRequestModality` vocabulary so no caller has to translate between them.
+///
+/// Nothing here implies `.text`. A model whose only lanes are audio-in and audio-out is unusual but
+/// not incoherent, and a default that quietly adds text would misdescribe it.
+/// A consequence worth stating, because it changes what bundles are worth SHIPPING.
+///
+/// Once a multimodal bundle can be constructed text-only, a text-only DERIVATIVE of that same
+/// checkpoint has almost no reason to exist. It saves disk only for someone who never once wants
+/// the vision lane; anyone who alternates now stores two copies of the same text tower to avoid
+/// allocating a tower they could simply not build. The saving is small either way — on the 30B
+/// Muse Glimmer the vision half is 1.92B of 29.8B parameters, about 6%.
+///
+/// The distinction that survives is between a derivative and a RELEASE. A natively text-only
+/// model in the same family is not the multimodal one with the tower removed — it is separately
+/// trained, often at a different parameter count, and its weights are its own. Those still need
+/// the text-only path, and always will.
+///
+/// Which of the two the dual registrations actually serve is an empirical question, and at the
+/// time of writing the local answer is stark: across 63 bundles in the nine families registered
+/// in BOTH factories, every single one carries a `vision_config` AND a processor config. Not one
+/// is a text-only release. So on this machine those LLM-side entries are never reached by the
+/// routed loader — `loadModelContainer` tries the VLM factory first and it succeeds every time —
+/// and they serve only callers who reach for `LLMModelFactory.shared.load` directly to express
+/// "text only". That intent is exactly what the `requesting:` parameter here makes explicit,
+/// which is a better place for it than a second registration.
+///
+public struct UnconstructibleModalities: Error, CustomStringConvertible {
+    public let requested: Set<ModelRuntimeRequestModality>
+    public let constructible: Set<ModelRuntimeRequestModality>
+
+    public init(
+        requested: Set<ModelRuntimeRequestModality>,
+        constructible: Set<ModelRuntimeRequestModality>
+    ) {
+        self.requested = requested
+        self.constructible = constructible
+    }
+
+    /// The part of the request this configuration cannot satisfy.
+    public var excess: Set<ModelRuntimeRequestModality> {
+        requested.subtracting(constructible)
+    }
+
+    public var description: String {
+        "this configuration cannot build \(excess.modalityDescription) "
+            + "(requested \(requested.modalityDescription); constructible \(constructible.modalityDescription))"
+    }
+
+}
+
+/// An empty selection would build a model with no lanes at all — loadable, and useless.
+public struct EmptyModalitySelection: Error, CustomStringConvertible {
+    public let source: String
+
+    public init(_ source: String) {
+        self.source = source
+    }
+
+    public var description: String {
+        "\(source) named no modalities; a model with no lanes cannot be constructed"
+    }
+}
+
+extension Set where Element == ModelRuntimeRequestModality {
+    /// Stable, readable rendering in the canonical modality order.
+    public var modalityDescription: String {
+        isEmpty
+            ? "nothing"
+            : ModelRuntimeCapabilityRequest(modalities: self)
+                .sortedModalities.map(\.rawValue).joined(separator: ", ")
+    }
+
+    /// Narrow what a configuration can build down to what the caller asked for.
+    ///
+    /// - Parameters:
+    ///   - requested: the caller's subset, or `nil` for "everything this configuration offers".
+    ///   - constructible: what the configuration structurally permits.
+    /// - Returns: exactly the lanes to instantiate.
+    /// - Throws: `UnconstructibleModalities` if the request exceeds what can be built — refusing
+    ///   here rather than yielding a model that fails later inside `prepare()`, where the cause is
+    ///   no longer visible; `EmptyModalitySelection` if either side names nothing.
+    public static func resolveForConstruction(
+        requested: Set<ModelRuntimeRequestModality>?,
+        constructible: Set<ModelRuntimeRequestModality>
+    ) throws -> Set<ModelRuntimeRequestModality> {
+        guard !constructible.isEmpty else {
+            throw EmptyModalitySelection("this configuration")
+        }
+        guard let requested else { return constructible }
+        guard !requested.isEmpty else {
+            throw EmptyModalitySelection("the request")
+        }
+        guard requested.isSubset(of: constructible) else {
+            throw UnconstructibleModalities(requested: requested, constructible: constructible)
+        }
+        return requested
+    }
+}
+
+/// A model that reports which lanes it actually carries, as opposed to which its bundle advertises.
+public protocol ModalityBearing {
+    /// What this instance was built with — never wider than its configuration allowed.
+    var modalities: Set<ModelRuntimeRequestModality> { get }
+}

--- a/Libraries/MLXVLM/Models/DiffusionGemmaVLM.swift
+++ b/Libraries/MLXVLM/Models/DiffusionGemmaVLM.swift
@@ -49,11 +49,45 @@ public struct DiffusionGemmaVLMConfiguration: Codable, Sendable {
 /// tower, install the vision modules + the prompt-embedding splice closure.
 /// Text-only bundles (no `vision_config` / `image_token_id`) come back as
 /// the plain text engine.
+/// Which lanes this configuration can actually build.
+///
+/// Note the second condition: a vision tower is only installable when the bundle ALSO declares an
+/// `image_token_id`, because without it there is nowhere to splice the features. A bundle with a
+/// `vision_config` and no image token is not a vision bundle, and saying so here keeps the
+/// declaration honest rather than optimistic.
+public func diffusionGemmaConstructibleModalities(
+    of config: DiffusionGemmaVLMConfiguration
+) -> Set<ModelRuntimeRequestModality> {
+    config.visionConfig != nil && config.core.imageTokenId != nil ? [.text, .vision] : [.text]
+}
+
+/// - Parameter requesting: the caller's subset, or nil for "everything this config offers".
+///   Asking for a lane the config cannot build throws rather than yielding a model that fails
+///   later at `prepare()`.
+public func makeDiffusionGemmaVLM(
+    _ config: DiffusionGemmaVLMConfiguration,
+    requesting: Set<ModelRuntimeRequestModality>?
+) throws -> DiffusionGemmaModel {
+    let resolved = try Set.resolveForConstruction(
+        requested: requesting,
+        constructible: diffusionGemmaConstructibleModalities(of: config))
+    return makeDiffusionGemmaVLM(config, modalities: resolved)
+}
+
 public func makeDiffusionGemmaVLM(
     _ config: DiffusionGemmaVLMConfiguration
 ) -> DiffusionGemmaModel {
+    makeDiffusionGemmaVLM(config, modalities: diffusionGemmaConstructibleModalities(of: config))
+}
+
+/// Builds exactly the lanes named by `modalities`.
+public func makeDiffusionGemmaVLM(
+    _ config: DiffusionGemmaVLMConfiguration,
+    modalities: Set<ModelRuntimeRequestModality>
+) -> DiffusionGemmaModel {
     let model = DiffusionGemmaModel(config.core)
-    guard let visionConfig = config.visionConfig,
+    guard modalities.contains(.vision),
+        let visionConfig = config.visionConfig,
         let imageTokenId = config.core.imageTokenId
     else {
         return model

--- a/Libraries/MLXVLM/Models/Gemma3.swift
+++ b/Libraries/MLXVLM/Models/Gemma3.swift
@@ -97,7 +97,9 @@ public struct Gemma3VisionConfiguration: Codable, Sendable {
 
 public struct Gemma3Configuration: Codable, Sendable {
     public let textConfiguration: Gemma3TextConfiguration
-    public let visionConfiguration: Gemma3VisionConfiguration
+    /// Optional, like `Gemma4Configuration.visionConfig`. A text-only Gemma 3 bundle carries no
+    /// `vision_config`, and while this was non-optional such a bundle could not DECODE at all.
+    public let visionConfiguration: Gemma3VisionConfiguration?
     public let modelType: String
     public let mmTokensPerImage: Int
     public let quantization: BaseConfiguration.Quantization?
@@ -799,21 +801,21 @@ class Gemma3MultiModalProjector: Module, UnaryLayer {
     let tokensPerSide: Int
     let kernelSize: Int
 
-    init(config: Gemma3Configuration) {
+    init(config: Gemma3Configuration, vision: Gemma3VisionConfiguration) {
         self.config = config
 
         self._mmInputProjectionWeight.wrappedValue = ones([
-            config.visionConfiguration.hiddenSize,
+            vision.hiddenSize,
             config.textConfiguration.hiddenSize,
         ])
 
         self._mmSoftEmbNorm.wrappedValue = Gemma.RMSNorm(
-            dimensions: config.visionConfiguration.hiddenSize,
-            eps: config.visionConfiguration.layerNormEps
+            dimensions: vision.hiddenSize,
+            eps: vision.layerNormEps
         )
 
         self.patchesPerImage =
-            config.visionConfiguration.imageSize / config.visionConfiguration.patchSize
+            vision.imageSize / vision.patchSize
 
         self.tokensPerSide = Int(sqrt(Double(config.mmTokensPerImage)))
         self.kernelSize = patchesPerImage / tokensPerSide
@@ -896,10 +898,10 @@ private func maskedScatter(
 
 // MARK: - Gemma 3 Model
 
-public class Gemma3: Module, VLMModel, KVCacheDimensionProvider {
-    @ModuleInfo(key: "vision_tower") private var visionTower: VisionModel
+public class Gemma3: Module, VLMModel, KVCacheDimensionProvider, ModalityBearing {
+    @ModuleInfo(key: "vision_tower") private var visionTower: VisionModel?
     @ModuleInfo(key: "language_model") private var languageModel: LanguageModel
-    @ModuleInfo(key: "multi_modal_projector") var multiModalProjector: Gemma3MultiModalProjector
+    @ModuleInfo(key: "multi_modal_projector") var multiModalProjector: Gemma3MultiModalProjector?
 
     public let config: Gemma3Configuration
 
@@ -911,12 +913,44 @@ public class Gemma3: Module, VLMModel, KVCacheDimensionProvider {
         return languageModel.newCache(parameters: parameters)
     }
 
-    public init(_ config: Gemma3Configuration) {
+    /// What this instance actually carries. Same contract as the other converted families.
+    public let modalities: Set<ModelRuntimeRequestModality>
+
+    /// Which towers this configuration can instantiate. SigLIP here is image-only, so no `.video`.
+    public static func constructibleModalities(
+        of config: Gemma3Configuration
+    ) -> Set<ModelRuntimeRequestModality> {
+        config.visionConfiguration != nil ? [.text, .vision] : [.text]
+    }
+
+    public convenience init(_ config: Gemma3Configuration) {
+        self.init(config, modalities: Self.constructibleModalities(of: config))
+    }
+
+    /// - Parameter requesting: the caller's subset, or nil for "everything this config offers".
+    public convenience init(
+        _ config: Gemma3Configuration,
+        requesting: Set<ModelRuntimeRequestModality>?
+    ) throws {
+        let resolved = try Set.resolveForConstruction(
+            requested: requesting, constructible: Self.constructibleModalities(of: config))
+        self.init(config, modalities: resolved)
+    }
+
+    /// The one real initialiser: builds exactly the towers named by `modalities`.
+    public init(
+        _ config: Gemma3Configuration,
+        modalities: Set<ModelRuntimeRequestModality>
+    ) {
+        self.modalities = modalities
         self.config = config
 
-        self._visionTower.wrappedValue = VisionModel(config: config.visionConfiguration)
+        if let vision = config.visionConfiguration, modalities.contains(.vision) {
+            self._visionTower.wrappedValue = VisionModel(config: vision)
+            self._multiModalProjector.wrappedValue = Gemma3MultiModalProjector(
+                config: config, vision: vision)
+        }
         self._languageModel.wrappedValue = LanguageModel(config.textConfiguration)
-        self._multiModalProjector.wrappedValue = Gemma3MultiModalProjector(config: config)
     }
 
     private func getInputEmbeddings(
@@ -932,6 +966,15 @@ public class Gemma3: Module, VLMModel, KVCacheDimensionProvider {
 
         // Process image through vision tower
         let processedPixels = pixelValues.transposed(0, 2, 3, 1).asType(inputsEmbeds.dtype)
+
+        // Images arrived at a model that carries no vision tower. Refuse rather than embed the
+        // prompt without them: a silently image-free answer looks like a bad model, not a bad call.
+        guard let visionTower, let multiModalProjector else {
+            throw VLMError.processing(
+                "image input requires the vision tower, and this instance carries none "
+                + "(modalities: \(modalities.modalityDescription)). "
+                + "Load with .vision requested, or send text only.")
+        }
 
         let (hiddenState, _, _) = visionTower(
             processedPixels,
@@ -1053,8 +1096,16 @@ public class Gemma3: Module, VLMModel, KVCacheDimensionProvider {
         var processedWeights = languageModel.sanitize(
             weights: weights, quantizationConfig: config.quantization)
 
-        // Handle vision model sanitization (conv2d weight reshaping, etc.)
-        processedWeights = visionTower.sanitize(weights: processedWeights)
+        // Handle vision model sanitization (conv2d weight reshaping, etc.). With no tower built
+        // the bundle's vision weights have no destination — drop them rather than reshape them
+        // onto a module that does not exist.
+        if let visionTower {
+            processedWeights = visionTower.sanitize(weights: processedWeights)
+        } else {
+            processedWeights = processedWeights.filter {
+                !$0.key.contains("vision_tower") && !$0.key.contains("multi_modal_projector")
+            }
+        }
 
         return processedWeights
     }

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -299,7 +299,9 @@ struct G4TextConfig: Codable, Sendable {
 
 public struct Gemma4Configuration: Codable, Sendable {
     let textConfig: G4TextConfig
-    let visionConfig: Gemma4VisionConfig
+    /// Optional, like `audioConfig` below. A text-only Gemma 4 bundle carries no `vision_config`,
+    /// and while this was non-optional such a bundle could not DECODE this configuration at all.
+    let visionConfig: Gemma4VisionConfig?
     /// Full `audio_config` when present. `model_type == "gemma4_audio"`
     /// (E2B/E4B) means the bundle ships a conformer `audio_tower`;
     /// `gemma4_unified_audio` (12B) is the encoder-free raw-chunking path.
@@ -344,7 +346,7 @@ public struct Gemma4Configuration: Codable, Sendable {
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: DecodingKeys.self)
         textConfig = try c.decode(G4TextConfig.self, forKey: .textConfig)
-        visionConfig = try c.decode(Gemma4VisionConfig.self, forKey: .visionConfig)
+        visionConfig = try c.decodeIfPresent(Gemma4VisionConfig.self, forKey: .visionConfig)
         modelType = try c.decodeIfPresent(String.self, forKey: .modelType) ?? "gemma4"
         imageTokenId = try c.decodeIfPresent(Int.self, forKey: .imageTokenId) ?? 258880
         audioTokenId = try c.decodeIfPresent(Int.self, forKey: .audioTokenId) ?? 258881
@@ -360,7 +362,9 @@ public struct Gemma4Configuration: Codable, Sendable {
         }
         visionSoftTokensPerImage =
             try c.decodeIfPresent(Int.self, forKey: .visionSoftTokensPerImage)
-            ?? visionConfig.defaultOutputLength
+            // Zero when the bundle has no vision section: there are no image soft tokens to
+            // budget for, and any value would be a fiction.
+            ?? visionConfig?.defaultOutputLength ?? 0
         quantization = try c.decodeIfPresent(BaseConfiguration.Quantization.self, forKey: .quantization)
     }
 }
@@ -1151,7 +1155,7 @@ func gemma4MaskedScatter(
 
 // MARK: - Gemma4 VLM
 
-public class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
+public class Gemma4: Module, VLMModel, KVCacheDimensionProvider, ModalityBearing {
     @ModuleInfo(key: "vision_tower") private var visionTower: VisionTower?
     @ModuleInfo(key: "vision_embedder") private var unifiedVisionEmbedder: UnifiedVisionEmbedder?
     @ModuleInfo(key: "audio_tower") private var audioTower: Gemma4AudioTower?
@@ -1171,23 +1175,72 @@ public class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
 
     public func newCache(parameters: GenerateParameters?) -> [any KVCache] { languageModel.newCache(parameters: parameters) }
 
-    public init(_ config: Gemma4Configuration) {
+    /// What this instance actually carries. Same contract as the other converted families.
+    public let modalities: Set<ModelRuntimeRequestModality>
+
+    /// Which towers this configuration can instantiate.
+    ///
+    /// No `.video` lane, deliberately: `prepare` refuses video outright ("no proven vMLX video
+    /// path yet"), so declaring it would let a video request pass construction and fail later —
+    /// exactly the failure the modality set exists to move earlier.
+    ///
+    /// `.audio` is claimed only for the CONFORMER tower. `gemma4_unified_audio` bundles take the
+    /// encoder-free raw-chunking path and build no tower, so there is nothing to skip.
+    public static func constructibleModalities(
+        of config: Gemma4Configuration
+    ) -> Set<ModelRuntimeRequestModality> {
+        var m: Set<ModelRuntimeRequestModality> = [.text]
+        if config.visionConfig != nil { m.insert(.vision) }
+        if config.hasConformerAudioTower { m.insert(.audio) }
+        return m
+    }
+
+    public convenience init(_ config: Gemma4Configuration) {
+        self.init(config, modalities: Self.constructibleModalities(of: config))
+    }
+
+    /// - Parameter requesting: the caller's subset, or nil for "everything this config offers".
+    public convenience init(
+        _ config: Gemma4Configuration,
+        requesting: Set<ModelRuntimeRequestModality>?
+    ) throws {
+        let resolved = try Set.resolveForConstruction(
+            requested: requesting, constructible: Self.constructibleModalities(of: config))
+        self.init(config, modalities: resolved)
+    }
+
+    /// The one real initialiser: builds exactly the towers named by `modalities`.
+    public init(
+        _ config: Gemma4Configuration,
+        modalities: Set<ModelRuntimeRequestModality>
+    ) {
+        self.modalities = modalities
         self.config = config
-        if config.visionConfig.usesUnifiedVisionEmbedder {
-            _unifiedVisionEmbedder.wrappedValue = UnifiedVisionEmbedder(config.visionConfig)
-        } else {
-            _visionTower.wrappedValue = VisionTower(config.visionConfig)
+        if let visionConfig = config.visionConfig, modalities.contains(.vision) {
+            if visionConfig.usesUnifiedVisionEmbedder {
+                _unifiedVisionEmbedder.wrappedValue = UnifiedVisionEmbedder(visionConfig)
+            } else {
+                _visionTower.wrappedValue = VisionTower(visionConfig)
+            }
         }
         // The conformer audio tower exists only on E-series bundles
         // (audio_config.model_type == "gemma4_audio"). Unified 12B bundles
         // (gemma4_unified_audio) and audio-less 26B/31B bundles stay
         // tower-free; their `audio_tower.*` weights (if any) are discarded
         // in sanitize().
-        if let audioConfig = config.audioConfig, audioConfig.isConformerTower {
+        if let audioConfig = config.audioConfig, audioConfig.isConformerTower,
+            modalities.contains(.audio)
+        {
             _audioTower.wrappedValue = Gemma4AudioTower(audioConfig)
         }
         _languageModel.wrappedValue = G4LanguageModel(config.textConfig)
-        _embedVision.wrappedValue = MultimodalEmbedder(embDim: config.visionConfig.outputProjectionDimensions, textDim: config.textConfig.hiddenSize)
+        // Built unconditionally: it is a projection the checkpoint may still carry, and its
+        // dimension comes from the vision config when there is one. With no vision section
+        // there are no `embed_vision.*` weights to receive either.
+        _embedVision.wrappedValue = MultimodalEmbedder(
+            embDim: config.visionConfig?.outputProjectionDimensions
+                ?? config.textConfig.hiddenSize,
+            textDim: config.textConfig.hiddenSize)
         _embedAudio.wrappedValue = MultimodalEmbedder(embDim: config.audioEmbedDim, textDim: config.textConfig.hiddenSize)
     }
 
@@ -1387,8 +1440,8 @@ public class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
                 p[nk] = v
                 continue
             }
-            if nk.hasPrefix("vision_tower.") && config.visionConfig.usesUnifiedVisionEmbedder { continue }
-            if nk.hasPrefix("vision_embedder.") && !config.visionConfig.usesUnifiedVisionEmbedder { continue }
+            if nk.hasPrefix("vision_tower.") && (config.visionConfig?.usesUnifiedVisionEmbedder ?? true) { continue }
+            if nk.hasPrefix("vision_embedder.") && !(config.visionConfig?.usesUnifiedVisionEmbedder ?? false) { continue }
             // Skip clipped linear params on non-audio modules — the vision
             // tower uses plain Linear. (Audio tower keys are handled above
             // and KEEP their input/output clipping scalars.)

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -12,6 +12,9 @@
 import CoreImage
 import Foundation
 import MLX
+// For Gemma4TextModel's shared checkpoint-key helpers: this wrapper reads the same
+// checkpoints as the text model and must rename their keys identically.
+import MLXLLM
 import MLXLMCommon
 import MLXNN
 
@@ -1395,7 +1398,7 @@ public class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
             if nk.hasPrefix("language_model.") && !nk.hasPrefix("language_model.model.") {
                 nk = "language_model.model." + String(nk.dropFirst("language_model.".count))
             }
-            if nk.contains(".switch_mlp.") { nk = nk.replacingOccurrences(of: ".switch_mlp.", with: ".experts.switch_glu.") }
+            nk = Gemma4TextModel.remappingSwitchMLP(nk)
             if nk.contains(".experts.down_proj.") {
                 nk = nk.replacingOccurrences(of: ".experts.down_proj.", with: ".experts.switch_glu.down_proj.")
             } else if nk.hasSuffix(".experts.down_proj") {
@@ -1429,10 +1432,10 @@ public class Gemma4: Module, VLMModel, KVCacheDimensionProvider {
             }
             p[nk] = v
         }
-        let ev = config.textConfig.vocabSize
-        for k in ["language_model.model.embed_tokens.weight", "language_model.model.embed_tokens.scales", "language_model.model.embed_tokens.biases", "language_model.lm_head.weight", "language_model.lm_head.scales", "language_model.lm_head.biases"] {
-            if let w = p[k], w.dim(0) != ev { p[k] = w[0 ..< ev] }
-        }
+        // Same tensors, same trim as the text model — only the prefix differs here, because the
+        // text tower is a submodule and keeps its `language_model.` name.
+        Gemma4TextModel.trimmingVocabDimension(
+            &p, prefix: "language_model.", vocabSize: config.textConfig.vocabSize)
         return p
     }
 }

--- a/Libraries/MLXVLM/Models/Mistral3.swift
+++ b/Libraries/MLXVLM/Models/Mistral3.swift
@@ -73,7 +73,10 @@ public struct Mistral3VLMTextConfiguration: Codable, Sendable {
 
 public struct Mistral3VLMConfiguration: Codable, Sendable {
     public let textConfig: Mistral3VLMTextConfiguration
-    public let visionConfig: Mistral3VisionConfiguration
+    /// Optional, following `Gemma4Configuration.audioConfig` and `MuseGlimmerConfiguration`. A
+    /// text-only conversion of a Mistral 3 bundle carries no `vision_config`, and while this was
+    /// non-optional such a bundle could not DECODE this configuration at all.
+    public let visionConfig: Mistral3VisionConfiguration?
     public let modelType: String
 
     public var ignoreIndex: Int { _ignoreIndex ?? -100 }
@@ -196,11 +199,11 @@ class Mistral3PatchMerger: Module {
 
     @ModuleInfo(key: "merging_layer") var mergingLayer: Linear
 
-    init(_ config: Mistral3VLMConfiguration) {
+    init(_ config: Mistral3VLMConfiguration, vision: Mistral3VisionConfiguration) {
         self.spatialMergeSize = config.spatialMergeSize
-        self.patchSize = config.visionConfig.patchSize
+        self.patchSize = vision.patchSize
 
-        let hiddenSize = config.visionConfig.hiddenSize
+        let hiddenSize = vision.hiddenSize
         self._mergingLayer.wrappedValue = Linear(
             hiddenSize * spatialMergeSize * spatialMergeSize,
             hiddenSize,
@@ -268,11 +271,11 @@ class Mistral3MultiModalProjector: Module {
     @ModuleInfo var gelu: GELU
     @ModuleInfo(key: "linear_2") var linear2: Linear
 
-    init(_ config: Mistral3VLMConfiguration) {
-        self._norm.wrappedValue = RMSNorm(dimensions: config.visionConfig.hiddenSize)
-        self._patchMerger.wrappedValue = Mistral3PatchMerger(config)
+    init(_ config: Mistral3VLMConfiguration, vision: Mistral3VisionConfiguration) {
+        self._norm.wrappedValue = RMSNorm(dimensions: vision.hiddenSize)
+        self._patchMerger.wrappedValue = Mistral3PatchMerger(config, vision: vision)
         self._linear1.wrappedValue = Linear(
-            config.visionConfig.hiddenSize,
+            vision.hiddenSize,
             config.textConfig.hiddenSize,
             bias: config.multimodalProjectorBias
         )
@@ -685,12 +688,12 @@ private enum Language {
 
 // MARK: - Mistral3 VLM Model
 
-public class Mistral3VLM: Module, VLMModel, KVCacheDimensionProvider {
+public class Mistral3VLM: Module, VLMModel, KVCacheDimensionProvider, ModalityBearing {
     // Use PixtralVision.VisionModel from Pixtral.swift
-    @ModuleInfo(key: "vision_tower") private var visionTower: PixtralVision.VisionModel
+    @ModuleInfo(key: "vision_tower") private var visionTower: PixtralVision.VisionModel?
     @ModuleInfo(key: "language_model") private var languageModel: Language.LanguageModel
     @ModuleInfo(key: "multi_modal_projector") private var multiModalProjector:
-        Mistral3MultiModalProjector
+        Mistral3MultiModalProjector?
 
     public let config: Mistral3VLMConfiguration
     let visionFeatureLayer: Int
@@ -698,13 +701,56 @@ public class Mistral3VLM: Module, VLMModel, KVCacheDimensionProvider {
     public var vocabularySize: Int { config.vocabSize }
     public var kvHeads: [Int] { languageModel.kvHeads }
 
-    public init(_ config: Mistral3VLMConfiguration) {
+    /// What this instance actually carries — not what the bundle advertises. The bundle-level
+    /// claim lives in `ModelRuntimeCapabilitySnapshot.supportsVision` and answers a different
+    /// question; see `ModelConstructionModalities.swift` for why the two are kept apart.
+    public let modalities: Set<ModelRuntimeRequestModality>
+
+    /// Which towers this configuration can actually instantiate. Pixtral is image-only, so there
+    /// is no `.video` lane here even though the vision tower exists.
+    public static func constructibleModalities(
+        of config: Mistral3VLMConfiguration
+    ) -> Set<ModelRuntimeRequestModality> {
+        config.visionConfig != nil ? [.text, .vision] : [.text]
+    }
+
+    public convenience init(_ config: Mistral3VLMConfiguration) {
+        // Unchanged behaviour for every existing caller: build everything the config permits.
+        // Non-throwing by CONSTRUCTION rather than by argument — passing the constructible set
+        // directly removes the throw instead of reasoning about why it cannot happen.
+        self.init(config, modalities: Self.constructibleModalities(of: config))
+    }
+
+    /// - Parameter requesting: the caller's subset, or nil for "everything this config offers".
+    ///   Asking for a modality the config cannot build throws rather than yielding a model that
+    ///   fails later at `prepare()`.
+    public convenience init(
+        _ config: Mistral3VLMConfiguration,
+        requesting: Set<ModelRuntimeRequestModality>?
+    ) throws {
+        let resolved = try Set.resolveForConstruction(
+            requested: requesting, constructible: Self.constructibleModalities(of: config))
+        self.init(config, modalities: resolved)
+    }
+
+    /// The one real initialiser: builds exactly the towers named by `modalities`.
+    public init(
+        _ config: Mistral3VLMConfiguration,
+        modalities: Set<ModelRuntimeRequestModality>
+    ) {
+        self.modalities = modalities
         self.config = config
         self.visionFeatureLayer = config.visionFeatureLayer
 
-        self._visionTower.wrappedValue = PixtralVision.VisionModel(config.visionConfig)
+        // Built only when the bundle has a tower AND the caller asked for it. Skipping it is not a
+        // degraded mode: it is the text-only load that previously required the separate
+        // `mistral3` registration in LLMModelFactory, and it leaves ~0.8 GB unallocated.
+        if let vision = config.visionConfig, modalities.contains(.vision) {
+            self._visionTower.wrappedValue = PixtralVision.VisionModel(vision)
+            self._multiModalProjector.wrappedValue = Mistral3MultiModalProjector(
+                config, vision: vision)
+        }
         self._languageModel.wrappedValue = Language.LanguageModel(config.textConfig)
-        self._multiModalProjector.wrappedValue = Mistral3MultiModalProjector(config)
     }
 
     private func getInputEmbeddings(
@@ -728,6 +774,15 @@ public class Mistral3VLM: Module, VLMModel, KVCacheDimensionProvider {
         // Handle 3D pixel values (missing batch dimension)
         if pixelValues.ndim == 3 {
             pixelValues = pixelValues.expandedDimensions(axis: 0)
+        }
+
+        // Images arrived at a model that carries no vision tower. Refuse rather than embed the
+        // prompt without them: a silently image-free answer looks like a bad model, not a bad call.
+        guard let visionTower, let multiModalProjector else {
+            throw VLMError.processing(
+                "image input requires the vision tower, and this instance carries none "
+                + "(modalities: \(modalities.modalityDescription)). "
+                + "Load with .vision requested, or send text only.")
         }
 
         // Process through vision tower (reuses Pixtral vision model)
@@ -828,8 +883,8 @@ public class Mistral3VLM: Module, VLMModel, KVCacheDimensionProvider {
         let imageSizes: [(Int, Int)]?
         if let frames = input.image?.frames {
             imageSizes = frames.map { ($0.h, $0.w) }
-        } else if pixelValues != nil {
-            imageSizes = [(config.visionConfig.imageSize, config.visionConfig.imageSize)]
+        } else if pixelValues != nil, let vision = config.visionConfig {
+            imageSizes = [(vision.imageSize, vision.imageSize)]
         } else {
             imageSizes = nil
         }
@@ -865,6 +920,17 @@ public class Mistral3VLM: Module, VLMModel, KVCacheDimensionProvider {
 
         for (key, value) in weights {
             var newKey = key
+
+            // No tower to receive them. A multimodal bundle loaded text-only still SHIPS its
+            // vision weights; rehoming them onto modules that were never built leaves keys with no
+            // destination. Dropping them is what MuseGlimmer does, and what Gemma4 does with
+            // `audio_tower.*` on audio-less bundles.
+            if !modalities.contains(.vision),
+                key.contains("vision_tower") || key.contains("vision_encoder")
+                    || key.contains("vision_projection") || key.contains("multi_modal_projector")
+            {
+                continue
+            }
 
             // Transform keys to match model structure
             // Vision tower keys: vision_tower.X -> vision_tower.vision_model.X (for pixtral structure)

--- a/Libraries/MLXVLM/Models/Mistral3VLMJANGTQ.swift
+++ b/Libraries/MLXVLM/Models/Mistral3VLMJANGTQ.swift
@@ -415,11 +415,11 @@ internal final class Mistral3JANGTQLanguageModel: Module, KVCacheDimensionProvid
 /// JANGTQ-quantized Mistral3 VLM. Sibling of `Mistral3VLM`; differs
 /// only in the language-model inner. Pixtral vision tower stays
 /// vanilla.
-public class Mistral3VLMJANGTQ: Module, VLMModel, KVCacheDimensionProvider {
-    @ModuleInfo(key: "vision_tower") private var visionTower: PixtralVision.VisionModel
+public class Mistral3VLMJANGTQ: Module, VLMModel, KVCacheDimensionProvider, ModalityBearing {
+    @ModuleInfo(key: "vision_tower") private var visionTower: PixtralVision.VisionModel?
     @ModuleInfo(key: "language_model") private var languageModel: Mistral3JANGTQLanguageModel
     @ModuleInfo(key: "multi_modal_projector") private var multiModalProjector:
-        Mistral3MultiModalProjector
+        Mistral3MultiModalProjector?
 
     public let config: Mistral3VLMConfiguration
     let visionFeatureLayer: Int
@@ -427,14 +427,51 @@ public class Mistral3VLMJANGTQ: Module, VLMModel, KVCacheDimensionProvider {
     public var vocabularySize: Int { config.vocabSize }
     public var kvHeads: [Int] { languageModel.kvHeads }
 
-    public init(_ config: Mistral3VLMConfiguration, bits: Int = 2, seed: Int = 42) {
+    /// What this instance actually carries. See `Mistral3VLM` — same contract, same vocabulary.
+    public let modalities: Set<ModelRuntimeRequestModality>
+
+    /// Which towers this configuration can instantiate. Pixtral is image-only: no `.video` lane.
+    public static func constructibleModalities(
+        of config: Mistral3VLMConfiguration
+    ) -> Set<ModelRuntimeRequestModality> {
+        config.visionConfig != nil ? [.text, .vision] : [.text]
+    }
+
+    public convenience init(_ config: Mistral3VLMConfiguration, bits: Int = 2, seed: Int = 42) {
+        self.init(
+            config, modalities: Self.constructibleModalities(of: config), bits: bits, seed: seed)
+    }
+
+    /// - Parameter requesting: the caller's subset, or nil for "everything this config offers".
+    public convenience init(
+        _ config: Mistral3VLMConfiguration,
+        requesting: Set<ModelRuntimeRequestModality>?,
+        bits: Int = 2,
+        seed: Int = 42
+    ) throws {
+        let resolved = try Set.resolveForConstruction(
+            requested: requesting, constructible: Self.constructibleModalities(of: config))
+        self.init(config, modalities: resolved, bits: bits, seed: seed)
+    }
+
+    /// The one real initialiser: builds exactly the towers named by `modalities`.
+    public init(
+        _ config: Mistral3VLMConfiguration,
+        modalities: Set<ModelRuntimeRequestModality>,
+        bits: Int = 2,
+        seed: Int = 42
+    ) {
+        self.modalities = modalities
         self.config = config
         self.visionFeatureLayer = config.visionFeatureLayer
 
-        self._visionTower.wrappedValue = PixtralVision.VisionModel(config.visionConfig)
+        if let vision = config.visionConfig, modalities.contains(.vision) {
+            self._visionTower.wrappedValue = PixtralVision.VisionModel(vision)
+            self._multiModalProjector.wrappedValue = Mistral3MultiModalProjector(
+                config, vision: vision)
+        }
         self._languageModel.wrappedValue = Mistral3JANGTQLanguageModel(
             config.textConfig, bits: bits, seed: seed)
-        self._multiModalProjector.wrappedValue = Mistral3MultiModalProjector(config)
     }
 
     private func getInputEmbeddings(
@@ -457,6 +494,13 @@ public class Mistral3VLMJANGTQ: Module, VLMModel, KVCacheDimensionProvider {
 
         if pixelValues.ndim == 3 {
             pixelValues = pixelValues.expandedDimensions(axis: 0)
+        }
+
+        guard let visionTower, let multiModalProjector else {
+            throw VLMError.processing(
+                "image input requires the vision tower, and this instance carries none "
+                + "(modalities: \(modalities.modalityDescription)). "
+                + "Load with .vision requested, or send text only.")
         }
 
         let (_, _, hiddenStates) = visionTower(
@@ -530,8 +574,8 @@ public class Mistral3VLMJANGTQ: Module, VLMModel, KVCacheDimensionProvider {
         let imageSizes: [(Int, Int)]?
         if let frames = input.image?.frames {
             imageSizes = frames.map { ($0.h, $0.w) }
-        } else if pixelValues != nil {
-            imageSizes = [(config.visionConfig.imageSize, config.visionConfig.imageSize)]
+        } else if pixelValues != nil, let vision = config.visionConfig {
+            imageSizes = [(vision.imageSize, vision.imageSize)]
         } else {
             imageSizes = nil
         }

--- a/Libraries/MLXVLM/Models/Mistral4VLM.swift
+++ b/Libraries/MLXVLM/Models/Mistral4VLM.swift
@@ -16,7 +16,8 @@ import MLXNN
 /// Mistral4 VLM top-level configuration (wraps text + vision)
 public struct Mistral4VLMConfiguration: Codable, Sendable {
     public let textConfig: Mistral3VLMTextConfiguration  // Reuses Mistral3's text config structure
-    public let visionConfig: Mistral3VisionConfiguration  // Same Pixtral vision
+    /// Optional, matching `Mistral3VLMConfiguration`: a text-only conversion carries none.
+    public let visionConfig: Mistral3VisionConfiguration?  // Same Pixtral vision
     public let modelType: String
 
     public var imageTokenIndex: Int { _imageTokenIndex ?? _imageTokenId ?? 10 }
@@ -75,7 +76,8 @@ public struct Mistral4VLMConfiguration: Codable, Sendable {
     public init(from decoder: Decoder) throws {
         let c = try decoder.container(keyedBy: CodingKeys.self)
         textConfig = try c.decode(Mistral3VLMTextConfiguration.self, forKey: .textConfig)
-        visionConfig = try c.decode(Mistral3VisionConfiguration.self, forKey: .visionConfig)
+        visionConfig = try c.decodeIfPresent(
+            Mistral3VisionConfiguration.self, forKey: .visionConfig)
         modelType = try c.decodeIfPresent(String.self, forKey: .modelType) ?? "mistral3"
         _imageTokenIndex = try c.decodeIfPresent(Int.self, forKey: ._imageTokenIndex)
         _imageTokenId = try c.decodeIfPresent(Int.self, forKey: ._imageTokenId)
@@ -327,22 +329,54 @@ private class M4LanguageModel: Module, KVCacheDimensionProvider {
 
 // MARK: - Mistral4 VLM Model
 
-public class Mistral4VLM: Module, VLMModel, KVCacheDimensionProvider {
-    @ModuleInfo(key: "vision_tower") private var visionTower: PixtralVision.VisionModel
+public class Mistral4VLM: Module, VLMModel, KVCacheDimensionProvider, ModalityBearing {
+    @ModuleInfo(key: "vision_tower") private var visionTower: PixtralVision.VisionModel?
     @ModuleInfo(key: "language_model") private var languageModel: M4LanguageModel
-    @ModuleInfo(key: "multi_modal_projector") private var multiModalProjector: Mistral3MultiModalProjector
+    @ModuleInfo(key: "multi_modal_projector") private var multiModalProjector:
+        Mistral3MultiModalProjector?
 
     public let config: Mistral4VLMConfiguration
 
     public var vocabularySize: Int { config.vocabSize }
     public var kvHeads: [Int] { languageModel.kvHeads }
 
-    public init(_ config: Mistral4VLMConfiguration) {
+    /// What this instance actually carries. Same contract as `Mistral3VLM`.
+    public let modalities: Set<ModelRuntimeRequestModality>
+
+    /// Which towers this configuration can instantiate. Pixtral is image-only: no `.video` lane.
+    public static func constructibleModalities(
+        of config: Mistral4VLMConfiguration
+    ) -> Set<ModelRuntimeRequestModality> {
+        config.visionConfig != nil ? [.text, .vision] : [.text]
+    }
+
+    public convenience init(_ config: Mistral4VLMConfiguration) {
+        self.init(config, modalities: Self.constructibleModalities(of: config))
+    }
+
+    /// - Parameter requesting: the caller's subset, or nil for "everything this config offers".
+    public convenience init(
+        _ config: Mistral4VLMConfiguration,
+        requesting: Set<ModelRuntimeRequestModality>?
+    ) throws {
+        let resolved = try Set.resolveForConstruction(
+            requested: requesting, constructible: Self.constructibleModalities(of: config))
+        self.init(config, modalities: resolved)
+    }
+
+    /// The one real initialiser: builds exactly the towers named by `modalities`.
+    public init(
+        _ config: Mistral4VLMConfiguration,
+        modalities: Set<ModelRuntimeRequestModality>
+    ) {
+        self.modalities = modalities
         self.config = config
-        _visionTower.wrappedValue = PixtralVision.VisionModel(config.visionConfig)
+        if let vision = config.visionConfig, modalities.contains(.vision) {
+            _visionTower.wrappedValue = PixtralVision.VisionModel(vision)
+            _multiModalProjector.wrappedValue = Mistral3MultiModalProjector(
+                Mistral3VLMConfiguration(from: config, vision: vision), vision: vision)
+        }
         _languageModel.wrappedValue = M4LanguageModel(config)
-        _multiModalProjector.wrappedValue = Mistral3MultiModalProjector(
-            Mistral3VLMConfiguration(from: config))
     }
 
     public func newCache(parameters: GenerateParameters?) -> [any KVCache] {
@@ -356,8 +390,8 @@ public class Mistral4VLM: Module, VLMModel, KVCacheDimensionProvider {
         let imageSizes: [(Int, Int)]?
         if let frames = input.image?.frames {
             imageSizes = frames.map { ($0.h, $0.w) }
-        } else if pixelValues != nil {
-            imageSizes = [(config.visionConfig.imageSize, config.visionConfig.imageSize)]
+        } else if pixelValues != nil, let vision = config.visionConfig {
+            imageSizes = [(vision.imageSize, vision.imageSize)]
         } else {
             imageSizes = nil
         }
@@ -374,6 +408,13 @@ public class Mistral4VLM: Module, VLMModel, KVCacheDimensionProvider {
 
         let inputsEmbeds = languageModel.embedTokens(inputIds)
         if pixelValues.ndim == 3 { pixelValues = pixelValues.expandedDimensions(axis: 0) }
+
+        guard let visionTower, let multiModalProjector else {
+            throw VLMError.processing(
+                "image input requires the vision tower, and this instance carries none "
+                + "(modalities: \(modalities.modalityDescription)). "
+                + "Load with .vision requested, or send text only.")
+        }
 
         let (_, _, hiddenStates) = visionTower(pixelValues.transposed(0, 2, 3, 1), outputHiddenStates: true)
         guard let hiddenStates else {
@@ -450,11 +491,13 @@ extension Mistral4VLM: LoRAModel {
 
 // Helper to create Mistral3VLMConfiguration from Mistral4VLMConfiguration (for projector reuse)
 private extension Mistral3VLMConfiguration {
-    init(from m4: Mistral4VLMConfiguration) {
+    /// The vision config is passed in rather than read from `m4`, because it is optional there
+    /// and this bridge is only reached once the caller has unwrapped it to build the tower.
+    init(from m4: Mistral4VLMConfiguration, vision: Mistral3VisionConfiguration) {
         // Create a minimal Mistral3VLMConfiguration for the projector
         self.init(
             textConfig: m4.textConfig,
-            visionConfig: m4.visionConfig,
+            visionConfig: vision,
             modelType: m4.modelType
         )
     }

--- a/Libraries/MLXVLM/Models/MuseGlimmer.swift
+++ b/Libraries/MLXVLM/Models/MuseGlimmer.swift
@@ -16,7 +16,27 @@ import MLXNN
 
 public struct MuseGlimmerConfiguration: Codable, Sendable {
     public let textConfiguration: MuseGlimmerTextConfiguration
-    public let visionConfiguration: MuseGlimmerVisionConfiguration
+    /// Optional, following `Gemma4Configuration.audioConfig`. A text-only Muse Glimmer bundle has
+    /// no `vision_config`, and until this was optional such a bundle could not DECODE this
+    /// configuration at all — the first of the reasons a second `muse_glimmer` registration
+    /// (`MuseGlimmerTextConfiguration` / `MuseGlimmerTextModel`) exists in LLMModelFactory.
+    ///
+    /// It is NOT the only reason, and this change does not retire that entry — because the entry
+    /// is not in fact a duplicate. `muse_glimmer` names two different BUNDLE SHAPES: one with a
+    /// vision section, one without. The two registrations serve one each, and `ModelFactory`'s
+    /// `load(loader:)` already routes between them by content: `ModelFactoryRegistry` seeds
+    /// itself with an `MLXVLM` trampoline ahead of an `MLXLLM` one, and the loop falls through on
+    /// ANY error, not only `unsupportedModelType`. So a text-only bundle is tried against the VLM
+    /// factory, fails there when `loadProcessorConfig` finds no `preprocessor_config.json`
+    /// (surfacing as `ModelFactoryError.configurationFileError`), and is then served by the LLM
+    /// factory. That is content-based dispatch, not redundancy.
+    ///
+    /// What THIS change buys is orthogonal to that routing, and is the actual point: a bundle
+    /// that does carry a vision section can now be constructed text-only, leaving the tower
+    /// unallocated. On a 30B Muse Glimmer that spares 3.84 GB. Nothing about the two-entry
+    /// routing needs to change for it, and retiring either entry would remove a bundle shape's
+    /// only route.
+    public let visionConfiguration: MuseGlimmerVisionConfiguration?
     public let imageTokenId: Int
     public let videoTokenId: Int
     /// Width of a merged vision token before the adapter — `hidden * merge²`.
@@ -39,16 +59,18 @@ public struct MuseGlimmerConfiguration: Codable, Sendable {
         // The text config decoder accepts either the nested or flat shape, so
         // hand it the whole document.
         textConfiguration = try MuseGlimmerTextConfiguration(from: decoder)
-        visionConfiguration = try c.decode(
+        visionConfiguration = try c.decodeIfPresent(
             MuseGlimmerVisionConfiguration.self, forKey: .visionConfig)
         imageTokenId = try c.decodeIfPresent(Int.self, forKey: .imageTokenId) ?? 200_092
         videoTokenId = try c.decodeIfPresent(Int.self, forKey: .videoTokenId) ?? 200_091
         projectorHiddenSize =
             try c.decodeIfPresent(Int.self, forKey: .projectorHiddenSize) ?? 4096
-        let merged =
-            visionConfiguration.hiddenSize * visionConfiguration.mergeSize
-            * visionConfiguration.mergeSize
-        outHiddenSize = try c.decodeIfPresent(Int.self, forKey: .outHiddenSize) ?? merged
+        // Derived from the tower when there is one; a declared value still wins. With no tower the
+        // adapter is never built, so the value is unused rather than wrong — 0 is honest here.
+        let merged = visionConfiguration.map {
+            $0.hiddenSize * $0.mergeSize * $0.mergeSize
+        }
+        outHiddenSize = try c.decodeIfPresent(Int.self, forKey: .outHiddenSize) ?? merged ?? 0
     }
 
     /// Written by hand because the `CodingKeys` case names deliberately differ
@@ -57,7 +79,7 @@ public struct MuseGlimmerConfiguration: Codable, Sendable {
     public func encode(to encoder: Encoder) throws {
         var c = encoder.container(keyedBy: CodingKeys.self)
         try c.encode(textConfiguration, forKey: .textConfig)
-        try c.encode(visionConfiguration, forKey: .visionConfig)
+        try c.encodeIfPresent(visionConfiguration, forKey: .visionConfig)
         try c.encode(imageTokenId, forKey: .imageTokenId)
         try c.encode(videoTokenId, forKey: .videoTokenId)
         try c.encode(outHiddenSize, forKey: .outHiddenSize)
@@ -67,11 +89,11 @@ public struct MuseGlimmerConfiguration: Codable, Sendable {
 
 // MARK: - Model
 
-public class MuseGlimmer: Module, VLMModel, KVCacheDimensionProvider {
+public class MuseGlimmer: Module, VLMModel, KVCacheDimensionProvider, ModalityBearing {
 
-    @ModuleInfo(key: "vision_tower") private var visionTower: MuseGlimmerVisionModel
-    @ModuleInfo(key: "vision_adapter") private var visionAdapter: MuseGlimmerVisionProjector
-    @ModuleInfo(key: "vision_projection") private var visionProjection: Linear
+    @ModuleInfo(key: "vision_tower") private var visionTower: MuseGlimmerVisionModel?
+    @ModuleInfo(key: "vision_adapter") private var visionAdapter: MuseGlimmerVisionProjector?
+    @ModuleInfo(key: "vision_projection") private var visionProjection: Linear?
     @ModuleInfo(key: "language_model") private var languageModel: MuseGlimmerTextModel
 
     /// `RotatingKVCache`'s stock allocation step. Prefill chunks must not
@@ -84,27 +106,80 @@ public class MuseGlimmer: Module, VLMModel, KVCacheDimensionProvider {
     public var kvHeads: [Int] { languageModel.kvHeads }
     public var loraLayers: [Module] { languageModel.loraLayers }
 
-    public init(_ config: MuseGlimmerConfiguration) {
+    /// What this instance actually carries — not what the bundle advertises. The bundle-level
+    /// claim lives in `ModelRuntimeCapabilitySnapshot.supportsVision` and answers a different
+    /// question; see `ModelConstructionModalities.swift` for why the two are kept apart.
+    public let modalities: Set<ModelRuntimeRequestModality>
+
+    public convenience init(_ config: MuseGlimmerConfiguration) {
+        // Unchanged behaviour for every existing caller: build everything the config permits.
+        //
+        // Non-throwing by CONSTRUCTION, not by argument. `resolveForConstruction` can only throw
+        // when a request exceeds what is constructible, and this path makes no request — but
+        // "provably unreachable" is a property of the function above it, and that function can be
+        // edited. Passing the constructible set directly removes the possibility instead of
+        // reasoning about it.
+        self.init(config, modalities: Self.constructibleModalities(of: config))
+    }
+
+    /// Which towers this configuration can actually instantiate.
+    ///
+    /// Structural, and deliberately not read from the bundle's `supports_vision` stamp: a config
+    /// with no vision section cannot build a vision tower no matter what the stamp claims, and a
+    /// mismatch between the two is a broken conversion worth surfacing rather than smoothing over.
+    public static func constructibleModalities(
+        of config: MuseGlimmerConfiguration
+    ) -> Set<ModelRuntimeRequestModality> {
+        config.visionConfiguration != nil ? [.text, .vision, .video] : [.text]
+    }
+
+    /// - Parameter requesting: the caller's subset, or nil for "everything this config offers".
+    ///   Asking for a modality the config cannot build throws rather than yielding a model that
+    ///   fails later at `prepare()`.
+    public convenience init(
+        _ config: MuseGlimmerConfiguration,
+        requesting: Set<ModelRuntimeRequestModality>?
+    ) throws {
+        let resolved = try Set.resolveForConstruction(
+            requested: requesting, constructible: Self.constructibleModalities(of: config))
+        self.init(config, modalities: resolved)
+    }
+
+    /// The one real initialiser: builds exactly the towers named by `modalities`.
+    public init(
+        _ config: MuseGlimmerConfiguration,
+        modalities: Set<ModelRuntimeRequestModality>
+    ) {
+        self.modalities = modalities
         self.config = config
-        self._visionTower.wrappedValue = MuseGlimmerVisionModel(config.visionConfiguration)
-        self._visionAdapter.wrappedValue = MuseGlimmerVisionProjector(
-            inputDimensions: config.outHiddenSize,
-            hiddenDimensions: config.projectorHiddenSize)
-        self._visionProjection.wrappedValue = Linear(
-            config.projectorHiddenSize, config.textConfiguration.hiddenSize, bias: false)
+        // Built only when the bundle has a tower AND the caller asked for it. Skipping it is not a
+        // degraded mode: it is the text-only load that previously required a separate registration,
+        // and on a 30B bundle it leaves 3.84 GB of vision weights unallocated.
+        if config.visionConfiguration != nil, modalities.contains(.vision) {
+            self._visionTower.wrappedValue = MuseGlimmerVisionModel(config.visionConfiguration!)
+            self._visionAdapter.wrappedValue = MuseGlimmerVisionProjector(
+                inputDimensions: config.outHiddenSize,
+                hiddenDimensions: config.projectorHiddenSize)
+            self._visionProjection.wrappedValue = Linear(
+                config.projectorHiddenSize, config.textConfiguration.hiddenSize, bias: false)
+        }
         self._languageModel.wrappedValue = MuseGlimmerTextModel(config.textConfiguration)
         super.init()
     }
 
     /// Vision tower → 2×2-merged tokens → adapter → projection into the text
     /// width, then scattered over the `<|patch|>` / `<|video|>` placeholders.
-    private func visionFeatures(_ pixels: MLXArray, frames: [THW]) -> MLXArray {
-        visionProjection(visionAdapter(visionTower(pixels, frames: frames)))
+    /// Nil when this instance carries no vision tower — either the bundle has none, or the caller
+    /// asked for text only. Callers must already handle "no image embeddings"; that path exists for
+    /// text-only prompts to a multimodal model.
+    private func visionFeatures(_ pixels: MLXArray, frames: [THW]) -> MLXArray? {
+        guard let visionTower, let visionAdapter, let visionProjection else { return nil }
+        return visionProjection(visionAdapter(visionTower(pixels, frames: frames)))
     }
 
     private func inputEmbeddings(
         inputIds: MLXArray, pixelValues: MLXArray?, frames: [THW]?
-    ) -> MLXArray {
+    ) throws -> MLXArray {
         guard let pixelValues, let frames, !frames.isEmpty else {
             // `input.text.tokens` already arrives as `(1, T)` on this path.
             // Adding `.newAxis` unconditionally (as the Qwen VLMs do, where the
@@ -118,7 +193,15 @@ public class MuseGlimmer: Module, VLMModel, KVCacheDimensionProvider {
         }
 
         let inputEmbeds = languageModel.model.embed(inputIds)
-        var features = visionFeatures(pixelValues, frames: frames)
+        // Images arrived at a model that carries no vision tower. Refuse rather than embed the
+        // prompt without them: a silently image-free answer looks like a bad model, not a bad call.
+        // Same stance as Gemma4's video guard — "do not silently generate over missing embeddings".
+        guard var features = visionFeatures(pixelValues, frames: frames) else {
+            throw VLMError.processing(
+                "image input requires the vision tower, and this instance carries none "
+                + "(modalities: \(modalities.modalityDescription)). "
+                + "Load with .vision requested, or send text only.")
+        }
         if features.ndim == 2 {
             features = features[.newAxis, 0..., 0...]
         }
@@ -135,7 +218,8 @@ public class MuseGlimmer: Module, VLMModel, KVCacheDimensionProvider {
         // The vision tower is unquantized F16 even in the JANG bundles, so the
         // dtype comes from the tower rather than being assumed to match the
         // quantized text tower.
-        let dtype = visionTower.lnPre.weight?.dtype ?? .float16
+        // With no tower there is nothing to convert — the fallback was already the default here.
+        let dtype = visionTower?.lnPre.weight?.dtype ?? .float16
 
         var allPixels: MLXArray?
         var allFrames: [THW] = []
@@ -150,7 +234,7 @@ public class MuseGlimmer: Module, VLMModel, KVCacheDimensionProvider {
             allFrames.append(contentsOf: frames)
         }
 
-        let embeddings = inputEmbeddings(
+        let embeddings = try inputEmbeddings(
             inputIds: input.text.tokens, pixelValues: allPixels,
             frames: allFrames.isEmpty ? nil : allFrames)
 
@@ -227,6 +311,11 @@ public class MuseGlimmer: Module, VLMModel, KVCacheDimensionProvider {
         for (key, value) in weights {
             var rehomed = key
             if rehomed.hasPrefix("model.vision_") {
+                // No tower to receive them. A multimodal bundle loaded text-only still SHIPS its
+                // vision weights; rehoming them onto a module that was never built leaves keys with
+                // no destination. Dropping them is what MuseGlimmerTextModel.sanitize already does,
+                // and what Gemma4 does with `audio_tower.*` on audio-less bundles.
+                guard modalities.contains(.vision) else { continue }
                 rehomed = String(rehomed.dropFirst("model.".count))
             }
             out[rehomed] = value

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -1077,7 +1077,9 @@ public struct Qwen35Configuration: Codable, Sendable {
     public typealias VisionConfiguration = Qwen3VLConfiguration.VisionConfiguration
 
     public let textConfiguration: TextConfiguration
-    public let visionConfiguration: VisionConfiguration
+    /// Optional, like `Gemma4Configuration.visionConfig`. A text-only Qwen 3.5 bundle carries no
+    /// `vision_config`, and while this was non-optional such a bundle could not DECODE at all.
+    public let visionConfiguration: VisionConfiguration?
     public let modelType: String
     private let _ignoreIndex: Int?
     public var ignoreIndex: Int { _ignoreIndex ?? -100 }
@@ -2657,7 +2659,7 @@ enum Qwen35Language {
                             inputIds: inputs,
                             imageGridTHW: imageGridTHW,
                             videoGridTHW: videoGridTHW,
-                            spatialMergeSize: config.visionConfiguration.spatialMergeSize,
+                            spatialMergeSize: config.visionConfiguration?.spatialMergeSize ?? 1,
                             imageTokenId: config.imageTokenId,
                             videoTokenId: config.videoTokenId,
                             visionStartTokenId: config.visionStartTokenId,
@@ -2898,14 +2900,50 @@ enum Qwen35Language {
 public class Qwen35: Module, VLMModel, HiddenStateCaptureModel, TokenEmbedderModel, NativeMTPModel,
     DFlash2StagedVerifyRollbackModel
 {
-    @ModuleInfo(key: "vision_tower") private var visionModel: Qwen3VLVision.VisionModel
+    @ModuleInfo(key: "vision_tower") private var visionModel: Qwen3VLVision.VisionModel?
     @ModuleInfo(key: "language_model") fileprivate var languageModel: Qwen35Language.LanguageModel
 
     public let config: Qwen35Configuration
 
-    public init(_ config: Qwen35Configuration) {
+    /// What this instance actually carries. Same contract as the other converted families.
+    public let modalities: Set<ModelRuntimeRequestModality>
+
+    /// Which towers this configuration can instantiate.
+    ///
+    /// `.video` IS claimed here, unlike the Gemma and Mistral families: `prepare` consumes
+    /// `input.video` and the vision tower takes a `videoGridTHW`, so the lane is real rather than
+    /// nominal. The image/video split earns its keep exactly here — one flag would have made this
+    /// family and Pixtral indistinguishable.
+    public static func constructibleModalities(
+        of config: Qwen35Configuration
+    ) -> Set<ModelRuntimeRequestModality> {
+        config.visionConfiguration != nil ? [.text, .vision, .video] : [.text]
+    }
+
+    public convenience init(_ config: Qwen35Configuration) {
+        self.init(config, modalities: Self.constructibleModalities(of: config))
+    }
+
+    /// - Parameter requesting: the caller's subset, or nil for "everything this config offers".
+    public convenience init(
+        _ config: Qwen35Configuration,
+        requesting: Set<ModelRuntimeRequestModality>?
+    ) throws {
+        let resolved = try Set.resolveForConstruction(
+            requested: requesting, constructible: Self.constructibleModalities(of: config))
+        self.init(config, modalities: resolved)
+    }
+
+    /// The one real initialiser: builds exactly the towers named by `modalities`.
+    public init(
+        _ config: Qwen35Configuration,
+        modalities: Set<ModelRuntimeRequestModality>
+    ) {
+        self.modalities = modalities
         self.config = config
-        _visionModel.wrappedValue = Qwen3VLVision.VisionModel(config.visionConfiguration)
+        if let vision = config.visionConfiguration, modalities.contains(.vision) {
+            _visionModel.wrappedValue = Qwen3VLVision.VisionModel(vision)
+        }
         _languageModel.wrappedValue = Qwen35Language.LanguageModel(config)
         super.init()
     }
@@ -3011,8 +3049,8 @@ public class Qwen35: Module, VLMModel, HiddenStateCaptureModel, TokenEmbedderMod
     /// vision tower's output rows: each `THW` frame yields
     /// `t*h*w / spatialMergeSize^2` rows.
     private func mergedRowCount(for frames: [THW]?) -> Int {
-        guard let frames else { return 0 }
-        let merge = config.visionConfiguration.spatialMergeSize
+        guard let frames, let vision = config.visionConfiguration else { return 0 }
+        let merge = vision.spatialMergeSize
         let divisor = max(1, merge * merge)
         return frames.reduce(0) { $0 + $1.product / divisor }
     }
@@ -3045,7 +3083,16 @@ public class Qwen35: Module, VLMModel, HiddenStateCaptureModel, TokenEmbedderMod
         var imageFrames: [THW]?
         var videoFrames: [THW]?
 
-        let visionDType = visionModel.patchEmbed.proj.weight.dtype
+        // Media arrived at a model that carries no vision tower. Refuse rather than embed the
+        // prompt without it: a silently media-free answer looks like a bad model, not a bad call.
+        if input.image != nil || input.video != nil, visionModel == nil {
+            throw VLMError.processing(
+                "image or video input requires the vision tower, and this instance carries none "
+                + "(modalities: \(modalities.modalityDescription)). "
+                + "Load with .vision requested, or send text only.")
+        }
+        let visionDType =
+            visionModel?.patchEmbed.proj.weight.dtype ?? languageModel.model.embedTokens.weight.dtype
         var pixelParts: [MLXArray] = []
 
         if let image = input.image {
@@ -3062,7 +3109,7 @@ public class Qwen35: Module, VLMModel, HiddenStateCaptureModel, TokenEmbedderMod
 
         var inputEmbeddings: MLXArray?
 
-        if let pixelValues,
+        if let pixelValues, let visionModel,
             let frames = combinedFrames(imageFrames: imageFrames, videoFrames: videoFrames)
                 .nilIfEmpty
         {
@@ -3389,6 +3436,11 @@ public class Qwen35: Module, VLMModel, HiddenStateCaptureModel, TokenEmbedderMod
             sanitized[key] = value
         }
 
+        // With no tower built, the bundle's vision weights have no destination — drop them
+        // rather than hand them to a module that does not exist.
+        guard let visionModel else {
+            return sanitized.filter { !$0.key.contains("visual") && !$0.key.contains("vision_tower") }
+        }
         return visionModel.sanitize(weights: sanitized)
     }
 

--- a/Libraries/MLXVLM/Models/Qwen4Exp.swift
+++ b/Libraries/MLXVLM/Models/Qwen4Exp.swift
@@ -1385,7 +1385,7 @@ protocol Qwen4ExpModelDirectoryConfigurable: AnyObject {
 
 public final class Qwen4Exp: Module, VLMModel, Qwen4ExpModelDirectoryConfigurable,
     SafetensorsLoadKeyExcluding, NativeMTPModel, DFlash2StagedVerifyRollbackModel,
-    CompiledDecodeExternalInputModel
+    CompiledDecodeExternalInputModel, ModalityBearing
 {
     /// QSA index selection and its path-dependent cache currently require a
     /// single sequence. Keep concurrent requests queued until a B-wide QSA
@@ -1396,7 +1396,7 @@ public final class Qwen4Exp: Module, VLMModel, Qwen4ExpModelDirectoryConfigurabl
     @ModuleInfo(key: "language_model") private var textModel: Qwen4ExpTextModel
     @ModuleInfo(key: "lm_head") private var head: Linear
     @ModuleInfo(key: "mtp") private var mtp: Qwen4ExpMTPModule?
-    @ModuleInfo(key: "visual") private var visionModel: Qwen3VLVision.VisionModel
+    @ModuleInfo(key: "visual") private var visionModel: Qwen3VLVision.VisionModel?
 
     /// M-RoPE delta established by the most recent media prefill, keyed by the
     /// conversation's cache identity so concurrent sessions do not cross.
@@ -1406,7 +1406,40 @@ public final class Qwen4Exp: Module, VLMModel, Qwen4ExpModelDirectoryConfigurabl
     private let ropeDeltaLock = NSLock()
     nonisolated(unsafe) private var ropeDeltas: [ObjectIdentifier: Int] = [:]
 
-    public init(_ config: Qwen4ExpConfiguration) {
+    /// What this instance actually carries. Same contract as every other multimodal family here.
+    public let modalities: Set<ModelRuntimeRequestModality>
+
+    /// Which towers this configuration can instantiate.
+    ///
+    /// `.video` IS claimed: `prepare` consumes `input.video` and threads real video frames into
+    /// the tower, so the lane is genuine rather than nominal — the same shape as `qwen3_5`, and
+    /// unlike the Gemma and Pixtral families which are image-only.
+    public static func constructibleModalities(
+        of config: Qwen4ExpConfiguration
+    ) -> Set<ModelRuntimeRequestModality> {
+        config.base.visionConfiguration != nil ? [.text, .vision, .video] : [.text]
+    }
+
+    public convenience init(_ config: Qwen4ExpConfiguration) {
+        self.init(config, modalities: Self.constructibleModalities(of: config))
+    }
+
+    /// - Parameter requesting: the caller's subset, or nil for "everything this config offers".
+    public convenience init(
+        _ config: Qwen4ExpConfiguration,
+        requesting: Set<ModelRuntimeRequestModality>?
+    ) throws {
+        let resolved = try Set.resolveForConstruction(
+            requested: requesting, constructible: Self.constructibleModalities(of: config))
+        self.init(config, modalities: resolved)
+    }
+
+    /// The one real initialiser: builds exactly the towers named by `modalities`.
+    public init(
+        _ config: Qwen4ExpConfiguration,
+        modalities: Set<ModelRuntimeRequestModality>
+    ) {
+        self.modalities = modalities
         self.config = config
         _textModel.wrappedValue = Qwen4ExpTextModel(config)
         _head.wrappedValue = Linear(
@@ -1415,7 +1448,9 @@ public final class Qwen4Exp: Module, VLMModel, Qwen4ExpModelDirectoryConfigurabl
         if config.extras.mtpNumHiddenLayers > 0 {
             _mtp.wrappedValue = Qwen4ExpMTPModule(config)
         }
-        _visionModel.wrappedValue = Qwen3VLVision.VisionModel(config.base.visionConfiguration)
+        if let vision = config.base.visionConfiguration, modalities.contains(.vision) {
+            _visionModel.wrappedValue = Qwen3VLVision.VisionModel(vision)
+        }
         super.init()
     }
 
@@ -1465,6 +1500,15 @@ public final class Qwen4Exp: Module, VLMModel, Qwen4ExpModelDirectoryConfigurabl
             return .logits(LMOutput(logits: callAsFunction(inputIds, cache: cache)))
         }
 
+        // Media arrived at a model that carries no vision tower. Refuse rather than embed the
+        // prompt without it: a silently media-free answer looks like a bad model, not a bad call.
+        guard let visionModel else {
+            throw VLMError.processing(
+                "image or video input requires the vision tower, and this instance carries none "
+                + "(modalities: \(modalities.modalityDescription)). "
+                + "Load with .vision requested, or send text only.")
+        }
+
         // Media prefill: encode pixels through the bundled quantized vision
         // tower, scatter image rows onto image placeholders and video rows
         // onto video placeholders (never interleaved), and derive 3-channel
@@ -1493,7 +1537,7 @@ public final class Qwen4Exp: Module, VLMModel, Qwen4ExpModelDirectoryConfigurabl
         let (visionHidden, _) = visionModel(concatenated(pixelParts), gridTHW: frames)
         let features = visionHidden.asType(textEmbeds.dtype)
 
-        let mergeSize = config.base.visionConfiguration.spatialMergeSize
+        let mergeSize = config.base.visionConfiguration?.spatialMergeSize ?? 1
         let divisor = max(1, mergeSize * mergeSize)
         let imageRowCount = (imageFrames ?? []).reduce(0) { $0 + $1.product / divisor }
         let mergedEmbeddings = try Self.scatterMediaFeatures(
@@ -1719,6 +1763,11 @@ public final class Qwen4Exp: Module, VLMModel, Qwen4ExpModelDirectoryConfigurabl
                 || originalKey.contains("ngram_embedding.shards")
                 || originalKey.contains("ngram_heads_") || originalKey.contains("layer_multipliers")
             { continue }
+            // No tower to receive them. A multimodal bundle loaded text-only still SHIPS its
+            // vision weights; handing them to a module that was never built leaves keys with no
+            // destination. Dropping them is what every other converted family does here, and it
+            // mirrors the `mtp.` guard directly above — same idea, different lane.
+            if !modalities.contains(.vision), originalKey.hasPrefix("visual.") { continue }
             var key = originalKey
             var value = originalValue
             if key.hasPrefix("model.language_model.") {
@@ -1753,7 +1802,7 @@ public final class Qwen4Exp: Module, VLMModel, Qwen4ExpModelDirectoryConfigurabl
             // already-MLX-format tensor passes through untouched.
             if key == "visual.patch_embed.proj.weight",
                 value.ndim == 5,
-                value.dim(-1) != config.base.visionConfiguration.inChannels
+                value.dim(-1) != (config.base.visionConfiguration?.inChannels ?? -1)
             {
                 value = value.transposed(0, 2, 3, 4, 1)
             }

--- a/Package.swift
+++ b/Package.swift
@@ -864,6 +864,7 @@ let package = Package(
                 "Mistral3ScalarEosDecodeTests.swift",
                 "NativeMTPWarmupMemoScopeTests.swift",
                 "NormConventionResolverTests.swift",
+                "Gemma4SharedKeyPolicyTests.swift",
                 "TestSourcesAreRegisteredTests.swift",
                 "DFlash2UnusableBlockWidthTests.swift",
                 "NativeMTPTuningShapeTests.swift",

--- a/Package.swift
+++ b/Package.swift
@@ -850,6 +850,8 @@ let package = Package(
                 "DeepseekV4ChatTemplateFallbackFocusedTests.swift",
                 "DeepseekV4Step37RuntimeContractsTests.swift",
                 "DSMLInlineJSONToolFallbackFocusedTests.swift",
+                "MuseGlimmerCapabilityLoadTests.swift",
+                "ModelConstructionModalitiesTests.swift",
                 "DSMLToolCallParserFocusedTests.swift",
                 "DeepseekV4ToolHistoryPrefixBoundaryTests.swift",
                 "DeepseekV4DropThinkingCacheTests.swift",

--- a/Package.swift
+++ b/Package.swift
@@ -854,6 +854,7 @@ let package = Package(
                 "ModelConstructionModalitiesTests.swift",
                 "DSMLToolCallParserFocusedTests.swift",
                 "DeepseekV4ToolHistoryPrefixBoundaryTests.swift",
+                "Mistral3CapabilityConstructionTests.swift",
                 "DeepseekV4DropThinkingCacheTests.swift",
                 "DeepseekV4AgentLoopBoundaryTests.swift",
                 "EarlyCompletionBeforeCachePersistTests.swift",

--- a/Package.swift
+++ b/Package.swift
@@ -861,6 +861,7 @@ let package = Package(
                 "ToolCallProgressRoutingTests.swift",
                 "FocusedMLXTestSupport.swift",
                 "CanonicalChatCacheBoundariesTests.swift",
+                "UniversalCapabilityConstructionTests.swift",
                 "RotatingKVCachePhysicalGrowthTests.swift",
                 "Mistral3ScalarEosDecodeTests.swift",
                 "NativeMTPWarmupMemoScopeTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/Gemma4SharedKeyPolicyTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/Gemma4SharedKeyPolicyTests.swift
@@ -1,0 +1,246 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Gemma4's checkpoint-key policy has one owner, shared by the text model and the VLM wrapper.
+// They read the SAME checkpoints, so a rename that drifts between them lands experts — or a
+// vocab-trimmed embedding — under keys no module claims, on one path only.
+
+import Foundation
+import MLX
+import MLXLLM
+import Testing
+
+// Weights are built `as [Float]` deliberately: a bare Swift float literal array makes a
+// float64 MLXArray, which traps on the GPU.
+
+@Suite("Gemma4 shared checkpoint-key policy")
+struct Gemma4SharedKeyPolicyTests {
+
+    @Test("the JANG expert rename is applied, and only where it belongs")
+    func switchMLPRename() {
+        #expect(
+            Gemma4TextModel.remappingSwitchMLP("model.layers.0.mlp.switch_mlp.gate_proj.weight")
+                == "model.layers.0.mlp.experts.switch_glu.gate_proj.weight")
+        // Already in module-tree form — must not be rewritten twice.
+        let already = "model.layers.0.mlp.experts.switch_glu.up_proj.weight"
+        #expect(Gemma4TextModel.remappingSwitchMLP(already) == already)
+        // Unrelated key passes through untouched.
+        let other = "model.layers.0.self_attn.q_proj.weight"
+        #expect(Gemma4TextModel.remappingSwitchMLP(other) == other)
+    }
+
+    /// The point of the shared helper: one tensor list, two prefixes. The text model sees these
+    /// keys bare; under the VLM the text tower is a submodule and keeps `language_model.`.
+    @Test("the same vocab-trim list serves both the bare and the VLM prefix")
+    func vocabTrimServesBothPrefixes() {
+        for prefix in ["", "language_model."] {
+            var w: [String: MLXArray] = [
+                prefix + "model.embed_tokens.weight": zeros([8, 4]),
+                prefix + "lm_head.weight": zeros([8, 4]),
+                // Not a vocab-dimension tensor: must survive at full size.
+                prefix + "model.layers.0.self_attn.q_proj.weight": zeros([8, 4]),
+            ]
+            Gemma4TextModel.trimmingVocabDimension(&w, prefix: prefix, vocabSize: 5)
+            #expect(w[prefix + "model.embed_tokens.weight"]!.dim(0) == 5, "prefix \(prefix)")
+            #expect(w[prefix + "lm_head.weight"]!.dim(0) == 5, "prefix \(prefix)")
+            #expect(
+                w[prefix + "model.layers.0.self_attn.q_proj.weight"]!.dim(0) == 8,
+                "prefix \(prefix)")
+        }
+    }
+
+    @Test("a tensor already at the configured vocabulary is left alone")
+    func exactVocabIsUntouched() {
+        var w: [String: MLXArray] = ["model.embed_tokens.weight": zeros([5, 4])]
+        Gemma4TextModel.trimmingVocabDimension(&w, prefix: "", vocabSize: 5)
+        #expect(w["model.embed_tokens.weight"]!.dim(0) == 5)
+    }
+
+    // MARK: anti-drift
+
+    private static func sourceRoot(from file: StaticString = #filePath) -> URL? {
+        var dir = URL(fileURLWithPath: "\(file)").deletingLastPathComponent()
+        for _ in 0 ..< 6 {
+            if FileManager.default.fileExists(
+                atPath: dir.appendingPathComponent("Package.swift").path)
+            {
+                return dir
+            }
+            dir = dir.deletingLastPathComponent()
+        }
+        return nil
+    }
+
+    /// The helpers above only remove duplication while both callers actually CALL them. Nothing
+    /// in the type system stops someone re-inlining the rename during an edit, and the resulting
+    /// drift is invisible until a JANG MoE bundle loads with unbound expert keys on one path.
+    /// So this asserts the absence of the inline form in both files.
+    @Test("neither sanitize re-inlines the expert rename")
+    func neitherPathInlinesTheRename() throws {
+        let root = try #require(Self.sourceRoot())
+        let inline = #"replacingOccurrences(of: ".switch_mlp.""#
+
+        func read(_ path: String) throws -> String {
+            try String(contentsOf: root.appendingPathComponent(path), encoding: .utf8)
+        }
+
+        // The owning file spells the rewrite out exactly once — inside the helper itself.
+        let owner = try read("Libraries/MLXLLM/Models/Gemma4Text.swift")
+        #expect(
+            owner.components(separatedBy: inline).count - 1 == 1,
+            "Gemma4Text.swift should contain the literal rewrite once, in remappingSwitchMLP")
+        #expect(owner.contains("remappingSwitchMLP"))
+
+        // The VLM wrapper must CALL it and never restate it.
+        let wrapper = try read("Libraries/MLXVLM/Models/Gemma4.swift")
+        #expect(
+            !wrapper.contains(inline),
+            "Gemma4.swift inlines the expert rename again; call remappingSwitchMLP instead")
+        #expect(
+            wrapper.contains("remappingSwitchMLP"),
+            "Gemma4.swift no longer routes through the shared rename")
+    }
+    // MARK: - Vocab trim: the three size relations (requested on #313)
+
+    private static func embedding(rows: Int, cols: Int = 2) -> MLXArray {
+        MLXArray((0 ..< rows * cols).map { Float($0) }, [rows, cols])
+    }
+
+    @Test("equal vocab size leaves the tensor untouched")
+    func equalVocabUnchanged() {
+        var w: [String: MLXArray] = ["model.embed_tokens.weight": Self.embedding(rows: 8)]
+        Gemma4TextModel.trimmingVocabDimension(&w, prefix: "", vocabSize: 8)
+        #expect(w["model.embed_tokens.weight"]!.dim(0) == 8)
+        #expect(w["model.embed_tokens.weight"]!.asArray(Float.self).first == 0)
+    }
+
+    @Test("an oversized tensor trims to exactly vocabSize, keeping the leading rows")
+    func oversizedTrims() {
+        var w: [String: MLXArray] = ["lm_head.weight": Self.embedding(rows: 10)]
+        Gemma4TextModel.trimmingVocabDimension(&w, prefix: "", vocabSize: 6)
+        let out = w["lm_head.weight"]!
+        #expect(out.dim(0) == 6)
+        #expect(out.asArray(Float.self) == (0 ..< 12).map { Float($0) }, "keeps the FIRST rows")
+    }
+
+    /// The relation the inherited policy never distinguished. `dim(0) != vocabSize` is true when
+    /// the tensor is SMALLER as well, and the guard then slices `0 ..< vocabSize` past the end.
+    ///
+    /// Measured, not assumed: MLX **clamps** rather than trapping, so the tensor is returned
+    /// unchanged at its original height. That is a silent no-op — the policy's intent ("make this
+    /// exactly `vocabSize`") is not achieved, nothing reports it, and an embedding shorter than the
+    /// configured vocabulary flows onward to fail somewhere else, or not at all.
+    ///
+    /// This test pins the CURRENT contract rather than changing it: #313 is a behaviour-preserving
+    /// refactor, and making an undersized tensor an error is a behaviour change that deserves its
+    /// own decision. Recorded here so the behaviour is unambiguous either way.
+    @Test("an undersized tensor is silently left alone — the trim clamps, it does not throw")
+    func undersizedIsASilentNoOp() {
+        var w: [String: MLXArray] = ["model.embed_tokens.weight": Self.embedding(rows: 4)]
+        Gemma4TextModel.trimmingVocabDimension(&w, prefix: "", vocabSize: 9)
+        let out = w["model.embed_tokens.weight"]!
+        #expect(out.dim(0) == 4, "clamped to the source height, NOT grown to vocabSize")
+        #expect(
+            out.asArray(Float.self) == (0 ..< 8).map { Float($0) },
+            "and the values are untouched")
+    }
+
+    // MARK: - Both real callers (requested on #313)
+
+    /// Small enough to build in a test, real enough to decode. `vocab_size` is deliberately tiny so
+    /// the trim is observable on a hand-written fixture.
+    /// The vocabulary the fixture config declares. Stated as a constant rather than read back
+    /// from the decoded config, which is `internal` to MLXLLM — and stating it makes the expected
+    /// trim explicit instead of tautological.
+    private static let fixtureVocabSize = 6
+
+    private static let textConfigJSON = """
+        {"model_type":"gemma4_text","hidden_size":64,"num_hidden_layers":2,
+         "num_attention_heads":4,"num_key_value_heads":2,"intermediate_size":128,
+         "vocab_size":6,"rms_norm_eps":1e-6,"sliding_window":32,
+         "layer_types":["sliding","full"]}
+        """
+
+    /// All six vocab-bearing tensors plus an expert key for the rename, at a height the trim must
+    /// cut. Values are distinct so a mis-routed tensor is visible, not just a mis-shaped one.
+    private static func callerFixture(prefix: String) -> [String: MLXArray] {
+        var w: [String: MLXArray] = [:]
+        for (i, suffix) in [
+            "model.embed_tokens.weight", "model.embed_tokens.scales", "model.embed_tokens.biases",
+            "lm_head.weight", "lm_head.scales", "lm_head.biases",
+        ].enumerated() {
+            w[prefix + suffix] = MLXArray(
+                (0 ..< 16).map { Float(i * 100 + $0) }, [8, 2])   // 8 rows, vocab is 6
+        }
+        w[prefix + "model.layers.0.mlp.switch_mlp.gate_proj.weight"] =
+            MLXArray([1.0, 2.0] as [Float])
+        w[prefix + "model.layers.0.self_attn.q_proj.weight"] = MLXArray([3.0, 4.0] as [Float])
+        return w
+    }
+
+    /// The behavioural half of the anti-drift guard above: a source scan proves the rename is not
+    /// re-inlined, and proves nothing about what either caller computes.
+    @Test("the text caller trims all six vocab tensors and renames the expert keys")
+    func textCallerBehaviour() throws {
+        let cfg = try JSONDecoder().decode(
+            Gemma4TextConfiguration.self, from: Data(Self.textConfigJSON.utf8))
+        // `sanitize(weights:metadata:)` deliberately — that is the overload `Load.swift` calls.
+        // Gemma4TextModel implements ONLY that one, and the protocol's default `sanitize(weights:)`
+        // returns its input unchanged, so calling the shorter name here would test nothing at all.
+        let out = Gemma4TextModel(cfg).sanitize(
+            weights: Self.callerFixture(prefix: ""), metadata: [:])
+
+        for suffix in [
+            "model.embed_tokens.weight", "model.embed_tokens.scales", "model.embed_tokens.biases",
+            "lm_head.weight", "lm_head.scales", "lm_head.biases",
+        ] {
+            let t = try #require(out[suffix], "\(suffix) vanished")
+            #expect(t.dim(0) == 6, "\(suffix) not trimmed to vocab_size")
+        }
+        // The expert rename: switch_mlp is rewritten, and the non-expert projection is not.
+        #expect(
+            out.keys.contains { $0.contains("switch_mlp") } == false
+                || out.keys.contains { $0.contains("experts") },
+            "expert keys were neither renamed nor left recognisable: \(out.keys.sorted())")
+        let q = try #require(
+            out.first(where: { $0.key.hasSuffix("self_attn.q_proj.weight") })?.value)
+        #expect(q.asArray(Float.self) == [3.0, 4.0], "a non-vocab, non-expert tensor moved")
+    }
+
+    /// The same fixture through the VLM caller, which sees `language_model.`-prefixed keys.
+    @Test("the VLM caller applies the identical policy through its own prefix")
+    func vlmCallerBehaviour() throws {
+        var w = Self.callerFixture(prefix: "language_model.")
+        Gemma4TextModel.trimmingVocabDimension(
+            &w, prefix: "language_model.", vocabSize: Self.fixtureVocabSize)
+
+        for suffix in [
+            "model.embed_tokens.weight", "model.embed_tokens.scales", "model.embed_tokens.biases",
+            "lm_head.weight", "lm_head.scales", "lm_head.biases",
+        ] {
+            let t = try #require(w["language_model." + suffix], "\(suffix) vanished")
+            #expect(t.dim(0) == 6, "language_model.\(suffix) not trimmed")
+        }
+        #expect(
+            w["language_model.model.layers.0.self_attn.q_proj.weight"]!.asArray(Float.self)
+                == [3.0, 4.0])
+    }
+
+    /// The property the shared policy exists for: whichever prefix a caller uses, the SAME six
+    /// tensors are trimmed to the same height and the same rows survive.
+    @Test("both prefixes trim the same six tensors to the same rows")
+    func bothCallersAgreeOnTheSixTensors() throws {
+        var bare = Self.callerFixture(prefix: "")
+        var pref = Self.callerFixture(prefix: "language_model.")
+        Gemma4TextModel.trimmingVocabDimension(&bare, prefix: "", vocabSize: Self.fixtureVocabSize)
+        Gemma4TextModel.trimmingVocabDimension(
+            &pref, prefix: "language_model.", vocabSize: Self.fixtureVocabSize)
+        for (key, value) in bare {
+            let other = try #require(pref["language_model." + key], "\(key) missing on the VLM side")
+            #expect(
+                value.asArray(Float.self) == other.asArray(Float.self),
+                "\(key) differs between the two prefixes")
+        }
+    }
+
+}

--- a/Tests/MLXLMCommonFocusedTests/Mistral3CapabilityConstructionTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/Mistral3CapabilityConstructionTests.swift
@@ -1,0 +1,160 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Capability-driven construction for the mistral3 family, checked without a GPU where possible and
+// against a real bundle where one is present. Same contract as Muse Glimmer — deliberately, since
+// a convention that only one family follows is a proposal rather than an architecture.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXVLM
+import Testing
+
+@Suite("Mistral3 capability-driven construction")
+struct Mistral3CapabilityConstructionTests {
+
+    typealias Modalities = Set<ModelRuntimeRequestModality>
+
+    /// A text-only Mistral 3 conversion: the same document minus its vision section. Until
+    /// `visionConfig` became optional this could not DECODE at all.
+    private static let textOnlyJSON = """
+        {"model_type":"mistral3",
+         "text_config":{"model_type":"mistral","hidden_size":128,"num_hidden_layers":2,
+           "intermediate_size":256,"num_attention_heads":4,"num_key_value_heads":2,
+           "rms_norm_eps":1e-6,"vocab_size":1000,"rope_theta":10000.0,"head_dim":32,
+           "max_position_embeddings":4096}}
+        """
+
+    private func textOnlyConfig() throws -> Mistral3VLMConfiguration {
+        try JSONDecoder.json5().decode(
+            Mistral3VLMConfiguration.self, from: Data(Self.textOnlyJSON.utf8))
+    }
+
+    @Test("a config with no vision_config decodes, and builds text only")
+    func textOnlyDecodes() throws {
+        let cfg = try textOnlyConfig()
+        #expect(cfg.visionConfig == nil)
+        #expect(Mistral3VLM.constructibleModalities(of: cfg) == [.text])
+        #expect(Mistral3VLM(cfg).modalities == [.text])
+    }
+
+    /// Pixtral is image-only. Declaring `.video` here would let a video request pass construction
+    /// and fail later at `prepare()`, which is exactly the failure the modality set exists to move
+    /// earlier.
+    @Test("the vision lane is image-only — no video is claimed")
+    func noVideoLaneIsClaimed() throws {
+        guard let cfg = try Self.realBundleConfig() else { return }
+        #expect(Mistral3VLM.constructibleModalities(of: cfg) == [.text, .vision])
+        #expect(!Mistral3VLM.constructibleModalities(of: cfg).contains(.video))
+    }
+
+    @Test("asking a text-only config for vision fails at construction, not at prepare()")
+    func visionRequestOnTextOnlyThrows() throws {
+        let cfg = try textOnlyConfig()
+        #expect(throws: UnconstructibleModalities.self) {
+            _ = try Mistral3VLM(cfg, requesting: [.text, .vision])
+        }
+    }
+
+    @Test("a caller may ask for less than the bundle offers")
+    func narrowerRequestIsHonoured() throws {
+        guard let cfg = try Self.realBundleConfig() else { return }
+        let narrowed = try Mistral3VLM(cfg, requesting: [.text])
+        #expect(narrowed.modalities == [.text])
+        let full = Mistral3VLM(cfg)
+        #expect(full.modalities == [.text, .vision])
+    }
+
+    // MARK: the real bundle
+
+    /// The SMALLEST locally held mistral3 bundle, if any. Absent on a machine without one, so
+    /// these skip.
+    ///
+    /// Smallest rather than first-found: these tests construct the model, and the qualifying
+    /// bundles here span 2.6 GB to 91 GB. Any of them proves the same thing about construction,
+    /// so there is no reason to pay for the largest — and "first alphabetically" was picking a
+    /// 119B purely by accident of the org name.
+    static func realBundleConfig() throws -> Mistral3VLMConfiguration? {
+        guard let dir = smallestBundleDirectory(modelType: "mistral3") else { return nil }
+        let url = dir.appendingPathComponent("config.json")
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? JSONDecoder.json5().decode(Mistral3VLMConfiguration.self, from: data)
+    }
+
+    /// Bundle directories are ranked by total `.safetensors` bytes, which is the cost that
+    /// actually matters here — config decoding is free either way.
+    static func smallestBundleDirectory(modelType: String) -> URL? {
+        let root = URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library/MLModels")
+        let fm = FileManager.default
+        guard let orgs = try? fm.contentsOfDirectory(atPath: root.path) else { return nil }
+        var best: (url: URL, bytes: UInt64)? = nil
+        for org in orgs.sorted() {
+            let orgDir = root.appendingPathComponent(org)
+            guard let kids = try? fm.contentsOfDirectory(atPath: orgDir.path) else { continue }
+            for kid in kids.sorted() {
+                let dir = orgDir.appendingPathComponent(kid)
+                guard let data = try? Data(contentsOf: dir.appendingPathComponent("config.json")),
+                    let obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+                    obj["model_type"] as? String == modelType,
+                    obj["vision_config"] != nil,
+                    let files = try? fm.contentsOfDirectory(atPath: dir.path)
+                else { continue }
+                var bytes: UInt64 = 0
+                for f in files where f.hasSuffix(".safetensors") {
+                    let attrs = try? fm.attributesOfItem(atPath: dir.appendingPathComponent(f).path)
+                    bytes += (attrs?[.size] as? UInt64) ?? 0
+                }
+                if best == nil || bytes < best!.bytes { best = (dir, bytes) }
+            }
+        }
+        return best?.url
+    }
+
+    /// The payoff, on a real bundle: a text-only load allocates no vision tower and no projector.
+    /// Pixtral's tower is a flat ~0.75 GiB whatever the text model's size, so this is a smaller
+    /// win than Muse Glimmer's 3.84 GB — but it is the same win, and it is measured.
+    @Test("text-only construction omits the vision tower entirely")
+    func textOnlyOmitsTheTower() throws {
+        guard let cfg = try Self.realBundleConfig() else { return }
+        func count(_ m: Mistral3VLM) -> Int {
+            m.parameters().flattened().reduce(0) { $0 + $1.1.size }
+        }
+        let full = count(Mistral3VLM(cfg))
+        let text = count(try Mistral3VLM(cfg, requesting: [.text]))
+        #expect(text < full)
+        print("full  : \(full) params")
+        print("text  : \(text) params")
+        print("spared: \(full - text) params")
+    }
+
+    /// A text-only instance must expose no vision parameters at all — not merely fewer.
+    @Test("a text-only instance exposes no vision keys")
+    func textOnlyHasNoVisionKeys() throws {
+        guard let cfg = try Self.realBundleConfig() else { return }
+        let text = try Mistral3VLM(cfg, requesting: [.text])
+        let keys = text.parameters().flattened().map(\.0)
+        #expect(!keys.isEmpty)
+        for k in keys {
+            #expect(!k.contains("vision_tower"), "vision parameter present: \(k)")
+            #expect(!k.contains("multi_modal_projector"), "projector parameter present: \(k)")
+        }
+    }
+
+    /// The bundle still SHIPS its vision weights. Sanitize must drop them rather than rehome them
+    /// onto modules that were never built, which would leave keys with no destination.
+    @Test("sanitize drops the vision weights a text-only instance cannot receive")
+    func sanitizeDropsVisionWeights() throws {
+        guard let cfg = try Self.realBundleConfig() else { return }
+        let text = try Mistral3VLM(cfg, requesting: [.text])
+        let out = text.sanitize(weights: [
+            "vision_tower.transformer.layers.0.attention.wq.weight": MLXArray([0.0] as [Float]),
+            "model.multi_modal_projector.linear_1.weight": MLXArray([0.0] as [Float]),
+            "model.language_model.layers.0.self_attn.q_proj.weight": MLXArray([0.0] as [Float]),
+        ])
+        #expect(out.keys.first { $0.contains("vision_tower") } == nil)
+        #expect(out.keys.first { $0.contains("multi_modal_projector") } == nil)
+        // The language weight survives, so the drop is targeted rather than wholesale.
+        #expect(out.count == 1)
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/ModelConstructionModalitiesTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/ModelConstructionModalitiesTests.swift
@@ -1,0 +1,145 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Construction-time modality selection, checked without a GPU or a bundle.
+
+import Foundation
+import MLXLMCommon
+import MLXVLM
+import Testing
+
+@Suite("Model construction modalities")
+struct ModelConstructionModalitiesTests {
+
+    typealias Modalities = Set<ModelRuntimeRequestModality>
+
+    // MARK: the subset rule
+
+    @Test("no request means everything the configuration can build")
+    func nilRequestTakesAll() throws {
+        let constructible: Modalities = [.text, .vision, .video]
+        #expect(
+            try Modalities.resolveForConstruction(requested: nil, constructible: constructible)
+                == constructible)
+    }
+
+    @Test("a caller may ask for LESS — that is the point")
+    func narrowerRequestIsHonoured() throws {
+        // This is the load that is impossible today for any family nobody hand-registered twice:
+        // a vision bundle opened text-only, leaving its tower unallocated.
+        let got = try Modalities.resolveForConstruction(
+            requested: [.text], constructible: [.text, .vision, .video])
+        #expect(got == [.text])
+        #expect(!got.contains(.vision))
+    }
+
+    @Test("asking for MORE than can be built is an error, and an early one")
+    func widerRequestThrows() {
+        #expect(throws: UnconstructibleModalities.self) {
+            try Modalities.resolveForConstruction(requested: [.text, .vision], constructible: [.text])
+        }
+    }
+
+    @Test("text is NOT implied — a speech-to-speech model must be expressible")
+    func textIsNotImplied() throws {
+        // audio in, audio out, no text anywhere. Unlikely, not impossible; implying text would make
+        // it inexpressible, and the cost of not implying is that callers say what they mean.
+        let got = try Modalities.resolveForConstruction(requested: [.audio], constructible: [.audio])
+        #expect(got == [.audio])
+        #expect(!got.contains(.text))
+    }
+
+    @Test("an empty configuration or request is rejected, not silently accepted")
+    func emptyIsRejected() {
+        // With every component optional, "nothing" is reachable by a config that merely failed to
+        // parse. A model that can do nothing is a bug far more often than an intent.
+        #expect(throws: EmptyModalitySelection.self) {
+            try Modalities.resolveForConstruction(requested: nil, constructible: [])
+        }
+        #expect(throws: EmptyModalitySelection.self) {
+            try Modalities.resolveForConstruction(requested: [], constructible: [.text])
+        }
+    }
+
+    /// The vocabulary is `ModelRuntimeRequestModality` — shared with
+    /// `ModelRuntimeCapabilitySnapshot.validate`, and CLOSED. A downstream package cannot mint a
+    /// modality; a new one is a case added upstream, which is deliberate: the exhaustive switch in
+    /// `support(for:)` then forces it to be wired through everywhere before it can be requested.
+    /// What this test pins is that the resolver itself is modality-agnostic — it hardcodes no
+    /// subset, so a new case costs nothing here.
+    @Test("the resolver covers the whole vocabulary, with no lane special-cased")
+    func resolverIsModalityAgnostic() throws {
+        for modality in ModelRuntimeRequestModality.allCases {
+            let got = try Modalities.resolveForConstruction(
+                requested: [modality], constructible: Set(ModelRuntimeRequestModality.allCases))
+            #expect(got == [modality])
+        }
+    }
+
+    @Test("vision and video are separate, because bundles differ on exactly that")
+    func visionAndVideoAreDistinct() {
+        // JangLoader's own comment: "many VLMs accept images but not videos", and Gemma4 throws on
+        // video input. One vision flag would let such a request pass here and fail at prepare().
+        #expect(ModelRuntimeRequestModality.vision != ModelRuntimeRequestModality.video)
+        #expect(throws: UnconstructibleModalities.self) {
+            try Modalities.resolveForConstruction(
+                requested: [.video], constructible: [.text, .vision])
+        }
+    }
+
+    @Test("the error names what is missing, not just that something is")
+    func errorIsActionable() {
+        let e = UnconstructibleModalities(
+            requested: [.text, .audio], constructible: [.text, .vision])
+        #expect(e.excess == [.audio])
+        #expect(e.description.contains("audio"))
+    }
+
+    // MARK: the two questions are deliberately distinct
+
+    /// `ModelRuntimeCapabilitySnapshot` says what a bundle was TRAINED for; this says what a config
+    /// can BUILD. Keeping them apart is what lets a broken conversion — a `supports_vision` stamp
+    /// over a config with no vision section — stay visible instead of being averaged away.
+    @Test("a bundle may declare vision while its config cannot build it")
+    func declarationAndConstructibilityCanDisagree() throws {
+        let json = """
+            {"model_type":"muse_glimmer","hidden_size":128,"num_hidden_layers":2,
+             "intermediate_size":256,"num_attention_heads":4,"num_key_value_heads":2,
+             "rms_norm_eps":1e-6,"vocab_size":1000,"rope_theta":10000.0}
+            """
+        let cfg = try JSONDecoder.json5().decode(
+            MuseGlimmerConfiguration.self, from: Data(json.utf8))
+
+        // The config cannot build a vision tower...
+        #expect(MuseGlimmer.constructibleModalities(of: cfg) == [.text])
+        // ...and construction refuses, regardless of what any stamp elsewhere claims.
+        #expect(throws: UnconstructibleModalities.self) {
+            _ = try MuseGlimmer(cfg, requesting: [.text, .vision])
+        }
+    }
+
+    // MARK: the change that removes the need for a second registration
+
+    /// A text-only Muse Glimmer bundle has no `vision_config`, and until it became optional this
+    /// configuration could not DECODE such a bundle at all.
+    ///
+    /// That does NOT make the LLM-side `muse_glimmer` entry redundant. `muse_glimmer` names two
+    /// bundle shapes, and the two registrations serve one each — `ModelFactory` routes between
+    /// them by trying the VLM factory first and falling through on any error. See
+    /// `MuseGlimmerConfiguration.visionConfiguration`. What this test pins is only that a
+    /// vision-less config decodes and builds nothing but text.
+    @Test("a config with no vision_config decodes, and builds text only")
+    func textOnlyBundleDecodes() throws {
+        let json = """
+            {"model_type":"muse_glimmer","hidden_size":128,"num_hidden_layers":2,
+             "intermediate_size":256,"num_attention_heads":4,"num_key_value_heads":2,
+             "rms_norm_eps":1e-6,"vocab_size":1000,"rope_theta":10000.0}
+            """
+        let cfg = try JSONDecoder.json5().decode(
+            MuseGlimmerConfiguration.self, from: Data(json.utf8))
+        #expect(cfg.visionConfiguration == nil)
+
+        let model = MuseGlimmer(cfg)
+        #expect(model.modalities == [.text])
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/MuseGlimmerCapabilityLoadTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/MuseGlimmerCapabilityLoadTests.swift
@@ -1,0 +1,99 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// The claim, against a real bundle: a multimodal Muse Glimmer loaded text-only builds no vision
+// tower, and its language tower is unchanged.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import MLXVLM
+import Testing
+
+@Suite("Muse Glimmer capability-driven load (real bundle)")
+struct MuseGlimmerCapabilityLoadTests {
+
+    /// The real converted bundle. Absent on a machine without it, so every test here skips rather
+    /// than fails — a missing 26 GB model is not a defect in this code.
+    static var bundleConfig: URL? {
+        let root = URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent("Library/MLModels")
+        for org in ["OsaurusAI", "cubiculum", "JANGQ-AI"] {
+            let d = root.appendingPathComponent(org)
+            guard let kids = try? FileManager.default.contentsOfDirectory(atPath: d.path) else { continue }
+            for k in kids where k.hasPrefix("Muse-Glimmer") {
+                let c = d.appendingPathComponent(k).appendingPathComponent("config.json")
+                if FileManager.default.fileExists(atPath: c.path) { return c }
+            }
+        }
+        return nil
+    }
+
+    private func config() throws -> MuseGlimmerConfiguration? {
+        guard let url = Self.bundleConfig else { return nil }
+        return try JSONDecoder.json5().decode(
+            MuseGlimmerConfiguration.self, from: Data(contentsOf: url))
+    }
+
+    @Test("the real bundle declares text, image and video")
+    func realBundleDeclares() throws {
+        guard let cfg = try config() else { return }
+        #expect(cfg.visionConfiguration != nil)
+        #expect(MuseGlimmer.constructibleModalities(of: cfg) == [.text, .vision, .video])
+    }
+
+    /// The measurement that matters: same bundle, two loads, and the text-only one must not carry
+    /// the tower. Parameter COUNT is the observable — it is what allocation follows from.
+    @Test("text-only construction omits the vision tower entirely")
+    func textOnlyOmitsTower() throws {
+        guard let cfg = try config() else { return }
+
+        let full = MuseGlimmer(cfg)                                   // everything declared
+        let text = try MuseGlimmer(cfg, requesting: [.text])          // narrowed
+
+        func params(_ m: Module) -> Int {
+            m.parameters().flattened().reduce(0) { $0 + $1.1.size }
+        }
+        let pFull = params(full), pText = params(text)
+
+        #expect(text.modalities == [.text])
+        #expect(full.modalities == [.text, .vision, .video])
+        #expect(pText < pFull, "text-only must allocate strictly less")
+
+        let savedGB = Double(pFull - pText) * 2.0 / 1e9   // fp16 lower bound on the tower
+        print("""
+              full  : \(pFull) params
+              text  : \(pText) params
+              spared: \(pFull - pText) params (>= \(String(format: "%.2f", savedGB)) GB at fp16)
+              """)
+    }
+
+    /// The language tower must be untouched by narrowing — otherwise this changes answers rather
+    /// than packaging, and every banked Muse Glimmer row would be invalidated.
+    @Test("the language tower is identical in both loads")
+    func languageTowerUnchanged() throws {
+        guard let cfg = try config() else { return }
+        let full = MuseGlimmer(cfg)
+        let text = try MuseGlimmer(cfg, requesting: [.text])
+
+        func languageKeys(_ m: Module) -> [String] {
+            m.parameters().flattened().map(\.0).filter { $0.hasPrefix("language_model") }.sorted()
+        }
+        func languageSize(_ m: Module) -> Int {
+            m.parameters().flattened().filter { $0.0.hasPrefix("language_model") }
+                .reduce(0) { $0 + $1.1.size }
+        }
+        #expect(languageKeys(full) == languageKeys(text), "the text tower's shape must not change")
+        #expect(languageSize(full) == languageSize(text), "…nor its parameter count")
+    }
+
+    @Test("a text-only instance exposes no vision keys at all")
+    func noVisionKeysWhenNarrowed() throws {
+        guard let cfg = try config() else { return }
+        let text = try MuseGlimmer(cfg, requesting: [.text])
+        let visionish = text.parameters().flattened().map(\.0)
+            .filter { $0.contains("vision") }
+        #expect(visionish.isEmpty, "leftover vision parameters: \(visionish.prefix(3))")
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/UniversalCapabilityConstructionTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/UniversalCapabilityConstructionTests.swift
@@ -89,9 +89,12 @@ struct UniversalCapabilityConstructionTests {
     /// factory, so they are not this suite's subject at all.
     @Test("report which families this machine can actually exercise")
     func coverageIsLegible() {
+        // The nine dual-path families PLUS qwen4_exp, which is VLM-only and therefore not in
+        // DualPathFamilies — but the modality convention is about multimodal construction, not
+        // about dual registration, so it belongs in this suite's scope.
         let families = [
             "gemma3", "gemma4", "gemma4_unified", "qwen3_5", "qwen3_5_moe",
-            "mistral3", "ministral3", "muse_glimmer", "diffusion_gemma",
+            "mistral3", "ministral3", "muse_glimmer", "diffusion_gemma", "qwen4_exp",
         ]
         var withVision: [String] = []
         var textOnlyOnly: [String] = []
@@ -152,6 +155,33 @@ struct UniversalCapabilityConstructionTests {
         // Audio is claimed only for the conformer tower; whether THIS bundle has one is a
         // property of the bundle, so pin only that the claim is one of the two coherent answers.
         #expect(lanes.isSubset(of: [.text, .vision, .audio]))
+    }
+
+    /// qwen4_exp is the first family to ARRIVE after the convention existed, which makes it the
+    /// real test of whether the convention is one. Like qwen3_5 it genuinely consumes video —
+    /// `prepare` reads `input.video` and threads video frames into the tower — so it claims the
+    /// video lane rather than the image-only shape the Gemma and Pixtral families use.
+    @Test("qwen4_exp declares text, vision and video, and narrows like the rest")
+    func qwen4ExpFollowsTheConvention() throws {
+        guard let raw = Self.rawConfig(modelType: "qwen4_exp") else { return }
+        let cfg = try JSONDecoder.json5().decode(Qwen4ExpConfiguration.self, from: Self.asData(raw))
+        #expect(Qwen4Exp.constructibleModalities(of: cfg) == [.text, .vision, .video])
+
+        let narrowed = try Qwen4Exp(cfg, requesting: [.text])
+        #expect(narrowed.modalities == [.text])
+        #expect(Qwen4Exp(cfg).modalities == [.text, .vision, .video])
+
+        // Narrowing must SKIP the tower, not merely declare a smaller set.
+        let visionKeys = narrowed.parameters().flattened().map(\.0).filter { $0.contains("visual") }
+        #expect(visionKeys.isEmpty)
+
+        // And the weights it cannot receive are dropped rather than handed to nothing.
+        let out = narrowed.sanitize(weights: [
+            "visual.patch_embed.proj.weight": MLXArray([0.0] as [Float]),
+            "model.language_model.layers.0.self_attn.q_proj.weight": MLXArray([0.0] as [Float]),
+        ])
+        #expect(out.keys.first { $0.contains("visual") } == nil)
+        #expect(out.count == 1)
     }
 
     // MARK: a vision-less config decodes, and builds text only

--- a/Tests/MLXLMCommonFocusedTests/UniversalCapabilityConstructionTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/UniversalCapabilityConstructionTests.swift
@@ -1,0 +1,291 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Every dual-path family now answers the same question the same way. The point of this suite is
+// UNIVERSALITY: a convention a few families follow is a proposal, and the next person adding a
+// multimodal model should find a pattern rather than a special case. So these tests assert the
+// SHAPE across families rather than one family's behaviour.
+//
+// Configurations come from real local bundles, with `vision_config` removed where a text-only case
+// is needed — which is what a text-only conversion of that bundle would look like. Hand-written
+// fixtures were tried first and drifted from the real schemas immediately; deriving from the
+// bundles keeps the test honest and removes a whole class of maintenance.
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import MLXNN
+import MLXVLM
+import Testing
+
+@Suite("Capability-driven construction across the dual-path families")
+struct UniversalCapabilityConstructionTests {
+
+    typealias Modalities = Set<ModelRuntimeRequestModality>
+
+    /// The raw `config.json` of the SMALLEST local bundle with this `model_type`, if any.
+    ///
+    /// Smallest rather than first-found: several of these tests construct the model, and the
+    /// qualifying bundles span 2.6 GB to 91 GB. Any of them proves the same thing, so ranking by
+    /// weight size keeps the suite cheap — "first alphabetically" was selecting a 119B by accident
+    /// of the org name.
+    static func rawConfig(modelType: String, needsVision: Bool = true) -> [String: Any]? {
+        let root = URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("Library/MLModels")
+        let fm = FileManager.default
+        guard let orgs = try? fm.contentsOfDirectory(atPath: root.path) else { return nil }
+        var best: (obj: [String: Any], bytes: UInt64)? = nil
+        for org in orgs.sorted() {
+            let orgDir = root.appendingPathComponent(org)
+            guard let kids = try? fm.contentsOfDirectory(atPath: orgDir.path) else { continue }
+            for kid in kids.sorted() {
+                let dir = orgDir.appendingPathComponent(kid)
+                guard let data = try? Data(contentsOf: dir.appendingPathComponent("config.json")),
+                    let obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+                    obj["model_type"] as? String == modelType,
+                    !needsVision || obj["vision_config"] != nil,
+                    let files = try? fm.contentsOfDirectory(atPath: dir.path)
+                else { continue }
+                var bytes: UInt64 = 0
+                for f in files where f.hasSuffix(".safetensors") {
+                    let attrs = try? fm.attributesOfItem(atPath: dir.appendingPathComponent(f).path)
+                    bytes += (attrs?[.size] as? UInt64) ?? 0
+                }
+                if best == nil || bytes < best!.bytes { best = (obj, bytes) }
+            }
+        }
+        return best?.obj
+    }
+
+    /// The same document with its vision section removed.
+    static func visionStripped(_ cfg: [String: Any]) -> Data {
+        var c = cfg
+        c.removeValue(forKey: "vision_config")
+        if var t = c["text_config"] as? [String: Any] {
+            t.removeValue(forKey: "vision_config")
+            c["text_config"] = t
+        }
+        return try! JSONSerialization.data(withJSONObject: c)
+    }
+
+    private static func asData(_ cfg: [String: Any]) -> Data {
+        try! JSONSerialization.data(withJSONObject: cfg)
+    }
+
+    /// Which families this run actually exercised.
+    ///
+    /// Every test here is bundle-gated, and a gate that closes silently is indistinguishable from a
+    /// passing test — not hypothetical: a mutation to Gemma3's construction passed the whole suite
+    /// because no `gemma3` bundle exists on this machine, so its assertions never ran.
+    ///
+    /// The report distinguishes THREE states, because two of them look alike and are not. The
+    /// vision-bearing tests need a bundle WITH a `vision_config`; a text-only bundle of the same
+    /// family satisfies neither. An earlier version of this test asked only whether any bundle
+    /// existed, which would have reported a family as exercised while every one of its assertions
+    /// skipped — the precise failure this test exists to prevent, in the test itself.
+    ///
+    /// Note also that a family's text-only bundles often carry a DIFFERENT `model_type` entirely
+    /// (`gemma3_text` rather than `gemma3`, `mistral` rather than `mistral3`) and route to the LLM
+    /// factory, so they are not this suite's subject at all.
+    @Test("report which families this machine can actually exercise")
+    func coverageIsLegible() {
+        let families = [
+            "gemma3", "gemma4", "gemma4_unified", "qwen3_5", "qwen3_5_moe",
+            "mistral3", "ministral3", "muse_glimmer", "diffusion_gemma",
+        ]
+        var withVision: [String] = []
+        var textOnlyOnly: [String] = []
+        var absent: [String] = []
+        for f in families {
+            if Self.rawConfig(modelType: f) != nil {
+                withVision.append(f)
+            } else if Self.rawConfig(modelType: f, needsVision: false) != nil {
+                textOnlyOnly.append(f)
+            } else {
+                absent.append(f)
+            }
+        }
+        print("exercised          : \(withVision.sorted().joined(separator: ", "))")
+        if !textOnlyOnly.isEmpty {
+            print("NOT exercised      : \(textOnlyOnly.sorted().joined(separator: ", "))"
+                + "  — a bundle exists but carries no vision_config, so the assertions skip")
+        }
+        print("no bundle at all   : \(absent.sorted().joined(separator: ", "))")
+        #expect(!withVision.isEmpty, "no vision bundle for any dual-path family; this suite tested nothing")
+    }
+
+    // MARK: the lanes each family declares
+
+    /// The declared set must describe what `prepare` will actually accept, and the families DIFFER.
+    /// That difference is the evidence the image/video split earns its keep: one "vision" flag
+    /// could not tell Qwen 3.5 from Pixtral, and would let a video request pass construction on a
+    /// family that refuses video outright.
+    @Test("Qwen 3.5 claims video, because it actually consumes it")
+    func qwenClaimsVideo() throws {
+        guard let raw = Self.rawConfig(modelType: "qwen3_5") else { return }
+        let cfg = try JSONDecoder.json5().decode(
+            MLXVLM.Qwen35Configuration.self, from: Self.asData(raw))
+        #expect(Qwen35.constructibleModalities(of: cfg) == [.text, .vision, .video])
+    }
+
+    @Test("Mistral 3 claims vision without video, because Pixtral is image-only")
+    func mistralClaimsVisionNotVideo() throws {
+        guard let raw = Self.rawConfig(modelType: "mistral3") else { return }
+        let cfg = try JSONDecoder.json5().decode(
+            Mistral3VLMConfiguration.self, from: Self.asData(raw))
+        #expect(Mistral3VLM.constructibleModalities(of: cfg) == [.text, .vision])
+        #expect(!Mistral3VLM.constructibleModalities(of: cfg).contains(.video))
+    }
+
+    /// Gemma 4 refuses video in `prepare` ("no proven vMLX video path yet"), so it must not claim
+    /// the lane — and it may claim `.audio`, but only for the conformer tower.
+    @Test("Gemma 4 never claims video, and claims audio only for a conformer tower")
+    func gemma4LanesAreHonest() throws {
+        guard let raw = Self.rawConfig(modelType: "gemma4") else { return }
+        let cfg = try JSONDecoder.json5().decode(Gemma4Configuration.self, from: Self.asData(raw))
+        // Asserted through the public surface only: Gemma4Configuration's own fields are
+        // internal, and `constructibleModalities` is the thing callers actually consult.
+        let lanes = Gemma4.constructibleModalities(of: cfg)
+        #expect(lanes.contains(.text))
+        #expect(lanes.contains(.vision))
+        #expect(!lanes.contains(.video))
+        // Audio is claimed only for the conformer tower; whether THIS bundle has one is a
+        // property of the bundle, so pin only that the claim is one of the two coherent answers.
+        #expect(lanes.isSubset(of: [.text, .vision, .audio]))
+    }
+
+    // MARK: a vision-less config decodes, and builds text only
+
+    /// Before this work a text-only bundle of any of these families could not DECODE at all — the
+    /// vision section was non-optional. That, not the tower, was the original reason each family
+    /// needed a second registration.
+    @Test("a vision-stripped config decodes and builds text only, in every family")
+    func textOnlyEverywhere() throws {
+        if let raw = Self.rawConfig(modelType: "gemma3") {
+            let cfg = try JSONDecoder.json5().decode(
+                Gemma3Configuration.self, from: Self.visionStripped(raw))
+            #expect(cfg.visionConfiguration == nil)
+            #expect(Gemma3.constructibleModalities(of: cfg) == [.text])
+            #expect(Gemma3(cfg).modalities == [.text])
+        }
+        if let raw = Self.rawConfig(modelType: "mistral3") {
+            let cfg = try JSONDecoder.json5().decode(
+                Mistral3VLMConfiguration.self, from: Self.visionStripped(raw))
+            #expect(cfg.visionConfig == nil)
+            #expect(Mistral3VLM(cfg).modalities == [.text])
+        }
+        if let raw = Self.rawConfig(modelType: "gemma4") {
+            let cfg = try JSONDecoder.json5().decode(
+                Gemma4Configuration.self, from: Self.visionStripped(raw))
+            #expect(!Gemma4.constructibleModalities(of: cfg).contains(.vision))
+        }
+        if let raw = Self.rawConfig(modelType: "qwen3_5") {
+            let cfg = try JSONDecoder.json5().decode(
+                MLXVLM.Qwen35Configuration.self, from: Self.visionStripped(raw))
+            #expect(cfg.visionConfiguration == nil)
+            #expect(Qwen35.constructibleModalities(of: cfg) == [.text])
+        }
+    }
+
+    // MARK: the subset rule holds everywhere
+
+    @Test("asking a vision-stripped config for vision throws, in every family")
+    func overRequestThrowsEverywhere() throws {
+        if let raw = Self.rawConfig(modelType: "gemma3") {
+            let cfg = try JSONDecoder.json5().decode(
+                Gemma3Configuration.self, from: Self.visionStripped(raw))
+            #expect(throws: UnconstructibleModalities.self) {
+                _ = try Gemma3(cfg, requesting: [.text, .vision])
+            }
+        }
+        if let raw = Self.rawConfig(modelType: "mistral3") {
+            let cfg = try JSONDecoder.json5().decode(
+                Mistral3VLMConfiguration.self, from: Self.visionStripped(raw))
+            #expect(throws: UnconstructibleModalities.self) {
+                _ = try Mistral3VLM(cfg, requesting: [.text, .vision])
+            }
+        }
+        if let raw = Self.rawConfig(modelType: "qwen3_5") {
+            let cfg = try JSONDecoder.json5().decode(
+                MLXVLM.Qwen35Configuration.self, from: Self.visionStripped(raw))
+            #expect(throws: UnconstructibleModalities.self) {
+                _ = try Qwen35(cfg, requesting: [.text, .vision])
+            }
+        }
+    }
+
+    /// A caller may narrow, which is the whole point — and the narrowed instance must SAY so.
+    @Test("a narrowed instance reports the narrower set, in every family")
+    func narrowingIsReportedEverywhere() throws {
+        if let raw = Self.rawConfig(modelType: "mistral3") {
+            let cfg = try JSONDecoder.json5().decode(
+                Mistral3VLMConfiguration.self, from: Self.asData(raw))
+            #expect(try Mistral3VLM(cfg, requesting: [.text]).modalities == [.text])
+            #expect(Mistral3VLM(cfg).modalities == [.text, .vision])
+        }
+        if let raw = Self.rawConfig(modelType: "gemma3") {
+            let cfg = try JSONDecoder.json5().decode(
+                Gemma3Configuration.self, from: Self.asData(raw))
+            #expect(try Gemma3(cfg, requesting: [.text]).modalities == [.text])
+        }
+    }
+
+    /// Declaring a narrower set and BUILDING a narrower model are different claims, and only the
+    /// second one saves anything. A mutation that built the tower regardless of the request passed
+    /// every other test in this suite, which is exactly why this one exists: assert the parameters,
+    /// not the declaration.
+    @Test("a narrowed instance allocates no vision parameters, in every family")
+    func narrowingActuallySkipsTheTower() throws {
+        func visionKeys(_ m: Module) -> [String] {
+            m.parameters().flattened().map(\.0).filter {
+                $0.contains("vision_tower") || $0.contains("vision_model")
+                    || $0.contains("multi_modal_projector") || $0.contains("vision_embedder")
+            }
+        }
+
+        if let raw = Self.rawConfig(modelType: "gemma3") {
+            let cfg = try JSONDecoder.json5().decode(
+                Gemma3Configuration.self, from: Self.asData(raw))
+            #expect(!visionKeys(Gemma3(cfg)).isEmpty, "the full load should carry vision")
+            #expect(visionKeys(try Gemma3(cfg, requesting: [.text])).isEmpty)
+        }
+        if let raw = Self.rawConfig(modelType: "mistral3") {
+            let cfg = try JSONDecoder.json5().decode(
+                Mistral3VLMConfiguration.self, from: Self.asData(raw))
+            #expect(!visionKeys(Mistral3VLM(cfg)).isEmpty, "the full load should carry vision")
+            #expect(visionKeys(try Mistral3VLM(cfg, requesting: [.text])).isEmpty)
+        }
+        if let raw = Self.rawConfig(modelType: "gemma4") {
+            let cfg = try JSONDecoder.json5().decode(
+                Gemma4Configuration.self, from: Self.asData(raw))
+            #expect(!visionKeys(Gemma4(cfg)).isEmpty, "the full load should carry vision")
+            #expect(visionKeys(try Gemma4(cfg, requesting: [.text])).isEmpty)
+        }
+        if let raw = Self.rawConfig(modelType: "qwen3_5") {
+            let cfg = try JSONDecoder.json5().decode(
+                MLXVLM.Qwen35Configuration.self, from: Self.asData(raw))
+            #expect(!visionKeys(Qwen35(cfg)).isEmpty, "the full load should carry vision")
+            #expect(visionKeys(try Qwen35(cfg, requesting: [.text])).isEmpty)
+        }
+    }
+
+    /// diffusion_gemma was already closest to the target: its VLM creator returns the SAME type the
+    /// LLM factory registers, gaining a vision lane only when a tower is installed. So its modality
+    /// set is a `var` — and it still refuses an impossible request.
+    @Test("diffusion_gemma declares and refuses like the rest")
+    func diffusionGemmaFollowsTheConvention() throws {
+        guard let raw = Self.rawConfig(modelType: "diffusion_gemma") else { return }
+        let full = try JSONDecoder.json5().decode(
+            DiffusionGemmaVLMConfiguration.self, from: Self.asData(raw))
+        #expect(diffusionGemmaConstructibleModalities(of: full).contains(.vision))
+        #expect(makeDiffusionGemmaVLM(full).modalities.contains(.vision))
+
+        let stripped = try JSONDecoder.json5().decode(
+            DiffusionGemmaVLMConfiguration.self, from: Self.visionStripped(raw))
+        #expect(diffusionGemmaConstructibleModalities(of: stripped) == [.text])
+        #expect(makeDiffusionGemmaVLM(stripped).modalities == [.text])
+        #expect(throws: UnconstructibleModalities.self) {
+            _ = try makeDiffusionGemmaVLM(stripped, requesting: [.text, .vision])
+        }
+    }
+}

--- a/Tests/MLXLMTests/Gemma4VLMTests.swift
+++ b/Tests/MLXLMTests/Gemma4VLMTests.swift
@@ -155,9 +155,9 @@ private func maskedScatter(input: MLXArray, mask: MLXArray, source: MLXArray) ->
     let config = try JSONDecoder().decode(Gemma4Configuration.self, from: data)
 
     #expect(config.imageTokenId == 258880)
-    #expect(config.visionConfig.defaultOutputLength == 280)
-    #expect(config.visionConfig.poolingKernelSize == 3)
-    #expect(config.visionConfig.patchSize == 16)
+    #expect(config.visionConfig?.defaultOutputLength == 280)
+    #expect(config.visionConfig?.poolingKernelSize == 3)
+    #expect(config.visionConfig?.patchSize == 16)
     #expect(config.textConfig.numHiddenLayers == 35)
     #expect(config.textConfig.numKvSharedLayers == 20)
     #expect(config.textConfig.slidingWindow == 512)
@@ -270,12 +270,12 @@ private func maskedScatter(input: MLXArray, mask: MLXArray, source: MLXArray) ->
     #expect(config.textConfig.slidingWindow == 1024)
     #expect(config.textConfig.layerTypes.filter { $0 == "full_attention" }.count == 8)
     #expect(config.textConfig.layerTypes.filter { $0 == "sliding_attention" }.count == 40)
-    #expect(config.visionConfig.usesUnifiedVisionEmbedder)
-    #expect(config.visionConfig.hiddenSize == 3840)
-    #expect(config.visionConfig.outputProjectionDimensions == 3840)
-    #expect(config.visionConfig.modelPatchSize == 48)
-    #expect(config.visionConfig.positionEmbeddingSize == 1120)
-    #expect(config.visionConfig.defaultOutputLength == 280)
+    #expect(config.visionConfig?.usesUnifiedVisionEmbedder == true)
+    #expect(config.visionConfig?.hiddenSize == 3840)
+    #expect(config.visionConfig?.outputProjectionDimensions == 3840)
+    #expect(config.visionConfig?.modelPatchSize == 48)
+    #expect(config.visionConfig?.positionEmbeddingSize == 1120)
+    #expect(config.visionConfig?.defaultOutputLength == 280)
 }
 
 @Test func gemma4ProportionalRoPEHandlesAsymmetricGlobalKeyWidth() {
@@ -540,8 +540,8 @@ private func maskedScatter(input: MLXArray, mask: MLXArray, source: MLXArray) ->
 
     // This is the root invariant: processor token count must match vision feature count
     #expect(
-        procConfig.imageSeqLength == modelConfig.visionConfig.defaultOutputLength,
-        "Processor imageSeqLength (\(procConfig.imageSeqLength)) must equal vision defaultOutputLength (\(modelConfig.visionConfig.defaultOutputLength))")
+        procConfig.imageSeqLength == modelConfig.visionConfig?.defaultOutputLength,
+        "Processor imageSeqLength (\(procConfig.imageSeqLength)) must equal vision defaultOutputLength (\(modelConfig.visionConfig?.defaultOutputLength))")
 }
 
 @Test func gemma4E4BConfigDecode() throws {
@@ -556,6 +556,6 @@ private func maskedScatter(input: MLXArray, mask: MLXArray, source: MLXArray) ->
     let config = try JSONDecoder().decode(Gemma4Configuration.self, from: data)
 
     #expect(config.imageTokenId == 258880)
-    #expect(config.visionConfig.defaultOutputLength == 280)
-    #expect(config.visionConfig.poolingKernelSize == 3)
+    #expect(config.visionConfig?.defaultOutputLength == 280)
+    #expect(config.visionConfig?.poolingKernelSize == 3)
 }


### PR DESCRIPTION
> **Depends on #315 — review only the LAST commit.**
>
> The first four commits here *are* #315. They are carried in this branch because a
> PR's base must be a branch in this repository, and ours live in a fork, so GitHub
> cannot stack this on #315 directly. Rather than show you a diff with its own
> foundation missing, the dependency rides along. Once #315 merges these four
> collapse to no-ops on rebase and this becomes a single-commit PR.
>
> #315 introduces the convention; this applies it to the first family that arrived
> after it existed.

`qwen4_exp` is the first multimodal family to arrive **after** the modality
convention existed, which makes it the real test of whether #315 produced a
convention or nine one-offs. It gets the same three pieces every converted
family has:

| piece | question it answers |
|---|---|
| `constructibleModalities(of:)` | what could this configuration build? |
| `init(_:requesting:)` | what did the caller ask for — is it available? |
| `ModalityBearing` | what does this instance actually carry? |

## The video lane is claimed, and that is a real claim

```swift
config.base.visionConfiguration != nil ? [.text, .vision, .video] : [.text]
```

`prepare` consumes `input.video` and threads video frames into the tower — the
same shape as `qwen3_5`. The Gemma and Pixtral families are image-only and
correctly do **not** claim it. Declaring the lane is only worth doing because
the declaration can be wrong, so it is asserted per family rather than assumed.

## Narrowing skips the tower, it does not just report a smaller set

`visionModel` becomes optional, and three sites follow:

1. **`prepare` refuses media** with a message naming the instance's modalities,
   rather than embedding the prompt without the media it was handed. A silently
   media-free answer looks like a bad model, not a bad call.
2. **`sanitize` drops `visual.` weights** when no tower exists to receive them —
   mirroring the `mtp.` guard directly above it. A multimodal bundle loaded
   text-only still *ships* its vision weights.
3. Two `visionConfiguration` reads become optional-safe.

## Tested in the shared suite, which is the point

The four cross-family tests from #315 now cover `qwen4_exp` too — it is added to
the family list rather than given a bespoke suite. One family-specific test
asserts the parts that are its own:

```swift
#expect(Qwen4Exp.constructibleModalities(of: cfg) == [.text, .vision, .video])
#expect(try Qwen4Exp(cfg, requesting: [.text]).modalities == [.text])
// narrowing must SKIP the tower, not merely declare a smaller set
#expect(visionKeys.isEmpty)
// and the weights it cannot receive are dropped rather than handed to nothing
#expect(out.keys.first { $0.contains("visual") } == nil)
```

## Coverage is reported, not assumed

```
exercised        : diffusion_gemma, gemma3, gemma4, gemma4_unified, mistral3,
                   muse_glimmer, qwen3_5, qwen3_5_moe, qwen4_exp
no bundle at all : ministral3
```

These assertions are bundle-gated, and a gated assertion that never runs looks
exactly like one that passed — so the suite states which families it actually
exercised on the machine it ran on.
