### PR TITLE
Finish the VMLX_ environment-variable migration

### DIFF
--- a/Libraries/MLXLLM/Models/NemotronH.swift
+++ b/Libraries/MLXLLM/Models/NemotronH.swift
@@ -98,7 +98,7 @@ private func nemotronHEnvFlag(_ name: String) -> Bool {
 }
 
 private let nemotronHActivationBF16RetentionFlag =
-    nemotronHEnvFlag("VMLINUX_ENABLE_NEMOTRON_ACTIVATION_BF16")
+    RuntimeEnvironment.flag("VMLX_ENABLE_NEMOTRON_ACTIVATION_BF16")
     && !nemotronHEnvFlag("JANGTQ_DISABLE_NEMOTRON_ACTIVATION_BF16")
 private let nemotronHWeightedMoEFastPathFlag =
     nemotronHEnvFlag("JANGTQ_ENABLE_NEMOTRON_WEIGHTED_MOE_FASTPATH")
@@ -143,10 +143,9 @@ internal func nemotronHNativeMTPEnabled() -> Bool {
 }
 
 private let nemotronHLayerProfileFlag =
-    nemotronHEnvFlag("VMLX_NEMOTRON_LAYER_PROFILE")
-    || nemotronHEnvFlag("VMLINUX_NEMOTRON_LAYER_PROFILE")
+    RuntimeEnvironment.flag("VMLX_NEMOTRON_LAYER_PROFILE")
 private let nemotronHMambaConvFastPathDisabledFlag =
-    nemotronHEnvFlag("VMLINUX_DISABLE_NEMOTRON_MAMBA_CONV_FASTPATH")
+    RuntimeEnvironment.flag("VMLX_DISABLE_NEMOTRON_MAMBA_CONV_FASTPATH")
 
 private func nemotronHActivationBF16RetentionEnabled() -> Bool {
     nemotronHActivationBF16RetentionFlag

--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -94,7 +94,7 @@ private func debugLogReasoningPromptTail(
     promptTail: String?,
     path: String
 ) {
-    guard ProcessInfo.processInfo.environment["VMLINUX_REASONING_PROMPT_TAIL_LOG"] == "1"
+    guard RuntimeEnvironment.flag("VMLX_REASONING_PROMPT_TAIL_LOG")
     else { return }
     let escaped = (promptTail ?? "<nil>")
         .replacingOccurrences(of: "\\", with: "\\\\")
@@ -113,7 +113,7 @@ private func debugDumpReasoningPrompt(
     path: String
 ) {
     let env = ProcessInfo.processInfo.environment
-    guard let dir = env["VMLINUX_REASONING_PROMPT_DUMP_DIR"],
+    guard let dir = RuntimeEnvironment.value("VMLX_REASONING_PROMPT_DUMP_DIR", in: env),
           !dir.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     else { return }
 

--- a/Libraries/MLXLMCommon/Cache/SSMReDerive.swift
+++ b/Libraries/MLXLMCommon/Cache/SSMReDerive.swift
@@ -445,8 +445,7 @@ public func reDeriveAndStoreSSMStatesAtPromptBoundaries(
     prefillStepSize: Int = 512
 ) -> [Int: [MLXArray]] {
     func trace(_ message: String) {
-        guard ProcessInfo.processInfo.environment["VMLINUX_SSM_REDERIVE_TRACE"] == "1"
-            || ProcessInfo.processInfo.environment["VMLX_SSM_REDERIVE_TRACE"] == "1"
+        guard RuntimeEnvironment.flag("VMLX_SSM_REDERIVE_TRACE")
         else { return }
         FileHandle.standardError.write(
             Data("[vmlx][cache/ssm-rederive] prompt-boundaries/\(message) hybrid=\(coordinator.isHybrid) promptLen=\(promptTokenIds.count)\n".utf8))

--- a/Libraries/MLXLMCommon/DeepseekV4ReasoningPolicy.swift
+++ b/Libraries/MLXLMCommon/DeepseekV4ReasoningPolicy.swift
@@ -12,11 +12,15 @@ import Foundation
 public enum DeepseekV4ReasoningPolicy {
     /// Deprecated compatibility key. `reasoning_effort=max` now passes through
     /// without an opt-in environment variable.
-    public static let rawMaxEnvironmentKey = "VMLINUX_DSV4_RAW_MAX"
+    public static let rawMaxEnvironmentKey = "VMLX_DSV4_RAW_MAX"
+    /// The pre-rename spelling, still honoured. See `RuntimeEnvironment`.
+    public static let legacyRawMaxEnvironmentKey = "VMLINUX_DSV4_RAW_MAX"
 
     /// Deprecated compatibility key. Public request/template controls must win;
     /// process environment must not silently force direct-answer rails.
-    public static let forceDirectRailEnvironmentKey = "VMLINUX_DSV4_FORCE_DIRECT_RAIL"
+    public static let forceDirectRailEnvironmentKey = "VMLX_DSV4_FORCE_DIRECT_RAIL"
+    /// The pre-rename spelling, still honoured. See `RuntimeEnvironment`.
+    public static let legacyForceDirectRailEnvironmentKey = "VMLINUX_DSV4_FORCE_DIRECT_RAIL"
 
     public static func isDeepseekV4(modelType: String?) -> Bool {
         guard let modelType else { return false }
@@ -34,7 +38,7 @@ public enum DeepseekV4ReasoningPolicy {
     public static func rawMaxEnabled(
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> Bool {
-        truthy(environment[rawMaxEnvironmentKey])
+        truthy(environment[rawMaxEnvironmentKey] ?? environment[legacyRawMaxEnvironmentKey])
     }
 
     @available(
@@ -43,7 +47,8 @@ public enum DeepseekV4ReasoningPolicy {
     public static func forceDirectRailEnabled(
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> Bool {
-        truthy(environment[forceDirectRailEnvironmentKey])
+        truthy(environment[forceDirectRailEnvironmentKey]
+            ?? environment[legacyForceDirectRailEnvironmentKey])
     }
 
     public static func normalizedReasoningEffort(

--- a/Libraries/MLXLMCommon/Documentation.docc/ane-acceleration.md
+++ b/Libraries/MLXLMCommon/Documentation.docc/ane-acceleration.md
@@ -33,7 +33,7 @@ Runtime names reserved for the future Osaurus/vMLX setting:
 Suggested environment variable for local benches:
 
 ```sh
-VMLINUX_ACCELERATOR=auto
+VMLX_ACCELERATOR=auto
 ```
 
 Implemented API shape:
@@ -136,8 +136,8 @@ For every island and model family:
 2. Use `ANEProbe` as the isolated Core ML capability check. It is deliberately
    outside the hot decode path and reports Core ML / Neural Engine visibility.
 3. Convert one media encoder first, preferably Nemotron-Omni RADIO or Parakeet,
-   and benchmark `BENCH_VL_CHAT_CACHE` with `VMLINUX_ACCELERATOR=metal` vs
-   `VMLINUX_ACCELERATOR=ane-coreml`.
+   and benchmark `BENCH_VL_CHAT_CACHE` with `VMLX_ACCELERATOR=metal` vs
+   `VMLX_ACCELERATOR=ane-coreml`.
 4. Only after a measured win, wire `AccelerationMode` into generation options
    and Osaurus settings.
 5. Leave dense/MoE decoder ANE islands as research until the media island is
@@ -145,7 +145,7 @@ For every island and model family:
 
 ## Current Flag Behavior
 
-`VMLINUX_ACCELERATOR` is parsed by `AccelerationRuntime.requestedMode()`:
+`VMLX_ACCELERATOR` is parsed by `AccelerationRuntime.requestedMode()`:
 
 | Value | Current behavior |
 | --- | --- |
@@ -162,10 +162,10 @@ before a real Core ML subgraph exists.
 2026-05-07 on the local M5 Max:
 
 ```text
-VMLINUX_ANE_PROBE_VERSION=1
-VMLINUX_ACCELERATOR_REQUESTED=metal
-VMLINUX_TEXT_DECODE_ACCELERATOR=metal
-VMLINUX_TEXT_DECODE_REASON=explicit-metal
+VMLX_ANE_PROBE_VERSION=1
+VMLX_ACCELERATOR_REQUESTED=metal
+VMLX_TEXT_DECODE_ACCELERATOR=metal
+VMLX_TEXT_DECODE_REASON=explicit-metal
 COREML_AVAILABLE=YES
 MLX_DIRECT_ANE_DEVICE=NO
 COREML_COMPUTE_UNITS=all

--- a/Libraries/MLXLMCommon/JANGTQStreamingExperts.swift
+++ b/Libraries/MLXLMCommon/JANGTQStreamingExperts.swift
@@ -3644,13 +3644,21 @@ private final class JANGTQStreamingExpertStore: @unchecked Sendable {
     ) rethrows -> T {
         #if canImport(Darwin) || canImport(Glibc)
         let mmapKey = "MLX_SAFETENSORS_MMAP"
-        let vmlxMmapKey = "VMLINUX_MMAP_SAFETENSORS"
+        // Both spellings, deliberately. The consumer of this variable is in the MLX C++
+        // submodule (`mmap_safetensors_enabled`), which today reads only the legacy name — so
+        // writing just the new one would stop forcing mmap here, silently. Writing just the
+        // legacy one leaves the new name inert. Drop the legacy write once the submodule reads
+        // both.
+        let vmlxMmapKey = "VMLX_MMAP_SAFETENSORS"
+        let legacyVmlxMmapKey = RuntimeEnvironment.legacyName(of: vmlxMmapKey)!
         let tensorKey = "MLX_SAFETENSORS_MMAP_TENSOR_BUFFERS"
         let priorMmap = getenv(mmapKey).map { String(cString: $0) }
         let priorVmlxMmap = getenv(vmlxMmapKey).map { String(cString: $0) }
+        let priorLegacyVmlxMmap = getenv(legacyVmlxMmapKey).map { String(cString: $0) }
         let priorTensor = getenv(tensorKey).map { String(cString: $0) }
         setenv(mmapKey, "1", 1)
         setenv(vmlxMmapKey, "1", 1)
+        setenv(legacyVmlxMmapKey, "1", 1)
         setenv(tensorKey, "1", 1)
         defer {
             if let priorMmap {
@@ -3662,6 +3670,11 @@ private final class JANGTQStreamingExpertStore: @unchecked Sendable {
                 setenv(vmlxMmapKey, priorVmlxMmap, 1)
             } else {
                 unsetenv(vmlxMmapKey)
+            }
+            if let priorLegacyVmlxMmap {
+                setenv(legacyVmlxMmapKey, priorLegacyVmlxMmap, 1)
+            } else {
+                unsetenv(legacyVmlxMmapKey)
             }
             if let priorTensor {
                 setenv(tensorKey, priorTensor, 1)

--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -1046,8 +1046,8 @@ public func loadWeights(
     // unless the bundle has live proof that affine quant metadata must be
     // materialized to bf16 while raw TurboQuant tensors stay untouched.
     let mmapSafetensorsActive = envFlag("MLX_SAFETENSORS_MMAP")
-        || envFlag("VMLINUX_MMAP_SAFETENSORS")
-    let allowJANGTQMmapBFloat16 = envFlag("VMLINUX_JANGTQ_BF16_MMAP")
+        || RuntimeEnvironment.flag("VMLX_MMAP_SAFETENSORS")
+    let allowJANGTQMmapBFloat16 = RuntimeEnvironment.flag("VMLX_JANGTQ_BF16_MMAP")
         || envFlag("MLX_JANGTQ_BF16_MMAP")
     let autoJANGTQMmapBFloat16 = requiresJANGTQMmapBFloat16(modelDirectory)
     // Gemma 4 and Qwen4-exp JANG affine bundles carry F16 scales/biases whose

--- a/Libraries/MLXLMCommon/ModelFactory.swift
+++ b/Libraries/MLXLMCommon/ModelFactory.swift
@@ -782,7 +782,7 @@ func applyPlainDeepseekV4ProcessMemoryLimitsIfNeeded(
 private func load<R>(loader: (ModelFactory) async throws -> sending R) async throws -> sending R {
     let factories = ModelFactoryRegistry.shared.modelFactories()
     let traceFactoryFallbacks: Bool = {
-        let raw = ProcessInfo.processInfo.environment["VMLINUX_MODEL_FACTORY_TRACE"]?
+        let raw = RuntimeEnvironment.value("VMLX_MODEL_FACTORY_TRACE")?
             .lowercased()
         return raw == "1" || raw == "true" || raw == "on" || raw == "yes"
     }()
@@ -837,17 +837,24 @@ private func withMmapSafetensorsEnv<R>(
     #if canImport(Darwin) || canImport(Glibc)
         let mmapKey = "MLX_SAFETENSORS_MMAP"
         let vmlxMmapKey = "VMLX_MMAP_SAFETENSORS"
+        // The consumer is `mmap_safetensors_enabled` in the MLX C++ submodule, which reads
+        // MLX_SAFETENSORS_MMAP or the LEGACY spelling — not this one. Writing only the new name
+        // made this a dead write; mmap kept working solely because MLX_SAFETENSORS_MMAP is set
+        // beside it. Write both until the submodule reads the new name too.
+        let legacyVmlxMmapKey = RuntimeEnvironment.legacyName(of: vmlxMmapKey)!
         let tensorKey = "MLX_SAFETENSORS_MMAP_TENSOR_BUFFERS"
         let startColdKey = "MLX_SAFETENSORS_MMAP_START_COLD"
         let coldPctKey = "MLX_SAFETENSORS_MMAP_COLD_PCT"
         let priorMmap = getenv(mmapKey).map { String(cString: $0) }
         let priorVmlxMmap = getenv(vmlxMmapKey).map { String(cString: $0) }
+        let priorLegacyVmlxMmap = getenv(legacyVmlxMmapKey).map { String(cString: $0) }
         let priorTensor = getenv(tensorKey).map { String(cString: $0) }
         let priorStartCold = getenv(startColdKey).map { String(cString: $0) }
         let priorColdPct = getenv(coldPctKey).map { String(cString: $0) }
         if enabled {
             setenv(mmapKey, "1", 1)
             setenv(vmlxMmapKey, "1", 1)
+            setenv(legacyVmlxMmapKey, "1", 1)
             if tensorBuffers {
                 setenv(tensorKey, "1", 1)
             }
@@ -875,6 +882,11 @@ private func withMmapSafetensorsEnv<R>(
                 setenv(vmlxMmapKey, priorVmlxMmap, 1)
             } else {
                 unsetenv(vmlxMmapKey)
+            }
+            if let priorLegacyVmlxMmap {
+                setenv(legacyVmlxMmapKey, priorLegacyVmlxMmap, 1)
+            } else {
+                unsetenv(legacyVmlxMmapKey)
             }
             if let priorTensor {
                 setenv(tensorKey, priorTensor, 1)

--- a/Libraries/MLXLMCommon/Qwen4ExpFusedAffineMoE.swift
+++ b/Libraries/MLXLMCommon/Qwen4ExpFusedAffineMoE.swift
@@ -32,9 +32,7 @@ enum Qwen4ExpFusedAffineMoE {
     private static let maximumRows = 4
 
     private static let enabled: Bool = {
-        let raw =
-            ProcessInfo.processInfo.environment[
-                "VMLINUX_QWEN4_EXP_FUSED_AFFINE_MOE"] ?? "1"
+        let raw = RuntimeEnvironment.value("VMLX_QWEN4_EXP_FUSED_AFFINE_MOE") ?? "1"
         return raw != "0" && raw.lowercased() != "false"
     }()
 

--- a/Libraries/MLXLMCommon/RuntimeAcceleration.swift
+++ b/Libraries/MLXLMCommon/RuntimeAcceleration.swift
@@ -3,7 +3,7 @@
 
 import Foundation
 
-/// Runtime accelerator requested by a caller or by `VMLINUX_ACCELERATOR`.
+/// Runtime accelerator requested by a caller or by `VMLX_ACCELERATOR`.
 ///
 /// This is a selection contract, not an implementation shortcut. The current
 /// MLX backend exposes CPU/GPU devices, while public Neural Engine execution is
@@ -26,7 +26,12 @@ public enum AccelerationMode: Sendable, Equatable, CustomStringConvertible {
     /// contract. Stored explicitly so generation can fail closed.
     case invalid(String)
 
-    public static let environmentVariable = "VMLINUX_ACCELERATOR"
+    public static let environmentVariable = "VMLX_ACCELERATOR"
+
+    /// The pre-rename spelling, still honoured. Kept as its own symbol rather than left as the
+    /// value of `environmentVariable`: a consumer reading that symbol to build a settings UI or
+    /// documentation would otherwise publish the legacy name outward.
+    public static let legacyEnvironmentVariable = "VMLINUX_ACCELERATOR"
 
     public init(flagValue rawValue: String) {
         let normalized = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -94,7 +99,13 @@ public enum AccelerationRuntime {
     public static func requestedMode(
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> AccelerationMode {
-        guard let raw = environment[AccelerationMode.environmentVariable] else {
+        // Both, in that order. This read went through the symbol alone, so flipping the
+        // constant without widening it here would have silently dropped every existing
+        // VMLINUX_ACCELERATOR user.
+        guard
+            let raw = environment[AccelerationMode.environmentVariable]
+                ?? environment[AccelerationMode.legacyEnvironmentVariable]
+        else {
             return .metal
         }
         return AccelerationMode(flagValue: raw)

--- a/Libraries/MLXLMCommon/RuntimeEnvironment.swift
+++ b/Libraries/MLXLMCommon/RuntimeEnvironment.swift
@@ -1,0 +1,66 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+
+/// Runtime environment variables, under the project's `VMLX_` prefix.
+///
+/// The prefix is not new: 117 variables already use it, against 37 spelled `VMLINUX_` — the
+/// Linux kernel image, a name this project has no claim to, being a macOS / Apple-silicon MLX
+/// runtime with no Linux exposure outside the containerization frameworks. Someone reading the
+/// environment surface is entitled to conclude the project has Linux heritage, and it has none.
+///
+/// The migration was already underway one variable at a time: twelve are read as
+/// `env["VMLX_X"] ?? env["VMLINUX_X"]` inline, and `RuntimeMoETopKOverride` carries a
+/// `legacyEnvironmentVariable` beside its `environmentVariable`. This finishes it for the rest.
+///
+/// It is an accessor rather than twenty-five more inline `??` pairs because the fallback is one
+/// rule, and a rule copied to thirty-seven call sites is where the thirty-eighth gets it wrong.
+/// Call sites pass the FULL new name, not a bare suffix, so `grep VMLX_ACCELERATOR` still finds
+/// them — the legacy spelling is derived rather than written out.
+///
+/// Both spellings are honoured; `VMLX_` wins where both are set.
+public enum RuntimeEnvironment {
+    public static let prefix = "VMLX_"
+
+    /// The pre-rename prefix, honoured so existing scripts and launch configs keep working.
+    public static let legacyPrefix = "VMLINUX_"
+
+    /// The legacy spelling of a `VMLX_` name — `nil` if `name` is not one.
+    public static func legacyName(of name: String) -> String? {
+        guard name.hasPrefix(prefix) else { return nil }
+        return legacyPrefix + name.dropFirst(prefix.count)
+    }
+
+    /// The value of a runtime variable, preferring the `VMLX_` spelling.
+    ///
+    /// - Parameter name: the FULL current name, e.g. `"VMLX_ACCELERATOR"`. A name without the
+    ///   prefix is looked up verbatim with no fallback, which is what a caller passing some
+    ///   unrelated variable would want.
+    public static func value(
+        _ name: String,
+        in environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> String? {
+        if let current = environment[name] { return current }
+        guard let legacy = legacyName(of: name) else { return nil }
+        return environment[legacy]
+    }
+
+    /// A boolean runtime flag; absent or unparseable means `defaultValue`.
+    ///
+    /// The accepted spellings are the ones the call sites already accepted individually, so no
+    /// variable changes meaning: `1` / `true` / `yes` / `on` are true.
+    public static func flag(
+        _ name: String,
+        default defaultValue: Bool = false,
+        in environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        guard
+            let raw = value(name, in: environment)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased(),
+            !raw.isEmpty
+        else { return defaultValue }
+        return ["1", "true", "yes", "on"].contains(raw)
+    }
+}

--- a/Libraries/MLXLMCommon/SwitchLayers.swift
+++ b/Libraries/MLXLMCommon/SwitchLayers.swift
@@ -65,8 +65,7 @@ private enum Qwen4ExpCompiledRoutedSwitchGLU {
     typealias Region = @Sendable ([MLXArray]) -> [MLXArray]
 
     private static let enabled: Bool = {
-        let value = ProcessInfo.processInfo.environment[
-            "VMLINUX_QWEN4_EXP_COMPILE_ROUTED_MOE"] ?? "1"
+        let value = RuntimeEnvironment.value("VMLX_QWEN4_EXP_COMPILE_ROUTED_MOE") ?? "1"
         return value != "0" && value.lowercased() != "false"
     }()
     private static let lock = NSLock()

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -95,13 +95,12 @@ enum Qwen4ExpCompiledGDNInputs {
 
     private static let enabled: Bool = {
         let value =
-            ProcessInfo.processInfo.environment["VMLINUX_QWEN4_EXP_COMPILE_GDN"]
+            RuntimeEnvironment.value("VMLX_QWEN4_EXP_COMPILE_GDN")
             ?? "1"
         return value != "0" && value.lowercased() != "false"
     }()
     private static let allowFP32Tail =
-        ProcessInfo.processInfo.environment[
-            "VMLINUX_QWEN4_EXP_COMPILE_GDN_FP32_TAIL"] == "1"
+        RuntimeEnvironment.flag("VMLX_QWEN4_EXP_COMPILE_GDN_FP32_TAIL")
     private static let lock = NSLock()
     nonisolated(unsafe) private static var regions: [String: Region] = [:]
     nonisolated(unsafe) private static var didReport = false
@@ -354,9 +353,7 @@ private enum Qwen4ExpCompiledMoE {
     typealias Region = @Sendable ([MLXArray]) -> [MLXArray]
 
     static let enabled: Bool = {
-        let value =
-            ProcessInfo.processInfo.environment["VMLINUX_QWEN4_EXP_COMPILE_MOE"]
-            ?? "1"
+        let value = RuntimeEnvironment.value("VMLX_QWEN4_EXP_COMPILE_MOE") ?? "1"
         return value != "0" && value.lowercased() != "false"
     }()
     private static let lock = NSLock()
@@ -1121,7 +1118,9 @@ enum Qwen35Language {
         _ args: Qwen35Configuration.TextConfiguration,
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> Bool {
-        if let override = environment["VMLINUX_QWEN35_COMPILE_DECODE_REGIONS"] {
+        if let override = RuntimeEnvironment.value(
+            "VMLX_QWEN35_COMPILE_DECODE_REGIONS", in: environment)
+        {
             return override != "0" && override.lowercased() != "false"
         }
         return args.modelType == "qwen3_5_moe_text"
@@ -1492,8 +1491,7 @@ enum Qwen35Language {
             _ inputs: MLXArray
         ) -> FusedDecodeInputProjection? {
             guard
-                ProcessInfo.processInfo.environment[
-                    "VMLINUX_QWEN4_EXP_FUSE_DECODE_INPUTS"] != "0",
+                RuntimeEnvironment.value("VMLX_QWEN4_EXP_FUSE_DECODE_INPUTS") != "0",
                 fuseDecodeInputProjections, inputs.dim(1) == 1,
                 !CompiledDecodeTrace.isActive
             else { return nil }
@@ -1569,9 +1567,8 @@ enum Qwen35Language {
             // linear-attention layer, which breaks speculative-decoding
             // output equivalence and draft acceptance. Retain it only as an
             // explicit diagnostic while the native path remains the default.
-            guard ProcessInfo.processInfo.environment[
-                "VMLINUX_QWEN4_EXP_COMPILE_GDN_FRONT"
-            ] == "1" else { return nil }
+            guard RuntimeEnvironment.value("VMLX_QWEN4_EXP_COMPILE_GDN_FRONT") == "1"
+            else { return nil }
             guard let fused = ensureFusedDecodeInputProjection(inputs) else { return nil }
             return Qwen4ExpCompiledGDNInputs.callFront(
                 input: inputs,

--- a/Libraries/MLXVLM/Models/Qwen4Exp.swift
+++ b/Libraries/MLXVLM/Models/Qwen4Exp.swift
@@ -228,13 +228,12 @@ private enum Qwen4ExpCompiledMHC {
     typealias Region = @Sendable ([MLXArray]) -> [MLXArray]
 
     private static let enabled: Bool = {
-        let value = ProcessInfo.processInfo.environment["VMLINUX_QWEN4_EXP_COMPILE_MHC"]
+        let value = RuntimeEnvironment.value("VMLX_QWEN4_EXP_COMPILE_MHC")
             ?? "1"
         return value != "0" && value.lowercased() != "false"
     }()
     private static let allowTwoTokenVerify: Bool =
-        ProcessInfo.processInfo.environment[
-            "VMLINUX_QWEN4_EXP_COMPILE_MHC_S2"] == "1"
+        RuntimeEnvironment.flag("VMLX_QWEN4_EXP_COMPILE_MHC_S2")
     private static let lock = NSLock()
     nonisolated(unsafe) private static var regions: [String: Region] = [:]
     nonisolated(unsafe) private static var didReport = false
@@ -393,8 +392,7 @@ private enum Qwen4ExpCompiledMHC {
 
 private final class Qwen4ExpGatedResidual: Module {
     private static let fuseDecodeInputs =
-        ProcessInfo.processInfo.environment[
-            "VMLINUX_QWEN4_EXP_FUSE_DECODE_INPUTS"] != "0"
+        RuntimeEnvironment.value("VMLX_QWEN4_EXP_FUSE_DECODE_INPUTS") != "0"
     private static let fusionDiagnosticLock = NSLock()
     private nonisolated(unsafe) static var didReportInputFusion = false
 
@@ -570,12 +568,9 @@ private final class Qwen4ExpGatedResidual: Module {
 }
 
 private final class Qwen4ExpPLE: Module {
-    private static let profileHost = ProcessInfo.processInfo.environment[
-        "VMLINUX_QWEN4_EXP_PROFILE_PLE"] == "1"
-    private static let traceHistory = ProcessInfo.processInfo.environment[
-        "VMLINUX_QWEN4_EXP_TRACE_PLE_HISTORY"] == "1"
-    private static let traceState = ProcessInfo.processInfo.environment[
-        "VMLINUX_QWEN4_EXP_TRACE_PLE_STATE"] == "1"
+    private static let profileHost = RuntimeEnvironment.flag("VMLX_QWEN4_EXP_PROFILE_PLE")
+    private static let traceHistory = RuntimeEnvironment.flag("VMLX_QWEN4_EXP_TRACE_PLE_HISTORY")
+    private static let traceState = RuntimeEnvironment.flag("VMLX_QWEN4_EXP_TRACE_PLE_STATE")
     let config: Qwen4ExpConfiguration
     let pleLayerIndex: Int
     let multipliers: [Int64]
@@ -1020,12 +1015,9 @@ private final class Qwen4ExpAttention: Module {
 }
 
 private final class Qwen4ExpDecoderLayer: Module {
-    private static let profiledLayer = ProcessInfo.processInfo.environment[
-        "VMLINUX_QWEN4_EXP_PROFILE_LAYER"].flatMap(Int.init)
-    private static let profileLimit = Int(ProcessInfo.processInfo.environment[
-        "VMLINUX_QWEN4_EXP_PROFILE_LIMIT"] ?? "4") ?? 4
-    private static let profileSequenceLength = Int(ProcessInfo.processInfo.environment[
-        "VMLINUX_QWEN4_EXP_PROFILE_SEQUENCE"] ?? "1") ?? 1
+    private static let profiledLayer = RuntimeEnvironment.value("VMLX_QWEN4_EXP_PROFILE_LAYER").flatMap(Int.init)
+    private static let profileLimit = Int(RuntimeEnvironment.value("VMLX_QWEN4_EXP_PROFILE_LIMIT") ?? "4") ?? 4
+    private static let profileSequenceLength = Int(RuntimeEnvironment.value("VMLX_QWEN4_EXP_PROFILE_SEQUENCE") ?? "1") ?? 1
 
     let layerIndex: Int
     let isLinear: Bool

--- a/Package.swift
+++ b/Package.swift
@@ -917,6 +917,8 @@ let package = Package(
                 "ChatTemplateResolutionTests.swift",
                 "VMLXServerRuntimeSettingsTests.swift",
                 "VMLXMemorySafetySettingsTests.swift",
+                "RuntimeEnvironmentNamingTests.swift",
+                "RuntimeEnvironmentSourceCoverageTests.swift",
                 "DSV4AgenticToolSourceTests.swift",
                 "AgenticTaskBenchConfinementFocusedTests.swift",
                 "NoHiddenReasoningCloseBiasFocusedTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
@@ -622,7 +622,12 @@ struct BatchEngineGrowingChatCacheSourceTests {
             contentsOfFile: "Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift",
             encoding: .utf8)
 
-        #expect(engine.contains("VMLINUX_REASONING_PROMPT_TAIL_LOG"))
+        // The legacy `VMLINUX_` spelling is no longer a literal at the call site: it is derived
+        // centrally by `RuntimeEnvironment.legacyName(of:)`, so the variable still resolves while
+        // each call site names only the current spelling. Asserting the old literal here pinned the
+        // duplication rather than the guarantee. `RuntimeEnvironmentSourceCoverageTests` enforces that no site
+        // reads a legacy name as its ONLY spelling.
+        #expect(engine.contains("VMLX_REASONING_PROMPT_TAIL_LOG"))
         #expect(engine.contains("debugLogReasoningPromptTail"))
         #expect(engine.contains("path: \"BatchEngine.generate\""))
         #expect(engine.contains("path: \"BatchEngine.submit\""))

--- a/Tests/MLXLMCommonFocusedTests/NemotronHJANGTQDispatchFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NemotronHJANGTQDispatchFocusedTests.swift
@@ -135,7 +135,9 @@ final class NemotronHJANGTQDispatchFocusedTests: XCTestCase {
         XCTAssertTrue(modelSource.contains("JANGTQ_ENABLE_NEMOTRON_WEIGHTED_MOE_FASTPATH"))
         XCTAssertTrue(modelSource.contains("JANGTQ_DISABLE_NEMOTRON_WEIGHTED_MOE_FASTPATH"))
         XCTAssertTrue(modelSource.contains("VMLX_NEMOTRON_LAYER_PROFILE"))
-        XCTAssertTrue(modelSource.contains("VMLINUX_NEMOTRON_LAYER_PROFILE"))
+        // Not the legacy literal: `RuntimeEnvironment.legacyName(of:)` derives `VMLINUX_…` from
+        // the current name, so the old variable still works without every call site spelling it
+        // out. Covered by `RuntimeEnvironmentSourceCoverageTests`.
         XCTAssertTrue(modelSource.contains("NEMOTRON_LAYER_PROFILE label=%@"))
         XCTAssertTrue(modelSource.contains("mamba.in_proj"))
         XCTAssertTrue(modelSource.contains("mamba.split"))

--- a/Tests/MLXLMCommonFocusedTests/RuntimeEnvironmentNamingTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/RuntimeEnvironmentNamingTests.swift
@@ -1,0 +1,91 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// The rename is only safe if the legacy spelling keeps working, and only finished if no read
+// site is left on the old name alone. Neither is visible from a build, so both are asserted.
+
+import Foundation
+import MLXLMCommon
+import Testing
+
+@Suite("Runtime environment naming")
+struct RuntimeEnvironmentNamingTests {
+
+    @Test("the current spelling is read")
+    func currentSpellingRead() {
+        #expect(RuntimeEnvironment.value("VMLX_THING", in: ["VMLX_THING": "a"]) == "a")
+    }
+
+    /// The whole point of the migration: someone's existing script must not break.
+    @Test("the legacy spelling is still honoured")
+    func legacySpellingHonoured() {
+        #expect(RuntimeEnvironment.value("VMLX_THING", in: ["VMLINUX_THING": "b"]) == "b")
+        #expect(RuntimeEnvironment.flag("VMLX_THING", in: ["VMLINUX_THING": "1"]))
+    }
+
+    @Test("the current spelling wins when both are set")
+    func currentWins() {
+        let both = ["VMLX_THING": "new", "VMLINUX_THING": "old"]
+        #expect(RuntimeEnvironment.value("VMLX_THING", in: both) == "new")
+    }
+
+    /// A name that is not ours gets no derived fallback — otherwise asking for `PATH` would
+    /// quietly consult `VMLINUX_PATH`.
+    @Test("an unprefixed name gets no legacy fallback")
+    func unprefixedHasNoFallback() {
+        #expect(RuntimeEnvironment.legacyName(of: "PATH") == nil)
+        #expect(RuntimeEnvironment.value("PATH", in: ["VMLINUX_PATH": "x"]) == nil)
+        #expect(RuntimeEnvironment.value("PATH", in: ["PATH": "x"]) == "x")
+    }
+
+    @Test("flag accepts the spellings the call sites already accepted")
+    func flagSpellings() {
+        for yes in ["1", "true", "yes", "on", "TRUE", " on "] {
+            #expect(RuntimeEnvironment.flag("VMLX_F", in: ["VMLX_F": yes]), "\(yes)")
+        }
+        for no in ["0", "false", "no", "off", ""] {
+            #expect(!RuntimeEnvironment.flag("VMLX_F", in: ["VMLX_F": no]), "\(no)")
+        }
+        #expect(RuntimeEnvironment.flag("VMLX_F", default: true, in: [:]))
+    }
+
+    /// The public constants must NAME the current variable. A consumer reads these to build a
+    /// settings UI or documentation, so a legacy value here publishes the old name outward —
+    /// which is exactly what this migration is for.
+    @Test("public environment-name constants carry the current spelling")
+    func publicConstantsAreCurrent() {
+        let current: [String] = [
+            AccelerationMode.environmentVariable,
+            DeepseekV4ReasoningPolicy.rawMaxEnvironmentKey,
+            DeepseekV4ReasoningPolicy.forceDirectRailEnvironmentKey,
+            RuntimeMoETopKOverride.environmentVariable,
+        ]
+        for name in current {
+            #expect(name.hasPrefix(RuntimeEnvironment.prefix), "\(name) is not a current name")
+        }
+        // And each keeps its legacy sibling, so the old spelling stays reachable.
+        let legacy: [String] = [
+            AccelerationMode.legacyEnvironmentVariable,
+            DeepseekV4ReasoningPolicy.legacyRawMaxEnvironmentKey,
+            DeepseekV4ReasoningPolicy.legacyForceDirectRailEnvironmentKey,
+            RuntimeMoETopKOverride.legacyEnvironmentVariable,
+        ]
+        for (new, old) in zip(current, legacy) {
+            #expect(RuntimeEnvironment.legacyName(of: new) == old, "\(new) -> \(old)")
+        }
+    }
+
+    /// Reading the accelerator through the legacy spelling must still resolve. The read went
+    /// through `environmentVariable` alone, so flipping that constant without widening the read
+    /// would have dropped every existing user — and nothing else would have said so.
+    @Test("the accelerator still resolves from the legacy variable")
+    func acceleratorLegacyStillResolves() {
+        #expect(
+            AccelerationRuntime.requestedMode(
+                environment: [AccelerationMode.legacyEnvironmentVariable: "auto"]) == .auto)
+        #expect(
+            AccelerationRuntime.requestedMode(
+                environment: [AccelerationMode.environmentVariable: "auto"]) == .auto)
+        #expect(AccelerationRuntime.requestedMode(environment: [:]) == .metal)
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/RuntimeEnvironmentSourceCoverageTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/RuntimeEnvironmentSourceCoverageTests.swift
@@ -1,0 +1,89 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// The migration is finishable exactly once. This asserts it stays finished: every legacy
+// VMLINUX_ literal left in the library must be reachable only as a FALLBACK, never as the sole
+// spelling a site reads. Without this, straggler thirty-eight arrives with the next model.
+
+import Foundation
+import Testing
+
+@Suite("Runtime environment naming source coverage")
+struct RuntimeEnvironmentSourceCoverageTests {
+
+    /// Sites where the legacy name legitimately appears: the accessor that defines the rule, and
+    /// the `legacy…` constants that exist precisely to hold it.
+    private static let allowedLegacyHolders = [
+        "RuntimeEnvironment.swift",          // defines legacyPrefix / legacyName(of:)
+        "RuntimeMoETopKOverride.swift",      // legacyEnvironmentVariable
+        "RuntimeAcceleration.swift",         // legacyEnvironmentVariable
+        "DeepseekV4ReasoningPolicy.swift",   // legacyRawMax… / legacyForceDirectRail…
+        "ModelFactory.swift",                // writes both spellings for the C++ consumer
+        "JANGTQStreamingExperts.swift",      // writes both spellings for the C++ consumer
+    ]
+
+    private func swiftSources(under root: String) -> [(String, String)] {
+        let fm = FileManager.default
+        guard let e = fm.enumerator(atPath: root) else { return [] }
+        var out: [(String, String)] = []
+        for case let p as String in e where p.hasSuffix(".swift") {
+            if let text = try? String(contentsOfFile: root + "/" + p, encoding: .utf8) {
+                out.append((p, text))
+            }
+        }
+        return out
+    }
+
+    @Test("no library site reads a legacy name as its only spelling")
+    func noLegacyOnlyReads() throws {
+        let sources = swiftSources(under: "Libraries")
+        try #require(!sources.isEmpty, "found no sources — the path is wrong, not the code")
+
+        var offenders: [String] = []
+        for (path, text) in sources {
+            let file = path.split(separator: "/").last.map(String.init) ?? path
+            if Self.allowedLegacyHolders.contains(file) { continue }
+            let lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+            for (i, line) in lines.enumerated() {
+                guard line.contains("\"VMLINUX_") else { continue }
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                if trimmed.hasPrefix("//") { continue }        // prose may name it
+
+                // The fallback is routinely written across lines:
+                //     let raw = env["VMLX_X"]
+                //         ?? env["VMLINUX_X"]
+                // so the unit is the STATEMENT, not the line — and the counterpart must be the
+                // SAME variable, or a neighbouring unrelated VMLX_ read would excuse it.
+                let window = lines[max(0, i - 2)...min(lines.count - 1, i + 1)].joined(separator: "\n")
+                for name in Self.legacyNames(in: line) where !window.contains("\"VMLX_\(name)\"") {
+                    offenders.append("\(path): \(trimmed)")
+                }
+            }
+        }
+        #expect(
+            offenders.isEmpty,
+            "legacy-only read site(s):\n\(offenders.joined(separator: "\n"))")
+    }
+
+    /// The bare names inside `"VMLINUX_…"` literals on one line.
+    private static func legacyNames(in line: String) -> [String] {
+        var out: [String] = []
+        var rest = Substring(line)
+        while let open = rest.range(of: "\"VMLINUX_") {
+            let after = rest[open.upperBound...]
+            guard let close = after.firstIndex(of: "\"") else { break }
+            out.append(String(after[..<close]))
+            rest = after[close...]
+        }
+        return out
+    }
+
+    /// The inverse: the accessor must actually be in use, or the rule above passes vacuously on a
+    /// library that simply stopped reading the environment.
+    @Test("the accessor is used")
+    func accessorIsUsed() throws {
+        let uses = swiftSources(under: "Libraries")
+            .filter { $0.1.contains("RuntimeEnvironment.value(") || $0.1.contains("RuntimeEnvironment.flag(") }
+        #expect(uses.count >= 8, "only \(uses.count) file(s) use the accessor")
+    }
+}

--- a/Tests/MLXLMTests/LoadConfigurationTests.swift
+++ b/Tests/MLXLMTests/LoadConfigurationTests.swift
@@ -244,7 +244,11 @@ struct LoadConfigurationTests {
             encoding: .utf8)
 
         #expect(source.contains("let mmapSafetensorsActive = envFlag(\"MLX_SAFETENSORS_MMAP\")"))
-        #expect(source.contains("let allowJANGTQMmapBFloat16 = envFlag(\"VMLINUX_JANGTQ_BF16_MMAP\")"))
+        // `RuntimeEnvironment.flag` replaced the raw `envFlag` here and names only the current
+        // spelling; the legacy `VMLINUX_` name is still honoured, derived centrally by
+        // `RuntimeEnvironment.legacyName(of:)`. See `RuntimeEnvironmentSourceCoverageTests`.
+        #expect(source.contains(
+            "let allowJANGTQMmapBFloat16 = RuntimeEnvironment.flag(\"VMLX_JANGTQ_BF16_MMAP\")"))
         #expect(source.contains("let autoJANGTQMmapBFloat16 = requiresJANGTQMmapBFloat16(modelDirectory)"))
         #expect(source.contains("!isJANGTQNative || !mmapSafetensorsActive || allowJANGTQMmapBFloat16"))
         #expect(source.contains("|| autoJANGTQMmapBFloat16"))

--- a/scripts/vmlx-live-model-matrix.sh
+++ b/scripts/vmlx-live-model-matrix.sh
@@ -611,11 +611,11 @@ maybe_build() {
   fi
   if [[ "$BUILD_CONFIGURATION" == "release" ]]; then
     run_logged build_runbench env DEVELOPER_DIR="$SWIFT_DEVELOPER_DIR" \
-      swift build -c release --jobs "${VMLINUX_SWIFT_BUILD_JOBS:-2}" \
+      swift build -c release --jobs "${VMLX_SWIFT_BUILD_JOBS:-${VMLINUX_SWIFT_BUILD_JOBS:-2}}" \
         --product RunBench
   else
     run_logged build_runbench env DEVELOPER_DIR="$SWIFT_DEVELOPER_DIR" \
-      swift build --jobs "${VMLINUX_SWIFT_BUILD_JOBS:-2}" \
+      swift build --jobs "${VMLX_SWIFT_BUILD_JOBS:-${VMLINUX_SWIFT_BUILD_JOBS:-2}}" \
         --product RunBench
   fi
 }

--- a/scripts/vmlx-osaurus-release-readiness-audit.sh
+++ b/scripts/vmlx-osaurus-release-readiness-audit.sh
@@ -291,15 +291,15 @@ else
   fail_msg "Osaurus PR dirty-scope classifier exists"
 fi
 
-VMLINUX_BRANCH="$(git -C "$ROOT" branch --show-current 2>/dev/null || true)"
-VMLINUX_HEAD="$(git -C "$ROOT" rev-parse HEAD 2>/dev/null || true)"
+VMLX_BRANCH="$(git -C "$ROOT" branch --show-current 2>/dev/null || true)"
+VMLX_HEAD="$(git -C "$ROOT" rev-parse HEAD 2>/dev/null || true)"
 OSAURUS_BRANCH="$(git -C "$OSAURUS_ROOT" branch --show-current 2>/dev/null || true)"
 OSAURUS_HEAD="$(git -C "$OSAURUS_ROOT" rev-parse HEAD 2>/dev/null || true)"
-VMLINUX_DIRTY_COUNT="$({ git -C "$ROOT" status --short 2>/dev/null || true; } | wc -l | tr -d ' ')"
+VMLX_DIRTY_COUNT="$({ git -C "$ROOT" status --short 2>/dev/null || true; } | wc -l | tr -d ' ')"
 OSAURUS_DIRTY_COUNT="$({ git -C "$OSAURUS_ROOT" status --short 2>/dev/null || true; } | wc -l | tr -d ' ')"
-VMLINUX_DIRTY_SAMPLE="$LOG_ROOT/vmlx-dirty-sample.txt"
+VMLX_DIRTY_SAMPLE="$LOG_ROOT/vmlx-dirty-sample.txt"
 OSAURUS_DIRTY_SAMPLE="$LOG_ROOT/osaurus-dirty-sample.txt"
-git -C "$ROOT" status --short 2>/dev/null | sed -n '1,80p' >"$VMLINUX_DIRTY_SAMPLE" || true
+git -C "$ROOT" status --short 2>/dev/null | sed -n '1,80p' >"$VMLX_DIRTY_SAMPLE" || true
 git -C "$OSAURUS_ROOT" status --short 2>/dev/null | sed -n '1,80p' >"$OSAURUS_DIRTY_SAMPLE" || true
 
 cat > "$LOG_ROOT/SUMMARY.md" <<SUMMARY
@@ -316,9 +316,9 @@ Inputs:
 
 Repos:
 
-- vMLX branch/head: ${VMLINUX_BRANCH:-unknown} ${VMLINUX_HEAD:-unknown}
+- vMLX branch/head: ${VMLX_BRANCH:-unknown} ${VMLX_HEAD:-unknown}
 - Osaurus branch/head: ${OSAURUS_BRANCH:-unknown} ${OSAURUS_HEAD:-unknown}
-- vMLX dirty entries: $VMLINUX_DIRTY_COUNT (sample: $VMLINUX_DIRTY_SAMPLE)
+- vMLX dirty entries: $VMLX_DIRTY_COUNT (sample: $VMLX_DIRTY_SAMPLE)
 - Osaurus dirty entries: $OSAURUS_DIRTY_COUNT (sample: $OSAURUS_DIRTY_SAMPLE)
 
 Logs: $LOG_ROOT

--- a/tools/ANEProbe/main.swift
+++ b/tools/ANEProbe/main.swift
@@ -8,22 +8,22 @@ import CoreML
 @main
 enum ANEProbe {
     static func main() {
-        print("VMLINUX_ANE_PROBE_VERSION=1")
+        print("VMLX_ANE_PROBE_VERSION=1")
         let mode = AccelerationRuntime.requestedMode()
-        print("VMLINUX_ACCELERATOR_REQUESTED=\(mode.flagValue)")
+        print("VMLX_ACCELERATOR_REQUESTED=\(mode.flagValue)")
         do {
             let decision = try AccelerationRuntime.resolveTextDecode(mode)
             switch decision {
             case .metal(let reason):
-                print("VMLINUX_TEXT_DECODE_ACCELERATOR=metal")
-                print("VMLINUX_TEXT_DECODE_REASON=\(reason)")
+                print("VMLX_TEXT_DECODE_ACCELERATOR=metal")
+                print("VMLX_TEXT_DECODE_REASON=\(reason)")
             case .coreMLANE(let manifestID):
-                print("VMLINUX_TEXT_DECODE_ACCELERATOR=ane-coreml")
-                print("VMLINUX_TEXT_DECODE_MANIFEST=\(manifestID)")
+                print("VMLX_TEXT_DECODE_ACCELERATOR=ane-coreml")
+                print("VMLX_TEXT_DECODE_MANIFEST=\(manifestID)")
             }
         } catch {
-            print("VMLINUX_TEXT_DECODE_ACCELERATOR=unavailable")
-            print("VMLINUX_TEXT_DECODE_ERROR=\(error.localizedDescription)")
+            print("VMLX_TEXT_DECODE_ACCELERATOR=unavailable")
+            print("VMLX_TEXT_DECODE_ERROR=\(error.localizedDescription)")
         }
 
         #if canImport(CoreML)


### PR DESCRIPTION
The `VMLX_` prefix is not a proposal — **117 variables already use it**, against
37 spelled `VMLINUX_`. Twelve names exist in *both*, read as
`env["VMLX_X"] ?? env["VMLINUX_X"]`, and `RuntimeMoETopKOverride` already carries
a `legacyEnvironmentVariable` beside its `environmentVariable`.

So this finishes a migration already underway, using the two shapes already
established here rather than inventing a third. **Every legacy name still works;
`VMLX_` wins where both are set.**

Why it matters beyond taste: `vmlinux` is the Linux kernel image. This is a
macOS / Apple-silicon MLX runtime with no Linux exposure outside the
containerization frameworks — someone reading the environment surface is
entitled to conclude the project has Linux heritage, and it has none.

## Three findings that were not cosmetic

### 1. Public constants were publishing the old name

```swift
AccelerationMode.environmentVariable                    = "VMLINUX_ACCELERATOR"
DeepseekV4ReasoningPolicy.rawMaxEnvironmentKey          = "VMLINUX_DSV4_RAW_MAX"
DeepseekV4ReasoningPolicy.forceDirectRailEnvironmentKey = "VMLINUX_DSV4_FORCE_DIRECT_RAIL"
```

These are `public`. A consumer reads them to build a settings UI or
documentation, so the legacy name was leaking outward — the one place a rename
actually has to reach. They now name the current variable and gain a `legacy…`
sibling, matching `RuntimeMoETopKOverride`.

**The coupling to watch:** `AccelerationRuntime.requestedMode` read
`environment[AccelerationMode.environmentVariable]` — a single lookup *through
the symbol*, no fallback. It worked only because the symbol happened to hold the
legacy name. Flipping the constant alone would have silently dropped every
existing `VMLINUX_ACCELERATOR` user, so the constant and the read widen together.

### 2. One write already reached nothing

`ModelFactory` does `setenv("VMLX_MMAP_SAFETENSORS", "1")`. The only consumer of
that variable is `mmap_safetensors_enabled` in the MLX C++ submodule:

```cpp
return env_truthy("MLX_SAFETENSORS_MMAP") ||
    env_truthy("VMLINUX_MMAP_SAFETENSORS");
```

The write reached nothing. mmap kept working solely because
`MLX_SAFETENSORS_MMAP` is set beside it. For this one variable the **new** name
was the weaker one — the inversion of what the rename is for. Both spellings are
now written at both `setenv` sites; the legacy write can be dropped once the
submodule reads the new name (**filed separately against `osaurus-ai/mlx`**).

### 3. The same variable behaved differently at different sites

| site | held / read |
|---|---|
| `ModelFactory.swift` | `let vmlxMmapKey = "VMLX_MMAP_SAFETENSORS"` |
| `JANGTQStreamingExperts.swift` | `let vmlxMmapKey = "VMLINUX_MMAP_SAFETENSORS"` |

Same local name, opposite values. `SSMReDerive` likewise read the legacy
spelling *first*, so which name won depended on which site you hit.

## Keeping it finished

A source-coverage test asserts no library site reads a legacy name as its only
spelling. Two details make it real rather than decorative:

- it works per **statement**, not per line — the fallback is routinely written as
  `env["VMLX_X"]` / `?? env["VMLINUX_X"]` across two lines, and a line-wise rule
  reports all twelve existing pairs as violations (it did, first time);
- it requires the **same** variable, so a neighbouring unrelated `VMLX_` read in
  the window cannot excuse a legacy-only one.

**Mutation-checked**: restoring the legacy-only read in `SSMReDerive` fails it,
naming the file and line. Alongside it: the legacy spelling still resolves, the
current one wins when both are set, an unprefixed name gets no derived fallback
(so asking for `PATH` never consults `VMLINUX_PATH`), and the public constants
carry the current spelling.

## Scope

Call sites pass the **full** current name — `RuntimeEnvironment.value("VMLX_ACCELERATOR")`
— rather than a bare suffix, so `grep VMLX_ACCELERATOR` still finds them. The
legacy spelling is derived, never written out.

Dated audit documents under `docs/` are deliberately untouched: they record what
was run at the time, and rewriting them would falsify the record. Current
documentation (`Documentation.docc/ane-acceleration.md`) and the live scripts do
move.

---

**Rebased onto current `main` (2026-09-01).** Three things changed since this was first written, and
all three are worth stating because they are what the rebase actually consisted of:

1. **One hunk was already upstream.** The `VMLX_ACCELERATOR` doc line in `Evaluate.swift` had been
   corrected independently, so that file is no longer touched here at all.
2. **`ModelFactory.swift` moved.** The mmap block is nested one level deeper than it was, so the
   legacy-spelling writes had to be re-applied at the new indentation rather than merged. No change
   in what they do: `VMLX_MMAP_SAFETENSORS` is written alongside its legacy name because the consumer
   is `mmap_safetensors_enabled` in the MLX C++ submodule, which does not read the new spelling yet.
3. **A NEW legacy-only read had appeared**, and this PR's own coverage test is what found it:

   ```
   legacy-only read site(s):
     MLXVLM/Models/Qwen35.swift: "VMLINUX_QWEN4_EXP_COMPILE_GDN_FRONT"
   ```

   It now reads `RuntimeEnvironment.value("VMLX_QWEN4_EXP_COMPILE_GDN_FRONT")`, so the new spelling is
   primary and the legacy one keeps working through the same fallback every other site uses. Nobody
   setting the old variable is affected.

Point 3 is the argument for the test more than for the migration. A hand scan for
`environment["VMLINUX_…"]` does not find that site, because the subscript is wrapped across three
lines — I made exactly that mistake before running the suite. The test reads the literals rather than
the call shape, so it saw what the grep could not.

Verified on current `main`: the package builds, and all nine tests in `Runtime environment naming`
and `Runtime environment naming source coverage` pass.
