### PR TITLE
JangLoader: decode the sampling defaults bundles actually carry

### DIFF
--- a/Libraries/MLXLMCommon/JangLoader.swift
+++ b/Libraries/MLXLMCommon/JangLoader.swift
@@ -725,14 +725,55 @@ public struct JangChatToolCalling: Sendable, Equatable {
 public struct JangChatSamplingDefaults: Sendable, Equatable {
     public let temperature: Float?
     public let topP: Float?
+    public let topK: Int?
+    public let minP: Float?
+    public let repetitionPenalty: Float?
+    public let presencePenalty: Float?
+
+    /// The generation length cap. Bundles spell this `max_tokens`; `max_new_tokens` is accepted as
+    /// an alias because this type has always named it that, though no bundle observed uses it.
     public let maxNewTokens: Int?
 
     public init(
-        temperature: Float? = nil, topP: Float? = nil, maxNewTokens: Int? = nil
+        temperature: Float? = nil, topP: Float? = nil, topK: Int? = nil, minP: Float? = nil,
+        repetitionPenalty: Float? = nil, presencePenalty: Float? = nil, maxNewTokens: Int? = nil
     ) {
         self.temperature = temperature
         self.topP = topP
+        self.topK = topK
+        self.minP = minP
+        self.repetitionPenalty = repetitionPenalty
+        self.presencePenalty = presencePenalty
         self.maxNewTokens = maxNewTokens
+    }
+
+    /// True when the block carried nothing this runtime can act on — provenance keys only.
+    public var isEmpty: Bool {
+        temperature == nil && topP == nil && topK == nil && minP == nil
+            && repetitionPenalty == nil && presencePenalty == nil && maxNewTokens == nil
+    }
+
+    /// Overlay these defaults onto `parameters`, replacing only what the bundle declares.
+    ///
+    /// This is deliberately something a CALLER invokes rather than something the loader applies:
+    /// which knobs a caller has already set is not visible from here (`GenerateParameters` stores
+    /// non-optional sampler fields, so "unset" and "set to the default value" are the same value),
+    /// and applying silently would change generation for every bundle carrying the block.
+    ///
+    /// Partial application is the trap worth naming. Every observed bundle that sets `temperature`
+    /// also sets `top_k`; a runtime that honoured the first and dropped the second would produce a
+    /// sampler configuration the vendor never specified and nobody validated — arguably worse than
+    /// honouring none of it. That is why the fields above track what bundles actually carry.
+    public func applied(to parameters: GenerateParameters) -> GenerateParameters {
+        var p = parameters
+        if let temperature { p.temperature = temperature }
+        if let topP { p.topP = topP }
+        if let topK { p.topK = topK }
+        if let minP { p.minP = minP }
+        if let repetitionPenalty { p.repetitionPenalty = repetitionPenalty }
+        if let presencePenalty { p.presencePenalty = presencePenalty }
+        if let maxNewTokens { p.maxTokens = maxNewTokens }
+        return p
     }
 }
 
@@ -1823,10 +1864,20 @@ public struct JangLoader: Sendable {
             // sampling_defaults subblock
             let sampling: JangChatSamplingDefaults?
             if let sDict = chDict["sampling_defaults"] as? [String: Any] {
+                // Every key here has a destination in `GenerateParameters`. Decoding only
+                // temperature and top_p discarded `top_k`, which EVERY observed bundle carrying a
+                // sampling block also sets, plus min_p / repetition_penalty / presence_penalty.
+                // Non-sampling keys in the block (`source`, `mode`, `temperature_note`, and the
+                // generation_config residue some bundles copy in wholesale) are ignored by
+                // omission, as before.
                 sampling = JangChatSamplingDefaults(
                     temperature: floatValue(sDict["temperature"]),
                     topP: floatValue(sDict["top_p"]),
-                    maxNewTokens: sDict["max_new_tokens"] as? Int
+                    topK: sDict["top_k"] as? Int,
+                    minP: floatValue(sDict["min_p"]),
+                    repetitionPenalty: floatValue(sDict["repetition_penalty"]),
+                    presencePenalty: floatValue(sDict["presence_penalty"]),
+                    maxNewTokens: (sDict["max_tokens"] as? Int) ?? (sDict["max_new_tokens"] as? Int)
                 )
             } else { sampling = nil }
 

--- a/Package.swift
+++ b/Package.swift
@@ -903,6 +903,7 @@ let package = Package(
                 "CompilableKVCacheSnapshotTests.swift",
                 "DFlash2DispatchReachabilityTests.swift",
                 "MixedGroupSizeQuantizationFocusedTests.swift",
+                "JangSamplingDefaultsTests.swift",
                 "MLXPressCLISourceContractsTests.swift",
                 "VMLXServerRuntimeSettingsTests.swift",
                 "VMLXMemorySafetySettingsTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/JangSamplingDefaultsTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/JangSamplingDefaultsTests.swift
@@ -1,0 +1,76 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// `chat.sampling_defaults` was decoded into three fields, one of which (`max_new_tokens`) no
+// observed bundle carries, while `top_k` — which every observed bundle carrying the block sets —
+// was dropped. Nothing read the result either way, so neither gap could surface at runtime.
+
+import Foundation
+import MLXLMCommon
+import Testing
+
+@Suite("Jang chat sampling defaults")
+struct JangSamplingDefaultsTests {
+
+    /// The shape real bundles ship. `source` and `mode` are provenance, not sampler knobs, and
+    /// must not become one; DeepSeek-V4-Flash additionally copies generation_config residue
+    /// (`_from_model_config`, `bos_token_id`, `transformers_version`) into the same block.
+    @Test("every sampler key a real bundle carries survives the decode")
+    func realBundleKeysSurvive() {
+        let d = JangChatSamplingDefaults(
+            temperature: 0.6, topP: 0.95, topK: 20, minP: 0.0,
+            repetitionPenalty: 1.0, presencePenalty: 0.0)
+        #expect(d.temperature == 0.6)
+        #expect(d.topK == 20, "top_k is carried by every observed bundle with a sampling block")
+        #expect(d.minP == 0.0)
+        #expect(d.repetitionPenalty == 1.0)
+        #expect(d.presencePenalty == 0.0)
+        #expect(!d.isEmpty)
+    }
+
+    /// A block of pure provenance resolves to nothing actionable, rather than to a struct that
+    /// looks applicable and would overwrite the caller's sampler with nils-turned-defaults.
+    @Test("a provenance-only block is empty")
+    func provenanceOnlyIsEmpty() {
+        #expect(JangChatSamplingDefaults().isEmpty)
+    }
+
+    /// The overlay replaces exactly what the bundle declares and leaves the rest of the caller's
+    /// configuration alone — including fields that have nothing to do with sampling.
+    @Test("applied(to:) overlays only the declared knobs")
+    func overlayIsScoped() {
+        var base = GenerateParameters()
+        base.temperature = 1.0
+        base.topP = 1.0
+        base.topK = 0
+        base.maxTokens = 4096
+        base.prefillStepSize = 999          // untouched by any sampling default
+
+        let partial = JangChatSamplingDefaults(temperature: 0.6, topK: 20)
+        let out = partial.applied(to: base)
+        #expect(out.temperature == 0.6)
+        #expect(out.topK == 20)
+        #expect(out.topP == 1.0, "not declared, so the caller's value stands")
+        #expect(out.maxTokens == 4096, "not declared, so the caller's cap stands")
+        #expect(out.prefillStepSize == 999, "sampling defaults must not reach non-sampler fields")
+    }
+
+    /// Both spellings of the length cap land on `maxTokens`. Bundles write `max_tokens`; the type
+    /// has always called it `maxNewTokens`, and no bundle observed uses that spelling.
+    @Test("the length cap lands on maxTokens")
+    func lengthCapApplies() {
+        let out = JangChatSamplingDefaults(maxNewTokens: 20480).applied(to: GenerateParameters())
+        #expect(out.maxTokens == 20480)
+    }
+
+    /// An empty block must be a no-op, not a reset.
+    @Test("an empty block changes nothing")
+    func emptyIsNoOp() {
+        var base = GenerateParameters()
+        base.temperature = 0.42
+        base.topK = 7
+        let out = JangChatSamplingDefaults().applied(to: base)
+        #expect(out.temperature == 0.42)
+        #expect(out.topK == 7)
+    }
+}


### PR DESCRIPTION
> **Draft on purpose.** The decode fix here is not in question; whether the
> runtime should *apply* these defaults is, and that is your call. See the
> decision at the bottom.

`chat.sampling_defaults` is decoded into three fields and read by **nobody**.
The doc comment promises otherwise:

```swift
/// Consumers (BatchEngine / Evaluate) may apply these when the
/// caller doesn't pass explicit sampler params.
```

No consumer does. But the decode is wrong independently of that, and *that* part
isn't a policy question.

## What 14 local JANG bundles actually declare

| key | bundles | decoded today |
|---|---|---|
| `temperature` | 14 | ✅ |
| `top_p` | 14 | ✅ |
| **`top_k`** | **14** | ❌ |
| `repetition_penalty` | 9 | ❌ |
| `min_p` | 7 | ❌ |
| `presence_penalty` | 6 | ❌ |
| `max_tokens` | 2 | ❌ |
| **`max_new_tokens`** | **0** | ✅ |

The one field the struct models that no bundle uses is decoded. `top_k`, which
**every** bundle carrying the block sets, is dropped.

And every one of these already has a destination in `GenerateParameters` —
`temperature`, `topP`, `topK`, `minP`, `repetitionPenalty`, `presencePenalty`.
The loader was discarding values the runtime is fully able to act on.

## Why partial application is the crux

Every observed bundle that sets `temperature` also sets `top_k`. A runtime that
honoured the first and dropped the second would produce a sampler configuration
**the vendor never specified and nobody validated** — plausibly worse than
honouring none of it.

That is the shape of today's three-field decode. It is the argument for fixing
the decode *even if* the answer to "apply automatically?" turns out to be no.

## What this PR does, and does not

- completes the decode to the keys bundles carry;
- adds `applied(to:)`, overlaying only the declared knobs onto a caller's
  `GenerateParameters`;
- **calls it from nowhere.** Behaviour is unchanged by this PR.

`applied(to:)` is a caller's method rather than something the loader performs,
for a concrete reason: `GenerateParameters` stores its sampler fields
non-optionally, so "the caller left this unset" and "the caller set it to the
default value" are indistinguishable from inside the loader. Anything automatic
would have to overwrite deliberate choices or guess.

Provenance keys (`source`, `mode`, `temperature_note`, plus the generation_config
residue `DeepSeek-V4-Flash-0731-JANG` copies in wholesale — `_from_model_config`,
`bos_token_id`, `transformers_version`) are ignored by omission, as before.
`isEmpty` reports a block that carried nothing actionable.

## The decision this needs from you

1. **Apply automatically** when the caller passes no sampler params — matches the
   doc comment's promise, changes generation for every bundle with the block, and
   needs a way to tell "unset" from "set to the default".
2. **Expose only** — this PR as it stands. Osaurus (or any caller) opts in per
   request; vmlx's own defaults are untouched.
3. **Neither** — then the block is documentation, and `applied(to:)` should
   probably go, though the decode fix still stands on its own.

I have implemented (2) because it is the one that is correct under all three
answers. Say which you want and I will finish it in this PR.
