### PR TITLE
Give chat-template resolution a single owner, and guard it

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -1506,19 +1506,7 @@ public final class LLMModelFactory: ModelFactory {
     }
 
     private static func chatTemplateText(modelDirectory: URL) -> String? {
-        let templateURL = modelDirectory.appending(component: "chat_template.jinja")
-        if let template = try? String(contentsOf: templateURL, encoding: .utf8) {
-            return template
-        }
-        let tokenizerConfigURL = modelDirectory.appending(component: "tokenizer_config.json")
-        guard
-            let data = try? Data(contentsOf: tokenizerConfigURL),
-            let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-            let template = object["chat_template"] as? String
-        else {
-            return nil
-        }
-        return template
+        ChatTemplateResolver.text(modelDirectory: modelDirectory)
     }
 
     public func _load(

--- a/Libraries/MLXLMCommon/ChatTemplateResolution.swift
+++ b/Libraries/MLXLMCommon/ChatTemplateResolution.swift
@@ -1,0 +1,63 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+
+/// Where a bundle's chat template came from.
+///
+/// Worth reporting rather than discarding: a template that fails to resolve is replaced by a
+/// generic one, and the model then generates fluent, plausible text through the wrong prompt
+/// format. Generation cannot distinguish "template applied" from "template silently replaced", so
+/// the provenance has to be observable somewhere or the failure has no tell at all.
+public enum ChatTemplateSource: String, Equatable, Sendable {
+    /// A sibling `chat_template.jinja`. Several VLMs ship the template ONLY here and leave
+    /// `tokenizer_config.json` without one — GLM-4.5V is the case that prompted this.
+    case sidecar
+
+    /// The `chat_template` string inside `tokenizer_config.json`.
+    case tokenizerConfig
+}
+
+public struct ResolvedChatTemplate: Equatable, Sendable {
+    public let text: String
+    public let source: ChatTemplateSource
+
+    public init(text: String, source: ChatTemplateSource) {
+        self.text = text
+        self.source = source
+    }
+}
+
+/// Resolving a bundle's chat template, in one place.
+///
+/// This rule was written twice — once in `LLMModelFactory`, once in `VLMModelFactory` — with
+/// identical bodies. Identical today; the point of a single owner is that a bundle loaded through
+/// the text path and the same bundle loaded through the multimodal path cannot start disagreeing
+/// about which file its prompt format comes from.
+public enum ChatTemplateResolver {
+    /// The sidecar takes precedence over the inline template.
+    ///
+    /// That order is not arbitrary: a converter that rewrites the template writes the sidecar and
+    /// commonly leaves a stale inline copy behind, so preferring the sidecar prefers the newer of
+    /// the two. Bundles carrying only one are unaffected either way.
+    public static func resolve(modelDirectory: URL) -> ResolvedChatTemplate? {
+        let sidecarURL = modelDirectory.appending(component: "chat_template.jinja")
+        if let text = try? String(contentsOf: sidecarURL, encoding: .utf8) {
+            return ResolvedChatTemplate(text: text, source: .sidecar)
+        }
+        let tokenizerConfigURL = modelDirectory.appending(component: "tokenizer_config.json")
+        guard
+            let data = try? Data(contentsOf: tokenizerConfigURL),
+            let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+            let text = object["chat_template"] as? String
+        else {
+            return nil
+        }
+        return ResolvedChatTemplate(text: text, source: .tokenizerConfig)
+    }
+
+    /// The resolved template text, or `nil` when the bundle carries neither source.
+    public static func text(modelDirectory: URL) -> String? {
+        resolve(modelDirectory: modelDirectory)?.text
+    }
+}

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -73,19 +73,7 @@ private func create<C: Codable, M>(
 }
 
 private func chatTemplateText(modelDirectory: URL) -> String? {
-    let templateURL = modelDirectory.appending(component: "chat_template.jinja")
-    if let template = try? String(contentsOf: templateURL, encoding: .utf8) {
-        return template
-    }
-    let tokenizerConfigURL = modelDirectory.appending(component: "tokenizer_config.json")
-    guard
-        let data = try? Data(contentsOf: tokenizerConfigURL),
-        let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-        let template = object["chat_template"] as? String
-    else {
-        return nil
-    }
-    return template
+    ChatTemplateResolver.text(modelDirectory: modelDirectory)
 }
 
 private func create<C: Codable, P>(

--- a/Package.swift
+++ b/Package.swift
@@ -911,6 +911,7 @@ let package = Package(
                 "MixedGroupSizeQuantizationFocusedTests.swift",
                 "JangSamplingDefaultsTests.swift",
                 "MLXPressCLISourceContractsTests.swift",
+                "ChatTemplateResolutionTests.swift",
                 "VMLXServerRuntimeSettingsTests.swift",
                 "VMLXMemorySafetySettingsTests.swift",
                 "DSV4AgenticToolSourceTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/ChatTemplateResolutionTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/ChatTemplateResolutionTests.swift
@@ -1,0 +1,107 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// A chat template that fails to resolve does not fail loudly: the runtime falls back to a generic
+// format and the model goes on producing fluent, plausible text through the wrong prompt shape.
+// Generation therefore cannot distinguish "template applied" from "template silently replaced",
+// which is why this is asserted on the RESOLUTION rather than on any output.
+//
+// The concrete case: several VLMs ship their template ONLY as a sibling `chat_template.jinja` and
+// leave `tokenizer_config.json` without one. GLM-4.5V is such a bundle.
+
+import Foundation
+import MLXLMCommon
+import Testing
+
+@Suite("Chat template resolution")
+struct ChatTemplateResolutionTests {
+
+    private func makeBundle(
+        sidecar: String?, inline: String?, file: StaticString = #filePath
+    ) throws -> URL {
+        let dir = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("cts-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        if let sidecar {
+            try sidecar.write(
+                to: dir.appendingPathComponent("chat_template.jinja"), atomically: true,
+                encoding: .utf8)
+        }
+        var config: [String: Any] = ["model_max_length": 4096]
+        if let inline { config["chat_template"] = inline }
+        try JSONSerialization.data(withJSONObject: config)
+            .write(to: dir.appendingPathComponent("tokenizer_config.json"))
+        return dir
+    }
+
+    @Test("a sidecar-only bundle resolves, and reports where it came from")
+    func sidecarOnlyResolves() throws {
+        let dir = try makeBundle(sidecar: "SIDECAR", inline: nil)
+        let resolved = try #require(ChatTemplateResolver.resolve(modelDirectory: dir))
+        #expect(resolved.text == "SIDECAR")
+        #expect(resolved.source == .sidecar)
+    }
+
+    @Test("an inline-only bundle resolves from tokenizer_config")
+    func inlineOnlyResolves() throws {
+        let dir = try makeBundle(sidecar: nil, inline: "INLINE")
+        let resolved = try #require(ChatTemplateResolver.resolve(modelDirectory: dir))
+        #expect(resolved.text == "INLINE")
+        #expect(resolved.source == .tokenizerConfig)
+    }
+
+    /// Precedence is observable, not incidental: a converter that rewrites the template writes the
+    /// sidecar and often leaves a stale inline copy behind.
+    @Test("the sidecar wins when both are present")
+    func sidecarWins() throws {
+        let dir = try makeBundle(sidecar: "SIDECAR", inline: "INLINE")
+        let resolved = try #require(ChatTemplateResolver.resolve(modelDirectory: dir))
+        #expect(resolved.text == "SIDECAR")
+        #expect(resolved.source == .sidecar)
+    }
+
+    @Test("a bundle carrying neither resolves to nil rather than to something generic")
+    func neitherResolvesToNil() throws {
+        let dir = try makeBundle(sidecar: nil, inline: nil)
+        #expect(ChatTemplateResolver.resolve(modelDirectory: dir) == nil)
+    }
+
+    /// The guard that matters on real bundles, stated without a per-family marker table: whatever a
+    /// bundle ships as its sidecar is EXACTLY what resolution returns. A silent replacement — the
+    /// failure this whole file exists for — breaks this for every bundle at once.
+    @Test("on every local bundle, a shipped sidecar is returned verbatim")
+    func localBundlesResolveToTheirOwnSidecar() throws {
+        let root = URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent("Library/MLModels")
+        let fm = FileManager.default
+        guard let orgs = try? fm.contentsOfDirectory(atPath: root.path) else { return }
+
+        var checkedSidecar = 0, checkedInline = 0, neither = 0
+        for org in orgs.sorted() {
+            let orgDir = root.appendingPathComponent(org)
+            guard let kids = try? fm.contentsOfDirectory(atPath: orgDir.path) else { continue }
+            for kid in kids.sorted() {
+                let dir = orgDir.appendingPathComponent(kid)
+                guard fm.fileExists(atPath: dir.appendingPathComponent("config.json").path)
+                else { continue }
+                let sidecarURL = dir.appendingPathComponent("chat_template.jinja")
+                let resolved = ChatTemplateResolver.resolve(modelDirectory: dir)
+                if let shipped = try? String(contentsOf: sidecarURL, encoding: .utf8) {
+                    let r = try #require(resolved, "\(kid): ships a sidecar but resolved to nil")
+                    #expect(r.source == .sidecar, "\(kid)")
+                    #expect(r.text == shipped, "\(kid): resolved template is not the shipped one")
+                    checkedSidecar += 1
+                } else if resolved?.source == .tokenizerConfig {
+                    checkedInline += 1
+                } else {
+                    neither += 1
+                }
+            }
+        }
+        // A bundle-gated assertion that never runs looks exactly like one that passed.
+        print(
+            "chat template resolution: \(checkedSidecar) sidecar, \(checkedInline) inline, "
+                + "\(neither) neither")
+        #expect(checkedSidecar + checkedInline > 0, "no local bundle carried a chat template")
+    }
+}


### PR DESCRIPTION
Follow-up to #92, on your question about VLMs that ship a template only in a
sidecar and silently fall back once tools are involved.

**It does not reproduce** — I checked both GLM-4.5V bundles (which are exactly
that shape: no `chat_template` in `tokenizer_config.json`) against
GLM-4.6V-Flash as a control, with and without tools declared in the native slot:
`<|im_start|>` count zero in all six cells, GLM's own markers present in all six,
the tool branch firing in exactly the three tools cells.

That was a check, though, not a guard. This is the guard — plus the thing the
check turned up.

## The rule was written twice

`LLMModelFactory.chatTemplateText` and `VLMModelFactory.chatTemplateText` are
byte-identical private copies of the same resolution rule. Identical *today*.
One owner means a bundle loaded through the text path and the same bundle loaded
through the multimodal path cannot start disagreeing about where its prompt
format comes from — the same argument as #311.

## Resolution now reports its source

```swift
public enum ChatTemplateSource { case sidecar, tokenizerConfig }
```

This is the part with teeth. A template that fails to resolve is replaced by a
generic one, and the model goes on producing **fluent, plausible text through
the wrong prompt shape** — so generation cannot distinguish "applied" from
"silently replaced". Unless provenance is observable somewhere, that failure has
no tell at all.

## Precedence is load-bearing, not academic

Of **58** local bundles carrying both a sidecar and an inline template, **13
carry two different ones**:

| bundle | sidecar | inline |
|---|---|---|
| `Nemotron-3-Nano-Omni-30B-A3B-{MXFP4,JANGTQ4,JANGTQ2}` | 14277 B | 10504 B |
| `Ornith-1.5-9B-{JANG_4D,MXFP8}` | 7593 B | 7756 B |
| `Ornith-1.5-35B-A3B-JANG_6M` | 7536 B | 7764 B |

For those, which file wins **decides the prompt format**. Sidecar-first is
preserved exactly as it was, and now documented: a converter that rewrites the
template writes the sidecar and commonly leaves a stale inline copy behind, so
preferring the sidecar prefers the newer of the two.

## The guard

Stated without a per-family marker table, which would rot as families are added:
**whatever a bundle ships as its sidecar is exactly what resolution returns.** A
silent replacement breaks that for every bundle at once.

It runs over **121 local bundles** here — 103 sidecar, 12 inline, 6 neither —
and prints the split, because a bundle-gated assertion that never ran looks
exactly like one that passed.

**Mutation-checked**: flipping precedence to prefer `tokenizer_config` fails it,
naming the Ornith and Nemotron bundles specifically.

Synthetic cases cover the rest of the matrix — sidecar only, inline only, both,
neither — so the behaviour is pinned without depending on any particular machine
having any particular bundle.
