### PR TITLE
GLM-4V: establish the grid invariant where throwing is allowed

### DIFF
--- a/Libraries/MLXVLM/Models/Glm4Vision.swift
+++ b/Libraries/MLXVLM/Models/Glm4Vision.swift
@@ -10,6 +10,7 @@
 
 import Foundation
 import MLX
+import MLXLMCommon
 
 enum Glm4SharedVision {
 
@@ -101,4 +102,31 @@ enum Glm4SharedVision {
         func conv2(_ x: MLXArray) -> MLXArray { ((a * x - 5 * a) * x + 8 * a) * x - 4 * a }
         return [conv2(t + 1), conv1(t), conv1(1 - t), conv2(2 - t)]
     }
+    /// Validate the grid invariants the vision path relies on, at a point where throwing is
+    /// allowed.
+    ///
+    /// The forward path reshapes each frame to `(h / merge, merge, w / merge, merge)`. If `h` or
+    /// `w` is not divisible by the merge size the element count does not match and MLX traps; if
+    /// the merge size is zero it divides by zero. Both are configuration mistakes with no
+    /// recovery, but a trap takes the process down with a message about shapes rather than about
+    /// the bundle.
+    ///
+    /// Checking once here rather than guarding each site is deliberate: `rotaryPositionEmbedding`
+    /// and the rope-index walk are NOT throwing, and making them so would change signatures across
+    /// the tower to restate an invariant that is fixed before any of them runs. `prepare` already
+    /// throws, so the invariant is established at the boundary and relied on inside.
+    public static func validateGrid(_ frames: [THW], spatialMergeSize merge: Int) throws {
+        guard merge > 0 else {
+            throw VLMError.processing(
+                "vision config declares spatial_merge_size = \(merge); it must be positive")
+        }
+        for (i, f) in frames.enumerated() where f.h % merge != 0 || f.w % merge != 0 {
+            throw VLMError.processing(
+                "frame \(i) is \(f.h)x\(f.w), which spatial_merge_size \(merge) does not "
+                    + "divide. The vision tower reshapes each frame by the merge size, so a "
+                    + "non-divisible grid cannot be formed. This is a property of the bundle's "
+                    + "preprocessor configuration, not of the request.")
+        }
+    }
+
 }

--- a/Libraries/MLXVLM/Models/Glm4v.swift
+++ b/Libraries/MLXVLM/Models/Glm4v.swift
@@ -1000,6 +1000,11 @@ public class Glm4v: Module, VLMModel, KVCacheDimensionProvider {
             allFrames.append(contentsOf: imageFrames)
         }
 
+        // Establish the grid invariant here, where throwing is allowed, so the non-throwing
+        // forward path below can rely on it instead of trapping deep inside a reshape.
+        try Glm4SharedVision.validateGrid(
+            allFrames, spatialMergeSize: config.visionConfiguration.spatialMergeSize)
+
         let inputEmbeddings = self.inputEmbeddings(
             inputIds: input.text.tokens, pixelValues: allPixels,
             frames: allFrames.isEmpty ? nil : allFrames)

--- a/Libraries/MLXVLM/Models/Glm4vMoe.swift
+++ b/Libraries/MLXVLM/Models/Glm4vMoe.swift
@@ -1107,6 +1107,11 @@ public class Glm4vMoe: Module, VLMModel, KVCacheDimensionProvider {
             allFrames.append(contentsOf: imageFrames)
         }
 
+        // Establish the grid invariant here, where throwing is allowed, so the non-throwing
+        // forward path below can rely on it instead of trapping deep inside a reshape.
+        try Glm4SharedVision.validateGrid(
+            allFrames, spatialMergeSize: config.visionConfiguration.spatialMergeSize)
+
         let inputEmbeddings = self.inputEmbeddings(
             inputIds: input.text.tokens, pixelValues: allPixels,
             frames: allFrames.isEmpty ? nil : allFrames)

--- a/Package.swift
+++ b/Package.swift
@@ -875,6 +875,7 @@ let package = Package(
                 "VLShapeGuardFocusedTests.swift",
                 "JANGTQStreamingExpertDescriptorTests.swift",
                 "JANGTQHadamardShuffleTests.swift",
+                "Glm4GridInvariantTests.swift",
                 "MiniMaxJANGTQResidentExpertTests.swift",
                 "JangPressMachCacheTests.swift",
                 "JangPressPrestackerCleanupTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/Glm4GridInvariantTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/Glm4GridInvariantTests.swift
@@ -1,0 +1,68 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// The GLM-4V vision path reshapes each frame to (h/merge, merge, w/merge, merge). A frame the
+// merge size does not divide makes the element count disagree and MLX traps; a merge size of zero
+// divides by zero. Neither is recoverable, but a trap ends the process with a message about tensor
+// shapes rather than about the bundle that caused it.
+//
+// The guard runs at `prepare`, which already throws — so the non-throwing forward path keeps its
+// signatures and simply relies on an invariant established before it runs.
+
+import Foundation
+import MLXLMCommon
+import Testing
+
+@testable import MLXVLM
+
+@Suite("GLM-4V grid invariants")
+struct Glm4GridInvariantTests {
+
+    @Test("a divisible grid passes")
+    func divisiblePasses() throws {
+        try Glm4SharedVision.validateGrid(
+            [THW(1, 32, 48), THW(1, 16, 16)], spatialMergeSize: 2)
+    }
+
+    @Test("an empty frame list passes — text-only requests are not vision requests")
+    func emptyPasses() throws {
+        try Glm4SharedVision.validateGrid([], spatialMergeSize: 2)
+    }
+
+    /// The message must name the bundle-level cause. "shape mismatch" from inside a reshape sends
+    /// the reader to the wrong layer entirely.
+    @Test("a non-divisible frame throws, naming the frame and the merge size")
+    func nonDivisibleThrows() {
+        #expect(throws: (any Error).self) {
+            try Glm4SharedVision.validateGrid([THW(1, 33, 48)], spatialMergeSize: 2)
+        }
+        do {
+            try Glm4SharedVision.validateGrid([THW(1, 32, 48), THW(1, 15, 20)], spatialMergeSize: 2)
+            Issue.record("expected a throw")
+        } catch {
+            let text = "\(error)"
+            #expect(text.contains("15"), "should name the offending extent: \(text)")
+            #expect(text.contains("frame 1"), "should name WHICH frame: \(text)")
+            #expect(text.contains("2"), "should name the merge size: \(text)")
+        }
+    }
+
+    @Test("a zero merge size throws instead of dividing by zero")
+    func zeroMergeThrows() {
+        #expect(throws: (any Error).self) {
+            try Glm4SharedVision.validateGrid([THW(1, 32, 32)], spatialMergeSize: 0)
+        }
+    }
+
+    /// Both towers must establish the invariant, not just the one that was debugged.
+    @Test("both GLM towers validate before touching the vision path")
+    func bothTowersGuard() throws {
+        for file in ["Libraries/MLXVLM/Models/Glm4v.swift", "Libraries/MLXVLM/Models/Glm4vMoe.swift"] {
+            let source = try #require(
+                try? String(contentsOfFile: file, encoding: .utf8), "missing \(file)")
+            #expect(
+                source.contains("Glm4SharedVision.validateGrid("),
+                "\(file) does not establish the grid invariant")
+        }
+    }
+}

--- a/Tests/MLXLMTests/Glm4VisionTests.swift
+++ b/Tests/MLXLMTests/Glm4VisionTests.swift
@@ -10,8 +10,13 @@ import Testing
 /// Two of these anchors are independent ground truth (they hold for any cubic-convolution constant
 /// `A`, so they'd survive a wrong kernel): sampling exactly on a pixel center returns that pixel, and
 /// a constant field stays constant (the weights partition to 1). The fractional-interior values are
-/// the `A`-sensitive ones; they're pinned to a numpy reimplementation of PyTorch's Keys `A = -0.75`
-/// coefficients (a torch cross-check is noted in the PR).
+/// the `A`-sensitive ones. They were originally pinned to a reimplementation of PyTorch's Keys
+/// `A = -0.75` coefficients — an oracle written from the same reading of the spec as the code, so
+/// a misreading would have satisfied both. Cross-checked against real `torch.nn.functional`
+/// (2.13.0) on 2026-08-28: worst deviation 3.8e-06 against a 1e-3 tolerance.
+///
+/// They earn their place: recomputing the first point with `A = -0.5` (PIL's constant) gives
+/// 5.282 against 5.087 — 195x the tolerance — so a wrong cubic constant does not slip past them.
 @Suite("Glm4SharedVision.gridSampleBicubic")
 struct Glm4VisionTests {
 


### PR DESCRIPTION
One of the three #92 follow-ups. Offered there as a choice; this is option (a),
implemented — happy to switch if you prefer (b).

## The problem

The GLM-4V vision path reshapes each frame:

```swift
.reshaped(h / spatialMergeSize, spatialMergeSize,
          w / spatialMergeSize, spatialMergeSize)
```

A frame the merge size does not divide makes the element count disagree and MLX
**traps**. A merge size of zero divides by zero. Neither is recoverable — but a
trap ends the process with a message about tensor shapes, when the cause is the
bundle's preprocessor configuration.

## Why not guard at the trap sites

`rotaryPositionEmbedding` and the rope-index walk are **not throwing**, and a
`precondition` still traps, which does not meet the bar you set on #92. Making
them throwing would change signatures across the tower in order to restate an
invariant that is already fixed before any of them runs.

`prepare` **already throws** on both towers. So the invariant is established
once at that boundary and relied on inside. No signature changes; the
non-throwing forward path stays non-throwing.

## Scope

Deliberately the two grid/merge cases only. The third trap noted on #92 — video
indexing — depends on **per-request input** rather than on configuration, so it
is not part of this invariant. That one is the case that genuinely argues for a
throwing forward path, and I would rather settle that separately than smuggle it
in here.

## The message

```
frame 1 is 15x20, which spatial_merge_size 2 does not divide. The vision tower
reshapes each frame by the merge size, so a non-divisible grid cannot be formed.
This is a property of the bundle's preprocessor configuration, not of the request.
```

Names the frame, the extent, the merge size, and the layer at fault.

## Both towers

Asserted by a test, not by inspection — fixing only the tower that was debugged
is the failure this family keeps repeating, and it is exactly what #311 and
#312/#313 are about.

## Also: the bicubic anchors are now cross-checked against torch

`Glm4VisionTests` carried an acknowledged gap. Its three fractional anchors are
the only ones that test the *kernel* — the others hold for any cubic constant —
and they were pinned to a reimplementation of PyTorch's Keys `A = -0.75`
coefficients written from the same reading of the spec as the code. A misreading
would have satisfied both, and the comment said so.

Cross-checked against real `torch.nn.functional` 2.13.0:

| pinned | torch | \|diff\| |
|---|---|---|
| 5.087000 | 5.087001 | 8.5e-07 |
| 8.316000 | 8.315996 | 3.8e-06 |
| 14.378987 | 14.378986 | 6.4e-07 |

Worst deviation **3.8e-06** against a **1e-3** tolerance.

And they are load-bearing, not decorative: recomputing the first point with
`A = -0.5` (PIL's constant) gives **5.282** against 5.087 — **195x the
tolerance** — so a wrong cubic constant does not slip past them. There is no
offline substitute for this check: scipy's `map_coordinates` is B-spline with
prefiltering, a different algorithm, and PIL's bicubic uses a different `A`.

Only the doc comment changes; the values were already correct.
