### PR TITLE
GLM-4V: share the M-RoPE index walk between the two towers

### DIFF
--- a/Libraries/MLXVLM/Models/Glm4Vision.swift
+++ b/Libraries/MLXVLM/Models/Glm4Vision.swift
@@ -129,4 +129,99 @@ enum Glm4SharedVision {
         }
     }
 
+    /// The M-RoPE position-index walk, shared by both GLM-4V towers.
+    ///
+    /// `glm4v` and `glm4v_moe` carried byte-identical copies of this, 89 lines each, differing
+    /// only in the model name inside one `precondition` message. The walk depends on nothing but
+    /// the token ids, the image grid, and two configuration scalars, so there was never a reason
+    /// for there to be two of it — and a divergence here would show up as subtly wrong positions
+    /// rather than as a failure.
+    public static func ropeIndex(
+        inputIds: MLXArray, imageGridThw: [THW]?, spatialMergeSize: Int, imageTokenId: Int,
+        family: String
+    ) -> (MLXArray, MLXArray) {
+        let batchSize = inputIds.dim(0)
+        let seqLength = inputIds.dim(1)
+
+        guard let imageGridThw, !imageGridThw.isEmpty else {
+            let positions = MLXArray(0 ..< Int32(seqLength)).expandedDimensions(axis: 0)
+            let positionIds = tiled(
+                broadcast(positions, to: [batchSize, seqLength]).expandedDimensions(axis: 0),
+                repetitions: [3, 1, 1])
+            let deltas = MLXArray(Int32(0))
+            return (positionIds, deltas)
+        }
+
+        precondition(batchSize == 1, "\(family) getRopeIndex only supports batchSize == 1")
+        let positionIds = zeros([3, batchSize, seqLength], type: Int32.self)
+        var imageIndex = 0
+        var mropePositionDelta: Int = 0
+
+        for batchIdx in 0 ..< batchSize {
+            let inputTokens: [Int32] = inputIds[batchIdx].asArray(Int32.self)
+
+            var dimT = [Int32]()
+            var dimH = [Int32]()
+            var dimW = [Int32]()
+            dimT.reserveCapacity(seqLength)
+            dimH.reserveCapacity(seqLength)
+            dimW.reserveCapacity(seqLength)
+            var st = 0
+            var lastMax: Int32 = -1
+
+            let appendTextPositions = { (count: Int) in
+                guard count > 0 else { return }
+                let base: Int32 = lastMax + 1
+                for j in 0 ..< count {
+                    let pos = base + Int32(j)
+                    dimT.append(pos)
+                    dimH.append(pos)
+                    dimW.append(pos)
+                }
+                lastMax = base + Int32(count) - 1
+            }
+
+            while imageIndex < imageGridThw.count {
+                guard let ed = inputTokens[st...].firstIndex(of: Int32(imageTokenId)) else {
+                    break
+                }
+
+                let frame = imageGridThw[imageIndex]
+                let llmGridT = frame.t
+                let llmGridH = frame.h / spatialMergeSize
+                let llmGridW = frame.w / spatialMergeSize
+                imageIndex += 1
+
+                appendTextPositions(ed - st)
+
+                let imgOffset: Int32 = lastMax + 1
+                for t in 0 ..< llmGridT {
+                    for h in 0 ..< llmGridH {
+                        for w in 0 ..< llmGridW {
+                            dimT.append(Int32(t) + imgOffset)
+                            dimH.append(Int32(h) + imgOffset)
+                            dimW.append(Int32(w) + imgOffset)
+                        }
+                    }
+                }
+                let tMax = Int32(llmGridT - 1) + imgOffset
+                let hMax = Int32(llmGridH - 1) + imgOffset
+                let wMax = Int32(llmGridW - 1) + imgOffset
+                lastMax = max(tMax, max(hMax, wMax))
+
+                st = ed + llmGridT * llmGridH * llmGridW
+            }
+
+            appendTextPositions(inputTokens.count - st)
+
+            positionIds[0, batchIdx] = MLXArray(dimT)
+            positionIds[1, batchIdx] = MLXArray(dimH)
+            positionIds[2, batchIdx] = MLXArray(dimW)
+
+            mropePositionDelta = Int(lastMax) + 1 - inputTokens.count
+        }
+
+        let deltas = MLXArray(Int32(mropePositionDelta))
+        return (positionIds, deltas)
+    }
 }

--- a/Libraries/MLXVLM/Models/Glm4v.swift
+++ b/Libraries/MLXVLM/Models/Glm4v.swift
@@ -870,91 +870,11 @@ public class Glm4v: Module, VLMModel, KVCacheDimensionProvider {
     private func getRopeIndex(
         inputIds: MLXArray, imageGridThw: [THW]?
     ) -> (MLXArray, MLXArray) {
-        let batchSize = inputIds.dim(0)
-        let seqLength = inputIds.dim(1)
-        let spatialMergeSize = config.visionConfiguration.spatialMergeSize
-        let imageTokenId = config.baseConfiguration.imageTokenId
-
-        guard let imageGridThw, !imageGridThw.isEmpty else {
-            let positions = MLXArray(0 ..< Int32(seqLength)).expandedDimensions(axis: 0)
-            let positionIds = tiled(
-                broadcast(positions, to: [batchSize, seqLength]).expandedDimensions(axis: 0),
-                repetitions: [3, 1, 1])
-            let deltas = MLXArray(Int32(0))
-            return (positionIds, deltas)
-        }
-
-        precondition(batchSize == 1, "Glm4v getRopeIndex only supports batchSize == 1")
-        let positionIds = zeros([3, batchSize, seqLength], type: Int32.self)
-        var imageIndex = 0
-        var mropePositionDelta: Int = 0
-
-        for batchIdx in 0 ..< batchSize {
-            let inputTokens: [Int32] = inputIds[batchIdx].asArray(Int32.self)
-
-            var dimT = [Int32]()
-            var dimH = [Int32]()
-            var dimW = [Int32]()
-            dimT.reserveCapacity(seqLength)
-            dimH.reserveCapacity(seqLength)
-            dimW.reserveCapacity(seqLength)
-            var st = 0
-            var lastMax: Int32 = -1
-
-            let appendTextPositions = { (count: Int) in
-                guard count > 0 else { return }
-                let base: Int32 = lastMax + 1
-                for j in 0 ..< count {
-                    let pos = base + Int32(j)
-                    dimT.append(pos)
-                    dimH.append(pos)
-                    dimW.append(pos)
-                }
-                lastMax = base + Int32(count) - 1
-            }
-
-            while imageIndex < imageGridThw.count {
-                guard let ed = inputTokens[st...].firstIndex(of: Int32(imageTokenId)) else {
-                    break
-                }
-
-                let frame = imageGridThw[imageIndex]
-                let llmGridT = frame.t
-                let llmGridH = frame.h / spatialMergeSize
-                let llmGridW = frame.w / spatialMergeSize
-                imageIndex += 1
-
-                appendTextPositions(ed - st)
-
-                let imgOffset: Int32 = lastMax + 1
-                for t in 0 ..< llmGridT {
-                    for h in 0 ..< llmGridH {
-                        for w in 0 ..< llmGridW {
-                            dimT.append(Int32(t) + imgOffset)
-                            dimH.append(Int32(h) + imgOffset)
-                            dimW.append(Int32(w) + imgOffset)
-                        }
-                    }
-                }
-                let tMax = Int32(llmGridT - 1) + imgOffset
-                let hMax = Int32(llmGridH - 1) + imgOffset
-                let wMax = Int32(llmGridW - 1) + imgOffset
-                lastMax = max(tMax, max(hMax, wMax))
-
-                st = ed + llmGridT * llmGridH * llmGridW
-            }
-
-            appendTextPositions(inputTokens.count - st)
-
-            positionIds[0, batchIdx] = MLXArray(dimT)
-            positionIds[1, batchIdx] = MLXArray(dimH)
-            positionIds[2, batchIdx] = MLXArray(dimW)
-
-            mropePositionDelta = Int(lastMax) + 1 - inputTokens.count
-        }
-
-        let deltas = MLXArray(Int32(mropePositionDelta))
-        return (positionIds, deltas)
+        Glm4SharedVision.ropeIndex(
+            inputIds: inputIds, imageGridThw: imageGridThw,
+            spatialMergeSize: config.visionConfiguration.spatialMergeSize,
+            imageTokenId: config.baseConfiguration.imageTokenId,
+            family: "Glm4v")
     }
 
     private func inputEmbeddings(inputIds: MLXArray, pixelValues: MLXArray?, frames: [THW]?)

--- a/Libraries/MLXVLM/Models/Glm4vMoe.swift
+++ b/Libraries/MLXVLM/Models/Glm4vMoe.swift
@@ -977,91 +977,11 @@ public class Glm4vMoe: Module, VLMModel, KVCacheDimensionProvider {
     private func getRopeIndex(
         inputIds: MLXArray, imageGridThw: [THW]?
     ) -> (MLXArray, MLXArray) {
-        let batchSize = inputIds.dim(0)
-        let seqLength = inputIds.dim(1)
-        let spatialMergeSize = config.visionConfiguration.spatialMergeSize
-        let imageTokenId = config.baseConfiguration.imageTokenId
-
-        guard let imageGridThw, !imageGridThw.isEmpty else {
-            let positions = MLXArray(0 ..< Int32(seqLength)).expandedDimensions(axis: 0)
-            let positionIds = tiled(
-                broadcast(positions, to: [batchSize, seqLength]).expandedDimensions(axis: 0),
-                repetitions: [3, 1, 1])
-            let deltas = MLXArray(Int32(0))
-            return (positionIds, deltas)
-        }
-
-        precondition(batchSize == 1, "Glm4vMoe getRopeIndex only supports batchSize == 1")
-        let positionIds = zeros([3, batchSize, seqLength], type: Int32.self)
-        var imageIndex = 0
-        var mropePositionDelta: Int = 0
-
-        for batchIdx in 0 ..< batchSize {
-            let inputTokens: [Int32] = inputIds[batchIdx].asArray(Int32.self)
-
-            var dimT = [Int32]()
-            var dimH = [Int32]()
-            var dimW = [Int32]()
-            dimT.reserveCapacity(seqLength)
-            dimH.reserveCapacity(seqLength)
-            dimW.reserveCapacity(seqLength)
-            var st = 0
-            var lastMax: Int32 = -1
-
-            let appendTextPositions = { (count: Int) in
-                guard count > 0 else { return }
-                let base: Int32 = lastMax + 1
-                for j in 0 ..< count {
-                    let pos = base + Int32(j)
-                    dimT.append(pos)
-                    dimH.append(pos)
-                    dimW.append(pos)
-                }
-                lastMax = base + Int32(count) - 1
-            }
-
-            while imageIndex < imageGridThw.count {
-                guard let ed = inputTokens[st...].firstIndex(of: Int32(imageTokenId)) else {
-                    break
-                }
-
-                let frame = imageGridThw[imageIndex]
-                let llmGridT = frame.t
-                let llmGridH = frame.h / spatialMergeSize
-                let llmGridW = frame.w / spatialMergeSize
-                imageIndex += 1
-
-                appendTextPositions(ed - st)
-
-                let imgOffset: Int32 = lastMax + 1
-                for t in 0 ..< llmGridT {
-                    for h in 0 ..< llmGridH {
-                        for w in 0 ..< llmGridW {
-                            dimT.append(Int32(t) + imgOffset)
-                            dimH.append(Int32(h) + imgOffset)
-                            dimW.append(Int32(w) + imgOffset)
-                        }
-                    }
-                }
-                let tMax = Int32(llmGridT - 1) + imgOffset
-                let hMax = Int32(llmGridH - 1) + imgOffset
-                let wMax = Int32(llmGridW - 1) + imgOffset
-                lastMax = max(tMax, max(hMax, wMax))
-
-                st = ed + llmGridT * llmGridH * llmGridW
-            }
-
-            appendTextPositions(inputTokens.count - st)
-
-            positionIds[0, batchIdx] = MLXArray(dimT)
-            positionIds[1, batchIdx] = MLXArray(dimH)
-            positionIds[2, batchIdx] = MLXArray(dimW)
-
-            mropePositionDelta = Int(lastMax) + 1 - inputTokens.count
-        }
-
-        let deltas = MLXArray(Int32(mropePositionDelta))
-        return (positionIds, deltas)
+        Glm4SharedVision.ropeIndex(
+            inputIds: inputIds, imageGridThw: imageGridThw,
+            spatialMergeSize: config.visionConfiguration.spatialMergeSize,
+            imageTokenId: config.baseConfiguration.imageTokenId,
+            family: "Glm4vMoe")
     }
 
     private func inputEmbeddings(inputIds: MLXArray, pixelValues: MLXArray?, frames: [THW]?)


### PR DESCRIPTION
> Depends on #326 (the grid invariant); the diff here is the last commit only.

The first extraction from the duplication left after #92, offered there as a
shape to agree on before doing the rest.

## What was duplicated

`getRopeIndex` — **89 lines in each tower**, byte-identical modulo whitespace
except for one word:

```
< precondition(batchSize == 1, "Glm4v getRopeIndex only supports batchSize == 1")
> precondition(batchSize == 1, "Glm4vMoe getRopeIndex only supports batchSize == 1")
```

It reads nothing from `self` beyond two configuration scalars
(`spatialMergeSize`, `imageTokenId`), so it moves to `Glm4SharedVision` as a
static function and each tower keeps a 9-line call.

## Why it matters more than line count

The failure mode is not a crash. Two copies of a position-index walk drift into
computing slightly **different positions**, and wrong M-RoPE positions degrade
output without failing anything — which is the same shape as every other
duplication in this family, and the reason #311/#312/#313 exist.

## Equivalence, checked not asserted

Same image, same prompt, GLM-4.6V-Flash at temperature 0, before and after:

```
The image shows the JANG Studio software interface with a left - side navigation
panel listing steps (1 - Source Model, 2 - Architecture, etc.) and a main
```

**Byte-identical.**

## The rest, if you want it

Remaining identical runs of ≥20 lines between the two towers:

| lines | glm4v | glm4v_moe | what |
|---:|---|---|---|
| 118 | L888–1042 | L995–1149 | **this PR** |
| 71 | L753–839 | L860–943 | vision-embedding interpolation |
| 55 | L337–399 | L462–524 | tied-embedding head |
| 55 | L548–617 | L662–728 | attention block init |
| 55 | L1106–1165 | L1266–1325 | |

**553 lines across 11 runs** (670 counting runs of ≥6) — more than the ~450 I
estimated on #92.

One PR per extraction, each with the same before/after check, rather than one
large move. Say which you want and in what order — or say no, and I will leave
the rest alone.
