### PR TITLE
qwen4_exp: persist the QSA indexer-keys lane across disk restore

### DIFF
--- a/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
@@ -862,10 +862,57 @@ private func restoreFromV2Arrays(
                     "[disk cache] restore SKIPPED: layer \(i) has incompatible shape (k=\(keys.shape) v=\(values.shape)). Need >= 3D. Falling back to fresh prefill.\n".utf8))
                 return 0
             }
+            // A plain 2-array KV record seated into a QSAKVCache leaves
+            // `offset` large with an EMPTY indexer lane; the sparse
+            // selector then sizes its mask from the post-restore suffix and
+            // SDPA fatals on the shape mismatch (osaurus#2525). Any such
+            // record predates the `.qsaKV` kind — refuse the whole entry
+            // (one re-prefill) instead of diverging.
+            guard !(cache[i] is QSAKVCache) else {
+                FileHandle.standardError.write(Data(
+                    "[disk cache] restore SKIPPED: layer \(i) is a QSA layer but the stored record has no indexer lane (pre-qsaKV entry). Falling back to fresh prefill.\n".utf8))
+                return 0
+            }
             if totalTokens == 0 {
                 totalTokens = keys.dim(2)
             }
             restoreKVLayer(keys: keys, values: values, into: cache[i])
+
+        case .qsaKV(let comp):
+            var keys = comp.keys
+            var values = comp.values
+            var indexer = comp.indexerKeys
+            if keys.dtype == .float16 {
+                keys = keys.asType(.bfloat16)
+                values = values.asType(.bfloat16)
+            }
+            if indexer.dtype == .float16 {
+                indexer = indexer.asType(.bfloat16)
+            }
+            guard keys.shape.count >= 3, values.shape.count >= 3,
+                indexer.shape.count >= 3
+            else {
+                FileHandle.standardError.write(Data(
+                    "[disk cache] restore SKIPPED: QSA layer \(i) has incompatible shape (k=\(keys.shape) v=\(values.shape) idx=\(indexer.shape)). Falling back to fresh prefill.\n".utf8))
+                return 0
+            }
+            guard let qsa = cache[i] as? QSAKVCache else {
+                FileHandle.standardError.write(Data(
+                    "[disk cache] restore SKIPPED: stored QSA record for layer \(i) but the live cache is \(type(of: cache[i])). Falling back to fresh prefill.\n".utf8))
+                return 0
+            }
+            // The indexer lane must cover exactly the restored offset —
+            // `state`'s setter derives offset from keys, and a shorter lane
+            // would recreate the divergence this record exists to prevent.
+            guard indexer.dim(1) == keys.dim(2) else {
+                FileHandle.standardError.write(Data(
+                    "[disk cache] restore SKIPPED: QSA layer \(i) indexer lane length \(indexer.dim(1)) != KV offset \(keys.dim(2)). Falling back to fresh prefill.\n".utf8))
+                return 0
+            }
+            qsa.state = [keys, values, indexer]
+            if totalTokens == 0 {
+                totalTokens = keys.dim(2)
+            }
 
         case .mamba(let comp):
             // Mamba state arrays are cumulative — no sequence dim to
@@ -1004,10 +1051,11 @@ private func restoreFromV2Arrays(
                     }
 
                 case .tq, .qkv, .deepseekV4, .zayaCCA, .zayaCCATQ, .cacheList,
-                     .requiredMiss, .skip:
+                     .qsaKV, .requiredMiss, .skip:
                     // .skip is a per-sub no-op (sub-cache had no
-                    // persistable state). The other cases are not
-                    // currently emitted as sub-cache kinds — see
+                    // persistable state). The other cases (incl. .qsaKV —
+                    // no model nests a QSAKVCache inside a CacheList) are
+                    // not currently emitted as sub-cache kinds — see
                     // TQDiskSerializer.deserializeCacheListLayer.
                     continue
                 }
@@ -1132,6 +1180,17 @@ private func restoreKVLayer(
     values restoredValues: MLXArray,
     into layer: any KVCache
 ) {
+    if layer is QSAKVCache {
+        // A 2-array seat into a QSA cache erases the indexer lane and
+        // diverges the sparse selector (osaurus#2525). The v2 `.standard`
+        // restore refuses the whole record before reaching here; legacy v1
+        // entries predate qwen4_exp and CacheList never wraps QSA, so this
+        // is a defense-in-depth backstop for future call sites. Loud no-op:
+        // the layer stays empty rather than becoming inconsistent.
+        FileHandle.standardError.write(Data(
+            "[disk cache] restoreKVLayer REFUSED: 2-array record for a QSAKVCache (would drop the indexer lane).\n".utf8))
+        return
+    }
     if let simple = layer as? KVCacheSimple {
         simple.state = [restoredKeys, restoredValues]
     } else if let quantizedCache = layer as? QuantizedKVCache {

--- a/Libraries/MLXLMCommon/Cache/TQDiskSerializer.swift
+++ b/Libraries/MLXLMCommon/Cache/TQDiskSerializer.swift
@@ -129,6 +129,16 @@ public enum TQDiskSerializer {
         /// state are one atomic prompt-boundary record; restoring either half
         /// alone would be a false cache hit.
         case zayaCCATQ = 10
+        /// `QSAKVCache` (qwen4_exp QSA full-attention layers) — the standard
+        /// KV pair PLUS the raw indexer-keys lane (`state[2]`,
+        /// `[B, T, indexerHeadDim]`). The sparse block selector sizes its
+        /// attention mask from this lane, so restoring KV without it leaves
+        /// `offset` large while the lane restarts at the post-restore suffix
+        /// — the broadcast_shapes crash of osaurus#2525. The three arrays
+        /// are one atomic record; a QSA layer written as plain `.kv` (any
+        /// pre-fix entry) must be refused on restore, never seated.
+        /// Added 2026-08-28.
+        case qsaKV = 11
         /// Cache type we don't know how to persist. On restore, treated as
         /// a forced miss for the affected layer only.
         case skip = 4
@@ -284,6 +294,23 @@ public enum TQDiskSerializer {
                 serializeQKVLayer(qkv, index: i, into: &result)
                 // serializeQKVLayer sets the kind tag itself so it can mark
                 // empty caches as `.skip` instead of `.qkv`.
+            } else if let qsa = layer as? QSAKVCache {
+                // MUST precede the generic KVCacheSimple branch: QSAKVCache
+                // IS a KVCacheSimple, and writing it as a 2-array `.kv`
+                // record silently drops the indexer lane (osaurus#2525).
+                let state = qsa.state
+                if state.count >= 3 {
+                    result["kv_\(i)_keys"] = state[0]
+                    result["kv_\(i)_values"] = state[1]
+                    result["kv_\(i)_indexer_keys"] = state[2]
+                    result[kindKey(for: i)] = kindArray(.qsaKV)
+                } else {
+                    // A QSA layer whose indexer lane is missing cannot be
+                    // restored faithfully — the selector would mis-size its
+                    // mask. Record skip (forced miss) instead of a lossy
+                    // `.kv` record. Also covers the empty pre-prefill case.
+                    result[kindKey(for: i)] = kindArray(.skip)
+                }
             } else if layer is KVCacheSimple || layer is TurboQuantKVCache {
                 // KVCacheSimple always, plus TurboQuantKVCache in fill phase.
                 // A compressed TQ layer restored from paged decoded KV also
@@ -848,6 +875,15 @@ public enum TQDiskSerializer {
         public let values: MLXArray
     }
 
+    /// Standard KV pair plus the raw QSA indexer-keys lane for one
+    /// qwen4_exp full-attention layer. The three arrays are one atomic
+    /// record — see `LayerKind.qsaKV`.
+    public struct QSAKVLayerComponents {
+        public let keys: MLXArray
+        public let values: MLXArray
+        public let indexerKeys: MLXArray
+    }
+
     /// Mamba SSM state for a single hybrid layer. `state1` is nil for
     /// single-slot layouts: LFM2/LFM2.5 short-conv layers only ever occupy
     /// slot 0 of their 2-slot `MambaCache` container
@@ -942,6 +978,7 @@ public enum TQDiskSerializer {
     public indirect enum LayerData {
         case tq(TQLayerComponents)
         case standard(KVLayerComponents)
+        case qsaKV(QSAKVLayerComponents)
         case mamba(MambaLayerComponents)
         case qkv(QKVLayerComponents)
         case rotating(RotatingLayerComponents)
@@ -1065,6 +1102,24 @@ public enum TQDiskSerializer {
                     // A typed TQ layer is required state. Treat an incomplete
                     // payload as an atomic miss so a rotating companion cannot
                     // turn it into a false mixed-topology hit.
+                    out.append(IndexedLayerData(index: i, data: .requiredMiss))
+                }
+            case .qsaKV:
+                if let keys = arrays["kv_\(i)_keys"],
+                   let values = arrays["kv_\(i)_values"],
+                   let indexer = arrays["kv_\(i)_indexer_keys"]
+                {
+                    out.append(
+                        IndexedLayerData(
+                            index: i,
+                            data: .qsaKV(
+                                QSAKVLayerComponents(
+                                    keys: keys, values: values, indexerKeys: indexer))
+                        )
+                    )
+                } else {
+                    // The kind tag promised a 3-array QSA record; anything
+                    // less is damage — refuse the whole entry, same as .kv.
                     out.append(IndexedLayerData(index: i, data: .requiredMiss))
                 }
             case .kv:
@@ -1503,12 +1558,12 @@ public enum TQDiskSerializer {
                 }
             case .skip, .unknown:
                 subs.append(.skip)
-            case .tq, .qkv, .deepseekV4, .cacheList, .zayaCCA, .zayaCCATQ:
+            case .tq, .qkv, .deepseekV4, .cacheList, .zayaCCA, .zayaCCATQ, .qsaKV:
                 // Not currently emitted as sub-cache types — see
-                // serializeCacheListLayer. If a future bundle ships
-                // these we'll need to extend serialize too. Skip for
-                // now so old readers don't crash on a tag they can't
-                // round-trip.
+                // serializeCacheListLayer (no model nests a QSAKVCache
+                // inside a CacheList). If a future bundle ships these
+                // we'll need to extend serialize too. Skip for now so
+                // old readers don't crash on a tag they can't round-trip.
                 subs.append(.skip)
             }
         }

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -2562,7 +2562,11 @@ public struct TokenIterator: TokenIteratorProtocol {
             //                      The compilable form also preserves Qwen3.8
             //                      PLE companion slots 2...5.
             let allPromotable = cache.allSatisfy { layer in
-                layer is KVCacheSimple
+                // QSAKVCache IS a KVCacheSimple, but promotion to
+                // CompilableKVCache erases the type — the qwen4_exp
+                // indexer's `as? QSAKVCache` then fails and the sparse
+                // selector runs cacheless (osaurus#2525 secondary hazard).
+                (layer is KVCacheSimple && !(layer is QSAKVCache))
                     || (layer is RotatingKVCache && !(layer is CompilableRotatingKVCache))
                     || (layer is MambaCache && !(layer is CompilableMambaCache))
             }

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -2140,6 +2140,15 @@ public func maybeQuantizeKVCache(
         guard hasEligibleLayer else { return }
 
         for i in 0..<cache.count {
+            if cache[i] is QSAKVCache {
+                // TurboQuant promotion would replace the QSAKVCache with a
+                // cache that has no indexer lane (and `fromSimpleCache`
+                // refuses 3-array state, yielding an EMPTY cache) — the
+                // qwen4_exp sparse selector then diverges (osaurus#2525).
+                FileHandle.standardError.write(Data(
+                    "[kv quant] skipping QSA layer \(i): TurboQuant promotion would drop the indexer lane.\n".utf8))
+                continue
+            }
             if let simpleCache = cache[i] as? KVCacheSimple {
                 guard simpleCache.offset > tqMinStart,
                       TurboQuantKVCache.hasCompressibleMiddle(tokenCount: simpleCache.offset)
@@ -2169,6 +2178,7 @@ public func maybeQuantizeKVCache(
         else { return }
 
         for i in 0..<cache.count {
+            if cache[i] is QSAKVCache { continue }  // osaurus#2525: keep the indexer lane
             if let simpleCache = cache[i] as? KVCacheSimple {
                 cache[i] = simpleCache.toQuantized(groupSize: groupSize, bits: bits)
             }
@@ -2189,6 +2199,7 @@ public func maybeQuantizeKVCache(
     }
 
     for i in 0..<cache.count {
+        if cache[i] is QSAKVCache { continue }  // osaurus#2525: keep the indexer lane
         if let simpleCache = cache[i] as? KVCacheSimple {
             cache[i] = simpleCache.toQuantized(groupSize: kvGroupSize, bits: kvBits)
         }

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -700,7 +700,11 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             let promptOffset = self.cache.map(\.offset).max() ?? promptTokenIds.count
             let bufferLength = promptOffset + (self.maxTokens ?? 4096) + self.depth + 8
             self.cache = self.cache.map { layer in
-                if !(layer is CompilableKVCache), layer is KVCacheSimple {
+                // Never promote QSAKVCache: the qwen4_exp indexer needs the
+                // concrete type for its raw-key lane (osaurus#2525).
+                if !(layer is CompilableKVCache), layer is KVCacheSimple,
+                    !(layer is QSAKVCache)
+                {
                     return CompilableKVCache(from: layer, maxLength: bufferLength)
                 }
                 return layer

--- a/Tests/MLXLMTests/QSAKVCachePersistenceTests.swift
+++ b/Tests/MLXLMTests/QSAKVCachePersistenceTests.swift
@@ -1,0 +1,138 @@
+// Copyright © 2026 Apple Inc.
+
+// Regression tests for osaurus#2525: the qwen4_exp QSA indexer-keys lane
+// must survive the disk round-trip, and any restore that would leave the
+// lane out of sync with `offset` must fail CLOSED (fresh prefill), never
+// seat a divergent cache. The shipped crash was a restore that kept the
+// main K/V (offset ~2700) while the lane restarted at the post-restore
+// suffix (2052 rows) — the sparse selector then emitted a [1,1,T,2052]
+// mask against a ~4770-long KV and SDPA fataled on the broadcast.
+
+import Foundation
+import MLX
+import Testing
+
+@testable import MLXLMCommon
+
+private func makeQSACache(
+    tokens: Int, kvHeads: Int = 2, headDim: Int = 8, indexerDim: Int = 4
+) -> QSAKVCache {
+    let cache = QSAKVCache()
+    let keys = MLXArray.ones([1, kvHeads, tokens, headDim]).asType(.bfloat16)
+    let values = MLXArray.ones([1, kvHeads, tokens, headDim]).asType(.bfloat16)
+    // The layer calls updateIndexerKeys BEFORE update() advances offset,
+    // matching Qwen4ExpQSAIndexer's forward order.
+    _ = cache.updateIndexerKeys(MLXArray.ones([1, tokens, indexerDim]).asType(.bfloat16))
+    _ = cache.update(keys: keys, values: values)
+    return cache
+}
+
+/// The full round-trip: serialize → deserialize (kind `.qsaKV`) → restore
+/// into a fresh QSAKVCache → the lane covers exactly `offset`, and a
+/// follow-up segment keeps `total == offset + S` — the invariant whose
+/// violation was the shipped broadcast crash. Uses a restored offset just
+/// UNDER the 2048 indexer budget and a suffix that crosses it: the hard
+/// shape, because the sparse mask only materializes past the budget.
+@Test func qsaRoundTripPreservesIndexerLaneAcrossBudgetCrossing() {
+    MLXMetalTestLock.withLock {
+        let restoredTokens = 2040
+        let cache = makeQSACache(tokens: restoredTokens)
+        let dict = TQDiskSerializer.serialize(cache: [cache])
+
+        let layers = TQDiskSerializer.deserializeIndexed(dict)
+        #expect(layers.count == 1)
+        guard case .qsaKV(let comp) = layers[0].data else {
+            Issue.record("expected .qsaKV, got \(layers[0].data)")
+            return
+        }
+        #expect(comp.indexerKeys.dim(1) == restoredTokens)
+
+        var fresh: [any KVCache] = [QSAKVCache()]
+        let restored = restoreFromDiskArrays(dict, into: &fresh)
+        #expect(restored == restoredTokens)
+        guard let qsa = fresh[0] as? QSAKVCache else {
+            Issue.record("restore replaced the QSAKVCache type")
+            return
+        }
+        #expect(qsa.offset == restoredTokens)
+        #expect(qsa.indexerKeys?.dim(1) == restoredTokens)
+
+        // Continuation segment crossing the 2048 budget: the lane total MUST
+        // track offset + S or the selector mask and the KV length diverge.
+        let suffix = 16
+        let all = qsa.updateIndexerKeys(
+            MLXArray.ones([1, suffix, 4]).asType(.bfloat16))
+        #expect(all.dim(1) == restoredTokens + suffix)
+        #expect(all.dim(1) > 2048)
+    }
+}
+
+/// A pre-fix disk entry (plain `.kv`, no indexer lane) restored into a QSA
+/// layer must be a WHOLE-RECORD miss: zero restored tokens and an untouched
+/// cache, so the caller re-prefills instead of decoding against a cache
+/// whose lane restarts at zero.
+@Test func legacyTwoArrayRecordForQSALayerFailsClosed() {
+    MLXMetalTestLock.withLock {
+        // Build the legacy record by serializing a plain KVCacheSimple.
+        let simple = KVCacheSimple()
+        _ = simple.update(
+            keys: MLXArray.ones([1, 2, 64, 8]).asType(.bfloat16),
+            values: MLXArray.ones([1, 2, 64, 8]).asType(.bfloat16))
+        let legacyDict = TQDiskSerializer.serialize(cache: [simple])
+
+        var qsaCache: [any KVCache] = [QSAKVCache()]
+        let restored = restoreFromDiskArrays(legacyDict, into: &qsaCache)
+        #expect(restored == 0)
+        #expect((qsaCache[0] as? QSAKVCache)?.offset == 0)
+        #expect((qsaCache[0] as? QSAKVCache)?.indexerKeys == nil)
+    }
+}
+
+/// A QSA cache that somehow lost its lane (2-array state) must serialize
+/// as `.skip` — a lossy `.kv` record would recreate the divergence on the
+/// NEXT process's restore.
+@Test func qsaWithoutIndexerLaneSerializesAsSkip() {
+    MLXMetalTestLock.withLock {
+        let cache = QSAKVCache()
+        cache.state = [
+            MLXArray.ones([1, 2, 32, 8]).asType(.bfloat16),
+            MLXArray.ones([1, 2, 32, 8]).asType(.bfloat16),
+        ]
+        #expect(cache.indexerKeys == nil)
+        let dict = TQDiskSerializer.serialize(cache: [cache])
+        let layers = TQDiskSerializer.deserializeIndexed(dict)
+        #expect(layers.count == 1)
+        guard case .skip = layers[0].data else {
+            Issue.record("expected .skip for a lane-less QSA cache, got \(layers[0].data)")
+            return
+        }
+    }
+}
+
+/// A stored QSA record whose lane length disagrees with the KV offset is
+/// damage — restore must refuse it rather than seat a divergent state.
+@Test func qsaRecordWithShortLaneFailsClosed() {
+    MLXMetalTestLock.withLock {
+        let cache = makeQSACache(tokens: 64)
+        var dict = TQDiskSerializer.serialize(cache: [cache])
+        dict["kv_0_indexer_keys"] = MLXArray.ones([1, 40, 4]).asType(.bfloat16)
+
+        var fresh: [any KVCache] = [QSAKVCache()]
+        let restored = restoreFromDiskArrays(dict, into: &fresh)
+        #expect(restored == 0)
+        #expect((fresh[0] as? QSAKVCache)?.offset == 0)
+    }
+}
+
+/// KV-cache quantization must leave QSA layers untouched: TurboQuant's
+/// `fromSimpleCache` refuses 3-array state and would return an EMPTY
+/// cache, and the affine path would replace the type the indexer needs.
+@Test func kvQuantizationSkipsQSALayers() {
+    MLXMetalTestLock.withLock {
+        let qsa = makeQSACache(tokens: 6000)
+        var cache: [KVCache] = [qsa]
+        maybeQuantizeKVCache(cache: &cache, kvBits: 4, quantizedKVStart: 128)
+        #expect((cache[0] as? QSAKVCache) === qsa)
+        #expect((cache[0] as? QSAKVCache)?.indexerKeys != nil)
+    }
+}


### PR DESCRIPTION
Fixes the qwen4_exp `broadcast_shapes` fatal tracked in osaurus-ai/osaurus#2525 — a hard crash on the FIRST model step after a tool result on every Flash-Next bundle, MTP on or off.

## Root cause

`QSAKVCache` carries a third state array (the raw indexer keys the sparse block selector re-pools every forward) that must stay row-for-row in sync with `offset`:

1. `TQDiskSerializer` stored any `KVCacheSimple` as a 2-array `.kv` record — `state[2]` (the lane) was silently dropped on disk-L2 store.
2. Every restore path seated 2-array state back; `QSAKVCache.state`'s setter then set `offset = keys.dim(2)` (large) and **`indexerKeys = nil`**.
3. The next segment re-seeded the lane at the suffix length, so the selector emitted a `[1,1,T,laneLen]` mask against a full-length KV → `[broadcast_shapes] (1,1,T,2052) vs (…,4770)`. The `2052` was simply that rung's post-restore suffix; the mask only materializes once the lane exceeds the 2048 indexer budget, which is why plain first-turn chats never crashed.

qwen4_exp is forced onto the disk-L2 restore path (its GDN layers make the cache disk-backed), so the agent loop's second step — fresh `newCache` → restore → suffix prefill — hits this deterministically.

## Fix (no change to QSA math; nothing cropped, padded, or disabled)

- New `LayerKind.qsaKV` disk record: keys + values + indexer lane as one atomic unit. QSA layers serialize as this, or `.skip` when the lane is absent.
- Restore seats the full 3-array state; refuses records whose lane length disagrees with the KV offset; refuses legacy 2-array records aimed at a QSA layer — a whole-record miss (one re-prefill), never a divergent seat. `restoreKVLayer` gains a loud backstop.
- Three cache-replacing paths with the same 2-array assumption now skip `QSAKVCache`: compiled-decode promotion to `CompilableKVCache` (solo iterator + MTP compiled-verify, which would erase the type the indexer `as?`-casts for) and KV quantization (TurboQuant `fromSimpleCache` returns an EMPTY cache for 3-array state; affine/legacy replace the type).

## Evidence

**Unit** — 5 regression tests (`QSAKVCachePersistenceTests`): round-trip at the hard shape (restored offset 2040 + suffix crossing the 2048 budget), legacy-record fail-closed, short-lane fail-closed, lane-less serialize-as-skip, quantization no-op on QSA. All pass; they cannot compile pre-fix (no `.qsaKV` case) — they pin the new contract.

**Live before** (vmlx `b52ddf18`, frozen logs): `JANGQ-AI/Qwen3.8-Flash-Next-JANG_2L` crashed 3/3 at model step 2 (`(1,1,2,4779)×(1,1,2,2052)` MTP-on at ops.cpp:1866; `(1,1,1,2052)×(1,24,1,4772)` MTP-off at fast.cpp:629); `JANG_4M` crashed identically (`(1,1,1,2052)×(1,24,1,4770)`) with MTP not even launched — quant-independent.

**Live after** (this branch `dc251262`, osaurus eval binary rebuilt against it, MTP controlled per-row with the fail-closed `--mtp` controls from osaurus#2531 and verified via the resolution telemetry): 10/10 rows pass with **zero** `broadcast_shapes`:

| row | MTP resolution (verified) | outcome |
|---|---|---|
| 2L 2K, `--mtp off` | strategy=none, 0 `[NativeMTP]` | passed |
| 2L 2K, auto / d1 / d2 / d3 | native_mtp:d1/d1/d2/d3 active | passed ×4 |
| 2L 22K, auto | native_mtp:d1, 10 MTP stats lines | passed |
| 2L 2K rerun (cross-process disk restore) | native_mtp:d1 | passed |
| 4M 2K, auto | strategy=none (stamp not auto-launchable — stated by the resolution telemetry, not hidden) | passed |
| 4M 2K, off | strategy=none | passed |
| 27B (`qwen3_5_text`, no QSA — negative-control architecture) 2K, auto | native_mtp:d2 | passed |

Report hashes: `d2a6004867580b0e` (2L auto), `50229e93c405bea1` (2L off), `f88e04c3931a6127`/`da4a365065bd13b2`/`a39e593df1151c82` (d1/d2/d3), `24943658f98d73f7` (22K), `57144d263599af1e` (rerun), `468576147771cbbe`/`0e15c320e99e517b` (4M), `e921e7181c84f181` (27B). Artifacts out-of-repo.

An osaurus repin PR (every resolved pin site) plus the Release-app GUI leg (multi-step tool workflow reaching step 2 and continuing ≥10 turns, Stop/continue, restart/disk-restore) follows before any merge claim.