### PR TITLE
Emit .info before cache persistence: end the visible turn at the last token

### DIFF
--- a/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
@@ -862,10 +862,57 @@ private func restoreFromV2Arrays(
                     "[disk cache] restore SKIPPED: layer \(i) has incompatible shape (k=\(keys.shape) v=\(values.shape)). Need >= 3D. Falling back to fresh prefill.\n".utf8))
                 return 0
             }
+            // A plain 2-array KV record seated into a QSAKVCache leaves
+            // `offset` large with an EMPTY indexer lane; the sparse
+            // selector then sizes its mask from the post-restore suffix and
+            // SDPA fatals on the shape mismatch (osaurus#2525). Any such
+            // record predates the `.qsaKV` kind — refuse the whole entry
+            // (one re-prefill) instead of diverging.
+            guard !(cache[i] is QSAKVCache) else {
+                FileHandle.standardError.write(Data(
+                    "[disk cache] restore SKIPPED: layer \(i) is a QSA layer but the stored record has no indexer lane (pre-qsaKV entry). Falling back to fresh prefill.\n".utf8))
+                return 0
+            }
             if totalTokens == 0 {
                 totalTokens = keys.dim(2)
             }
             restoreKVLayer(keys: keys, values: values, into: cache[i])
+
+        case .qsaKV(let comp):
+            var keys = comp.keys
+            var values = comp.values
+            var indexer = comp.indexerKeys
+            if keys.dtype == .float16 {
+                keys = keys.asType(.bfloat16)
+                values = values.asType(.bfloat16)
+            }
+            if indexer.dtype == .float16 {
+                indexer = indexer.asType(.bfloat16)
+            }
+            guard keys.shape.count >= 3, values.shape.count >= 3,
+                indexer.shape.count >= 3
+            else {
+                FileHandle.standardError.write(Data(
+                    "[disk cache] restore SKIPPED: QSA layer \(i) has incompatible shape (k=\(keys.shape) v=\(values.shape) idx=\(indexer.shape)). Falling back to fresh prefill.\n".utf8))
+                return 0
+            }
+            guard let qsa = cache[i] as? QSAKVCache else {
+                FileHandle.standardError.write(Data(
+                    "[disk cache] restore SKIPPED: stored QSA record for layer \(i) but the live cache is \(type(of: cache[i])). Falling back to fresh prefill.\n".utf8))
+                return 0
+            }
+            // The indexer lane must cover exactly the restored offset —
+            // `state`'s setter derives offset from keys, and a shorter lane
+            // would recreate the divergence this record exists to prevent.
+            guard indexer.dim(1) == keys.dim(2) else {
+                FileHandle.standardError.write(Data(
+                    "[disk cache] restore SKIPPED: QSA layer \(i) indexer lane length \(indexer.dim(1)) != KV offset \(keys.dim(2)). Falling back to fresh prefill.\n".utf8))
+                return 0
+            }
+            qsa.state = [keys, values, indexer]
+            if totalTokens == 0 {
+                totalTokens = keys.dim(2)
+            }
 
         case .mamba(let comp):
             // Mamba state arrays are cumulative — no sequence dim to
@@ -1004,10 +1051,11 @@ private func restoreFromV2Arrays(
                     }
 
                 case .tq, .qkv, .deepseekV4, .zayaCCA, .zayaCCATQ, .cacheList,
-                     .requiredMiss, .skip:
+                     .qsaKV, .requiredMiss, .skip:
                     // .skip is a per-sub no-op (sub-cache had no
-                    // persistable state). The other cases are not
-                    // currently emitted as sub-cache kinds — see
+                    // persistable state). The other cases (incl. .qsaKV —
+                    // no model nests a QSAKVCache inside a CacheList) are
+                    // not currently emitted as sub-cache kinds — see
                     // TQDiskSerializer.deserializeCacheListLayer.
                     continue
                 }
@@ -1132,6 +1180,17 @@ private func restoreKVLayer(
     values restoredValues: MLXArray,
     into layer: any KVCache
 ) {
+    if layer is QSAKVCache {
+        // A 2-array seat into a QSA cache erases the indexer lane and
+        // diverges the sparse selector (osaurus#2525). The v2 `.standard`
+        // restore refuses the whole record before reaching here; legacy v1
+        // entries predate qwen4_exp and CacheList never wraps QSA, so this
+        // is a defense-in-depth backstop for future call sites. Loud no-op:
+        // the layer stays empty rather than becoming inconsistent.
+        FileHandle.standardError.write(Data(
+            "[disk cache] restoreKVLayer REFUSED: 2-array record for a QSAKVCache (would drop the indexer lane).\n".utf8))
+        return
+    }
     if let simple = layer as? KVCacheSimple {
         simple.state = [restoredKeys, restoredValues]
     } else if let quantizedCache = layer as? QuantizedKVCache {

--- a/Libraries/MLXLMCommon/Cache/TQDiskSerializer.swift
+++ b/Libraries/MLXLMCommon/Cache/TQDiskSerializer.swift
@@ -129,6 +129,16 @@ public enum TQDiskSerializer {
         /// state are one atomic prompt-boundary record; restoring either half
         /// alone would be a false cache hit.
         case zayaCCATQ = 10
+        /// `QSAKVCache` (qwen4_exp QSA full-attention layers) — the standard
+        /// KV pair PLUS the raw indexer-keys lane (`state[2]`,
+        /// `[B, T, indexerHeadDim]`). The sparse block selector sizes its
+        /// attention mask from this lane, so restoring KV without it leaves
+        /// `offset` large while the lane restarts at the post-restore suffix
+        /// — the broadcast_shapes crash of osaurus#2525. The three arrays
+        /// are one atomic record; a QSA layer written as plain `.kv` (any
+        /// pre-fix entry) must be refused on restore, never seated.
+        /// Added 2026-08-28.
+        case qsaKV = 11
         /// Cache type we don't know how to persist. On restore, treated as
         /// a forced miss for the affected layer only.
         case skip = 4
@@ -284,6 +294,23 @@ public enum TQDiskSerializer {
                 serializeQKVLayer(qkv, index: i, into: &result)
                 // serializeQKVLayer sets the kind tag itself so it can mark
                 // empty caches as `.skip` instead of `.qkv`.
+            } else if let qsa = layer as? QSAKVCache {
+                // MUST precede the generic KVCacheSimple branch: QSAKVCache
+                // IS a KVCacheSimple, and writing it as a 2-array `.kv`
+                // record silently drops the indexer lane (osaurus#2525).
+                let state = qsa.state
+                if state.count >= 3 {
+                    result["kv_\(i)_keys"] = state[0]
+                    result["kv_\(i)_values"] = state[1]
+                    result["kv_\(i)_indexer_keys"] = state[2]
+                    result[kindKey(for: i)] = kindArray(.qsaKV)
+                } else {
+                    // A QSA layer whose indexer lane is missing cannot be
+                    // restored faithfully — the selector would mis-size its
+                    // mask. Record skip (forced miss) instead of a lossy
+                    // `.kv` record. Also covers the empty pre-prefill case.
+                    result[kindKey(for: i)] = kindArray(.skip)
+                }
             } else if layer is KVCacheSimple || layer is TurboQuantKVCache {
                 // KVCacheSimple always, plus TurboQuantKVCache in fill phase.
                 // A compressed TQ layer restored from paged decoded KV also
@@ -848,6 +875,15 @@ public enum TQDiskSerializer {
         public let values: MLXArray
     }
 
+    /// Standard KV pair plus the raw QSA indexer-keys lane for one
+    /// qwen4_exp full-attention layer. The three arrays are one atomic
+    /// record — see `LayerKind.qsaKV`.
+    public struct QSAKVLayerComponents {
+        public let keys: MLXArray
+        public let values: MLXArray
+        public let indexerKeys: MLXArray
+    }
+
     /// Mamba SSM state for a single hybrid layer. `state1` is nil for
     /// single-slot layouts: LFM2/LFM2.5 short-conv layers only ever occupy
     /// slot 0 of their 2-slot `MambaCache` container
@@ -942,6 +978,7 @@ public enum TQDiskSerializer {
     public indirect enum LayerData {
         case tq(TQLayerComponents)
         case standard(KVLayerComponents)
+        case qsaKV(QSAKVLayerComponents)
         case mamba(MambaLayerComponents)
         case qkv(QKVLayerComponents)
         case rotating(RotatingLayerComponents)
@@ -1065,6 +1102,24 @@ public enum TQDiskSerializer {
                     // A typed TQ layer is required state. Treat an incomplete
                     // payload as an atomic miss so a rotating companion cannot
                     // turn it into a false mixed-topology hit.
+                    out.append(IndexedLayerData(index: i, data: .requiredMiss))
+                }
+            case .qsaKV:
+                if let keys = arrays["kv_\(i)_keys"],
+                   let values = arrays["kv_\(i)_values"],
+                   let indexer = arrays["kv_\(i)_indexer_keys"]
+                {
+                    out.append(
+                        IndexedLayerData(
+                            index: i,
+                            data: .qsaKV(
+                                QSAKVLayerComponents(
+                                    keys: keys, values: values, indexerKeys: indexer))
+                        )
+                    )
+                } else {
+                    // The kind tag promised a 3-array QSA record; anything
+                    // less is damage — refuse the whole entry, same as .kv.
                     out.append(IndexedLayerData(index: i, data: .requiredMiss))
                 }
             case .kv:
@@ -1503,12 +1558,12 @@ public enum TQDiskSerializer {
                 }
             case .skip, .unknown:
                 subs.append(.skip)
-            case .tq, .qkv, .deepseekV4, .cacheList, .zayaCCA, .zayaCCATQ:
+            case .tq, .qkv, .deepseekV4, .cacheList, .zayaCCA, .zayaCCATQ, .qsaKV:
                 // Not currently emitted as sub-cache types — see
-                // serializeCacheListLayer. If a future bundle ships
-                // these we'll need to extend serialize too. Skip for
-                // now so old readers don't crash on a tag they can't
-                // round-trip.
+                // serializeCacheListLayer (no model nests a QSAKVCache
+                // inside a CacheList). If a future bundle ships these
+                // we'll need to extend serialize too. Skip for now so
+                // old readers don't crash on a tag they can't round-trip.
                 subs.append(.skip)
             }
         }

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -2562,7 +2562,11 @@ public struct TokenIterator: TokenIteratorProtocol {
             //                      The compilable form also preserves Qwen3.8
             //                      PLE companion slots 2...5.
             let allPromotable = cache.allSatisfy { layer in
-                layer is KVCacheSimple
+                // QSAKVCache IS a KVCacheSimple, but promotion to
+                // CompilableKVCache erases the type — the qwen4_exp
+                // indexer's `as? QSAKVCache` then fails and the sparse
+                // selector runs cacheless (osaurus#2525 secondary hazard).
+                (layer is KVCacheSimple && !(layer is QSAKVCache))
                     || (layer is RotatingKVCache && !(layer is CompilableRotatingKVCache))
                     || (layer is MambaCache && !(layer is CompilableMambaCache))
             }

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1233,6 +1233,15 @@ public protocol TokenIteratorProtocol: Sequence, IteratorProtocol where Element 
     var turboQuantCompressionCount: Int { get }
     var lastTurboQuantCacheTransition: TurboQuantCacheTransitionSnapshot? { get }
     var nativeMTPStats: NativeMTPGenerationStats? { get }
+    /// CPU-only end-of-generation bookkeeping needed to BUILD the completion
+    /// info (e.g. the native-MTP stats snapshot). Split from
+    /// `storeCacheAfterGeneration` so the generate loop can emit `.info` —
+    /// the user-visible "generation finished" signal — BEFORE the expensive
+    /// GPU drain + cache persistence, instead of holding the spinner hostage
+    /// to a multi-second KV serialization. Must not touch Metal encoders and
+    /// must be idempotent (`storeCacheAfterGeneration` may call it again as
+    /// a backstop for callers that skip the loop's ordering).
+    mutating func finalizeGenerationStats(generatedTokenIds: [Int])
     mutating func storeCacheAfterGeneration(
         generatedTokenIds: [Int],
         includeGeneratedBoundary: Bool)
@@ -1243,6 +1252,8 @@ extension TokenIteratorProtocol {
     public var turboQuantCompressionCount: Int { 0 }
     public var lastTurboQuantCacheTransition: TurboQuantCacheTransitionSnapshot? { nil }
     public var nativeMTPStats: NativeMTPGenerationStats? { nil }
+
+    public mutating func finalizeGenerationStats(generatedTokenIds: [Int]) {}
 
     public mutating func storeCacheAfterGeneration(
         generatedTokenIds: [Int],
@@ -4539,37 +4550,23 @@ private func generateLoopTask<Handler: TokenLoopHandler>(
             MLXPressGenerationProfile.dumpAndReset(
                 reason: "generation-end tokens=\(tokenCount)")
 
-            // Multi-tier cache: drain the final async token eval before cache
-            // snapshot/store, then keep completion info behind the cache-store
-            // drain. Local chat/tool consumers may start a post-tool decode as
-            // soon as `.info` closes the stream, so `.info` must not be visible
-            // while this generation task can still touch MLX command encoders.
-            // The three phases below run on the request path, so the stream
-            // does not finish until they do. Timed to split "GPU drain" from
-            // "disk store" for the post-output hang: the fix differs by an
-            // order of magnitude depending on which phase owns the wall time.
-            let genTailTrace =
-                ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1"
-            let tailT0 = Date()
-            Stream().synchronize()
-            let tailT1 = Date()
-            iterator.storeCacheAfterGeneration(
-                generatedTokenIds: generatedTokenIds,
-                includeGeneratedBoundary: stopReason == .stop
-                    && !handler.stopSequenceHit
-                    && !handler.emittedToolCall)
-            let tailT2 = Date()
-
-            // Build completion info only after `storeCacheAfterGeneration`
-            // returns: the native-MTP iterator snapshots `nativeMTPStats`
-            // there, from the same source values its `[NativeMTP]` stderr
-            // summary line prints for the corresponding keys (`outputTokens`
-            // depends on `generatedTokenIds`, which the iterator only sees
-            // in that call). `.info` is yielded
-            // further below, after the cache-store drain, exactly as before —
-            // only the construction moved — and no iterator mutates
-            // `turboQuantCompressionCount` or `promptPrefillTime` during the
-            // cache store, so every existing field is unchanged.
+            // Completion contract (rewritten for the end-of-output hang):
+            // `.info` is the USER-VISIBLE end of generation and is emitted
+            // as soon as the last token has flushed and the CPU-only stats
+            // are finalized — BEFORE the GPU drain, cache snapshot/store,
+            // and advisor drain that used to hold it back for seconds on
+            // large models. Safety is preserved by the STREAM END, not by
+            // `.info` ordering: `continuation.finish()` still runs only
+            // after both Metal drains, the cache persistence, and the
+            // advisor drain, so any consumer that serializes on stream
+            // termination (the osaurus adapter holds its model lease and
+            // Metal gate until the producer completes) cannot start a new
+            // decode while this task can still touch MLX command encoders.
+            // Consumers acting on `.info` alone get exactly the intended
+            // early spinner-off; they cannot reach the model without the
+            // lease. No per-family special case: this is the shared
+            // terminal path for every local model.
+            iterator.finalizeGenerationStats(generatedTokenIds: generatedTokenIds)
             let info = GenerateCompletionInfo(
                 promptTokenCount: promptTokenCount,
                 generationTokenCount: tokenCount,
@@ -4582,25 +4579,44 @@ private func generateLoopTask<Handler: TokenLoopHandler>(
                 nativeMTPStats: iterator.nativeMTPStats,
                 toolCallProtocolFailure: handler.toolCallProtocolFailure
             )
+            _ = continuation.yield(handler.infoEvent(info))
 
+            // Post-completion cleanup, still on the request path so the
+            // stream does not FINISH until it is done. Timed to split
+            // "GPU drain" from "disk store" from "advisor" for the
+            // post-output tail: the fix differs by an order of magnitude
+            // depending on which phase owns the wall time.
+            let genTailTrace =
+                ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1"
+            let tailT0 = Date()
             Stream().synchronize()
-            if genTailTrace {
-                let tailT3 = Date()
-                print(
-                    "[vmlx][gen/tail] drain1=\(tailT1.timeIntervalSince(tailT0))s"
-                        + " store=\(tailT2.timeIntervalSince(tailT1))s"
-                        + " drain2=\(tailT3.timeIntervalSince(tailT2))s")
-            }
+            let tailT1 = Date()
+            iterator.storeCacheAfterGeneration(
+                generatedTokenIds: generatedTokenIds,
+                includeGeneratedBoundary: stopReason == .stop
+                    && !handler.stopSequenceHit
+                    && !handler.emittedToolCall)
+            let tailT2 = Date()
+            Stream().synchronize()
+            let tailT3 = Date()
 
             // Router-advice readback runs on its own Dispatch queue. Drain it
             // after MLX synchronization so short-lived CLI runs and app unload
             // paths do not tear down runtime state while the advisor is still
             // applying mmap page advice.
             MLXPressCanonicalExpertAdvisor.shared.waitUntilIdle()
+            if genTailTrace {
+                let tailT4 = Date()
+                print(
+                    "[vmlx][gen/tail] infoEmitted=early"
+                        + " drain1=\(tailT1.timeIntervalSince(tailT0))s"
+                        + " store=\(tailT2.timeIntervalSince(tailT1))s"
+                        + " drain2=\(tailT3.timeIntervalSince(tailT2))s"
+                        + " advisor=\(tailT4.timeIntervalSince(tailT3))s")
+            }
 
-            _ = continuation.yield(handler.infoEvent(info))
-
-            // Finalize the stream
+            // Finalize the stream — the serialization point for the next
+            // generation.
             continuation.finish()
         }
 

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -2140,6 +2140,15 @@ public func maybeQuantizeKVCache(
         guard hasEligibleLayer else { return }
 
         for i in 0..<cache.count {
+            if cache[i] is QSAKVCache {
+                // TurboQuant promotion would replace the QSAKVCache with a
+                // cache that has no indexer lane (and `fromSimpleCache`
+                // refuses 3-array state, yielding an EMPTY cache) — the
+                // qwen4_exp sparse selector then diverges (osaurus#2525).
+                FileHandle.standardError.write(Data(
+                    "[kv quant] skipping QSA layer \(i): TurboQuant promotion would drop the indexer lane.\n".utf8))
+                continue
+            }
             if let simpleCache = cache[i] as? KVCacheSimple {
                 guard simpleCache.offset > tqMinStart,
                       TurboQuantKVCache.hasCompressibleMiddle(tokenCount: simpleCache.offset)
@@ -2169,6 +2178,7 @@ public func maybeQuantizeKVCache(
         else { return }
 
         for i in 0..<cache.count {
+            if cache[i] is QSAKVCache { continue }  // osaurus#2525: keep the indexer lane
             if let simpleCache = cache[i] as? KVCacheSimple {
                 cache[i] = simpleCache.toQuantized(groupSize: groupSize, bits: bits)
             }
@@ -2189,6 +2199,7 @@ public func maybeQuantizeKVCache(
     }
 
     for i in 0..<cache.count {
+        if cache[i] is QSAKVCache { continue }  // osaurus#2525: keep the indexer lane
         if let simpleCache = cache[i] as? KVCacheSimple {
             cache[i] = simpleCache.toQuantized(groupSize: kvGroupSize, bits: kvBits)
         }

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -700,7 +700,11 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             let promptOffset = self.cache.map(\.offset).max() ?? promptTokenIds.count
             let bufferLength = promptOffset + (self.maxTokens ?? 4096) + self.depth + 8
             self.cache = self.cache.map { layer in
-                if !(layer is CompilableKVCache), layer is KVCacheSimple {
+                // Never promote QSAKVCache: the qwen4_exp indexer needs the
+                // concrete type for its raw-key lane (osaurus#2525).
+                if !(layer is CompilableKVCache), layer is KVCacheSimple,
+                    !(layer is QSAKVCache)
+                {
                     return CompilableKVCache(from: layer, maxLength: bufferLength)
                 }
                 return layer

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -348,6 +348,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private var adaptiveWindow: [AdaptiveCycle] = []
     private var adaptiveFallbackReason: String?
     private(set) var nativeMTPStats: NativeMTPGenerationStats?
+    private var generationStatsFinalized = false
     private let iteratorStartTime = Date.timeIntervalSinceReferenceDate
 
     private var usesHybridMambaCache: Bool {
@@ -938,6 +939,18 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             }
         }
 
+        finalizeGenerationStats(generatedTokenIds: generatedTokenIds)
+    }
+
+    /// CPU-only stats snapshot + stderr summary, split out of
+    /// `storeCacheAfterGeneration` so the generate loop can emit `.info`
+    /// (and the host can stop its spinner) BEFORE the GPU drain and cache
+    /// persistence. Touches only accumulated counters — no Metal work.
+    /// Idempotent: `storeCacheAfterGeneration` calls it as a backstop for
+    /// callers that never ran the loop's early-finalize step.
+    mutating func finalizeGenerationStats(generatedTokenIds: [Int]) {
+        guard !generationStatsFinalized else { return }
+        generationStatsFinalized = true
         let accepted = acceptedByDepth
             .sorted { $0.key < $1.key }
             .map { "\($0.key):\($0.value)" }

--- a/Package.swift
+++ b/Package.swift
@@ -854,6 +854,7 @@ let package = Package(
                 "DeepseekV4ToolHistoryPrefixBoundaryTests.swift",
                 "DeepseekV4DropThinkingCacheTests.swift",
                 "DeepseekV4AgentLoopBoundaryTests.swift",
+                "EarlyCompletionBeforeCachePersistTests.swift",
                 "ToolCallProgressRoutingTests.swift",
                 "FocusedMLXTestSupport.swift",
                 "CanonicalChatCacheBoundariesTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/EarlyCompletionBeforeCachePersistTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/EarlyCompletionBeforeCachePersistTests.swift
@@ -1,0 +1,176 @@
+// Copyright © 2026 Apple Inc.
+
+// Regression tests for the end-of-output hang: `generateLoopTask` (the
+// shared terminal path for EVERY local model) used to hold the `.info`
+// completion event — the user-visible "generation finished" signal —
+// behind the GPU drains, the cache snapshot/store, and the advisor
+// drain, so large models visibly stalled for seconds after the last
+// token rendered. The rewritten contract emits `.info` right after the
+// detokenizer tail flush and the CPU-only stats finalize, while the
+// STREAM END (`continuation.finish()`) still waits for cleanup — that
+// is the serialization point hosts (the osaurus adapter's model lease /
+// Metal gate) key on before starting the next decode.
+
+import Foundation
+import MLX
+import Testing
+import os
+
+@testable import MLXLMCommon
+
+/// Iterator whose cache store blocks for a configurable delay and records
+/// when the store started/ended, so the test can prove `.info` arrived
+/// while the store was still running — not merely before some later event.
+private struct ClockState: Sendable {
+    var storeStarted: Date?
+    var storeEnded: Date?
+    var statsFinalizedAt: Date?
+}
+
+private final class DelayedStoreClock: Sendable {
+    let state = OSAllocatedUnfairLock(initialState: ClockState())
+}
+
+private struct DelayedStoreIterator: TokenIteratorProtocol {
+    let maxTokens: Int? = nil
+    var tokenCount = 0
+    let promptPrefillTime: TimeInterval = 0
+    let clock: DelayedStoreClock
+    let storeDelay: TimeInterval
+    private var emitted = 0
+    private let tokens = [11, 12, 13]
+
+    init(clock: DelayedStoreClock, storeDelay: TimeInterval) {
+        self.clock = clock
+        self.storeDelay = storeDelay
+    }
+
+    mutating func next() -> Int? {
+        guard emitted < tokens.count else { return nil }
+        defer { emitted += 1 }
+        return tokens[emitted]
+    }
+
+    mutating func finalizeGenerationStats(generatedTokenIds: [Int]) {
+        clock.state.withLock { $0.statsFinalizedAt = Date() }
+    }
+
+    mutating func storeCacheAfterGeneration(
+        generatedTokenIds: [Int], includeGeneratedBoundary: Bool
+    ) {
+        clock.state.withLock { $0.storeStarted = Date() }
+        Thread.sleep(forTimeInterval: storeDelay)
+        clock.state.withLock { $0.storeEnded = Date() }
+    }
+}
+
+private struct TailTestTokenizer: Tokenizer {
+    let vocabularySize = 64
+    let eosTokenId: Int? = 60
+    let unknownTokenId: Int? = 61
+    let bosToken: String? = nil
+    let eosToken: String? = nil
+    let unknownToken: String? = nil
+
+    func encode(text: String, addSpecialTokens: Bool) -> [Int] { [3, 5, 7] }
+    func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+        tokenIds.map(String.init).joined(separator: " ")
+    }
+    func convertTokenToId(_ token: String) -> Int? { nil }
+    func convertIdToToken(_ id: Int) -> String? { String(id) }
+    func applyChatTemplate(
+        messages: [[String: any Sendable]],
+        tools: [[String: any Sendable]]?,
+        additionalContext: [String: any Sendable]?
+    ) throws -> [Int] { [3, 5, 7] }
+}
+
+/// `.info` must arrive while an artificially delayed cache store is STILL
+/// RUNNING (spinner-off precedes persistence), and the stream must not
+/// finish until the store has completed (the next generation still
+/// serializes safely on stream termination).
+@Test func infoArrivesWhileDelayedCacheStoreStillRunning() async throws {
+    let clock = DelayedStoreClock()
+    let delay: TimeInterval = 1.5
+    let tokenizer = TailTestTokenizer()
+
+    let (stream, task) = generateTaskDeferred(
+        promptTokenCount: 3,
+        modelConfiguration: ModelConfiguration(id: "tail-test/none"),
+        tokenizer: tokenizer,
+        promptTokenIds: [3, 5, 7],
+        makeIterator: { DelayedStoreIterator(clock: clock, storeDelay: delay) }
+    )
+
+    var infoAt: Date?
+    var infoCount = 0
+    for await event in stream {
+        if case .info = event {
+            infoAt = Date()
+            infoCount += 1
+        }
+    }
+    let streamEndedAt = Date()
+    _ = await task.result
+
+    let snapshot = clock.state.withLock { $0 }
+    let storeStarted = snapshot.storeStarted
+    let storeEnded = snapshot.storeEnded
+    let statsAt = snapshot.statsFinalizedAt
+
+    #expect(infoCount == 1)
+    let info = try #require(infoAt)
+    let started = try #require(storeStarted)
+    let ended = try #require(storeEnded)
+    #expect(statsAt != nil, "CPU-only stats finalize must run")
+    // The user-visible completion precedes even the START of persistence.
+    #expect(info <= started, "info \(info) must precede store start \(started)")
+    // And by construction precedes its end by ~the injected delay.
+    #expect(ended.timeIntervalSince(info) >= delay * 0.9)
+    // The stream itself (the host's serialization point) does NOT end
+    // until the store has fully completed.
+    #expect(streamEndedAt >= ended)
+}
+
+/// The idempotency backstop: an iterator whose stats finalize runs twice
+/// (once from the loop, once from a legacy direct `storeCacheAfterGeneration`
+/// call) must not double-finalize. Uses the native-MTP iterator's contract
+/// indirectly via the default no-op — here we just pin that the loop calls
+/// finalize exactly once per generation.
+@Test func loopFinalizesStatsExactlyOnce() async throws {
+    let counter = FinalizeCounter()
+    let (stream, task) = generateTaskDeferred(
+        promptTokenCount: 3,
+        modelConfiguration: ModelConfiguration(id: "tail-test/none"),
+        tokenizer: TailTestTokenizer(),
+        promptTokenIds: [3, 5, 7],
+        makeIterator: { CountingIterator(counter: counter) }
+    )
+    for await _ in stream {}
+    _ = await task.result
+    #expect(counter.count.withLock { $0 } == 1)
+}
+
+private final class FinalizeCounter: Sendable {
+    let count = OSAllocatedUnfairLock(initialState: 0)
+}
+
+private struct CountingIterator: TokenIteratorProtocol {
+    let maxTokens: Int? = nil
+    var tokenCount = 0
+    let promptPrefillTime: TimeInterval = 0
+    let counter: FinalizeCounter
+    private var emitted = 0
+
+    init(counter: FinalizeCounter) { self.counter = counter }
+
+    mutating func next() -> Int? {
+        guard emitted < 1 else { return nil }
+        emitted += 1
+        return 9
+    }
+
+    mutating func finalizeGenerationStats(generatedTokenIds: [Int]) {
+        counter.count.withLock { $0 += 1 }
+    }
+}

--- a/Tests/MLXLMTests/QSAKVCachePersistenceTests.swift
+++ b/Tests/MLXLMTests/QSAKVCachePersistenceTests.swift
@@ -1,0 +1,138 @@
+// Copyright © 2026 Apple Inc.
+
+// Regression tests for osaurus#2525: the qwen4_exp QSA indexer-keys lane
+// must survive the disk round-trip, and any restore that would leave the
+// lane out of sync with `offset` must fail CLOSED (fresh prefill), never
+// seat a divergent cache. The shipped crash was a restore that kept the
+// main K/V (offset ~2700) while the lane restarted at the post-restore
+// suffix (2052 rows) — the sparse selector then emitted a [1,1,T,2052]
+// mask against a ~4770-long KV and SDPA fataled on the broadcast.
+
+import Foundation
+import MLX
+import Testing
+
+@testable import MLXLMCommon
+
+private func makeQSACache(
+    tokens: Int, kvHeads: Int = 2, headDim: Int = 8, indexerDim: Int = 4
+) -> QSAKVCache {
+    let cache = QSAKVCache()
+    let keys = MLXArray.ones([1, kvHeads, tokens, headDim]).asType(.bfloat16)
+    let values = MLXArray.ones([1, kvHeads, tokens, headDim]).asType(.bfloat16)
+    // The layer calls updateIndexerKeys BEFORE update() advances offset,
+    // matching Qwen4ExpQSAIndexer's forward order.
+    _ = cache.updateIndexerKeys(MLXArray.ones([1, tokens, indexerDim]).asType(.bfloat16))
+    _ = cache.update(keys: keys, values: values)
+    return cache
+}
+
+/// The full round-trip: serialize → deserialize (kind `.qsaKV`) → restore
+/// into a fresh QSAKVCache → the lane covers exactly `offset`, and a
+/// follow-up segment keeps `total == offset + S` — the invariant whose
+/// violation was the shipped broadcast crash. Uses a restored offset just
+/// UNDER the 2048 indexer budget and a suffix that crosses it: the hard
+/// shape, because the sparse mask only materializes past the budget.
+@Test func qsaRoundTripPreservesIndexerLaneAcrossBudgetCrossing() {
+    MLXMetalTestLock.withLock {
+        let restoredTokens = 2040
+        let cache = makeQSACache(tokens: restoredTokens)
+        let dict = TQDiskSerializer.serialize(cache: [cache])
+
+        let layers = TQDiskSerializer.deserializeIndexed(dict)
+        #expect(layers.count == 1)
+        guard case .qsaKV(let comp) = layers[0].data else {
+            Issue.record("expected .qsaKV, got \(layers[0].data)")
+            return
+        }
+        #expect(comp.indexerKeys.dim(1) == restoredTokens)
+
+        var fresh: [any KVCache] = [QSAKVCache()]
+        let restored = restoreFromDiskArrays(dict, into: &fresh)
+        #expect(restored == restoredTokens)
+        guard let qsa = fresh[0] as? QSAKVCache else {
+            Issue.record("restore replaced the QSAKVCache type")
+            return
+        }
+        #expect(qsa.offset == restoredTokens)
+        #expect(qsa.indexerKeys?.dim(1) == restoredTokens)
+
+        // Continuation segment crossing the 2048 budget: the lane total MUST
+        // track offset + S or the selector mask and the KV length diverge.
+        let suffix = 16
+        let all = qsa.updateIndexerKeys(
+            MLXArray.ones([1, suffix, 4]).asType(.bfloat16))
+        #expect(all.dim(1) == restoredTokens + suffix)
+        #expect(all.dim(1) > 2048)
+    }
+}
+
+/// A pre-fix disk entry (plain `.kv`, no indexer lane) restored into a QSA
+/// layer must be a WHOLE-RECORD miss: zero restored tokens and an untouched
+/// cache, so the caller re-prefills instead of decoding against a cache
+/// whose lane restarts at zero.
+@Test func legacyTwoArrayRecordForQSALayerFailsClosed() {
+    MLXMetalTestLock.withLock {
+        // Build the legacy record by serializing a plain KVCacheSimple.
+        let simple = KVCacheSimple()
+        _ = simple.update(
+            keys: MLXArray.ones([1, 2, 64, 8]).asType(.bfloat16),
+            values: MLXArray.ones([1, 2, 64, 8]).asType(.bfloat16))
+        let legacyDict = TQDiskSerializer.serialize(cache: [simple])
+
+        var qsaCache: [any KVCache] = [QSAKVCache()]
+        let restored = restoreFromDiskArrays(legacyDict, into: &qsaCache)
+        #expect(restored == 0)
+        #expect((qsaCache[0] as? QSAKVCache)?.offset == 0)
+        #expect((qsaCache[0] as? QSAKVCache)?.indexerKeys == nil)
+    }
+}
+
+/// A QSA cache that somehow lost its lane (2-array state) must serialize
+/// as `.skip` — a lossy `.kv` record would recreate the divergence on the
+/// NEXT process's restore.
+@Test func qsaWithoutIndexerLaneSerializesAsSkip() {
+    MLXMetalTestLock.withLock {
+        let cache = QSAKVCache()
+        cache.state = [
+            MLXArray.ones([1, 2, 32, 8]).asType(.bfloat16),
+            MLXArray.ones([1, 2, 32, 8]).asType(.bfloat16),
+        ]
+        #expect(cache.indexerKeys == nil)
+        let dict = TQDiskSerializer.serialize(cache: [cache])
+        let layers = TQDiskSerializer.deserializeIndexed(dict)
+        #expect(layers.count == 1)
+        guard case .skip = layers[0].data else {
+            Issue.record("expected .skip for a lane-less QSA cache, got \(layers[0].data)")
+            return
+        }
+    }
+}
+
+/// A stored QSA record whose lane length disagrees with the KV offset is
+/// damage — restore must refuse it rather than seat a divergent state.
+@Test func qsaRecordWithShortLaneFailsClosed() {
+    MLXMetalTestLock.withLock {
+        let cache = makeQSACache(tokens: 64)
+        var dict = TQDiskSerializer.serialize(cache: [cache])
+        dict["kv_0_indexer_keys"] = MLXArray.ones([1, 40, 4]).asType(.bfloat16)
+
+        var fresh: [any KVCache] = [QSAKVCache()]
+        let restored = restoreFromDiskArrays(dict, into: &fresh)
+        #expect(restored == 0)
+        #expect((fresh[0] as? QSAKVCache)?.offset == 0)
+    }
+}
+
+/// KV-cache quantization must leave QSA layers untouched: TurboQuant's
+/// `fromSimpleCache` refuses 3-array state and would return an EMPTY
+/// cache, and the affine path would replace the type the indexer needs.
+@Test func kvQuantizationSkipsQSALayers() {
+    MLXMetalTestLock.withLock {
+        let qsa = makeQSACache(tokens: 6000)
+        var cache: [KVCache] = [qsa]
+        maybeQuantizeKVCache(cache: &cache, kvBits: 4, quantizedKVStart: 128)
+        #expect((cache[0] as? QSAKVCache) === qsa)
+        #expect((cache[0] as? QSAKVCache)?.indexerKeys != nil)
+    }
+}


### PR DESCRIPTION
Fixes the universal end-of-output hang: models visibly stall for seconds after the last token renders, before the turn finalizes. `generateLoopTask` — the shared terminal path for every local model (the BatchEngine solo fast path wraps it, so every real osaurus chat request takes it) — held the `.info` completion event behind Metal drain → cache snapshot/store → Metal drain → advisor drain. Large models pay multi-second KV serialization there; hybrid SSM companion writes and MTP finalization amplify but do not cause it.

**New contract (generic, no per-family special case):** `.info` (spinner-off) is emitted right after the detokenizer tail flush + a new CPU-only `finalizeGenerationStats` step (the native-MTP stats snapshot moved there, idempotent). The GPU drains, cache persistence, and advisor drain still run on the request path and `continuation.finish()` runs only after them — **the stream end remains the serialization point**, so hosts that gate the next decode on stream termination (the osaurus adapter's model lease + Metal gate) are unchanged. Caching is not disabled, moved off-path, or bypassed for any family.

**Proof:** regression test with an artificially delayed (1.5 s) cache store — `.info` arrives before the store even *starts*, and the stream refuses to finish until the store completes; a second test pins exactly-once stats finalization. 70 neighboring NativeMTP/QSA/Qwen4Exp tests green and unchanged. The env-gated `[vmlx][gen/tail]` trace now splits drain1/store/drain2/advisor for the cross-family timing matrix (dense / hybrid-SSM / MoE × MTP on/off × disk on/off × short/long × direct/tool), which runs on the repinned osaurus head.

Branch based on `dc251262` (#328, the QSA indexer-lane fix) so both merge cleanly in sequence.