### PR TITLE
Qwen3.5: preserve per-sequence positions in batch decode

### DIFF
--- a/Libraries/MLXLLM/Models/DeepseekV4.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV4.swift
@@ -1332,6 +1332,11 @@ public class DeepseekV4ModelInner: Module {
 // MARK: - Outer model
 
 public class DeepseekV4Model: Module, LLMModel, KVCacheDimensionProvider, LoRAModel {
+    /// The canonical SWA + CSA/HSA `DeepseekV4Cache` pool is path-dependent
+    /// and has no B-wide wrapper. Preserve concurrent request queuing while
+    /// decoding one DSV4 sequence at a time.
+    public var maximumSupportedDecodeBatchSize: Int? { 1 }
+
     public var kvHeads: [Int]
     var config: DeepseekV4Configuration
     public var model: DeepseekV4ModelInner

--- a/Libraries/MLXLMCommon/BatchEngine/BATCH_ENGINE.md
+++ b/Libraries/MLXLMCommon/BatchEngine/BATCH_ENGINE.md
@@ -267,6 +267,7 @@ keeps the hot path from paying a yield every token while still allowing
 | `BatchKVCache` | `BaseKVCache` | `KVCache` | All standard attention layers |
 | `BatchArraysCache` | `MambaCache` | `MambaCache` | SSM layers (Qwen3.5, Jamba, LFM2, etc.) |
 | `BatchCacheList` | `CacheList` | `CacheList` | Composite layers (FalconH1, BaichuanM1) |
+| `BatchZayaCCACache` | `BaseKVCache` | `KVCache` | Zaya CCA layers (KV plus per-sequence conv/hidden state) |
 
 ### RoPE
 
@@ -280,7 +281,25 @@ Gemma4 KV-shared layers now pass `sharedOffsetArray: MLXArray?` through the atte
 
 ## Model Compatibility
 
-**All model families supported.** No sequential fallback.
+Batch support is an architecture contract, not a global assumption. A model
+with `maximumSupportedDecodeBatchSize == nil` may use the configured engine
+width. A model that returns `1` retains concurrent request queuing but decodes
+one request at a time. This fail-safe serialization is not reported as native
+B>1 batching.
+
+| Architecture/cache topology | Decode contract | Required current proof |
+|---|---|---|
+| Dense/standard attention (Gemma control) | Native B>1 through `BatchKVCache` | Same-model AgentLoop CB=2/3; both tool loops and final responses complete |
+| Qwen3.5/Ornith GatedDelta SSM | Native B>1 through `BatchArraysCache` plus per-sequence KV positions | Unequal-prefix B=2 decode, SSM split-back, AgentLoop CB=2, multi-turn cache continuation |
+| Zaya CCA | Native B>1 through `BatchZayaCCACache` gather/scatter | Unequal-prefix B=2 decode, CCA isolation, AgentLoop CB=2, multi-turn cache continuation |
+| DSV4 SWA + CSA/HSA pool | B=1 safe serialization (`maximumSupportedDecodeBatchSize = 1`) | Two concurrent submissions queue and both finish; telemetry must report effective width 1, never claim B>1 |
+| Qwen3.8 Flash Next QSA | B=1 safe serialization (`maximumSupportedDecodeBatchSize = 1`) until QSA has a B-wide index/cache contract | AgentLoop two-request queue under MTP off/auto/manual depth; both finish and MTP telemetry belongs to the active request only |
+
+Passing unit cache tests alone does not promote an architecture. The live gate
+must use the real OsaurusEvals AgentLoop continuous-batching fixture and record
+the requested/effective width, completion of every child, TTFT, token/s, peak
+physical footprint, cache/companion counters, stop reason, and process survival.
+Unsupported or unavailable rows are `BLOCKED`, not implicit passes.
 
 ### LLM — Full Batching via BatchKVCache
 

--- a/Libraries/MLXLMCommon/BatchEngine/BATCH_ENGINE.md
+++ b/Libraries/MLXLMCommon/BatchEngine/BATCH_ENGINE.md
@@ -1,8 +1,17 @@
 # Continuous Batching Engine
 
-**Status**: **PRODUCTION-READY** as of 2026-04-19 (iter 63) for `mlxBatchEngine=YES` default flip on osaurus's side.
+**Status**: **PARTIAL BY ARCHITECTURE** as of 2026-08-29. Native B>1
+decode is production-gated per cache topology; architectures without a proven
+B-wide state contract must advertise a smaller decode limit and retain only
+safe request queuing. See `docs/CONTINUOUS_BATCHING_FAMILY_TRIAGE_2026_08_29.md`
+for the current source and live-evidence matrix.
 
-Real continuous batching for mlx-swift-lm. Multiple generation requests are batched through a single model forward pass during decode. All model families supported — LLM, VLM, MoE, hybrid SSM, JANG quantized, Gemma-4 sliding-window.
+Real continuous batching for mlx-swift-lm. Multiple generation requests may be
+batched through one model forward pass only when the model's cache topology has
+a proven B-wide contract. Other architectures remain concurrent at the request
+queue but decode at their declared safe width. Do not interpret “request
+accepted,” a two-child `spawn_batch`, or process survival as proof of native
+B>1 decode.
 
 ## Osaurus integration (read first)
 

--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -246,6 +246,12 @@ public actor BatchEngine {
     /// Additional requests are queued until a slot opens.
     public private(set) var maxBatchSize: Int
 
+    /// Architecture limit captured from the loaded model. This is distinct
+    /// from host/RAM admission: it prevents the scheduler from constructing a
+    /// B-wide forward for a cache topology whose model implementation only
+    /// supports B=1.
+    private let modelMaximumDecodeBatchSize: Int?
+
     /// Number of iterations between GPU memory cache purges.
     /// Matches the 256-token interval used by ``TokenIterator``.
     public let memoryPurgeInterval: Int
@@ -376,10 +382,17 @@ public actor BatchEngine {
     ) {
         precondition(maxBatchSize > 0, "BatchEngine maxBatchSize must be greater than zero")
         self.context = context
-        self.maxBatchSize = maxBatchSize
+        let modelLimit = context.model.maximumSupportedDecodeBatchSize
+        if let modelLimit {
+            precondition(modelLimit > 0,
+                "LanguageModel maximumSupportedDecodeBatchSize must be positive")
+        }
+        let effectiveMaxBatchSize = min(maxBatchSize, modelLimit ?? maxBatchSize)
+        self.modelMaximumDecodeBatchSize = modelLimit
+        self.maxBatchSize = effectiveMaxBatchSize
         self.memoryPurgeInterval = memoryPurgeInterval
         self.cacheCoordinator = cacheCoordinator
-        self.initialAdmissionCoalescingNanos = maxBatchSize > 1 ? 25_000_000 : 0
+        self.initialAdmissionCoalescingNanos = effectiveMaxBatchSize > 1 ? 25_000_000 : 0
 
         let resolvedStops = resolveStopSequences(
             modelConfiguration: context.configuration,
@@ -387,6 +400,11 @@ public actor BatchEngine {
             includeUnknownToken: true)
         self.stopTokenIDs = resolvedStops.tokenIDs
         self.defaultStopStrings = resolvedStops.textStopStrings
+        if effectiveMaxBatchSize != maxBatchSize {
+            Self.logger.info(
+                "Clamped requested maxBatchSize=\(maxBatchSize, privacy: .public) to architecture limit=\(effectiveMaxBatchSize, privacy: .public) model=\(context.configuration.name, privacy: .public)"
+            )
+        }
     }
 
     // MARK: - Public API
@@ -407,15 +425,17 @@ public actor BatchEngine {
         guard !isShutdown else {
             throw BatchEngineConfigurationError.engineShutdown
         }
-        guard newMaxBatchSize != maxBatchSize else { return }
+        let effectiveMaxBatchSize = min(
+            newMaxBatchSize, modelMaximumDecodeBatchSize ?? newMaxBatchSize)
+        guard effectiveMaxBatchSize != maxBatchSize else { return }
 
         let old = maxBatchSize
-        maxBatchSize = newMaxBatchSize
+        maxBatchSize = effectiveMaxBatchSize
         Self.logger.info(
-            "Updated maxBatchSize from \(old, privacy: .public) to \(newMaxBatchSize, privacy: .public)"
+            "Updated maxBatchSize from \(old, privacy: .public) to \(effectiveMaxBatchSize, privacy: .public) requested=\(newMaxBatchSize, privacy: .public)"
         )
 
-        if newMaxBatchSize > old && soloFastPathTask == nil {
+        if effectiveMaxBatchSize > old && soloFastPathTask == nil {
             admitPendingRequests()
             if !activeSlots.isEmpty {
                 ensureLoopRunning()

--- a/Libraries/MLXLMCommon/LanguageModel.swift
+++ b/Libraries/MLXLMCommon/LanguageModel.swift
@@ -427,6 +427,14 @@ public protocol VisionLanguageModelProtocol: LanguageModel {}
 /// - the ``TokenIterator`` accumulates this information into a ``GenerateResult``
 public protocol LanguageModel: Module {
 
+    /// Maximum number of sequences this architecture can decode in one
+    /// model forward. `nil` means the architecture supports the batch
+    /// engine's configured width. Models with path-dependent cache state that
+    /// does not yet have a B-wide wrapper must return `1`; the engine will
+    /// retain request concurrency in its queue without entering an invalid
+    /// batched forward.
+    var maximumSupportedDecodeBatchSize: Int? { get }
+
     /// Prepare the cache state and consume the ``LMInput``.
     ///
     /// This can return:
@@ -464,6 +472,10 @@ public protocol LanguageModel: Module {
 }
 
 extension LanguageModel {
+    /// Most standard-attention and wrapped recurrent-cache architectures use
+    /// the batch engine's configured width.
+    public var maximumSupportedDecodeBatchSize: Int? { nil }
+
     public func callAsFunction(_ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?)
         -> LMOutput
     {

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -2465,7 +2465,12 @@ enum Qwen35Language {
                 let batchSize = inputs.dim(0)
                 let seqLength = inputs.dim(1)
 
-                var delta = graphOffset.reshaped([]).asType(.int32)
+                // Compiled single-sequence caches expose `[1]`, while
+                // `BatchKVCache` exposes one offset per live sequence as
+                // `[B]`. Preserve that batch dimension: reshaping `[B]` to a
+                // scalar is only valid for B == 1 and process-fatals as soon
+                // as continuous batching decodes two Qwen3.5/Ornith slots.
+                var delta = graphOffset.asType(.int32)
                 if let ropeDeltas {
                     delta = delta + ropeDeltas.asType(.int32)
                 }

--- a/Libraries/MLXVLM/Models/Qwen4Exp.swift
+++ b/Libraries/MLXVLM/Models/Qwen4Exp.swift
@@ -1357,6 +1357,11 @@ public final class Qwen4Exp: Module, VLMModel, Qwen4ExpModelDirectoryConfigurabl
     SafetensorsLoadKeyExcluding, NativeMTPModel, DFlash2StagedVerifyRollbackModel,
     CompiledDecodeExternalInputModel
 {
+    /// QSA index selection and its path-dependent cache currently require a
+    /// single sequence. Keep concurrent requests queued until a B-wide QSA
+    /// cache/indexer contract is implemented and proven.
+    public var maximumSupportedDecodeBatchSize: Int? { 1 }
+
     public let config: Qwen4ExpConfiguration
     @ModuleInfo(key: "language_model") private var textModel: Qwen4ExpTextModel
     @ModuleInfo(key: "lm_head") private var head: Linear

--- a/Tests/MLXLMTests/BatchEngineTests.swift
+++ b/Tests/MLXLMTests/BatchEngineTests.swift
@@ -417,9 +417,12 @@ class BatchEngineIntegrationTests: XCTestCase {
 
     private func makeSlowPrefillEngine(
         prefillDelayMicroseconds: UInt32 = 800_000,
-        maxBatchSize: Int = 2
+        maxBatchSize: Int = 2,
+        modelMaximumDecodeBatchSize: Int? = nil
     ) -> BatchEngine {
-        let model = SlowPrefillLanguageModel(prefillDelayMicroseconds: prefillDelayMicroseconds)
+        let model = SlowPrefillLanguageModel(
+            prefillDelayMicroseconds: prefillDelayMicroseconds,
+            maximumSupportedDecodeBatchSize: modelMaximumDecodeBatchSize)
         let tokenizer = TestTokenizer(vocabularySize: model.vocabularySize)
         let processor = TestInputProcessor(
             tokenizer: tokenizer,
@@ -740,6 +743,24 @@ class BatchEngineIntegrationTests: XCTestCase {
             let result = await collectTokens(from: stream)
             XCTAssertNotNil(result.info, "Resized engine should finish every stream")
         }
+    }
+
+    /// Architectures with path-dependent caches that have no B-wide wrapper
+    /// must queue concurrent requests instead of entering an invalid forward.
+    func testModelDecodeBatchLimitClampsInitAndRuntimeResize() async throws {
+        let engine = makeSlowPrefillEngine(
+            maxBatchSize: 3,
+            modelMaximumDecodeBatchSize: 1)
+        let initialMaximum = await engine.maxBatchSize
+        let initialCapacity = await engine.capacitySnapshot
+        XCTAssertEqual(initialMaximum, 1)
+        XCTAssertEqual(initialCapacity.configuredMaximum, 1)
+
+        try await engine.updateMaxBatchSize(4)
+        let resizedMaximum = await engine.maxBatchSize
+        let resizedCapacity = await engine.capacitySnapshot
+        XCTAssertEqual(resizedMaximum, 1)
+        XCTAssertEqual(resizedCapacity.configuredMaximum, 1)
     }
 
     /// A capacity increase and the resulting queue admission happen on the
@@ -1459,11 +1480,16 @@ private final class SlowPrefillLanguageModel: Module, LanguageModel,
     KVCacheDimensionProvider, @unchecked Sendable
 {
     let prefillDelayMicroseconds: UInt32
+    let maximumSupportedDecodeBatchSize: Int?
     let vocabularySize = 32
     var kvHeads: [Int] { [1] }
 
-    init(prefillDelayMicroseconds: UInt32) {
+    init(
+        prefillDelayMicroseconds: UInt32,
+        maximumSupportedDecodeBatchSize: Int? = nil
+    ) {
         self.prefillDelayMicroseconds = prefillDelayMicroseconds
+        self.maximumSupportedDecodeBatchSize = maximumSupportedDecodeBatchSize
     }
 
     func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult {

--- a/Tests/MLXLMTests/Qwen35VLMGatedDeltaTests.swift
+++ b/Tests/MLXLMTests/Qwen35VLMGatedDeltaTests.swift
@@ -6,56 +6,58 @@ import Testing
 
 @Suite("Qwen3.5-VL gated-delta forward", .serialized)
 struct Qwen35VLMGatedDeltaTests {
+    private func tinyConfiguration() throws -> Qwen35Configuration {
+        try JSONDecoder.json5().decode(
+            Qwen35Configuration.self,
+            from: """
+            {
+              "model_type": "qwen3_5_moe",
+              "text_config": {
+                "model_type": "qwen3_5_moe_text",
+                "hidden_size": 32,
+                "num_hidden_layers": 4,
+                "intermediate_size": 64,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 2,
+                "linear_num_value_heads": 4,
+                "linear_num_key_heads": 2,
+                "linear_key_head_dim": 8,
+                "linear_value_head_dim": 8,
+                "linear_conv_kernel_dim": 2,
+                "head_dim": 8,
+                "full_attention_interval": 4,
+                "vocab_size": 100,
+                "rms_norm_eps": 1e-6,
+                "rope_parameters": {
+                  "rope_type": "default",
+                  "rope_theta": 100000.0,
+                  "partial_rotary_factor": 0.25,
+                  "mrope_section": [1, 1, 1]
+                }
+              },
+              "vision_config": {
+                "model_type": "qwen3_vl",
+                "depth": 1,
+                "hidden_size": 16,
+                "intermediate_size": 32,
+                "out_hidden_size": 32,
+                "num_heads": 4,
+                "patch_size": 2,
+                "spatial_merge_size": 2,
+                "temporal_patch_size": 1,
+                "num_position_embeddings": 32
+              },
+              "vocab_size": 100,
+              "image_token_id": 98,
+              "video_token_id": 97
+            }
+            """.data(using: .utf8)!)
+    }
+
     @Test("tiny VLM text path executes linear-attention gated-delta cache")
     func tinyVLMTextPathExecutesGatedDeltaCache() throws {
         try MLXMetalTestLock.withLock {
-            let config = try JSONDecoder.json5().decode(
-                Qwen35Configuration.self,
-                from: """
-                {
-                  "model_type": "qwen3_5_moe",
-                  "text_config": {
-                    "model_type": "qwen3_5_moe_text",
-                    "hidden_size": 32,
-                    "num_hidden_layers": 4,
-                    "intermediate_size": 64,
-                    "num_attention_heads": 4,
-                    "num_key_value_heads": 2,
-                    "linear_num_value_heads": 4,
-                    "linear_num_key_heads": 2,
-                    "linear_key_head_dim": 8,
-                    "linear_value_head_dim": 8,
-                    "linear_conv_kernel_dim": 2,
-                    "head_dim": 8,
-                    "full_attention_interval": 4,
-                    "vocab_size": 100,
-                    "rms_norm_eps": 1e-6,
-                    "rope_parameters": {
-                      "rope_type": "default",
-                      "rope_theta": 100000.0,
-                      "partial_rotary_factor": 0.25,
-                      "mrope_section": [1, 1, 1]
-                    }
-                  },
-                  "vision_config": {
-                    "model_type": "qwen3_vl",
-                    "depth": 1,
-                    "hidden_size": 16,
-                    "intermediate_size": 32,
-                    "out_hidden_size": 32,
-                    "num_heads": 4,
-                    "patch_size": 2,
-                    "spatial_merge_size": 2,
-                    "temporal_patch_size": 1,
-                    "num_position_embeddings": 32
-                  },
-                  "vocab_size": 100,
-                  "image_token_id": 98,
-                  "video_token_id": 97
-                }
-                """.data(using: .utf8)!)
-
-            let model = Qwen35(config)
+            let model = Qwen35(try tinyConfiguration())
             let cache = model.newCache(parameters: nil)
             let input = MLXArray([1, 2, 3])[.newAxis, .ellipsis]
 
@@ -68,6 +70,32 @@ struct Qwen35VLMGatedDeltaTests {
             #expect(cache.first?.offset == 3)
             let mambaCache = try #require(cache.first as? MambaCache)
             #expect(mambaCache[1]?.dtype == .float32)
+        }
+    }
+
+    @Test("batch=2 decode preserves one position offset per sequence")
+    func batchDecodePreservesPerSequenceOffsets() throws {
+        try MLXMetalTestLock.withLock {
+            let model = Qwen35(try tinyConfiguration())
+            let first = model.newCache(parameters: nil)
+            let second = model.newCache(parameters: nil)
+
+            MLX.eval(model(MLXArray([1, 2, 3])[.newAxis, .ellipsis], cache: first))
+            MLX.eval(model(MLXArray([4, 5])[.newAxis, .ellipsis], cache: second))
+
+            let batchCaches: [KVCache] = zip(first, second).map { lhs, rhs in
+                if let lhs = lhs as? ArraysCache, let rhs = rhs as? ArraysCache {
+                    return BatchArraysCache(slotCaches: [lhs, rhs])
+                }
+                return BatchKVCache(slotCaches: [lhs, rhs])
+            }
+            let decodeTokens = MLXArray([Int32(6), Int32(7)]).reshaped(2, 1)
+            let logits = model(decodeTokens, cache: batchCaches)
+            MLX.eval(logits)
+
+            #expect(logits.shape == [2, 1, 100])
+            let fullAttention = try #require(batchCaches.last as? BatchKVCache)
+            #expect(fullAttention.offsetArray.asArray(Int32.self) == [4, 3])
         }
     }
 }

--- a/docs/CONTINUOUS_BATCHING_FAMILY_TRIAGE_2026_08_29.md
+++ b/docs/CONTINUOUS_BATCHING_FAMILY_TRIAGE_2026_08_29.md
@@ -1,0 +1,233 @@
+# Continuous-batching family triage — 2026-08-29
+
+## Status and purpose
+
+This is the handoff for the PRs following vMLX PR #331. It separates four
+failure surfaces that previously appeared as one “batching is broken” symptom:
+
+1. a vMLX model/cache implementation that cannot represent B-wide state;
+2. an Osaurus scheduler that requests more slots than the model can execute;
+3. an OsaurusEvals fixture or scorer that assumes every model must execute B>1;
+4. a model tool-template/parser failure that occurs before batching starts.
+
+The overall family gate is **PARTIAL**. The Qwen3.5 crash is reversed on the
+current PR head with a real AgentLoop row. DSV4 safe serialization works but the
+eval assertion and RAM footprint are broken. Zaya never reached the batch
+engine because all three AgentLoop trials emitted malformed tool arguments.
+Flash-Next and the dense Gemma control still require live rows.
+
+## Frozen proof provenance
+
+- vMLX branch: `fix/qwen35-batch-position`
+- vMLX proof head: `295f8c5c182b789d880a84e89b29c40ba2ac1b15`
+- Qwen3.5 position fix: `8999e6d0f54ddd8b34079740e067093d9b3979dc`
+- Osaurus proof base: `a1760574e`, with only the six vMLX pin sites repinned to
+  `295f8c5c...`
+- Release app build: `build/pr331-dd/Build/Products/Release/osaurus.app`
+- Release app binary SHA-256:
+  `30fd1787e4ce5863db41b2f3326d2e30eeb2fc502133bc0d41a2ac77741765fc`
+- MLX metallib SHA-256:
+  `24d4cfcd3ca8b15ead691e46219f35adabbea64c9f8de4eae9bf293fd8d5eb7b`
+- Evidence root: `/private/tmp/vmlx-pr331-proof-295f8c5c`
+
+GitHub Actions on the fork were skipped by the upstream-repository identity
+guard. They are not CI evidence. Current source evidence is the clean vMLX
+build (`swift build --build-tests`, RC 0), focused tests, and the live rows
+below.
+
+## Current family matrix
+
+| Family / topology | Current source contract | Current live result | Classification | Next focused PR |
+|---|---|---|---|---|
+| Qwen3.5 / Ornith GatedDelta SSM + KV | Native B>1 through `BatchArraysCache` plus per-sequence KV offsets | **PASS on PR head**: exact former crash fixture completed 2/2 children in subwave `[2]`; 26.87 tok/s, 233 ms TTFT, 3346.67 MB peak footprint, process survived | vMLX crash fixed for this row; broader multi-turn/cache continuation still pending | Finish PR #331 proof with Release-app visual row and unequal-prefix/multi-turn continuation; do not broaden the position fix |
+| Zaya CCA | Native B>1 through `BatchZayaCCACache` | **FAILED before batching**: 0/3 AgentLoop trials formed a valid `spawn_batch`; no execution wave, therefore no live CCA B=2 verdict | Tool-schema/template/parser/model-output lane first; batching result is **BLOCKED**, not failed | Add raw emitted-byte + resolved-template + resolved-parser telemetry; isolate parser transformation from model emission; then rerun AgentLoop and a raw two-request CCA row |
+| DSV4 SWA + CSA/HSA pool | `maximumSupportedDecodeBatchSize = 1`; requests may queue but must serialize | Runtime safety **PASS**, eval row **FAIL**, RAM **FAIL**: both children completed, subwaves `[1,1]`, limited by `engineCapacity`, 13.51 tok/s, 185 ms TTFT; scorer expected `[2]`; peak footprint 104,993 MB | OsaurusEvals assertion bug and separate vMLX/runtime-memory defect | PR A: architecture-aware eval expectation and truthful requested-vs-effective telemetry. PR B: DSV4 allocation-retention/footprint investigation. Never make PR A waive the RAM gate |
+| Qwen3.8 Flash-Next QSA + optional MTP | `maximumSupportedDecodeBatchSize = 1`; QSA itself preconditions B=1 | **UNVERIFIED on PR head** | Runtime cap is source-only until live proof | Run off/auto/manual-depth rows; require queued `[1,1]`, both children complete, request-local MTP telemetry, cache counters, tok/s, TTFT, footprint, process survival |
+| Dense Gemma control | No architecture cap; native B>1 through `BatchKVCache` | **UNVERIFIED on PR head** | Needed to prove the new cap does not serialize capable dense models | Run exact two-worker fixture; require effective slots 2, subwave `[2]`, coherent final, bundle generation config, tok/s, TTFT, footprint and cache telemetry |
+
+## Source trace by failure boundary
+
+### 1. Qwen3.5 crash: vMLX runtime bug
+
+The old Qwen3.5 VLM language path treated the `BatchKVCache` graph offset as a
+scalar. At B=2 the offset is a two-element vector, so `reshaped([])` trapped:
+
+```text
+[reshape] Cannot reshape array of size 2 into shape ().
+```
+
+The crash report at
+`~/Library/Logs/DiagnosticReports/osaurus-evals-2026-08-29-010159.ips`
+traces `MLXArray.reshaped` to
+`Qwen35Language.LanguageModel.resolvedPositionIds` and then
+`BatchEngine.stepBatchDecode`. Commit `8999e6d0` preserves the offset vector as
+`int32`. The regression prefills two unequal sequences, decodes them together,
+requires logits shape `[2, 1, 100]`, and verifies independent offsets advance
+from `[3, 2]` to `[4, 3]`.
+
+This is a runtime/cache bug. OsaurusEvals merely exposed it.
+
+### 2. DSV4 safe serialization: runtime correct, eval contract wrong
+
+DSV4 now advertises `maximumSupportedDecodeBatchSize = 1`. `BatchEngine`
+clamps both construction and later resize requests to that model limit. The
+live AgentLoop row requested two concurrent sequences, but the execution
+envelope truthfully reported:
+
+```text
+effective_local_slots = 1
+local_subwaves = [1, 1]
+limited_by = ["engineCapacity"]
+succeeded = 2
+failed = 0
+```
+
+Both children returned the required tokens and the parent exited
+`finalResponse`. That is a safe-serialization pass, not a native B=2 pass.
+
+The eval fixture currently hardcodes `effectiveLocalSlots: 2` and
+`localSubwaves: [2]`. Its setup note also calls
+`InferenceFeatureFlags.mlxBatchEngineMaxBatchSize` “effective,” even though it
+is only the requested/configured value and does not include the model cap.
+Therefore the eval fails behavior that is correct for this architecture.
+
+The eval PR must:
+
+- preserve a strict native-B>1 fixture for architectures that claim B>1;
+- add an explicit safe-serialization expectation for capped architectures;
+- record requested width, model maximum, engine-effective width, observed
+  local slots, subwaves, and limiting factors as distinct fields;
+- reject a serialized row if any two children overlap inside a B=1 model
+  forward, either child fails, or the process exits;
+- never convert DSV4's 104,993 MB footprint into a pass merely because the
+  behavioral expectation is corrected.
+
+Evidence:
+
+- `dsv4-serialized.json`
+- `dsv4-serialized.log`
+- `dsv4-serialized-footprint.csv`
+- `dsv4-serialized.transcripts/`
+
+### 3. Zaya: the AgentLoop row did not test batching
+
+Across three trials, the first `spawn_batch` arguments contained schema-like
+XML placeholders instead of a JSON `jobs` array, for example:
+
+```json
+{"job_id":"writing","jobs":"<element>\n<name>job_id</name>..."}
+```
+
+Later calls repeated `<value>...</value>` placeholders, guessed unavailable
+tools, or reached the iteration cap. Since no valid `spawn_batch` executed,
+these runs say nothing about `BatchZayaCCACache` under B=2.
+
+Do not immediately call this a cache bug or a parser bug. The next diagnostic
+PR must capture all three boundaries for the same step:
+
+1. exact rendered tool-schema/template bytes given to the model;
+2. exact raw model bytes before tool parsing;
+3. parsed tool name/arguments plus the resolved `ToolCallFormat` and its source
+   (explicit override, JANG capability stamp, or heuristic).
+
+Interpretation:
+
+- malformed schema in (1) means Osaurus schema/template composition is broken;
+- valid schema in (1), malformed raw output in (2) means the bundle template,
+  model capability, or model behavior needs correction/evaluation;
+- valid raw tool syntax in (2), malformed arguments in (3) means the vMLX tool
+  parser is broken.
+
+Only after that boundary is fixed should AgentLoop be used as the CCA B=2 gate.
+In parallel, a raw engine-level two-request row should exercise CCA
+gather/scatter without tools so parser quality cannot mask a cache failure.
+
+Evidence:
+
+- `zaya-cb2-repeat3.json`
+- `zaya-cb2-repeat3.log`
+- `zaya-cb2-repeat3.transcripts/`
+
+### 4. Flash-Next QSA and MTP: safe width is not yet a live result
+
+`Qwen4ExpQSAIndexer` currently preconditions `B == 1`. The model-level cap
+prevents the scheduler from feeding it a wider batch, but this remains only
+source and unit evidence until the real model passes:
+
+- MTP off;
+- MTP auto, with activation justified by measured tuning;
+- an explicit supported depth (currently depth 2 in the proof plan).
+
+For every row, record requested and effective widths, queue/subwave shape,
+both child outcomes, MTP configured and active depth, verify/accepted/rejected
+or AR counts, cache topology/counters, TTFT, token/s, peak physical footprint,
+stop reason, and final visible coherency. MTP telemetry from one queued request
+must never bleed into the next.
+
+## Required PR sequence
+
+### PR 1 — finish vMLX #331 narrowly
+
+- Keep the Qwen3.5 vector-position correction.
+- Keep the general model-declared maximum decode width and the DSV4/QSA caps.
+- Retain the behavioral clamp test.
+- Run the remaining Flash-Next and dense-Gemma rows.
+- Obtain one exact Release-app visual proof with one app instance; CLI/evals
+  remain paired diagnosis, not GUI proof.
+- If Zaya's parser lane cannot be repaired without broadening #331, document it
+  as a blocking follow-up rather than mixing an unrelated parser change into
+  the Qwen3.5 runtime fix.
+
+### PR 2 — OsaurusEvals architecture-aware batching contracts
+
+- Split native-parallel and safe-serialized expectations.
+- Replace the misleading static “effectiveMaxBatchSize” note with actual
+  runtime capacity telemetry.
+- Keep failure semantics strict for wrong width, missing child, overlap under a
+  cap, crash, malformed execution envelope, missing tok/s, or footprint breach.
+- Add fixture/scorer tests for a native `[2]` row and capped `[1,1]` row.
+
+### PR 3 — Zaya tool boundary and CCA live gate
+
+- Add the three-boundary trace described above.
+- Fix only the boundary proven wrong.
+- Re-run three AgentLoop trials plus raw B=2 unequal-prefix CCA decode,
+  multi-turn continuation, and cache restore/isolation.
+
+### PR 4 — DSV4 footprint retention
+
+- Treat 104,993 MB as a failed row.
+- Attribute retained memory by weights, prefill activations, SWA cache,
+  CSA/HSA pool, compiled graphs, disk-L2 staging, and per-child lifetime.
+- Sample `phys_footprint` throughout warm-up, parent prefill, child 1, child 2,
+  parent continuation, cache store, and unload.
+- Prove old per-request state is released before claiming the serialization
+  path is production-safe on constrained hosts.
+
+### PR 5 — Osaurus repin and app proof
+
+After vMLX changes merge, repin every Osaurus vMLX lock site to the merged SHA,
+build the Release app, verify one instance, and drive the actual UI. Re-run the
+family matrix from the repinned app/runtime path. Do not use HTTP-only results
+as a substitute for rendered app behavior.
+
+## Acceptance checklist for every live family row
+
+- exact app/eval binary and vMLX SHA recorded;
+- exact model ID and bundle generation config used, with no hidden sampler or
+  reasoning coercion;
+- requested width, architecture limit, engine-effective width, observed slots,
+  subwaves, and limiting factors;
+- all child results and parent final response coherent;
+- multi-turn continuation, stop/cancel, and restart/disk-restore where the
+  family gate requires them;
+- TTFT and decode token/s;
+- `phys_footprint`, not only allocator/RSS estimates;
+- prefix/paged/disk-L2 counters and architecture companion state (SSM, CCA,
+  QSA/MTP, media) as applicable;
+- no marker leakage, loop, silent terminal row, length-cap fake pass, crash, or
+  stale cache reuse;
+- real image/video payload and cache reuse for VL/video claims;
+- Release-app visual confirmation before calling user-facing behavior fixed.
+
+Anything missing is `PARTIAL` or `BLOCKED`, with the artifact and reason named.


### PR DESCRIPTION
## Root cause

Continuous batching supplies `Qwen35Language.LanguageModel.resolvedPositionIds` a graph offset shaped `[B]`: one offset for every live sequence. The implementation forced that array through `reshaped([])`, which is valid only at `B == 1`. At `B == 2`, MLX process-fatals before the existing per-batch broadcast/truncation logic can run.

Exact production failure on the prior vMLX pin `aeb5e21c195d8519609488ef75a25ce7e48d8f88`:

- model: `JANGQ-AI/Ornith-1.5-9B-JANG_4D`
- fixture: `agent_loop.spawn-batch-two-configured-workers`
- runtime: continuous batching ON, `maxConcurrentSequences=2`, effective batch size 2
- fatal: `[reshape] Cannot reshape array of size 2 into shape ().`
- symbolized path: `MLXArray.reshaped` → `Qwen35Language.LanguageModel.resolvedPositionIds` (`Qwen35.swift:2468`) → `Qwen35Language.LanguageModel.callAsFunction` → `BatchEngine.stepBatchDecode`
- crash report: `osaurus-evals-2026-08-29-010159.ips`

## Fix

Preserve the graph offset's `[1]`/`[B]` shape and convert its dtype without scalarizing it. The following code already handles scalar/vector `delta` and aligns it to the input batch; the crash prevented that code from receiving the valid batch vector.

No sampler, prompt, generation-config, cache policy, or model behavior is changed.

## Regression coverage

A behavioral Qwen3.5 test now:

1. prefills two sequences to different offsets (3 and 2),
2. constructs the same `BatchArraysCache` + `BatchKVCache` shape used by continuous batching,
3. runs a real batch=2 model decode,
4. requires logits `[2, 1, 100]`, and
5. requires the two KV offsets to advance independently to `[4, 3]`.

Focused source/test evidence at `8999e6d0`:

- `Qwen35VLMGatedDeltaTests`: 2/2 passed
- `BatchKVCache` suites: 16/16 passed
- `BatchArraysCache` suites: 2/2 passed
- total: 20/20 passed
- `git diff --check`: clean

## Live gate

**PARTIAL — do not merge yet.** The exact real-model after-arm is queued behind an unrelated GPU eval already running on the proof Mac. Required before merge:

- same Ornith bundle and exact CB=2 fixture,
- zero process crash,
- both child sequences finish,
- visible final response and coherent tool results,
- TTFT, token/s, peak `phys_footprint`, and cache counters recorded,
- Osaurus repin PR and app-path proof after this engine PR merges.

## Why prior community evals did not catch it

The earlier Qwen3.8 community report did not contain either continuous-batching fixture (`spawn-batch-two-configured-workers` / `spawn-batch-two-different-local-workers`) and recorded no `runtimeConcurrency`/`continuousBatching` configuration. Its `batch-error-isolation` row batches tool invocations, not simultaneous model sequences. So its success is consistent with this narrowly triggered `B > 1` model-decode crash.
