### PR TITLE
CI: point the pull-request guard at this repository

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   lint:
-    if: github.repository == 'ml-explore/mlx-swift'
+    if: github.repository == 'osaurus-ai/vmlx-swift'
     runs-on: ubuntu-latest
     container:
       image: swift:6.2-rhel-ubi9
@@ -71,7 +71,7 @@ jobs:
 
   mac_build_and_test:
     needs: lint
-    if: github.repository == 'ml-explore/mlx-swift'
+    if: github.repository == 'osaurus-ai/vmlx-swift'
     runs-on: [self-hosted, macos]
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
`lint` and `mac_build_and_test` are gated on the guard inherited from Apple's
mlx-swift:

```yaml
if: github.repository == 'ml-explore/mlx-swift'
```

That is never true in `osaurus-ai/vmlx-swift`, so both jobs skip
unconditionally, and `linux_build_cmake_container` / `linux_build_cmake_cuda`
skip with them through `needs: lint`.

The last **20** workflow runs all concluded `skipped`. The workflow has never
executed in this repository — not on fork PRs, and not on maintainer PRs
(#329 shows the same four jobs `skipping`).

## Please read before merging — this is not purely cosmetic

Repointing the constant is the whole fix *textually*, but the repository
currently has **0 registered self-hosted runners**, and:

| job | `runs-on` | after this change |
|---|---|---|
| `lint` | `ubuntu-latest` | **runs** — GitHub-hosted |
| `mac_build_and_test` | `[self-hosted, macos]` | **queues indefinitely** unless a runner is registered |
| `linux_build_cmake_container` | `ubuntu-22.04` matrix | starts running (was gated behind `lint`) |
| `linux_build_cmake_cuda` | `gpu-t4-4-core` | **queues indefinitely** — self-hosted |

So merging this alone trades two silent skips for two jobs that never start,
which is arguably worse. That is your call and your infrastructure, so I have
left it draft rather than guessing.

## Options

1. **Merge as-is and register runners** — a self-hosted macOS runner and a
   `gpu-t4-4-core` host. Best outcome, most setup.
2. **Merge with `mac_build_and_test` on a GitHub-hosted runner** — change
   `runs-on: [self-hosted, macos]` to `runs-on: macos-15`. This is the one that
   actually gets the package built and tested on every PR without any
   infrastructure; the cost is GitHub-hosted macOS minutes. Say the word and I
   will add that commit here.
3. **Enable `lint` only** — keep explicit guards on the three jobs needing
   runners you do not have, so nothing queues. Smallest safe step; gives one
   executing check.
4. **Close this** — if CI is intentionally dormant, that is fine too, but then
   "please run real checks" cannot be a review requirement, and I will keep
   posting local runs labelled as local.

I have no preference beyond wanting review requests I can actually satisfy.
Happy to push whichever variant you pick.
