### PR TITLE
Gemma4: an undersized vocab tensor is reported, not silently ignored

### DIFF
--- a/Libraries/MLXLLM/Models/Gemma4Text.swift
+++ b/Libraries/MLXLLM/Models/Gemma4Text.swift
@@ -8,6 +8,9 @@
 // Python reference: mlx_vlm/models/gemma4/language.py
 
 import Foundation
+import OSLog
+
+private let gemma4WeightsLogger = Logger(subsystem: "vmlx", category: "Gemma4Weights")
 import MLX
 import MLXLMCommon
 import MLXNN
@@ -929,8 +932,28 @@ public class Gemma4TextModel: Module, LLMModel {
             "lm_head.weight", "lm_head.scales", "lm_head.biases",
         ] {
             let key = prefix + suffix
-            if let w = weights[key], w.dim(0) != vocabSize {
+            guard let w = weights[key] else { continue }
+            let height = w.dim(0)
+            if height > vocabSize {
                 weights[key] = w[0 ..< vocabSize]
+            } else if height < vocabSize {
+                // The guard used to be `!=`, which sent this case through the same slice. MLX
+                // CLAMPS an out-of-range slice rather than trapping, so the tensor came back
+                // unchanged and the policy's intent — "make this exactly vocabSize" — silently did
+                // not happen. The load then continues with an embedding shorter than the
+                // vocabulary the config declares, which is not recoverable by trimming: there are
+                // no rows to trim.
+                //
+                // Reported rather than thrown because `sanitize` is not throwing (that is Apple's
+                // `LanguageModel` protocol, so making it throwing is an upstream change, not a
+                // local one). A warning is at least a tell; silence was not.
+                gemma4WeightsLogger.warning(
+                    """
+                    \(key, privacy: .public) has \(height, privacy: .public) rows but the config \
+                    declares vocab_size \(vocabSize, privacy: .public). A vocabulary-sized tensor \
+                    cannot be produced by trimming a shorter one; the bundle is malformed and the \
+                    weights should be re-converted. Leaving the tensor as-is.
+                    """)
             }
         }
     }

--- a/Tests/MLXLMCommonFocusedTests/Gemma4SharedKeyPolicyTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/Gemma4SharedKeyPolicyTests.swift
@@ -123,26 +123,30 @@ struct Gemma4SharedKeyPolicyTests {
         #expect(out.asArray(Float.self) == (0 ..< 12).map { Float($0) }, "keeps the FIRST rows")
     }
 
-    /// The relation the inherited policy never distinguished. `dim(0) != vocabSize` is true when
-    /// the tensor is SMALLER as well, and the guard then slices `0 ..< vocabSize` past the end.
+    /// The relation the guard used to conflate. `dim(0) != vocabSize` is true when the tensor is
+    /// SMALLER as well, and that sent it through the same slice — which MLX CLAMPS rather than
+    /// trapping, so the tensor came back unchanged and the policy's intent silently did not happen.
     ///
-    /// Measured, not assumed: MLX **clamps** rather than trapping, so the tensor is returned
-    /// unchanged at its original height. That is a silent no-op — the policy's intent ("make this
-    /// exactly `vocabSize`") is not achieved, nothing reports it, and an embedding shorter than the
-    /// configured vocabulary flows onward to fail somewhere else, or not at all.
-    ///
-    /// This test pins the CURRENT contract rather than changing it: #313 is a behaviour-preserving
-    /// refactor, and making an undersized tensor an error is a behaviour change that deserves its
-    /// own decision. Recorded here so the behaviour is unambiguous either way.
-    @Test("an undersized tensor is silently left alone — the trim clamps, it does not throw")
-    func undersizedIsASilentNoOp() {
+    /// The tensor is still left alone, because there is nothing correct to do: a vocabulary-sized
+    /// embedding cannot be produced by trimming a shorter one. What changed is that it is now
+    /// REPORTED. Asserted here as behaviour (unchanged, not truncated, not grown) — the warning
+    /// itself is checked by reading the source, since `Logger` output is not capturable in-process.
+    @Test("an undersized tensor is left unchanged, and is no longer silent about it")
+    func undersizedIsReportedNotSilent() throws {
         var w: [String: MLXArray] = ["model.embed_tokens.weight": Self.embedding(rows: 4)]
         Gemma4TextModel.trimmingVocabDimension(&w, prefix: "", vocabSize: 9)
         let out = w["model.embed_tokens.weight"]!
-        #expect(out.dim(0) == 4, "clamped to the source height, NOT grown to vocabSize")
+        #expect(out.dim(0) == 4, "left at its own height — trimming cannot invent rows")
+        #expect(out.asArray(Float.self) == (0 ..< 8).map { Float($0) }, "values untouched")
+
+        // The three relations are now distinct branches, not one `!=`.
+        let source = try #require(
+            try? String(
+                contentsOfFile: "Libraries/MLXLLM/Models/Gemma4Text.swift", encoding: .utf8))
         #expect(
-            out.asArray(Float.self) == (0 ..< 8).map { Float($0) },
-            "and the values are untouched")
+            source.contains("height > vocabSize") && source.contains("height < vocabSize"),
+            "the undersized case must be its own branch, not folded into `!=`")
+        #expect(source.contains("gemma4WeightsLogger.warning"), "and it must report")
     }
 
     // MARK: - Both real callers (requested on #313)


### PR DESCRIPTION
> Stacked on #313 — the second commit is this change. `trimmingVocabDimension`
> is introduced by that PR, so this cannot stand alone.

Split out of the #313 review. You asked me to pin the undersized case rather
than leave it ambiguous; pinning it showed it was worth fixing.

## What was wrong

```swift
if let w = weights[key], w.dim(0) != vocabSize {
    weights[key] = w[0 ..< vocabSize]
}
```

`!=` is also true when the tensor is **shorter** than the declared vocabulary,
and that case went through the same slice. Measured, not assumed: **MLX clamps
an out-of-range slice rather than trapping**, so the tensor comes back unchanged
and the policy's intent silently does not happen. The load continues with an
embedding shorter than `vocab_size`.

## The three relations, now distinct

| relation | behaviour |
|---|---|
| `height > vocabSize` | trim — unchanged from before |
| `height == vocabSize` | untouched — unchanged from before |
| `height < vocabSize` | left alone **and reported** |

Still left alone, because there is nothing correct to do: a vocabulary-sized
embedding cannot be produced by trimming a shorter one — there are no rows to
trim. What changes is that it is no longer silent.

**Well-formed bundles are unaffected**: the oversized and equal paths are
byte-identical.

## Why a warning and not a throw

You may reasonably prefer this to fail the load rather than warn. I agree it is
the better contract — an embedding shorter than the declared vocabulary cannot
produce correct output — but it is not a local change:

`sanitize(weights:)` and `sanitize(weights:metadata:)` are **non-throwing
requirements on Apple's `LanguageModel` protocol** (`ml-explore/mlx-swift-lm`,
`Libraries/MLXLMCommon/LanguageModel.swift`, identical declarations and
defaults). Making them throwing means:

- changing a protocol this project inherits rather than owns, so every future
  sync with Apple conflicts;
- **87 files** in `Libraries/` implement `sanitize(weights:)` and would need the
  signature change;
- ~24 internal call sites plus `Load.swift:514` and
  `MLXEmbedders/Load.swift:192` would need `try` and a throwing context.

So: mechanical but wide, and it changes an Apple-owned surface. Worth doing if
you want it — say so and I will scope it as its own PR — but it should not ride
along with a two-branch fix.

The warning follows the pattern `Weights.stripLanguageModelPrefix` already uses
for its malformed-bundle case, so it is at least consistent with how this
codebase reports the same class of problem.
