### PR TITLE
Expose requested and architecture batch capacity

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BATCH_ENGINE.md
+++ b/Libraries/MLXLMCommon/BatchEngine/BATCH_ENGINE.md
@@ -296,6 +296,12 @@ width. A model that returns `1` retains concurrent request queuing but decodes
 one request at a time. This fail-safe serialization is not reported as native
 B>1 batching.
 
+Capacity diagnostics keep the three widths distinct. `requestedMaximum` is
+the serving layer's latest request, `architectureMaximum` is the model's
+optional hard ceiling, and `configuredMaximum` is the effective engine width
+after applying that ceiling. A capped `[1, 1]` run must not be reported as a
+native width-two run merely because the caller requested two slots.
+
 | Architecture/cache topology | Decode contract | Required current proof |
 |---|---|---|
 | Dense/standard attention (Gemma control) | Native B>1 through `BatchKVCache` | Same-model AgentLoop CB=2/3; both tool loops and final responses complete |

--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -251,6 +251,10 @@ public actor BatchEngine {
     /// B-wide forward for a cache topology whose model implementation only
     /// supports B=1.
     private let modelMaximumDecodeBatchSize: Int?
+    /// Last serving-layer request, retained even when the model cap keeps the
+    /// effective width unchanged. Diagnostics need both values to distinguish
+    /// native parallelism from architecture-safe serialization.
+    private var requestedMaxBatchSize: Int
 
     /// Number of iterations between GPU memory cache purges.
     /// Matches the 256-token interval used by ``TokenIterator``.
@@ -389,6 +393,7 @@ public actor BatchEngine {
         }
         let effectiveMaxBatchSize = min(maxBatchSize, modelLimit ?? maxBatchSize)
         self.modelMaximumDecodeBatchSize = modelLimit
+        self.requestedMaxBatchSize = maxBatchSize
         self.maxBatchSize = effectiveMaxBatchSize
         self.memoryPurgeInterval = memoryPurgeInterval
         self.cacheCoordinator = cacheCoordinator
@@ -427,6 +432,7 @@ public actor BatchEngine {
         }
         let effectiveMaxBatchSize = min(
             newMaxBatchSize, modelMaximumDecodeBatchSize ?? newMaxBatchSize)
+        requestedMaxBatchSize = newMaxBatchSize
         guard effectiveMaxBatchSize != maxBatchSize else { return }
 
         let old = maxBatchSize
@@ -1551,6 +1557,8 @@ public actor BatchEngine {
         let active = activeCount
         let accepting = !isShutdown
         return BatchEngineCapacitySnapshot(
+            requestedMaximum: requestedMaxBatchSize,
+            architectureMaximum: modelMaximumDecodeBatchSize,
             configuredMaximum: maxBatchSize,
             activeCount: active,
             pendingCount: waitQueue.count,

--- a/Libraries/MLXLMCommon/BatchEngine/BatchTypes.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchTypes.swift
@@ -32,7 +32,16 @@ public struct BatchRequestID: Hashable, Sendable, CustomStringConvertible {
 /// example, hybrid-pool cache requests), and another request can consume the
 /// headroom immediately after the snapshot is returned.
 public struct BatchEngineCapacitySnapshot: Sendable, Equatable {
+    /// Most recent width requested by the serving layer. This remains distinct
+    /// from `configuredMaximum`: an architecture may clamp the request.
+    public let requestedMaximum: Int
+
+    /// Model-declared decode-width ceiling, or nil when the architecture does
+    /// not impose a narrower ceiling than the serving configuration.
+    public let architectureMaximum: Int?
+
     /// Configured maximum number of simultaneously active sequences.
+    /// This is the effective value after applying `architectureMaximum`.
     public let configuredMaximum: Int
 
     /// Currently active sequences, including the direct B=1 solo path.
@@ -54,6 +63,8 @@ public struct BatchEngineCapacitySnapshot: Sendable, Equatable {
     public let activeCountHighWatermark: Int
 
     public init(
+        requestedMaximum: Int,
+        architectureMaximum: Int?,
         configuredMaximum: Int,
         activeCount: Int,
         pendingCount: Int,
@@ -62,6 +73,8 @@ public struct BatchEngineCapacitySnapshot: Sendable, Equatable {
         isShutdown: Bool,
         activeCountHighWatermark: Int
     ) {
+        self.requestedMaximum = requestedMaximum
+        self.architectureMaximum = architectureMaximum
         self.configuredMaximum = configuredMaximum
         self.activeCount = activeCount
         self.pendingCount = pendingCount

--- a/Tests/MLXLMTests/BatchEngineTests.swift
+++ b/Tests/MLXLMTests/BatchEngineTests.swift
@@ -754,13 +754,33 @@ class BatchEngineIntegrationTests: XCTestCase {
         let initialMaximum = await engine.maxBatchSize
         let initialCapacity = await engine.capacitySnapshot
         XCTAssertEqual(initialMaximum, 1)
+        XCTAssertEqual(initialCapacity.requestedMaximum, 3)
+        XCTAssertEqual(initialCapacity.architectureMaximum, 1)
         XCTAssertEqual(initialCapacity.configuredMaximum, 1)
 
         try await engine.updateMaxBatchSize(4)
         let resizedMaximum = await engine.maxBatchSize
         let resizedCapacity = await engine.capacitySnapshot
         XCTAssertEqual(resizedMaximum, 1)
+        XCTAssertEqual(resizedCapacity.requestedMaximum, 4)
+        XCTAssertEqual(resizedCapacity.architectureMaximum, 1)
         XCTAssertEqual(resizedCapacity.configuredMaximum, 1)
+    }
+
+    /// An uncapped architecture reports the requested/effective width while
+    /// leaving the architecture ceiling absent instead of inventing one.
+    func testCapacitySnapshotSeparatesUncappedRequestFromArchitectureLimit() async throws {
+        let engine = makeSlowPrefillEngine(maxBatchSize: 2)
+        var snapshot = await engine.capacitySnapshot
+        XCTAssertEqual(snapshot.requestedMaximum, 2)
+        XCTAssertNil(snapshot.architectureMaximum)
+        XCTAssertEqual(snapshot.configuredMaximum, 2)
+
+        try await engine.updateMaxBatchSize(3)
+        snapshot = await engine.capacitySnapshot
+        XCTAssertEqual(snapshot.requestedMaximum, 3)
+        XCTAssertNil(snapshot.architectureMaximum)
+        XCTAssertEqual(snapshot.configuredMaximum, 3)
     }
 
     /// A capacity increase and the resulting queue admission happen on the


### PR DESCRIPTION
## Purpose

Expose the provenance OsaurusEvals needs to distinguish native batching from architecture-safe serialization.

Before this change, `BatchEngineCapacitySnapshot.configuredMaximum` contained only the post-clamp width. A caller requesting 2 on a model capped at 1 could observe effective 1 but could not report the requested width and architecture ceiling separately without model-name heuristics.

## Change

- `requestedMaximum`: the latest serving-layer request, retained even when the architecture cap means the effective width does not change.
- `architectureMaximum`: the model-declared hard limit, or nil for an uncapped architecture.
- `configuredMaximum`: unchanged behavior; documented as the effective post-clamp width.
- No scheduler, admission, cache, sampler, or model-forward behavior changes.

## Current-head verification

Head: `2a84b4d75ec301d1afed3bb2f8d90dec052bec7a`

Focused runtime tests: **2/2 passed**:
- capped model: request 3 -> architecture 1 -> effective 1; resize request 4 remains effective 1 while provenance updates;
- uncapped model: request/effective 2 then 3, architecture nil.

Log: `/private/tmp/vmlx-batch-capacity-provenance-focused.log`

The full `BatchEngineIntegrationTests` run built and executed 30 tests: 29 passed and one existing stochastic stop-reason assertion failed twice (`testUpdateMaxBatchSizeDoesNotWakeSchedulerDuringSoloFastPath`, observed `stop` vs expected `length`). This PR does not change generation or stop handling. The non-perfect result is disclosed rather than reported green.

Metal test setup used the pinned submodules and metallib SHA-256 `cffe8fbfa9cfb794f1d920ff187016f823a555f7814cede99026699a936b92c7`.

## Downstream gate

This is a telemetry dependency, not user-facing proof. The paired Osaurus PR must propagate all three fields into the production `spawn_batch` envelope and prove:

- dense native request 2 / architecture nil / effective 2 / observed `[2]`;
- DSV4 or QSA request 2 / architecture 1 / effective 1 / observed `[1,1]` limited by `engineCapacity`;
- missing/malformed provenance fails the strict eval contract;
- the DSV4 ~105 GB footprint remains an independent failure.

Until that downstream Release-app/eval evidence exists, the overall batching-truth lane remains PARTIAL.