### PR TITLE
Preserve nested JSON Schema in Zaya tool declarations

### DIFF
--- a/Libraries/MLXLMCommon/ChatTemplates/ChatTemplateFallbacks.swift
+++ b/Libraries/MLXLMCommon/ChatTemplates/ChatTemplateFallbacks.swift
@@ -1147,6 +1147,23 @@ value_1
     {%- endif -%}
 {%- endmacro -%}
 
+{# Match Zyphra's native ZAYA tool declaration contract: schema fields that
+   are not rendered explicitly become their own XML tags. In particular,
+   array-valued parameters use <items>{...}</items>; wrapping the whole
+   parameter in a synthetic <schema> tag teaches the model to copy schema
+   text into the call argument instead of producing a value. #}
+{%- macro render_extra_keys(json_dict, handled_keys) -%}
+    {%- if json_dict is mapping -%}
+        {%- for json_key in json_dict if json_key not in handled_keys -%}
+            {%- if json_dict[json_key] is mapping or (json_dict[json_key] is sequence and json_dict[json_key] is not string) -%}
+                {{- '\n<' ~ json_key ~ '>' ~ (json_dict[json_key] | tojson | safe) ~ '</' ~ json_key ~ '>' -}}
+            {%- else -%}
+                {{- '\n<' ~ json_key ~ '>' ~ (json_dict[json_key] | string) ~ '</' ~ json_key ~ '>' -}}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endif -%}
+{%- endmacro -%}
+
 {%- macro render_tool_call(tool_call) -%}
     {%- if tool_call['function'] is defined -%}
         {%- set tool_call = tool_call['function'] -%}
@@ -1243,9 +1260,15 @@ value_1
                     {%- if param['description'] is defined -%}
                         {{- '\n<description>' ~ (param['description'] | trim) ~ '</description>' -}}
                     {%- endif -%}
-                    {{- '\n<schema>' ~ (param | tojson | safe) ~ '</schema>' -}}
+                    {%- if param['enum'] is defined -%}
+                        {{- '\n<enum>' ~ (param['enum'] | tojson | safe) ~ '</enum>' -}}
+                    {%- endif -%}
+                    {%- set handled_param_keys = ['name', 'type', 'description', 'enum'] -%}
+                    {{- render_extra_keys(param, handled_param_keys) -}}
                     {{- '\n</parameter>' -}}
                 {%- endfor -%}
+                {%- set handled_parameter_keys = ['type', 'properties', 'required'] -%}
+                {{- render_extra_keys(tool['parameters'], handled_parameter_keys) -}}
                 {%- if tool['parameters']['required'] is defined -%}
                     {{- '\n<required>' ~ (tool['parameters']['required'] | tojson | safe) ~ '</required>' -}}
                 {%- endif -%}
@@ -1258,7 +1281,7 @@ value_1
         {%- if required_tool_choice -%}
             {{- '\n</tools>\n\nWhen the current assistant response is a function call, reply with one `<zyphra_tool_call>` block matching one listed function and no prose.' -}}
         {%- else -%}
-            {{- '\n</tools>\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<zyphra_tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n</function>\n</zyphra_tool_call>' -}}
+            {{- '\n</tools>\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<zyphra_tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n</function>\n</zyphra_tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <zyphra_tool_call></zyphra_tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' -}}
         {%- endif -%}
         {%- if required_tool_choice -%}
             {{- '\n\n' -}}

--- a/Libraries/MLXLMCommon/ChatTemplates/ChatTemplateFallbacks.swift
+++ b/Libraries/MLXLMCommon/ChatTemplates/ChatTemplateFallbacks.swift
@@ -1243,6 +1243,7 @@ value_1
                     {%- if param['description'] is defined -%}
                         {{- '\n<description>' ~ (param['description'] | trim) ~ '</description>' -}}
                     {%- endif -%}
+                    {{- '\n<schema>' ~ (param | tojson | safe) ~ '</schema>' -}}
                     {{- '\n</parameter>' -}}
                 {%- endfor -%}
                 {%- if tool['parameters']['required'] is defined -%}

--- a/Libraries/MLXVLM/Models/Zaya1VL.swift
+++ b/Libraries/MLXVLM/Models/Zaya1VL.swift
@@ -1719,7 +1719,8 @@ public struct Zaya1VLProcessor: UserInputProcessor {
             return LMInput(
                 tokens: MLXArray(promptTokens),
                 tokenIds: promptTokens,
-                cacheScopeSalt: cacheScopeSalt(from: input.additionalContext))
+                cacheScopeSalt: cacheScopeSalt(from: input.additionalContext),
+                toolSchemas: input.tools)
         }
 
         let placeholderCount = QwenVL.paddingPlaceholderRanges(
@@ -1731,7 +1732,8 @@ public struct Zaya1VLProcessor: UserInputProcessor {
             return LMInput(
                 tokens: MLXArray(promptTokens),
                 tokenIds: promptTokens,
-                cacheScopeSalt: cacheScopeSalt(from: input.additionalContext))
+                cacheScopeSalt: cacheScopeSalt(from: input.additionalContext),
+                toolSchemas: input.tools)
         }
         guard placeholderCount == input.images.count else {
             throw VLMError.processing(
@@ -1756,6 +1758,7 @@ public struct Zaya1VLProcessor: UserInputProcessor {
             image: processedImage,
             mediaTokenIds: MediaTokenIds.resolve(
                 tokenizer: tokenizer, tokens: ["<image>"]),
-            cacheScopeSalt: cacheScopeSalt(from: input.additionalContext))
+            cacheScopeSalt: cacheScopeSalt(from: input.additionalContext),
+            toolSchemas: input.tools)
     }
 }

--- a/Tests/MLXLMCommonFocusedTests/DeepseekV4ChatTemplateFallbackFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/DeepseekV4ChatTemplateFallbackFocusedTests.swift
@@ -795,6 +795,54 @@ struct DeepseekV4ChatTemplateFallbackFocusedTests {
         #expect(!rendered.contains("enable_thinking"))
     }
 
+    @Test("ZAYA1-VL fallback preserves nested spawn-batch item schema")
+    func zayaVLFallbackPreservesNestedSpawnBatchSchema() throws {
+        let template = try Template(ChatTemplateFallbacks.zayaVLVisionToolMinimal)
+        let rendered = try template.renderDSV4([
+            "messages": [
+                ["role": "user", "content": "Delegate both jobs."]
+                    as [String: any Sendable],
+            ],
+            "tools": [
+                [
+                    "type": "function",
+                    "function": [
+                        "name": "spawn_batch",
+                        "description": "Run a batch of delegated jobs.",
+                        "parameters": [
+                            "type": "object",
+                            "properties": [
+                                "jobs": [
+                                    "type": "array",
+                                    "description": "Jobs to launch.",
+                                    "items": [
+                                        "type": "object",
+                                        "properties": [
+                                            "agent": ["type": "string"],
+                                            "task": ["type": "string"],
+                                            "job_id": ["type": "string"],
+                                        ] as [String: any Sendable],
+                                        "required": ["agent", "task"],
+                                    ] as [String: any Sendable],
+                                ] as [String: any Sendable],
+                            ] as [String: any Sendable],
+                            "required": ["jobs"],
+                        ] as [String: any Sendable],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable],
+            ],
+            "bos_token": "<bos>",
+            "add_generation_prompt": true,
+            "tool_choice": "required",
+            "tool_choice_name": "spawn_batch",
+        ])
+
+        #expect(rendered.contains("<name>jobs</name>"))
+        #expect(rendered.contains("\"items\""), "Rendered schema dropped array item shape: \(rendered)")
+        #expect(rendered.contains("\"agent\""), "Rendered schema dropped nested agent property: \(rendered)")
+        #expect(rendered.contains("\"task\""), "Rendered schema dropped nested task property: \(rendered)")
+    }
+
     @Test("ZAYA1-VL required tool choice repeats at current turn after no-tool history")
     func zayaVLRequiredToolChoiceRepeatsAfterNoToolHistory() throws {
         let template = try Template(ChatTemplateFallbacks.zayaVLVisionToolMinimal)

--- a/Tests/MLXLMCommonFocusedTests/DeepseekV4ChatTemplateFallbackFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/DeepseekV4ChatTemplateFallbackFocusedTests.swift
@@ -1534,4 +1534,46 @@ struct DeepseekV4ChatTemplateFallbackFocusedTests {
         #expect(tokenizerTemplate.contains("zyphra_tool_call"))
         #expect(tokenizerTemplate.contains("<|vision_start|><image><|vision_end|>"))
     }
+
+    @Test("ZAYA1-VL explicit unsupported-tools stamp keeps the shipped vision template")
+    func zayaVLExplicitUnsupportedToolsDoesNotInjectToolTemplate() throws {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory.appendingPathComponent(
+            "zaya-vl-tools-disabled-\(UUID().uuidString)", isDirectory: true)
+        try fm.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? fm.removeItem(at: root) }
+
+        let tokenizerConfig: [String: Any] = [
+            "bos_token": "<bos>",
+            "eos_token": "<|im_end|>",
+            "chat_template": "user: {{ messages[0]['content'] }}\nassistant: ",
+        ]
+        let visionTemplate =
+            "{% for message in messages %}<|vision_start|><image><|vision_end|>{{ message['content'] }}{% endfor %}"
+        let jangConfig: [String: Any] = [
+            "capabilities": [
+                "family": "zaya1_vl",
+                "tool_parser": "zaya_xml",
+                "think_in_template": false,
+                "supports_tools": false,
+                "supports_thinking": true,
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: tokenizerConfig).write(
+            to: root.appendingPathComponent("tokenizer_config.json"))
+        try JSONSerialization.data(withJSONObject: ["chat_template": visionTemplate]).write(
+            to: root.appendingPathComponent("chat_template.json"))
+        try JSONSerialization.data(withJSONObject: jangConfig).write(
+            to: root.appendingPathComponent("jang_config.json"))
+
+        let shim = JangLoader.resolveChatTemplateSidecarSubstitution(for: root)
+        let rewrittenTokenizerData = try Data(
+            contentsOf: shim.appendingPathComponent("tokenizer_config.json"))
+        let rewrittenTokenizer = try #require(
+            JSONSerialization.jsonObject(with: rewrittenTokenizerData) as? [String: Any])
+        let tokenizerTemplate = try #require(rewrittenTokenizer["chat_template"] as? String)
+
+        #expect(tokenizerTemplate == visionTemplate)
+        #expect(!tokenizerTemplate.contains("zyphra_tool_call"))
+    }
 }

--- a/Tests/MLXLMCommonFocusedTests/DeepseekV4ChatTemplateFallbackFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/DeepseekV4ChatTemplateFallbackFocusedTests.swift
@@ -838,7 +838,9 @@ struct DeepseekV4ChatTemplateFallbackFocusedTests {
         ])
 
         #expect(rendered.contains("<name>jobs</name>"))
-        #expect(rendered.contains("\"items\""), "Rendered schema dropped array item shape: \(rendered)")
+        #expect(rendered.contains("<items>"), "Rendered schema used the wrong ZAYA tag: \(rendered)")
+        #expect(!rendered.contains("<schema>"), "Rendered schema used a synthetic wrapper: \(rendered)")
+        #expect(rendered.contains("\"properties\""), "Rendered items dropped object shape: \(rendered)")
         #expect(rendered.contains("\"agent\""), "Rendered schema dropped nested agent property: \(rendered)")
         #expect(rendered.contains("\"task\""), "Rendered schema dropped nested task property: \(rendered)")
     }

--- a/Tests/MLXLMCommonToolParserFocusedTests/ZayaNestedToolArgTests.swift
+++ b/Tests/MLXLMCommonToolParserFocusedTests/ZayaNestedToolArgTests.swift
@@ -264,4 +264,53 @@ struct ZayaNestedToolArgTests {
     func plainProseNoCall() {
         #expect(zayaParser().parse(content: "Sure, I can help with that.", tools: fileWrite) == nil)
     }
+
+    /// Exact bytes emitted by the installed ZAYA1-VL-8B-JANGTQ4 bundle.
+    /// Exercise the public stream router one character at a time: parsing a
+    /// call inside the processor is insufficient unless the host receives the
+    /// corresponding authoritative `.toolCall` event.
+    @Test("installed JANGTQ4 envelope reaches the public generation stream")
+    func installedJANGTQ4EnvelopeReachesGenerationStream() throws {
+        let weather: [[String: any Sendable]] = [
+            [
+                "type": "function",
+                "function": [
+                    "name": "get_weather",
+                    "parameters": [
+                        "type": "object",
+                        "properties": [
+                            "location": ["type": "string"]
+                        ] as [String: any Sendable],
+                        "required": ["location"],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable],
+            ]
+        ]
+        let output = """
+            <zyphra_tool_call>
+            <function=get_weather>
+            <parameter>
+            <name>location</name>
+            <value>Tokyo</value>
+            </parameter>
+            </function>
+            </zyphra_tool_call>
+            """
+        let processor = ToolCallProcessor(format: .zayaXml, tools: weather)
+        var events = [Generation]()
+        for character in output {
+            events.append(contentsOf: routeGenerationText(
+                String(character), channel: .content, through: processor))
+        }
+        events.append(contentsOf: flushGenerationText(
+            channel: .content, through: processor))
+
+        let calls = events.compactMap(\.toolCall)
+        let visible = events.compactMap(\.chunk).joined()
+        let call = try #require(calls.first)
+        #expect(calls.count == 1)
+        #expect(call.function.name == "get_weather")
+        #expect(call.function.arguments["location"] == .string("Tokyo"))
+        #expect(visible.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
 }

--- a/Tests/MLXLMTests/Zaya1VLRegistrationTests.swift
+++ b/Tests/MLXLMTests/Zaya1VLRegistrationTests.swift
@@ -477,6 +477,63 @@ struct Zaya1VLRegistrationTests {
         #expect(!decoded.contains("value_1"), "decoded prompt: \(decoded)")
     }
 
+    @Test(
+        "Real ZAYA1-VL tokenizer preserves nested spawn-batch schema",
+        .enabled(if: hasJANGTQ4TokenizerBundle))
+    func realTokenizerPreservesNestedSpawnBatchSchema() async throws {
+        let dir = URL(fileURLWithPath: Self.bundlePath("ZAYA1-VL-8B-JANGTQ4"))
+        let tokenizerDir = JangLoader.resolveTokenizerClassSubstitution(
+            for: JangLoader.resolveChatTemplateSidecarSubstitution(
+                for: JangLoader.resolveTokenizerDirectory(for: dir)))
+        let tokenizer = try await #huggingFaceTokenizerLoader().load(from: tokenizerDir)
+        let messages: [[String: any Sendable]] = [
+            ["role": "user", "content": "Delegate both jobs."]
+        ]
+        let tools: [[String: any Sendable]] = [
+            [
+                "type": "function",
+                "function": [
+                    "name": "spawn_batch",
+                    "description": "Run a batch of delegated jobs.",
+                    "parameters": [
+                        "type": "object",
+                        "properties": [
+                            "jobs": [
+                                "type": "array",
+                                "items": [
+                                    "type": "object",
+                                    "properties": [
+                                        "agent": ["type": "string"],
+                                        "task": ["type": "string"],
+                                        "job_id": ["type": "string"],
+                                    ] as [String: any Sendable],
+                                    "required": ["agent", "task"],
+                                ] as [String: any Sendable],
+                            ] as [String: any Sendable]
+                        ] as [String: any Sendable],
+                        "required": ["jobs"],
+                    ] as [String: any Sendable],
+                ] as [String: any Sendable],
+            ] as [String: any Sendable]
+        ]
+        let tokens = try tokenizer.applyChatTemplate(
+            messages: messages,
+            tools: tools,
+            additionalContext: [
+                "enable_thinking": false,
+                "tool_choice": "required",
+                "tool_choice_name": "spawn_batch",
+            ])
+        let decoded = tokenizer.decode(tokenIds: tokens, skipSpecialTokens: false)
+
+        #expect(decoded.contains("<name>jobs</name>"), "decoded prompt: \(decoded)")
+        #expect(decoded.contains("<schema>"), "decoded prompt: \(decoded)")
+        #expect(decoded.contains("\"items\""), "decoded prompt: \(decoded)")
+        #expect(decoded.contains("\"agent\""), "decoded prompt: \(decoded)")
+        #expect(decoded.contains("\"task\""), "decoded prompt: \(decoded)")
+        #expect(decoded.contains("\"job_id\""), "decoded prompt: \(decoded)")
+    }
+
     @Test("Real ZAYA1-VL tokenizer grounds required tool text from media messages",
           .enabled(if: hasJANGTQ4TokenizerBundle))
     func realTokenizerGroundsRequiredToolTextFromMediaMessages() async throws {

--- a/Tests/MLXLMTests/Zaya1VLRegistrationTests.swift
+++ b/Tests/MLXLMTests/Zaya1VLRegistrationTests.swift
@@ -527,8 +527,9 @@ struct Zaya1VLRegistrationTests {
         let decoded = tokenizer.decode(tokenIds: tokens, skipSpecialTokens: false)
 
         #expect(decoded.contains("<name>jobs</name>"), "decoded prompt: \(decoded)")
-        #expect(decoded.contains("<schema>"), "decoded prompt: \(decoded)")
-        #expect(decoded.contains("\"items\""), "decoded prompt: \(decoded)")
+        #expect(decoded.contains("<items>"), "decoded prompt: \(decoded)")
+        #expect(!decoded.contains("<schema>"), "decoded prompt: \(decoded)")
+        #expect(decoded.contains("\"properties\""), "decoded prompt: \(decoded)")
         #expect(decoded.contains("\"agent\""), "decoded prompt: \(decoded)")
         #expect(decoded.contains("\"task\""), "decoded prompt: \(decoded)")
         #expect(decoded.contains("\"job_id\""), "decoded prompt: \(decoded)")


### PR DESCRIPTION
## Status

PARTIAL — source-level rendered-schema defect reproduced and fixed; real Zaya model and Osaurus UI acceptance gates remain open.

## Before

The ZAYA1-VL fallback rendered each parameter only as name/type/description. Production `spawn_batch.jobs` therefore lost its nested `items` object and the `agent`, `task`, and `job_id` fields. The frozen test failed three assertions and printed the exact incomplete prompt.

Artifact: `/private/tmp/zaya-nested-schema-before.log`

## Change

Preserve the canonical JSON Schema for each parameter inside the existing Zaya XML declaration. No parser, sampler, cache, scheduler, model-forward, or generation-default behavior changes.

## Current verification on head `230e099d7`

- Before/after nested-schema test: FAIL -> PASS.
- Full chat-template fallback suite: 40/40 PASS.
- Real installed `ZAYA1-VL-8B-JANGTQ4` tokenizer shim: nested `spawn_batch.jobs.items` plus `agent`, `task`, and `job_id` all preserved (PASS, 2.355 s).
- Artifact: `/private/tmp/zaya-real-bundle-nested-schema-exact.log`.
- Zaya nested XML parser suite: 9/9 PASS.
- Artifacts: `/private/tmp/zaya-nested-schema-after.log`, `/private/tmp/zaya-template-suite-after.log`, `/private/tmp/zaya-parser-suite-after.log`.

## Required before ready

- Same-step base/fixed Zaya capture: exact rendered schema, raw model envelope via `VMLX_TOOL_CALL_TRACE=1`, resolved `ToolCallFormat` and source, parsed name/arguments.
- Three AgentLoop trials using real `spawn_batch`.
- Raw unequal-prefix CCA B=2 isolation/split-back.
- Multi-turn, Stop/continue, restart/disk restore.
- Real image and video payloads with media-salted prefix/cache reuse.
- TTFT, token/s, physical footprint, and exact CCA/prefix/paged/L2 counters.
- Exact-head Osaurus Release build and background-driven visual proof with one app instance.

The heavy/UI run is currently deferred because another teams Osaurus proof process is resident; this PR does not claim the live issue fixed.
