### PR TITLE
Stream DSV4 affine routed experts from exact SSD regions

### DIFF
--- a/Libraries/MLXLLM/Models/DeepseekV4.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV4.swift
@@ -1404,9 +1404,11 @@ public class DeepseekV4Model: Module, LLMModel, KVCacheDimensionProvider, LoRAMo
     public func configureSafetensorsModelDirectory(_ modelDirectory: URL) throws {
         try affineExpertCatalog.configure(
             modelDirectory: modelDirectory, layerCount: config.numHiddenLayers)
-        for (layerIndex, layer) in model.layers.enumerated() {
+        var moduleUpdates: [(String, Module)] = []
+        moduleUpdates.reserveCapacity(model.layers.count)
+        for layerIndex in model.layers.indices {
             let limit = config.swigluLimit
-            layer.mlp.switchMLP = AffineStreamingSwitchGLU(
+            let streamingSwitch = AffineStreamingSwitchGLU(
                 inputDims: config.hiddenSize,
                 hiddenDims: config.moeIntermediateSize,
                 numExperts: config.nRoutedExperts,
@@ -1421,7 +1423,19 @@ public class DeepseekV4Model: Module, LLMModel, KVCacheDimensionProvider, LoRAMo
                     DeepseekV4Math.dsv4ScoredSwiGLU(
                         gate: gate, up: up, scores: scores, limit: limit)
                 })
+            moduleUpdates.append((
+                "model.layers.\(layerIndex).mlp.switch_mlp",
+                streamingSwitch
+            ))
         }
+        // `switchMLP` is registered through `@ModuleInfo`; direct assignment
+        // after construction violates MLXNN's module-tree invariants and
+        // process-fatals in `ModuleInfo.set`. Replace the registered children
+        // through the supported tree update API before generic weight loading.
+        try update(
+            modules: ModuleChildren.unflattened(moduleUpdates),
+            verify: .none
+        )
         FileHandle.standardError.write(
             Data(
                 ("[DSV4AffineExperts] production path=exact-mmap-region "

--- a/Libraries/MLXLLM/Models/DeepseekV4.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV4.swift
@@ -130,7 +130,7 @@ class DeepseekV4RoPE: Module {
         if let e = tables[key], e.offset == offset, e.length == length {
             return (e.cos, e.sin)
         }
-        let positions = MLXArray(Int32(offset)..<Int32(offset + length)).asType(.float32)
+        let positions = MLXArray(Int32(offset) ..< Int32(offset + length)).asType(.float32)
         // positions: (L,), invFreq: (dim/2,) → angles: (L, dim/2)
         let angles = positions.expandedDimensions(axis: -1) * invFreq.expandedDimensions(axis: 0)
         let c = cos(angles)
@@ -154,7 +154,7 @@ class DeepseekV4RoPE: Module {
             return (e.cos, e.sin)
         }
         let positions =
-            MLXArray(Int32(0)..<Int32(count)).asType(.float32) * Float(stride)
+            MLXArray(Int32(0) ..< Int32(count)).asType(.float32) * Float(stride)
             + Float(base)
         let angles = positions.expandedDimensions(axis: -1) * invFreq.expandedDimensions(axis: 0)
         let c = cos(angles)
@@ -694,7 +694,7 @@ private enum DeepseekV4CompiledSelectorCache {
             let originalScores = sqrt(log1p(exp(logits)))
             let biasedScores = originalScores + bias
             let indices = argPartition(
-                -biasedScores, kth: topK - 1, axis: -1)[.ellipsis, 0..<topK]
+                -biasedScores, kth: topK - 1, axis: -1)[.ellipsis, 0 ..< topK]
                 .asType(.int32)
             var weights = takeAlong(originalScores, indices, axis: -1)
             if topK > 1 && normalize {
@@ -804,11 +804,33 @@ class DeepseekV4MoEGate: Module {
 
 // MARK: - MoE (SwitchGLU routed + shared expert)
 
+private protocol DeepseekV4RoutedSwitch: Module {
+    func dsv4Routed(
+        _ input: MLXArray, indices: MLXArray, preDownScores: MLXArray
+    ) -> MLXArray
+}
+
+extension SwitchGLU: DeepseekV4RoutedSwitch {
+    fileprivate func dsv4Routed(
+        _ input: MLXArray, indices: MLXArray, preDownScores: MLXArray
+    ) -> MLXArray {
+        callAsFunction(input, indices, preDownScores: preDownScores)
+    }
+}
+
+extension AffineStreamingSwitchGLU: DeepseekV4RoutedSwitch {
+    fileprivate func dsv4Routed(
+        _ input: MLXArray, indices: MLXArray, preDownScores: MLXArray
+    ) -> MLXArray {
+        routed(input, indices: indices, preDownScores: preDownScores)
+    }
+}
+
 class DeepseekV4MoE: Module, UnaryLayer {
     let config: DeepseekV4Configuration
     let layerIdx: Int
     let topK: Int
-    @ModuleInfo(key: "switch_mlp") var switchMLP: SwitchGLU
+    @ModuleInfo(key: "switch_mlp") var switchMLP: Module
     var gate: DeepseekV4MoEGate
     @ModuleInfo(key: "shared_experts") var sharedExperts: DeepseekV4MLP
     /// Python `_decode_moe_region` parity: one compiled region per layer
@@ -821,6 +843,9 @@ class DeepseekV4MoE: Module, UnaryLayer {
     private let regionLock = NSLock()
     private var moeDecodeRegion: DeepseekV4CompiledRegion? = nil
     fileprivate var moeRegionWarm = false
+    fileprivate var usesStreamingExperts: Bool {
+        switchMLP is AffineStreamingSwitchGLU
+    }
     init(config: DeepseekV4Configuration, layerIdx: Int) {
         self.config = config
         self.layerIdx = layerIdx
@@ -854,9 +879,11 @@ class DeepseekV4MoE: Module, UnaryLayer {
             swigluLimit: limit)
     }
 
-    fileprivate func moeMath(_ x: MLXArray, inputIds: MLXArray?) -> (y: MLXArray, indices: MLXArray) {
+    fileprivate func moeMath(_ x: MLXArray, inputIds: MLXArray?) -> (y: MLXArray, indices: MLXArray)
+    {
         let (indices, scores) = gate(x, inputIds: inputIds)
-        let routed = switchMLP(x, indices, preDownScores: scores)
+        let routed = (switchMLP as! any DeepseekV4RoutedSwitch).dsv4Routed(
+            x, indices: indices, preDownScores: scores)
         let y = DeepseekV4Math.addSharedExpertFP32(
             DeepseekV4Math.reduceRoutedExpertsFP32(routed),
             shared: sharedExperts(x), outputDType: x.dtype)
@@ -879,7 +906,7 @@ class DeepseekV4MoE: Module, UnaryLayer {
         // Hash layers without threaded ids fall back to eager (mirrors the
         // Python guard) so the trace never bakes the wrong gate variant.
         let ids = gate.isHashLayer ? inputIds : nil
-        if DeepseekV4Math.compileRegionsEnabled, !profileStages,
+        if DeepseekV4Math.compileRegionsEnabled, !usesStreamingExperts, !profileStages,
             x.dim(1) == 1, moeRegionWarm, !(gate.isHashLayer && ids == nil)
         {
             let region = deepseekV4CachedRegion(regionLock, &moeDecodeRegion) {
@@ -908,16 +935,21 @@ class DeepseekV4MoE: Module, UnaryLayer {
             guard profileStages else { return }
             MLX.eval(arrays)
             let now = CFAbsoluteTimeGetCurrent()
-            FileHandle.standardError.write(Data(String(format:
-                "[DSV4MoEProfile] layer=%d stage=%@ ms=%.3f\n",
-                layerIdx, name, (now - stageStart) * 1_000).utf8))
+            FileHandle.standardError.write(
+                Data(
+                    String(
+                        format:
+                            "[DSV4MoEProfile] layer=%d stage=%@ ms=%.3f\n",
+                        layerIdx, name, (now - stageStart) * 1_000
+                    ).utf8))
             stageStart = now
         }
 
         let (indices, scores) = gate(x, inputIds: ids)
         finishStage("gate", [indices, scores])
         JangPressCanonicalExpertAdvisor.shared.observe(layer: layerIdx, indices: indices)
-        let routed = switchMLP(x, indices, preDownScores: scores)
+        let routed = (switchMLP as! any DeepseekV4RoutedSwitch).dsv4Routed(
+            x, indices: indices, preDownScores: scores)
         var y = DeepseekV4Math.reduceRoutedExpertsFP32(routed)
         finishStage("routed", [y])
         finishStage("route_reduce", [y])
@@ -1067,7 +1099,8 @@ class DeepseekV4HyperHead: Module {
             weight: hcHeadRMSOnes.asType(.float32),
             eps: hcEps)
         let mixes = xNormed.matmul(fn.asType(.float32).transposed())  // (B, L, hcMult)
-        let pre = sigmoid(mixes * scale.asType(.float32) + base.asType(.float32))
+        let pre =
+            sigmoid(mixes * scale.asType(.float32) + base.asType(.float32))
             + MLXArray(hcEps)
         let xReshape = xFlat.reshaped(B, L, hcMult, hiddenSize)
         return (pre.asType(dtype).expandedDimensions(axis: -1) * xReshape).sum(axis: -2)
@@ -1129,9 +1162,13 @@ class DeepseekV4DecoderLayer: Module {
             guard profileStages else { return }
             MLX.eval(arrays)
             let now = CFAbsoluteTimeGetCurrent()
-            FileHandle.standardError.write(Data(String(format:
-                "[DSV4StageProfile] layer=%d stage=%@ ms=%.3f\n",
-                layerIdx, name, (now - stageStart) * 1_000).utf8))
+            FileHandle.standardError.write(
+                Data(
+                    String(
+                        format:
+                            "[DSV4StageProfile] layer=%d stage=%@ ms=%.3f\n",
+                        layerIdx, name, (now - stageStart) * 1_000
+                    ).utf8))
             stageStart = now
         }
         // ---- Attention HC ----
@@ -1179,7 +1216,7 @@ class DeepseekV4DecoderLayer: Module {
         // having run eager once (`moeRegionWarm`) so SwitchGLU's fused
         // gate+up cache — which evals — materializes before any trace.
         let ids = mlp.gate.isHashLayer ? inputIds : nil
-        if DeepseekV4Math.compileRegionsEnabled, !profileStages,
+        if DeepseekV4Math.compileRegionsEnabled, !mlp.usesStreamingExperts, !profileStages,
             h.dim(1) == 1, mlp.moeRegionWarm,
             !(mlp.gate.isHashLayer && ids == nil)
         {
@@ -1250,7 +1287,7 @@ public class DeepseekV4ModelInner: Module {
         self.config = config
         self._embedTokens.wrappedValue = Embedding(
             embeddingCount: config.vocabSize, dimensions: config.hiddenSize)
-        self.layers = (0..<config.numHiddenLayers).map {
+        self.layers = (0 ..< config.numHiddenLayers).map {
             DeepseekV4DecoderLayer(config: config, layerIdx: $0)
         }
         self._hcHead.wrappedValue = DeepseekV4HyperHead(config: config)
@@ -1331,7 +1368,9 @@ public class DeepseekV4ModelInner: Module {
 
 // MARK: - Outer model
 
-public class DeepseekV4Model: Module, LLMModel, KVCacheDimensionProvider, LoRAModel {
+public class DeepseekV4Model: Module, LLMModel, KVCacheDimensionProvider, LoRAModel,
+    SafetensorsLoadKeyExcluding, SafetensorsModelDirectoryConfigurable
+{
     /// The canonical SWA + CSA/HSA `DeepseekV4Cache` pool is path-dependent
     /// and has no B-wide wrapper. Preserve concurrent request queuing while
     /// decoding one DSV4 sequence at a time.
@@ -1341,15 +1380,54 @@ public class DeepseekV4Model: Module, LLMModel, KVCacheDimensionProvider, LoRAMo
     var config: DeepseekV4Configuration
     public var model: DeepseekV4ModelInner
     @ModuleInfo(key: "lm_head") var lmHead: Linear
+    private let affineExpertCatalog: AffineStreamingExpertCatalog
 
     public init(_ config: DeepseekV4Configuration) {
         self.config = config
+        self.affineExpertCatalog = AffineStreamingExpertCatalog(
+            numExperts: config.nRoutedExperts,
+            inputDims: config.hiddenSize,
+            hiddenDims: config.moeIntermediateSize,
+            layout: .deepseekV4PerExpert)
         // Single latent KV head per layer — report kvHeads as [1]*L so
         // the cache allocator sizes per-layer caches correctly.
         self.kvHeads = Array(repeating: 1, count: config.numHiddenLayers)
         self.model = DeepseekV4ModelInner(config: config)
         self._lmHead.wrappedValue = Linear(
             config.hiddenSize, config.vocabSize, bias: false)
+    }
+
+    public func excludeFromGenericSafetensorsLoad(key: String) -> Bool {
+        AffineStreamingExpertCatalog.isDeepseekV4RoutedTensorKey(key)
+    }
+
+    public func configureSafetensorsModelDirectory(_ modelDirectory: URL) throws {
+        try affineExpertCatalog.configure(
+            modelDirectory: modelDirectory, layerCount: config.numHiddenLayers)
+        for (layerIndex, layer) in model.layers.enumerated() {
+            let limit = config.swigluLimit
+            layer.mlp.switchMLP = AffineStreamingSwitchGLU(
+                inputDims: config.hiddenSize,
+                hiddenDims: config.moeIntermediateSize,
+                numExperts: config.nRoutedExperts,
+                layerIndex: layerIndex,
+                catalog: affineExpertCatalog,
+                cacheExpertLimit: max(config.numExpertsPerTok, 8),
+                prefillChunkSize: 4,
+                glue: { gate, up in
+                    DeepseekV4Math.dsv4SwiGLU(gate: gate, up: up, limit: limit)
+                },
+                scoredGlue: { gate, up, scores in
+                    DeepseekV4Math.dsv4ScoredSwiGLU(
+                        gate: gate, up: up, scores: scores, limit: limit)
+                })
+        }
+        FileHandle.standardError.write(
+            Data(
+                ("[DSV4AffineExperts] production path=exact-mmap-region "
+                    + "layers=\(config.numHiddenLayers) experts=\(config.nRoutedExperts) "
+                    + "top_k=\(config.numExpertsPerTok) cache_experts_per_layer="
+                    + "\(max(config.numExpertsPerTok, 8))\n").utf8))
     }
 
     /// Build per-layer caches.
@@ -1385,7 +1463,7 @@ public class DeepseekV4Model: Module, LLMModel, KVCacheDimensionProvider, LoRAMo
         let envMode = env["DSV4_KV_MODE"]?.lowercased()
         let mode: String = envMode ?? "sliding"
 
-        return (0..<config.numHiddenLayers).map { layerIdx in
+        return (0 ..< config.numHiddenLayers).map { layerIdx in
             switch mode {
             case "full", "tq":
                 return KVCacheSimple()
@@ -1634,7 +1712,7 @@ public class DeepseekV4Model: Module, LLMModel, KVCacheDimensionProvider, LoRAMo
         // and the in-tree `TurboQuantSwitchLinear` use `tq_packed` /
         // `tq_norms`. Rewrite the un-prefixed names so the
         // `@ParameterInfo` keys match. Layout-preserving rename only.
-        for layerIdx in 0..<config.numHiddenLayers {
+        for layerIdx in 0 ..< config.numHiddenLayers {
             for projName in ["gate_proj", "down_proj", "up_proj"] {
                 for (src, dst) in [("packed", "tq_packed"), ("norms", "tq_norms")] {
                     let from = "model.layers.\(layerIdx).mlp.switch_mlp.\(projName).\(src)"
@@ -1665,21 +1743,22 @@ public class DeepseekV4Model: Module, LLMModel, KVCacheDimensionProvider, LoRAMo
         // `model.layers.L.mlp.switch_mlp.{gate,down,up}_proj.{suffix}`.
         let suffixes = ["weight", "scales", "biases", "tq_packed", "tq_norms"]
         let streamJANGTQExperts = JANGTQStreamingExperts.isEnabled
-        for layerIdx in 0..<config.numHiddenLayers {
+        let streamAffineExperts = model.layers.first?.mlp.usesStreamingExperts == true
+        for layerIdx in 0 ..< config.numHiddenLayers {
             let prefix = "model.layers.\(layerIdx).mlp.experts"
             for projName in ["gate_proj", "down_proj", "up_proj"] {
                 for suffix in suffixes {
                     let first = "\(prefix).0.\(projName).\(suffix)"
                     guard out[first] != nil else { continue }
                     if streamJANGTQExperts && (suffix == "tq_packed" || suffix == "tq_norms") {
-                        for e in 0..<config.nRoutedExperts {
+                        for e in 0 ..< config.nRoutedExperts {
                             out.removeValue(
                                 forKey: "\(prefix).\(e).\(projName).\(suffix)")
                         }
                         continue
                     }
                     var tensors: [MLXArray] = []
-                    for e in 0..<config.nRoutedExperts {
+                    for e in 0 ..< config.nRoutedExperts {
                         let key = "\(prefix).\(e).\(projName).\(suffix)"
                         guard let t = out[key] else {
                             tensors = []
@@ -1687,13 +1766,13 @@ public class DeepseekV4Model: Module, LLMModel, KVCacheDimensionProvider, LoRAMo
                         }
                         tensors.append(t)
                     }
-                    if tensors.count == config.nRoutedExperts {
+                    if tensors.count == config.nRoutedExperts && !streamAffineExperts {
                         let stackedKey =
                             "model.layers.\(layerIdx).mlp.switch_mlp.\(projName).\(suffix)"
                         if out[stackedKey] == nil {
                             out[stackedKey] = stacked(tensors)
                         }
-                        for e in 0..<config.nRoutedExperts {
+                        for e in 0 ..< config.nRoutedExperts {
                             out.removeValue(
                                 forKey: "\(prefix).\(e).\(projName).\(suffix)")
                         }
@@ -1706,7 +1785,7 @@ public class DeepseekV4Model: Module, LLMModel, KVCacheDimensionProvider, LoRAMo
                 // prestacked bundles (DSV4-Flash JANGTQ_K, etc.) ship a
                 // single `mlp.switch_mlp.{proj}.tq_bits` per layer.
                 // Drop both regardless of which layout.
-                for e in 0..<config.nRoutedExperts {
+                for e in 0 ..< config.nRoutedExperts {
                     out.removeValue(
                         forKey: "\(prefix).\(e).\(projName).tq_bits")
                 }

--- a/Libraries/MLXLMCommon/AffineStreamingSwitchGLU.swift
+++ b/Libraries/MLXLMCommon/AffineStreamingSwitchGLU.swift
@@ -32,13 +32,17 @@ public enum AffineStreamingExpertError: Error, CustomStringConvertible {
     }
 }
 
-/// Header-only catalog for Qwen4's stacked native-affine expert tensors.
+/// Header-only catalog for stacked or per-expert native-affine routed tensors.
 ///
 /// The generic loader must exclude these tensors. At runtime this catalog maps
 /// one exact expert slice at a time with `mlx_array_new_mmap_file_region`, so a
-/// Metal command never receives the 512-expert backing buffer that caused the
-/// entire routed bank to become Wired Memory.
+/// Metal command never receives a full routed-expert backing buffer that would
+/// otherwise fault the entire bank into the process footprint.
 public final class AffineStreamingExpertCatalog: @unchecked Sendable {
+    public enum Layout: Sendable {
+        case qwen4Stacked
+        case deepseekV4PerExpert
+    }
     public enum Projection: String, CaseIterable, Sendable {
         case gate = "gate_proj"
         case up = "up_proj"
@@ -81,24 +85,34 @@ public final class AffineStreamingExpertCatalog: @unchecked Sendable {
         let bits: Int
     }
 
+    private enum ProjectionStorage: Sendable {
+        case stacked(ProjectionSpec)
+        case perExpert([ProjectionSpec])
+    }
+
     private struct LayerSpec: Sendable {
-        let gate: ProjectionSpec
-        let up: ProjectionSpec
-        let down: ProjectionSpec
+        let gate: ProjectionStorage
+        let up: ProjectionStorage
+        let down: ProjectionStorage
     }
 
     public let numExperts: Int
     public let inputDims: Int
     public let hiddenDims: Int
+    public let layout: Layout
 
     private let lock = NSLock()
     private var layers: [Int: LayerSpec] = [:]
     private var configuredDirectory: URL?
 
-    public init(numExperts: Int, inputDims: Int, hiddenDims: Int) {
+    public init(
+        numExperts: Int, inputDims: Int, hiddenDims: Int,
+        layout: Layout = .qwen4Stacked
+    ) {
         self.numExperts = numExperts
         self.inputDims = inputDims
         self.hiddenDims = hiddenDims
+        self.layout = layout
     }
 
     /// Exact key predicate used by Qwen4's generic-loader exclusion gate.
@@ -110,6 +124,21 @@ public final class AffineStreamingExpertCatalog: @unchecked Sendable {
             parts[0] == "language_model", parts[1] == "layers",
             Int(parts[2]) != nil, parts[3] == "mlp", parts[4] == "switch_mlp",
             ["gate_proj", "up_proj", "down_proj"].contains(String(parts[5])),
+            ["weight", "scales", "biases"].contains(String(parts[6]))
+        else { return false }
+        return true
+    }
+
+    /// Exact DSV4 affine routed-expert predicate. Shared experts, the router,
+    /// dense layers, attention, and JANGTQ tensors are deliberately excluded.
+    public static func isDeepseekV4RoutedTensorKey(_ originalKey: String) -> Bool {
+        var key = originalKey
+        if key.hasPrefix("model.") { key.removeFirst("model.".count) }
+        let parts = key.split(separator: ".", omittingEmptySubsequences: false)
+        guard parts.count == 7,
+            parts[0] == "layers", Int(parts[1]) != nil,
+            parts[2] == "ffn", parts[3] == "experts", Int(parts[4]) != nil,
+            ["w1", "w2", "w3"].contains(String(parts[5])),
             ["weight", "scales", "biases"].contains(String(parts[6]))
         else { return false }
         return true
@@ -138,6 +167,18 @@ public final class AffineStreamingExpertCatalog: @unchecked Sendable {
 
         func canonicalName(layer: Int, projection: Projection, suffix: String) -> String {
             "language_model.layers.\(layer).mlp.switch_mlp.\(projection.rawValue).\(suffix)"
+        }
+
+        func deepseekName(
+            layer: Int, expert: Int, projection: Projection, suffix: String
+        ) -> String {
+            let source: String
+            switch projection {
+            case .gate: source = "w1"
+            case .down: source = "w2"
+            case .up: source = "w3"
+            }
+            return "layers.\(layer).ffn.experts.\(expert).\(source).\(suffix)"
         }
 
         func locate(_ canonical: String) throws -> Region {
@@ -181,49 +222,76 @@ public final class AffineStreamingExpertCatalog: @unchecked Sendable {
                 dataOffset: descriptor.dataOffset, dataLength: descriptor.dataLength)
         }
 
-        func projectionSpec(layer: Int, projection: Projection) throws -> ProjectionSpec {
-            let weight = try locate(canonicalName(layer: layer, projection: projection, suffix: "weight"))
-            let scales = try locate(canonicalName(layer: layer, projection: projection, suffix: "scales"))
-            let biases = try locate(canonicalName(layer: layer, projection: projection, suffix: "biases"))
+        func projectionSpec(
+            layer: Int, expert: Int? = nil, projection: Projection
+        ) throws -> ProjectionSpec {
+            func name(_ suffix: String) -> String {
+                if let expert {
+                    return deepseekName(
+                        layer: layer, expert: expert, projection: projection, suffix: suffix)
+                }
+                return canonicalName(layer: layer, projection: projection, suffix: suffix)
+            }
+            let weight = try locate(name("weight"))
+            let scales = try locate(name("scales"))
+            let biases = try locate(name("biases"))
             let inFeatures = projection == .down ? hiddenDims : inputDims
             let outFeatures = projection == .down ? inputDims : hiddenDims
             let label = weight.name
+            let expertPrefix = expert == nil ? [numExperts] : []
             guard weight.dtype == .uint32, scales.dtype == .float16,
                 biases.dtype == .float16,
-                weight.shape.count == 3, scales.shape.count == 3,
+                weight.shape.count == expertPrefix.count + 2,
+                scales.shape.count == expertPrefix.count + 2,
                 biases.shape == scales.shape,
-                weight.shape[0] == numExperts, scales.shape[0] == numExperts,
-                weight.shape[1] == outFeatures, scales.shape[1] == outFeatures,
-                weight.shape[2] > 0, scales.shape[2] > 0
+                Array(weight.shape.prefix(expertPrefix.count)) == expertPrefix,
+                Array(scales.shape.prefix(expertPrefix.count)) == expertPrefix,
+                weight.shape[expertPrefix.count] == outFeatures,
+                scales.shape[expertPrefix.count] == outFeatures,
+                weight.shape.last! > 0, scales.shape.last! > 0
             else {
                 throw AffineStreamingExpertError.invalidTensor(
-                    label, "expected stacked U32 weight and matching F16 affine companions")
+                    label, "expected U32 weight and matching F16 affine companions")
             }
-            let packedBits = weight.shape[2].multipliedReportingOverflow(by: 32)
+            let packedBits = weight.shape.last!.multipliedReportingOverflow(by: 32)
             guard !packedBits.overflow, packedBits.partialValue % inFeatures == 0 else {
-                throw AffineStreamingExpertError.invalidTensor(label, "non-integral packed bit width")
+                throw AffineStreamingExpertError.invalidTensor(
+                    label, "non-integral packed bit width")
             }
             let bits = packedBits.partialValue / inFeatures
-            // MLX's native affine quantized kernels accept 2/4/8-bit packed
-            // weights. PLE's independent SSD row decoder supports odd widths,
-            // but routed matmul must reject those rather than reaching Metal.
-            guard [2, 4, 8].contains(bits),
-                inFeatures % scales.shape[2] == 0
+            // MLX's native affine Metal kernels support the complete packed
+            // width set below. DSV4 uses it per projection (including 3-bit
+            // gate tensors), so the catalog validates each expert tensor's
+            // exact geometry rather than imposing one bundle-wide width.
+            guard [1, 2, 3, 4, 5, 6, 8].contains(bits),
+                inFeatures % scales.shape.last! == 0
             else {
                 throw AffineStreamingExpertError.invalidTensor(
                     label, "unsupported bit width or affine group geometry")
             }
-            let groupSize = inFeatures / scales.shape[2]
+            let groupSize = inFeatures / scales.shape.last!
             return ProjectionSpec(
                 weight: weight, scales: scales, biases: biases,
                 groupSize: groupSize, bits: bits)
         }
 
         for layer in 0 ..< layerCount {
-            built[layer] = try LayerSpec(
-                gate: projectionSpec(layer: layer, projection: .gate),
-                up: projectionSpec(layer: layer, projection: .up),
-                down: projectionSpec(layer: layer, projection: .down))
+            switch layout {
+            case .qwen4Stacked:
+                built[layer] = try LayerSpec(
+                    gate: .stacked(projectionSpec(layer: layer, projection: .gate)),
+                    up: .stacked(projectionSpec(layer: layer, projection: .up)),
+                    down: .stacked(projectionSpec(layer: layer, projection: .down)))
+            case .deepseekV4PerExpert:
+                func all(_ projection: Projection) throws -> ProjectionStorage {
+                    .perExpert(
+                        try (0 ..< numExperts).map {
+                            try projectionSpec(layer: layer, expert: $0, projection: projection)
+                        })
+                }
+                built[layer] = try LayerSpec(
+                    gate: all(.gate), up: all(.up), down: all(.down))
+            }
         }
 
         lock.lock()
@@ -232,8 +300,10 @@ public final class AffineStreamingExpertCatalog: @unchecked Sendable {
         lock.unlock()
 
         let mappedBytes = shards.values.reduce(UInt64(0)) { $0 + $1.fileSize }
-        FileHandle.standardError.write(Data(
-            "[Qwen4AffineExperts] exact-region catalog ready layers=\(layerCount) experts=\(numExperts) files=\(shards.count) indexed_file_bytes=\(mappedBytes) cache=file-backed\n".utf8))
+        FileHandle.standardError.write(
+            Data(
+                "[AffineStreamingExperts] exact-region catalog ready layout=\(String(describing: layout)) layers=\(layerCount) experts=\(numExperts) files=\(shards.count) indexed_file_bytes=\(mappedBytes) cache=file-backed\n"
+                    .utf8))
     }
 
     public func loadExpert(layer: Int, expert: Int) throws -> ExpertArrays {
@@ -254,31 +324,58 @@ public final class AffineStreamingExpertCatalog: @unchecked Sendable {
             down: loadProjection(layerSpec.down, expert: expert))
     }
 
-    private func loadProjection(_ spec: ProjectionSpec, expert: Int) throws -> ProjectionArrays {
-        ProjectionArrays(
-            weight: try mapExpertRegion(spec.weight, expert: expert),
-            scales: try mapExpertRegion(spec.scales, expert: expert),
-            biases: try mapExpertRegion(spec.biases, expert: expert),
+    private func loadProjection(
+        _ storage: ProjectionStorage, expert: Int
+    ) throws -> ProjectionArrays {
+        let spec: ProjectionSpec
+        let slicesStacked: Bool
+        switch storage {
+        case .stacked(let value):
+            spec = value
+            slicesStacked = true
+        case .perExpert(let values):
+            guard expert < values.count else {
+                throw AffineStreamingExpertError.invalidExpert(layer: -1, expert: expert)
+            }
+            spec = values[expert]
+            slicesStacked = false
+        }
+        return ProjectionArrays(
+            weight: try mapRegion(spec.weight, expert: expert, slicesStacked: slicesStacked),
+            scales: try mapRegion(spec.scales, expert: expert, slicesStacked: slicesStacked),
+            biases: try mapRegion(spec.biases, expert: expert, slicesStacked: slicesStacked),
             groupSize: spec.groupSize,
             bits: spec.bits)
     }
 
-    private func mapExpertRegion(_ region: Region, expert: Int) throws -> MLXArray {
-        guard region.shape.first == numExperts,
-            region.dataLength % UInt64(numExperts) == 0
-        else {
-            throw AffineStreamingExpertError.invalidTensor(
-                region.name, "expert dimension does not divide payload")
+    private func mapRegion(
+        _ region: Region, expert: Int, slicesStacked: Bool
+    ) throws -> MLXArray {
+        let length: UInt64
+        let offset: UInt64
+        let shape: [Int]
+        if slicesStacked {
+            guard region.shape.first == numExperts,
+                region.dataLength % UInt64(numExperts) == 0
+            else {
+                throw AffineStreamingExpertError.invalidTensor(
+                    region.name, "expert dimension does not divide payload")
+            }
+            length = region.dataLength / UInt64(numExperts)
+            let offsetResult = UInt64(expert).multipliedReportingOverflow(by: length)
+            guard !offsetResult.overflow,
+                region.dataOffset <= UInt64.max - offsetResult.partialValue
+            else {
+                throw AffineStreamingExpertError.invalidTensor(
+                    region.name, "expert offset overflow")
+            }
+            offset = region.dataOffset + offsetResult.partialValue
+            shape = Array(region.shape.dropFirst())
+        } else {
+            length = region.dataLength
+            offset = region.dataOffset
+            shape = region.shape
         }
-        let length = region.dataLength / UInt64(numExperts)
-        let offsetResult = UInt64(expert).multipliedReportingOverflow(by: length)
-        guard !offsetResult.overflow,
-            region.dataOffset <= UInt64.max - offsetResult.partialValue
-        else {
-            throw AffineStreamingExpertError.invalidTensor(region.name, "expert offset overflow")
-        }
-        let offset = region.dataOffset + offsetResult.partialValue
-        let shape = Array(region.shape.dropFirst())
         var cShape = shape.map(Int32.init)
         var result = mlx_array_new()
         let rc = region.url.withUnsafeFileSystemRepresentation { path -> Int32 in
@@ -304,7 +401,8 @@ public final class AffineStreamingExpertCatalog: @unchecked Sendable {
         }
     }
 
-    private static func checkedByteCount(shape: [Int], dtype: DType, name: String) throws -> UInt64 {
+    private static func checkedByteCount(shape: [Int], dtype: DType, name: String) throws -> UInt64
+    {
         var count = UInt64(dtype.size)
         for dimension in shape {
             guard dimension >= 0 else {
@@ -338,6 +436,8 @@ public final class AffineStreamingSwitchGLU: Module {
     public let prefillChunkSize: Int
 
     private let catalog: AffineStreamingExpertCatalog
+    private let glue: ((MLXArray, MLXArray) -> MLXArray)?
+    private let scoredGlue: ((MLXArray, MLXArray, MLXArray) -> MLXArray)?
     private let lock = NSLock()
     private var cache: [Int: CachedExpert] = [:]
     private var accessClock: UInt64 = 0
@@ -349,7 +449,9 @@ public final class AffineStreamingSwitchGLU: Module {
         layerIndex: Int,
         catalog: AffineStreamingExpertCatalog,
         cacheExpertLimit: Int = 16,
-        prefillChunkSize: Int = 4
+        prefillChunkSize: Int = 4,
+        glue: ((MLXArray, MLXArray) -> MLXArray)? = nil,
+        scoredGlue: ((MLXArray, MLXArray, MLXArray) -> MLXArray)? = nil
     ) {
         self.inputDims = inputDims
         self.hiddenDims = hiddenDims
@@ -358,6 +460,8 @@ public final class AffineStreamingSwitchGLU: Module {
         self.catalog = catalog
         self.cacheExpertLimit = max(1, cacheExpertLimit)
         self.prefillChunkSize = max(1, prefillChunkSize)
+        self.glue = glue
+        self.scoredGlue = scoredGlue
         super.init()
     }
 
@@ -368,11 +472,21 @@ public final class AffineStreamingSwitchGLU: Module {
     }
 
     public func reduced(_ x: MLXArray, indices: MLXArray, scores: MLXArray) -> MLXArray {
+        let routed = routed(x, indices: indices, preDownScores: nil)
+        return (routed * scores[.ellipsis, .newAxis]).sum(axis: -2)
+    }
+
+    /// Exact routed output shaped like `SwitchGLU`: (..., topK, inputDims).
+    /// DSV4 passes `preDownScores` so route weighting happens in fp32 before
+    /// the quantized down projection, matching its checkpoint graph.
+    public func routed(
+        _ x: MLXArray, indices: MLXArray, preDownScores: MLXArray?
+    ) -> MLXArray {
         let totalTokens = x.size / inputDims
         let kSlots = indices.dim(-1)
         let xFlat = x.reshaped([totalTokens, inputDims])
         let indicesFlat = indices.reshaped([totalTokens, kSlots])
-        let scoresFlat = scores.reshaped([totalTokens, kSlots])
+        let scoresFlat = preDownScores?.reshaped([totalTokens, kSlots])
         var chunks: [MLXArray] = []
         chunks.reserveCapacity((totalTokens + prefillChunkSize - 1) / prefillChunkSize)
 
@@ -382,7 +496,7 @@ public final class AffineStreamingSwitchGLU: Module {
             let chunkIndices = indicesFlat[start ..< end, 0...]
             let ids = chunkIndices.reshaped([-1]).asArray(Int32.self).map(Int.init)
             guard !ids.isEmpty, ids.allSatisfy({ $0 >= 0 && $0 < numExperts }) else {
-                fatalError("[Qwen4AffineExperts] invalid routed IDs at layer \(layerIndex)")
+                fatalError("[AffineStreamingExperts] invalid routed IDs at layer \(layerIndex)")
             }
             let unique = Array(Set(ids)).sorted()
             let selected = unique.map { expert($0) }
@@ -390,7 +504,8 @@ public final class AffineStreamingSwitchGLU: Module {
             remap.reserveCapacity(unique.count)
             for (local, global) in unique.enumerated() { remap[global] = Int32(local) }
             let localIndices = MLXArray(
-                ids.map { remap[$0]! }, chunkIndices.shape).asType(.uint32)
+                ids.map { remap[$0]! }, chunkIndices.shape
+            ).asType(.uint32)
 
             func bank(
                 _ projection: (AffineStreamingExpertCatalog.ExpertArrays)
@@ -419,7 +534,14 @@ public final class AffineStreamingSwitchGLU: Module {
                 biases: bank({ $0.gate }, { $0.biases }), rhsIndices: localIndices,
                 transpose: true, groupSize: gate0.groupSize, bits: gate0.bits,
                 mode: .affine)
-            let activated = silu(gate) * up
+            let activated: MLXArray
+            if let scores = scoresFlat?[start ..< end, 0...], let scoredGlue {
+                activated = scoredGlue(gate, up, scores)
+            } else if let glue {
+                activated = glue(gate, up)
+            } else {
+                activated = silu(gate) * up
+            }
             let down = MLX.gatherQuantizedMM(
                 activated, bank({ $0.down }, { $0.weight }),
                 scales: bank({ $0.down }, { $0.scales }),
@@ -427,15 +549,13 @@ public final class AffineStreamingSwitchGLU: Module {
                 transpose: true, groupSize: down0.groupSize, bits: down0.bits,
                 mode: .affine)
             let routed = squeezed(down, axis: -2)
-            let reduced = (routed * scoresFlat[start ..< end, 0...][.ellipsis, .newAxis])
-                .sum(axis: -2)
-            MLX.eval(reduced)
-            chunks.append(reduced)
+            MLX.eval(routed)
+            chunks.append(routed)
             start = end
         }
 
         let result = chunks.count == 1 ? chunks[0] : concatenated(chunks, axis: 0)
-        return result.reshaped(x.shape)
+        return result.reshaped(Array(x.shape.dropLast()) + [kSlots, inputDims])
     }
 
     private func expert(_ index: Int) -> AffineStreamingExpertCatalog.ExpertArrays {
@@ -453,7 +573,7 @@ public final class AffineStreamingSwitchGLU: Module {
         do {
             loaded = try catalog.loadExpert(layer: layerIndex, expert: index)
         } catch {
-            fatalError("[Qwen4AffineExperts] \(error)")
+            fatalError("[AffineStreamingExperts] \(error)")
         }
 
         lock.lock()
@@ -472,8 +592,10 @@ public final class AffineStreamingSwitchGLU: Module {
         lock.unlock()
 
         if accessClock == 2 || accessClock % 256 == 0 {
-            FileHandle.standardError.write(Data(
-                "[Qwen4AffineExperts] layer=\(layerIndex) mapped_expert=\(index) cache=\(count)/\(cacheExpertLimit) backend=exact-mmap-region mode=affine\n".utf8))
+            FileHandle.standardError.write(
+                Data(
+                    "[AffineStreamingExperts] layer=\(layerIndex) mapped_expert=\(index) cache=\(count)/\(cacheExpertLimit) backend=exact-mmap-region mode=affine\n"
+                        .utf8))
         }
         return loaded
     }

--- a/Libraries/MLXLMCommon/AffineStreamingSwitchGLU.swift
+++ b/Libraries/MLXLMCommon/AffineStreamingSwitchGLU.swift
@@ -263,7 +263,7 @@ public final class AffineStreamingExpertCatalog: @unchecked Sendable {
             // width set below. DSV4 uses it per projection (including 3-bit
             // gate tensors), so the catalog validates each expert tensor's
             // exact geometry rather than imposing one bundle-wide width.
-            guard [1, 2, 3, 4, 5, 6, 8].contains(bits),
+            guard [2, 3, 4, 5, 6, 8].contains(bits),
                 inFeatures % scales.shape.last! == 0
             else {
                 throw AffineStreamingExpertError.invalidTensor(

--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -18,6 +18,15 @@ public extension SafetensorsLoadKeyExcluding {
     var requiresResidentSafetensorsWeights: Bool { false }
 }
 
+/// Lets a model configure file-backed runtime components before the generic
+/// safetensors loader decides which tensor keys to map into the model graph.
+/// Configuration is part of loading, not an optional post-load optimization:
+/// a model that excludes tensors must have a complete model-owned reader ready
+/// before those tensors are skipped.
+public protocol SafetensorsModelDirectoryConfigurable: AnyObject {
+    func configureSafetensorsModelDirectory(_ modelDirectory: URL) throws
+}
+
 private func isPreservedMTPWeightKey(_ key: String) -> Bool {
     let lower = key.lowercased()
     return lower.hasPrefix("mtp.")
@@ -170,6 +179,9 @@ public func loadWeights(
 
     // Resolve symlinks (mlxstudio uses symlinked model directories)
     let modelDirectory = modelDirectory.resolvingSymlinksInPath()
+    if let configurable = model as? any SafetensorsModelDirectoryConfigurable {
+        try configurable.configureSafetensorsModelDirectory(modelDirectory)
+    }
 
     // JANGTQ-native detection: `weight_format: "mxtq"` means the bundle
     // ships tq_packed/tq_norms tensors that should be consumed RAW by

--- a/Tests/MLXLMTests/AffineStreamingSwitchGLUTests.swift
+++ b/Tests/MLXLMTests/AffineStreamingSwitchGLUTests.swift
@@ -9,6 +9,38 @@ import Testing
 
 @Suite("native affine active-expert SSD routing", .serialized)
 struct AffineStreamingSwitchGLUTests {
+    private final class LoaderOrderingModel: Module, LanguageModel,
+        SafetensorsLoadKeyExcluding, SafetensorsModelDirectoryConfigurable
+    {
+        private(set) var configuredDirectory: URL?
+        private(set) var exclusionObservedConfiguration = true
+
+        var kvHeads: [Int] { [] }
+        var vocabularySize: Int { 1 }
+
+        func configureSafetensorsModelDirectory(_ modelDirectory: URL) throws {
+            configuredDirectory = modelDirectory.resolvingSymlinksInPath()
+        }
+
+        func excludeFromGenericSafetensorsLoad(key: String) -> Bool {
+            exclusionObservedConfiguration =
+                exclusionObservedConfiguration && configuredDirectory != nil
+            return true
+        }
+
+        func prepare(
+            _ input: LMInput, cache: [KVCache], windowSize: Int?
+        ) throws -> PrepareResult {
+            .tokens(input.text)
+        }
+
+        func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+            MLXArray.zeros([1, 1, 1])
+        }
+
+        func newCache(parameters: GenerateParameters?) -> [KVCache] { [] }
+    }
+
     private final class ConcurrentResults: @unchecked Sendable {
         private let lock = NSLock()
         private(set) var shapes: [[Int]] = []
@@ -93,16 +125,175 @@ struct AffineStreamingSwitchGLUTests {
         return Fixture(directory: directory, tensors: tensors)
     }
 
+    private func makeDeepseekFixture(
+        numExperts: Int = 4, dimensions: Int = 32
+    ) throws -> Fixture {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("dsv4-affine-streaming-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        func dense(expert: Int, projection: Int) -> MLXArray {
+            let values = (0 ..< dimensions * dimensions).map { index -> Float in
+                let centered = Float((index * 11 + expert * 19 + projection * 29) % 97) - 48
+                return centered / Float(180 + projection * 30)
+            }
+            return MLXArray(values, [dimensions, dimensions])
+        }
+
+        var tensors: [String: MLXArray] = [:]
+        for expert in 0 ..< numExperts {
+            for (projectionIndex, source) in ["w1", "w3", "w2"].enumerated() {
+                let bits = [3, 4, 2][projectionIndex]
+                let quantized = MLX.quantized(
+                    dense(expert: expert, projection: projectionIndex),
+                    groupSize: dimensions, bits: bits, mode: .affine)
+                let base = "layers.0.ffn.experts.\(expert).\(source)"
+                tensors[base + ".weight"] = quantized.wq
+                tensors[base + ".scales"] = quantized.scales.asType(.float16)
+                tensors[base + ".biases"] = quantized.biases!.asType(.float16)
+            }
+        }
+        MLX.eval(Array(tensors.values))
+
+        let shardName = "model.safetensors"
+        let shardURL = directory.appendingPathComponent(shardName)
+        try MLX.save(arrays: tensors, url: shardURL)
+        let saved = try Data(contentsOf: shardURL)
+        let oldHeaderLength = saved.prefix(8).withUnsafeBytes {
+            $0.loadUnaligned(as: UInt64.self).littleEndian
+        }
+        var header = saved.subdata(in: 8 ..< (8 + Int(oldHeaderLength)))
+        let padding = (4096 - ((8 + header.count) % 4096)) % 4096
+        header.append(Data(repeating: 0x20, count: padding))
+        var aligned = Data()
+        var newHeaderLength = UInt64(header.count).littleEndian
+        aligned.append(contentsOf: withUnsafeBytes(of: &newHeaderLength) { Array($0) })
+        aligned.append(header)
+        aligned.append(saved.suffix(from: 8 + Int(oldHeaderLength)))
+        try aligned.write(to: shardURL)
+        let index = [
+            "weight_map": Dictionary(
+                uniqueKeysWithValues: tensors.keys.map { ($0, shardName) })
+        ]
+        try JSONSerialization.data(withJSONObject: index, options: [.sortedKeys])
+            .write(to: directory.appendingPathComponent("model.safetensors.index.json"))
+        return Fixture(directory: directory, tensors: tensors)
+    }
+
     @Test("loader exclusion is exact and does not swallow shared experts")
     func exactLoaderExclusion() {
-        #expect(AffineStreamingExpertCatalog.isRoutedTensorKey(
-            "language_model.layers.4.mlp.switch_mlp.gate_proj.weight"))
-        #expect(AffineStreamingExpertCatalog.isRoutedTensorKey(
-            "model.language_model.layers.4.mlp.switch_mlp.down_proj.biases"))
-        #expect(!AffineStreamingExpertCatalog.isRoutedTensorKey(
-            "language_model.layers.4.mlp.shared_expert.gate_proj.weight"))
-        #expect(!AffineStreamingExpertCatalog.isRoutedTensorKey(
-            "language_model.layers.4.mlp.switch_mlp.gate_proj.tq_packed"))
+        #expect(
+            AffineStreamingExpertCatalog.isRoutedTensorKey(
+                "language_model.layers.4.mlp.switch_mlp.gate_proj.weight"))
+        #expect(
+            AffineStreamingExpertCatalog.isRoutedTensorKey(
+                "model.language_model.layers.4.mlp.switch_mlp.down_proj.biases"))
+        #expect(
+            !AffineStreamingExpertCatalog.isRoutedTensorKey(
+                "language_model.layers.4.mlp.shared_expert.gate_proj.weight"))
+        #expect(
+            !AffineStreamingExpertCatalog.isRoutedTensorKey(
+                "language_model.layers.4.mlp.switch_mlp.gate_proj.tq_packed"))
+        #expect(
+            AffineStreamingExpertCatalog.isDeepseekV4RoutedTensorKey(
+                "layers.4.ffn.experts.255.w2.weight"))
+        #expect(
+            !AffineStreamingExpertCatalog.isDeepseekV4RoutedTensorKey(
+                "layers.4.ffn.shared_experts.w2.weight"))
+        #expect(
+            !AffineStreamingExpertCatalog.isDeepseekV4RoutedTensorKey(
+                "layers.4.ffn.experts.255.w2.tq_packed"))
+    }
+
+    @Test("generic loader configures model-owned readers before excluding tensors")
+    func loaderConfiguresBeforeExclusion() throws {
+        let fixture = try makeDeepseekFixture(numExperts: 1)
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        let model = LoaderOrderingModel()
+
+        try loadWeights(modelDirectory: fixture.directory, model: model)
+
+        #expect(
+            model.configuredDirectory
+                == fixture.directory.resolvingSymlinksInPath())
+        #expect(model.exclusionObservedConfiguration)
+    }
+
+    @Test("DSV4 per-expert files preserve scored-before-down numerical order")
+    func deepseekPerExpertScoredParity() throws {
+        try MLXMetalTestLock.withLock {
+            let fixture = try makeDeepseekFixture()
+            defer { try? FileManager.default.removeItem(at: fixture.directory) }
+            let catalog = AffineStreamingExpertCatalog(
+                numExperts: 4, inputDims: 32, hiddenDims: 32,
+                layout: .deepseekV4PerExpert)
+            try catalog.configure(modelDirectory: fixture.directory, layerCount: 1)
+            let streaming = AffineStreamingSwitchGLU(
+                inputDims: 32, hiddenDims: 32, numExperts: 4, layerIndex: 0,
+                catalog: catalog, cacheExpertLimit: 2, prefillChunkSize: 1,
+                scoredGlue: { gate, up, scores in
+                    (silu(gate.asType(.float32)) * up.asType(.float32)
+                        * scores.asType(.float32)[.ellipsis, .newAxis, .newAxis])
+                        .asType(gate.dtype)
+                })
+
+            let input = (MLXArray(0 ..< 32).asType(.float32) / 64).reshaped([1, 1, 32])
+            let indices = MLXArray([Int32(3), Int32(1)], [1, 1, 2]).asType(.uint32)
+            let scores = MLXArray([Float(0.65), Float(0.35)], [1, 1, 2])
+            let actual = streaming.routed(
+                input, indices: indices, preDownScores: scores)
+
+            func bank(_ source: String, _ suffix: String) -> MLXArray {
+                stacked(
+                    (0 ..< 4).map {
+                        fixture.tensors["layers.0.ffn.experts.\($0).\(source).\(suffix)"]!
+                    }, axis: 0)
+            }
+            let expanded = expandedDimensions(input, axes: [-2, -3])
+            func project(_ source: String, _ value: MLXArray) -> MLXArray {
+                let bits = source == "w1" ? 3 : (source == "w2" ? 2 : 4)
+                return MLX.gatherQuantizedMM(
+                    value, bank(source, "weight"),
+                    scales: bank(source, "scales"), biases: bank(source, "biases"),
+                    rhsIndices: indices, transpose: true,
+                    groupSize: 32, bits: bits, mode: .affine)
+            }
+            let gate = project("w1", expanded)
+            let up = project("w3", expanded)
+            let activated =
+                (silu(gate.asType(.float32)) * up.asType(.float32)
+                * scores.asType(.float32)[.ellipsis, .newAxis, .newAxis]).asType(gate.dtype)
+            let expected = squeezed(project("w2", activated), axis: -2)
+            MLX.eval(actual, expected)
+
+            #expect(actual.shape == [1, 1, 2, 32])
+            #expect(MLX.allClose(actual, expected, rtol: 1e-5, atol: 1e-5).item(Bool.self))
+            #expect(streaming.cachedExpertCount == 2)
+        }
+    }
+
+    @Test("DSV4 catalog fails closed when one routed tensor is absent")
+    func deepseekIncompleteCatalogFailsClosed() throws {
+        let fixture = try makeDeepseekFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directory) }
+        let indexURL = fixture.directory.appendingPathComponent(
+            "model.safetensors.index.json")
+        let data = try Data(contentsOf: indexURL)
+        var index = try #require(
+            JSONSerialization.jsonObject(with: data) as? [String: Any])
+        var weightMap = try #require(index["weight_map"] as? [String: String])
+        let missing = "layers.0.ffn.experts.3.w2.biases"
+        #expect(weightMap.removeValue(forKey: missing) != nil)
+        index["weight_map"] = weightMap
+        try JSONSerialization.data(withJSONObject: index, options: [.sortedKeys])
+            .write(to: indexURL)
+
+        let catalog = AffineStreamingExpertCatalog(
+            numExperts: 4, inputDims: 32, hiddenDims: 32,
+            layout: .deepseekV4PerExpert)
+        #expect(throws: AffineStreamingExpertError.self) {
+            try catalog.configure(modelDirectory: fixture.directory, layerCount: 1)
+        }
     }
 
     @Test("exact expert regions preserve projection geometry")
@@ -148,7 +339,8 @@ struct AffineStreamingSwitchGLUTests {
                 biases: tensor(projection, "biases"), rhsIndices: indices,
                 transpose: true, groupSize: 32, bits: 4, mode: .affine)
         }
-        let activated = silu(project("gate_proj", expanded))
+        let activated =
+            silu(project("gate_proj", expanded))
             * project("up_proj", expanded)
         let routed = squeezed(project("down_proj", activated), axis: -2)
         let expected = (routed * scores[.ellipsis, .newAxis]).sum(axis: -2)
@@ -203,5 +395,26 @@ struct AffineStreamingSwitchGLUTests {
         #expect(last.gate.bits == 4)
         #expect(last.down.groupSize == 64)
         #expect(last.down.bits == 4)
+    }
+
+    @Test("optional real DSV4 bundle validates every per-expert affine descriptor")
+    func optionalRealDeepseekGeometry() throws {
+        guard let path = ProcessInfo.processInfo.environment["DSV4_REAL_MODEL"],
+            !path.isEmpty
+        else { return }
+        let catalog = AffineStreamingExpertCatalog(
+            numExperts: 256, inputDims: 4096, hiddenDims: 2048,
+            layout: .deepseekV4PerExpert)
+        try catalog.configure(
+            modelDirectory: URL(fileURLWithPath: path, isDirectory: true),
+            layerCount: 43)
+        let first = try catalog.loadExpert(layer: 0, expert: 0)
+        let last = try catalog.loadExpert(layer: 42, expert: 255)
+        #expect(first.gate.weight.shape[0] == 2048)
+        #expect(first.down.weight.shape[0] == 4096)
+        #expect([1, 2, 3, 4, 5, 6, 8].contains(first.gate.bits))
+        #expect([1, 2, 3, 4, 5, 6, 8].contains(last.down.bits))
+        #expect(first.gate.groupSize > 0)
+        #expect(last.down.groupSize > 0)
     }
 }

--- a/Tests/MLXLMTests/AffineStreamingSwitchGLUTests.swift
+++ b/Tests/MLXLMTests/AffineStreamingSwitchGLUTests.swift
@@ -412,8 +412,8 @@ struct AffineStreamingSwitchGLUTests {
         let last = try catalog.loadExpert(layer: 42, expert: 255)
         #expect(first.gate.weight.shape[0] == 2048)
         #expect(first.down.weight.shape[0] == 4096)
-        #expect([1, 2, 3, 4, 5, 6, 8].contains(first.gate.bits))
-        #expect([1, 2, 3, 4, 5, 6, 8].contains(last.down.bits))
+        #expect([2, 3, 4, 5, 6, 8].contains(first.gate.bits))
+        #expect([2, 3, 4, 5, 6, 8].contains(last.down.bits))
         #expect(first.gate.groupSize > 0)
         #expect(last.down.groupSize > 0)
     }

--- a/docs/DSV4_AFFINE_EXPERT_FOOTPRINT_2026_08_29.md
+++ b/docs/DSV4_AFFINE_EXPERT_FOOTPRINT_2026_08_29.md
@@ -1,9 +1,11 @@
 # DSV4 Affine Expert Footprint — 2026-08-29
 
-Status: **PARTIAL**. The causal source mechanism and a bounded exact-region
-implementation have source-test coverage. No production/live performance or
-footprint claim is accepted until the real DSV4 bundle completes the matrix
-below on the exact branch head.
+Status: **FAILED PERFORMANCE GATE / PARTIAL INVESTIGATION**. The causal source
+mechanism and exact-region implementation have source-test coverage, and the
+real bundle now loads and produces coherent multi-turn output without
+materializing the complete routed bank. However, the exact-region strategy is
+not production-viable: live decode fell to 0.08--0.75 token/s versus 13.68
+token/s on the resident path. No production/readiness claim is accepted.
 
 ## Before evidence
 
@@ -54,6 +56,53 @@ the DSV4 one-sequence architecture cap and separate from cache size.
   first and last expert regions mapped successfully.
 - DSV4 + affine neighboring suites: 31/31.
 
+The exact-head lifecycle correction also replaces the routed modules through
+MLXNN's supported `update(modules:)` tree operation. The first live attempt
+found that direct mutation of the `@ModuleInfo` property process-fataled at
+load; the corrected head loads the real bundle without that fatal. Focused
+tests remain 9/9 after the correction.
+
+## Live result on head `c09c7f28`
+
+Bundle:
+`/Users/eric/models/dealign.ai/DeepSeek-V4-Flash-0731-JANG-CRACK`
+
+- Catalog accepted all 43 x 256 expert layouts and excluded 99,072 routed
+  tensors from generic hydration.
+- Model load completed in 4.02 seconds.
+- Three consecutive chat turns completed coherently; the previous MLXNN
+  module-mutation fatal did not recur.
+- Decode rates were 0.08, 0.75, and 0.14 token/s.
+- The matched current resident-path OsaurusEvals row measured 13.6766 token/s
+  and 169.37 ms TTFT, but failed its independent RAM gate at 104,971.37 MB
+  peak physical footprint.
+
+Verdict: the exact-region prototype proves that the full-bank materialization
+is avoidable, but **fails the speed gate**. It synchronizes routed IDs back to
+the CPU in every routed layer, constructs compact projection banks dynamically,
+and forces evaluation before proceeding. With 43 routed layers, that destroys
+decode throughput. Increasing the per-layer mmap cache cannot remove those
+43 CPU/GPU synchronization boundaries.
+
+Artifact: `/private/tmp/dsv4-338-live-chat2.log`.
+
+## Layout constraint and next implementation boundary
+
+The 256 per-expert tensors for a layer/projection are not one contiguous
+safetensors region. They span 3--4 shards and have irregular offsets within
+those shards. Consequently, `mlx_array_new_mmap_file_region` cannot expose
+them as one ordinary `[experts, out, in]` array without copying or writing a
+prestacked overlay. A permanent overlay and per-token active SSD streaming are
+both outside the accepted product methodology.
+
+The next viable design must retain GPU-side routing and fused affine matmul.
+The concrete boundary under investigation is a shard-span/offset-addressed
+affine kernel: map a bounded number of file-backed spans, provide per-expert
+shard IDs and element offsets, and let Metal touch only the selected expert
+pages. It must prove that Metal/MLX does not pin or fault the complete backing
+spans. If that cannot be shown, this lane stays blocked rather than shipping
+the 0.08--0.75 token/s prototype.
+
 Artifacts:
 
 - `/private/tmp/dsv4-streaming-build-xcode.log`
@@ -62,6 +111,7 @@ Artifacts:
 - `/private/tmp/dsv4-streaming-loader-ordering.log`
 - `/private/tmp/dsv4-streaming-real-descriptor-tests3.log`
 - `/private/tmp/dsv4-streaming-broad-tests.log`
+- `/private/tmp/dsv4-338-live-chat2.log`
 
 ## Mandatory live gates
 

--- a/docs/DSV4_AFFINE_EXPERT_FOOTPRINT_2026_08_29.md
+++ b/docs/DSV4_AFFINE_EXPERT_FOOTPRINT_2026_08_29.md
@@ -33,7 +33,9 @@ the DSV4 one-sequence architecture cap and separate from cache size.
 - Exclude only exact DSV4 affine routed keys; shared experts, router,
   attention, cache, MTP, and JANGTQ tensors remain on their existing paths.
 - Map only the selected experts' exact file regions.
-- Preserve mixed 1/2/3/4/5/6/8-bit affine geometry per projection.
+- Preserve the MLX-native mixed 2/3/4/5/6/8-bit affine geometry per
+  projection. Reject 1-bit descriptors fail-closed; MLX's native affine
+  kernels do not support that width.
 - Preserve DSV4's required score-before-quantized-down ordering and fp32
   limited-SwiGLU operation.
 - Bound the mapping cache per layer; do not install a permanent stacked

--- a/docs/DSV4_AFFINE_EXPERT_FOOTPRINT_2026_08_29.md
+++ b/docs/DSV4_AFFINE_EXPERT_FOOTPRINT_2026_08_29.md
@@ -1,0 +1,83 @@
+# DSV4 Affine Expert Footprint — 2026-08-29
+
+Status: **PARTIAL**. The causal source mechanism and a bounded exact-region
+implementation have source-test coverage. No production/live performance or
+footprint claim is accepted until the real DSV4 bundle completes the matrix
+below on the exact branch head.
+
+## Before evidence
+
+The prior PR-head OsaurusEvals row completed two children through safe
+serialization (`[1,1]`, limited by `engineCapacity`) at 13.51 token/s and
+185 ms TTFT, but reported 104,993 MB peak physical footprint. Behavioral
+success does not waive that RAM failure.
+
+Header-only inspection of
+`dealign.ai/DeepSeek-V4-Flash-0731-JANG-CRACK` found:
+
+- 43 routed layers and 256 experts per layer;
+- 99,072 affine routed tensors across all `w1`, `w2`, and `w3`
+  weight/scale/bias components;
+- 93,952,409,600 routed bytes (87.5 GiB) across 102 shards;
+- mixed per-projection widths, including 3-bit `w1` tensors.
+
+Current `DeepseekV4Model.sanitize` renames every per-expert tensor and then
+constructs one lazy full-bank `stacked(tensors)` value for every
+layer/projection/suffix. The first routed evaluation can therefore materialize
+or fault essentially the complete 87.5 GiB expert bank. This is separate from
+the DSV4 one-sequence architecture cap and separate from cache size.
+
+## Candidate correction
+
+- Configure a model-owned header catalog before generic safetensors loading.
+- Exclude only exact DSV4 affine routed keys; shared experts, router,
+  attention, cache, MTP, and JANGTQ tensors remain on their existing paths.
+- Map only the selected experts' exact file regions.
+- Preserve mixed 1/2/3/4/5/6/8-bit affine geometry per projection.
+- Preserve DSV4's required score-before-quantized-down ordering and fp32
+  limited-SwiGLU operation.
+- Bound the mapping cache per layer; do not install a permanent stacked
+  overlay or enable JangPress.
+- Disable the whole-tail compiled region only for this dynamic expert path,
+  because CPU-resolved route IDs cannot be captured as constants. The speed
+  cost must be measured and is a release gate.
+
+## Current source verification
+
+- Xcode-toolchain build with tests: RC 0.
+- Affine streaming suite: 9/9, including mixed 3/4/2-bit scored-before-down
+  numerical parity, exact loader exclusion, production loader ordering, and
+  fail-closed rejection of an incomplete per-expert catalog.
+- Real-bundle descriptor validation: all 43 x 256 expert layouts accepted;
+  first and last expert regions mapped successfully.
+- DSV4 + affine neighboring suites: 31/31.
+
+Artifacts:
+
+- `/private/tmp/dsv4-streaming-build-xcode.log`
+- `/private/tmp/dsv4-streaming-build-final.log`
+- `/private/tmp/dsv4-streaming-focused-final.log`
+- `/private/tmp/dsv4-streaming-loader-ordering.log`
+- `/private/tmp/dsv4-streaming-real-descriptor-tests3.log`
+- `/private/tmp/dsv4-streaming-broad-tests.log`
+
+## Mandatory live gates
+
+Run only with no competing model/build process and one exact binary:
+
+1. Matched base vs branch prompt, generation config, cache settings, and
+   output limit.
+2. Load, TTFT, token/s, coherent output, stop reason, current/peak
+   `phys_footprint`, swap, compressor, and process survival.
+3. At least 10 turns with tool call -> tool result -> continuation.
+4. Stop mid-stream -> continue; no stale cache or endless Thinking state.
+5. Restart and disk restore with prefix/paged/L2 plus DSV4 companion cache
+   counters.
+6. Safe-serialized two-child eval (`[1,1]`, `engineCapacity`) with both child
+   outputs and parent final response.
+7. Release Osaurus app built from the exact downstream pin, visually driven
+   with expected permissions set to Always Allow.
+
+Fail the lane if footprint remains near full model size, token/s becomes
+unusable, output becomes incoherent, a length cap masks failure, or any cache
+or tool continuation result is missing.


### PR DESCRIPTION
## Status

**PARTIAL / DRAFT. Do not merge yet.** This PR addresses the source mechanism behind the measured DSV4 footprint runaway, but the exact current head still requires the real-bundle performance, memory, cache, AgentLoop, and Osaurus UI gates below.

## Before reproduction and causal trace

The prior PR-head DSV4 eval completed both children via safe serialization (`[1,1]`, limited by `engineCapacity`) at 13.51 tok/s and 185 ms TTFT, but measured **104,993 MB peak physical footprint**. That is a RAM failure, not a blocked row.

Header-only inspection of `dealign.ai/DeepSeek-V4-Flash-0731-JANG-CRACK` found 43 routed layers, 256 experts per layer, 99,072 affine routed tensors, and **93,952,409,600 bytes (87.5 GiB)** of routed expert tensors across 102 shards. `DeepseekV4Model.sanitize` stacked every per-expert tensor into full layer/projection banks; first routed evaluation could fault/materialize the complete bank.

## Candidate correction

- Configure a model-owned safetensors catalog before generic tensor exclusion.
- Fail closed if any required expert weight/scales/biases descriptor is absent or malformed.
- Exclude only exact `layers.L.ffn.experts.E.{w1,w2,w3}.{weight,scales,biases}` keys.
- Map selected experts by exact safetensors file region, preserving mixed 1/2/3/4/5/6/8-bit affine geometry.
- Preserve DSV4 score-before-down and fp32 limited-SwiGLU ordering.
- Bound the per-layer expert cache; no permanent prestacked overlay and no JangPress.
- Disable compiled regions only for this dynamic expert path; ordinary DSV4 and Qwen paths remain unchanged.

## Current exact-head verification

Head: `c6bd478d`

- Xcode-toolchain `swift build --build-tests`: RC 0.
- Focused affine streaming suite: **9/9**.
- Real-bundle descriptor validation: all **43 x 256** expert layouts accepted; first/last regions mapped.
- DSV4 plus neighboring affine suites: **31/31**.
- Tests include scored-before-down numerical parity, exact exclusion, bounded cache, concurrent region opens, production loader ordering, mixed widths, and fail-closed missing-tensor rejection.

Artifacts:

- `/private/tmp/dsv4-streaming-build-final.log`
- `/private/tmp/dsv4-streaming-focused-final.log`
- `/private/tmp/dsv4-streaming-loader-ordering.log`
- `/private/tmp/dsv4-streaming-real-descriptor-tests3.log`
- `/private/tmp/dsv4-streaming-broad-tests.log`
- `docs/DSV4_AFFINE_EXPERT_FOOTPRINT_2026_08_29.md`

## Mandatory remaining gates

1. Matched base vs branch live bundle: load, TTFT, tok/s, coherent output, stop reason, process survival, current/peak `phys_footprint`, swap/compressor.
2. Reject if footprint remains near full model size or SSD routing makes decode unusably slow.
3. Ten-turn tool loop, Stop mid-stream then continue, restart and disk-backed restore.
4. Prefix/paged/L2 and DSV4 companion-cache counters.
5. Safe-serialized two-child eval `[1,1]` with `engineCapacity`, both children, parent final response.
6. Exact downstream Osaurus Release build driven through the real UI with expected permissions set to Always Allow.

No production/readiness claim is made until those live gates pass on this exact head.

