### PR TITLE
Qwen3.8: recover tool parsing from legacy Hermes stamps

### DIFF
--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -439,13 +439,6 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
             return .xmlFunction
         }
 
-        // Qwen 3.8 Flash Next bundles dispatch as `qwen4_exp`. Their native
-        // template uses the same nested XML-function envelope and converters
-        // may stamp that contract as `tool_parser = "hermes"`.
-        if normalized.hasPrefix("qwen4_exp") || compact.hasPrefix("qwen4exp") {
-            return .xmlFunction
-        }
-
         // StepFun Step 3.5 / 3.7 templates advertise the XML function
         // envelope, but live Step 3.7 rows can emit schema-valid
         // `name({"arg": ...})` calls inside the reasoning rail.

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -633,7 +633,7 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
         switch n {
         // Qwen 3.5 / 3.6 family — XML-style <tool_call>…</tool_call>
         // (vLLM ecosystem names `qwen3_coder` / `qwen3_coder_xml` aliased here).
-        case "qwen", "qwen3", "qwen3_5", "qwen35", "qwen3_6", "qwen36", "hermes",
+        case "qwen", "qwen3", "qwen3_5", "qwen35", "qwen3_6", "qwen36",
             "qwen3_coder", "qwen3_coder_xml", "mimo", "mimo_v2", "mimo_v2_flash":
             return .xmlFunction
         // StepFun Step 3.5 / 3.7 parser aliases. JANG

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -643,11 +643,14 @@ public final class VLMModelFactory: ModelFactory {
             // bundles will stamp `chat.tool_calling.parser = "dsml"`.
             let chatStamped = ToolCallFormat.fromCapabilityName(
                 jangConfig?.chat?.toolCalling?.parser)
-            let jangStamped = ToolCallFormat.fromCapabilityName(
-                jangConfig?.capabilities?.toolParser)
+            let templateAwareJang = ParserResolution.toolCall(
+                capabilities: jangConfig?.capabilities,
+                modelType: baseConfig.modelType,
+                chatTemplate: chatTemplateText(modelDirectory: modelDirectory)
+            ).format
             mutableConfiguration.toolCallFormat =
                 chatStamped
-                ?? jangStamped
+                ?? templateAwareJang
                 ?? ToolCallFormat.infer(from: baseConfig.modelType)
         }
 

--- a/Tests/MLXLMTests/Qwen3ToolFormatTemplateDetectTests.swift
+++ b/Tests/MLXLMTests/Qwen3ToolFormatTemplateDetectTests.swift
@@ -111,17 +111,28 @@ struct Qwen3ToolFormatTemplateDetectTests {
         #expect(r.source == .modelTypeHeuristic)
     }
 
-    @Test("hermes-stamped qwen4_exp bundle recovers .xmlFunction via template")
+    @Test("hermes-stamped qwen4_exp bundle recovers .xmlFunction from its template")
     func hermesStampedQwen4ExpRecovers() {
         // Qwen3.8 Flash-Next bundles: model_type=qwen4_exp. The bad stamp
-        // falls through to the family heuristic, which agrees with the real
-        // template envelope: <function=/<parameter=>.
+        // falls through to the real template envelope: <function=/<parameter=>.
+        // Do not guess solely from model_type: a future qwen4_exp template may
+        // declare a different wire contract.
         let r = ParserResolution.toolCall(
             capabilities: JangCapabilities(toolParser: "hermes"),
             modelType: "qwen4_exp",
             chatTemplate: qwen3CoderTemplate)
         #expect(r.format == .xmlFunction)
-        #expect(r.source == .modelTypeHeuristic)
+        #expect(r.source == .chatTemplate)
+    }
+
+    @Test("hermes-stamped qwen4_exp without a template fails closed")
+    func hermesStampedQwen4ExpWithoutTemplateFailsClosed() {
+        let r = ParserResolution.toolCall(
+            capabilities: JangCapabilities(toolParser: "hermes"),
+            modelType: "qwen4_exp",
+            chatTemplate: nil)
+        #expect(r.format == nil)
+        #expect(r.source == .none)
     }
 
     @Test("hermes-stamped genuine Hermes-style instruct still lands .json")
@@ -172,6 +183,6 @@ struct Qwen3ToolFormatTemplateDetectTests {
             modelType: modelType,
             chatTemplate: template)
         #expect(resolved.format == .xmlFunction)
-        #expect(resolved.source == .modelTypeHeuristic)
+        #expect(resolved.source == .chatTemplate)
     }
 }

--- a/Tests/MLXLMTests/Qwen3ToolFormatTemplateDetectTests.swift
+++ b/Tests/MLXLMTests/Qwen3ToolFormatTemplateDetectTests.swift
@@ -17,6 +17,10 @@ import Testing
 ///   - Qwen/Qwen3-Coder-30B-A3B-Instruct (qwen3_moe):
 ///       <tool_call>\n<function=name>\n<parameter=key>\nvalue\n</parameter>\n</function>\n</tool_call>
 struct Qwen3ToolFormatTemplateDetectTests {
+    private static let installedFlashNextPath = ProcessInfo.processInfo.environment[
+        "VMLINUX_QWEN38_BUNDLE_ROOT"
+    ].map(URL.init(fileURLWithPath:))
+
     private let qwen3InstructTemplate = """
         You are a helpful assistant. For each function call return a json object \
         with function name and arguments within <tool_call></tool_call> XML tags:
@@ -109,15 +113,15 @@ struct Qwen3ToolFormatTemplateDetectTests {
 
     @Test("hermes-stamped qwen4_exp bundle recovers .xmlFunction via template")
     func hermesStampedQwen4ExpRecovers() {
-        // Qwen3.8 Flash-Next bundles: model_type=qwen4_exp, which the
-        // heuristic does not know — the bundle's own chat template (real
-        // envelope: <function=/<parameter=) is the ground truth.
+        // Qwen3.8 Flash-Next bundles: model_type=qwen4_exp. The bad stamp
+        // falls through to the family heuristic, which agrees with the real
+        // template envelope: <function=/<parameter=>.
         let r = ParserResolution.toolCall(
             capabilities: JangCapabilities(toolParser: "hermes"),
             modelType: "qwen4_exp",
             chatTemplate: qwen3CoderTemplate)
         #expect(r.format == .xmlFunction)
-        #expect(r.source == .chatTemplate)
+        #expect(r.source == .modelTypeHeuristic)
     }
 
     @Test("hermes-stamped genuine Hermes-style instruct still lands .json")
@@ -144,5 +148,30 @@ struct Qwen3ToolFormatTemplateDetectTests {
             #expect(r.format == .xmlFunction, "stamp '\(stamp)' must resolve")
             #expect(r.source == .jangStamped)
         }
+    }
+
+    @Test(
+        "installed legacy Flash-Next bundle resolves XML through its real metadata",
+        .enabled(if: Self.installedFlashNextPath != nil))
+    func installedLegacyFlashNextBundleResolves() throws {
+        let directory = try #require(Self.installedFlashNextPath)
+        let configData = try Data(contentsOf: directory.appendingPathComponent("config.json"))
+        let config = try #require(
+            JSONSerialization.jsonObject(with: configData) as? [String: Any])
+        let modelType = try #require(config["model_type"] as? String)
+        let jangConfig = try JangLoader.loadConfig(at: directory)
+        let template = try String(
+            contentsOf: directory.appendingPathComponent("chat_template.jinja"),
+            encoding: .utf8)
+
+        #expect(jangConfig.capabilities?.toolParser == "hermes")
+        #expect(modelType == "qwen4_exp")
+        #expect(template.contains("<function="))
+        let resolved = ParserResolution.toolCall(
+            capabilities: jangConfig.capabilities,
+            modelType: modelType,
+            chatTemplate: template)
+        #expect(resolved.format == .xmlFunction)
+        #expect(resolved.source == .modelTypeHeuristic)
     }
 }

--- a/Tests/MLXLMTests/ToolTests.swift
+++ b/Tests/MLXLMTests/ToolTests.swift
@@ -1227,11 +1227,12 @@ struct ToolTests {
         #expect(ToolCallFormat.infer(from: "qwen3_5_moe") == .xmlFunction)
         #expect(ToolCallFormat.infer(from: "QWEN3_5") == .xmlFunction)
 
-        // Qwen 3.8 Flash Next dispatches as qwen4_exp. An accidentally stamped
-        // `hermes` bundle must fall through to this family inference or its
-        // own template; `hermes` is not itself an XML-function alias.
-        #expect(ToolCallFormat.infer(from: "qwen4_exp") == .xmlFunction)
-        #expect(ToolCallFormat.infer(from: "QWEN4_EXP_TEXT") == .xmlFunction)
+        // Qwen 3.8 Flash Next dispatches as qwen4_exp, but model_type alone
+        // does not define its tool wire contract. An accidentally stamped
+        // `hermes` bundle must recover from its own template; without that
+        // evidence both the model-type and capability guesses fail closed.
+        #expect(ToolCallFormat.infer(from: "qwen4_exp") == nil)
+        #expect(ToolCallFormat.infer(from: "QWEN4_EXP_TEXT") == nil)
         #expect(ToolCallFormat.fromCapabilityName("hermes") == nil)
 
         // Mistral3 models (prefix matching)

--- a/Tests/MLXLMTests/ToolTests.swift
+++ b/Tests/MLXLMTests/ToolTests.swift
@@ -1227,11 +1227,12 @@ struct ToolTests {
         #expect(ToolCallFormat.infer(from: "qwen3_5_moe") == .xmlFunction)
         #expect(ToolCallFormat.infer(from: "QWEN3_5") == .xmlFunction)
 
-        // Qwen 3.8 Flash Next dispatches as qwen4_exp and converter bundles
-        // stamp the same XML-function contract with the Hermes alias.
+        // Qwen 3.8 Flash Next dispatches as qwen4_exp. An accidentally stamped
+        // `hermes` bundle must fall through to this family inference or its
+        // own template; `hermes` is not itself an XML-function alias.
         #expect(ToolCallFormat.infer(from: "qwen4_exp") == .xmlFunction)
         #expect(ToolCallFormat.infer(from: "QWEN4_EXP_TEXT") == .xmlFunction)
-        #expect(ToolCallFormat.fromCapabilityName("hermes") == .xmlFunction)
+        #expect(ToolCallFormat.fromCapabilityName("hermes") == nil)
 
         // Mistral3 models (prefix matching)
         #expect(ToolCallFormat.infer(from: "mistral3") == .mistral)


### PR DESCRIPTION
## Status
PARTIAL: source and exact installed-bundle metadata resolution are proven. A Release-app tool call with the affected bundle is still required before merge.

## Before
Published Qwen3.8 bundles could carry capabilities.tool_parser = hermes. Current main also globally treated hermes as the Qwen XML parser, while the parser contract documents real Hermes as JSON inside tool_call tags. VLMModelFactory bypassed ParserResolution and therefore could not use the bundle template to recover ambiguous or bad stamps.

Affected installed fixture:
- /Users/eric/models/JANGQ-AI/Qwen3.8-Flash-Next-JANG_4M-aligned
- model_type: qwen4_exp
- stamped parser: hermes
- real template: nested function/parameter XML

## Fix
- Stop treating hermes as a global XML-function alias.
- Let bad stamps fall through to model-type or template inference.
- Route VLMModelFactory through the same template-aware ParserResolution used by LLMModelFactory.
- Preserve genuine Hermes JSON templates as json.

## Current-head proof
Head: 92d1931d

Focused suite: 11/11 PASS.
Artifact: /private/tmp/qwen38-hermes-template-aware-tests3.log

Exact installed-bundle metadata row: PASS. JangLoader read the real embedded hermes stamp, qwen4_exp model type, and XML template, then resolved xmlFunction from modelTypeHeuristic.
Artifact: /private/tmp/qwen38-real-bundle-parser-resolution.log

## Remaining merge gate
Build Osaurus Release with this exact vMLX head, confirm one process and binary hash, select the affected installed bundle, approve expected harness permission prompts with Always Allow, and prove tool call -> tool result -> continued answer in the visible UI with no marker leakage. Capture DB/log/parser-source evidence, TTFT, tok/s, cache counters, stop reason, and physical footprint. HTTP-only evidence is not accepted.