### PR TITLE
Make AgenticTaskBench safe and production-truthful

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -907,6 +907,7 @@ let package = Package(
                 "VMLXServerRuntimeSettingsTests.swift",
                 "VMLXMemorySafetySettingsTests.swift",
                 "DSV4AgenticToolSourceTests.swift",
+                "AgenticTaskBenchConfinementFocusedTests.swift",
                 "NoHiddenReasoningCloseBiasFocusedTests.swift",
                 "MinimumReasoningFloorFocusedTests.swift",
                 "TokenizerAddedTokenRegexFocusedTests.swift",

--- a/RunBench/AgenticTaskBench.swift
+++ b/RunBench/AgenticTaskBench.swift
@@ -2,7 +2,12 @@
 // SPDX-License-Identifier: MIT
 
 import Foundation
+import MLX
 import MLXLMCommon
+
+#if canImport(Darwin)
+import Darwin
+#endif
 
 /// Real-world agentic tasks with filesystem/sqlite-verified outcomes, run
 /// IN-PROCESS against the shipping bundle.
@@ -20,6 +25,65 @@ import MLXLMCommon
 /// step poisons the rest, a needle in a long file, a folder that starts broken,
 /// and cases where the correct action is to not act.
 public enum AgenticTaskBench {
+
+    /// Owns the process from the watchdog's `@Sendable` closure and records
+    /// whether the wall-clock limit actually fired.  The process is placed in
+    /// its own group before the watchdog is armed so a command such as
+    /// `find /` cannot survive as an orphan after its shell is terminated.
+    private final class ShellWatchdog: @unchecked Sendable {
+        private let lock = NSLock()
+        private let process: Process
+        private(set) var timedOut = false
+
+        init(process: Process) {
+            self.process = process
+        }
+
+        func fire() {
+            lock.lock()
+            defer { lock.unlock() }
+            guard process.isRunning else { return }
+            timedOut = true
+            #if canImport(Darwin)
+            _ = Darwin.kill(-process.processIdentifier, SIGTERM)
+            #else
+            process.terminate()
+            #endif
+        }
+
+        func didTimeOut() -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return timedOut
+        }
+    }
+
+    private static func sandboxEscaped(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+
+    /// macOS seatbelt profile for the benchmark shell.  Commands may execute
+    /// normal system binaries, but reads of the user's home/temp trees and all
+    /// writes are denied unless they target this task's fixture directory.
+    /// This is an eval-integrity boundary: setting only `cwd` does not confine
+    /// absolute paths, `..`, subprocesses, or shell redirections.
+    private static func shellSandboxProfile(taskDirectory: URL) -> String {
+        let task = sandboxEscaped(taskDirectory.resolvingSymlinksInPath().path)
+        let home = sandboxEscaped(URL(fileURLWithPath: NSHomeDirectory())
+            .resolvingSymlinksInPath().path)
+        let temporary = sandboxEscaped(URL(fileURLWithPath: NSTemporaryDirectory())
+            .resolvingSymlinksInPath().path)
+        return """
+        (version 1)
+        (allow default)
+        (deny file-write*)
+        (allow file-write* (subpath "\(task)") (literal "/dev/null"))
+        (deny file-read* (subpath "\(home)") (subpath "\(temporary)"))
+        (allow file-read* (subpath "\(task)"))
+        """
+    }
 
     struct Task: @unchecked Sendable {
         let id: String
@@ -158,20 +222,44 @@ public enum AgenticTaskBench {
         case "run_shell":
             guard let command = str("command") else { return "error: missing command" }
             let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/bin/bash")
-            process.arguments = ["-lc", command]
+            #if os(macOS)
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/sandbox-exec")
+            process.arguments = [
+                "-p", shellSandboxProfile(taskDirectory: dir),
+                "/bin/bash", "-c", command,
+            ]
+            #else
+            return "error: run_shell benchmark confinement is unavailable on this platform"
+            #endif
             process.currentDirectoryURL = dir
-            let out = Pipe()
-            let err = Pipe()
-            process.standardOutput = out
-            process.standardError = err
+            var environment = ProcessInfo.processInfo.environment
+            environment["HOME"] = dir.path
+            environment["TMPDIR"] = dir.path
+            process.environment = environment
+            let output = Pipe()
+            process.standardOutput = output
+            process.standardError = output
             do { try process.run() } catch { return "error: \(error.localizedDescription)" }
-            let outData = out.fileHandleForReading.readDataToEndOfFile()
-            let errData = err.fileHandleForReading.readDataToEndOfFile()
+
+            #if canImport(Darwin)
+            _ = Darwin.setpgid(process.processIdentifier, process.processIdentifier)
+            #endif
+            let watchdog = ShellWatchdog(process: process)
+            let timeoutSeconds = ProcessInfo.processInfo.environment[
+                "BENCH_AGENT_SHELL_TIMEOUT_SECONDS"
+            ].flatMap(Double.init) ?? 10
+            let timeoutWork = DispatchWorkItem { watchdog.fire() }
+            DispatchQueue.global().asyncAfter(
+                deadline: .now() + max(0.1, timeoutSeconds), execute: timeoutWork)
+
+            let data = output.fileHandleForReading.readDataToEndOfFile()
             process.waitUntilExit()
-            var text = String(data: outData, encoding: .utf8) ?? ""
-            let errText = String(data: errData, encoding: .utf8) ?? ""
-            if !errText.isEmpty { text += "\n[stderr] " + errText }
+            timeoutWork.cancel()
+            var text = String(data: data, encoding: .utf8) ?? ""
+            if watchdog.didTimeOut() {
+                text += "\n[terminated: shell command exceeded "
+                    + String(format: "%.1f", timeoutSeconds) + " seconds]"
+            }
             if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 text = "(no output, exit \(process.terminationStatus))"
             }
@@ -631,18 +719,37 @@ public enum AgenticTaskBench {
         let thinking = (ProcessInfo.processInfo.environment["BENCH_AGENT_THINK"] ?? "0") == "1"
         let verbose = (ProcessInfo.processInfo.environment["BENCH_AGENT_VERBOSE"] ?? "0") == "1"
         // Two knobs for attributing a failure to PROMPT or SAMPLING rather than
-        // weights: swap the system message, or leave greedy for the bundle's own
-        // sampling defaults. Both are "can we fix this without a retrain?" tests.
+        // weights.  With no explicit sampler override, the exact bundle
+        // generation config is authoritative; the old harness silently forced
+        // temperature 0 and therefore did not score the artifact users run.
         let systemOverride = ProcessInfo.processInfo.environment["BENCH_AGENT_SYSTEM"]
-        let temperature = ProcessInfo.processInfo.environment["BENCH_AGENT_TEMP"]
-            .flatMap(Float.init) ?? 0
+        let explicitTemperature = ProcessInfo.processInfo.environment["BENCH_AGENT_TEMP"]
+            .flatMap(Float.init)
+        let seed = ProcessInfo.processInfo.environment["BENCH_AGENT_SEED"]
+            .flatMap(UInt64.init) ?? 42
 
         print("=== Agentic task bench (real tasks, filesystem-verified) ===")
         print("model: \(modelDir.lastPathComponent)  maxSteps=\(maxSteps)  thinking=\(thinking)")
 
         let context = try await VLBench.loadProductionContext(from: modelDir)
-        let params = GenerateParameters(
-            maxTokens: maxNewTokens, temperature: temperature, prefillStepSize: 512)
+        let fallback = GenerateParameters(
+            maxTokens: maxNewTokens,
+            temperature: 0,
+            topP: 1,
+            topK: 0,
+            minP: 0,
+            randomSeed: seed,
+            repetitionPenalty: nil,
+            prefillStepSize: 512)
+        var params = GenerateParameters(
+            generationConfig: context.configuration.generationDefaults,
+            fallback: fallback)
+        params.maxTokens = maxNewTokens
+        params.prefillStepSize = 512
+        params.randomSeed = seed
+        if let explicitTemperature {
+            params.temperature = explicitTemperature
+        }
         nonisolated(unsafe) let ctx = context
         let engine = BatchEngine(context: ctx, maxBatchSize: 1)
 
@@ -651,7 +758,12 @@ public enum AgenticTaskBench {
             + "real files. Do exactly what is asked — no more. When the task is done, reply "
             + "with a one-line summary and stop."
         let system = Chat.Message.system(systemOverride ?? defaultSystem)
-        print("  system: \(systemOverride == nil ? "default" : "OVERRIDE") temp=\(temperature)")
+        print(
+            "  system: \(systemOverride == nil ? "default" : "OVERRIDE")"
+                + " sampling=\(explicitTemperature == nil ? "bundle-defaults" : "temperature-override")"
+                + " seed=\(seed) temp=\(params.temperature) topP=\(params.topP)"
+                + " topK=\(params.topK) minP=\(params.minP)"
+                + " repetitionPenalty=\(params.repetitionPenalty.map { String($0) } ?? "nil")")
 
         var outcomes: [Outcome] = []
         let root = URL(fileURLWithPath: NSTemporaryDirectory())
@@ -774,6 +886,19 @@ public enum AgenticTaskBench {
             print(String(
                 format: "  [%@] %@  steps=%d calls=%d %.1fs %@",
                 task.id, passed ? "PASS" : "FAIL", steps, totalCalls, seconds, note))
+
+            // Cases are independent fixtures.  Do not let MLX allocator-pool
+            // residue from an earlier case inflate later cases or the suite's
+            // physical-footprint gate.  Active bytes are reported separately:
+            // if they grow, that is a real engine/request-lifecycle leak and
+            // must not be hidden by clearing reusable allocator cache.
+            let activeBeforeClear = MLX.Memory.activeMemory
+            let cachedBeforeClear = MLX.Memory.cacheMemory
+            MLX.Memory.clearCache()
+            print(
+                "      memory activeBytes=\(activeBeforeClear)"
+                    + " allocatorCacheBefore=\(cachedBeforeClear)"
+                    + " allocatorCacheAfter=\(MLX.Memory.cacheMemory)")
         }
 
         // Summary by tier, then overall — the shape the comparison table needs.

--- a/RunBench/Bench.swift
+++ b/RunBench/Bench.swift
@@ -640,6 +640,14 @@ struct Bench {
             return
         }
 
+        // AgenticTaskBench owns a production-tokenizer context.  It must run
+        // before the legacy pre-tokenized context below: loading both used to
+        // double model residency and made every agentic RAM score false.
+        if (env["BENCH_AGENTIC_TASKS"] ?? "0") == "1" {
+            try await AgenticTaskBench.run(modelPath: modelPath, maxNewTokens: maxNew)
+            return
+        }
+
         print("=== vmlx-swift-lm — \(modelDir.lastPathComponent) MULTI-TURN ===")
         print("Tokens: \(tokensPath)")
         print("Loading...")
@@ -934,15 +942,6 @@ struct Bench {
         // on/off/on, tools none/offered/called/withdrawn, reasoning+tools in
         // one turn, tool-result feedback, grow control, verbatim replay — are
         // all crossed.
-        // BENCH_AGENTIC_TASKS=1: real-world agentic tasks with filesystem
-        // verification (the DGX harness's tiers 2-5, run in-process against the
-        // shipping bundle instead of over HTTP). BENCH_AGENT_FILTER selects a
-        // subset, BENCH_AGENT_THINK=1 runs them with reasoning on.
-        if (env["BENCH_AGENTIC_TASKS"] ?? "0") == "1" {
-            try await AgenticTaskBench.run(modelPath: modelPath, maxNewTokens: maxNew)
-            return
-        }
-
         if (env["BENCH_TEXT_VARIATING"] ?? "0") == "1" {
             try await VLBench.runVariatingTextPattern(
                 modelPath: modelPath, maxNewTokens: maxNew)

--- a/Tests/MLXLMCommonFocusedTests/AgenticTaskBenchConfinementFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/AgenticTaskBenchConfinementFocusedTests.swift
@@ -1,0 +1,71 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import Testing
+
+@Suite("Agentic task benchmark shell confinement")
+struct AgenticTaskBenchConfinementFocusedTests {
+    private func source() throws -> String {
+        try String(
+            contentsOfFile: "RunBench/AgenticTaskBench.swift",
+            encoding: .utf8)
+    }
+
+    @Test("run_shell is a seatbelt-confined non-login shell")
+    func shellUsesTaskScopedSeatbeltProfile() throws {
+        let source = try source()
+        #expect(source.contains(#"process.executableURL = URL(fileURLWithPath: "/usr/bin/sandbox-exec")"#))
+        #expect(source.contains(#"(deny file-write*)"#))
+        #expect(source.contains(#"(allow file-write* (subpath "\(task)") (literal "/dev/null"))"#))
+        #expect(source.contains(#"(deny file-read* (subpath "\(home)") (subpath "\(temporary)"))"#))
+        #expect(source.contains(#""/bin/bash", "-c", command"#))
+        #expect(!source.contains(#"process.arguments = ["-lc", command]"#))
+        #expect(source.contains("run_shell benchmark confinement is unavailable"))
+    }
+
+    @Test("run_shell has a bounded wall clock and terminates its process group")
+    func shellHasBoundedProcessGroupWatchdog() throws {
+        let source = try source()
+        #expect(source.contains("BENCH_AGENT_SHELL_TIMEOUT_SECONDS"))
+        #expect(source.contains("Darwin.setpgid(process.processIdentifier"))
+        #expect(source.contains("Darwin.kill(-process.processIdentifier, SIGTERM)"))
+        #expect(source.contains("[terminated: shell command exceeded "))
+    }
+
+    @Test("run_shell redirects temporary and home state into the task fixture")
+    func shellEnvironmentIsFixtureScoped() throws {
+        let source = try source()
+        #expect(source.contains(#"environment["HOME"] = dir.path"#))
+        #expect(source.contains(#"environment["TMPDIR"] = dir.path"#))
+        #expect(source.contains("process.currentDirectoryURL = dir"))
+    }
+
+    @Test("agentic mode dispatches before the legacy model load")
+    func agenticModeOwnsExactlyOneModelContext() throws {
+        let bench = try String(contentsOfFile: "RunBench/Bench.swift", encoding: .utf8)
+        let dispatch = try #require(bench.range(of: #"env["BENCH_AGENTIC_TASKS"]"#))
+        let legacyLoad = try #require(bench.range(of: #"print("Loading...")"#))
+        #expect(dispatch.lowerBound < legacyLoad.lowerBound)
+        #expect(bench.components(separatedBy: #"env["BENCH_AGENTIC_TASKS"]"#).count == 2)
+    }
+
+    @Test("agentic score uses bundle sampling and a reproducible seed")
+    func scoreUsesBundleGenerationContract() throws {
+        let source = try source()
+        #expect(source.contains("generationConfig: context.configuration.generationDefaults"))
+        #expect(source.contains(#"environment["BENCH_AGENT_SEED"]"#))
+        #expect(source.contains("params.randomSeed = seed"))
+        #expect(source.contains(#"sampling=\(explicitTemperature == nil ? "bundle-defaults""#))
+        #expect(!source.contains(#".flatMap(Float.init) ?? 0"#))
+    }
+
+    @Test("independent cases clear only allocator cache and expose active bytes")
+    func independentCasesDoNotAccumulateAllocatorResidue() throws {
+        let source = try source()
+        #expect(source.contains("let activeBeforeClear = MLX.Memory.activeMemory"))
+        #expect(source.contains("let cachedBeforeClear = MLX.Memory.cacheMemory"))
+        #expect(source.contains("MLX.Memory.clearCache()"))
+        #expect(source.contains("memory activeBytes="))
+    }
+}


### PR DESCRIPTION
## Summary

Fixes four independent reasons `AgenticTaskBench` could not produce a trustworthy model score:

1. `run_shell` only set `cwd`; absolute paths, `..`, subprocesses, and redirects escaped the fixture. On macOS it now runs under a task-scoped Seatbelt profile, uses a non-login shell with fixture-local `HOME`/`TMPDIR`, and has a process-group wall-clock watchdog. Platforms without an implemented confinement boundary fail the shell tool closed.
2. `BENCH_AGENTIC_TASKS=1` was dispatched after the legacy `NullTokenizerLoader` model load, then loaded a second production-tokenizer context. It now dispatches before that load and owns exactly one context.
3. The scorer silently forced temperature `0`, ignoring the shipped bundle generation config. Bundle defaults are now authoritative unless `BENCH_AGENT_TEMP` is explicitly supplied; a deterministic `BENCH_AGENT_SEED` defaults to `42`, and the resolved sampler is printed.
4. Independent cases accumulated MLX allocator-pool residue. The runner now reports active/cache bytes and clears only reusable allocator cache between cases. Active-byte growth remains visible as a real lifecycle failure.

## Causal reproduction

Exact model artifact: `OsaurusAI/Raptor-v0.5-8B-A1B-JANG_6M`, locally header-aligned without changing tensor data (`SHA256(data section)=547dc8144cc19f73504a1b61bc4b50d918bc5a1bbf1d28cb6957ef55ace6f76c` in both source and aligned proof copy).

Before `41803d05`:

- `t4-recover-wrongpath` issued `find /`, escaped the fixture read boundary, and spent **139.7 s** in one case.
- One filtered task printed two independent model loads and peaked at **16,007,059,720 bytes** physical footprint.
- A seeded, bundle-sampler 11-case run scored **5/11**, took **73.5 s**, and peaked at **36,326,426,592 bytes**; unrelated cases retained allocator residue.
- The earlier temperature-only run scored 9/11, demonstrating why the prior number was not the shipped-model score.

After `41803d05`:

- The exact `find /` behavior was terminated at the configured 2.0-second test limit; the model recovered with `find .`. No child survived.
- A one-case Release run printed one model load and peaked at **8,755,513,288 bytes** (the semantic task still failed; this PR does not tune the model).
- The exact seeded bundle sampler is printed as `temp=0.7 topP=0.95 topK=20 minP=0 repetitionPenalty=1.05`.
- Full hard suite remains honestly **5/11**; cache cleanup reduced wall time to **48.7 s** and peak footprint to **24,083,433,488 bytes**. That footprint is still a failed model/RAM gate and is not waived by this harness fix.

Artifacts:

- `/private/tmp/raptor05-agentic-hard-temp07.log`
- `/private/tmp/raptor05-shellfix-t4-recover-wrongpath.log`
- `/private/tmp/raptor05-shellfix-singleload.log`
- `/private/tmp/raptor05-agentic-hard-fixed-seed42.log`
- `/private/tmp/raptor05-agentic-hard-fixed-cacheclear-seed42.log`
- `/private/tmp/raptor-evaltruth-build2.log`
- `/private/tmp/raptor-evaltruth-tests-final.log`

## Tests

- Release `RunBench` build: RC 0.
- `swift test --filter AgenticTaskBenchConfinementFocusedTests`: **6/6 pass** on exact head.
- Live Release model rows above: process survived, no parser markers leaked, filesystem verifiers remained authoritative.

## Honest status

This PR fixes the evaluator, not Raptor's model quality or its remaining RAM peak. Raptor stays **PARTIAL / not default-ready** at 5/11 and ~24.08 GB full-suite peak until those separate lanes are resolved. The source HF bundle also needs its safetensors data section aligned; that is a separate artifact issue.
