### PR TITLE
Canonicalize AgenticTaskBench sandbox paths

### DIFF
--- a/RunBench/AgenticTaskBench.swift
+++ b/RunBench/AgenticTaskBench.swift
@@ -64,17 +64,27 @@ public enum AgenticTaskBench {
             .replacingOccurrences(of: "\"", with: "\\\"")
     }
 
+    private static func canonicalSandboxPath(_ url: URL) -> String {
+        #if canImport(Darwin)
+        var buffer = [CChar](repeating: 0, count: Int(PATH_MAX))
+        if Darwin.realpath(url.path, &buffer) != nil {
+            return String(cString: buffer)
+        }
+        #endif
+        return url.standardizedFileURL.resolvingSymlinksInPath().path
+    }
+
     /// macOS seatbelt profile for the benchmark shell.  Commands may execute
     /// normal system binaries, but reads of the user's home/temp trees and all
     /// writes are denied unless they target this task's fixture directory.
     /// This is an eval-integrity boundary: setting only `cwd` does not confine
     /// absolute paths, `..`, subprocesses, or shell redirections.
     private static func shellSandboxProfile(taskDirectory: URL) -> String {
-        let task = sandboxEscaped(taskDirectory.resolvingSymlinksInPath().path)
-        let home = sandboxEscaped(URL(fileURLWithPath: NSHomeDirectory())
-            .resolvingSymlinksInPath().path)
-        let temporary = sandboxEscaped(URL(fileURLWithPath: NSTemporaryDirectory())
-            .resolvingSymlinksInPath().path)
+        let task = sandboxEscaped(canonicalSandboxPath(taskDirectory))
+        let home = sandboxEscaped(canonicalSandboxPath(
+            URL(fileURLWithPath: NSHomeDirectory())))
+        let temporary = sandboxEscaped(canonicalSandboxPath(
+            URL(fileURLWithPath: NSTemporaryDirectory())))
         return """
         (version 1)
         (allow default)
@@ -223,9 +233,13 @@ public enum AgenticTaskBench {
             guard let command = str("command") else { return "error: missing command" }
             let process = Process()
             #if os(macOS)
+            let sandboxProfile = shellSandboxProfile(taskDirectory: dir)
+            if ProcessInfo.processInfo.environment["BENCH_AGENT_SHELL_TRACE"] == "1" {
+                print("      shell sandbox task=\(dir.path) profile=\(sandboxProfile)")
+            }
             process.executableURL = URL(fileURLWithPath: "/usr/bin/sandbox-exec")
             process.arguments = [
-                "-p", shellSandboxProfile(taskDirectory: dir),
+                "-p", sandboxProfile,
                 "/bin/bash", "-c", command,
             ]
             #else

--- a/Tests/MLXLMCommonFocusedTests/AgenticTaskBenchConfinementFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/AgenticTaskBenchConfinementFocusedTests.swift
@@ -22,6 +22,8 @@ struct AgenticTaskBenchConfinementFocusedTests {
         #expect(source.contains(#""/bin/bash", "-c", command"#))
         #expect(!source.contains(#"process.arguments = ["-lc", command]"#))
         #expect(source.contains("run_shell benchmark confinement is unavailable"))
+        #expect(source.contains("Darwin.realpath(url.path, &buffer)"))
+        #expect(source.contains("canonicalSandboxPath(taskDirectory)"))
     }
 
     @Test("run_shell has a bounded wall clock and terminates its process group")


### PR DESCRIPTION
## Corrective follow-up to #341

#341's task-scoped Seatbelt profile used `URL.resolvingSymlinksInPath()`. On this macOS host that left `/var/folders/...` unchanged, while Seatbelt evaluates fixture writes through `/private/var/folders/...`. The allow-write rule therefore did not match, and shell-based task writes were falsely denied.

This PR canonicalizes task/home/temp paths with Darwin `realpath(3)` before interpolating the profile. A trace-only env (`BENCH_AGENT_SHELL_TRACE=1`) prints the exact generated profile for future attribution.

## Before

Exact Release head `55d8feb7` (#341 merge):

- profile allowed `/var/folders/.../task`;
- `pwd`/kernel operations resolved the same fixture under `/private/var/folders/.../task`;
- `echo > east.txt`, `mkdir new`, and `rm ./a.log` failed `Operation not permitted` inside the intended fixture;
- the resulting Raptor score of 5/11 was **invalid and is retracted**.

Artifact: `/private/tmp/raptor-shell-profile-trace.log` and `/private/tmp/raptor05-agentic-hard-fixed-cacheclear-seed42.log`.

## After (`06f02fc2`)

- traced profile contains `/private/var/folders/.../task` for both read and write rules;
- exact formerly-failing shell-write case `t3-longctx-aggregate` passes 1/1 in 1.4 s;
- full seeded hard suite against the aligned Raptor artifact: **8/11**, 42 tool calls, 29.7 s wall, no parser markers;
- exact bundle sampler printed: temperature 0.7, top-p 0.95, top-k 20, min-p 0, repetition penalty 1.05, seed 42;
- peak physical footprint: **13,345,032,208 bytes**. This remains a failed default-model RAM gate and is not waived.

Remaining semantic failures are preserved:

- `t2-pipeline-migrate`: step-cap loop;
- `t4-recover-readonly`: overwrites instead of appending;
- `t5-restraint-ambiguous`: acts when clarification is required.

Artifacts:

- `/private/tmp/raptor-shell-canonical-live.log`
- `/private/tmp/raptor05-agentic-hard-canonical-seed42.log`
- `/private/tmp/raptor-shell-canonical-build.log`
- `/private/tmp/raptor-shell-canonical-tests.log`

## Tests

- exact-head Release RunBench build: RC 0;
- `AgenticTaskBenchConfinementFocusedTests`: 6/6 pass;
- live former-failure row: PASS;
- full live suite: 8/11, process survived, no orphan shell/model process.
