### PR TITLE
Require workload-general tuning for MTP Auto

### DIFF
--- a/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
+++ b/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
@@ -123,6 +123,7 @@ public struct NativeMTPTuning: Codable, Sendable, Equatable {
         guard !blocked,
               validated,
               outputEquivalent,
+              isWorkloadGeneral,
               let bestDepth,
               bestDepth > 0,
               let baselineTokensPerSecond,
@@ -135,6 +136,23 @@ public struct NativeMTPTuning: Codable, Sendable, Equatable {
             return nil
         }
         return bestDepth
+    }
+
+    /// Auto is a global product policy, so a tuning row measured only for one
+    /// prompt class must not silently govern unrelated chat, tool, or coding
+    /// requests. A caller can still explicitly select a manual depth for a
+    /// diagnostic run. Missing prompt metadata remains accepted for legacy
+    /// tuning files; newly scoped rows must declare a workload-general class.
+    public var isWorkloadGeneral: Bool {
+        guard let promptClass else { return true }
+        let normalized = promptClass
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "-", with: "_")
+            .replacingOccurrences(of: " ", with: "_")
+        if normalized.isEmpty { return true }
+        return ["all", "general", "general_mixed", "mixed", "representative"].contains(
+            normalized)
     }
 
     /// The verifier mode the artifact EXPLICITLY specifies, or nil when it is

--- a/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
@@ -454,6 +454,35 @@ struct MTPRuntimeFocusedTests {
         #expect(fasterThanBaseline.usableBestDepth == 3)
     }
 
+    @Test("prompt-scoped MTP tuning cannot authorize global auto launch")
+    func promptScopedTuningIsNotGloballyUsable() {
+        func tuning(promptClass: String?) -> NativeMTPTuning {
+            NativeMTPTuning(
+                bestDepth: 1,
+                validated: true,
+                outputEquivalent: true,
+                promptClass: promptClass,
+                baselineTokensPerSecond: 20,
+                bestTokensPerSecond: 24,
+                speedupVsBaseline: 1.2)
+        }
+
+        #expect(tuning(promptClass: "code").usableBestDepth == nil)
+        #expect(tuning(promptClass: "prose_greedy_200tok_seed42").usableBestDepth == nil)
+        #expect(tuning(promptClass: "general").usableBestDepth == 1)
+        #expect(tuning(promptClass: "mixed").usableBestDepth == 1)
+        #expect(tuning(promptClass: nil).usableBestDepth == 1)
+
+        let scopedStatus = MTPBundleStatus(
+            bundleHasMTP: true,
+            configuredLayers: 1,
+            tensorCount: 10,
+            mode: .speculativeVerified,
+            nativeMTPTuning: tuning(promptClass: "code"))
+        #expect(!scopedStatus.canAutoLaunchMTP)
+        #expect(scopedStatus.requiresNativeMTPTuningBeforeAutoLaunch)
+    }
+
     @Test("MTP config without tensors is reported as metadata-only")
     func configOnlyMTPIsMetadataOnlyMissingWeights() throws {
         let root = try makeTemporaryBundle(name: "qwen-mtp-missing-weights")


### PR DESCRIPTION
## Problem

`vmlx_mtp_tuning.json` records `prompt_class`, but `NativeMTPTuning.usableBestDepth` ignored it. A speedup measured only on one code/prose benchmark therefore authorized global MTP Auto for unrelated chat and tool workloads.

This is live-reproduced on current merged vMLX `071b8a4f`:

- Ornith-35B (`prompt_class=code`): `canAutoLaunchMTP=true`, `launchMode=speculative`, d1. Yet the exact-head loader proof measured AR 23.6–23.7 tok/s versus d1 23.2 tok/s, only 3/12 d1 accepts, 47 AR fallbacks, adaptive fallback, and higher footprint (27,868 vs 27,101 MB).
- Qwen3.8 Flash-Next 2L (`prompt_class=prose_greedy_200tok_seed42`): `canAutoLaunchMTP=true`, d1. The current Osaurus matrix measured MTP Auto slower/heavier than Off (7.3 vs 10.1 tok/s; 71,311 vs 59,398 MB peak).

## Fix

A prompt-scoped tuning row is no longer production-usable for global Auto. Workload-general classes (`general`, `mixed`, `general_mixed`, `representative`, `all`) remain eligible. Missing/empty prompt metadata remains compatible with legacy tuning files. Explicit manual depths remain available and continue to enforce greedy sampling and expose runtime telemetry; this is not a model-name hardcode and it does not silently clobber an explicit request.

## Exact-head proof

Head: `9dd8130ac7fa327a11457bbb04312a5403f31952` (rebased on vMLX `071b8a4f`).

- New focused test: **1/1 pass** after a real rebuild (`/private/tmp/mtp-prompt-scope-rebase.log`). It pins both narrow prompt classes as ineligible, workload-general/legacy classes as eligible, and the status-level Auto refusal.
- Ornith real-bundle metadata A/B: before `canAutoLaunchMTP=true`, `nativeMTP(d1)`; after `canAutoLaunchMTP=false`, `launchMode=off`, `strategy=nil` (`/private/tmp/mtp-prompt-scope-before-ornith.log`, `/private/tmp/mtp-prompt-scope-ornith-probe.log`).
- Flash-Next real-bundle metadata A/B: before d1 speculative; after Off for Auto (`/private/tmp/mtp-prompt-scope-before-flash.log`, `/private/tmp/mtp-prompt-scope-flash-probe.log`).
- No model weights were loaded for the metadata probes. The performance evidence is from the prior real inference rows named above; this PR changes launch policy only.

## Remaining downstream gate

After merge, Osaurus must repin the exact vMLX SHA and prove the Auto selector/runtime telemetry in the Release app. Manual d1 remains an explicit diagnostic and must still run when selected.