### PR TITLE
Honor bundle manual MTP safety blocks

### DIFF
--- a/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
+++ b/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
@@ -363,8 +363,14 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
                 if mtp.explicitDepth != nil {
                     // Manual depth is a deliberate user activation: it needs
                     // tensor-complete evidence for a supported runtime, not a
-                    // measured tuning artifact — the user IS the measurement.
-                    if !status.hasCompleteMTPArtifact {
+                    // measured tuning artifact. An explicit bundle safety
+                    // block still wins; a user request is not permission to
+                    // bypass a known-bad production result.
+                    if status.nativeMTPTuning?.manualBlocked == true {
+                        issues.append(.error(
+                            field: "mtp.mode",
+                            message: "MTP is explicitly blocked by this bundle's tuning metadata: \(status.nativeMTPTuning?.reason ?? "no reason recorded")"))
+                    } else if !status.hasCompleteMTPArtifact {
                         issues.append(.error(
                             field: "mtp.mode",
                             message: "MTP manual depth requires complete MTP tensor evidence in the bundle (this bundle's artifact is absent or incomplete)."))
@@ -430,9 +436,10 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
             return (status?.canAutoLaunchMTP == true) ? .speculative : .off
         case .forceOn:
             if mtp.explicitDepth != nil {
-                // Manual depth: tensor evidence alone activates; tuning is
-                // an Auto-mode requirement only.
-                return (status?.hasCompleteMTPArtifact == true) ? .speculative : .blocked
+                // Manual depth can bypass missing measurement, never an
+                // explicit bundle safety block.
+                return (status?.hasCompleteMTPArtifact == true
+                    && status?.nativeMTPTuning?.manualBlocked != true) ? .speculative : .blocked
             }
             return (status?.canAutoLaunchMTP == true) ? .speculative : .blocked
         }
@@ -469,6 +476,12 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
                     launchMode: .blocked,
                     recommendation: nil,
                     reason: "MTP explicit depth must be 1, 2, or 3 (got \(depth)).")
+            }
+            if status?.nativeMTPTuning?.manualBlocked == true {
+                return .init(
+                    launchMode: .blocked,
+                    recommendation: nil,
+                    reason: "MTP is explicitly blocked by this bundle's tuning metadata: \(status?.nativeMTPTuning?.reason ?? "no reason recorded")")
             }
             guard let manual = NativeMTPAutoDecodePolicy.manualRecommendation(
                 depth: depth,

--- a/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
+++ b/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
@@ -68,6 +68,7 @@ public struct NativeMTPTuning: Codable, Sendable, Equatable {
     public let validated: Bool
     public let outputEquivalent: Bool
     public let blocked: Bool
+    public let manualBlocked: Bool
     public let cacheMode: String?
     public let promptClass: String?
     public let measuredAt: String?
@@ -87,6 +88,7 @@ public struct NativeMTPTuning: Codable, Sendable, Equatable {
         validated: Bool = false,
         outputEquivalent: Bool = false,
         blocked: Bool = false,
+        manualBlocked: Bool = false,
         cacheMode: String? = nil,
         promptClass: String? = nil,
         measuredAt: String? = nil,
@@ -105,6 +107,7 @@ public struct NativeMTPTuning: Codable, Sendable, Equatable {
         self.validated = validated
         self.outputEquivalent = outputEquivalent
         self.blocked = blocked
+        self.manualBlocked = manualBlocked
         self.cacheMode = cacheMode
         self.promptClass = promptClass
         self.measuredAt = measuredAt
@@ -121,6 +124,7 @@ public struct NativeMTPTuning: Codable, Sendable, Equatable {
 
     public var usableBestDepth: Int? {
         guard !blocked,
+              !manualBlocked,
               validated,
               outputEquivalent,
               isWorkloadGeneral,
@@ -192,6 +196,7 @@ public struct NativeMTPTuning: Codable, Sendable, Equatable {
             validated: try c.decodeIfPresent(Bool.self, forKey: .validated) ?? false,
             outputEquivalent: try c.decodeIfPresent(Bool.self, forKey: .outputEquivalent) ?? false,
             blocked: try c.decodeIfPresent(Bool.self, forKey: .blocked) ?? false,
+            manualBlocked: try c.decodeIfPresent(Bool.self, forKey: .manualBlocked) ?? false,
             cacheMode: try c.decodeIfPresent(String.self, forKey: .cacheMode),
             promptClass: try c.decodeIfPresent(String.self, forKey: .promptClass),
             measuredAt: try c.decodeIfPresent(String.self, forKey: .measuredAt),
@@ -214,6 +219,7 @@ public struct NativeMTPTuning: Codable, Sendable, Equatable {
         case validated
         case outputEquivalent = "output_equivalent"
         case blocked
+        case manualBlocked = "manual_blocked"
         case cacheMode = "cache_mode"
         case promptClass = "prompt_class"
         case measuredAt = "measured_at"
@@ -237,6 +243,7 @@ public struct NativeMTPTuningSnapshot: Codable, Sendable, Equatable {
     public let validated: Bool
     public let outputEquivalent: Bool
     public let blocked: Bool
+    public let manualBlocked: Bool
     public let cacheMode: String?
     public let promptClass: String?
     public let measuredAt: String?
@@ -258,6 +265,7 @@ public struct NativeMTPTuningSnapshot: Codable, Sendable, Equatable {
         validated: Bool,
         outputEquivalent: Bool,
         blocked: Bool,
+        manualBlocked: Bool = false,
         cacheMode: String? = nil,
         promptClass: String? = nil,
         measuredAt: String? = nil,
@@ -278,6 +286,7 @@ public struct NativeMTPTuningSnapshot: Codable, Sendable, Equatable {
         self.validated = validated
         self.outputEquivalent = outputEquivalent
         self.blocked = blocked
+        self.manualBlocked = manualBlocked
         self.cacheMode = cacheMode
         self.promptClass = promptClass
         self.measuredAt = measuredAt
@@ -300,6 +309,7 @@ public struct NativeMTPTuningSnapshot: Codable, Sendable, Equatable {
         case validated
         case outputEquivalent = "output_equivalent"
         case blocked
+        case manualBlocked = "manual_blocked"
         case cacheMode = "cache_mode"
         case promptClass = "prompt_class"
         case measuredAt = "measured_at"
@@ -407,6 +417,7 @@ extension NativeMTPTuning {
             validated: validated,
             outputEquivalent: outputEquivalent,
             blocked: blocked,
+            manualBlocked: manualBlocked,
             cacheMode: cacheMode,
             promptClass: promptClass,
             measuredAt: measuredAt,
@@ -492,6 +503,9 @@ public struct MTPBundleStatus: Codable, Sendable, Equatable {
     public var statusLine: String {
         let base = "mtp: \(mode.rawValue), layers=\(configuredLayers), tensors=\(tensorCount)"
         let tuned = nativeMTPTuning?.usableBestDepth.map { ", tuning=d\($0)" } ?? ""
+        if nativeMTPTuning?.manualBlocked == true {
+            return "\(base), speculative=off, manual=blocked"
+        }
         if speculativeDecodeEnabled {
             return "\(base)\(tuned), speculative=on"
         }
@@ -590,6 +604,7 @@ public extension NativeMTPModel {
 public enum NativeMTPActivationError: Error, LocalizedError, CustomStringConvertible {
     case requestedButMissingArtifact(MTPBundleStatus?)
     case requestedWithoutUsableTuning(MTPBundleStatus?)
+    case requestedWithBlockedTuning(MTPBundleStatus?)
     case requestedForUnsupportedModel([String])
     case invalidConfigData
 
@@ -604,6 +619,9 @@ public enum NativeMTPActivationError: Error, LocalizedError, CustomStringConvert
             return "native MTP was requested but this bundle does not have complete MTP tensor evidence: \(status?.statusLine ?? "no status")"
         case .requestedWithoutUsableTuning(let status):
             return "native MTP was requested but this bundle does not have usable \(NativeMTPTuning.fileName) metadata: \(status?.statusLine ?? "no status")"
+        case .requestedWithBlockedTuning(let status):
+            let reason = status?.nativeMTPTuning?.reason ?? "no block reason recorded"
+            return "native MTP was requested but this bundle explicitly blocks it: \(reason) (\(status?.statusLine ?? "no status"))"
         case .requestedForUnsupportedModel(let types):
             return "native MTP was requested for unsupported model type(s): \(types.joined(separator: ", "))"
         case .invalidConfigData:
@@ -689,6 +707,9 @@ public enum NativeMTPActivation {
         }
         if isTuningMeasurementRun {
             return true
+        }
+        guard status?.nativeMTPTuning?.manualBlocked != true else {
+            throw NativeMTPActivationError.requestedWithBlockedTuning(status)
         }
         // Manual-depth activation: the user pressed an explicit depth button.
         // Like measurement mode, a complete tensor artifact loads without a
@@ -807,10 +828,11 @@ public struct NativeMTPAutoDecodeRecommendation: Codable, Sendable, Equatable {
 public enum NativeMTPAutoDecodePolicy {
     /// Manual-depth recommendation: validates the same family/tensor evidence
     /// as the auto path but takes the user's explicit depth instead of a
-    /// measured tuning artifact. A tuning file, when present, contributes only
-    /// its explicit verifier mode; a blocked or unusable artifact does not
-    /// veto a deliberate user activation. Callers must pair this with
-    /// enforced greedy sampling for the model+session.
+    /// measured tuning artifact. A tuning file, when present, contributes its
+    /// explicit verifier mode. An explicitly blocked artifact vetoes manual
+    /// activation too: `blocked` is the bundle owner's safety decision, not a
+    /// missing-measurement condition. Callers must pair every accepted manual
+    /// activation with greedy sampling for the model+session.
     public static func manualRecommendation(
         depth: Int,
         configData: Data?,
@@ -819,6 +841,7 @@ public enum NativeMTPAutoDecodePolicy {
     ) -> NativeMTPAutoDecodeRecommendation? {
         guard (1...3).contains(depth) else { return nil }
         guard let status, status.hasCompleteMTPArtifact else { return nil }
+        guard status.nativeMTPTuning?.manualBlocked != true else { return nil }
         let config = (configData.flatMap { try? JSONSerialization.jsonObject(with: $0) })
             as? [String: Any]
         let modelTypes = modelTypes(config: config, fallback: jangConfig?.sourceModel.architecture)
@@ -1532,6 +1555,7 @@ public enum MTPBundleInspector {
             statusEvidence.append("tuning.validated=\(nativeMTPTuning.validated)")
             statusEvidence.append("tuning.output_equivalent=\(nativeMTPTuning.outputEquivalent)")
             statusEvidence.append("tuning.blocked=\(nativeMTPTuning.blocked)")
+            statusEvidence.append("tuning.manual_blocked=\(nativeMTPTuning.manualBlocked)")
         } else if metadataClaimsMTP || bundleHasMTP {
             // "missing" and "present but unreadable" are different problems and
             // point at different fixes. Reporting both as missing sent the

--- a/Tests/MLXLMCommonFocusedTests/MTPLaunchPlanProbeTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/MTPLaunchPlanProbeTests.swift
@@ -31,10 +31,23 @@ struct MTPLaunchPlanProbeTests {
 
         let configData = try? Data(
             contentsOf: dir.appendingPathComponent("config.json"))
-        let settings = VMLXServerRuntimeSettings()
+        var settings = VMLXServerRuntimeSettings()
+        if let rawDepth = ProcessInfo.processInfo.environment["VMLX_MTP_PROBE_MANUAL_DEPTH"],
+            let depth = Int(rawDepth)
+        {
+            settings.mtp.mode = .forceOn
+            settings.mtp.explicitDepth = depth
+            print("[probe] requestedManualDepth=\(depth)")
+        }
         let launch = settings.resolvedMTPLaunch(
             configData: configData, jangConfig: nil, status: status)
         print("[probe] launchMode=\(launch.launchMode) reason=\(launch.reason)")
+        if settings.mtp.mode == .forceOn,
+            status.nativeMTPTuning?.manualBlocked == true
+        {
+            #expect(launch.launchMode == .blocked)
+            #expect(launch.recommendation == nil)
+        }
         let strategy = settings.resolvedMTPDraftStrategy(
             configData: configData, jangConfig: nil, status: status)
         print("[probe] strategy=\(String(describing: strategy))")

--- a/Tests/MLXLMCommonFocusedTests/NativeMTPActivationErrorTextTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NativeMTPActivationErrorTextTests.swift
@@ -23,6 +23,7 @@ struct NativeMTPActivationErrorTextTests {
         let cases: [NativeMTPActivationError] = [
             .requestedButMissingArtifact(nil),
             .requestedWithoutUsableTuning(nil),
+            .requestedWithBlockedTuning(nil),
             .requestedForUnsupportedModel(["gemma4"]),
             .invalidConfigData,
         ]

--- a/Tests/MLXLMTests/NativeMTPManualDepthTests.swift
+++ b/Tests/MLXLMTests/NativeMTPManualDepthTests.swift
@@ -34,6 +34,38 @@ struct NativeMTPManualDepthTests {
             nativeMTPTuning: nil)
     }
 
+    /// A complete head whose bundle owner recorded a production safety block.
+    private static var blockedStatus: MTPBundleStatus {
+        MTPBundleStatus(
+            bundleHasMTP: true,
+            configuredLayers: 1,
+            tensorCount: 57,
+            mode: .preservedEnabled,
+            nativeMTPTuning: NativeMTPTuning(
+                bestDepth: 1,
+                validated: true,
+                outputEquivalent: true,
+                blocked: true,
+                manualBlocked: true,
+                reason: "live workload regressed versus autoregressive decode"))
+    }
+
+    /// Auto has no winning depth, but manual diagnostics remain permitted.
+    /// This is the existing Flash-Next 4M shape and must not be changed by the
+    /// Ornith-specific `manual_blocked` contract.
+    private static var autoOnlyBlockedStatus: MTPBundleStatus {
+        MTPBundleStatus(
+            bundleHasMTP: true,
+            configuredLayers: 1,
+            tensorCount: 57,
+            mode: .preservedEnabled,
+            nativeMTPTuning: NativeMTPTuning(
+                bestDepth: 0,
+                blocked: true,
+                manualBlocked: false,
+                reason: "no automatic depth beat autoregressive decode"))
+    }
+
     private static func settings(
         mode: VMLXMTPServerMode, explicitDepth: Int? = nil
     ) -> VMLXServerRuntimeSettings {
@@ -124,6 +156,67 @@ struct NativeMTPManualDepthTests {
                     configData: Self.config(),
                     baseModelType: "qwen4_exp",
                     status: Self.completeUntunedStatus)
+            }
+        }
+    }
+
+    @Test("a blocked tuning row vetoes manual depth and names the reason")
+    func blockedTuningVetoesManualDepth() throws {
+        let settings = Self.settings(mode: .forceOn, explicitDepth: 1)
+        #expect(settings.effectiveMTPLaunchMode(for: Self.blockedStatus) == .blocked)
+        #expect(
+            settings.validationIssues(mtpStatus: Self.blockedStatus)
+                .contains { $0.field == "mtp.mode" && $0.message.contains("explicitly blocked") })
+        let launch = settings.resolvedMTPLaunch(
+            configData: Self.config(),
+            jangConfig: nil,
+            status: Self.blockedStatus)
+        #expect(launch.launchMode == .blocked)
+        #expect(launch.recommendation == nil)
+        #expect(launch.reason.contains("explicitly blocked"))
+
+        try NativeMTPActivation.$explicitRequestOverride.withValue(true) {
+            try NativeMTPActivation.$manualDepthOverride.withValue(1) {
+                #expect(throws: NativeMTPActivationError.self) {
+                    _ = try NativeMTPActivation.shouldLoadNativeMTPWeights(
+                        configData: Self.config(),
+                        baseModelType: "qwen4_exp",
+                        status: Self.blockedStatus)
+                }
+                do {
+                    _ = try NativeMTPActivation.shouldLoadNativeMTPWeights(
+                        configData: Self.config(),
+                        baseModelType: "qwen4_exp",
+                        status: Self.blockedStatus)
+                    Issue.record("blocked tuning unexpectedly loaded")
+                } catch let error as NativeMTPActivationError {
+                    #expect(error.description.contains("explicitly blocks"))
+                    #expect(error.description.contains("regressed versus autoregressive"))
+                }
+            }
+        }
+    }
+
+    @Test("an Auto-only block does not disable explicit diagnostics")
+    func autoOnlyBlockStillAllowsManualDepth() throws {
+        let settings = Self.settings(mode: .forceOn, explicitDepth: 2)
+        #expect(
+            settings.effectiveMTPLaunchMode(for: Self.autoOnlyBlockedStatus)
+                == .speculative)
+        let launch = settings.resolvedMTPLaunch(
+            configData: Self.config(),
+            jangConfig: nil,
+            status: Self.autoOnlyBlockedStatus)
+        #expect(launch.launchMode == .speculative)
+        #expect(launch.recommendation?.depth == 2)
+
+        try NativeMTPActivation.$explicitRequestOverride.withValue(true) {
+            try NativeMTPActivation.$manualDepthOverride.withValue(2) {
+                let allowed = try NativeMTPActivation.shouldLoadNativeMTPWeights(
+                    configData: Self.config(),
+                    baseModelType: "qwen4_exp",
+                    status: Self.autoOnlyBlockedStatus)
+                #expect(allowed)
             }
         }
     }

--- a/Tests/MLXLMTests/NemotronMTPActivationWiringTests.swift
+++ b/Tests/MLXLMTests/NemotronMTPActivationWiringTests.swift
@@ -86,7 +86,8 @@ struct NemotronMTPActivationWiringTests {
                 switch error {
                 case .requestedForUnsupportedModel(let types):
                     Issue.record("still rejected as an unsupported family: \(types)")
-                case .requestedButMissingArtifact, .requestedWithoutUsableTuning:
+                case .requestedButMissingArtifact, .requestedWithoutUsableTuning,
+                    .requestedWithBlockedTuning:
                     break  // correct: the family is accepted, the evidence is not
                 case .invalidConfigData:
                     Issue.record("unexpected config error")


### PR DESCRIPTION
## Problem

The existing `blocked` flag is an Auto recommendation result. Manual d1/d2/d3 deliberately bypass it so users can diagnose a complete but untuned/non-winning head. Reusing `blocked` to force Ornith-1.5 off would also disable explicit diagnostics for two Flash-Next 4M bundles.

Ornith-1.5 35B needs a stronger, bundle-specific decision: its exact-head general-chat row measured d1 slower than AR (23.2 vs 23.6–23.7 tok/s), 3/12 d1 accepts, 47 AR fallbacks, adaptive fallback, and higher footprint. Its old code-only stamp is not safe for Auto or manual product use.

## Change

- Add explicit `manual_blocked` tuning metadata (default false, Codable/snapshotted).
- `manual_blocked=true` vetoes Auto, effective launch mode, settings validation, manual recommendation, and the final weight-load gate.
- Surface the recorded bundle reason instead of the misleading “unsupported family” message.
- Keep ordinary `blocked=true, manual_blocked=false` behavior unchanged: Auto stays off, explicit diagnostics still work.
- Tuning-measurement mode remains the only intentional bypass so a bad head can be re-evaluated deliberately outside product launch.

No model-name check exists in runtime code. Only a bundle explicitly stamped `manual_blocked=true` is affected.

## Exact-head proof

Head `3f54e39234a3b10dd5d2b65003c4a05bb8f6def7`:

- Focused contracts: **10/10 pass** (`/private/tmp/mtp-manual-scope-control2.log`): untuned manual d1–d3 still activate, bad depths/incomplete heads still refuse, Auto-only blocked still permits manual, manual-blocked refuses at settings and load gates with its reason.
- Full local tuning inventory: only the two installed Ornith-1.5 35B bundles carry `manual_blocked=true`; Qwen3.8 27B and Flash-Next do not.
- Real metadata probes, manual d1:
  - Ornith-1.5 35B 4M: `launchMode=blocked`, `strategy=nil`, recorded performance reason shown.
  - Flash-Next 4M (`blocked=true`, `manual_blocked=false`): `launchMode=speculative`, `nativeMTP(d1)`.
  - Qwen3.8-27B 4D: `launchMode=speculative`, `nativeMTP(d1)`.
  Logs: `/private/tmp/mtp-manual-probe-{ornith,flash4m,qwen27}.log`.

The installed Ornith 4M/6M sidecars were separately stamped `blocked=true, manual_blocked=true` locally. Those model-file edits are not part of this source PR and must be applied to the published bundle metadata by the bundle owner.