### PR TITLE
Qwen3.5: restore 90+ tok/s Ornith 35B decode

### DIFF
--- a/Libraries/MLXLMCommon/Qwen4ExpFusedAffineMoE.swift
+++ b/Libraries/MLXLMCommon/Qwen4ExpFusedAffineMoE.swift
@@ -2,25 +2,35 @@ import Foundation
 import MLX
 import MLXFast
 
-/// Exact-shape Qwen4Exp q2/q3/q4/q6 affine routed-MoE decode kernels.
+/// Exact-shape Qwen4Exp/Ornith q2/q3/q4/q5/q6 affine routed-MoE decode kernels.
 ///
 /// Gate and up share one packed-weight walk. The second kernel applies the
-/// ten router scores while reducing the down projections directly into the
-/// 2560-wide hidden vector, avoiding a materialized `[10, 2560]` routed
+/// router scores while reducing the down projections directly into the
+/// hidden vector, avoiding a materialized `[routes, hidden]` routed
 /// output. Inputs and outputs are BF16; quantized dot products and reduction
 /// accumulate in FP32 registers.
 enum Qwen4ExpFusedAffineMoE {
     typealias Reducer = (MLXArray, MLXArray, MLXArray) -> MLXArray?
 
-    private static let inputDimensions = 2560
-    private static let expertDimensions = 640
-    private static let routes = 10
-    private static let supportedBits = Set([2, 3, 4, 6])
+    private struct Shape: Equatable {
+        let inputDimensions: Int
+        let expertDimensions: Int
+        let routes: Int
+    }
+
+    /// Deliberately exact, audited production contracts. Do not turn this into
+    /// an arbitrary-shape fast path without adding parity and live rows.
+    private static let qwen4ExpShape = Shape(
+        inputDimensions: 2560, expertDimensions: 640, routes: 10)
+    private static let ornith35Shape = Shape(
+        inputDimensions: 2048, expertDimensions: 512, routes: 8)
+    private static let supportedBits = Set([2, 3, 4, 5, 6])
     private static let supportedGroupSizes = Set([32, 64])
 
     private static let enabled: Bool = {
-        let raw = ProcessInfo.processInfo.environment[
-            "VMLINUX_QWEN4_EXP_FUSED_AFFINE_MOE"] ?? "1"
+        let raw =
+            ProcessInfo.processInfo.environment[
+                "VMLINUX_QWEN4_EXP_FUSED_AFFINE_MOE"] ?? "1"
         return raw != "0" && raw.lowercased() != "false"
     }()
 
@@ -32,26 +42,26 @@ enum Qwen4ExpFusedAffineMoE {
             uint tid = thread_position_in_grid.x;
             uint sgid = tid / 32u;
             uint lane = thread_index_in_simdgroup;
-            uint m = sgid % 640u;
-            uint k = sgid / 640u;
+            uint m = sgid % EXPERT_DIM;
+            uint k = sgid / EXPERT_DIM;
             uint e = uint(inds[k]);
-            size_t rowoff = size_t(e) * 640u + m;
-            constexpr uint G_VALUES_PER_PACK = G_BITS == 3 ? 8u : (G_BITS == 6 ? 4u : 32u / G_BITS);
-            constexpr uint U_VALUES_PER_PACK = U_BITS == 3 ? 8u : (U_BITS == 6 ? 4u : 32u / U_BITS);
-            constexpr uint G_BYTES_PER_PACK = (G_BITS == 3 || G_BITS == 6) ? 3u : 4u;
-            constexpr uint U_BYTES_PER_PACK = (U_BITS == 3 || U_BITS == 6) ? 3u : 4u;
-            constexpr uint G_PACKS_INPUT = 2560u / G_VALUES_PER_PACK;
-            constexpr uint U_PACKS_INPUT = 2560u / U_VALUES_PER_PACK;
+            size_t rowoff = size_t(e) * EXPERT_DIM + m;
+            constexpr uint G_VALUES_PER_PACK = (G_BITS == 3 || G_BITS == 5) ? 8u : (G_BITS == 6 ? 4u : 32u / G_BITS);
+            constexpr uint U_VALUES_PER_PACK = (U_BITS == 3 || U_BITS == 5) ? 8u : (U_BITS == 6 ? 4u : 32u / U_BITS);
+            constexpr uint G_BYTES_PER_PACK = G_BITS == 5 ? 5u : ((G_BITS == 3 || G_BITS == 6) ? 3u : 4u);
+            constexpr uint U_BYTES_PER_PACK = U_BITS == 5 ? 5u : ((U_BITS == 3 || U_BITS == 6) ? 3u : 4u);
+            constexpr uint G_PACKS_INPUT = INPUT_DIM / G_VALUES_PER_PACK;
+            constexpr uint U_PACKS_INPUT = INPUT_DIM / U_VALUES_PER_PACK;
             constexpr uint G_PACKS_PER_GROUP = G_GROUP_SIZE / G_VALUES_PER_PACK;
             constexpr uint U_PACKS_PER_GROUP = U_GROUP_SIZE / U_VALUES_PER_PACK;
-            constexpr uint G_CODE_MASK = (1u << G_BITS) - 1u;
-            constexpr uint U_CODE_MASK = (1u << U_BITS) - 1u;
+            constexpr ulong G_CODE_MASK = (ulong(1) << G_BITS) - ulong(1);
+            constexpr ulong U_CODE_MASK = (ulong(1) << U_BITS) - ulong(1);
             const device uint8_t* grow = reinterpret_cast<const device uint8_t*>(gw)
                 + rowoff * G_PACKS_INPUT * G_BYTES_PER_PACK;
             const device uint8_t* urow = reinterpret_cast<const device uint8_t*>(uw)
                 + rowoff * U_PACKS_INPUT * U_BYTES_PER_PACK;
-            size_t gsoff = rowoff * (2560u / G_GROUP_SIZE);
-            size_t usoff = rowoff * (2560u / U_GROUP_SIZE);
+            size_t gsoff = rowoff * (INPUT_DIM / G_GROUP_SIZE);
+            size_t usoff = rowoff * (INPUT_DIM / U_GROUP_SIZE);
             float gacc = 0.0f;
             float uacc = 0.0f;
             for (uint pack_idx = lane; pack_idx < G_PACKS_INPUT; pack_idx += 32u) {
@@ -59,11 +69,14 @@ enum Qwen4ExpFusedAffineMoE {
               float gsc = float(gs[gsoff + grp]);
               float gbi = float(gb[gsoff + grp]);
               const device uint8_t* gp = grow + pack_idx * G_BYTES_PER_PACK;
-              uint32_t gwrd;
-              if (G_BITS == 3 || G_BITS == 6) {
-                gwrd = uint32_t(gp[0]) | (uint32_t(gp[1]) << 8u) | (uint32_t(gp[2]) << 16u);
+              ulong gwrd;
+              if (G_BITS == 5) {
+                gwrd = ulong(gp[0]) | (ulong(gp[1]) << 8u) | (ulong(gp[2]) << 16u)
+                    | (ulong(gp[3]) << 24u) | (ulong(gp[4]) << 32u);
+              } else if (G_BITS == 3 || G_BITS == 6) {
+                gwrd = ulong(gp[0]) | (ulong(gp[1]) << 8u) | (ulong(gp[2]) << 16u);
               } else {
-                gwrd = *reinterpret_cast<const device uint32_t*>(gp);
+                gwrd = ulong(*reinterpret_cast<const device uint32_t*>(gp));
               }
               uint xbase = pack_idx * G_VALUES_PER_PACK;
               float qsg = 0.0f;
@@ -80,11 +93,14 @@ enum Qwen4ExpFusedAffineMoE {
               float usc = float(us[usoff + grp]);
               float ubi = float(ub[usoff + grp]);
               const device uint8_t* up = urow + pack_idx * U_BYTES_PER_PACK;
-              uint32_t uwrd;
-              if (U_BITS == 3 || U_BITS == 6) {
-                uwrd = uint32_t(up[0]) | (uint32_t(up[1]) << 8u) | (uint32_t(up[2]) << 16u);
+              ulong uwrd;
+              if (U_BITS == 5) {
+                uwrd = ulong(up[0]) | (ulong(up[1]) << 8u) | (ulong(up[2]) << 16u)
+                    | (ulong(up[3]) << 24u) | (ulong(up[4]) << 32u);
+              } else if (U_BITS == 3 || U_BITS == 6) {
+                uwrd = ulong(up[0]) | (ulong(up[1]) << 8u) | (ulong(up[2]) << 16u);
               } else {
-                uwrd = *reinterpret_cast<const device uint32_t*>(up);
+                uwrd = ulong(*reinterpret_cast<const device uint32_t*>(up));
               }
               uint xbase = pack_idx * U_VALUES_PER_PACK;
               float qsu = 0.0f;
@@ -102,7 +118,7 @@ enum Qwen4ExpFusedAffineMoE {
               float g = float(T(gacc));
               float u = float(T(uacc));
               float activated = g / (1.0f + metal::fast::exp(-g)) * u;
-              act[k * 640u + m] = T(activated);
+              act[k * EXPERT_DIM + m] = T(activated);
             }
             """,
         ensureRowContiguous: false)
@@ -117,30 +133,33 @@ enum Qwen4ExpFusedAffineMoE {
             uint lane = thread_index_in_simdgroup;
             uint d = sgid;
             float weighted = 0.0f;
-            for (uint k = 0; k < 10u; ++k) {
+            for (uint k = 0; k < ROUTES; ++k) {
               uint e = uint(inds[k]);
-              size_t rowoff = size_t(e) * 2560u + d;
-              constexpr uint VALUES_PER_PACK = BITS == 3 ? 8u : (BITS == 6 ? 4u : 32u / BITS);
-              constexpr uint BYTES_PER_PACK = (BITS == 3 || BITS == 6) ? 3u : 4u;
-              constexpr uint PACKS_HIDDEN = 640u / VALUES_PER_PACK;
+              size_t rowoff = size_t(e) * INPUT_DIM + d;
+              constexpr uint VALUES_PER_PACK = (BITS == 3 || BITS == 5) ? 8u : (BITS == 6 ? 4u : 32u / BITS);
+              constexpr uint BYTES_PER_PACK = BITS == 5 ? 5u : ((BITS == 3 || BITS == 6) ? 3u : 4u);
+              constexpr uint PACKS_HIDDEN = EXPERT_DIM / VALUES_PER_PACK;
               constexpr uint PACKS_PER_GROUP = GROUP_SIZE / VALUES_PER_PACK;
-              constexpr uint CODE_MASK = (1u << BITS) - 1u;
+              constexpr ulong CODE_MASK = (ulong(1) << BITS) - ulong(1);
               const device uint8_t* dwrow = reinterpret_cast<const device uint8_t*>(dw)
                   + rowoff * PACKS_HIDDEN * BYTES_PER_PACK;
-              size_t soff = rowoff * (640u / GROUP_SIZE);
+              size_t soff = rowoff * (EXPERT_DIM / GROUP_SIZE);
               float acc = 0.0f;
               for (uint pack_idx = lane; pack_idx < PACKS_HIDDEN; pack_idx += 32u) {
                 uint grp = pack_idx / PACKS_PER_GROUP;
                 float sc = float(ds[soff + grp]);
                 float bi = float(db[soff + grp]);
                 const device uint8_t* dp = dwrow + pack_idx * BYTES_PER_PACK;
-                uint32_t wrd;
-                if (BITS == 3 || BITS == 6) {
-                  wrd = uint32_t(dp[0]) | (uint32_t(dp[1]) << 8u) | (uint32_t(dp[2]) << 16u);
+                ulong wrd;
+                if (BITS == 5) {
+                  wrd = ulong(dp[0]) | (ulong(dp[1]) << 8u) | (ulong(dp[2]) << 16u)
+                      | (ulong(dp[3]) << 24u) | (ulong(dp[4]) << 32u);
+                } else if (BITS == 3 || BITS == 6) {
+                  wrd = ulong(dp[0]) | (ulong(dp[1]) << 8u) | (ulong(dp[2]) << 16u);
                 } else {
-                  wrd = *reinterpret_cast<const device uint32_t*>(dp);
+                  wrd = ulong(*reinterpret_cast<const device uint32_t*>(dp));
                 }
-                size_t abase = size_t(k) * 640u + pack_idx * VALUES_PER_PACK;
+                size_t abase = size_t(k) * EXPERT_DIM + pack_idx * VALUES_PER_PACK;
                 float qs = 0.0f;
                 float xs = 0.0f;
                 for (uint j = 0; j < VALUES_PER_PACK; ++j) {
@@ -158,7 +177,7 @@ enum Qwen4ExpFusedAffineMoE {
         ensureRowContiguous: false)
 
     private static let reportLock = NSLock()
-    nonisolated(unsafe) private static var reportedRowCounts = Set<Int>()
+    nonisolated(unsafe) private static var reportedShapes = Set<String>()
     nonisolated(unsafe) private static var didReportConstructionRejection = false
     nonisolated(unsafe) private static var didReportInvocationRejection = false
 
@@ -171,11 +190,13 @@ enum Qwen4ExpFusedAffineMoE {
         defer { reportLock.unlock() }
         guard !didReportConstructionRejection else { return }
         didReportConstructionRejection = true
-        FileHandle.standardError.write(Data(
-            ("[Qwen4Exp] fused_affine_moe_decode=construction_rejected"
-                + " gate=\(gate.inputDims)x\(gate.outputDims):\(gate.bits)b:g\(gate.groupSize):\(gate.mode):\(gate.weight.dtype):\(gate.scales.dtype):\(String(describing: gate.biases?.dtype))"
-                + " up=\(up.inputDims)x\(up.outputDims):\(up.bits)b:g\(up.groupSize):\(up.mode):\(up.weight.dtype):\(up.scales.dtype):\(String(describing: up.biases?.dtype))"
-                + " down=\(down.inputDims)x\(down.outputDims):\(down.bits)b:g\(down.groupSize):\(down.mode):\(down.weight.dtype):\(down.scales.dtype):\(String(describing: down.biases?.dtype))\n").utf8))
+        FileHandle.standardError.write(
+            Data(
+                ("[Qwen4Exp] fused_affine_moe_decode=construction_rejected"
+                    + " gate=\(gate.inputDims)x\(gate.outputDims):\(gate.bits)b:g\(gate.groupSize):\(gate.mode):\(gate.weight.dtype):\(gate.scales.dtype):\(String(describing: gate.biases?.dtype))"
+                    + " up=\(up.inputDims)x\(up.outputDims):\(up.bits)b:g\(up.groupSize):\(up.mode):\(up.weight.dtype):\(up.scales.dtype):\(String(describing: up.biases?.dtype))"
+                    + " down=\(down.inputDims)x\(down.outputDims):\(down.bits)b:g\(down.groupSize):\(down.mode):\(down.weight.dtype):\(down.scales.dtype):\(String(describing: down.biases?.dtype))\n")
+                    .utf8))
     }
 
     private static func reportInvocationRejection(
@@ -185,23 +206,27 @@ enum Qwen4ExpFusedAffineMoE {
         defer { reportLock.unlock() }
         guard !didReportInvocationRejection else { return }
         didReportInvocationRejection = true
-        FileHandle.standardError.write(Data(
-            ("[Qwen4Exp] fused_affine_moe_decode=invocation_rejected"
-                + " input=\(input.shape):\(input.dtype):size\(input.size)"
-                + " indices=\(indices.shape):\(indices.dtype):size\(indices.size)"
-                + " scores=\(scores.shape):\(scores.dtype):size\(scores.size)\n").utf8))
+        FileHandle.standardError.write(
+            Data(
+                ("[Qwen4Exp] fused_affine_moe_decode=invocation_rejected"
+                    + " input=\(input.shape):\(input.dtype):size\(input.size)"
+                    + " indices=\(indices.shape):\(indices.dtype):size\(indices.size)"
+                    + " scores=\(scores.shape):\(scores.dtype):size\(scores.size)\n").utf8))
     }
 
-    private static func reportActivation() {
+    private static func reportActivation(shape: Shape) {
         reportLock.lock()
         defer { reportLock.unlock() }
-        guard reportedRowCounts.insert(1).inserted else { return }
-        FileHandle.standardError.write(Data(
-            ("[Qwen4Exp] fused_affine_moe_decode=active rows=1"
-                + " shape=2560x640 topk=10 mixed_q2_q3_q4_q6_g32_g64 input=bfloat16 output=bfloat16"
-                + " affine_metadata=bf16_or_f16 router_scores=bf16_or_f32"
-                + " accumulator=float32"
-                + " weighted_down=true\n").utf8))
+        let label = "\(shape.inputDimensions)x\(shape.expertDimensions):topk\(shape.routes)"
+        guard reportedShapes.insert(label).inserted else { return }
+        FileHandle.standardError.write(
+            Data(
+                ("[Qwen4Exp] fused_affine_moe_decode=active rows=1"
+                    + " shape=\(shape.inputDimensions)x\(shape.expertDimensions) topk=\(shape.routes)"
+                    + " mixed_q2_q3_q4_q5_q6_g32_g64 input=bfloat16 output=bfloat16"
+                    + " affine_metadata=bf16_or_f16 router_scores=bf16_or_f32"
+                    + " accumulator=float32"
+                    + " weighted_down=true\n").utf8))
     }
 
     private static func supports(_ projection: QuantizedSwitchLinear) -> Bool {
@@ -224,10 +249,18 @@ enum Qwen4ExpFusedAffineMoE {
         up: QuantizedSwitchLinear,
         down: QuantizedSwitchLinear
     ) -> Reducer? {
+        let shape = Shape(
+            inputDimensions: gate.inputDims,
+            expertDimensions: gate.outputDims,
+            routes: gate.inputDims == ornith35Shape.inputDimensions
+                && gate.outputDims == ornith35Shape.expertDimensions
+                ? ornith35Shape.routes : qwen4ExpShape.routes)
         guard enabled,
-            gate.inputDims == inputDimensions, gate.outputDims == expertDimensions,
-            up.inputDims == inputDimensions, up.outputDims == expertDimensions,
-            down.inputDims == expertDimensions, down.outputDims == inputDimensions,
+            shape == qwen4ExpShape || shape == ornith35Shape,
+            up.inputDims == shape.inputDimensions,
+            up.outputDims == shape.expertDimensions,
+            down.inputDims == shape.expertDimensions,
+            down.outputDims == shape.inputDimensions,
             supports(gate), supports(up), supports(down),
             let gateBiases = gate.biases, let upBiases = up.biases,
             let downBiases = down.biases
@@ -257,16 +290,18 @@ enum Qwen4ExpFusedAffineMoE {
             // BF16 activation/result contract.
             guard input.dtype == .bfloat16,
                 scores.dtype == .bfloat16 || scores.dtype == .float32,
-                input.size == inputDimensions,
-                input.dim(-1) == inputDimensions,
-                indices.size == routes, indices.dim(-1) == routes,
-                scores.size == routes, scores.dim(-1) == routes
+                input.size == shape.inputDimensions,
+                input.dim(-1) == shape.inputDimensions,
+                indices.size == shape.routes, indices.dim(-1) == shape.routes,
+                scores.size == shape.routes, scores.dim(-1) == shape.routes
             else {
                 reportInvocationRejection(input: input, indices: indices, scores: scores)
                 return nil
             }
 
-            let pairShape = Array(input.shape.dropLast()) + [routes, expertDimensions]
+            let pairShape =
+                Array(input.shape.dropLast())
+                + [shape.routes, shape.expertDimensions]
             let pair = pairKernel(
                 [
                     input,
@@ -280,8 +315,10 @@ enum Qwen4ExpFusedAffineMoE {
                     ("U_BITS", upBits),
                     ("G_GROUP_SIZE", gateGroupSize),
                     ("U_GROUP_SIZE", upGroupSize),
+                    ("INPUT_DIM", shape.inputDimensions),
+                    ("EXPERT_DIM", shape.expertDimensions),
                 ],
-                grid: (32 * expertDimensions * routes, 1, 1),
+                grid: (32 * shape.expertDimensions * shape.routes, 1, 1),
                 threadGroup: (128, 1, 1),
                 outputShapes: [pairShape],
                 outputDTypes: [input.dtype])[0]
@@ -295,13 +332,16 @@ enum Qwen4ExpFusedAffineMoE {
                     ("T", input.dtype),
                     ("BITS", downBits),
                     ("GROUP_SIZE", downGroupSize),
+                    ("INPUT_DIM", shape.inputDimensions),
+                    ("EXPERT_DIM", shape.expertDimensions),
+                    ("ROUTES", shape.routes),
                 ],
-                grid: (32 * inputDimensions, 1, 1),
+                grid: (32 * shape.inputDimensions, 1, 1),
                 threadGroup: (128, 1, 1),
                 outputShapes: [input.shape],
                 outputDTypes: [input.dtype])[0]
 
-            reportActivation()
+            reportActivation(shape: shape)
             return output
         }
     }

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -15,7 +15,8 @@ import MLXNN
 /// Compiled sigmoid multiply: fuses x * sigmoid(gate) into one Metal dispatch.
 /// Used in GatedDeltaNet output projection (per-layer, ~30 layers per forward).
 private let compiledSigmoidMultiply: @Sendable (MLXArray, MLXArray) -> MLXArray = {
-    let body: @Sendable (MLXArray, MLXArray) -> MLXArray = { (x: MLXArray, gate: MLXArray) -> MLXArray in
+    let body: @Sendable (MLXArray, MLXArray) -> MLXArray = {
+        (x: MLXArray, gate: MLXArray) -> MLXArray in
         x * sigmoid(gate)
     }
     guard HardwareInfo.isCompiledDecodeSupported else { return body }
@@ -28,7 +29,8 @@ private let compiledSigmoidMultiply: @Sendable (MLXArray, MLXArray) -> MLXArray 
 
 /// Compiled shared expert gate: sigmoid(gate_output) * expert_output → 1 fused op.
 private let compiledSigmoidGate: @Sendable (MLXArray, MLXArray) -> MLXArray = {
-    let body: @Sendable (MLXArray, MLXArray) -> MLXArray = { (gateOutput: MLXArray, expertOutput: MLXArray) -> MLXArray in
+    let body: @Sendable (MLXArray, MLXArray) -> MLXArray = {
+        (gateOutput: MLXArray, expertOutput: MLXArray) -> MLXArray in
         sigmoid(gateOutput) * expertOutput
     }
     guard HardwareInfo.isCompiledDecodeSupported else { return body }
@@ -45,7 +47,8 @@ private enum Qwen35VLError: Error {
 
 /// Compiled compute_g — fuses exp+softplus+mul into 1 Metal dispatch.
 private let _vlmCompiledComputeG: @Sendable (MLXArray, MLXArray, MLXArray) -> MLXArray = {
-    let body: @Sendable (MLXArray, MLXArray, MLXArray) -> MLXArray = { (aLog: MLXArray, a: MLXArray, dtBias: MLXArray) -> MLXArray in
+    let body: @Sendable (MLXArray, MLXArray, MLXArray) -> MLXArray = {
+        (aLog: MLXArray, a: MLXArray, dtBias: MLXArray) -> MLXArray in
         let decay = exp(-exp(aLog.asType(.float32)) * softplus(a + dtBias))
         return decay
     }
@@ -87,11 +90,12 @@ private let _vlmCompiledPreciseSwiGLU: @Sendable (MLXArray, MLXArray, MLXArray) 
 /// linear-attention layer.  Pass each layer's packed affine tensors as graph
 /// inputs so one trusted BF16 decode graph can be reused without retaining
 /// layer-specific weight constants.
-private enum Qwen4ExpCompiledGDNInputs {
+enum Qwen4ExpCompiledGDNInputs {
     typealias Region = @Sendable ([MLXArray]) -> [MLXArray]
 
     private static let enabled: Bool = {
-        let value = ProcessInfo.processInfo.environment["VMLINUX_QWEN4_EXP_COMPILE_GDN"]
+        let value =
+            ProcessInfo.processInfo.environment["VMLINUX_QWEN4_EXP_COMPILE_GDN"]
             ?? "1"
         return value != "0" && value.lowercased() != "false"
     }()
@@ -118,12 +122,15 @@ private enum Qwen4ExpCompiledGDNInputs {
         let metadataDType = scales.dtype
         guard enabled, !CompiledDecodeTrace.isActive, input.dim(1) == 1,
             input.dtype == .bfloat16,
-            (metadataDType == .bfloat16 || metadataDType == .float16),
+            metadataDType == .bfloat16 || metadataDType == .float16,
             biases.dtype == metadataDType
         else { return nil }
 
-        let key = ([String(describing: metadataDType), String(groupSize),
-            String(bits), String(describing: mode)]
+        let key =
+            ([
+                String(describing: metadataDType), String(groupSize),
+                String(bits), String(describing: mode),
+            ]
             + splitIndices.map(String.init)).joined(separator: "|")
         lock.lock()
         var region = regions[key]
@@ -138,8 +145,10 @@ private enum Qwen4ExpCompiledGDNInputs {
         }
         if !didReport {
             didReport = true
-            FileHandle.standardError.write(Data(
-                "[Qwen4Exp] compiled_gdn_input_projection=active shared_weight_inputs=true input=bfloat16 metadata=\(metadataDType)\n".utf8))
+            FileHandle.standardError.write(
+                Data(
+                    "[Qwen4Exp] compiled_gdn_input_projection=active shared_weight_inputs=true input=bfloat16 metadata=\(metadataDType)\n"
+                        .utf8))
         }
         lock.unlock()
 
@@ -167,7 +176,8 @@ private enum Qwen4ExpCompiledGDNInputs {
         headVDim: Int
     ) -> [MLXArray]? {
         let metadataDType = scales.dtype
-        let supported = enabled && !CompiledDecodeTrace.isActive && input.dim(1) == 1
+        let supported =
+            enabled && !CompiledDecodeTrace.isActive && input.dim(1) == 1
             && input.dtype == .bfloat16
             && (convState.dtype == .bfloat16 || convState.dtype == .float32)
             && (metadataDType == .bfloat16 || metadataDType == .float16)
@@ -177,26 +187,28 @@ private enum Qwen4ExpCompiledGDNInputs {
             lock.lock()
             if !didReportFrontRejection {
                 didReportFrontRejection = true
-                FileHandle.standardError.write(Data(
-                    ("[Qwen4Exp] compiled_gdn_front=rejected"
-                        + " enabled=\(enabled) trace=\(CompiledDecodeTrace.isActive)"
-                        + " input=\(input.shape):\(input.dtype)"
-                        + " conv_state=\(convState.shape):\(convState.dtype)"
-                        + " scales=\(metadataDType) biases=\(biases.dtype)"
-                        + " conv_weight=\(convWeight.dtype)\n").utf8))
+                FileHandle.standardError.write(
+                    Data(
+                        ("[Qwen4Exp] compiled_gdn_front=rejected"
+                            + " enabled=\(enabled) trace=\(CompiledDecodeTrace.isActive)"
+                            + " input=\(input.shape):\(input.dtype)"
+                            + " conv_state=\(convState.shape):\(convState.dtype)"
+                            + " scales=\(metadataDType) biases=\(biases.dtype)"
+                            + " conv_weight=\(convWeight.dtype)\n").utf8))
             }
             lock.unlock()
             return nil
         }
 
-        let key = ([
-            "front", String(describing: metadataDType), String(groupSize),
-            String(bits), String(describing: mode),
-            String(describing: convState.dtype),
-            String(convDim), String(convKernelSize), String(keyDim),
-            String(numKHeads), String(headKDim), String(numVHeads),
-            String(headVDim),
-        ] + splitIndices.map(String.init)).joined(separator: "|")
+        let key =
+            ([
+                "front", String(describing: metadataDType), String(groupSize),
+                String(bits), String(describing: mode),
+                String(describing: convState.dtype),
+                String(convDim), String(convKernelSize), String(keyDim),
+                String(numKHeads), String(headKDim), String(numVHeads),
+                String(headVDim),
+            ] + splitIndices.map(String.init)).joined(separator: "|")
         lock.lock()
         var region = regions[key]
         if region == nil {
@@ -215,17 +227,20 @@ private enum Qwen4ExpCompiledGDNInputs {
                 let convEnd = convInput.dim(1)
                 let convTail = convInput[
                     0..., (convEnd - (convKernelSize - 1)) ..< convEnd, 0...]
-                let convOut = silu(conv1d(
-                    convInput, args[5], stride: 1, padding: 0,
-                    dilation: 1, groups: convDim))
+                let convOut = silu(
+                    conv1d(
+                        convInput, args[5], stride: 1, padding: 0,
+                        dilation: 1, groups: convDim))
                 let qkv = MLX.split(convOut, indices: [keyDim, 2 * keyDim], axis: -1)
                 let q = qkv[0].reshaped(B, S, numKHeads, headKDim)
                 let k = qkv[1].reshaped(B, S, numKHeads, headKDim)
                 let v = qkv[2].reshaped(B, S, numVHeads, headVDim)
                 let invScale = pow(Float(headKDim), -0.5)
-                let qNormed = MLXArray(pow(invScale, 2), dtype: q.dtype)
+                let qNormed =
+                    MLXArray(pow(invScale, 2), dtype: q.dtype)
                     * MLXFast.rmsNorm(q, weight: MLXArray.mlxNone, eps: 1e-6)
-                let kNormed = MLXArray(invScale, dtype: k.dtype)
+                let kNormed =
+                    MLXArray(invScale, dtype: k.dtype)
                     * MLXFast.rmsNorm(k, weight: MLXArray.mlxNone, eps: 1e-6)
                 return [
                     z, projections[2], projections[3], qNormed, kNormed, v,
@@ -236,8 +251,10 @@ private enum Qwen4ExpCompiledGDNInputs {
         }
         if !didReport {
             didReport = true
-            FileHandle.standardError.write(Data(
-                "[Qwen4Exp] compiled_gdn_front=active shared_weight_inputs=true input=bfloat16 metadata=\(metadataDType) conv_state=\(convState.dtype) recurrence=float32\n".utf8))
+            FileHandle.standardError.write(
+                Data(
+                    "[Qwen4Exp] compiled_gdn_front=active shared_weight_inputs=true input=bfloat16 metadata=\(metadataDType) conv_state=\(convState.dtype) recurrence=float32\n"
+                        .utf8))
         }
         lock.unlock()
 
@@ -250,6 +267,7 @@ private enum Qwen4ExpCompiledGDNInputs {
     static func callTail(
         output: MLXArray,
         gate: MLXArray,
+        sigmoidGate: Bool,
         normWeight: MLXArray,
         outWeight: MLXArray,
         outScales: MLXArray,
@@ -260,7 +278,8 @@ private enum Qwen4ExpCompiledGDNInputs {
         mode: QuantizationMode
     ) -> MLXArray? {
         let metadataDType = outScales.dtype
-        let supported = enabled && !CompiledDecodeTrace.isActive && output.dim(1) == 1
+        let supported =
+            enabled && !CompiledDecodeTrace.isActive && output.dim(1) == 1
             && (output.dtype == .bfloat16
                 || (output.dtype == .float32 && allowFP32Tail))
             && (gate.dtype == .bfloat16 || gate.dtype == .float32)
@@ -272,12 +291,13 @@ private enum Qwen4ExpCompiledGDNInputs {
             lock.lock()
             if output.dim(1) == 1, !didReportTailRejection {
                 didReportTailRejection = true
-                FileHandle.standardError.write(Data(
-                    ("[Qwen4Exp] compiled_gdn_tail=rejected"
-                        + " enabled=\(enabled) trace=\(CompiledDecodeTrace.isActive)"
-                        + " output=\(output.shape):\(output.dtype)"
-                        + " gate=\(gate.shape):\(gate.dtype) norm=\(normWeight.dtype)"
-                        + " scales=\(metadataDType) biases=\(outBiases.dtype)\n").utf8))
+                FileHandle.standardError.write(
+                    Data(
+                        ("[Qwen4Exp] compiled_gdn_tail=rejected"
+                            + " enabled=\(enabled) trace=\(CompiledDecodeTrace.isActive)"
+                            + " output=\(output.shape):\(output.dtype)"
+                            + " gate=\(gate.shape):\(gate.dtype) norm=\(normWeight.dtype)"
+                            + " scales=\(metadataDType) biases=\(outBiases.dtype)\n").utf8))
             }
             lock.unlock()
             return nil
@@ -285,6 +305,7 @@ private enum Qwen4ExpCompiledGDNInputs {
 
         let key = [
             "tail", String(output.dim(-1)), String(gate.dim(-1)),
+            sigmoidGate ? "sigmoid" : "silu",
             String(describing: output.dtype),
             String(describing: gate.dtype),
             String(describing: metadataDType),
@@ -295,8 +316,12 @@ private enum Qwen4ExpCompiledGDNInputs {
         if region == nil {
             region = vmlxTrustedCompile { (args: [MLXArray]) -> [MLXArray] in
                 let normalized = MLXFast.rmsNorm(args[0], weight: args[2], eps: eps)
-                let gated = (normalized.asType(.float32)
-                    * sigmoid(args[1].asType(.float32))).asType(args[0].dtype)
+                let gate =
+                    sigmoidGate
+                    ? sigmoid(args[1].asType(.float32))
+                    : silu(args[1].asType(.float32))
+                let gated = (normalized.asType(.float32) * gate)
+                    .asType(args[0].dtype)
                 let projected = quantizedMM(
                     gated.reshaped(gated.dim(0), gated.dim(1), -1),
                     args[3], scales: args[4], biases: args[5],
@@ -307,8 +332,10 @@ private enum Qwen4ExpCompiledGDNInputs {
         }
         if !didReportTail {
             didReportTail = true
-            FileHandle.standardError.write(Data(
-                "[Qwen4Exp] compiled_gdn_tail=active recurrence_output=\(output.dtype) gate=\(gate.dtype) metadata=\(metadataDType) shared_weight_inputs=true\n".utf8))
+            FileHandle.standardError.write(
+                Data(
+                    "[Qwen4Exp] compiled_gdn_tail=active gate_mode=\(sigmoidGate ? "sigmoid" : "silu") recurrence_output=\(output.dtype) gate=\(gate.dtype) metadata=\(metadataDType) shared_weight_inputs=true\n"
+                        .utf8))
         }
         lock.unlock()
 
@@ -322,7 +349,8 @@ private enum Qwen4ExpCompiledMoE {
     typealias Region = @Sendable ([MLXArray]) -> [MLXArray]
 
     static let enabled: Bool = {
-        let value = ProcessInfo.processInfo.environment["VMLINUX_QWEN4_EXP_COMPILE_MOE"]
+        let value =
+            ProcessInfo.processInfo.environment["VMLINUX_QWEN4_EXP_COMPILE_MOE"]
             ?? "1"
         return value != "0" && value.lowercased() != "false"
     }()
@@ -365,8 +393,10 @@ private enum Qwen4ExpCompiledMoE {
         }
         if !didReportRouter {
             didReportRouter = true
-            FileHandle.standardError.write(Data(
-                "[Qwen4Exp] compiled_moe_router=active shared_weight_inputs=true dtype=bfloat16\n".utf8))
+            FileHandle.standardError.write(
+                Data(
+                    "[Qwen4Exp] compiled_moe_router=active shared_weight_inputs=true dtype=bfloat16\n"
+                        .utf8))
         }
         lock.unlock()
         let outputs = region!([x, weight, scales, biases])
@@ -401,8 +431,10 @@ private enum Qwen4ExpCompiledMoE {
         }
         if !didReportRouter {
             didReportRouter = true
-            FileHandle.standardError.write(Data(
-                "[Qwen4Exp] compiled_moe_router=active kind=dense shared_weight_inputs=true dtype=bfloat16\n".utf8))
+            FileHandle.standardError.write(
+                Data(
+                    "[Qwen4Exp] compiled_moe_router=active kind=dense shared_weight_inputs=true dtype=bfloat16\n"
+                        .utf8))
         }
         lock.unlock()
         let outputs = region!([x, weight])
@@ -420,10 +452,12 @@ private enum Qwen4ExpCompiledMoE {
     ) -> MLXArray? {
         guard enabled, !CompiledDecodeTrace.isActive, x.dim(1) == 1,
             x.dtype == .bfloat16,
-            [gateScales, gateBiases, upScales, upBiases, downScales,
-             downBiases]
-                .allSatisfy({ $0.dtype == .bfloat16 })
-            && sharedGateWeight.dtype == .bfloat16
+            [
+                gateScales, gateBiases, upScales, upBiases, downScales,
+                downBiases,
+            ]
+            .allSatisfy({ $0.dtype == .bfloat16 })
+                && sharedGateWeight.dtype == .bfloat16
         else { return nil }
         let key = "shared|\(x.dim(-1))|\(gateWeight.dim(0))|\(groupSize)|\(bits)|\(mode)"
         lock.lock()
@@ -447,8 +481,10 @@ private enum Qwen4ExpCompiledMoE {
         }
         if !didReportShared {
             didReportShared = true
-            FileHandle.standardError.write(Data(
-                "[Qwen4Exp] compiled_moe_shared_expert=active shared_weight_inputs=true dtype=bfloat16\n".utf8))
+            FileHandle.standardError.write(
+                Data(
+                    "[Qwen4Exp] compiled_moe_shared_expert=active shared_weight_inputs=true dtype=bfloat16\n"
+                        .utf8))
         }
         lock.unlock()
         let outputs = region!([
@@ -592,7 +628,8 @@ private func gatedDeltaOps(
             mask: maskT
         )
         ys.append(y)
-        state = roundStateEachStep
+        state =
+            roundStateEachStep
             ? newState.asType(q.dtype).asType(.float32)
             : newState
     }
@@ -613,7 +650,8 @@ private func makeVLMGatedDeltaKernel(
     roundStateEachStep: Bool = false
 ) -> MLXFast.MLXFastKernel? {
     let maskSource = hasMask ? "mask[b_idx * T + t]" : "true"
-    let stepRoundSource = roundStateEachStep
+    let stepRoundSource =
+        roundStateEachStep
         ? """
                 for (int i = 0; i < n_per_t; ++i) {
                   state[i] = static_cast<float>(static_cast<InT>(state[i]));
@@ -833,8 +871,10 @@ private enum QwenGatedDeltaDTypeTrace {
         defer { lock.unlock() }
         guard !didReport else { return }
         didReport = true
-        FileHandle.standardError.write(Data(
-            "[QwenGDN] live_dtype_boundaries q=\(q.dtype) k=\(k.dtype) v=\(v.dtype) a=\(a.dtype) b=\(b.dtype) beta=fused_from_\(b.dtype) decay=\(decay.dtype) recurrent_state=\(state.dtype) output=\(q.dtype)\n".utf8))
+        FileHandle.standardError.write(
+            Data(
+                "[QwenGDN] live_dtype_boundaries q=\(q.dtype) k=\(k.dtype) v=\(v.dtype) a=\(a.dtype) b=\(b.dtype) beta=fused_from_\(b.dtype) decay=\(decay.dtype) recurrent_state=\(state.dtype) output=\(q.dtype)\n"
+                    .utf8))
     }
 }
 
@@ -1067,6 +1107,25 @@ public struct Qwen35Configuration: Codable, Sendable {
 // MARK: - Language
 
 enum Qwen35Language {
+    static func shouldCompileDecodeRegions(
+        _ args: Qwen35Configuration.TextConfiguration,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        if let override = environment["VMLINUX_QWEN35_COMPILE_DECODE_REGIONS"] {
+            return override != "0" && override.lowercased() != "false"
+        }
+        return args.modelType == "qwen3_5_moe_text"
+            && args.hiddenSize == 2048
+            && args.hiddenLayers == 40
+            && args.fullAttentionInterval == 4
+            && args.numExperts == 256
+            && args.numExpertsPerTok == 8
+            && args.moeIntermediateSize == 512
+            && args.linearNumKeyHeads == 16
+            && args.linearNumValueHeads == 32
+            && args.linearKeyHeadDim == 128
+            && args.linearValueHeadDim == 128
+    }
 
     final class RotaryEmbedding {
         private let invFreq: MLXArray
@@ -1254,7 +1313,8 @@ enum Qwen35Language {
             // buffer from `update` and its `makeMask` already covers it, so
             // the kvSeqLen mask slice must not run — and reading `.offset`
             // (Int) is an illegal `.item()` inside the compile trace.
-            let fullBufferCache = !(cache is BatchKVCache)
+            let fullBufferCache =
+                !(cache is BatchKVCache)
                 && graphOffsetArray(for: cache) != nil
 
             if positionIds == nil {
@@ -1268,7 +1328,8 @@ enum Qwen35Language {
                     let base = offsets.reshaped(1, B, 1)
                     positionIds = tiled(base, repetitions: [3, 1, L])
                 } else if fullBufferCache, let graphOffset = graphOffsetArray(for: cache) {
-                    var base = graphOffset.reshaped([]).asType(.int32)
+                    var base =
+                        graphOffset.reshaped([]).asType(.int32)
                         + MLXArray(0 ..< L).asType(.int32)
                     base = tiled(base[.newAxis, 0...], repetitions: [B, 1])
                     positionIds = tiled(base[.newAxis, 0..., 0...], repetitions: [3, 1, 1])
@@ -1292,7 +1353,8 @@ enum Qwen35Language {
             if let mask {
                 // Full-buffer (Compilable) caches: mask and K/V both span the
                 // whole static buffer — pass through unsliced.
-                attentionMask = fullBufferCache
+                attentionMask =
+                    fullBufferCache
                     ? .array(mask) : .array(mask[.ellipsis, 0 ..< kvSeqLen])
             } else {
                 attentionMask = .none
@@ -1419,7 +1481,8 @@ enum Qwen35Language {
         private func ensureFusedDecodeInputProjection(
             _ inputs: MLXArray
         ) -> FusedDecodeInputProjection? {
-            guard ProcessInfo.processInfo.environment[
+            guard
+                ProcessInfo.processInfo.environment[
                     "VMLINUX_QWEN4_EXP_FUSE_DECODE_INPUTS"] != "0",
                 fuseDecodeInputProjections, inputs.dim(1) == 1,
                 !CompiledDecodeTrace.isActive
@@ -1456,8 +1519,10 @@ enum Qwen35Language {
                 Self.fusionDiagnosticLock.lock()
                 if !Self.didReportDecodeInputFusion {
                     Self.didReportDecodeInputFusion = true
-                    FileHandle.standardError.write(Data(
-                        "[Qwen4Exp] fused_gdn_decode_input_projections=active dtype=\(inputs.dtype)\n".utf8))
+                    FileHandle.standardError.write(
+                        Data(
+                            "[Qwen4Exp] fused_gdn_decode_input_projections=active dtype=\(inputs.dtype)\n"
+                                .utf8))
                 }
                 Self.fusionDiagnosticLock.unlock()
             }
@@ -1511,13 +1576,14 @@ enum Qwen35Language {
         }
 
         private func compiledDecodeTail(_ output: MLXArray, gate: MLXArray) -> MLXArray? {
-            guard norm.sigmoidGate,
+            guard fuseDecodeInputProjections,
                 let quantized = outProj as? QuantizedLinear,
                 let biases = quantized.biases,
                 quantized.bias == nil
             else { return nil }
             return Qwen4ExpCompiledGDNInputs.callTail(
-                output: output, gate: gate, normWeight: norm.weight,
+                output: output, gate: gate, sigmoidGate: norm.sigmoidGate,
+                normWeight: norm.weight,
                 outWeight: quantized.weight, outScales: quantized.scales,
                 outBiases: biases, eps: norm.eps,
                 groupSize: quantized.groupSize, bits: quantized.bits,
@@ -1571,7 +1637,8 @@ enum Qwen35Language {
             // Staged verify (compiled DFlash 2): committed cache slots and
             // offset stay UNTOUCHED for the whole forward; everything the
             // post-acceptance commit needs goes into fixed staging slots.
-            let stageVerify = cache != nil && S > 1 && mask == nil
+            let stageVerify =
+                cache != nil && S > 1 && mask == nil
                 && NativeMTPVerifierStatePolicy.shouldStageVerifyInputs
             let front = compiledDecodeFront(inputs, convState: convState)
             let z: MLXArray
@@ -1620,9 +1687,11 @@ enum Qwen35Language {
                 let k = split[1].reshaped(B, S, numKHeads, headKDim)
                 v = split[2].reshaped(B, S, numVHeads, headVDim)
                 let invScale = pow(Float(headKDim), -0.5)
-                qNormed = MLXArray(pow(invScale, 2), dtype: q.dtype)
+                qNormed =
+                    MLXArray(pow(invScale, 2), dtype: q.dtype)
                     * MLXFast.rmsNorm(q, weight: MLXArray.mlxNone, eps: 1e-6)
-                kNormed = MLXArray(invScale, dtype: k.dtype)
+                kNormed =
+                    MLXArray(invScale, dtype: k.dtype)
                     * MLXFast.rmsNorm(k, weight: MLXArray.mlxNone, eps: 1e-6)
             }
 
@@ -1682,7 +1751,8 @@ enum Qwen35Language {
                     // commitVerifyStaged after acceptance.
                 } else {
                     if recordPrefixCommitStates, S > 1,
-                       NativeMTPVerifierStatePolicy.shouldRecordAcceptedPrefixStates {
+                        NativeMTPVerifierStatePolicy.shouldRecordAcceptedPrefixStates
+                    {
                         self.recordPrefixCommitStates(
                             cache: cache,
                             convInput: convInput,
@@ -1804,9 +1874,13 @@ enum Qwen35Language {
                 }
                 let diff = abs(prefixState - chained!).max().item(Float.self)
                 let scale = abs(chained!).max().item(Float.self)
-                FileHandle.standardError.write(Data(String(
-                    format: "[rollback-audit] n=%d replay-vs-chained maxdiff=%.3e scale=%.3e\n",
-                    n, diff, scale).utf8))
+                FileHandle.standardError.write(
+                    Data(
+                        String(
+                            format:
+                                "[rollback-audit] n=%d replay-vs-chained maxdiff=%.3e scale=%.3e\n",
+                            n, diff, scale
+                        ).utf8))
             }
             cache[1] = prefixState
             cache[0] = convInput[0..., convStart ..< convEnd, 0...]
@@ -2029,7 +2103,8 @@ enum Qwen35Language {
             if let eagerCombined, let shared = compiledSharedExpert(x) {
                 return eagerCombined + shared
             }
-            let combined = eagerCombined
+            let combined =
+                eagerCombined
                 ?? (routed! * scores[.ellipsis, .newAxis]).sum(axis: -2)
             let sharedY = sharedExpert(x)
             let gatedSharedY = compiledSigmoidGate(sharedExpertGate(x), sharedY)
@@ -2051,15 +2126,21 @@ enum Qwen35Language {
 
         init(_ args: Qwen35Configuration.TextConfiguration, layerIdx: Int) {
             self.isLinear = (layerIdx + 1) % args.fullAttentionInterval != 0
+            let compiledDecodeRegions = shouldCompileDecodeRegions(args)
 
             if isLinear {
-                _linearAttn.wrappedValue = GatedDeltaNet(args)
+                _linearAttn.wrappedValue = GatedDeltaNet(
+                    args,
+                    fuseDecodeInputProjections: compiledDecodeRegions)
             } else {
                 _selfAttn.wrappedValue = Attention(args)
             }
 
             if args.numExperts > 0 {
-                _mlp.wrappedValue = SparseMoeBlock(args, layerIdx: layerIdx)
+                _mlp.wrappedValue = SparseMoeBlock(
+                    args,
+                    layerIdx: layerIdx,
+                    compileDecodeRegions: compiledDecodeRegions)
             } else {
                 _mlp.wrappedValue = MLP(
                     dimensions: args.hiddenSize, hiddenDimensions: args.intermediateSize)
@@ -2153,11 +2234,13 @@ enum Qwen35Language {
             cache: KVCache?,
             positionIds: MLXArray?
         ) -> MLXArray {
-            let h = x + selfAttn(
-                inputLayerNorm(x),
-                mask: attentionMask,
-                cache: cache,
-                positionIds: positionIds)
+            let h =
+                x
+                + selfAttn(
+                    inputLayerNorm(x),
+                    mask: attentionMask,
+                    cache: cache,
+                    positionIds: positionIds)
             return h + (mlp as! UnaryLayer)(postAttentionLayerNorm(h))
         }
     }
@@ -2189,10 +2272,11 @@ enum Qwen35Language {
             cache: [KVCache]?
         ) -> MLXArray {
             let embeds = embedTokens(nextTokenIds)
-            let fusedInput = concatenated([
-                preFCNormEmbedding(embeds),
-                preFCNormHidden(hiddenStates),
-            ], axis: -1)
+            let fusedInput = concatenated(
+                [
+                    preFCNormEmbedding(embeds),
+                    preFCNormHidden(hiddenStates),
+                ], axis: -1)
             var hiddenStates = fc(fusedInput)
 
             var cacheArray = cache
@@ -2224,11 +2308,12 @@ enum Qwen35Language {
             embedTokens: Embedding,
             cache: [KVCache]?
         ) -> MLXArray {
-            norm(preNormHidden(
-                hiddenStates: hiddenStates,
-                nextTokenIds: nextTokenIds,
-                embedTokens: embedTokens,
-                cache: cache))
+            norm(
+                preNormHidden(
+                    hiddenStates: hiddenStates,
+                    nextTokenIds: nextTokenIds,
+                    embedTokens: embedTokens,
+                    cache: cache))
         }
 
         func makeCache() -> [KVCache] {
@@ -2611,7 +2696,8 @@ enum Qwen35Language {
             // (measured: restored offset 1375, chunk 33, slice [1408..<1412]
             // → broadcast abort). `nil` positions make attention derive
             // them from the cache offset, exactly like the plain forward.
-            let positionIds: MLXArray? = ropeDeltas != nil
+            let positionIds: MLXArray? =
+                ropeDeltas != nil
                 ? resolvedPositionIds(
                     inputs: inputs,
                     cache: cacheOpt,
@@ -2742,7 +2828,9 @@ enum Qwen35Language {
 
 // MARK: - Model
 
-public class Qwen35: Module, VLMModel, HiddenStateCaptureModel, TokenEmbedderModel, NativeMTPModel, DFlash2StagedVerifyRollbackModel {
+public class Qwen35: Module, VLMModel, HiddenStateCaptureModel, TokenEmbedderModel, NativeMTPModel,
+    DFlash2StagedVerifyRollbackModel
+{
     @ModuleInfo(key: "vision_tower") private var visionModel: Qwen3VLVision.VisionModel
     @ModuleInfo(key: "language_model") fileprivate var languageModel: Qwen35Language.LanguageModel
 
@@ -2764,7 +2852,6 @@ public class Qwen35: Module, VLMModel, HiddenStateCaptureModel, TokenEmbedderMod
     public func newCache(parameters: GenerateParameters?) -> [KVCache] {
         languageModel.makeCache(maxKVSize: parameters?.maxKVSize)
     }
-
 
     /// Scatters vision features onto their placeholder positions.
     ///
@@ -3161,7 +3248,8 @@ public class Qwen35: Module, VLMModel, HiddenStateCaptureModel, TokenEmbedderMod
             weights: weights,
             probeSuffixes: [".input_layernorm.weight", ".post_attention_layernorm.weight"],
             fallbackWhenNoProbe: { !Self.isMLXFormatLike(weights) })
-        let shouldShiftMTPNormWeights = loadNativeMTP
+        let shouldShiftMTPNormWeights =
+            loadNativeMTP
             && (shouldShiftNormWeights || Self.mtpNormWeightsNeedShift(weights))
 
         if config.textConfiguration.tieWordEmbeddings {
@@ -3172,7 +3260,9 @@ public class Qwen35: Module, VLMModel, HiddenStateCaptureModel, TokenEmbedderMod
         if isMLXFormat && !hasUnsanitizedConv1d && !shouldShiftNormWeights
             && !shouldShiftMTPNormWeights
         {
-            let needsRemap = weights.keys.contains { $0.contains("model.language_model") || $0.contains("model.visual") }
+            let needsRemap = weights.keys.contains {
+                $0.contains("model.language_model") || $0.contains("model.visual")
+            }
             if !needsRemap {
                 return weights
             }
@@ -3216,11 +3306,13 @@ public class Qwen35: Module, VLMModel, HiddenStateCaptureModel, TokenEmbedderMod
             if key.contains("conv1d.weight") && value.dim(-1) != 1 {
                 value = value.movedAxis(source: 2, destination: 1)
             }
-            let isMTPNorm = loadNativeMTP
+            let isMTPNorm =
+                loadNativeMTP
                 && Self.isMTPWeightKey(key)
                 && key.hasSuffix(".weight")
                 && (key.contains("norm") || key.contains("q_norm") || key.contains("k_norm"))
-            let shouldShiftBaseNorm = shouldShiftNormWeights
+            let shouldShiftBaseNorm =
+                shouldShiftNormWeights
                 && normKeys.contains(where: { key.hasSuffix($0) })
             let shouldShiftMTPNorm = isMTPNorm && shouldShiftMTPNormWeights
             if (shouldShiftBaseNorm || shouldShiftMTPNorm) && value.ndim == 1 {

--- a/Tests/MLXLMTests/Qwen35VLMGatedDeltaTests.swift
+++ b/Tests/MLXLMTests/Qwen35VLMGatedDeltaTests.swift
@@ -1,8 +1,9 @@
 import Foundation
 import MLX
 import MLXLMCommon
-@testable import MLXVLM
 import Testing
+
+@testable import MLXVLM
 
 @Suite("Qwen3.5-VL gated-delta forward", .serialized)
 struct Qwen35VLMGatedDeltaTests {
@@ -10,48 +11,48 @@ struct Qwen35VLMGatedDeltaTests {
         try JSONDecoder.json5().decode(
             Qwen35Configuration.self,
             from: """
-            {
-              "model_type": "qwen3_5_moe",
-              "text_config": {
-                "model_type": "qwen3_5_moe_text",
-                "hidden_size": 32,
-                "num_hidden_layers": 4,
-                "intermediate_size": 64,
-                "num_attention_heads": 4,
-                "num_key_value_heads": 2,
-                "linear_num_value_heads": 4,
-                "linear_num_key_heads": 2,
-                "linear_key_head_dim": 8,
-                "linear_value_head_dim": 8,
-                "linear_conv_kernel_dim": 2,
-                "head_dim": 8,
-                "full_attention_interval": 4,
-                "vocab_size": 100,
-                "rms_norm_eps": 1e-6,
-                "rope_parameters": {
-                  "rope_type": "default",
-                  "rope_theta": 100000.0,
-                  "partial_rotary_factor": 0.25,
-                  "mrope_section": [1, 1, 1]
+                {
+                  "model_type": "qwen3_5_moe",
+                  "text_config": {
+                    "model_type": "qwen3_5_moe_text",
+                    "hidden_size": 32,
+                    "num_hidden_layers": 4,
+                    "intermediate_size": 64,
+                    "num_attention_heads": 4,
+                    "num_key_value_heads": 2,
+                    "linear_num_value_heads": 4,
+                    "linear_num_key_heads": 2,
+                    "linear_key_head_dim": 8,
+                    "linear_value_head_dim": 8,
+                    "linear_conv_kernel_dim": 2,
+                    "head_dim": 8,
+                    "full_attention_interval": 4,
+                    "vocab_size": 100,
+                    "rms_norm_eps": 1e-6,
+                    "rope_parameters": {
+                      "rope_type": "default",
+                      "rope_theta": 100000.0,
+                      "partial_rotary_factor": 0.25,
+                      "mrope_section": [1, 1, 1]
+                    }
+                  },
+                  "vision_config": {
+                    "model_type": "qwen3_vl",
+                    "depth": 1,
+                    "hidden_size": 16,
+                    "intermediate_size": 32,
+                    "out_hidden_size": 32,
+                    "num_heads": 4,
+                    "patch_size": 2,
+                    "spatial_merge_size": 2,
+                    "temporal_patch_size": 1,
+                    "num_position_embeddings": 32
+                  },
+                  "vocab_size": 100,
+                  "image_token_id": 98,
+                  "video_token_id": 97
                 }
-              },
-              "vision_config": {
-                "model_type": "qwen3_vl",
-                "depth": 1,
-                "hidden_size": 16,
-                "intermediate_size": 32,
-                "out_hidden_size": 32,
-                "num_heads": 4,
-                "patch_size": 2,
-                "spatial_merge_size": 2,
-                "temporal_patch_size": 1,
-                "num_position_embeddings": 32
-              },
-              "vocab_size": 100,
-              "image_token_id": 98,
-              "video_token_id": 97
-            }
-            """.data(using: .utf8)!)
+                """.data(using: .utf8)!)
     }
 
     @Test("tiny VLM text path executes linear-attention gated-delta cache")
@@ -96,6 +97,93 @@ struct Qwen35VLMGatedDeltaTests {
             #expect(logits.shape == [2, 1, 100])
             let fullAttention = try #require(batchCaches.last as? BatchKVCache)
             #expect(fullAttention.offsetArray.asArray(Int32.self) == [4, 3])
+        }
+    }
+
+    @Test("compiled decode policy is architecture-scoped and explicitly overridable")
+    func compiledDecodePolicyIsArchitectureScoped() throws {
+        var ornith = try tinyConfiguration().textConfiguration
+        ornith.modelType = "qwen3_5_moe_text"
+        ornith.hiddenSize = 2048
+        ornith.hiddenLayers = 40
+        ornith.fullAttentionInterval = 4
+        ornith.numExperts = 256
+        ornith.numExpertsPerTok = 8
+        ornith.moeIntermediateSize = 512
+        ornith.linearNumKeyHeads = 16
+        ornith.linearNumValueHeads = 32
+        ornith.linearKeyHeadDim = 128
+        ornith.linearValueHeadDim = 128
+
+        #expect(Qwen35Language.shouldCompileDecodeRegions(ornith, environment: [:]))
+        #expect(
+            !Qwen35Language.shouldCompileDecodeRegions(
+                ornith,
+                environment: ["VMLINUX_QWEN35_COMPILE_DECODE_REGIONS": "false"]))
+
+        var neighbor = ornith
+        neighbor.hiddenSize = 2560
+        #expect(!Qwen35Language.shouldCompileDecodeRegions(neighbor, environment: [:]))
+        #expect(
+            Qwen35Language.shouldCompileDecodeRegions(
+                neighbor,
+                environment: ["VMLINUX_QWEN35_COMPILE_DECODE_REGIONS": "1"]))
+    }
+
+    @Test("compiled GDN tail matches eager SiLU and sigmoid gate contracts")
+    func compiledGDNTailMatchesEagerContracts() throws {
+        try MLXMetalTestLock.withLock {
+            let heads = 4
+            let headDimension = 8
+            let valueDimension = heads * headDimension
+            let hiddenDimension = 16
+            let eps: Float = 1e-6
+            let output = MLXRandom.uniform(
+                low: -1, high: 1, [1, 1, heads, headDimension],
+                key: MLXRandom.key(701)
+            ).asType(.bfloat16)
+            let gate = MLXRandom.uniform(
+                low: -1, high: 1, [1, 1, heads, headDimension],
+                key: MLXRandom.key(702)
+            ).asType(.bfloat16)
+            let normWeight = MLXRandom.uniform(
+                low: 0.5, high: 1.5, [headDimension],
+                key: MLXRandom.key(703)
+            ).asType(.bfloat16)
+            let sourceWeight = MLXRandom.uniform(
+                low: -0.5, high: 0.5, [hiddenDimension, valueDimension],
+                key: MLXRandom.key(704)
+            ).asType(.bfloat16)
+            let (weight, scales, biases) = MLX.quantized(
+                sourceWeight, groupSize: 32, bits: 4, mode: .affine)
+            let affineBiases = try #require(biases)
+
+            for sigmoidGate in [false, true] {
+                let compiled = try #require(
+                    Qwen4ExpCompiledGDNInputs.callTail(
+                        output: output, gate: gate, sigmoidGate: sigmoidGate,
+                        normWeight: normWeight,
+                        outWeight: weight, outScales: scales, outBiases: affineBiases,
+                        eps: eps, groupSize: 32, bits: 4, mode: .affine))
+                let normalized = MLXFast.rmsNorm(output, weight: normWeight, eps: eps)
+                let activatedGate =
+                    sigmoidGate
+                    ? sigmoid(gate.asType(.float32))
+                    : gate.asType(.float32) * sigmoid(gate.asType(.float32))
+                let gated = (normalized.asType(.float32) * activatedGate)
+                    .asType(output.dtype)
+                    .reshaped(1, 1, valueDimension)
+                let eager = quantizedMM(
+                    gated, weight, scales: scales, biases: affineBiases,
+                    transpose: true, groupSize: 32, bits: 4, mode: .affine)
+                MLX.eval(compiled, eager)
+
+                #expect(compiled.shape == eager.shape)
+                let difference = abs(
+                    compiled.asType(.float32) - eager.asType(.float32)
+                ).max().item(Float.self)
+                #expect(difference < 1e-3, "gate=\(sigmoidGate) max diff \(difference)")
+            }
         }
     }
 }

--- a/Tests/MLXLMTests/Qwen4ExpFusedAffineMoETests.swift
+++ b/Tests/MLXLMTests/Qwen4ExpFusedAffineMoETests.swift
@@ -38,6 +38,8 @@ struct Qwen4ExpFusedAffineMoETests {
         Combo(label: "2L_down_g32", gate: (2, 64), up: (2, 64), down: (2, 32)),
         Combo(label: "6S_down_q6", gate: (4, 64), up: (4, 64), down: (6, 64)),
         Combo(label: "6S_up_down_q6", gate: (4, 64), up: (6, 64), down: (6, 64)),
+        Combo(label: "Ornith_late_gate_up_q5", gate: (5, 64), up: (5, 64), down: (4, 64)),
+        Combo(label: "q5_all_projections", gate: (5, 64), up: (5, 64), down: (5, 64)),
     ]
 
     private static func makeProjection(
@@ -87,8 +89,9 @@ struct Qwen4ExpFusedAffineMoETests {
                 inputDims: Self.expertDims, outputDims: Self.inputDims,
                 bits: combo.down.bits, groupSize: combo.down.group, seed: seedBase + 2)
 
-            guard let reducer = Qwen4ExpFusedAffineMoE.makeReducer(
-                gate: gate, up: up, down: down)
+            guard
+                let reducer = Qwen4ExpFusedAffineMoE.makeReducer(
+                    gate: gate, up: up, down: down)
             else {
                 Issue.record("construction rejected for \(combo.label)")
                 continue
@@ -159,6 +162,64 @@ struct Qwen4ExpFusedAffineMoETests {
                 fusedError < max(4 * eagerError, 0.01),
                 "combo \(combo.label): fused \(fusedError) far above eager \(eagerError)")
         }
+    }
+
+    @Test("Ornith 2048x512 top-8 q5 contract matches eager quantized math")
+    func ornith35ShapeParity() throws {
+        let inputDims = 2048
+        let expertDims = 512
+        let topK = 8
+        let seed: UInt64 = 9001
+        let (gate, _) = Self.makeProjection(
+            inputDims: inputDims, outputDims: expertDims,
+            bits: 5, groupSize: 64, seed: seed)
+        let (up, _) = Self.makeProjection(
+            inputDims: inputDims, outputDims: expertDims,
+            bits: 5, groupSize: 64, seed: seed + 1)
+        let (down, _) = Self.makeProjection(
+            inputDims: expertDims, outputDims: inputDims,
+            bits: 4, groupSize: 64, seed: seed + 2)
+
+        let reducer = try #require(
+            Qwen4ExpFusedAffineMoE.makeReducer(
+                gate: gate, up: up, down: down))
+        let x = MLXRandom.uniform(
+            low: -1.0, high: 1.0, [1, 1, inputDims],
+            key: MLXRandom.key(seed + 3)
+        ).asType(.bfloat16)
+        let indexValues: [UInt32] = [0, 2, 4, 6, 9, 11, 13, 15]
+        let indices = MLXArray(indexValues, [1, 1, topK])
+        let scores = MLX.softmax(
+            MLXRandom.uniform(
+                low: 0.0, high: 1.0, [1, 1, topK],
+                key: MLXRandom.key(seed + 4)
+            ).asType(.float32), axis: -1)
+        let fused = try #require(reducer(x, indices, scores))
+
+        let xb = x.reshaped([1, inputDims])
+        var eager = MLXArray.zeros([inputDims], dtype: .float32)
+        for (k, expert) in indexValues.enumerated() {
+            let e = Int(expert)
+            let g = quantizedMM(
+                xb, gate.weight[e], scales: gate.scales[e], biases: gate.biases?[e],
+                transpose: true, groupSize: 64, bits: 5, mode: .affine)
+            let u = quantizedMM(
+                xb, up.weight[e], scales: up.scales[e], biases: up.biases?[e],
+                transpose: true, groupSize: 64, bits: 5, mode: .affine)
+            let activation = (g * MLX.sigmoid(g)) * u
+            let projected = quantizedMM(
+                activation, down.weight[e], scales: down.scales[e],
+                biases: down.biases?[e], transpose: true,
+                groupSize: 64, bits: 4, mode: .affine)
+            eager =
+                eager
+                + scores.reshaped(-1)[k].asType(.float32)
+                * projected.asType(.float32).reshaped(-1)
+        }
+
+        let error = Self.relativeError(fused, eager)
+        print("[FusedMoEParity] combo=ornith35_q5q5q4_g64_top8 fused_vs_eager=\(error)")
+        #expect(error < 0.01, "Ornith fused/eager relative error \(error)")
     }
 
     @Test("construction rejects unsupported metadata and group sizes")

--- a/docs/CONTINUOUS_BATCHING_FAMILY_TRIAGE_2026_08_29.md
+++ b/docs/CONTINUOUS_BATCHING_FAMILY_TRIAGE_2026_08_29.md
@@ -231,3 +231,44 @@ as a substitute for rendered app behavior.
 - Release-app visual confirmation before calling user-facing behavior fixed.
 
 Anything missing is `PARTIAL` or `BLOCKED`, with the artifact and reason named.
+
+## Ornith 1.5 35B decode-performance follow-up
+
+The MTP-MoE load fix did not explain the reported roughly 25 tok/s decode
+rate.  On merged vMLX `aee2a8e0`, the production Qwen3.5-VL decoder left its
+existing compiled GDN and MoE decode regions disabled for this exact
+architecture.  Enabling those regions only for the measured model topology,
+while retaining an explicit environment opt-out, is the causal speed change.
+The policy is based on the decoded architecture fields rather than a bundle
+name, so neighboring Qwen3.5, Qwen3.8, Gemma, Laguna, and DSV4 configurations
+do not inherit it.
+
+Current unmerged proof from `fix/ornith35-fused-affine-moe`:
+
+- Release, 128 generated tokens: median **94.0 tok/s**
+  (`94.2/94.0/92.7`), TTFT 164-169 ms, peak physical footprint 27,393 MiB;
+- Release, 512 generated tokens: median **91.5 tok/s**
+  (`90.9/91.5/91.5`), TTFT 168-169 ms, peak physical footprint 27,315 MiB;
+- output was coherent and byte-stable across each greedy three-run row, with
+  no loop, unclosed reasoning, or protocol-marker leak;
+- the three-turn tool row produced a structured `xmlFunction` call, consumed
+  its result, summarized it, and recalled the launch ID on the next turn;
+- hybrid cache telemetry recorded paged hit 1, SSM hits 2/re-derives 2, and
+  seven disk stores;
+- cross-session disk restore matched 138/138 prompt tokens and reduced prompt
+  processing from 501 ms cold to 29 ms warm;
+- focused numerical tests pass for both SiLU/sigmoid compiled GDN tails and
+  the real q5/q5/q4 Ornith expert topology.
+
+Artifacts:
+
+- `/private/tmp/ornith35-final-release-default-128.log`
+- `/private/tmp/ornith35-final-release-default-512.log`
+- `/private/tmp/ornith35-final-agentic-tool.log`
+- `/private/tmp/ornith35-final-disk-restore.log`
+- `/private/tmp/ornith35-compiled-policy-tests2.log`
+- `/private/tmp/ornith35-fused-moe-tests-final.log`
+
+This lane remains `PARTIAL` until the focused branch is reviewed in its own PR
+and current-head CI passes.  The rows above are engine/runtime proof, not a
+Release Osaurus UI proof.


### PR DESCRIPTION
## Summary

Ornith 1.5 35B decoded at roughly 25 tok/s on the stale public runtime and about 80-82 tok/s on current vMLX, below the expected 90+ tok/s class. The Qwen3.5-VL decoder already had compatible compiled GDN/MoE regions, but construction left them disabled for this shipped topology.

This change:

- enables the existing compiled GDN and MoE decode regions by an exact decoded architecture contract, not by bundle/repository name;
- preserves an explicit `VMLINUX_QWEN35_COMPILE_DECODE_REGIONS=0` opt-out;
- supports the real q5/q5/q4 affine expert layout in the fused top-8 MoE kernel;
- makes the compiled GDN tail respect the model's SiLU vs sigmoid gate contract;
- keeps neighboring Qwen3.5 shapes and all other model families out of the default policy.

Closes #345.

## Source trace

`Qwen35Language.DecoderLayer` constructed both `GatedDeltaNet` and `SparseMoeBlock` with their compiled decode regions disabled. The new `shouldCompileDecodeRegions` policy checks the actual text architecture fields (model type, width/layers, full-attention interval, expert topology, and GDN head geometry). An explicit environment value still wins.

No sampler, prompt, template, reasoning, MTP, or cache policy is changed.

## Focused tests (head `67575f9a`)

- `Qwen35VLMGatedDeltaTests`: **4/4 PASS**
  - architecture-scoped default + override/neighbor negative controls;
  - compiled GDN tail parity for both SiLU and sigmoid gates;
  - batch=2 position isolation;
  - tiny real gated-delta/cache forward.
- `Qwen4ExpFusedAffineMoETests`: **3/3 PASS**
  - shipped bit/group layouts;
  - exact Ornith 2048x512 top-8 q5/q5/q4 contract, fused-vs-eager relative error `0.0031157418`;
  - unsupported metadata rejection.
- Release `RunBench` build: **RC 0**.

## Live Release runtime proof

Model: `dealign.ai/Ornith-1.5-35B-A3B-UNCENSORED-JANG_4M`  
Path: real `BatchEngine`, mmap on, JangPress off, greedy deterministic sampling.  
No `VMLINUX_QWEN35_COMPILE_DECODE_REGIONS` opt-in was present.

| Row | Result | TTFT | Peak phys footprint | Coherency |
|---|---:|---:|---:|---|
| 128 tokens, 3 runs | **94.0 tok/s median** (`94.2/94.0/92.7`) | 164-169 ms | 27,393 MiB | identical coherent text; no loop/leak/unclosed reasoning |
| 512 tokens, 3 runs | **91.5 tok/s median** (`90.9/91.5/91.5`) | 168-169 ms | 27,315 MiB | identical coherent text; no loop/leak/unclosed reasoning |

The logs confirm all intended regions active: fused q5-capable affine MoE, compiled dense router, compiled shared expert, fused GDN inputs, compiled GDN front, and compiled SiLU tail.

## Multi-turn/tool/cache proof

- Three-turn tool workflow: **PASS**
  - turn 1 emitted one parsed `xmlFunction` call;
  - turn 2 consumed the result and summarized `LAGUNA-77`;
  - turn 3 recalled `LAGUNA-77` exactly.
- Hybrid cache telemetry: paged hit 1; SSM hits 2, misses 0, re-derives 2; disk stores 7.
- Cross-session disk restore: **PASS**, matched 138/138 prompt tokens; prompt processing 501 ms cold -> 29 ms warm; both sessions completed coherently.

Artifacts:

- `/private/tmp/ornith35-final-release-default-128.log`
- `/private/tmp/ornith35-final-release-default-512.log`
- `/private/tmp/ornith35-final-agentic-tool.log`
- `/private/tmp/ornith35-final-disk-restore.log`
- `/private/tmp/ornith35-compiled-policy-tests2.log`
- `/private/tmp/ornith35-fused-moe-tests-final.log`

## Scope / remaining gate

This is current engine/runtime proof, not Osaurus Release-app visual proof. Osaurus must repin the merged vMLX SHA and run the exact app UI before making a user-facing release claim. Other family lanes (DSV4 footprint, Zaya CCA/VLM, Flash-Next MTP matrix) remain separate defects and are not waived by this result.
