### PR TITLE
Serialize evaluated MLX host reads through backing copy

### DIFF
--- a/Source/MLX/MLXArray+Bytes.swift
+++ b/Source/MLX/MLXArray+Bytes.swift
@@ -125,15 +125,39 @@ extension MLXArray {
             return self.asType(type).asArray(type)
         }
 
-        self.eval()
-
-        return [T](unsafeUninitializedCapacity: self.size) { destination, initializedCount in
-            let source = UnsafeRawBufferPointer(
-                start: mlx_array_data_uint8(self.ctx), count: physicalSize * itemSize)
-            copy(from: source, toContiguous: UnsafeMutableRawBufferPointer(destination))
-            initializedCount = self.size
+        // Keep the shared-stream lock through the host copy, not only through
+        // `mlx_array_eval`. A concurrent teardown/cache-clear may otherwise
+        // enter after eval has returned but before `mlx_array_data_uint8`
+        // reads the backing descriptor. Qwen4Exp PLE performs this host read
+        // once per decode step, so server cancellation/load churn made that
+        // tiny gap a production EXC_BAD_ACCESS in Buffer::raw_ptr().
+        return withEvaluatedHostAccess {
+            return [T](unsafeUninitializedCapacity: self.size) { destination, initializedCount in
+                let source = UnsafeRawBufferPointer(
+                    start: mlx_array_data_uint8(self.ctx), count: physicalSize * itemSize)
+                copy(from: source, toContiguous: UnsafeMutableRawBufferPointer(destination))
+                initializedCount = self.size
+            }
         }
     }
+
+    /// Evaluate and keep the global MLX stream driver lock held while a
+    /// caller reads the realized host backing. Internal so every host-copy
+    /// surface can share the same lifetime boundary without exposing the lock.
+    func withEvaluatedHostAccess<Result>(
+        _ body: () throws -> Result
+    ) rethrows -> Result {
+        try evalLock.withLock {
+            self.eval()
+            return try body()
+        }
+    }
+
+#if DEBUG
+    static func withEvalLockForTesting(_ body: () -> Void) {
+        evalLock.withLock(body)
+    }
+#endif
 
     /// How to access backing data with ``asData(access:)`` -- this controls how
     /// ``MLXArrayData`` is produced.

--- a/Tests/MLXTests/MLXArrayEmptyHostReadTests.swift
+++ b/Tests/MLXTests/MLXArrayEmptyHostReadTests.swift
@@ -1,0 +1,78 @@
+@testable import MLX
+import Dispatch
+import Testing
+
+@Suite("MLXArray empty host reads")
+struct MLXArrayEmptyHostReadTests {
+    @Test("asArray returns an empty Swift array for a zero-element tensor")
+    func emptyAsArray() {
+        let empty = MLXArray.zeros([1, 0], type: Int32.self)
+
+        #expect(empty.asArray(Int32.self).isEmpty)
+    }
+
+    @Test("asArray returns empty for a zero-length lazy slice")
+    func emptySliceAsArray() {
+        let tokens = MLXArray([Int32(11), Int32(22)]).reshaped(1, 2)
+        let emptySuffix = tokens[0..., 2 ..< 2]
+
+        #expect(emptySuffix.shape == [1, 0])
+        #expect(emptySuffix.asArray(Int32.self).isEmpty)
+    }
+
+    @Test("evaluated host access holds the stream lock through the read")
+    func hostAccessLockScope() {
+        nonisolated(unsafe) let array = MLXArray([Int32(7)])
+        let enteredRead = DispatchSemaphore(value: 0)
+        let releaseRead = DispatchSemaphore(value: 0)
+        let readFinished = DispatchSemaphore(value: 0)
+        let competingLockAcquired = DispatchSemaphore(value: 0)
+
+        DispatchQueue.global().async {
+            array.withEvaluatedHostAccess {
+                enteredRead.signal()
+                releaseRead.wait()
+            }
+            readFinished.signal()
+        }
+        #expect(enteredRead.wait(timeout: .now() + 2) == .success)
+
+        DispatchQueue.global().async {
+            MLXArray.withEvalLockForTesting {
+                competingLockAcquired.signal()
+            }
+        }
+        #expect(competingLockAcquired.wait(timeout: .now() + 0.05) == .timedOut)
+
+        releaseRead.signal()
+        #expect(readFinished.wait(timeout: .now() + 2) == .success)
+        #expect(competingLockAcquired.wait(timeout: .now() + 2) == .success)
+    }
+
+    @Test("host reads stay valid during concurrent stream maintenance")
+    func concurrentHostReads() async {
+        await withTaskGroup(of: Bool.self) { group in
+            for reader in 0 ..< 8 {
+                group.addTask {
+                    for iteration in 0 ..< 2_000 {
+                        let expected = Int32(reader + iteration)
+                        let lazy = MLXArray(Int32(reader)) + MLXArray(Int32(iteration))
+                        guard lazy.asArray(Int32.self) == [expected] else { return false }
+                    }
+                    return true
+                }
+            }
+            group.addTask {
+                for _ in 0 ..< 2_000 {
+                    Stream.gpu.synchronize()
+                    Memory.clearCache()
+                }
+                return true
+            }
+
+            for await passed in group {
+                #expect(passed)
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Keep MLX's shared stream-driver lock held through `MLXArray.asArray`'s host copy, closing the interval between `mlx_array_eval` and `mlx_array_data_uint8` in which concurrent cache clear, stream synchronization, cancellation, or teardown could invalidate the backing descriptor.

## Production incident

- Osaurus 0.24.2 incident: `APPLE-MACOS-1X5`, one production user, 2026-08-30.
- Exact release binary UUID: `1E4CBE4B-D52D-342D-A78C-575F345382E5`.
- Exact 0.24.2 dSYM symbolication:
  `Buffer::raw_ptr -> mlx_array_data_uint8 -> MLXArray.asArray -> Qwen4ExpPLE.prefetch(inputIds:) -> Qwen4ExpTextModel.forward -> TokenIterator.step`.
- Fault: `EXC_BAD_ACCESS / SIGSEGV`, null dereference at `allocator.cpp:28`; no OOM signature.
- Sentry breadcrumbs show a Qwen3.8 Flash-Next 2L server workload with repeated load admissions and request/cancellation churn. Every submitted request advertised batch width 1, so this is not explained by the already-merged Qwen4Exp batch-width cap.

## Causal source trace

`MLXArray.eval()` serializes only `mlx_array_eval`. `asArray` released `evalLock` before calling `mlx_array_data_uint8` and copying the backing bytes. Other stream drivers (`Memory.clearCache`, `Stream.synchronize`, teardown/cancel paths) use the same lock, so they could enter in that gap. Qwen4Exp PLE performs this host read on every decode step.

This change introduces `withEvaluatedHostAccess` and keeps the lock held from evaluation through the completed host copy. It does not alter model loading, sampling, generation config, MTP policy, cache contents, or n-gram lookup behavior.

## Tests

- `MLXArrayEmptyHostReadTests`: 4/4 pass.
  - lock-scope test proves a competing stream-lock acquisition cannot enter during evaluated host access;
  - concurrent host-read + synchronize/clear-cache stress;
  - zero-element tensor and zero-length lazy-slice host reads.
- Exact focused command used a valid colocated MLX metallib and completed with zero failures.

## Live reproduction / stress boundary

Before-patch live stress used the exact signed 0.24.2 app and exact Flash-Next 2L bundle on the server surface:

- 88 completed concurrent requests;
- 204 mixed completed/client-cancelled requests across 17 rounds;
- repeated 384-token generations crossing the 256-token cache-clear boundary;
- native MTP d1 active with verifier/accept/bonus telemetry;
- PLE n-gram table stayed SSD-backed (`pread-fnocache`, 21.672 GiB backing file) and row-read counters advanced;
- disk L2 stores/hits and SSM companion hits advanced.

The crash is rare and did not recur on the available M5 Max running macOS 26.3.2. The originating machine was Mac15,14 on macOS 27.0. Therefore current live status is **PARTIAL** until the patched exact-head app completes the same stress matrix and, ideally, a macOS 27 reporter confirms. The source fault and exact production stack are current evidence; the pre-patch stress is not being misrepresented as a deterministic A/B failure.
