### PR TITLE
Defer speculative prefill into cancellable streams

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -1256,20 +1256,38 @@ public actor BatchEngine {
                         "\(type(of: context.model)) does not expose per-layer hidden states and a shared LM head"
                     )
                 }
-                let drafter = try DFlash2DrafterResolver.shared.drafter(at: drafterPath)
-                let iterator = try DFlash2TokenIterator(
-                    input: input,
-                    target: dflashTarget,
-                    drafter: drafter,
-                    blockSize: strategy.dflash2BlockSize,
-                    cache: nil,
-                    parameters: soloParameters,
-                    cacheCoordinator: cacheCoordinator)
-                (sourceStream, generationTask) = generateTask(
+                // DFlash prefill and drafter loading are GPU-backed setup too.
+                // Keep them behind the same cancellable producer boundary as
+                // AR, block diffusion, and native MTP so a disconnected client
+                // cannot leave an unowned prefill holding the shared stream.
+                let promptTokenIdsForTail = input.text.tokens.reshaped(-1).asArray(Int.self)
+                let deferredParameters = soloParameters
+                let deferredBlockSize = strategy.dflash2BlockSize
+                let deferredDrafterPath = drafterPath
+                let deferredInputs = SendableBox(
+                    (input, dflashTarget, cacheCoordinator))
+                let makeIterator: @Sendable () throws -> any TokenIteratorProtocol = {
+                    try Task.checkCancellation()
+                    let (deferredInput, deferredTarget, deferredCoordinator) =
+                        deferredInputs.consume()
+                    let deferredDrafter = try DFlash2DrafterResolver.shared.drafter(
+                        at: deferredDrafterPath)
+                    try Task.checkCancellation()
+                    return try DFlash2TokenIterator(
+                        input: deferredInput,
+                        target: deferredTarget,
+                        drafter: deferredDrafter,
+                        blockSize: deferredBlockSize,
+                        cache: nil,
+                        parameters: deferredParameters,
+                        cacheCoordinator: deferredCoordinator)
+                }
+                (sourceStream, generationTask) = generateTaskDeferred(
                     promptTokenCount: promptTokenCount,
                     modelConfiguration: context.configuration,
                     tokenizer: context.tokenizer,
-                    iterator: iterator,
+                    promptTokenIds: promptTokenIdsForTail,
+                    makeIterator: makeIterator,
                     extraStopStrings: soloParameters.extraStopStrings,
                     promptTail: promptTail,
                     toolSchemas: toolSchemas)
@@ -1280,18 +1298,37 @@ public actor BatchEngine {
                 guard let nativeModel = context.model as? any NativeMTPModel else {
                     throw NativeMTPRuntimeError.modelDoesNotExposeNativeMTP
                 }
-                let iterator = try NativeMTPTokenIterator(
-                    input: input,
-                    model: nativeModel,
-                    cache: nil,
-                    parameters: soloParameters,
-                    depth: depth,
-                    cacheCoordinator: cacheCoordinator)
-                (sourceStream, generationTask) = generateTask(
+                // Native MTP prefill used to run synchronously on the
+                // BatchEngine actor before `generationTask` and the stream's
+                // termination handler existed. A client disconnect during
+                // that window therefore could not cancel or drain the MTP
+                // producer, and later requests could enter after a half-built
+                // prefill still owned the shared Metal stream. Match the AR
+                // and block-diffusion paths: publish the stream first, then
+                // construct the iterator inside the cancellable producer.
+                let promptTokenIdsForTail = input.text.tokens.reshaped(-1).asArray(Int.self)
+                let deferredParameters = soloParameters
+                let deferredDepth = depth
+                let deferredInputs = SendableBox(
+                    (input, nativeModel, cacheCoordinator))
+                let makeIterator: @Sendable () throws -> any TokenIteratorProtocol = {
+                    try Task.checkCancellation()
+                    let (deferredInput, deferredModel, deferredCoordinator) =
+                        deferredInputs.consume()
+                    return try NativeMTPTokenIterator(
+                        input: deferredInput,
+                        model: deferredModel,
+                        cache: nil,
+                        parameters: deferredParameters,
+                        depth: deferredDepth,
+                        cacheCoordinator: deferredCoordinator)
+                }
+                (sourceStream, generationTask) = generateTaskDeferred(
                     promptTokenCount: promptTokenCount,
                     modelConfiguration: context.configuration,
                     tokenizer: context.tokenizer,
-                    iterator: iterator,
+                    promptTokenIds: promptTokenIdsForTail,
+                    makeIterator: makeIterator,
                     extraStopStrings: soloParameters.extraStopStrings,
                     promptTail: promptTail,
                     toolSchemas: toolSchemas)

--- a/Libraries/MLXLMCommon/SpecDec/DFlash2TokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/DFlash2TokenIterator.swift
@@ -323,6 +323,7 @@ struct DFlash2TokenIterator: TokenIteratorProtocol {
         guard input.text.tokens.size > 0 else {
             throw DFlash2RuntimeError.emptyPrompt
         }
+        try Task.checkCancellation()
         if let maxTokens = parameters.maxTokens, maxTokens <= 1 {
             throw DFlash2RuntimeError.maxTokensTooSmall
         }
@@ -518,6 +519,7 @@ struct DFlash2TokenIterator: TokenIteratorProtocol {
                 + " restored=\(restoredCount) offsets=\(offsets)\n"
             FileHandle.standardError.write(Data(line.utf8))
         }
+        try Task.checkCancellation()
         let prefill = try Self.prefill(
             tokens: tokensToPrefill,
             target: target,
@@ -648,6 +650,7 @@ struct DFlash2TokenIterator: TokenIteratorProtocol {
         var boundarySnapshot: [KVCache]?
         var start = 0
         while start < tokens.count {
+            try Task.checkCancellation()
             let remaining = tokens.count - start
             // Leave the final token to its own chunk so the last logits
             // row is the one the first sample comes from, matching the
@@ -678,10 +681,12 @@ struct DFlash2TokenIterator: TokenIteratorProtocol {
                 retained = retained.map { concatenated([$0, chunkHidden], axis: 1) } ?? chunkHidden
             }
             if end == captureBoundaryAt {
+                try Task.checkCancellation()
                 MLX.eval(cache)
                 boundarySnapshot = cache.map { $0.copy() }
             }
             if end < tokens.count {
+                try Task.checkCancellation()
                 MLX.eval(cache)
                 if let retained { MLX.eval(retained) }
                 Memory.clearCache()
@@ -692,6 +697,7 @@ struct DFlash2TokenIterator: TokenIteratorProtocol {
             throw DFlash2RuntimeError.emptyPrompt
         }
         let lastLogits = logits[0..., (logits.dim(1) - 1)..., 0...]
+        try Task.checkCancellation()
         MLX.eval(lastLogits, retained)
         return PrefillResult(
             lastLogits: lastLogits, hidden: retained, boundarySnapshot: boundarySnapshot)

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -380,6 +380,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         guard input.text.tokens.size > 0 else {
             throw NativeMTPRuntimeError.emptyPrompt
         }
+        try Task.checkCancellation()
         if NativeMTPGDNReplayDiagnostics.enabled {
             NativeMTPGDNReplayDiagnostics.reset()
         }
@@ -599,6 +600,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
 
         let start = Date.timeIntervalSinceReferenceDate
+        try Task.checkCancellation()
         let prepared = try model.prepare(
             inputForPrepare,
             cache: self.cache,
@@ -621,6 +623,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 processor: &processor)
                 .token
             let syncStart = Date.timeIntervalSinceReferenceDate
+            try Task.checkCancellation()
             MLX.eval(firstToken)
             self.materializeSyncTime += Date.timeIntervalSinceReferenceDate - syncStart
             self.seedMainForwardTime += Date.timeIntervalSinceReferenceDate - seedStart
@@ -649,6 +652,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 processor: &processor)
                 .token
             let syncStart = Date.timeIntervalSinceReferenceDate
+            try Task.checkCancellation()
             MLX.eval(firstToken)
             self.materializeSyncTime += Date.timeIntervalSinceReferenceDate - syncStart
         }
@@ -659,6 +663,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         pendingTokens.append(firstID)
 
         let bridgeStart = Date.timeIntervalSinceReferenceDate
+        try Task.checkCancellation()
         let bridge = model.nativeBackboneForward(Self.tokenInput(firstToken), cache: self.cache)
         let secondToken = Self.sampleLast(
             logits: bridge.logits,
@@ -667,6 +672,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             processor: &processor)
             .token
         let secondSyncStart = Date.timeIntervalSinceReferenceDate
+        try Task.checkCancellation()
         MLX.eval(secondToken)
         self.materializeSyncTime += Date.timeIntervalSinceReferenceDate - secondSyncStart
         self.seedMainForwardTime += Date.timeIntervalSinceReferenceDate - bridgeStart
@@ -675,6 +681,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         nextMain = secondToken
         pendingTokens.append(recordMaterializeSync { secondToken.item(Int.self) })
         let draftStart = Date.timeIntervalSinceReferenceDate
+        try Task.checkCancellation()
         let draftBatch = Self.makeDrafts(
             model: model,
             hidden: Self.lastHidden(bridge.hiddenStates),

--- a/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
@@ -1426,6 +1426,92 @@ struct MTPRuntimeFocusedTests {
         }
     }
 
+    @Test("BatchEngine publishes a cancellable stream before native MTP prefill")
+    func batchEngineDefersNativeMTPIteratorConstruction() throws {
+        let testFile = URL(fileURLWithPath: #filePath)
+        let repoRoot = testFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(
+            contentsOf: repoRoot.appendingPathComponent(
+                "Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift"),
+            encoding: .utf8)
+        let nativeStart = try #require(source.range(
+            of: "case .nativeMTP(depth: let depth, verifierMode: _) = strategy"))
+        let arStart = try #require(source.range(
+            of: "// Defer TokenIterator construction",
+            range: nativeStart.upperBound..<source.endIndex))
+        let nativeBranch = String(source[nativeStart.lowerBound..<arStart.lowerBound])
+
+        #expect(nativeBranch.contains("generateTaskDeferred("))
+        #expect(nativeBranch.contains("try Task.checkCancellation()"))
+        #expect(nativeBranch.contains("let deferredInputs = SendableBox("))
+        #expect(!nativeBranch.contains("let iterator = try NativeMTPTokenIterator("))
+    }
+
+    @Test("BatchEngine publishes a cancellable stream before DFlash setup")
+    func batchEngineDefersDFlashIteratorConstruction() throws {
+        let testFile = URL(fileURLWithPath: #filePath)
+        let repoRoot = testFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(
+            contentsOf: repoRoot.appendingPathComponent(
+                "Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift"),
+            encoding: .utf8)
+        let dflashStart = try #require(source.range(
+            of: "let drafterPath = strategy.dflash2DrafterPath"))
+        let nativeStart = try #require(source.range(
+            of: "case .nativeMTP(depth: let depth, verifierMode: _) = strategy",
+            range: dflashStart.upperBound..<source.endIndex))
+        let dflashBranch = String(source[dflashStart.lowerBound..<nativeStart.lowerBound])
+
+        #expect(dflashBranch.contains("generateTaskDeferred("))
+        #expect(dflashBranch.contains("try Task.checkCancellation()"))
+        #expect(dflashBranch.contains("let deferredInputs = SendableBox("))
+        #expect(!dflashBranch.contains("let iterator = try DFlash2TokenIterator("))
+    }
+
+    @Test("DFlash prefill checks cancellation around GPU materialization")
+    func dflashInitChecksCancellationBeforeGPUStages() throws {
+        let testFile = URL(fileURLWithPath: #filePath)
+        let repoRoot = testFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(
+            contentsOf: repoRoot.appendingPathComponent(
+                "Libraries/MLXLMCommon/SpecDec/DFlash2TokenIterator.swift"),
+            encoding: .utf8)
+
+        #expect(source.contains(
+            "while start < tokens.count {\n            try Task.checkCancellation()"))
+        #expect(source.contains(
+            "try Task.checkCancellation()\n        MLX.eval(lastLogits, retained)"))
+    }
+
+    @Test("native MTP prefill has cancellation checkpoints around GPU materialization")
+    func nativeMTPInitChecksCancellationBeforeGPUStages() throws {
+        let testFile = URL(fileURLWithPath: #filePath)
+        let repoRoot = testFile
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let source = try String(
+            contentsOf: repoRoot.appendingPathComponent(
+                "Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift"),
+            encoding: .utf8)
+
+        #expect(source.contains(
+            "try Task.checkCancellation()\n        let prepared = try model.prepare("))
+        #expect(source.contains(
+            "try Task.checkCancellation()\n        let bridge = model.nativeBackboneForward"))
+        #expect(source.contains(
+            "try Task.checkCancellation()\n        let draftBatch = Self.makeDrafts("))
+    }
+
     @Test("BatchEngine.submit rejects native MTP instead of silently batching AR")
     func batchEngineSubmitRejectsNativeMTP() async throws {
         try await FocusedMLXTestSupport.withLock {


### PR DESCRIPTION
## Summary

Moves native-MTP and DFlash2 iterator construction/prefill behind the streaming task's cancellation boundary, matching the ordinary autoregressive and block-diffusion paths.

## Reproduction and causal trace

The exact Osaurus 0.24.2 server binary remained alive but stopped completing requests during a mixed full-stream/client-cancel stress run on `JANGQ-AI/Qwen3.8-Flash-Next-JANG_2L` with native MTP forced to depth 1.

- 9 rounds completed; round 10 stalled.
- The stalled process was not out of memory: about 48.8 GB physical footprint, 49.5 GB peak, with 37% host memory free.
- The sampled stack was inside `BatchEngine.startSoloFastPath -> NativeMTPTokenIterator.init -> eval -> mlx_eval -> array::wait`, while Metal command submission was blocked.
- In source, the native-MTP branch constructed `NativeMTPTokenIterator` synchronously before `generationTask`, `soloFastPathID`, and the stream termination handler existed. A client disconnect during prefill therefore had no producer task to cancel or drain.

The same audit found that DFlash2 also loaded its drafter and constructed its iterator eagerly. It had the same lifecycle exposure even though the live incident was native MTP.

## Change

- Native MTP uses `generateTaskDeferred`; iterator construction now occurs inside the cancellable producer.
- DFlash2 drafter resolution and iterator construction use the same deferred boundary.
- Both iterator initializers check cancellation before and around GPU prefill/materialization stages.
- Existing `generateLoopTask` cancellation/error handling drains the shared MLX stream before finishing, so cancelled prefill cannot overlap the next producer.

This does not change model generation config, sampling, MTP depth, DFlash block size, cache policy, or parser behavior.

## Tests at `95f22d5d`

Focused SwiftPM build completed. The MTP runtime suite executed 87 tests: 86 passed. The six production-path/source-contract tests relevant to this change passed, including:

- active native MTP routes through the exclusive BatchEngine lane;
- native MTP publishes a cancellable stream before prefill;
- DFlash2 publishes a cancellable stream before drafter/prefill setup;
- both speculative iterators carry cancellation checkpoints around GPU materialization.

One unrelated pre-existing Qwen3.5 source-string invariant failed (`Qwen3.5 GDN verifier state has strict and fast modes`); no changed file touches that contract. The initial harness attempt also required colocating the real 3.6 MB MLX metallib before tests could execute.

## Status / remaining live gate

**PARTIAL.** This PR is intentionally based on `fix/qwen4exp-prefetch-null-buffer` / PR #347 because the production crash and this cancellation stall were discovered in the same exact server campaign.

Before merge/retarget:

1. Build Osaurus Release with PR #347 plus this head.
2. Repeat forced-MTP d1 mixed full-stream/client-cancel stress, then 30 sequential 384-token requests.
3. Prove the process accepts a follow-up request after every cancellation.
4. Prove native-MTP verify/accepted/rejected/AR counters remain present.
5. Prove n-gram PLE remains SSD-backed (`pread` + `F_NOCACHE`) and disk L2 / recurrent companion caches store and restore after restart.
6. Run representative AR, DFlash2, Qwen3.5/SSM, Qwen3.8/QSA, GLM/Ling, and multimodal paths one model at a time.

No live-fix claim is made until those exact-head rows complete.
