### PR TITLE
Qwen3.5 VL: the gated-delta fallback computes beta in float32, like the text path

### DIFF
--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -853,7 +853,12 @@ private func gatedDeltaUpdate(
             q: q, k: k, v: v, g: g, b: b, state: state, mask: mask,
             roundStateEachStep: roundStateEachStep)
     }
-    let beta = sigmoid(b)
+    // float32, matching `GatedDelta.swift`'s text path. Everything around this keeps the recurrent
+    // state in float32 precisely so a cached-prefix boundary cannot diverge; feeding it a `beta`
+    // still in the input dtype reintroduces exactly that divergence on the non-kernel route.
+    // `MTPRuntimeFocusedTests.qwen35GDNVerifierStateHasStrictAndFastModes` asserts this invariant
+    // over BOTH implementations and was failing on the VL one.
+    let beta = sigmoid(b).asType(.float32)
     return gatedDeltaOps(
         q: q, k: k, v: v, g: g, beta: beta, state: state, mask: mask,
         roundStateEachStep: roundStateEachStep)


### PR DESCRIPTION
`MTPRuntimeFocusedTests.qwen35GDNVerifierStateHasStrictAndFastModes` asserts the same fp32 discipline
over BOTH gated-delta implementations — `GatedDelta.swift` and `Qwen35.swift` — in a single loop.

Exactly one assertion diverges. The text path computes `sigmoid(b).asType(.float32)`; the VL path's
non-kernel route computed `sigmoid(b)`.

Everything around it keeps the recurrent state in float32 precisely so that a cached-prefix boundary
cannot diverge — `newState.asType(q.dtype).asType(.float32)`, `dtype: .float32`,
`if state.dtype != .float32`, all of which the VL path already satisfies. Feeding that a `beta` still
in the input dtype reintroduces exactly the divergence the rest of the function exists to prevent.

Fails on a clean checkout.
