### PR TITLE
Apertus 1.5: every LMInput carries the cache-scope salt

### DIFF
--- a/Libraries/MLXVLM/Models/Apertus1p5.swift
+++ b/Libraries/MLXVLM/Models/Apertus1p5.swift
@@ -1,0 +1,413 @@
+// Apertus 1.5 — discrete-token multimodal (VQ codebook), text + vision.
+//
+// See `Apertus1p5VisionTokenizer.swift` for why this model needs no projector: the image is
+// quantised into ids from a 131,072-entry codebook that lives INSIDE the token embedding table, so
+// image tokens are ordinary tokens and the language model is unmodified `ApertusModel`.
+//
+// That shapes the wiring in one non-obvious way. The framework builds a `UserInputProcessor` from
+// `(processorConfig, tokenizer)` alone — it never sees the model — but tokenizing an image REQUIRES
+// the model's VQ encoder weights. So the split is:
+//
+//   * the PROCESSOR renders the prompt with a single `<image>` placeholder and hands over the
+//     preprocessed pixels, exactly like any other VLM here;
+//   * `prepare(_:cache:windowSize:)` on the MODEL runs the encoder, offsets the ids, and splices
+//     them in place of the placeholder — then defers to the ordinary text path.
+//
+// The alternative (giving the processor a reference to the model) would invert the ownership the
+// factory is built around, for no gain.
+
+import CoreImage
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import MLXNN
+
+// MARK: - Configuration
+
+public struct Apertus1p5Configuration: Codable, Sendable {
+    public let textConfiguration: ApertusConfiguration
+    public let visionTokenizerConfiguration: Apertus1p5VisionTokenizerConfiguration
+    public let audioTokenizerConfiguration: Apertus1p5AudioTokenizerConfiguration?
+    public let imageTokenId: Int
+    public let imageTokenOffset: Int
+    /// Present on Omni bundles. Absent on a vision-only conversion, in which case audio input is
+    /// refused rather than silently ignored.
+    public let audioTokenId: Int?
+    public let audioTokenOffset: Int?
+    /// `<|audio_start|>` / `<|audio_end|>`. Fixed in the Apertus vocabulary; the reference carries
+    /// them as constants too, so defaulting is safe and keeps older configs loadable.
+    public var audioStartTokenId: Int { 131080 }
+    public var audioEndTokenId: Int { 131081 }
+
+    enum CodingKeys: String, CodingKey {
+        case textConfiguration = "text_config"
+        case visionTokenizerConfiguration = "vision_tokenizer_config"
+        case audioTokenizerConfiguration = "audio_tokenizer_config"
+        case imageTokenId = "image_token_id"
+        case imageTokenOffset = "image_token_offset"
+        case audioTokenId = "audio_token_id"
+        case audioTokenOffset = "audio_token_offset"
+    }
+}
+
+// MARK: - Model
+
+public class Apertus1p5: Module, VLMModel, KVCacheDimensionProvider {
+
+    @ModuleInfo(key: "language_model") public var languageModel: ApertusModel
+    @ModuleInfo(key: "vision_tokenizer") public var visionTokenizer: Apertus1p5VisionTokenizer
+    @ModuleInfo(key: "audio_tokenizer") public var audioTokenizer: Apertus1p5AudioTokenizer?
+
+    public let config: Apertus1p5Configuration
+
+    public var vocabularySize: Int { config.textConfiguration.vocabSize }
+    public var kvHeads: [Int] { languageModel.kvHeads }
+
+    public init(_ config: Apertus1p5Configuration) {
+        self.config = config
+        self._languageModel.wrappedValue = ApertusModel(config.textConfiguration)
+        self._visionTokenizer.wrappedValue = Apertus1p5VisionTokenizer(
+            config.visionTokenizerConfiguration)
+        self._audioTokenizer.wrappedValue = config.audioTokenizerConfiguration.map {
+            Apertus1p5AudioTokenizer($0)
+        }
+    }
+
+    /// Replace each `<image>` placeholder with the 256 codebook ids for the corresponding image,
+    /// offset into the shared vocabulary, then hand the result to the ordinary text path.
+    ///
+    /// The placeholder is expanded 1 -> 256 here rather than in the processor because the encoder
+    /// weights live on this object. A prompt with no image falls straight through.
+    /// Replace each media placeholder with the codebook ids for the corresponding item, offset into
+    /// the shared vocabulary, then hand the result to the ordinary text path.
+    ///
+    /// Vision and audio are the SAME mechanism with different offsets — that is the whole point of
+    /// this architecture — so they share one splice.
+    public func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws
+        -> PrepareResult
+    {
+        var imageIds: [Int] = []
+        if let image = input.image {
+            imageIds = visionTokenizer.encode(image.pixels).asArray(Int32.self)
+                .map { Int($0) + config.imageTokenOffset }
+        }
+        var audioIds: [Int] = []
+        if let audio = input.audio {
+            guard let audioTokenizer, let audioOffset = config.audioTokenOffset else {
+                throw VLMError.processing(
+                    "Apertus1p5: this bundle has no audio tokenizer (vision-only conversion), so "
+                        + "audio input cannot be encoded")
+            }
+            // The encoder's stride ladder is defined in SAMPLES, so a rate mismatch silently
+            // rescales time — 16 kHz audio fed to a 24 kHz encoder is heard 1.5x fast, and the
+            // tokens are wrong without anything failing.
+            guard audio.sampleRate == audioTokenizer.config.sampleRate else {
+                throw VLMError.processing(
+                    "Apertus1p5: audio is \(audio.sampleRate) Hz but the tokenizer expects "
+                        + "\(audioTokenizer.config.sampleRate) Hz; resample before submitting")
+            }
+            audioIds = audioTokenizer.encode(audio.waveform).asArray(Int32.self)
+                .map { Int($0) + audioOffset }
+        }
+        guard !imageIds.isEmpty || !audioIds.isEmpty else {
+            return try languageModel.prepare(input, cache: cache, windowSize: windowSize)
+        }
+
+        // ONE placeholder per code, consumed in raster order. The processor already expanded the
+        // template's single `<|image|>` into a framed grid — <|img_start|> "H*W" <|img_token_start|>
+        // rows separated by <|img_end_of_row|> <|img_end|> — so the framing tokens flow through
+        // untouched and only the placeholders are substituted. Splicing every code at the FIRST
+        // placeholder (the earlier approach) destroys the row structure the model reads geometry from.
+        var out: [Int] = []
+        var imageCursor = 0, audioCursor = 0
+        for token in input.text.tokens.asArray(Int32.self).map(Int.init) {
+            if token == config.imageTokenId, imageCursor < imageIds.count {
+                out.append(imageIds[imageCursor]); imageCursor += 1
+            } else if token == config.audioTokenId, !audioIds.isEmpty, audioCursor == 0 {
+                // The reference wraps audio as `<|audio_start|>` + one `<|audio|>` per code +
+                // `<|audio_end|>`, with NO row structure and no text — so unlike the image path
+                // this can be built entirely from ids, and the chat template's single placeholder
+                // is replaced by the whole run. Doing it here also avoids having to predict the
+                // code count in the processor before the encoder has run.
+                out.append(config.audioStartTokenId)
+                out.append(contentsOf: audioIds)
+                out.append(config.audioEndTokenId)
+                audioCursor = audioIds.count
+            } else {
+                out.append(token)
+            }
+        }
+        let replacedImage = imageCursor, replacedAudio = audioCursor
+        // A count mismatch means the encoder's grid and the prompt's grid disagree — the model
+        // would read a shifted image. Fail rather than emit a subtly wrong prompt.
+        if imageCursor != imageIds.count {
+            throw VLMError.processing(
+                "Apertus1p5: \(imageIds.count) image codes but only \(imageCursor) placeholders; "
+                    + "the processor grid and the encoder output disagree")
+        }
+        if !audioIds.isEmpty, audioCursor != audioIds.count {
+            throw VLMError.processing(
+                "Apertus1p5: audio supplied but the prompt has no \(config.audioTokenId.map(String.init) ?? "audio") placeholder")
+        }
+        // Media arrived but the rendered prompt carries no placeholder for it — the template and
+        // the config disagree. Failing loudly beats answering about something never inserted.
+        if !imageIds.isEmpty, replacedImage == 0 {
+            throw VLMError.processing(
+                "Apertus1p5: image supplied but the prompt contains no image token "
+                    + "(\(config.imageTokenId)); check the chat template")
+        }
+        if !audioIds.isEmpty, replacedAudio == 0 {
+            throw VLMError.processing(
+                "Apertus1p5: audio supplied but the prompt contains no audio token "
+                    + "(\(config.audioTokenId.map(String.init) ?? "unset")); check the chat template")
+        }
+        let spliced = LMInput.Text(
+            tokens: MLXArray(out.map { Int32($0) }).expandedDimensions(axis: 0))
+        return try languageModel.prepare(
+            LMInput(text: spliced, cacheScopeSalt: input.cacheScopeSalt),
+            cache: cache, windowSize: windowSize)
+    }
+
+    public func callAsFunction(_ input: LMInput.Text, cache: [KVCache]?, state: LMOutput.State?)
+        -> LMOutput
+    {
+        languageModel(input, cache: cache, state: state)
+    }
+
+    /// LoRA targets the TEXT transformer only. Adapting the VQ encoder would change the codebook
+    /// ids an image maps to, i.e. change the input alphabet rather than the model's use of it.
+    public var loraLayers: [Module] { languageModel.loraLayers }
+
+    /// Route the checkpoint into the text and vision halves, normalising TWO different layouts.
+    ///
+    /// The bf16 release and the MLX quantisations disagree about where the `language_model` segment
+    /// sits, and both are in circulation:
+    ///
+    ///     bf16 (HF layout):  model.language_model.layers.0...   lm_head.weight
+    ///     MLX quantisations: language_model.model.layers.0...   language_model.lm_head.weight
+    ///
+    /// Handling only one of them fails with `unhandledKeys(["language_model"])` on the other, which
+    /// is how this was found. Both normalise to the inner model's own names before being re-prefixed.
+    ///
+    /// The normalisation itself is `Weights.stripLanguageModelPrefix`, not a local loop. The rule is
+    /// identical, but the shared helper additionally resolves the case where a checkpoint carries
+    /// BOTH spellings of a key: it binds a fixed winner and logs the rest, where writing as we go
+    /// would let `Dictionary` iteration order decide — and that order is seeded per process, so the
+    /// same bundle could bind a different tensor from run to run. A 70B Apertus 1.5 quantisation
+    /// carries 2,084 body tensors through this path; one silently varying is not a failure anything
+    /// downstream would report.
+    public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        var lm: [String: MLXArray] = [:]
+        var vision: [String: MLXArray] = [:]
+        var audio: [String: MLXArray] = [:]
+        for (k, v) in weights {
+            if let r = k.range(of: "vision_tokenizer.") {
+                vision[String(k[r.upperBound...])] = v
+            } else if let r = k.range(of: "audio_tokenizer.") {
+                audio[String(k[r.upperBound...])] = v
+            } else {
+                lm[k] = v
+            }
+        }
+        // Normalise to what `ApertusModel` expects: `model.<...>` and `lm_head.<...>`.
+        lm = Weights.stripLanguageModelPrefix(lm)
+        var out: [String: MLXArray] = [:]
+        for (k, v) in languageModel.sanitize(weights: lm) { out["language_model.\(k)"] = v }
+        for (k, v) in visionTokenizer.sanitize(weights: vision) { out["vision_tokenizer.\(k)"] = v }
+        if let audioTokenizer {
+            for (k, v) in audioTokenizer.sanitize(weights: audio) { out["audio_tokenizer.\(k)"] = v }
+        }
+        return out
+    }
+}
+
+// MARK: - Processor
+
+public struct Apertus1p5ProcessorConfiguration: Codable, Sendable {
+    private let _minPixels: Int?
+    private let _maxPixels: Int?
+    private let _spatialFactor: Int?
+    /// Resolution is DYNAMIC, not a fixed 256x256: the area is clamped to this range and both sides
+    /// rounded to a multiple of `spatialFactor`, so a 640x480 photo becomes a 30x40 grid (1200
+    /// tokens) rather than 16x16 (256). Fixing it at 256 throws away most of the image.
+    public var minPixels: Int { _minPixels ?? (256 * 256) }
+    public var maxPixels: Int { _maxPixels ?? (1400 * 1400) }
+    /// One `spatialFactor x spatialFactor` patch becomes one discrete code — the encoder's total
+    /// downsampling, 16.
+    public var spatialFactor: Int { _spatialFactor ?? 16 }
+
+    enum CodingKeys: String, CodingKey {
+        case _minPixels = "min_pixels"
+        case _maxPixels = "max_pixels"
+        case _spatialFactor = "spatial_factor"
+    }
+}
+
+public struct Apertus1p5Processor: UserInputProcessor {
+    private let config: Apertus1p5ProcessorConfiguration
+    private let tokenizer: any Tokenizer
+    /// WavTokenizer's rate. Fixed rather than read from the processor config, which does not
+    /// carry it; the model-side guard catches any disagreement.
+    private let audioSampleRate = 24000
+    static let imageToken = "<|image|>"
+    /// The audio placeholder the chat template emits, replaced in `Apertus1p5.prepare` by
+    /// `<|audio_start|>` + one code per frame + `<|audio_end|>`. Named here so it can be DECLARED as
+    /// a media placeholder — see the `mediaTokenIds` note on the returned `LMInput`.
+    static let audioToken = "<|audio|>"
+    static let boiToken = "<|img_start|>"
+    static let eoiToken = "<|img_end|>"
+    static let wrapperToken = "<|img_token_start|>"
+    static let eolToken = "<|img_end_of_row|>"
+
+    /// The placeholder ids this processor leaves in the prompt, declared so a cache hit can resume.
+    ///
+    /// Undeclared, `LMInput.cacheHitSuffixContainsMediaPlaceholder` takes its
+    /// `guard let mediaTokenIds else { return true }` branch and rolls back on ANY non-empty suffix,
+    /// and `canCaptureHybridStripBoundary` returns false for want of the same value — so every turn
+    /// carrying an image or audio re-prefills the whole prompt, vision tower included. Apertus is the
+    /// worst case for that: one image expands to a `<|image|>` per grid cell, so the span that cannot
+    /// be resumed past is long.
+    ///
+    /// These are the PRE-SPLICE ids, and that is the load-bearing part. `Apertus1p5.prepare`
+    /// substitutes each `<|image|>` for a discrete visual code (`imageTokenOffset + code`, in
+    /// 131272..<262344 for the 8B bundle) and expands `<|audio|>` into a code run, so the sequence the
+    /// MODEL sees contains no placeholders at all. It would be natural to declare those code ranges
+    /// instead, and it would be wrong: the cache compares against `promptTokenIds`, which is the
+    /// PROCESSOR's sequence, because `requiresPostPrepareCacheKey` is `video?.embeddingTokenCount
+    /// != nil` and this family has no video path. Declaring the codes would name ids that never
+    /// appear in the compared sequence — no rollback would ever fire, which is the unsafe direction.
+    static func mediaTokenIds(_ tokenizer: any Tokenizer) -> [Int]? {
+        MediaTokenIds.resolve(tokenizer: tokenizer, tokens: [imageToken, audioToken])
+    }
+
+    public init(_ config: Apertus1p5ProcessorConfiguration, tokenizer: any Tokenizer) {
+        self.config = config
+        self.tokenizer = tokenizer
+    }
+
+    /// Aspect-preserving resize with the area clamped to [minPixels, maxPixels] and both sides
+    /// rounded HALF-UP to a multiple of `factor`. Ported verbatim from the reference
+    /// `smart_resize`, including its `int()` truncations — the grid it produces determines how many
+    /// image tokens the model receives, so any deviation changes the prompt the model was trained on.
+    static func smartResize(height: Int, width: Int, factor: Int, minPixels: Int, maxPixels: Int)
+        -> (height: Int, width: Int)
+    {
+        let targetArea = Double(max(min(maxPixels, height * width), minPixels))
+        let aspect = Double(width) / Double(height)
+        var h = Int((targetArea / aspect).squareRoot())
+        var w = Int(Double(h) * aspect)
+        h = ((h + factor / 2) / factor) * factor
+        w = ((w + factor / 2) / factor) * factor
+        return (max(h, factor), max(w, factor))
+    }
+
+    public func prepare(input: UserInput) async throws -> LMInput {
+        // Build the user message as STRUCTURED PARTS rather than via a MessageGenerator. The
+        // template renders `<|image|>` / `<|audio|>` from `part.type`, and the stock generators
+        // (Qwen2VL is vision-only; Default passes content through as a plain string) never emit an
+        // audio part — so audio silently never reached the prompt.
+        var parts: [[String: any Sendable]] = []
+        parts += Array(repeating: ["type": "image"], count: input.images.count)
+        parts += Array(repeating: ["type": "audio"], count: input.audios.count)
+        parts.append(["type": "text", "text": Self.promptText(from: input)])
+        let messages: [[String: any Sendable]] = [["role": "user", "content": parts]]
+        var promptTokens = try tokenizer.applyChatTemplate(
+            messages: messages, tools: input.tools, additionalContext: input.additionalContext)
+
+        var processedAudio: LMInput.ProcessedAudio? = nil
+        if !input.audios.isEmpty {
+            var pcm: [Float] = []
+            for audio in input.audios { pcm += try Self.waveform(audio, targetRate: audioSampleRate) }
+            // Peak-normalise to -3 dBFS, as the reference pipeline does before the codec. The
+            // feature extractor deliberately does NOT normalise, so skipping this feeds the encoder
+            // a different loudness than it was trained on.
+            let peak = pcm.map { Swift.abs($0) }.max() ?? 0
+            if peak > 1e-10 {
+                let target = Float(pow(10.0, -3.0 / 20.0))
+                pcm = pcm.map { $0 * (target / peak) }
+            }
+            processedAudio = .init(waveform: MLXArray(pcm), sampleRate: audioSampleRate)
+        }
+
+        guard !input.images.isEmpty else {
+            return LMInput(
+                text: .init(tokens: MLXArray(promptTokens).expandedDimensions(axis: 0)),
+                audio: processedAudio,
+                mediaTokenIds: Self.mediaTokenIds(tokenizer),
+                cacheScopeSalt: cacheScopeSalt(from: input.additionalContext))
+        }
+
+        var frames: [MLXArray] = []
+        var expansion: [Int] = []
+        for image in input.images {
+            let ci = try image.asCIImage().toSRGB()
+            let (h, w) = Self.smartResize(
+                height: Int(ci.extent.height), width: Int(ci.extent.width),
+                factor: config.spatialFactor, minPixels: config.minPixels, maxPixels: config.maxPixels)
+            let resized = ci.resampled(to: CGSize(width: w, height: h), method: .bicubic)
+            // `asMLXArray` renders CIFormat.RGBAf — float32 ALREADY in [0,1] — and returns NCHW.
+            // The bundle asks for rescale 1/255 then mean/std 0.5, which on [0,1] data is x*2-1.
+            let chw = resized.asMLXArray().asType(.float32)      // [1, 3, h, w]
+            frames.append(chw.transposed(0, 2, 3, 1) * 2 - 1)     // [1, h, w, 3] in [-1, 1]
+
+            // THE FRAMED SEQUENCE, ported from the reference `replace_image_token`:
+            //   <|img_start|> "{H}*{W}" <|img_token_start|> row ⏎ row ⏎ … <|img_end|>
+            // where each row is `<|image|>` repeated W times and rows are JOINED by
+            // <|img_end_of_row|> (H-1 separators, not H). The grid is written as LITERAL TEXT and
+            // tokenised normally — that is how the model is told the geometry, and it is the piece
+            // that cannot be guessed from the token names alone.
+            let (gh, gw) = (h / config.spatialFactor, w / config.spatialFactor)
+            let row = Array(repeating: Self.imageToken, count: gw).joined()
+            let rows = Array(repeating: row, count: gh).joined(separator: Self.eolToken)
+            let framed = "\(Self.boiToken)\(gh)*\(gw)\(Self.wrapperToken)\(rows)\(Self.eoiToken)"
+            expansion += tokenizer.encode(text: framed, addSpecialTokens: false)
+        }
+
+        // Replace the single `<|image|>` the chat template emitted with the full framed run.
+        guard let placeholder = tokenizer.convertTokenToId(Self.imageToken),
+            let at = promptTokens.firstIndex(of: placeholder)
+        else {
+            throw VLMError.processing(
+                "Apertus1p5: image supplied but the rendered prompt has no \(Self.imageToken)")
+        }
+        promptTokens.replaceSubrange(at ... at, with: expansion)
+
+        let tokensArray = MLXArray(promptTokens).expandedDimensions(axis: 0)
+        return LMInput(
+            text: .init(tokens: tokensArray, mask: ones(like: tokensArray)),
+            image: .init(pixels: concatenated(frames, axis: 0)), audio: processedAudio,
+            mediaTokenIds: Self.mediaTokenIds(tokenizer),
+            cacheScopeSalt: cacheScopeSalt(from: input.additionalContext))
+    }
+
+    /// The user's text, however the caller supplied it.
+    private static func promptText(from input: UserInput) -> String {
+        switch input.prompt {
+        case .text(let text): return text
+        case .messages(let messages): return messages.last?["content"] as? String ?? ""
+        case .chat(let messages): return messages.last?.content ?? ""
+        }
+    }
+
+    /// Decode any `UserInput.Audio` form to mono Float32 at `targetRate`, mirroring what the other
+    /// audio-capable models in this library do.
+    private static func waveform(_ audio: UserInput.Audio, targetRate: Int) throws -> [Float] {
+        switch audio {
+        case .url(let url):
+            return try nemotronOmniLoadAudioFile(url, targetSampleRate: Double(targetRate))
+        case .samples(let pcm, let rate):
+            return rate == targetRate
+                ? pcm : linearResamplePCM(pcm, fromRate: rate, toRate: targetRate)
+        case .array(let array, let rate):
+            let pcm = array.asType(.float32).asArray(Float.self)
+            return rate == targetRate
+                ? pcm : linearResamplePCM(pcm, fromRate: rate, toRate: targetRate)
+        case .preEncoded(let pcm, let rate, _):
+            // The pre-computed embedding is for encoder+projector models; this one needs the
+            // waveform, because its "embedding" is a codebook id sequence.
+            return rate == targetRate
+                ? pcm : linearResamplePCM(pcm, fromRate: rate, toRate: targetRate)
+        }
+    }
+}

--- a/Libraries/MLXVLM/Models/Apertus1p5AudioTokenizer.swift
+++ b/Libraries/MLXVLM/Models/Apertus1p5AudioTokenizer.swift
@@ -1,0 +1,269 @@
+// Apertus 1.5 audio tokenizer — the ENCODER half of WavTokenizer.
+//
+// Same design as the vision side (see `Apertus1p5VisionTokenizer.swift`): audio is quantised into
+// ids from a 4096-entry codebook and fed as ORDINARY TOKENS at `audio_token_offset` 262344. The
+// arithmetic closes — 262344 + 4096 = 266440, inside the 266,752 text vocabulary — so the language
+// model is again untouched.
+//
+// WHAT IS DELIBERATELY NOT PORTED. The checkpoint carries 226 audio tensors; only ~63 are used
+// here. `backbone.convnext` (108), `backbone.pos_net` (44) and `head.linear` [2402, 768] are the
+// DECODER — that head is an ISTFT magnitude/phase output (2402 = 1201 x 2), i.e. the vocoder that
+// turns tokens back into a waveform. A model consuming audio never runs it, exactly as the vision
+// side ships no decoder. `quantizer.codebook.{cluster_size,embed_avg,inited}` are EMA training
+// buffers, not inference state.
+//
+// The encoder is EnCodec/SEANet, read off the weights rather than assumed:
+//
+//     layer  0  conv 1 -> 32,   k=7            (input)
+//     layer  1  residual block  32 -> 16 -> 32 (+ 1x1 shortcut)
+//     layer  3  downsample      32 -> 64,  k=8   stride 4
+//     layer  4  residual block  64
+//     layer  6  downsample      64 -> 128, k=10  stride 5
+//     layer  7  residual block  128
+//     layer  9  downsample     128 -> 256, k=10  stride 5
+//     layer 10  residual block  256
+//     layer 12  downsample     256 -> 512, k=12  stride 6
+//     layer 13  2-layer LSTM   (2048 = 4 gates x 512)
+//     layer 15  conv 512 -> 512, k=7           (output)
+//
+// Even-numbered gaps are parameterless ELU activations. Total downsampling 4*5*5*6 = 600, which is
+// WavTokenizer's documented hop — so 24 kHz audio yields 40 tokens per second.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+// MARK: - Configuration
+
+public struct Apertus1p5AudioTokenizerConfiguration: Codable, Sendable {
+    public let codebookSize: Int
+    public let codebookDim: Int
+    private let _sampleRate: Int?
+    /// WavTokenizer operates at 24 kHz; the bundle does not always spell it out.
+    public var sampleRate: Int { _sampleRate ?? 24000 }
+
+    enum CodingKeys: String, CodingKey {
+        case codebookSize = "codebook_size"
+        case codebookDim = "codebook_dim"
+        case _sampleRate = "sample_rate"
+    }
+}
+
+// MARK: - Building blocks
+
+/// SEANet residual unit: ELU -> conv(k=3) -> ELU -> conv(k=1), plus a 1x1 shortcut.
+///
+/// The checkpoint numbers these as `block.1` and `block.3` because `block.0` and `block.2` are the
+/// parameterless activations — so the indices are not contiguous and must not be renumbered.
+private class AudioResidualUnit: Module {
+    @ModuleInfo(key: "block") var block: [Module]
+    @ModuleInfo(key: "shortcut") var shortcut: WeightNormConv1d
+
+    init(channels: Int, compress: Int, kernelSize: Int) {
+        let hidden = channels / compress
+        // Slots 0 and 2 are the parameterless ELUs. They are NUMBERED in the checkpoint
+        // (`block.1`, `block.3`), so renumbering the convs to 0/1 would leave every weight
+        // unbound — placeholders keep the indices honest.
+        self._block.wrappedValue = [
+            Identity(),
+            WeightNormConv1d(inC: channels, outC: hidden, k: kernelSize, stride: 1),
+            Identity(),
+            WeightNormConv1d(inC: hidden, outC: channels, k: 1, stride: 1),
+        ]
+        self._shortcut.wrappedValue = WeightNormConv1d(
+            inC: channels, outC: channels, k: 1, stride: 1)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        guard block.count == 4,
+            let c1 = block[1] as? WeightNormConv1d,
+            let c2 = block[3] as? WeightNormConv1d
+        else { return x }
+        var h = c1(elu(x))
+        h = c2(elu(h))
+        return shortcut(x) + h
+    }
+}
+
+/// A 1-D convolution whose checkpoint weight is stored under PyTorch weight-norm.
+///
+/// The weight lives as two tensors — `parametrizations.weight.original0` (g, per-output-channel
+/// magnitude) and `original1` (v, direction) — and the effective weight is `g * v / ||v||`. Loading
+/// `original1` alone runs perfectly well and is wrong by a per-channel scale, which is precisely the
+/// kind of silent error that produces plausible-but-meaningless codebook ids. The reconstruction is
+/// done once in `sanitize`, so at inference this is an ordinary Conv1d.
+private class WeightNormConv1d: Module, UnaryLayer {
+    @ModuleInfo(key: "conv") var conv: Conv1d
+    let padding: Int
+
+    init(inC: Int, outC: Int, k: Int, stride: Int) {
+        // SEANet pads causally-ish: total padding k - stride, applied on the left. Doing it here
+        // rather than via Conv1d's symmetric `padding` keeps the output length exact.
+        self.padding = max(0, k - stride)
+        self._conv.wrappedValue = Conv1d(
+            inputChannels: inC, outputChannels: outC, kernelSize: k, stride: stride, padding: 0)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        // NLC layout: pad the LENGTH axis on the left.
+        let padded = padded(x, widths: [.init((0, 0)), .init((padding, 0)), .init((0, 0))])
+        return conv(padded)
+    }
+}
+
+/// SEANet's recurrent block: a 2-layer LSTM whose output is added back to its input.
+///
+/// The checkpoint stores it as torch does — `lstm.weight_ih_l0/l1`, `weight_hh_l0/l1`,
+/// `bias_ih_l0/l1`, `bias_hh_l0/l1` — while MLX's `LSTM` uses `Wx`/`Wh`/`bias` per layer. The
+/// remapping happens in `sanitize`; the gate order needs no adjustment, because MLX splits
+/// i,f,g,o and so does torch.
+private class SEANetLSTM: Module {
+    @ModuleInfo(key: "lstm") var lstm: [LSTM]
+
+    init(size: Int) {
+        self._lstm.wrappedValue = [
+            LSTM(inputSize: size, hiddenSize: size), LSTM(inputSize: size, hiddenSize: size),
+        ]
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = x
+        for layer in lstm { h = layer(h).0 }
+        return h + x        // residual, as in SEANet
+    }
+}
+
+// MARK: - Encoder
+
+private class AudioEncoder: Module {
+    @ModuleInfo(key: "layers") var layers: [Module]
+
+    /// Indices match the checkpoint exactly, gaps and all — see the header table.
+    init(hiddenSize: Int, compress: Int, kernelSize: Int) {
+        var built: [Module] = []
+        let ratios = [(4, 8), (5, 10), (5, 10), (6, 12)]   // (stride, kernel)
+        var channels = 32
+        built.append(WeightNormConv1d(inC: 1, outC: channels, k: kernelSize, stride: 1))  // 0
+        for (stride, k) in ratios {
+            built.append(AudioResidualUnit(channels: channels, compress: compress, kernelSize: 3))
+            built.append(Identity())                                                       // ELU
+            built.append(
+                WeightNormConv1d(inC: channels, outC: channels * 2, k: k, stride: stride))
+            channels *= 2
+        }
+        built.append(SEANetLSTM(size: hiddenSize))                                         // 13
+        built.append(Identity())                                                           // 14
+        built.append(
+            WeightNormConv1d(inC: hiddenSize, outC: hiddenSize, k: kernelSize, stride: 1))  // 15
+        self._layers.wrappedValue = built
+    }
+}
+
+// MARK: - Tokenizer
+
+public class Apertus1p5AudioTokenizer: Module {
+    @ModuleInfo(key: "encoder") fileprivate var encoder: AudioEncoder
+    @ModuleInfo(key: "quantizer") var quantizer: Quantizer
+
+    /// Holds only the codebook itself; the EMA buffers in the checkpoint are training state.
+    public class Quantizer: Module {
+        @ModuleInfo(key: "codebook") var codebook: Codebook
+        public class Codebook: Module {
+            @ModuleInfo(key: "embed") var embed: MLXArray
+            init(size: Int, dim: Int) { self._embed.wrappedValue = MLXArray.zeros([size, dim]) }
+        }
+        init(size: Int, dim: Int) { self._codebook.wrappedValue = Codebook(size: size, dim: dim) }
+    }
+
+    public let config: Apertus1p5AudioTokenizerConfiguration
+
+    public init(_ config: Apertus1p5AudioTokenizerConfiguration) {
+        self.config = config
+        self._encoder.wrappedValue = AudioEncoder(
+            hiddenSize: config.codebookDim, compress: 2, kernelSize: 7)
+        self._quantizer.wrappedValue = Quantizer(
+            size: config.codebookSize, dim: config.codebookDim)
+    }
+
+    /// Reconstruct weight-norm and reorder convolutions, exactly once at load.
+    ///
+    /// Also DROPS the decoder (`backbone.*`, `head.*`) and the quantiser's EMA buffers — see the
+    /// header for why those exist but are not needed.
+    public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        // Pair up g and v before touching anything, since both are needed to rebuild one weight.
+        var g: [String: MLXArray] = [:], v: [String: MLXArray] = [:]
+        var out: [String: MLXArray] = [:]
+        for (k, value) in weights {
+            if k.hasPrefix("backbone.") || k.hasPrefix("head.") { continue }
+            if k.hasSuffix("cluster_size") || k.hasSuffix("inited") { continue }
+            // EMA training buffers, and the PACKED copies of the codebook. Quantised bundles ship
+            // the codebook twice -- plain float plus `.weight`/`.scales`/`.biases` -- and keeping
+            // both makes the loader see a nested module where the tree has a leaf. The float copy
+            // is full precision, and a codebook must not be quantised regardless: the encoder does
+            // a nearest-neighbour search in it.
+            if k.contains("embed_avg") { continue }
+            if let r = k.range(of: ".parametrizations.weight.original0") {
+                g[String(k[..<r.lowerBound])] = value
+            } else if let r = k.range(of: ".parametrizations.weight.original1") {
+                v[String(k[..<r.lowerBound])] = value
+            } else {
+                out[k] = value
+            }
+        }
+        // torch LSTM -> MLX LSTM. `Wx`/`Wh` map straight across (same i,f,g,o gate order); torch
+        // applies TWO biases and MLX one, so they are summed — dropping `bias_hh` would be a
+        // silent, plausible-looking error.
+        var lstmBias: [String: (ih: MLXArray?, hh: MLXArray?)] = [:]
+        for (k, value) in out where k.contains(".lstm.") {
+            guard let r = k.range(of: ".lstm.") else { continue }
+            let base = String(k[..<r.upperBound])          // "...layers.13.lstm."
+            let tail = String(k[r.upperBound...])          // "weight_ih_l0" etc
+            guard let layerChar = tail.last, let layer = Int(String(layerChar)) else { continue }
+            let target = "\(base)\(layer)"
+            if tail.hasPrefix("weight_ih") { out[target + ".Wx"] = value }
+            else if tail.hasPrefix("weight_hh") { out[target + ".Wh"] = value }
+            else if tail.hasPrefix("bias_ih") {
+                lstmBias[target, default: (nil, nil)].ih = value
+            } else if tail.hasPrefix("bias_hh") {
+                lstmBias[target, default: (nil, nil)].hh = value
+            }
+            out[k] = nil
+        }
+        for (target, b) in lstmBias {
+            if let ih = b.ih, let hh = b.hh { out[target + ".bias"] = ih + hh }
+        }
+
+        for (base, direction) in v {
+            guard let magnitude = g[base] else { continue }
+            // w = g * v / ||v||, norm taken over every axis except the output channel — matching
+            // torch's weight_norm(dim=0).
+            let axes = Array(1 ..< direction.ndim)
+            let norm = sqrt((direction * direction).sum(axes: axes, keepDims: true))
+            var w = magnitude * direction / norm
+            // torch Conv1d is [O, I, kW]; MLX is [O, kW, I].
+            if w.ndim == 3 { w = w.transposed(0, 2, 1) }
+            out["\(base).weight"] = w
+        }
+        return out
+    }
+
+    /// Encode mono PCM (shape [samples] or [1, samples]) to codebook ids, one per 600 samples.
+    public func encode(_ pcm: MLXArray) -> MLXArray {
+        var x = pcm.ndim == 1 ? pcm.reshaped(1, -1, 1) : pcm.reshaped(1, -1, 1)
+        for layer in encoder.layers {
+            switch layer {
+            case let c as WeightNormConv1d: x = c(x)
+            case let r as AudioResidualUnit: x = r(x)
+            case let l as SEANetLSTM: x = l(x)
+            default: x = elu(x)                        // the parameterless activation slots
+            }
+        }
+        let dim = x.dim(2)
+        let flat = x.reshaped(-1, dim)
+        let book = quantizer.codebook.embed
+        let bookSq = (book * book).sum(axis: 1)
+        let cross = matmul(flat, book.transposed(1, 0))
+        return argMin(bookSq.expandedDimensions(axis: 0) - 2 * cross, axis: 1)
+    }
+}

--- a/Libraries/MLXVLM/Models/Apertus1p5VisionTokenizer.swift
+++ b/Libraries/MLXVLM/Models/Apertus1p5VisionTokenizer.swift
@@ -1,0 +1,336 @@
+// Apertus 1.5 vision tokenizer — the ENCODER half of a VQ-VAE.
+//
+// Apertus 1.5 is multimodal in a way that is structurally unlike every other VLM in this repo, and
+// the difference is the whole reason this file is short on plumbing and long on convolutions.
+//
+// The usual design is an encoder plus a PROJECTOR: a vision transformer produces continuous
+// embeddings which are linearly mapped into the language model's hidden space and spliced into the
+// embedding sequence. Apertus 1.5 instead QUANTISES the image into discrete ids drawn from a
+// 131,072-entry codebook, offsets them by `image_token_offset`, and feeds them as ORDINARY TOKENS.
+// The arithmetic in the config confirms the intent exactly:
+//
+//     image_token_offset 131272 + codebook 131072 == 262344 == audio_token_offset
+//
+// inside a text vocabulary of 266,752. So the codebook lives *in the token embedding table*, and the
+// language model needs no architectural change whatsoever — no projector, no cross-attention, no
+// merge step. The entire port is: turn pixels into 256 integers.
+//
+// Only the ENCODER ships in the bundle (247 tensors, no decoder), which is right: a VLM never needs
+// to turn tokens back into pixels.
+//
+// The architecture is taming-transformers' `Encoder` verbatim, confirmed against the weights rather
+// than assumed:
+//
+//     conv_in 3->256
+//     down.0  256 -> 256  x4 res blocks, downsample      256x256 -> 128x128
+//     down.1  256 -> 256  x4 res blocks, downsample      128x128 ->  64x64
+//     down.2  256 -> 512  x4 res blocks, downsample       64x64  ->  32x32   (nin_shortcut)
+//     down.3  512 -> 512  x4 res blocks, downsample       32x32  ->  16x16
+//     down.4  512 -> 1024 x4 res blocks, ATTENTION         16x16            (nin_shortcut)
+//     mid     block_1, attn_1, block_2                     16x16
+//     norm_out, conv_out 1024 -> 256                       16x16
+//     quant_conv 256 -> 256 (1x1)                          16x16
+//     quantize: nearest neighbour in a [131072, 256] codebook
+//
+// 16 x 16 = 256 latent positions, hence exactly 256 image tokens per image.
+
+import CoreImage
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+// MARK: - Building blocks
+
+/// taming-transformers uses swish (x * sigmoid(x)) throughout, NOT gelu. Getting this wrong changes
+/// every activation subtly and shows up as slightly-wrong codebook ids rather than as a crash.
+private func swish(_ x: MLXArray) -> MLXArray { x * sigmoid(x) }
+
+/// `Normalize` in taming is `GroupNorm(num_groups=32, eps=1e-6, affine=True)`.
+///
+/// `pytorchCompatible: true` matters: MLX's default groups the channels differently, so without it
+/// the normalisation is subtly wrong in a way that produces plausible-looking output.
+private func normalize(_ channels: Int) -> GroupNorm {
+    GroupNorm(groupCount: 32, dimensions: channels, eps: 1e-6, affine: true, pytorchCompatible: true)
+}
+
+/// Pre-activation residual block. `nin_shortcut` exists ONLY where the channel count changes
+/// (stages 2 and 4 here), which is why it is optional rather than always present.
+private class ResnetBlock: Module {
+    @ModuleInfo(key: "norm1") var norm1: GroupNorm
+    @ModuleInfo(key: "conv1") var conv1: Conv2d
+    @ModuleInfo(key: "norm2") var norm2: GroupNorm
+    @ModuleInfo(key: "conv2") var conv2: Conv2d
+    @ModuleInfo(key: "nin_shortcut") var ninShortcut: Conv2d?
+
+    init(inChannels: Int, outChannels: Int) {
+        self._norm1.wrappedValue = normalize(inChannels)
+        self._conv1.wrappedValue = Conv2d(
+            inputChannels: inChannels, outputChannels: outChannels, kernelSize: 3, padding: 1)
+        self._norm2.wrappedValue = normalize(outChannels)
+        self._conv2.wrappedValue = Conv2d(
+            inputChannels: outChannels, outputChannels: outChannels, kernelSize: 3, padding: 1)
+        self._ninShortcut.wrappedValue =
+            inChannels == outChannels
+            ? nil
+            : Conv2d(inputChannels: inChannels, outputChannels: outChannels, kernelSize: 1)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = conv1(swish(norm1(x)))
+        h = conv2(swish(norm2(h)))
+        return (ninShortcut.map { $0(x) } ?? x) + h
+    }
+}
+
+/// Single-head spatial self-attention over the 16x16 grid, with 1x1 convolutions standing in for the
+/// projections — taming's `AttnBlock`. Applied only where the resolution is in `attn_resolutions`.
+private class AttnBlock: Module {
+    let channels: Int
+    @ModuleInfo(key: "norm") var norm: GroupNorm
+    @ModuleInfo(key: "q") var q: Conv2d
+    @ModuleInfo(key: "k") var k: Conv2d
+    @ModuleInfo(key: "v") var v: Conv2d
+    @ModuleInfo(key: "proj_out") var projOut: Conv2d
+
+    init(channels: Int) {
+        self.channels = channels
+        self._norm.wrappedValue = normalize(channels)
+        self._q.wrappedValue = Conv2d(inputChannels: channels, outputChannels: channels, kernelSize: 1)
+        self._k.wrappedValue = Conv2d(inputChannels: channels, outputChannels: channels, kernelSize: 1)
+        self._v.wrappedValue = Conv2d(inputChannels: channels, outputChannels: channels, kernelSize: 1)
+        self._projOut.wrappedValue = Conv2d(
+            inputChannels: channels, outputChannels: channels, kernelSize: 1)
+    }
+
+    /// `x` is NHWC (MLX's convolution layout).
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let h = norm(x)
+        let (B, H, W) = (x.dim(0), x.dim(1), x.dim(2))
+        // Flatten the grid to a sequence: [B, H*W, C]. Single head, scale 1/sqrt(C) — taming applies
+        // the scale to the SCORES, which is what scaledDotProductAttention does too.
+        let qh = q(h).reshaped(B, H * W, channels)
+        let kh = k(h).reshaped(B, H * W, channels)
+        let vh = v(h).reshaped(B, H * W, channels)
+        let attended = MLXFast.scaledDotProductAttention(
+            queries: qh.expandedDimensions(axis: 1),
+            keys: kh.expandedDimensions(axis: 1),
+            values: vh.expandedDimensions(axis: 1),
+            scale: 1.0 / sqrt(Float(channels)),
+            mask: .none
+        ).squeezed(axis: 1)
+        return x + projOut(attended.reshaped(B, H, W, channels))
+    }
+}
+
+/// Stride-2 convolution with taming's ASYMMETRIC padding: it pads right and bottom by one and uses
+/// no padding in the convolution itself. A symmetric `padding: 1` would shift the whole feature map
+/// by half a pixel — silently, and only visible as wrong codebook ids.
+private class Downsample: Module {
+    @ModuleInfo(key: "conv") var conv: Conv2d
+
+    init(channels: Int) {
+        self._conv.wrappedValue = Conv2d(
+            inputChannels: channels, outputChannels: channels, kernelSize: 3, stride: 2, padding: 0)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        // NHWC: pad H and W on the high side only.
+        let padded = padded(x, widths: [.init((0, 0)), .init((0, 1)), .init((0, 1)), .init((0, 0))])
+        return conv(padded)
+    }
+}
+
+/// One resolution stage: N residual blocks, optional attention, optional downsample. Modelled as a
+/// `Module` with array children so the weight paths land as `down.<i>.block.<j>...`, matching the
+/// checkpoint exactly.
+private class DownStage: Module {
+    @ModuleInfo(key: "block") var block: [ResnetBlock]
+    @ModuleInfo(key: "attn") var attn: [AttnBlock]
+    @ModuleInfo(key: "downsample") var downsample: Downsample?
+
+    init(inChannels: Int, outChannels: Int, numBlocks: Int, useAttention: Bool, downsampleAfter: Bool)
+    {
+        var blocks: [ResnetBlock] = []
+        var attns: [AttnBlock] = []
+        var c = inChannels
+        for _ in 0 ..< numBlocks {
+            blocks.append(ResnetBlock(inChannels: c, outChannels: outChannels))
+            c = outChannels
+            if useAttention { attns.append(AttnBlock(channels: outChannels)) }
+        }
+        self._block.wrappedValue = blocks
+        self._attn.wrappedValue = attns
+        self._downsample.wrappedValue = downsampleAfter ? Downsample(channels: outChannels) : nil
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = x
+        for (i, b) in block.enumerated() {
+            h = b(h)
+            if i < attn.count { h = attn[i](h) }
+        }
+        return downsample.map { $0(h) } ?? h
+    }
+}
+
+private class MidBlock: Module {
+    @ModuleInfo(key: "block_1") var block1: ResnetBlock
+    @ModuleInfo(key: "attn_1") var attn1: AttnBlock
+    @ModuleInfo(key: "block_2") var block2: ResnetBlock
+
+    init(channels: Int) {
+        self._block1.wrappedValue = ResnetBlock(inChannels: channels, outChannels: channels)
+        self._attn1.wrappedValue = AttnBlock(channels: channels)
+        self._block2.wrappedValue = ResnetBlock(inChannels: channels, outChannels: channels)
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray { block2(attn1(block1(x))) }
+}
+
+// MARK: - Encoder
+
+private class VQEncoder: Module {
+    @ModuleInfo(key: "conv_in") var convIn: Conv2d
+    @ModuleInfo(key: "down") var down: [DownStage]
+    @ModuleInfo(key: "mid") var mid: MidBlock
+    @ModuleInfo(key: "norm_out") var normOut: GroupNorm
+    @ModuleInfo(key: "conv_out") var convOut: Conv2d
+
+    init(_ config: Apertus1p5VisionTokenizerConfiguration) {
+        let base = config.baseChannels
+        let mults = config.channelMultiplier
+        self._convIn.wrappedValue = Conv2d(
+            inputChannels: config.inChannels, outputChannels: base, kernelSize: 3, padding: 1)
+
+        var stages: [DownStage] = []
+        var resolution = config.resolution
+        var inC = base
+        for (i, mult) in mults.enumerated() {
+            let outC = base * mult
+            let isLast = i == mults.count - 1
+            stages.append(
+                DownStage(
+                    inChannels: inC, outChannels: outC, numBlocks: config.numResBlocks,
+                    useAttention: config.attnResolutions.contains(resolution),
+                    downsampleAfter: !isLast))
+            inC = outC
+            if !isLast { resolution /= 2 }
+        }
+        self._down.wrappedValue = stages
+        self._mid.wrappedValue = MidBlock(channels: inC)
+        self._normOut.wrappedValue = normalize(inC)
+        self._convOut.wrappedValue = Conv2d(
+            inputChannels: inC, outputChannels: config.latentChannels, kernelSize: 3, padding: 1)
+    }
+
+    /// `x` is NHWC in [-1, 1]. Returns the pre-quantisation latent, NHWC.
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        var h = convIn(x)
+        for stage in down { h = stage(h) }
+        h = mid(h)
+        return convOut(swish(normOut(h)))
+    }
+}
+
+// MARK: - Tokenizer
+
+public class Apertus1p5VisionTokenizer: Module {
+    @ModuleInfo(key: "encoder") fileprivate var encoder: VQEncoder
+    @ModuleInfo(key: "quant_conv") var quantConv: Conv2d
+    @ModuleInfo(key: "quantize") var quantize: VQEmbedding
+
+    /// The codebook. Held in its own `Module` purely so the weight path is
+    /// `quantize.embedding.weight`, matching the checkpoint.
+    public class VQEmbedding: Module {
+        @ModuleInfo(key: "embedding") var embedding: Embedding
+        init(codebookSize: Int, embedDim: Int) {
+            self._embedding.wrappedValue = Embedding(
+                embeddingCount: codebookSize, dimensions: embedDim)
+        }
+    }
+
+    public init(_ config: Apertus1p5VisionTokenizerConfiguration) {
+        self._encoder.wrappedValue = VQEncoder(config)
+        self._quantConv.wrappedValue = Conv2d(
+            inputChannels: config.latentChannels, outputChannels: config.embedDim, kernelSize: 1)
+        self._quantize.wrappedValue = VQEmbedding(
+            codebookSize: config.codebookSize, embedDim: config.embedDim)
+    }
+
+    /// Encode one preprocessed image (NHWC, [-1, 1]) to codebook ids in raster order.
+    ///
+    /// The quantiser is nearest-neighbour in L2, expanded to `|z|^2 - 2 z.e + |e|^2` so it is two
+    /// reductions and one matmul rather than materialising a [positions, 131072, 256] difference
+    /// tensor — which at 256 positions would be 34 GB.
+    ///
+    /// `|z|^2` is dropped because it is constant across the argmin, and its absence is deliberate
+    /// rather than an oversight: keeping it would change nothing but the arithmetic cost.
+    public func encode(_ pixels: MLXArray) -> MLXArray {
+        let latent = quantConv(encoder(pixels))          // [B, 16, 16, embedDim]
+        let dim = latent.dim(3)
+        let flat = latent.reshaped(-1, dim)              // [B*256, embedDim]
+        let codebook = quantize.embedding.weight         // [codebookSize, embedDim]
+        let codebookSq = (codebook * codebook).sum(axis: 1)          // [codebookSize]
+        let cross = matmul(flat, codebook.transposed(1, 0))          // [B*256, codebookSize]
+        let distances = codebookSq.expandedDimensions(axis: 0) - 2 * cross
+        return argMin(distances, axis: 1)                // [B*256]
+    }
+
+    /// Reorder torch's OIHW convolution weights to MLX's OHWI, and leave everything else alone.
+    /// Bundles converted by MLX tooling are already OHWI, so the reorder is gated on shape rather
+    /// than applied blindly — a double transpose is silent and catastrophic.
+
+    public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        var out = [String: MLXArray]()
+        for (k, v) in weights {
+            // Quantised bundles ship the codebook TWICE: the plain float tensor plus a packed
+            // `.weight`/`.scales`/`.biases` triple. Keeping both makes the loader see a nested
+            // module where the tree has a leaf parameter (`incompatibleItems`). The float copy is
+            // full precision here, so the packed siblings are simply dropped -- and the codebook is
+            // the one tensor that must NOT be quantised anyway, since the encoder does a
+            // nearest-neighbour search in it.
+            guard k.contains("conv") || k.hasSuffix(".q.weight") || k.hasSuffix(".k.weight")
+                || k.hasSuffix(".v.weight") || k.hasSuffix(".proj_out.weight")
+                || k.contains("nin_shortcut")
+            else {
+                out[k] = v
+                continue
+            }
+            // torch: [O, I, kH, kW]. MLX: [O, kH, kW, I]. Already-MLX weights have their SMALLEST
+            // trailing dims in positions 1-2 (the kernel), so test that rather than guessing.
+            if v.ndim == 4, v.dim(1) > v.dim(2) || v.dim(1) > v.dim(3) {
+                out[k] = v.transposed(0, 2, 3, 1)
+            } else {
+                out[k] = v
+            }
+        }
+        return out
+    }
+}
+
+// MARK: - Configuration
+
+public struct Apertus1p5VisionTokenizerConfiguration: Codable, Sendable {
+    public let codebookSize: Int
+    public let embedDim: Int
+    public let latentChannels: Int
+    public let baseChannels: Int
+    public let channelMultiplier: [Int]
+    public let numResBlocks: Int
+    public let attnResolutions: [Int]
+    public let resolution: Int
+    public let inChannels: Int
+
+    enum CodingKeys: String, CodingKey {
+        case codebookSize = "codebook_size"
+        case embedDim = "embed_dim"
+        case latentChannels = "latent_channels"
+        case baseChannels = "base_channels"
+        case channelMultiplier = "channel_multiplier"
+        case numResBlocks = "num_res_blocks"
+        case attnResolutions = "attn_resolutions"
+        case resolution
+        case inChannels = "in_channels"
+    }
+}

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -141,6 +141,7 @@ public enum VLMTypeRegistry {
         // both keys to the same dispatch.
         "ministral3": dispatchMistral3VLM,
         "lfm2_vl": create(LFM2VLConfiguration.self, LFM2VL.init),
+            "apertus1p5": create(Apertus1p5Configuration.self, Apertus1p5.init),
         "lfm2-vl": create(LFM2VLConfiguration.self, LFM2VL.init),
         "glm_ocr": create(GlmOcrConfiguration.self, GlmOcr.init),
         "glm4v": create(Glm4vConfiguration.self, Glm4v.init),
@@ -236,6 +237,8 @@ public enum VLMProcessorTypeRegistry {
             Mistral3VLMProcessorConfiguration.self, Mistral3VLMProcessor.init),
         "Lfm2VlProcessor": create(
             LFM2VLProcessorConfiguration.self, LFM2VLProcessor.init),
+        "Apertus1p5Processor": create(
+            Apertus1p5ProcessorConfiguration.self, Apertus1p5Processor.init),
         "Glm46VProcessor": create(
             GlmOcrProcessorConfiguration.self, GlmOcrProcessor.init),
         "Glm4vProcessor": create(   // GLM-4.5V (glm4v_moe) — same QwenVL-style preprocessing as glm_ocr

--- a/Package.swift
+++ b/Package.swift
@@ -891,6 +891,7 @@ let package = Package(
                 "MediaCachePlaceholderTests.swift",
                 "VLGrowingConversationReuseTests.swift",
                 "VLMediaTokenDeclarationReachabilityTests.swift",
+                "Apertus1p5PrefixNormalisationTests.swift",
                 "NemotronHOmniPreEncodedAudioTests.swift",
                 "NemotronHJANGTQDispatchFocusedTests.swift",
                 "MTPRuntimeFocusedTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/Apertus1p5PrefixNormalisationTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/Apertus1p5PrefixNormalisationTests.swift
@@ -1,0 +1,71 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Apertus 1.5 routes its whole language tower through one prefix normalisation: a 70B quantisation
+// carries 2,084 body tensors that way. The rule is `Weights.stripLanguageModelPrefix`, and the
+// reason to call it rather than re-derive it is not brevity — the helper resolves a checkpoint that
+// carries BOTH spellings of a key to a FIXED winner, where a local `dict[key] = value` loop lets
+// Dictionary iteration order decide. That order is seeded per process, so the same bundle can bind
+// a different tensor from run to run: it loads, it generates, and it is wrong some fraction of the
+// time. Nothing downstream reports that, so the guard is here.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import Testing
+
+@Suite("Apertus 1.5 prefix normalisation")
+struct Apertus1p5PrefixNormalisationTests {
+
+    private static let source: String = {
+        (try? String(
+            contentsOfFile: "Libraries/MLXVLM/Models/Apertus1p5.swift", encoding: .utf8)) ?? ""
+    }()
+
+    @Test("sanitize delegates to the shared helper")
+    func delegatesToSharedHelper() throws {
+        try #require(!Self.source.isEmpty, "source not found — the path is wrong, not the code")
+        #expect(Self.source.contains("Weights.stripLanguageModelPrefix("))
+    }
+
+    /// The specific shape that must not come back: normalising inside the routing loop, which both
+    /// duplicates the rule and reintroduces the order-dependent bind.
+    @Test("the prefix rule is not re-derived locally")
+    func ruleIsNotReDerived() throws {
+        try #require(!Self.source.isEmpty)
+        let reDerived = [
+            #"key = "model." + key.dropFirst("model.language_model.".count)"#,
+            #"key = String(key.dropFirst("language_model.".count))"#,
+        ]
+        for fragment in reDerived {
+            #expect(!Self.source.contains(fragment), "re-derived: \(fragment)")
+        }
+    }
+
+    /// The behaviour the delegation buys, asserted on the helper itself: both layouts land on the
+    /// same destination, and a checkpoint carrying both binds the unprefixed key REGARDLESS of
+    /// insertion order. Built twice in opposite orders, because that is the only thing a local loop
+    /// would get wrong.
+    @Test("both layouts normalise, and a contested key binds the same way either order")
+    func contestedKeyIsOrderIndependent() {
+        let hf = Weights.stripLanguageModelPrefix(["model.language_model.layers.0.w": MLXArray([1])])
+        #expect(hf.keys.sorted() == ["model.layers.0.w"])
+
+        let mlx = Weights.stripLanguageModelPrefix(["language_model.model.layers.0.w": MLXArray([1])])
+        #expect(mlx.keys.sorted() == ["model.layers.0.w"])
+
+        let unprefixed = MLXArray([7])
+        let prefixed = MLXArray([9])
+        var forward: [String: MLXArray] = [:]
+        forward["model.layers.0.w"] = unprefixed
+        forward["model.language_model.layers.0.w"] = prefixed
+        var backward: [String: MLXArray] = [:]
+        backward["model.language_model.layers.0.w"] = prefixed
+        backward["model.layers.0.w"] = unprefixed
+
+        let a = Weights.stripLanguageModelPrefix(forward)["model.layers.0.w"]
+        let b = Weights.stripLanguageModelPrefix(backward)["model.layers.0.w"]
+        #expect(a?.item(Int.self) == 7, "the unprefixed key must win")
+        #expect(b?.item(Int.self) == 7, "…and win the same way in the other order")
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/VLMediaTokenDeclarationReachabilityTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/VLMediaTokenDeclarationReachabilityTests.swift
@@ -101,6 +101,7 @@ struct VLMediaTokenDeclarationReachabilityTests {
 
         #expect(
             declaring == [
+                "Apertus1p5.swift",
                 "Audex.swift", "DeepseekOCRProcessor.swift", "FastVLM.swift",
                 "Gemma4.swift", "LFM2VL.swift", "Mistral3.swift",
                 "MuseGlimmerProcessor.swift", "NemotronHOmni.swift", "Pixtral.swift",


### PR DESCRIPTION
`VLMCacheScopeSourceCoverageTests` requires every VLM `LMInput` construction to carry
`cacheScopeSalt`. Three sites in `Apertus1p5.swift` did not:

- the `prepare(_:cache:windowSize:)` path, which rebuilds an `LMInput` after splicing media
  placeholders and dropped the salt the caller had already resolved;
- both `prepare(input:)` returns, which never set one.

The first forwards `input.cacheScopeSalt`; the other two use
`cacheScopeSalt(from: input.additionalContext)`, as every other VLM does.
