### PR TITLE
BatchEngine: the solo-fast-path test stays under the repetition floor

### DIFF
--- a/Tests/MLXLMTests/BatchEngineTests.swift
+++ b/Tests/MLXLMTests/BatchEngineTests.swift
@@ -1217,7 +1217,14 @@ class BatchEngineIntegrationTests: XCTestCase {
 
         let stream = await engine.generate(
             input: LMInput(tokens: MLXArray(Int32(1) ..< Int32(5))),
-            parameters: GenerateParameters(maxTokens: 1_000, temperature: 0)
+            // 32, not 1000. `SlowPrefillLanguageModel` returns all-zero logits, so argmax is the
+            // same token every step and the decoded text is one letter repeated. Since
+            // `RepetitionCycleDetector` landed, that is halted as degeneration and reported as
+            // `.stop`, making `.length` unreachable at any cap above its floor — the test was
+            // asserting against a guard doing its job. This test is about the scheduler not being
+            // woken during the solo fast path, which the 20 ms prefill delay governs; the token
+            // count is scaffolding, so keep it under the floor rather than weaken the assertion.
+            parameters: GenerateParameters(maxTokens: 32, temperature: 0)
         )
         let soloActiveBeforeSubmit = await engine.isSoloFastPathActiveForTesting
         XCTAssertTrue(soloActiveBeforeSubmit)


### PR DESCRIPTION
`testUpdateMaxBatchSizeDoesNotWakeSchedulerDuringSoloFastPath` expects `.length` at
`maxTokens: 1_000`. `SlowPrefillLanguageModel` returns all-zero logits, so argmax is the same token
on every step and the decoded text is one letter repeated — maximally degenerate.

`RepetitionCycleDetector` halts that, correctly, and the turn reports `.stop`. Measured: it stops at
~133 tokens. So `.length` is unreachable at any cap above the detector's floor, and the test was
asserting against a guard doing its job.

The test's subject is that updating the batch size does not wake the scheduler while the solo fast
path is active — which the 20 ms prefill delay governs, not the token count. The cap moves under the
floor (`minimumOutputLength` is 128 CHARACTERS, and the mock's `decode` joins tokens with spaces, so
roughly two characters per token) rather than the `.length` assertion being weakened.

A non-repeating mock is not an alternative: the detector scans decoded text over a 26-letter test
vocabulary, so even a long-period token sequence still presents repeating text.
