### PR TITLE
ToolCall: the model's argument order survives a serialized history

### DIFF
--- a/Libraries/MLXLMCommon/DeepseekV4ChatEncoder.swift
+++ b/Libraries/MLXLMCommon/DeepseekV4ChatEncoder.swift
@@ -896,6 +896,42 @@ public struct DeepseekV4ChatEncoder: Sendable {
             "<\(DeepseekV4Tokens.dsml)invoke name=\"\(name)\">\n\(inner)\n</\(DeepseekV4Tokens.dsml)invoke>"
     }
 
+    /// Render with the model's own argument order when it is known.
+    ///
+    /// The `params:` overload sorts, which is stable but is NOT what the model emitted; re-rendering
+    /// a parsed call that way changes the bytes and breaks prefix reuse for every turn after it.
+    /// `ToolCall.Function.argumentOrder` survives a serialized history, so a caller that has one
+    /// can reproduce the original spelling. Names absent from `order` are appended in sorted order
+    /// so an incomplete order can never silently drop a parameter.
+    public static func renderToolCallInvoke(
+        name: String, params: [String: Any], order: [String]?
+    ) -> String {
+        guard let order, !order.isEmpty else {
+            return renderToolCallInvoke(name: name, params: params)
+        }
+        let ordered = order.filter { params[$0] != nil }
+        let remainder = params.keys.filter { !ordered.contains($0) }.sorted()
+        return renderToolCallInvoke(
+            name: name,
+            orderedParameters: (ordered + remainder).compactMap { key in
+                guard let v = params[key] else { return nil }
+                // Same value spelling as the sorted path below; only the ORDER differs.
+                let isString = v is String
+                let value: String
+                if isString, let str = v as? String {
+                    value = str
+                } else {
+                    value =
+                        (try? String(
+                            data: JSONSerialization.data(
+                                withJSONObject: v,
+                                options: [.fragmentsAllowed, .withoutEscapingSlashes]),
+                            encoding: .utf8)) ?? "\(v)"
+                }
+                return OrderedJSONParameter(name: key, value: value, isString: isString)
+            })
+    }
+
     public static func renderToolCallInvoke(name: String, params: [String: Any]) -> String {
         var paramBlocks: [String] = []
         // Encode each param — string params carry `string="true"` and

--- a/Libraries/MLXLMCommon/Tool/ToolCall.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCall.swift
@@ -17,29 +17,87 @@ public struct ToolCall: Hashable, Codable, Sendable {
         /// values. Keeping it out of `Codable` preserves the public wire shape.
         public let rawArgumentsJSON: String?
 
+        /// The argument names in the order the model emitted them.
+        ///
+        /// `arguments` is a Dictionary, so it cannot carry order, and `rawArgumentsJSON` — which
+        /// can — is deliberately kept out of `Codable`. That left a re-render after a serialized
+        /// history round trip falling back to SORTED order, so a tool call rendered
+        /// `path, content` came back `content, path` and every turn after it lost its prefix
+        /// boundary. This is the order alone: small, and unlike the raw text it is safe to carry
+        /// on the wire, so the boundary survives persistence.
+        public let argumentOrder: [String]?
+
         public init(
             name: String,
             arguments: [String: JSONValue],
-            rawArgumentsJSON: String? = nil
+            rawArgumentsJSON: String? = nil,
+            argumentOrder: [String]? = nil
         ) {
             self.name = name
             self.arguments = arguments
             self.rawArgumentsJSON = rawArgumentsJSON
+            self.argumentOrder =
+                argumentOrder ?? rawArgumentsJSON.flatMap(Self.topLevelKeyOrder(of:))
         }
 
         public init(
             name: String,
             arguments: [String: any Sendable],
-            rawArgumentsJSON: String? = nil
+            rawArgumentsJSON: String? = nil,
+            argumentOrder: [String]? = nil
         ) {
             self.name = name
             self.arguments = arguments.mapValues { JSONValue.from($0) }
             self.rawArgumentsJSON = rawArgumentsJSON
+            self.argumentOrder =
+                argumentOrder ?? rawArgumentsJSON.flatMap(Self.topLevelKeyOrder(of:))
+        }
+
+        /// Top-level key names of a JSON object, in source order.
+        ///
+        /// `JSONSerialization` yields a Dictionary and loses the order, so the order has to come
+        /// from the text. Only the keys are scanned; values are skipped by depth and string state,
+        /// which is enough to find the commas that separate top-level members.
+        static func topLevelKeyOrder(of json: String) -> [String]? {
+            let text = json.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard text.first == "{", text.last == "}" else { return nil }
+            var keys: [String] = []
+            var depth = 0
+            var inString = false
+            var escaped = false
+            var current = ""
+            var capturing = false
+            var expectKey = true
+            for ch in text.dropFirst().dropLast() {
+                if escaped { if capturing { current.append(ch) }; escaped = false; continue }
+                if ch == "\\" { if capturing { current.append(ch) }; escaped = true; continue }
+                if inString {
+                    if ch == "\"" {
+                        inString = false
+                        if capturing { keys.append(current); current = ""; capturing = false }
+                    } else if capturing {
+                        current.append(ch)
+                    }
+                    continue
+                }
+                switch ch {
+                case "\"":
+                    inString = true
+                    if depth == 0 && expectKey { capturing = true; current = "" }
+                case "{", "[": depth += 1
+                case "}", "]": depth -= 1
+                case ":": if depth == 0 { expectKey = false }
+                case ",": if depth == 0 { expectKey = true }
+                default: break
+                }
+            }
+            return keys.isEmpty ? nil : keys
         }
 
         private enum CodingKeys: String, CodingKey {
             case name
             case arguments
+            case argumentOrder
         }
 
         public init(from decoder: Decoder) throws {
@@ -50,12 +108,15 @@ public struct ToolCall: Hashable, Codable, Sendable {
                 forKey: .arguments
             )
             self.rawArgumentsJSON = nil
+            self.argumentOrder = try container.decodeIfPresent(
+                [String].self, forKey: .argumentOrder)
         }
 
         public func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(name, forKey: .name)
             try container.encode(arguments, forKey: .arguments)
+            try container.encodeIfPresent(argumentOrder, forKey: .argumentOrder)
         }
     }
 

--- a/Tests/MLXLMCommonFocusedTests/DeepseekV4AgentLoopBoundaryTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/DeepseekV4AgentLoopBoundaryTests.swift
@@ -340,19 +340,11 @@ struct DeepseekV4AgentLoopBoundaryTests {
     /// can alter.
     @Test("a written-file tool call survives emit -> parse -> re-render")
     func fileWriteToolCallRoundTripsByteExact() throws {
-        // KNOWN DEFECT, deliberately recorded rather than deleted or weakened.
-        //
-        // The re-render is NOT byte-stable once `rawArgumentsJSON` is lost:
-        // the sorted-key dict path emits `content` before `path`, diverging at
-        // char 56 from the model's own emission order. Fixing it means keeping
-        // the raw member order across a serialized transcript, which changes
-        // `ToolCall.Function`'s Codable surface — a public wire-shape change
-        // that does not belong in a tests-only change.
-        //
-        // `withKnownIssue` keeps CI green while the assertion stays live: if
-        // the ordering is ever fixed, this FAILS as an unexpected pass and
-        // whoever fixed it gets told to delete this wrapper.
-        try withKnownIssue("tool-call re-render loses the model's argument order") {
+        // Was a KNOWN DEFECT: the re-render was not byte-stable once `rawArgumentsJSON` was lost,
+        // because the dictionary path sorts and the model had emitted `path` before `content`.
+        // Fixed by carrying `ToolCall.Function.argumentOrder` — the names only, not the raw text —
+        // through `Codable`, so the order survives a serialized transcript and
+        // `renderToolCallInvoke(name:params:order:)` can reproduce the original spelling.
         let payload = """
             <!DOCTYPE html>
             <html lang="en">
@@ -401,10 +393,14 @@ struct DeepseekV4AgentLoopBoundaryTests {
         // history. Model the turn-N+1 path faithfully: rebuild the arguments
         // from the decoded values only, which is what a client that persisted
         // and reloaded the transcript can supply.
+        // Turn N+1 supplies the decoded values AND the order, which now survives `Codable` as
+        // `argumentOrder` — `rawArgumentsJSON` deliberately does not, and without either the
+        // re-render fell back to SORTED order and changed the bytes.
         let decoded = parsed[0].function.arguments
         let reRendered = DeepseekV4ChatEncoder.renderToolCallInvoke(
             name: parsed[0].function.name,
-            params: decoded.mapValues { $0.anyValue })
+            params: decoded.mapValues { $0.anyValue },
+            order: parsed[0].function.argumentOrder)
 
         guard rendered == reRendered else {
             let common = zip(rendered, reRendered).prefix { $0 == $1 }.count
@@ -417,7 +413,6 @@ struct DeepseekV4AgentLoopBoundaryTests {
                   second : \(String(reRendered.dropFirst(common).prefix(160)).debugDescription)
                 """)
             return
-        }
 
         // And the recovered payload must be the original, not a mangled copy.
         #expect(


### PR DESCRIPTION
Clears the `withKnownIssue` in `DeepseekV4AgentLoopBoundaryTests`, whose comment asked for exactly
this: *"if the ordering is ever fixed, this FAILS as an unexpected pass and whoever fixed it gets told
to delete this wrapper."*

`ToolCall.Function.arguments` is a Dictionary and cannot carry order. `rawArgumentsJSON` can, but is
deliberately excluded from `Codable` to preserve the public wire shape. So a re-render after a
serialized message history fell back to sorted keys: a call the model emitted as `path, content` came
back `content, path`, diverging at char 56 — and every turn after a tool call lost its prefix
boundary.

`argumentOrder: [String]?` carries the argument NAMES only. It is small, and unlike the raw text it
is safe to put on the wire, so it can be `Codable` without reopening the objection that kept
`rawArgumentsJSON` out. It is derived automatically from `rawArgumentsJSON` when that is present, so
existing call sites get it for free.

`renderToolCallInvoke(name:params:order:)` honours it, and appends any name missing from the order in
sorted position, so an incomplete order can never silently drop a parameter. The existing sorted
overload is untouched and remains the fallback.
