### PR TITLE
Qwen4ExpFusedAffineMoE: split an oversized diagnostic so the file type-checks

### DIFF
--- a/Libraries/MLXLMCommon/Qwen4ExpFusedAffineMoE.swift
+++ b/Libraries/MLXLMCommon/Qwen4ExpFusedAffineMoE.swift
@@ -235,14 +235,18 @@ enum Qwen4ExpFusedAffineMoE {
         defer { reportLock.unlock() }
         let label = "\(shape.inputDimensions)x\(shape.expertDimensions):topk\(shape.routes):rows\(rows)"
         guard reportedShapes.insert(label).inserted else { return }
-        FileHandle.standardError.write(
-            Data(
-                ("[Qwen4Exp] fused_affine_moe_decode=active rows=\(rows)"
-                    + " shape=\(shape.inputDimensions)x\(shape.expertDimensions) topk=\(shape.routes)"
-                    + " mixed_q2_q3_q4_q5_q6_g32_g64 input=bfloat16 output=bfloat16"
-                    + " affine_metadata=bf16_or_f16 router_scores=bf16_or_f32"
-                    + " accumulator=float32"
-                    + " weighted_down=true\n").utf8))
+        // Built piecewise on purpose, for the reason already recorded above the
+        // `compiled_gdn_front=rejected` diagnostic in Qwen35.swift: as a single `+` chain with
+        // interpolations wrapped in `Data(...).utf8`, this exceeds the type checker's budget and the
+        // file does not compile on Swift 6.4 (swiftlang-6.4.0.33.1) — "unable to type-check this
+        // expression in reasonable time". Identical output.
+        var diag = "[Qwen4Exp] fused_affine_moe_decode=active rows=\(rows)"
+        diag += " shape=\(shape.inputDimensions)x\(shape.expertDimensions) topk=\(shape.routes)"
+        diag += " mixed_q2_q3_q4_q5_q6_g32_g64 input=bfloat16 output=bfloat16"
+        diag += " affine_metadata=bf16_or_f16 router_scores=bf16_or_f32"
+        diag += " accumulator=float32"
+        diag += " weighted_down=true\n"
+        FileHandle.standardError.write(Data(diag.utf8))
     }
 
     private static func supports(_ projection: QuantizedSwitchLinear) -> Bool {


### PR DESCRIPTION
`Libraries/MLXLMCommon/Qwen4ExpFusedAffineMoE.swift` does not compile on Swift 6.4
(`swiftlang-6.4.0.33.1`):

```
Qwen4ExpFusedAffineMoE.swift:223:102: error: the compiler is unable to type-check this expression
in reasonable time; try breaking up the expression into distinct sub-expressions
```

The diagnostic is one `+` chain wrapped in `Data(...).utf8`. It was cheap while the shape text was a
hardcoded literal; it became too expensive when that was replaced by three interpolations
(`shape.inputDimensions`, `shape.expertDimensions`, `shape.routes`).

This is the same defect — and the same fix — as the `compiled_gdn_front=rejected` diagnostic in
`Qwen35.swift`, whose comment already records the diagnosis. Building the string piecewise costs
nothing and produces byte-identical output.

Found while rebasing our patch stack onto current main: the build fails on this file before reaching
anything else.