### PR TITLE
Model construction: separate the lanes a caller asks for from the modules that serve them

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -5,10 +5,11 @@ import MLX
 import MLXLMCommon
 
 /// Creates a function that decodes configuration data and instantiates a model with the proper configuration
-private func create<C: Codable, M>(
+private func create<C: Codable, M: LanguageModel>(
     _ configurationType: C.Type, _ modelInit: @escaping (C) -> M
-) -> (Data) throws -> M {
-    { data in
+) -> ModelCreator {
+    // Ignores the request: this family builds the same thing whatever is asked of it.
+    { data, _ in
         let configuration = try JSONDecoder.json5().decode(C.self, from: data)
         return modelInit(configuration)
     }
@@ -20,7 +21,7 @@ private func create<C: Codable, M>(
 public enum LLMTypeRegistry {
 
     // Split into functions to help the compiler type-check the large model registry
-    private static func coreModels() -> [String: (Data) throws -> any LanguageModel] {
+    private static func coreModels() -> [String: ModelCreator] {
         [
             "mistral": create(LlamaConfiguration.self, LlamaModel.init),
             "llama": create(LlamaConfiguration.self, LlamaModel.init),
@@ -49,7 +50,7 @@ public enum LLMTypeRegistry {
             "qwen3_moe": create(Qwen3MoEConfiguration.self, Qwen3MoEModel.init),
             "qwen3_next": create(Qwen3NextConfiguration.self, Qwen3NextModel.init),
             "qwen3_5": create(Qwen35Configuration.self, Qwen35Model.init),
-            "qwen3_5_moe": { data in
+            "qwen3_5_moe": { data, _ in
                 // Peek at weight_format — "mxtq" routes to the JANGTQ variant,
                 // which swaps the routed-expert SwitchGLU for TurboQuantSwitchGLU
                 // so the codebook Metal kernels run instead of gather_qmm.
@@ -72,7 +73,7 @@ public enum LLMTypeRegistry {
         ]
     }
 
-    private static func extendedModels() -> [String: (Data) throws -> any LanguageModel] {
+    private static func extendedModels() -> [String: ModelCreator] {
         [
             "mistral4": create(Mistral4Configuration.self, Mistral4Model.init),
             "minicpm": create(MiniCPMConfiguration.self, MiniCPMModel.init),
@@ -110,7 +111,7 @@ public enum LLMTypeRegistry {
             "mimo_v2_flash": create(MiMoV2FlashConfiguration.self, MiMoV2FlashModel.init),
             "nanbeige": create(NanbeigeConfiguration.self, NanbeigeModel.init),
             "minimax": create(MiniMaxConfiguration.self, MiniMaxModel.init),
-            "minimax_m2": { data in
+            "minimax_m2": { data, _ in
                 // Peek at weight_format — "mxtq" routes to the JANGTQ variant,
                 // which swaps the MoE SwitchGLU for TurboQuantSwitchGLU so the
                 // codebook Metal kernels run instead of gather_qmm. Attention
@@ -142,7 +143,7 @@ public enum LLMTypeRegistry {
             // full/SWA attention, 48/72 query heads, dual RoPE, 256 routed
             // experts with top-10 selection, and one shared expert. Older
             // Laguna variants continue to decode their bundle-specific arrays.
-            "laguna": { data in
+            "laguna": { data, _ in
                 // Legacy Laguna mxtq bundles are mixed-format.
                 //
                 //   - Dense paths (attention Q/K/V/O, layer-0 dense MLP
@@ -208,7 +209,7 @@ public enum LLMTypeRegistry {
         ]
     }
 
-    private static func additionalModels() -> [String: (Data) throws -> any LanguageModel] {
+    private static func additionalModels() -> [String: ModelCreator] {
         [
             "baichuan_m1": create(BaichuanM1Configuration.self, BaichuanM1Model.init),
             "exaone4": create(Exaone4Configuration.self, Exaone4Model.init),
@@ -268,7 +269,9 @@ public enum LLMTypeRegistry {
     /// CCA state (`conv_state`, `prev_hs`) round-trips via `ZayaCCACache`
     /// (LayerKind.zayaCCA) and `BatchZayaCCACache`; the BatchEngine
     /// auto-detects ZAYA caches and flips paged-incompatible+hybrid.
-    private static func dispatchZaya(data: Data) throws -> any LanguageModel {
+    private static func dispatchZaya(data: Data, requesting: Set<ModelRuntimeRequestModality>? = nil)
+        throws -> any LanguageModel
+    {
         struct Probe: Codable {
             let weightFormat: String?
             let mxtqBits: ProbeBits?
@@ -391,7 +394,9 @@ public enum LLMTypeRegistry {
     /// (`BailingMoeV3Model`, `architectures = ["BailingMoeV3ForCausalLM"]`).
     /// The `architectures` list is the discriminator; a KDA marker key is the
     /// fallback for configs that omit it.
-    private static func dispatchBailingHybrid(data: Data) throws -> any LanguageModel {
+    private static func dispatchBailingHybrid(data: Data, requesting: Set<ModelRuntimeRequestModality>? = nil)
+        throws -> any LanguageModel
+    {
         struct Probe: Decodable {
             var architectures: [String]?
             var linearAttention: String?
@@ -418,7 +423,9 @@ public enum LLMTypeRegistry {
         return BailingHybridModel(configuration)
     }
 
-    private static func dispatchNemotronH(data: Data) throws -> any LanguageModel {
+    private static func dispatchNemotronH(data: Data, requesting: Set<ModelRuntimeRequestModality>? = nil)
+        throws -> any LanguageModel
+    {
         enum ProbeBits: Decodable {
             case int(Int)
             case routed(up: Int?, down: Int?)
@@ -540,7 +547,9 @@ public enum LLMTypeRegistry {
     ///     paths without triggering DSV4 errors.
     ///
     /// Follow `Libraries/MLXLLM/Models/DSV4-PORT-STATUS.md` to finish.
-    private static func dispatchDeepseekV4(data: Data) throws -> any LanguageModel {
+    private static func dispatchDeepseekV4(data: Data, requesting: Set<ModelRuntimeRequestModality>? = nil)
+        throws -> any LanguageModel
+    {
         // DeepseekV4 (JANGTQ + JANG family). The right variant depends
         // on whether routed experts are stored as MXTQ codebook
         // (TurboQuantSwitchGLU) or plain affine (SwitchGLU).
@@ -689,7 +698,9 @@ public enum LLMTypeRegistry {
     ///      (Mistral 3 wrapper around a Mistral 4 text decoder).
     ///   3. If `weight_format == "mxtq"` → Mistral3TextJANGTQModel.
     ///   4. Otherwise → vanilla Mistral3TextModel.
-    static func dispatchMistral3LLM(data: Data) throws -> any LanguageModel {
+    static func dispatchMistral3LLM(data: Data, requesting: Set<ModelRuntimeRequestModality>? = nil)
+        throws -> any LanguageModel
+    {
         // 1. Vision gate — VLM bundles must not be loaded under this LLM route.
         struct VisionGate: Codable {
             let visionConfig: AnyDecodable?
@@ -750,7 +761,9 @@ public enum LLMTypeRegistry {
         return Mistral3TextModel(config)
     }
 
-    private static func dispatchDeepseekV3Family(data: Data) throws -> any LanguageModel {
+    private static func dispatchDeepseekV3Family(data: Data, requesting: Set<ModelRuntimeRequestModality>? = nil)
+        throws -> any LanguageModel
+    {
         struct FormatCheck: Codable {
             let weightFormat: String?
             enum CodingKeys: String, CodingKey { case weightFormat = "weight_format" }
@@ -801,7 +814,9 @@ public enum LLMTypeRegistry {
         return DeepseekV3Model(config)
     }
 
-    private static func dispatchStep3p5(data: Data) throws -> any LanguageModel {
+    private static func dispatchStep3p5(data: Data, requesting: Set<ModelRuntimeRequestModality>? = nil)
+        throws -> any LanguageModel
+    {
         struct Probe: Codable {
             let weightFormat: String?
             let mxtqBits: Int?
@@ -1795,7 +1810,8 @@ public final class LLMModelFactory: ModelFactory {
         let model: LanguageModel
         do {
             model = try await typeRegistry.createModel(
-                configuration: configData, modelType: baseConfig.modelType)
+                configuration: configData, modelType: baseConfig.modelType,
+                requesting: configuration.requestedModalities)
         } catch {
             // Top-level model_type failed (e.g. "mistral3" is a VLM type not in LLM registry,
             // or the config couldn't be decoded for that type).
@@ -1806,7 +1822,8 @@ public final class LLMModelFactory: ModelFactory {
             {
                 do {
                     model = try await typeRegistry.createModel(
-                        configuration: configData, modelType: textModelType)
+                        configuration: configData, modelType: textModelType,
+                        requesting: configuration.requestedModalities)
                 } catch let innerError as DecodingError {
                     throw ModelFactoryError.configurationDecodingError(
                         configurationURL.lastPathComponent, configuration.name, innerError)

--- a/Libraries/MLXLMCommon/Downloader.swift
+++ b/Libraries/MLXLMCommon/Downloader.swift
@@ -85,6 +85,13 @@ public struct ResolvedModelConfiguration: Sendable {
     /// No-load MTP/VL status inferred from bundle metadata and tensor names.
     public var mtpStatus: MTPBundleStatus?
 
+    /// Which lanes the caller intends to use, or `nil` for "everything this bundle supports".
+    ///
+    /// Rides in the configuration rather than as a parallel parameter on `_load`, because it is a
+    /// property of the load being requested — and because a second parameter threaded beside the
+    /// configuration is exactly the kind of path that gets forgotten at one call site out of three.
+    public var requestedModalities: Set<ModelRuntimeRequestModality>?
+
     public init(
         modelDirectory: URL,
         tokenizerDirectory: URL,
@@ -95,7 +102,8 @@ public struct ResolvedModelConfiguration: Sendable {
         toolCallFormat: ToolCallFormat?,
         reasoningParserName: String? = nil,
         generationDefaults: GenerationConfigFile? = nil,
-        mtpStatus: MTPBundleStatus? = nil
+        mtpStatus: MTPBundleStatus? = nil,
+        requestedModalities: Set<ModelRuntimeRequestModality>? = nil
     ) {
         self.modelDirectory = modelDirectory
         self.tokenizerDirectory = tokenizerDirectory
@@ -107,6 +115,7 @@ public struct ResolvedModelConfiguration: Sendable {
         self.reasoningParserName = reasoningParserName
         self.generationDefaults = generationDefaults
         self.mtpStatus = mtpStatus
+        self.requestedModalities = requestedModalities
     }
 }
 

--- a/Libraries/MLXLMCommon/ModelConstructedCapabilities.swift
+++ b/Libraries/MLXLMCommon/ModelConstructedCapabilities.swift
@@ -1,0 +1,88 @@
+// Copyright © 2026 osaurus-eval contributors
+// SPDX-License-Identifier: MIT
+//
+// The other half of `ModelRuntimeCapabilitySnapshot`.
+//
+// That type answers "what does this bundle DECLARE?" — read from `JangCapabilities` before
+// anything is loaded, and tri-state, because a bundle can simply be silent about a capability.
+// This one answers "what does this INSTANCE actually have?", and is deliberately shaped to match
+// it field for field so the two read as a designed pair rather than two unrelated mechanisms.
+//
+// It is NOT tri-state, and that difference is the point: `.unknown` exists in the snapshot because
+// a declaration can be missing. A constructed model has no such doubt — the component is either
+// there or it is not.
+
+import Foundation
+
+/// Whether a constructed model carries a capability. The two-state counterpart to
+/// ``ModelRuntimeCapabilitySupport``, which needs a third case only because a *declaration* can be
+/// absent.
+public enum ModelRuntimeCapabilityPresence: String, Codable, Sendable, Equatable {
+    case present
+    case absent
+
+    public init(_ isPresent: Bool) { self = isPresent ? .present : .absent }
+    public var isPresent: Bool { self == .present }
+}
+
+/// A module that provides runtime capability once it has been successfully constructed.
+///
+/// The declaration is on the INSTANCE, not the type, and it reports only what the component itself
+/// supplies. A vision tower says `.vision`; it does not say `.video`, because whether frames can be
+/// fed depends on the MODEL's configuration (video token ids), not on the encoder. The model unions
+/// what its components provide and then adds whatever its own configuration enables on top.
+///
+/// The reason to register rather than compute: a component that failed to build cannot register, so
+/// the report describes what EXISTS rather than what was planned.
+public protocol ModelCapabilityProviding {
+    /// What this component supplies on its own, now that it exists.
+    var providedModalities: Set<ModelRuntimeRequestModality> { get }
+}
+
+/// What a constructed model can actually do.
+///
+/// Mirrors ``ModelRuntimeCapabilitySnapshot``'s field-per-lane shape so a caller can hold both and
+/// compare them directly: the snapshot is the claim, this is the delivery. A lane that is
+/// `.supported` in the snapshot but `.absent` here is not a bug — it is the normal result of a
+/// caller narrowing construction with `requesting:`.
+public struct ModelRuntimeConstructedCapabilities: Codable, Sendable, Equatable {
+    public let text: ModelRuntimeCapabilityPresence
+    public let vision: ModelRuntimeCapabilityPresence
+    public let video: ModelRuntimeCapabilityPresence
+    public let audio: ModelRuntimeCapabilityPresence
+    public let tools: ModelRuntimeCapabilityPresence
+    public let reasoning: ModelRuntimeCapabilityPresence
+    public let nativeMTP: ModelRuntimeCapabilityPresence
+
+    /// The same information as a set, which is what most call sites want.
+    public let modalities: Set<ModelRuntimeRequestModality>
+
+    public init(_ modalities: Set<ModelRuntimeRequestModality>) {
+        self.modalities = modalities
+        self.text = .init(modalities.contains(.text))
+        self.vision = .init(modalities.contains(.vision))
+        self.video = .init(modalities.contains(.video))
+        self.audio = .init(modalities.contains(.audio))
+        self.tools = .init(modalities.contains(.tools))
+        self.reasoning = .init(modalities.contains(.reasoning))
+        self.nativeMTP = .init(modalities.contains(.nativeMTP))
+    }
+}
+
+extension ModalityBearing {
+    /// This instance's capabilities in the same shape the bundle's declaration uses.
+    public var constructedCapabilities: ModelRuntimeConstructedCapabilities {
+        ModelRuntimeConstructedCapabilities(modalities)
+    }
+}
+
+extension Set where Element == ModelRuntimeRequestModality {
+    /// Union of what a set of constructed components provides. `nil` components — the ones that
+    /// were not built — contribute nothing, which is the whole reason this is collected rather
+    /// than computed from the plan.
+    public static func provided(by components: [(any ModelCapabilityProviding)?])
+        -> Set<ModelRuntimeRequestModality>
+    {
+        components.compactMap { $0 }.reduce(into: []) { $0.formUnion($1.providedModalities) }
+    }
+}

--- a/Libraries/MLXLMCommon/ModelConstructionPlan.swift
+++ b/Libraries/MLXLMCommon/ModelConstructionPlan.swift
@@ -1,0 +1,109 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+
+/// A physical module a construction may or may not build.
+///
+/// Separate from ``ModelRuntimeRequestModality`` on purpose. A request names LANES the caller wants
+/// to use; this names MODULES that have to exist for those lanes to work, and the two do not
+/// correspond one-to-one:
+///
+///   * `.video` and `.vision` are different lanes served by the SAME tower;
+///   * `.audio` maps to different modules depending on the configuration — a conformer tower for
+///     Gemma 4's encoder path, a projection alone for its encoder-free unified path;
+///   * the language core is required by every request and is named by no lane at all.
+///
+/// Conflating the two is what let `requesting: [.video]` be accepted while nothing was built: the
+/// check asked "is `.video` constructible?" and the construction asked "does the set contain
+/// `.vision`?", and both answers were right about different questions.
+public enum ModelComponent: String, Sendable, Hashable, CaseIterable {
+    /// The language model itself. Every construction builds it; no request can omit it.
+    case languageCore
+
+    /// The shared image/video tower. Serves `.vision` and `.video` alike.
+    case visionTower
+
+    /// An audio encoder tower (Gemma 4's conformer path).
+    case audioTower
+
+    /// The projection from audio features into the text embedding space. Present on both audio
+    /// paths — with a tower for the conformer variant, alone for the encoder-free unified one.
+    case audioProjection
+}
+
+/// What a construction request resolved to.
+///
+/// Two fields because the two questions have different answers, and callers need both: `requested`
+/// is what the caller asked for and is what the instance reports; `components` is what gets built.
+public struct ResolvedConstructionPlan: Equatable, Sendable {
+    /// The lanes the caller asked for, after validation. Literal — never widened to include a lane
+    /// the caller did not name, because a video request is not an image request even though both
+    /// need the same tower.
+    public let requested: Set<ModelRuntimeRequestModality>
+
+    /// The modules to build. Always contains ``ModelComponent/languageCore``.
+    public let components: Set<ModelComponent>
+
+    /// What the built instance can serve. This — not ``requested`` — is what a model reports as its
+    /// `modalities`, because a caller asking "what can this do?" wants capability, not a receipt.
+    public let served: Set<ModelRuntimeRequestModality>
+
+    public init(
+        requested: Set<ModelRuntimeRequestModality>, components: Set<ModelComponent>,
+        served: Set<ModelRuntimeRequestModality>
+    ) {
+        self.requested = requested
+        self.components = components
+        self.served = served
+    }
+
+    public func builds(_ component: ModelComponent) -> Bool { components.contains(component) }
+}
+
+/// How a family maps requested lanes onto modules.
+///
+/// A family declares this instead of hardcoding `modalities.contains(.vision)` at each construction
+/// site, which is what made the dependency invisible and therefore wrong.
+public protocol ModelComponentMapping {
+    /// The lanes this configuration can serve at all.
+    static func constructibleModalities(of configuration: Configuration)
+        -> Set<ModelRuntimeRequestModality>
+
+    /// The modules needed to serve `requested`. Must include `.languageCore`.
+    static func components(
+        for requested: Set<ModelRuntimeRequestModality>, of configuration: Configuration
+    ) -> Set<ModelComponent>
+
+    /// What the BUILT instance can actually serve, given the modules it has.
+    ///
+    /// Deliberately has no default implementation, and in particular no "…and always text". Which
+    /// lanes a set of modules enables is a property of the family: a text LM core serves `.text`,
+    /// but a speech-to-speech model's core serves audio in and audio out and no text at all.
+    /// A blanket rule would describe such a model wrongly, and `modalities` is what a caller reads
+    /// to decide what it may send.
+    static func servedModalities(
+        by components: Set<ModelComponent>, of configuration: Configuration
+    ) -> Set<ModelRuntimeRequestModality>
+
+    associatedtype Configuration
+}
+
+extension ModelComponentMapping {
+    /// Validate a request against what the configuration offers, and resolve it to a plan.
+    ///
+    /// The only public route to a plan: a caller cannot assemble one with an empty or unsupported
+    /// selection, because this is where both are refused.
+    public static func resolveConstruction(
+        _ configuration: Configuration, requesting: Set<ModelRuntimeRequestModality>?
+    ) throws -> ResolvedConstructionPlan {
+        let constructible = constructibleModalities(of: configuration)
+        let resolved = try Set.resolveForConstruction(
+            requested: requesting, constructible: constructible)
+        var built = components(for: resolved, of: configuration)
+        built.insert(.languageCore)     // never optional, never omitted by a mapping's mistake
+        return ResolvedConstructionPlan(
+            requested: resolved, components: built,
+            served: servedModalities(by: built, of: configuration))
+    }
+}

--- a/Libraries/MLXLMCommon/Registries/ModelTypeRegistry.swift
+++ b/Libraries/MLXLMCommon/Registries/ModelTypeRegistry.swift
@@ -2,6 +2,15 @@
 
 import Foundation
 
+/// The one closure shape a registry stores.
+///
+/// Every model is built through this and only this. A family that has nothing to select simply
+/// ignores the request; a family with optional towers reads it. There is deliberately no second,
+/// modality-aware dictionary alongside this one — a parallel path is how the request came to be
+/// silently dropped before, with the modality-aware initialisers present but unreachable.
+public typealias ModelCreator =
+    (Data, Set<ModelRuntimeRequestModality>?) throws -> any LanguageModel
+
 public actor ModelTypeRegistry {
 
     /// Creates an empty registry.
@@ -10,17 +19,23 @@ public actor ModelTypeRegistry {
     }
 
     /// Creates a registry with given creators.
-    public init(creators: [String: (Data) throws -> any LanguageModel]) {
+    public init(creators: [String: ModelCreator]) {
         self.creators = creators
     }
 
-    private var creators: [String: (Data) throws -> any LanguageModel]
+    private var creators: [String: ModelCreator]
 
     /// Add a new model to the type registry.
+    public func registerModelType(_ type: String, creator: @escaping ModelCreator) {
+        creators[type] = creator
+    }
+
+    /// Register a model that has nothing to select — it is built the same way whatever is asked of
+    /// it. Adapts to the single stored shape; it does not add a second dispatch path.
     public func registerModelType(
         _ type: String, creator: @escaping (Data) throws -> any LanguageModel
     ) {
-        creators[type] = creator
+        creators[type] = { data, _ in try creator(data) }
     }
 
     /// Every `model_type` this registry can instantiate.
@@ -32,12 +47,17 @@ public actor ModelTypeRegistry {
     public var registeredModelTypes: Set<String> { Set(creators.keys) }
 
     /// Given a `modelType` and configuration data instantiate a new `LanguageModel`.
-    public func createModel(configuration: Data, modelType: String) throws -> sending LanguageModel
-    {
+    ///
+    /// - Parameter requesting: which lanes the caller intends to use, or `nil` for "everything this
+    ///   configuration supports". Families that build optional towers consult it; the rest ignore it.
+    public func createModel(
+        configuration: Data, modelType: String,
+        requesting: Set<ModelRuntimeRequestModality>? = nil
+    ) throws -> sending LanguageModel {
         guard let creator = creators[modelType] else {
             throw ModelFactoryError.unsupportedModelType(modelType)
         }
-        return try creator(configuration)
+        return try creator(configuration, requesting)
     }
 
 }

--- a/Libraries/MLXVLM/Models/DiffusionGemmaVLM.swift
+++ b/Libraries/MLXVLM/Models/DiffusionGemmaVLM.swift
@@ -81,7 +81,11 @@ public func makeDiffusionGemmaVLM(
 }
 
 /// Builds exactly the lanes named by `modalities`.
-public func makeDiffusionGemmaVLM(
+///
+/// INTERNAL on purpose. As a public entry point this accepted an empty or unsupported set and
+/// recorded it unchecked on the model, so a caller could describe an instance the configuration
+/// cannot produce. The validated `requesting:` overload above is the only public route.
+func makeDiffusionGemmaVLM(
     _ config: DiffusionGemmaVLMConfiguration,
     modalities: Set<ModelRuntimeRequestModality>
 ) -> DiffusionGemmaModel {

--- a/Libraries/MLXVLM/Models/Gemma4.swift
+++ b/Libraries/MLXVLM/Models/Gemma4.swift
@@ -1155,7 +1155,9 @@ func gemma4MaskedScatter(
 
 // MARK: - Gemma4 VLM
 
-public class Gemma4: Module, VLMModel, KVCacheDimensionProvider, ModalityBearing {
+public class Gemma4: Module, VLMModel, KVCacheDimensionProvider, ModalityBearing,
+    ModelComponentMapping
+{
     @ModuleInfo(key: "vision_tower") private var visionTower: VisionTower?
     @ModuleInfo(key: "vision_embedder") private var unifiedVisionEmbedder: UnifiedVisionEmbedder?
     @ModuleInfo(key: "audio_tower") private var audioTower: Gemma4AudioTower?
@@ -1191,12 +1193,48 @@ public class Gemma4: Module, VLMModel, KVCacheDimensionProvider, ModalityBearing
     ) -> Set<ModelRuntimeRequestModality> {
         var m: Set<ModelRuntimeRequestModality> = [.text]
         if config.visionConfig != nil { m.insert(.vision) }
-        if config.hasConformerAudioTower { m.insert(.audio) }
+        // BOTH audio paths, not just the conformer one. Gating on `hasConformerAudioTower`
+        // rejected `requesting: [.audio]` on unified 12B bundles (`gemma4_unified_audio`), which
+        // are encoder-free and feed raw 40 ms frames straight through
+        // `embed_audio.embedding_projection` — a proven audio path with no tower. A request
+        // modality asks what the model can SERVE; which modules that needs is a separate question,
+        // answered by `components(for:of:)`.
+        if config.audioConfig != nil { m.insert(.audio) }
         return m
     }
 
+
+    /// What the built modules serve. Image-only on the vision side — this family has no video lane
+    /// — and audio from either path's projection.
+    public static func servedModalities(
+        by components: Set<ModelComponent>, of config: Gemma4Configuration
+    ) -> Set<ModelRuntimeRequestModality> {
+        var m: Set<ModelRuntimeRequestModality> = []
+        if components.contains(.languageCore) { m.insert(.text) }
+        if components.contains(.visionTower) { m.insert(.vision) }
+        if components.contains(.audioProjection) { m.insert(.audio) }
+        return m
+    }
+
+    /// Which MODULES a request needs.
+    ///
+    /// The audio lane is the case that shows request modalities cannot equal optional towers: the
+    /// same `.audio` request needs a conformer tower plus a projection on E-series bundles, and the
+    /// projection alone on unified ones.
+    public static func components(
+        for requested: Set<ModelRuntimeRequestModality>, of config: Gemma4Configuration
+    ) -> Set<ModelComponent> {
+        var out: Set<ModelComponent> = []
+        if requested.contains(.vision) { out.insert(.visionTower) }
+        if requested.contains(.audio) {
+            out.insert(.audioProjection)                             // both paths
+            if config.hasConformerAudioTower { out.insert(.audioTower) }   // encoder path only
+        }
+        return out
+    }
+
     public convenience init(_ config: Gemma4Configuration) {
-        self.init(config, modalities: Self.constructibleModalities(of: config))
+        self.init(config, plan: try! Self.resolveConstruction(config, requesting: nil))
     }
 
     /// - Parameter requesting: the caller's subset, or nil for "everything this config offers".
@@ -1204,19 +1242,21 @@ public class Gemma4: Module, VLMModel, KVCacheDimensionProvider, ModalityBearing
         _ config: Gemma4Configuration,
         requesting: Set<ModelRuntimeRequestModality>?
     ) throws {
-        let resolved = try Set.resolveForConstruction(
-            requested: requesting, constructible: Self.constructibleModalities(of: config))
-        self.init(config, modalities: resolved)
+        self.init(config, plan: try Self.resolveConstruction(config, requesting: requesting))
     }
 
-    /// The one real initialiser: builds exactly the towers named by `modalities`.
-    public init(
+    /// What was actually built.
+    public let plan: ResolvedConstructionPlan
+
+    /// The one real initialiser. Private: a plan comes only from `resolveConstruction`.
+    private init(
         _ config: Gemma4Configuration,
-        modalities: Set<ModelRuntimeRequestModality>
+        plan: ResolvedConstructionPlan
     ) {
-        self.modalities = modalities
+        self.modalities = plan.served
+        self.plan = plan
         self.config = config
-        if let visionConfig = config.visionConfig, modalities.contains(.vision) {
+        if let visionConfig = config.visionConfig, plan.builds(.visionTower) {
             if visionConfig.usesUnifiedVisionEmbedder {
                 _unifiedVisionEmbedder.wrappedValue = UnifiedVisionEmbedder(visionConfig)
             } else {
@@ -1228,9 +1268,7 @@ public class Gemma4: Module, VLMModel, KVCacheDimensionProvider, ModalityBearing
         // (gemma4_unified_audio) and audio-less 26B/31B bundles stay
         // tower-free; their `audio_tower.*` weights (if any) are discarded
         // in sanitize().
-        if let audioConfig = config.audioConfig, audioConfig.isConformerTower,
-            modalities.contains(.audio)
-        {
+        if let audioConfig = config.audioConfig, plan.builds(.audioTower) {
             _audioTower.wrappedValue = Gemma4AudioTower(audioConfig)
         }
         _languageModel.wrappedValue = G4LanguageModel(config.textConfig)
@@ -2037,4 +2075,8 @@ private struct Gemma4MessageGenerator: MessageGenerator {
         dict["content"] = content.isEmpty ? message.content : content
         return dict
     }
+}
+extension VisionTower: ModelCapabilityProviding {
+    /// Gemma4's encoder is image-only; this family has no video lane at all.
+    var providedModalities: Set<ModelRuntimeRequestModality> { [.vision] }
 }

--- a/Libraries/MLXVLM/Models/MuseGlimmer.swift
+++ b/Libraries/MLXVLM/Models/MuseGlimmer.swift
@@ -89,7 +89,9 @@ public struct MuseGlimmerConfiguration: Codable, Sendable {
 
 // MARK: - Model
 
-public class MuseGlimmer: Module, VLMModel, KVCacheDimensionProvider, ModalityBearing {
+public class MuseGlimmer: Module, VLMModel, KVCacheDimensionProvider, ModalityBearing,
+    ModelComponentMapping
+{
 
     @ModuleInfo(key: "vision_tower") private var visionTower: MuseGlimmerVisionModel?
     @ModuleInfo(key: "vision_adapter") private var visionAdapter: MuseGlimmerVisionProjector?
@@ -119,7 +121,8 @@ public class MuseGlimmer: Module, VLMModel, KVCacheDimensionProvider, ModalityBe
         // "provably unreachable" is a property of the function above it, and that function can be
         // edited. Passing the constructible set directly removes the possibility instead of
         // reasoning about it.
-        self.init(config, modalities: Self.constructibleModalities(of: config))
+        // nil = everything the configuration offers, which cannot fail validation.
+        self.init(config, plan: try! Self.resolveConstruction(config, requesting: nil))
     }
 
     /// Which towers this configuration can actually instantiate.
@@ -140,22 +143,47 @@ public class MuseGlimmer: Module, VLMModel, KVCacheDimensionProvider, ModalityBe
         _ config: MuseGlimmerConfiguration,
         requesting: Set<ModelRuntimeRequestModality>?
     ) throws {
-        let resolved = try Set.resolveForConstruction(
-            requested: requesting, constructible: Self.constructibleModalities(of: config))
-        self.init(config, modalities: resolved)
+        self.init(config, plan: try Self.resolveConstruction(config, requesting: requesting))
     }
 
-    /// The one real initialiser: builds exactly the towers named by `modalities`.
-    public init(
+
+    /// What the built modules serve. `.text` is this family's core being a text LM, not a default.
+    public static func servedModalities(
+        by components: Set<ModelComponent>, of config: MuseGlimmerConfiguration
+    ) -> Set<ModelRuntimeRequestModality> {
+        var m: Set<ModelRuntimeRequestModality> = []
+        if components.contains(.languageCore) { m.insert(.text) }
+        if components.contains(.visionTower) { m.formUnion([.vision, .video]) }
+        return m
+    }
+
+    /// Which MODULES a request needs. `.vision` and `.video` are different lanes served by the SAME
+    /// tower, so gating on `.vision` alone accepted `requesting: [.text, .video]` and then built no
+    /// tower at all — the late `prepare()` failure this whole mechanism exists to prevent.
+    public static func components(
+        for requested: Set<ModelRuntimeRequestModality>, of config: MuseGlimmerConfiguration
+    ) -> Set<ModelComponent> {
+        var out: Set<ModelComponent> = []
+        if requested.contains(.vision) || requested.contains(.video) { out.insert(.visionTower) }
+        return out
+    }
+
+    /// What was actually built.
+    public let plan: ResolvedConstructionPlan
+
+    /// The one real initialiser. Private: a plan can only come from `resolveConstruction`, so no
+    /// caller can construct an empty or unsupported instance.
+    private init(
         _ config: MuseGlimmerConfiguration,
-        modalities: Set<ModelRuntimeRequestModality>
+        plan: ResolvedConstructionPlan
     ) {
-        self.modalities = modalities
+        self.modalities = plan.served
+        self.plan = plan
         self.config = config
         // Built only when the bundle has a tower AND the caller asked for it. Skipping it is not a
         // degraded mode: it is the text-only load that previously required a separate registration,
         // and on a 30B bundle it leaves 3.84 GB of vision weights unallocated.
-        if config.visionConfiguration != nil, modalities.contains(.vision) {
+        if config.visionConfiguration != nil, plan.builds(.visionTower) {
             self._visionTower.wrappedValue = MuseGlimmerVisionModel(config.visionConfiguration!)
             self._visionAdapter.wrappedValue = MuseGlimmerVisionProjector(
                 inputDimensions: config.outHiddenSize,
@@ -315,7 +343,10 @@ public class MuseGlimmer: Module, VLMModel, KVCacheDimensionProvider, ModalityBe
                 // vision weights; rehoming them onto a module that was never built leaves keys with
                 // no destination. Dropping them is what MuseGlimmerTextModel.sanitize already does,
                 // and what Gemma4 does with `audio_tower.*` on audio-less bundles.
-                guard modalities.contains(.vision) else { continue }
+                // The MODULE, not the lane: a video-only instance HAS the tower, so its
+                // weights must survive. Asking about `.vision` here would drop the weights
+                // of a tower that was just built.
+                guard plan.builds(.visionTower) else { continue }
                 rehomed = String(rehomed.dropFirst("model.".count))
             }
             out[rehomed] = value

--- a/Libraries/MLXVLM/Models/MuseGlimmerVision.swift
+++ b/Libraries/MLXVLM/Models/MuseGlimmerVision.swift
@@ -627,3 +627,8 @@ public class MuseGlimmerVisionProjector: Module {
         geluApproximate(fc2(geluApproximate(fc1(x))))
     }
 }
+
+extension MuseGlimmerVisionModel: ModelCapabilityProviding {
+    /// See `Qwen3VLVision.VisionModel`: the encoder claims `.vision` only.
+    public var providedModalities: Set<ModelRuntimeRequestModality> { [.vision] }
+}

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -2895,7 +2895,7 @@ enum Qwen35Language {
 // MARK: - Model
 
 public class Qwen35: Module, VLMModel, HiddenStateCaptureModel, TokenEmbedderModel, NativeMTPModel,
-    DFlash2StagedVerifyRollbackModel
+    DFlash2StagedVerifyRollbackModel, ModalityBearing, ModelComponentMapping
 {
     @ModuleInfo(key: "vision_tower") private var visionModel: Qwen3VLVision.VisionModel?
     @ModuleInfo(key: "language_model") fileprivate var languageModel: Qwen35Language.LanguageModel
@@ -2917,8 +2917,37 @@ public class Qwen35: Module, VLMModel, HiddenStateCaptureModel, TokenEmbedderMod
         config.visionConfiguration != nil ? [.text, .vision, .video] : [.text]
     }
 
+
+    /// What the built modules serve. `.text` comes from THIS family's core being a text LM — it is
+    /// not a universal truth, which is why there is no default doing it for everyone.
+    public static func servedModalities(
+        by components: Set<ModelComponent>, of config: Qwen35Configuration
+    ) -> Set<ModelRuntimeRequestModality> {
+        var m: Set<ModelRuntimeRequestModality> = []
+        if components.contains(.languageCore) { m.insert(.text) }
+        if components.contains(.visionTower) { m.formUnion([.vision, .video]) }
+        return m
+    }
+
+    /// Which MODULES a request needs, as opposed to which lanes it names.
+    ///
+    /// The distinction is the whole point: `.vision` and `.video` are different lanes served by the
+    /// SAME tower. Gating construction on `.vision` alone — which is what this did — accepted
+    /// `requesting: [.video]` and then built nothing, because validation asked "is video
+    /// constructible?" and construction asked "does the set contain vision?". Both were right about
+    /// different questions.
+    public static func components(
+        for requested: Set<ModelRuntimeRequestModality>, of config: Qwen35Configuration
+    ) -> Set<ModelComponent> {
+        var out: Set<ModelComponent> = []
+        if requested.contains(.vision) || requested.contains(.video) { out.insert(.visionTower) }
+        return out
+    }
+
     public convenience init(_ config: Qwen35Configuration) {
-        self.init(config, modalities: Self.constructibleModalities(of: config))
+        // `nil` means "everything this configuration offers", which cannot fail.
+        let plan = try! Self.resolveConstruction(config, requesting: nil)
+        self.init(config, plan: plan)
     }
 
     /// - Parameter requesting: the caller's subset, or nil for "everything this config offers".
@@ -2926,24 +2955,37 @@ public class Qwen35: Module, VLMModel, HiddenStateCaptureModel, TokenEmbedderMod
         _ config: Qwen35Configuration,
         requesting: Set<ModelRuntimeRequestModality>?
     ) throws {
-        let resolved = try Set.resolveForConstruction(
-            requested: requesting, constructible: Self.constructibleModalities(of: config))
-        self.init(config, modalities: resolved)
+        self.init(config, plan: try Self.resolveConstruction(config, requesting: requesting))
     }
 
-    /// The one real initialiser: builds exactly the towers named by `modalities`.
-    public init(
-        _ config: Qwen35Configuration,
-        modalities: Set<ModelRuntimeRequestModality>
-    ) {
-        self.modalities = modalities
+    /// The one real initialiser. Private on purpose: a plan can only come from
+    /// `resolveConstruction`, so no caller can hand this an empty or unsupported selection.
+    private init(_ config: Qwen35Configuration, plan: ResolvedConstructionPlan) {
+        self.plan = plan
         self.config = config
-        if let vision = config.visionConfiguration, modalities.contains(.vision) {
-            _visionModel.wrappedValue = Qwen3VLVision.VisionModel(vision)
+        // Built first, so the capability report can be COLLECTED from what actually exists rather
+        // than copied from the plan. A tower that did not get built — because the caller narrowed
+        // the request, or because the configuration had no vision stanza — cannot contribute, so
+        // the report cannot claim a lane the instance lacks.
+        var tower: Qwen3VLVision.VisionModel?
+        if let vision = config.visionConfiguration, plan.builds(.visionTower) {
+            tower = Qwen3VLVision.VisionModel(vision)
+            _visionModel.wrappedValue = tower
         }
         _languageModel.wrappedValue = Qwen35Language.LanguageModel(config)
+
+        // The components declare their own contribution; `.video` is added here because it needs
+        // this model's video token id, which the encoder knows nothing about.
+        var provided = Set<ModelRuntimeRequestModality>.provided(by: [tower])
+        provided.insert(.text)  // this family's core is a text LM
+        if provided.contains(.vision), config.videoTokenId != nil { provided.insert(.video) }
+        self.modalities = provided
         super.init()
     }
+
+    /// What was actually built. Kept so `prepare` and `sanitize` can ask about MODULES rather than
+    /// re-deriving them from lanes.
+    public let plan: ResolvedConstructionPlan
 
     public var vocabularySize: Int { config.vocabSize }
 

--- a/Libraries/MLXVLM/Models/Qwen3VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen3VL.swift
@@ -1937,3 +1937,9 @@ public struct Qwen3VLMessageGenerator: MessageGenerator {
         ]
     }
 }
+
+extension Qwen3VLVision.VisionModel: ModelCapabilityProviding {
+    /// An image encoder. `.video` is NOT claimed here: frames additionally need the model's video
+    /// token ids, so that lane is the model's to add on top of this one.
+    public var providedModalities: Set<ModelRuntimeRequestModality> { [.vision] }
+}

--- a/Libraries/MLXVLM/Models/Qwen4Exp.swift
+++ b/Libraries/MLXVLM/Models/Qwen4Exp.swift
@@ -1377,7 +1377,7 @@ protocol Qwen4ExpModelDirectoryConfigurable: AnyObject {
 
 public final class Qwen4Exp: Module, VLMModel, Qwen4ExpModelDirectoryConfigurable,
     SafetensorsLoadKeyExcluding, NativeMTPModel, DFlash2StagedVerifyRollbackModel,
-    CompiledDecodeExternalInputModel, ModalityBearing
+    CompiledDecodeExternalInputModel, ModalityBearing, ModelComponentMapping
 {
     /// QSA index selection and its path-dependent cache currently require a
     /// single sequence. Keep concurrent requests queued until a B-wide QSA
@@ -1412,8 +1412,29 @@ public final class Qwen4Exp: Module, VLMModel, Qwen4ExpModelDirectoryConfigurabl
         config.base.visionConfiguration != nil ? [.text, .vision, .video] : [.text]
     }
 
+
+    /// What the built modules serve. `.text` is this family's core being a text LM, not a default.
+    public static func servedModalities(
+        by components: Set<ModelComponent>, of config: Qwen4ExpConfiguration
+    ) -> Set<ModelRuntimeRequestModality> {
+        var m: Set<ModelRuntimeRequestModality> = []
+        if components.contains(.languageCore) { m.insert(.text) }
+        if components.contains(.visionTower) { m.formUnion([.vision, .video]) }
+        return m
+    }
+
+    /// Which MODULES a request needs. `.vision` and `.video` share one tower, so gating on
+    /// `.vision` alone accepted a video-only request and built nothing.
+    public static func components(
+        for requested: Set<ModelRuntimeRequestModality>, of config: Qwen4ExpConfiguration
+    ) -> Set<ModelComponent> {
+        var out: Set<ModelComponent> = []
+        if requested.contains(.vision) || requested.contains(.video) { out.insert(.visionTower) }
+        return out
+    }
+
     public convenience init(_ config: Qwen4ExpConfiguration) {
-        self.init(config, modalities: Self.constructibleModalities(of: config))
+        self.init(config, plan: try! Self.resolveConstruction(config, requesting: nil))
     }
 
     /// - Parameter requesting: the caller's subset, or nil for "everything this config offers".
@@ -1421,17 +1442,19 @@ public final class Qwen4Exp: Module, VLMModel, Qwen4ExpModelDirectoryConfigurabl
         _ config: Qwen4ExpConfiguration,
         requesting: Set<ModelRuntimeRequestModality>?
     ) throws {
-        let resolved = try Set.resolveForConstruction(
-            requested: requesting, constructible: Self.constructibleModalities(of: config))
-        self.init(config, modalities: resolved)
+        self.init(config, plan: try Self.resolveConstruction(config, requesting: requesting))
     }
 
-    /// The one real initialiser: builds exactly the towers named by `modalities`.
-    public init(
+    /// What was actually built.
+    public let plan: ResolvedConstructionPlan
+
+    /// The one real initialiser. Private: a plan comes only from `resolveConstruction`.
+    private init(
         _ config: Qwen4ExpConfiguration,
-        modalities: Set<ModelRuntimeRequestModality>
+        plan: ResolvedConstructionPlan
     ) {
-        self.modalities = modalities
+        self.modalities = plan.served
+        self.plan = plan
         self.config = config
         _textModel.wrappedValue = Qwen4ExpTextModel(config)
         _head.wrappedValue = Linear(
@@ -1440,7 +1463,7 @@ public final class Qwen4Exp: Module, VLMModel, Qwen4ExpModelDirectoryConfigurabl
         if config.extras.mtpNumHiddenLayers > 0 {
             _mtp.wrappedValue = Qwen4ExpMTPModule(config)
         }
-        if let vision = config.base.visionConfiguration, modalities.contains(.vision) {
+        if let vision = config.base.visionConfiguration, plan.builds(.visionTower) {
             _visionModel.wrappedValue = Qwen3VLVision.VisionModel(vision)
         }
         super.init()
@@ -1759,7 +1782,8 @@ public final class Qwen4Exp: Module, VLMModel, Qwen4ExpModelDirectoryConfigurabl
             // vision weights; handing them to a module that was never built leaves keys with no
             // destination. Dropping them is what every other converted family does here, and it
             // mirrors the `mtp.` guard directly above — same idea, different lane.
-            if !modalities.contains(.vision), originalKey.hasPrefix("visual.") { continue }
+            // The MODULE: a video-only instance HAS the tower and must keep its weights.
+            if !plan.builds(.visionTower), originalKey.hasPrefix("visual.") { continue }
             var key = originalKey
             var value = originalValue
             if key.hasPrefix("model.language_model.") {

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -63,10 +63,26 @@ public struct BaseProcessorConfiguration: Codable, Sendable {
 }
 
 /// Creates a function that loads a configuration file and instantiates a model with the proper configuration
-private func create<C: Codable, M>(
+/// Registration adapter for a family that SELECTS what it builds.
+///
+/// Written out at the registration site (`Model.init(_:requesting:)`) rather than resolved by
+/// overloading, so that a family which consults the request is visible in the registry table —
+/// the thing that was impossible to see when the request never left the factory.
+private func createSelecting<C: Codable, M: LanguageModel>(
+    _ configurationType: C.Type,
+    _ modelInit: @escaping (C, Set<ModelRuntimeRequestModality>?) throws -> M
+) -> ModelCreator {
+    { data, requesting in
+        let configuration = try JSONDecoder.json5().decode(C.self, from: data)
+        return try modelInit(configuration, requesting)
+    }
+}
+
+private func create<C: Codable, M: LanguageModel>(
     _ configurationType: C.Type, _ modelInit: @escaping (C) -> M
-) -> (Data) throws -> M {
-    { data in
+) -> ModelCreator {
+    // Ignores the request: this family builds the same thing whatever is asked of it.
+    { data, _ in
         let configuration = try JSONDecoder.json5().decode(C.self, from: data)
         return modelInit(configuration)
     }
@@ -102,21 +118,21 @@ public enum VLMTypeRegistry {
     /// Shared instance with default model types.
     public static let shared: ModelTypeRegistry = .init(creators: _creators)
 
-    nonisolated(unsafe) private static let _creators: [String: (Data) throws -> any LanguageModel] = [
+    nonisolated(unsafe) private static let _creators: [String: ModelCreator] = [
         "paligemma": create(PaliGemmaConfiguration.self, PaliGemma.init),
         // Block-diffusion Gemma: the MLXLLM engine with the Gemma4 vision
         // tower installed. Generation runs via BlockDiffusionTokenIterator;
         // the throwing prepare() guard keeps AR routes loud.
-        "diffusion_gemma": create(
-            DiffusionGemmaVLMConfiguration.self, makeDiffusionGemmaVLM),
+        "diffusion_gemma": createSelecting(
+            DiffusionGemmaVLMConfiguration.self, makeDiffusionGemmaVLM(_:requesting:)),
         "qwen2_vl": create(Qwen2VLConfiguration.self, Qwen2VL.init),
         "qwen2_5_vl": create(Qwen25VLConfiguration.self, Qwen25VL.init),
         "qwen3_vl": create(Qwen3VLConfiguration.self, Qwen3VL.init),
-        "qwen3_5": create(Qwen35Configuration.self, Qwen35.init),
-        "qwen3_5_moe": create(Qwen35Configuration.self, Qwen35MoE.init),
-        "qwen4_exp": create(Qwen4ExpConfiguration.self, Qwen4Exp.init),
+        "qwen3_5": createSelecting(Qwen35Configuration.self, Qwen35.init(_:requesting:)),
+        "qwen3_5_moe": createSelecting(Qwen35Configuration.self, Qwen35MoE.init(_:requesting:)),
+        "qwen4_exp": createSelecting(Qwen4ExpConfiguration.self, Qwen4Exp.init(_:requesting:)),
         "idefics3": create(Idefics3Configuration.self, Idefics3.init),
-        "muse_glimmer": create(MuseGlimmerConfiguration.self, MuseGlimmer.init),
+        "muse_glimmer": createSelecting(MuseGlimmerConfiguration.self, MuseGlimmer.init(_:requesting:)),
         "gemma3": create(Gemma3Configuration.self, Gemma3.init),
         "smolvlm": create(SmolVLM2Configuration.self, SmolVLM2.init),
         // TODO: see if we can make it work with fastvlm rather than llava_qwen2
@@ -137,8 +153,8 @@ public enum VLMTypeRegistry {
         // DeepSeek-OCR / Unlimited-OCR (top model_type "deepseek_vl_v2").
         "deepseek_vl_v2": create(DeepseekOCRConfiguration.self, DeepseekOCR.init),
         "deepseekocr": create(DeepseekOCRConfiguration.self, DeepseekOCR.init),
-        "gemma4": create(Gemma4Configuration.self, Gemma4.init),
-        "gemma4_unified": create(Gemma4Configuration.self, Gemma4.init),
+        "gemma4": createSelecting(Gemma4Configuration.self, Gemma4.init(_:requesting:)),
+        "gemma4_unified": createSelecting(Gemma4Configuration.self, Gemma4.init(_:requesting:)),
         "nemotron_dense_audex": create(AudexConfiguration.self, Audex.init),
         "nemotron_h_audex": create(AudexHConfiguration.self, AudexH.init),
         "nemotron_h_omni": create(NemotronHOmniConfiguration.self, NemotronHOmni.init),
@@ -147,7 +163,9 @@ public enum VLMTypeRegistry {
         "zaya1_vl": dispatchZaya1VL,
     ]
 
-    private static func dispatchZaya1VL(data: Data) throws -> any LanguageModel {
+    private static func dispatchZaya1VL(data: Data, requesting: Set<ModelRuntimeRequestModality>? = nil)
+        throws -> any LanguageModel
+    {
         let configuration = try JSONDecoder.json5().decode(Zaya1VLConfiguration.self, from: data)
         return try Zaya1VL(configuration)
     }
@@ -162,7 +180,9 @@ public enum VLMTypeRegistry {
     ///   2. `text_config.model_type == "mistral4"` → `Mistral4VLM` (Mistral 3
     ///      VLM wrapping a Mistral 4 text decoder).
     ///   3. Otherwise → vanilla `Mistral3VLM`.
-    static func dispatchMistral3VLM(data: Data) throws -> any LanguageModel {
+    static func dispatchMistral3VLM(data: Data, requesting: Set<ModelRuntimeRequestModality>? = nil)
+        throws -> any LanguageModel
+    {
         struct WFCheck: Codable {
             let weightFormat: String?
             enum CodingKeys: String, CodingKey { case weightFormat = "weight_format" }
@@ -585,7 +605,8 @@ public final class VLMModelFactory: ModelFactory {
         let model: LanguageModel
         do {
             model = try await typeRegistry.createModel(
-                configuration: mergedConfigData, modelType: dispatchModelType)
+                configuration: mergedConfigData, modelType: dispatchModelType,
+                requesting: configuration.requestedModalities)
         } catch let error as DecodingError {
             throw ModelFactoryError.configurationDecodingError(
                 configurationURL.lastPathComponent, configuration.name, error)

--- a/Package.swift
+++ b/Package.swift
@@ -861,6 +861,7 @@ let package = Package(
                 "DeepseekV4AgentLoopBoundaryTests.swift",
                 "EarlyCompletionBeforeCachePersistTests.swift",
                 "ToolCallProgressRoutingTests.swift",
+                "ModelConstructionPlanTests.swift",
                 "FocusedMLXTestSupport.swift",
                 "CanonicalChatCacheBoundariesTests.swift",
                 "UniversalCapabilityConstructionTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/ModelConstructionPlanTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/ModelConstructionPlanTests.swift
@@ -1,0 +1,342 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// The bug this design exists to make impossible: `requesting: [.video]` was accepted (video IS
+// constructible) and then built nothing, because construction asked `modalities.contains(.vision)`.
+// Both checks were right about different questions. Lanes and modules are now different types.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXVLM
+import Testing
+
+@Suite("Model construction plan")
+struct ModelConstructionPlanTests {
+
+    /// A stand-in for a qwen3_5-shaped family: one tower serving both image and video.
+    private struct SharedTowerFamily: ModelComponentMapping {
+        struct Configuration { let hasVision: Bool }
+
+        static func constructibleModalities(of c: Configuration)
+            -> Set<ModelRuntimeRequestModality>
+        { c.hasVision ? [.text, .vision, .video] : [.text] }
+
+        static func components(
+            for requested: Set<ModelRuntimeRequestModality>, of c: Configuration
+        ) -> Set<ModelComponent> {
+            var out: Set<ModelComponent> = []
+            // The dependency, stated once: EITHER media lane needs the tower.
+            if requested.contains(.vision) || requested.contains(.video) { out.insert(.visionTower) }
+            return out
+        }
+
+        static func servedModalities(
+            by components: Set<ModelComponent>, of c: Configuration
+        ) -> Set<ModelRuntimeRequestModality> {
+            var m: Set<ModelRuntimeRequestModality> = []
+            if components.contains(.languageCore) { m.insert(.text) }
+            if components.contains(.visionTower) { m.formUnion([.vision, .video]) }
+            return m
+        }
+    }
+
+    private static let multimodal = SharedTowerFamily.Configuration(hasVision: true)
+
+    @Test("a video-only request builds the shared tower — the bug this replaces")
+    func videoOnlyBuildsTheTower() throws {
+        let plan = try SharedTowerFamily.resolveConstruction(Self.multimodal, requesting: [.video])
+        #expect(plan.requested == [.video], "the lane stays literal — video is not an image request")
+        #expect(plan.builds(.visionTower), "video needs the tower")
+        #expect(plan.builds(.languageCore))
+    }
+
+    @Test("an image-only request builds the same tower")
+    func visionOnlyBuildsTheTower() throws {
+        let plan = try SharedTowerFamily.resolveConstruction(Self.multimodal, requesting: [.vision])
+        #expect(plan.requested == [.vision])
+        #expect(plan.builds(.visionTower))
+    }
+
+    @Test("a text-only request builds no tower")
+    func textOnlyBuildsNoTower() throws {
+        let plan = try SharedTowerFamily.resolveConstruction(Self.multimodal, requesting: [.text])
+        #expect(plan.components == [.languageCore])
+    }
+
+    @Test("the language core is present even when no lane names it")
+    func languageCoreAlwaysBuilt() throws {
+        for req: Set<ModelRuntimeRequestModality> in [[.text], [.vision], [.video], [.text, .video]] {
+            let plan = try SharedTowerFamily.resolveConstruction(Self.multimodal, requesting: req)
+            #expect(plan.builds(.languageCore), "\(req)")
+        }
+    }
+
+    @Test("nil requests everything the configuration offers")
+    func nilRequestsAll() throws {
+        let plan = try SharedTowerFamily.resolveConstruction(Self.multimodal, requesting: nil)
+        #expect(plan.requested == [.text, .vision, .video])
+        #expect(plan.builds(.visionTower))
+    }
+
+    @Test("empty and unsupported selections are refused")
+    func invalidSelectionsRefused() {
+        #expect(throws: (any Error).self) {
+            try SharedTowerFamily.resolveConstruction(Self.multimodal, requesting: [])
+        }
+        #expect(throws: (any Error).self) {
+            try SharedTowerFamily.resolveConstruction(Self.multimodal, requesting: [.audio])
+        }
+        let textOnly = SharedTowerFamily.Configuration(hasVision: false)
+        #expect(throws: (any Error).self) {
+            try SharedTowerFamily.resolveConstruction(textOnly, requesting: [.vision])
+        }
+    }
+
+    /// Gemma 4's two audio paths: the same lane, different modules. This is the case that showed
+    /// `constructibleModalities` cannot be a list of towers.
+    @Test("one audio lane maps to different modules depending on the path")
+    func audioLaneMapsPerPath() throws {
+        struct Gemma4Like: ModelComponentMapping {
+            struct Configuration { let conformer: Bool; let unifiedAudio: Bool }
+            static func constructibleModalities(of c: Configuration)
+                -> Set<ModelRuntimeRequestModality>
+            { c.conformer || c.unifiedAudio ? [.text, .vision, .audio] : [.text, .vision] }
+            static func components(
+                for requested: Set<ModelRuntimeRequestModality>, of c: Configuration
+            ) -> Set<ModelComponent> {
+                var out: Set<ModelComponent> = []
+                if requested.contains(.vision) { out.insert(.visionTower) }
+                if requested.contains(.audio) {
+                    out.insert(.audioProjection)               // both paths need it
+                    if c.conformer { out.insert(.audioTower) } // only the encoder path
+                }
+                return out
+            }
+            static func servedModalities(
+                by components: Set<ModelComponent>, of c: Configuration
+            ) -> Set<ModelRuntimeRequestModality> {
+                var m: Set<ModelRuntimeRequestModality> = []
+                if components.contains(.languageCore) { m.insert(.text) }
+                if components.contains(.visionTower) { m.insert(.vision) }
+                if components.contains(.audioProjection) { m.insert(.audio) }
+                return m
+            }
+        }
+        let conformer = try Gemma4Like.resolveConstruction(
+            .init(conformer: true, unifiedAudio: false), requesting: [.audio])
+        #expect(conformer.components == [.languageCore, .audioTower, .audioProjection])
+
+        let unified = try Gemma4Like.resolveConstruction(
+            .init(conformer: false, unifiedAudio: true), requesting: [.audio])
+        #expect(unified.components == [.languageCore, .audioProjection],
+                "the unified path has no conformer, and must not be rejected for lacking one")
+    }
+    // MARK: - The real family, not a stand-in
+
+    /// A vision-capable qwen3_5 config, decoded rather than hand-built so the shapes are real.
+    private static func qwen35Config() throws -> Qwen35Configuration {
+        let json = """
+            {"model_type":"qwen3_5","text_config":{"hidden_size":64,"num_hidden_layers":2,
+              "intermediate_size":128,"num_attention_heads":4,"num_key_value_heads":2,
+              "rms_norm_eps":1e-6,"vocab_size":100,"rope_theta":10000.0},
+             "vision_config":{"model_type":"qwen3_5","depth":2,"hidden_size":32,"num_heads":2,"in_channels":3,
+              "intermediate_size":64,"out_hidden_size":64,"patch_size":16,"spatial_merge_size":2,
+              "temporal_patch_size":2,"num_position_embeddings":64}}
+            """
+        return try JSONDecoder.json5().decode(
+            Qwen35Configuration.self, from: Data(json.utf8))
+    }
+
+    /// The bug, on the class that had it: `[.video]` was accepted and built NO tower.
+    @Test("Qwen35: a video-only request builds the vision tower")
+    func qwen35VideoOnlyBuildsTower() throws {
+        let cfg = try Self.qwen35Config()
+        let plan = try Qwen35.resolveConstruction(cfg, requesting: [.video])
+        #expect(plan.builds(.visionTower), "video needs the shared tower")
+
+        let model = try Qwen35(cfg, requesting: [.video])
+        let visionParams = model.parameters().flattened().map(\.0)
+            .filter { $0.contains("vision_tower") }
+        #expect(!visionParams.isEmpty, "video-only instance allocated NO vision parameters")
+    }
+
+    /// The control: text-only must still allocate nothing.
+    @Test("Qwen35: a text-only request allocates no vision parameters")
+    func qwen35TextOnlyAllocatesNothing() throws {
+        let model = try Qwen35(try Self.qwen35Config(), requesting: [.text])
+        let visionParams = model.parameters().flattened().map(\.0)
+            .filter { $0.contains("vision_tower") }
+        #expect(visionParams.isEmpty, "text-only leaked \(visionParams.count) vision parameters")
+    }
+
+    /// And the default is unchanged: everything the config offers.
+    @Test("Qwen35: the default construction still builds the tower")
+    func qwen35DefaultUnchanged() throws {
+        let model = Qwen35(try Self.qwen35Config())
+        #expect(model.plan.builds(.visionTower))
+        #expect(model.modalities == [.text, .vision, .video], "default serves every lane")
+    }
+
+    /// Muse Glimmer had the identical defect, with the request Jang cited: `[.text, .video]`.
+    @Test("MuseGlimmer: a text+video request builds the shared tower")
+    func museGlimmerTextVideoBuildsTower() throws {
+        let json = """
+            {"model_type":"muse_glimmer","hidden_size":64,"num_hidden_layers":2,
+             "intermediate_size":128,"num_attention_heads":4,"num_key_value_heads":2,
+             "rms_norm_eps":1e-6,"vocab_size":100,"rope_theta":10000.0,
+             "vision_config":{"model_type":"muse_glimmer","hidden_size":32,"num_hidden_layers":2,
+               "intermediate_size":64,"num_attention_heads":2,"patch_size":16,"image_size":64,
+               "merge_size":2}}
+            """
+        let cfg = try JSONDecoder.json5().decode(
+            MuseGlimmerConfiguration.self, from: Data(json.utf8))
+        let plan = try MuseGlimmer.resolveConstruction(cfg, requesting: [.text, .video])
+        #expect(plan.builds(.visionTower), "text+video needs the shared tower")
+
+        let model = try MuseGlimmer(cfg, requesting: [.text, .video])
+        let visionParams = model.parameters().flattened().map(\.0)
+            .filter { $0.lowercased().contains("vision") }
+        #expect(!visionParams.isEmpty, "text+video instance allocated NO vision parameters")
+
+        let textOnly = try MuseGlimmer(cfg, requesting: [.text])
+        let none = textOnly.parameters().flattened().map(\.0)
+            .filter { $0.lowercased().contains("vision") }
+        #expect(none.isEmpty, "text-only leaked \(none.count) vision parameters")
+    }
+
+    /// Jang's blocker #4, against REAL bundle configs on this machine: a unified-audio bundle can
+    /// process audio through an encoder-free projection, and was being told `.audio` is not
+    /// constructible because it has no conformer tower.
+    @Test("Gemma4: both audio paths accept an .audio request, with different modules")
+    func gemma4BothAudioPathsAccepted() throws {
+        let root = URL(fileURLWithPath: NSHomeDirectory())
+            .appendingPathComponent("Library/MLModels")
+        var sawUnified = false, sawConformer = false
+        let fm = FileManager.default
+        for org in (try? fm.contentsOfDirectory(atPath: root.path))?.sorted() ?? [] {
+            let orgDir = root.appendingPathComponent(org)
+            for kid in (try? fm.contentsOfDirectory(atPath: orgDir.path))?.sorted() ?? [] {
+                let cfgURL = orgDir.appendingPathComponent(kid).appendingPathComponent("config.json")
+                guard let data = try? Data(contentsOf: cfgURL),
+                    let obj = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any],
+                    (obj["model_type"] as? String)?.hasPrefix("gemma4") == true,
+                    let audio = obj["audio_config"] as? [String: Any],
+                    let cfg = try? JSONDecoder.json5().decode(Gemma4Configuration.self, from: data)
+                else { continue }
+                let unified = (audio["model_type"] as? String) == "gemma4_unified_audio"
+                let plan = try Gemma4.resolveConstruction(cfg, requesting: [.audio])
+                #expect(plan.builds(.audioProjection), "\(kid): audio needs the projection")
+                if unified {
+                    sawUnified = true
+                    #expect(!plan.builds(.audioTower), "\(kid): unified has no conformer to build")
+                } else {
+                    sawConformer = true
+                    #expect(plan.builds(.audioTower), "\(kid): E-series needs the conformer")
+                }
+            }
+        }
+        // A bundle-gated assertion that never ran looks exactly like one that passed.
+        print("gemma4 audio paths exercised — unified: \(sawUnified), conformer: \(sawConformer)")
+        #expect(sawUnified || sawConformer, "no gemma4 audio bundle on this machine")
+    }
+
+    /// The second-order form of the same conflation: a video-only instance HAS the tower, so
+    /// `sanitize` must keep its weights. Asking about the LANE there would drop the weights of a
+    /// tower that was just built — a model with an allocated but unloaded vision tower.
+    @Test("MuseGlimmer: a video-only instance keeps its vision weights through sanitize")
+    func museGlimmerVideoKeepsVisionWeights() throws {
+        let json = """
+            {"model_type":"muse_glimmer","hidden_size":64,"num_hidden_layers":2,
+             "intermediate_size":128,"num_attention_heads":4,"num_key_value_heads":2,
+             "rms_norm_eps":1e-6,"vocab_size":100,"rope_theta":10000.0,
+             "vision_config":{"model_type":"muse_glimmer","hidden_size":32,"num_hidden_layers":2,
+               "intermediate_size":64,"num_attention_heads":2,"patch_size":16,"image_size":64,
+               "merge_size":2}}
+            """
+        let cfg = try JSONDecoder.json5().decode(
+            MuseGlimmerConfiguration.self, from: Data(json.utf8))
+        let weights: [String: MLXArray] = [
+            "model.vision_tower.blocks.0.attn.qkv.weight": MLXArray([1.0] as [Float]),
+            "model.language_model.norm.weight": MLXArray([2.0] as [Float]),
+        ]
+        let videoOnly = try MuseGlimmer(cfg, requesting: [.text, .video])
+        let kept = videoOnly.sanitize(weights: weights)
+        #expect(
+            kept.keys.contains { $0.lowercased().contains("vision") },
+            "video-only built the tower but sanitize dropped its weights: \(kept.keys.sorted())")
+
+        let textOnly = try MuseGlimmer(cfg, requesting: [.text])
+        let dropped = textOnly.sanitize(weights: weights)
+        #expect(
+            !dropped.keys.contains { $0.lowercased().contains("vision") },
+            "text-only has no tower, so vision weights must be dropped")
+    }
+
+    /// Blocker #2: no PUBLIC path may construct an empty or unsupported instance.
+    ///
+    /// Asserted on the source rather than by calling the removed overloads — a test that could call
+    /// them would not compile, which is the point, but a compile error is not a regression signal.
+    /// This fails loudly if someone re-widens one.
+    @Test("no public initializer takes an unchecked modality set")
+    func noPublicUncheckedConstructor() throws {
+        let families = [
+            "Libraries/MLXVLM/Models/Qwen35.swift",
+            "Libraries/MLXVLM/Models/MuseGlimmer.swift",
+            "Libraries/MLXVLM/Models/Gemma4.swift",
+            "Libraries/MLXVLM/Models/Qwen4Exp.swift",
+            "Libraries/MLXVLM/Models/DiffusionGemmaVLM.swift",
+        ]
+        var offenders: [String] = []
+        for file in families {
+            guard let src = try? String(contentsOfFile: file, encoding: .utf8) else {
+                Issue.record("missing \(file)"); continue
+            }
+            let lines = src.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+            for (n, line) in lines.enumerated() {
+                // a public init/func whose parameter list carries a raw modality set
+                guard line.contains("public init(") || line.contains("public func make") else { continue }
+                let window = lines[n...min(n + 4, lines.count - 1)].joined(separator: " ")
+                if window.contains("modalities: Set<ModelRuntimeRequestModality>") {
+                    offenders.append("\(file.split(separator: "/").last!):\(n + 1)")
+                }
+            }
+        }
+        #expect(
+            offenders.isEmpty,
+            "public unchecked constructor(s): \(offenders.joined(separator: ", "))")
+    }
+
+    /// rcfa's point: `modalities` must report what the model CAN DO, and that is family-specific —
+    /// never "the request plus text". A speech-to-speech model has no text lane to append.
+    @Test("served modalities come from the family, not from a blanket text rule")
+    func servedIsFamilySpecific() throws {
+        /// A hypothetical voice-in/voice-out model: its core serves AUDIO, not text.
+        struct VoiceFamily: ModelComponentMapping {
+            struct Configuration { let hasAudio: Bool }
+            static func constructibleModalities(of c: Configuration)
+                -> Set<ModelRuntimeRequestModality>
+            { c.hasAudio ? [.audio] : [] }
+            static func components(
+                for requested: Set<ModelRuntimeRequestModality>, of c: Configuration
+            ) -> Set<ModelComponent> {
+                requested.contains(.audio) ? [.audioProjection] : []
+            }
+            static func servedModalities(
+                by components: Set<ModelComponent>, of c: Configuration
+            ) -> Set<ModelRuntimeRequestModality> {
+                // NO `.text`. The core here is not a text LM.
+                components.contains(.audioProjection) ? [.audio] : []
+            }
+        }
+        let plan = try VoiceFamily.resolveConstruction(.init(hasAudio: true), requesting: [.audio])
+        #expect(plan.served == [.audio], "a blanket +.text rule would describe this model wrongly")
+        #expect(plan.builds(.languageCore), "the core is still built; it just serves no text lane")
+
+        // And a text family still reports text, because ITS core is a text LM.
+        let text = try SharedTowerFamily.resolveConstruction(Self.multimodal, requesting: [.video])
+        #expect(text.served == [.text, .vision, .video],
+                "a video request still yields a model that can also take text and images")
+    }
+
+}

--- a/Tests/MLXLMCommonFocusedTests/NoHiddenReasoningCloseBiasFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NoHiddenReasoningCloseBiasFocusedTests.swift
@@ -2047,7 +2047,12 @@ struct Gemma4VLMFocusedSourceContractsTests {
         let llmFactory = try focusedRepositoryFile("Libraries/MLXLLM/LLMModelFactory.swift")
         let source = try gemma4VLMSource()
 
-        #expect(vlmFactory.contains(#""gemma4_unified": create(Gemma4Configuration.self, Gemma4.init)"#))
+        // `createSelecting` + the explicit `init(_:requesting:)` is the spelling that says this family
+        // CONSULTS the construction request; a plain `create` here would mean the request is dropped.
+        #expect(
+            vlmFactory.contains(
+                #""gemma4_unified": createSelecting(Gemma4Configuration.self, Gemma4.init(_:requesting:))"#
+            ))
         #expect(vlmFactory.contains(#""Gemma4UnifiedProcessor": create("#))
         #expect(llmFactory.contains(#""gemma4_unified": create(Gemma4TextConfiguration.self, Gemma4TextModel.init)"#))
         #expect(llmFactory.contains(#""gemma4_unified_text": create(Gemma4TextConfiguration.self, Gemma4TextModel.init)"#))

--- a/Tests/MLXLMTests/Gemma4AudioGuardTests.swift
+++ b/Tests/MLXLMTests/Gemma4AudioGuardTests.swift
@@ -121,8 +121,14 @@ struct Gemma4AudioGuardTests {
         let audioSource = try Self.gemma4AudioSource()
 
         // Tower instantiation is gated on audio_config presence + type.
-        #expect(source.contains("audioConfig.isConformerTower"),
-            "Gemma4.init must gate the audio tower on audio_config.model_type == gemma4_audio.")
+        // The gate moved behind a named property when construction became request-driven: the
+        // config now exposes `hasConformerAudioTower`, and the initialiser asks THAT. Pin both
+        // halves — the property's definition and the fact the tower is built only when it and the
+        // plan agree — rather than the raw `audioConfig.isConformerTower` spelling it replaced.
+        #expect(source.contains("audioConfig?.isConformerTower ?? false"),
+            "hasConformerAudioTower must still derive from audio_config.model_type.")
+        #expect(source.contains("config.hasConformerAudioTower"),
+            "Gemma4 must gate the audio tower on audio_config.model_type == gemma4_audio.")
         #expect(audioSource.contains("modelType == \"gemma4_audio\""),
             "isConformerTower must require model_type gemma4_audio so unified 12B bundles stay tower-free.")
         #expect(source.contains("@ModuleInfo(key: \"audio_tower\") private var audioTower"),

--- a/Tests/MLXLMTests/RoutedFactoryRequestDispatchTests.swift
+++ b/Tests/MLXLMTests/RoutedFactoryRequestDispatchTests.swift
@@ -1,0 +1,64 @@
+// Copyright © 2026 osaurus-eval contributors
+
+import Foundation
+import MLXLMCommon
+import Testing
+
+@testable import MLXVLM
+
+/// The registry is the ONLY route from a request to a model. These tests go through it rather than
+/// calling an initialiser, because the defect they guard against was never in the initialisers:
+/// the modality-aware `init(_:requesting:)` existed and was correct, and nothing called it. A test
+/// that constructs a model directly passes just as happily with the registration table unwired.
+@Suite("routed factory: the request reaches the model")
+struct RoutedFactoryRequestDispatchTests {
+
+    /// qwen3_5 with a vision tower in the config.
+    /// Reused verbatim from `Qwen35VLMGatedDeltaTests` — a fixture already known to decode,
+    /// so a failure here is the dispatch and never the JSON.
+    static let configJSON = #"""
+        {"model_type":"qwen3_5_moe","text_config":{"model_type":"qwen3_5_moe_text","hidden_size":32,"num_hidden_layers":4,"intermediate_size":64,"num_attention_heads":4,"num_key_value_heads":2,"linear_num_value_heads":4,"linear_num_key_heads":2,"linear_key_head_dim":8,"linear_value_head_dim":8,"linear_conv_kernel_dim":2,"head_dim":8,"full_attention_interval":4,"vocab_size":100,"rms_norm_eps":1e-06,"rope_parameters":{"rope_type":"default","rope_theta":100000.0,"partial_rotary_factor":0.25,"mrope_section":[1,1,1]}},"vision_config":{"model_type":"qwen3_vl","depth":1,"hidden_size":16,"intermediate_size":32,"out_hidden_size":32,"num_heads":4,"patch_size":2,"spatial_merge_size":2,"temporal_patch_size":1,"num_position_embeddings":32},"vocab_size":100,"image_token_id":98,"video_token_id":97}
+        """#
+
+    @Test("a text-only request builds no vision tower and says so")
+    func textOnlyRequestIsHonoured() async throws {
+        let data = Data(Self.configJSON.utf8)
+        let model = try await VLMTypeRegistry.shared.createModel(
+            configuration: data, modelType: "qwen3_5", requesting: [.text])
+        let bearing = try #require(model as? any ModalityBearing)
+
+        // If the registration table still routed to the plain `init`, this would be
+        // [.text, .vision, .video] — the request would have been accepted and discarded.
+        #expect(bearing.modalities == [.text], "the request must survive the trip through the registry")
+    }
+
+    @Test("no request builds everything the config offers")
+    func nilRequestBuildsEverything() async throws {
+        let data = Data(Self.configJSON.utf8)
+        let model = try await VLMTypeRegistry.shared.createModel(
+            configuration: data, modelType: "qwen3_5", requesting: nil)
+        #expect((model as? any ModalityBearing)?.modalities == [.text, .vision, .video])
+    }
+
+    /// `nil` is the default, so every existing caller keeps the old behaviour.
+    @Test("the legacy two-argument call is unchanged")
+    func legacyCallIsUnchanged() async throws {
+        let data = Data(Self.configJSON.utf8)
+        let model = try await VLMTypeRegistry.shared.createModel(
+            configuration: data, modelType: "qwen3_5")
+        #expect((model as? any ModalityBearing)?.modalities == [.text, .vision, .video])
+    }
+
+    @Test("asking for a lane the config cannot build is refused, not silently dropped")
+    func unsupportedLaneThrows() async throws {
+        let textOnly = #"""
+            {"model_type":"qwen3_5_moe","text_config":{"model_type":"qwen3_5_moe_text","hidden_size":32,"num_hidden_layers":4,"intermediate_size":64,"num_attention_heads":4,"num_key_value_heads":2,"linear_num_value_heads":4,"linear_num_key_heads":2,"linear_key_head_dim":8,"linear_value_head_dim":8,"linear_conv_kernel_dim":2,"head_dim":8,"full_attention_interval":4,"vocab_size":100,"rms_norm_eps":1e-06,"rope_parameters":{"rope_type":"default","rope_theta":100000.0,"partial_rotary_factor":0.25,"mrope_section":[1,1,1]}},"vocab_size":100}
+            """#
+        // Deliberately NOT `throws: (any Error).self` — that passes on a malformed fixture, which
+        // is how this test first went green while proving nothing.
+        await #expect(throws: UnconstructibleModalities.self) {
+            _ = try await VLMTypeRegistry.shared.createModel(
+                configuration: Data(textOnly.utf8), modelType: "qwen3_5", requesting: [.vision])
+        }
+    }
+}

--- a/Tests/MLXLMTests/SelectingFamiliesAreWiredSourceCoverageTests.swift
+++ b/Tests/MLXLMTests/SelectingFamiliesAreWiredSourceCoverageTests.swift
@@ -1,0 +1,80 @@
+// Copyright © 2026 osaurus-eval contributors
+
+import Foundation
+import Testing
+
+/// The defect this exists to make impossible: a family can implement `ModelComponentMapping`
+/// perfectly — resolve the request, build only the asked-for towers, report the right
+/// `modalities` — and still have the request DROPPED, because the registry entry says
+/// `create(Config.self, Model.init)` instead of `createSelecting(Config.self,
+/// Model.init(_:requesting:))`. That unwiring COMPILES WITH ZERO ERRORS, and a test that
+/// constructs the model directly passes just as happily, because it never touches the table.
+///
+/// So the guard cannot be a behaviour test on any one family — it has to be a statement about
+/// the table itself: if a family declares that it selects, its registration must say so.
+@Suite("selecting families are registered through the selecting creator")
+struct SelectingFamiliesAreWiredSourceCoverageTests {
+
+    private static var repoRoot: URL {
+        var root = URL(fileURLWithPath: #filePath)
+        for _ in 0 ..< 3 { root.deleteLastPathComponent() }
+        return root
+    }
+
+    /// Model classes that conform to `ModelComponentMapping`, by file.
+    private static func selectingClasses() throws -> [String] {
+        let modelsRoot = Self.repoRoot.appending(path: "Libraries/MLXVLM/Models")
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(atPath: modelsRoot.path) else { return [] }
+        var names: [String] = []
+        for entry in entries where entry.hasSuffix(".swift") {
+            let text = try String(
+                contentsOf: modelsRoot.appending(path: entry), encoding: .utf8)
+            guard text.contains("ModelComponentMapping") else { continue }
+            // The conforming class is the one whose declaration list mentions the protocol; the
+            // declaration may wrap across lines, so scan from each `class` to its opening brace.
+            var scan = text.startIndex
+            while let decl = text.range(of: "public class ", range: scan ..< text.endIndex) {
+                guard let brace = text.range(of: "{", range: decl.upperBound ..< text.endIndex)
+                else { break }
+                let header = String(text[decl.upperBound ..< brace.lowerBound])
+                if header.contains("ModelComponentMapping") {
+                    let name = header.prefix { $0.isLetter || $0.isNumber || $0 == "_" }
+                    if !name.isEmpty { names.append(String(name)) }
+                }
+                scan = brace.upperBound
+            }
+        }
+        return names
+    }
+
+    @Test("a family that selects is not registered through the plain creator")
+    func selectingFamiliesUseTheSelectingCreator() throws {
+        let classes = try Self.selectingClasses()
+        try #require(
+            !classes.isEmpty,
+            "found no ModelComponentMapping conformers — the scan is wrong, not the code")
+
+        let factory = try String(
+            contentsOf: Self.repoRoot.appending(path: "Libraries/MLXVLM/VLMModelFactory.swift"),
+            encoding: .utf8)
+
+        var unwired: [String] = []
+        for name in Set(classes) {
+            // A registration of this class through the PLAIN creator drops the request.
+            if factory.contains("create(\(name)Configuration.self, \(name).init)")
+                || factory.contains(", \(name).init)")
+            {
+                unwired.append(name)
+            }
+        }
+        #expect(
+            unwired.isEmpty,
+            """
+            these families implement ModelComponentMapping but are registered through the plain \
+            creator, so the construction request never reaches them: \
+            \(unwired.sorted().joined(separator: ", ")). \
+            Use createSelecting(…, Model.init(_:requesting:)).
+            """)
+    }
+}


### PR DESCRIPTION
Separates two things that were one: the **modalities a caller asks for** and the **modules that serve
them**.

## The half that was missing

The modality-aware initialisers already existed and were correct. Nothing called them.
`ModelTypeRegistry` stored `(Data) throws -> any LanguageModel`, so a construction request was
accepted by the public API and dropped before it reached a model.

The registry now stores ONE creator shape:

```swift
public typealias ModelCreator =
    (Data, Set<ModelRuntimeRequestModality>?) throws -> any LanguageModel
```

`requesting:` defaults to `nil`, so every existing call site is unchanged. There is deliberately no
second, modality-aware dictionary alongside it — a parallel path is how the request came to be
dropped in the first place. Registrations that select say so in the table:

```swift
"qwen3_5": createSelecting(Qwen35Configuration.self, Qwen35.init(_:requesting:)),
```

`createSelecting` is a distinct name rather than an overload, so the table itself records which
families consult the request.

## Reporting what was built, not what was planned

A family declares `components(for:of:)` — what to build — and `servedModalities(by:of:)` — what the
result can do. The latter has **no default implementation**, deliberately: a blanket "…and always
text" describes a speech-to-speech model wrongly, and `modalities` is what a caller reads to decide
what it may send. There is a test for exactly that case.

Components then REGISTER what they provide, via `ModelCapabilityProviding`, and the model collects
the union at construction. A tower that did not get built cannot contribute, so the report describes
what exists rather than what was intended. The declaration is on the instance, not the type:
`Qwen3VLVision.VisionModel` backs two families and serves image-only or image+video depending on the
configuration it was built from. It claims `.vision`; `.video` is added by the model, which owns the
video token id.

`ModelRuntimeConstructedCapabilities` mirrors `ModelRuntimeCapabilitySnapshot` field for field, so
the two read as a pair: the snapshot is what the on-disk bundle DECLARES, before loading; this is
what the instance HAS. It is not tri-state — the snapshot needs `.unknown` because a declaration can
be absent, and a constructed model has no such doubt.

`Qwen35` also declared `modalities` without conforming to `ModalityBearing`, so no caller could
query it; an audit found it was the only one.

## Guards

`RoutedFactoryRequestDispatchTests` goes through the REGISTRY rather than calling an initialiser — a
test that constructs directly passes just as happily with the table unwired, which is how this
shipped broken. Reverting one registration to the plain init compiles with **zero errors** and fails
two of those tests.

Because that is exactly the failure mode, `SelectingFamiliesAreWiredSourceCoverageTests` states it
about the table itself: a family that implements `ModelComponentMapping` must not be registered
through the plain creator. Unwiring one entry still compiles, and that guard names it.
