### PR TITLE
Evaluate drain test: anchor on a site that occurs once

### DIFF
--- a/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
@@ -263,6 +263,20 @@ struct BatchEngineGrowingChatCacheSourceTests {
         #expect(source.contains("coordinator.hasValidatedDiskEntry("))
     }
 
+    /// Anchored FORWARD from the info yield, and deliberately not from `onGenerationEnd`.
+    ///
+    /// `handler.onGenerationEnd(emit: continuation.yield)` occurs THREE times in this task and
+    /// `continuation.finish()` FOUR — twice each on early-exit branches that precede the main path.
+    /// An unranged `range(of:)` returns the FIRST match, so anchoring there lands in a branch, and
+    /// `onEnd < info` then holds for a reason that has nothing to do with the terminal sequence: it
+    /// is two positions in unrelated code, ordered by accident of layout. The assertion cannot fail,
+    /// which is the same as not making it.
+    ///
+    /// `_ = continuation.yield(handler.infoEvent(info))` occurs exactly once, so every step below is
+    /// anchored to a unique site and each `<` says something about the order the runtime actually
+    /// runs in: info is published first, then the GPU drain, the cache store, the second drain, the
+    /// advisor drain, and only then the stream finishes. Safety is preserved by the STREAM END, not
+    /// by `.info` ordering — which is precisely why `.info` may come first and why the rest may not.
     @Test("token iterator publishes info early but finishes only after cache store drain")
     func tokenIteratorFinishesOnlyAfterCacheStoreDrain() throws {
         let source = try String(
@@ -271,17 +285,14 @@ struct BatchEngineGrowingChatCacheSourceTests {
         let taskRange = try #require(source.range(of: "private func generateLoopTask"))
         let task = String(source[taskRange.lowerBound...])
 
-        let onEnd = try #require(task.range(of: "handler.onGenerationEnd(emit: continuation.yield)"))
-        let store = try #require(task.range(of: "iterator.storeCacheAfterGeneration("))
-        let info = try #require(task.range(
-            of: "handler.infoEvent(info)",
-            range: onEnd.upperBound..<store.lowerBound))
+        let info = try #require(task.range(of: "_ = continuation.yield(handler.infoEvent(info))"))
         let preStoreSync = try #require(task.range(
-            of: "Stream().synchronize()",
-            range: info.upperBound..<store.lowerBound))
+            of: "Stream().synchronize()", range: info.upperBound..<task.endIndex))
+        let store = try #require(task.range(
+            of: "iterator.storeCacheAfterGeneration(",
+            range: preStoreSync.upperBound..<task.endIndex))
         let postStoreSync = try #require(task.range(
-            of: "Stream().synchronize()",
-            range: store.upperBound..<task.endIndex))
+            of: "Stream().synchronize()", range: store.upperBound..<task.endIndex))
         let advisorDrain = try #require(task.range(
             of: "MLXPressCanonicalExpertAdvisor.shared.waitUntilIdle()",
             range: postStoreSync.upperBound..<task.endIndex))
@@ -289,7 +300,6 @@ struct BatchEngineGrowingChatCacheSourceTests {
             of: "continuation.finish()",
             range: advisorDrain.upperBound..<task.endIndex))
 
-        #expect(onEnd.lowerBound < info.lowerBound)
         #expect(info.lowerBound < preStoreSync.lowerBound)
         #expect(preStoreSync.lowerBound < store.lowerBound)
         #expect(store.lowerBound < postStoreSync.lowerBound)


### PR DESCRIPTION
`tokenIteratorFinishesOnlyAfterCacheStoreDrain` pins the terminal sequence of `generateLoopTask` by
scanning `Evaluate.swift` for six call sites and asserting they appear in order. Five of those
assertions do real work. The first one cannot fail.

It anchors with an unranged search:

```swift
let onEnd = try #require(task.range(of: "handler.onGenerationEnd(emit: continuation.yield)"))
```

`range(of:)` returns the FIRST match, and in this task that string occurs **three times** — twice on
early-exit branches that precede the main path. `continuation.finish()` occurs **four** times, for
the same reason. So `onEnd` lands in a branch, and `#expect(onEnd.lowerBound < info.lowerBound)` then
compares two positions in unrelated code and holds by accident of layout. An assertion that cannot
fail is the same as not making it, and it is the one assertion here that would otherwise pin
"generation ended before info was published".

`_ = continuation.yield(handler.infoEvent(info))` occurs **exactly once**. Anchoring forward from it
makes every remaining step relative to a unique site, so each `<` says something about the order the
runtime actually runs in: info is published, then the GPU drain, the cache store, the second drain,
the advisor drain, and only then the stream finishes.

The vacuous assertion is dropped rather than re-anchored. What it was trying to say — that
`onGenerationEnd` precedes the info yield — cannot be stated by a first-match search while the string
appears three times, and the property that matters is already covered: safety is preserved by the
STREAM END, not by `.info` ordering, which is exactly why `.info` may come first and the rest may not.

**Mutation-checked**, because a source-scanning test that passes proves nothing on its own. Deleting
the pre-store `Stream().synchronize()` from `Evaluate.swift` makes this version FAIL (the store can no
longer be found after the surviving sync); restoring it makes it pass. Verified on current `main`.

No production code changes.
