### PR TITLE
Speculative decoding reproduces default generation under penalties

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -40,6 +40,15 @@ public protocol LogitProcessor {
     /// Called to visit and possibly modify the logits
     func process(logits: MLXArray) -> MLXArray
 
+    /// A copy whose mutable state is INDEPENDENT of the receiver's.
+    ///
+    /// Speculative decoding runs a throwaway processor over drafted positions and then advances the
+    /// real one over accepted tokens only. A processor whose state is all value types gets that from
+    /// an ordinary `var` copy; one holding a reference type does NOT — the copy shares the object,
+    /// so rejected drafts get recorded into the real processor and accepted ones recorded twice.
+    /// Default is the value copy, which is correct for the value-only case.
+    func independentCopy() -> Self
+
     /// Called to provide the sampled token
     mutating func didSample(token: MLXArray)
 }
@@ -911,6 +920,10 @@ struct TokenRing {
 }
 
 /// Processor that implements a `repetitionPenalty`.
+extension LogitProcessor {
+    public func independentCopy() -> Self { self }
+}
+
 public struct RepetitionContext: LogitProcessor {
     private var ring: TokenRing
     let repetitionPenalty: Float
@@ -955,18 +968,47 @@ public struct RepetitionContext: LogitProcessor {
 final class GeneratedTokenCounts {
     private var counts: MLXArray?
 
+    /// Tokens recorded before the vocabulary size was known, folded in by `vector`.
+    ///
+    /// `record` cannot allocate: it is handed a token, not the logits, so it does not know the
+    /// vocabulary size. It used to simply DROP those tokens. On the ordinary decode path that never
+    /// showed, because `process` runs before every `didSample` and allocates on the first step. On
+    /// the speculative path the real processor is advanced with `didSample` while only its
+    /// throwaway copies see logits, so it can be handed many tokens before it ever sees any — 64 of
+    /// them in `SpeculativeDecodingTests` — and every one was discarded.
+    private var pendingBeforeFirstLogits: [MLXArray] = []
+
     /// Counts as a `[vocabSize]` Float32 vector, allocating on first sight of the logits.
     func vector(vocabSize: Int) -> MLXArray {
         if let counts, counts.dim(0) == vocabSize { return counts }
-        let fresh = MLXArray.zeros([vocabSize], type: Float32.self)
-        counts = fresh
+        counts = MLXArray.zeros([vocabSize], type: Float32.self)
+        let deferred = pendingBeforeFirstLogits
+        pendingBeforeFirstLogits.removeAll()
+        for token in deferred { record(token) }
+        return counts!
+    }
+
+    /// A counts object that shares nothing with the receiver.
+    ///
+    /// Both halves matter: a new class instance, AND a new `MLXArray`, because `record` writes
+    /// through an indexed assignment, which updates the array in place — copying only the class
+    /// would still leave both objects pointing at one buffer.
+    func independentCopy() -> GeneratedTokenCounts {
+        let fresh = GeneratedTokenCounts()
+        if let counts { fresh.counts = counts + MLXArray(Float(0)) }
+        fresh.pendingBeforeFirstLogits = pendingBeforeFirstLogits
         return fresh
     }
 
     /// Record one sampled token. O(1): a one-element gather and a one-element scatter, NOT a
     /// vocab-sized rebuild.
     func record(_ token: MLXArray) {
-        guard let counts else { return }   // no logits seen yet, so nothing to count into
+        guard let counts else {
+            // No logits seen yet, so the vocabulary size is unknown. HOLD the token rather than
+            // dropping it; `vector` folds these in the moment it can size the buffer.
+            pendingBeforeFirstLogits.append(token)
+            return
+        }
         let idx = token.asType(.int32).reshaped(-1)
         counts[idx] = counts[idx] + MLXArray(Float(1))
     }
@@ -979,7 +1021,18 @@ final class GeneratedTokenCounts {
 public struct PresencePenaltyContext: LogitProcessor {
     /// Exactly one of these is non-nil: `ring` for the windowed mode, `counts` for the unbounded one.
     private var ring: TokenRing?
-    private let counts: GeneratedTokenCounts?
+    /// `var`, not `let`: `independentCopy()` must be able to replace it. `TokenRing` needs no
+    /// such treatment — its `append` REASSIGNS the buffer rather than writing through it.
+    private var counts: GeneratedTokenCounts?
+
+    /// `GeneratedTokenCounts` is a class, so the ordinary value copy of this struct SHARES it.
+    /// Speculative decoding relies on a throwaway copy; without this the drafted tokens it records —
+    /// including the rejected ones — land in the real processor.
+    public func independentCopy() -> Self {
+        var copy = self
+        copy.counts = counts?.independentCopy()
+        return copy
+    }
     let presencePenalty: Float
 
     /// `presenceContextSize == nil` selects the UNBOUNDED mode, which is the published semantics.
@@ -1038,7 +1091,17 @@ public struct PresencePenaltyContext: LogitProcessor {
 public struct FrequencyPenaltyContext: LogitProcessor {
     /// Exactly one of these is non-nil: `ring` for the windowed mode, `counts` for the unbounded one.
     private var ring: TokenRing?
-    private let counts: GeneratedTokenCounts?
+    /// See `PresencePenaltyContext.counts`.
+    private var counts: GeneratedTokenCounts?
+
+    /// `GeneratedTokenCounts` is a class, so the ordinary value copy of this struct SHARES it.
+    /// Speculative decoding relies on a throwaway copy; without this the drafted tokens it records —
+    /// including the rejected ones — land in the real processor.
+    public func independentCopy() -> Self {
+        var copy = self
+        copy.counts = counts?.independentCopy()
+        return copy
+    }
     let frequencyPenalty: Float
 
     /// `frequencyContextSize == nil` selects the UNBOUNDED mode. Note this is the mode that is also
@@ -1170,6 +1233,16 @@ public struct InitialSuppressTokensProcessor: LogitProcessor {
 
 /// Processor that composes generation-config logits processors.
 public struct PenaltyProcessor: LogitProcessor {
+
+    /// Propagates to the two members that hold reference-typed state. Without this the aggregate
+    /// silently satisfies the protocol via the value-copy default and the deep copy never happens.
+    public func independentCopy() -> Self {
+        var copy = self
+        copy.presenceContext = presenceContext?.independentCopy()
+        copy.frequencyContext = frequencyContext?.independentCopy()
+        return copy
+    }
+
     var repetitionContext: RepetitionContext?
     var presenceContext: PresencePenaltyContext?
     var frequencyContext: FrequencyPenaltyContext?
@@ -3320,7 +3393,11 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
         }
 
         // Draft generation: autoregressive loop with draft model
-        var draftProcessor = processor  // Copy to discard later
+        // `independentCopy`, not a plain `var` copy: the draft loop below records every proposed
+        // token, and a shared counts object would push all of them — including the ones about to be
+        // rejected — into the real processor. "Copy to discard later" only discards if the copy
+        // owns its state.
+        var draftProcessor = processor?.independentCopy()
         var draftTokens = [MLXArray]()
         for _ in 0 ..< numDraft {
             let draftResult = draftModel(draftY[text: .newAxis], cache: draftCache, state: nil)
@@ -3342,7 +3419,7 @@ public struct SpeculativeTokenIterator: TokenIteratorProtocol {
         mainState = mainResult.state
 
         let mainTokens: MLXArray
-        if var verifyProcessor = processor {
+        if var verifyProcessor = processor?.independentCopy() {
             // Process each position sequentially so that the processor sees tokens sampled at earlier positions
             var sampled = [MLXArray]()
             for i in 0 ..< (numDraft + 1) {

--- a/Package.swift
+++ b/Package.swift
@@ -913,6 +913,7 @@ let package = Package(
                 "TokenizerAddedTokenRegexFocusedTests.swift",
                 "LFM2ShortConvCacheRestoreFocusedTests.swift",
                 "LFM25ChatTemplateRenderFocusedTests.swift",
+                "LogitProcessorIndependentCopyTests.swift",
             ]
         ),
         .testTarget(

--- a/Tests/MLXLMCommonFocusedTests/LogitProcessorIndependentCopyTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/LogitProcessorIndependentCopyTests.swift
@@ -1,0 +1,51 @@
+// Copyright © 2026 osaurus-eval contributors
+
+import Foundation
+import MLX
+import Testing
+
+@testable import MLXLMCommon
+
+/// Isolates the copy mechanism from the speculative-decoding logic that consumes it.
+@Suite("LogitProcessor independent copy")
+struct LogitProcessorIndependentCopyTests {
+
+    private func makeProcessor() -> LogitProcessor {
+        GenerateParameters(
+            maxTokens: 8, temperature: 0,
+            repetitionPenalty: nil, presencePenalty: 0.5, frequencyPenalty: 0.2
+        ).processor()!
+    }
+
+    @Test("recording into a copy does not reach the original")
+    func copyDoesNotShareCounts() throws {
+        let vocab = 16
+        var original = makeProcessor()
+        // Force the counts vector to exist: it allocates on first sight of logits.
+        _ = original.process(logits: MLXArray.zeros([1, vocab], type: Float32.self))
+
+        var copy = original.independentCopy()
+        for _ in 0 ..< 4 { copy.didSample(token: MLXArray([Int32(3)])) }
+
+        // The original never sampled anything, so its penalty must still be a no-op.
+        let flat = MLXArray.zeros([1, vocab], type: Float32.self)
+        let afterOriginal = original.process(logits: flat)
+        eval(afterOriginal)
+        let values = afterOriginal.asArray(Float.self)
+        #expect(
+            values.allSatisfy { $0 == 0 },
+            "the original was penalised by tokens only the copy sampled: \(values)")
+    }
+
+    @Test("the copy still works — it is a copy, not a stub")
+    func copyIsFunctional() throws {
+        let vocab = 16
+        var copy = makeProcessor().independentCopy()
+        _ = copy.process(logits: MLXArray.zeros([1, vocab], type: Float32.self))
+        for _ in 0 ..< 4 { copy.didSample(token: MLXArray([Int32(3)])) }
+        let after = copy.process(logits: MLXArray.zeros([1, vocab], type: Float32.self))
+        eval(after)
+        let values = after.asArray(Float.self)
+        #expect(values[3] != 0, "the copy must still accumulate its own penalty")
+    }
+}

--- a/Tests/MLXLMTests/SpeculativeDecodingTests.swift
+++ b/Tests/MLXLMTests/SpeculativeDecodingTests.swift
@@ -82,4 +82,38 @@ struct SpeculativeDecodingTests {
         #expect(!speculativeTokens.isEmpty)
         #expect(normalTokens == speculativeTokens)
     }
+    /// Isolates WHICH penalty breaks speculative equivalence.
+    ///
+    /// `RepetitionContext` holds a `TokenRing`, whose `append` REASSIGNS its `MLXArray` buffer, so a
+    /// struct copy is genuinely independent. `PresencePenaltyContext` and `FrequencyPenaltyContext`
+    /// hold `GeneratedTokenCounts`, which is a `final class` mutated in place by `record`. The
+    /// speculative verifier copies the processor per round and walks it across all `numDraft + 1`
+    /// positions — including drafts it then REJECTS — so with a shared counts object those rejected
+    /// tokens are counted into the real processor, and accepted ones are counted twice.
+    @Test(arguments: ["repetition", "presence", "frequency"])
+    func whichPenaltyBreaksSpeculativeEquivalence(which: String) async throws {
+        let modelInput = LMInput(tokens: MLXArray([3, 5, 7, 11, 13, 17, 19, 23]))
+        let parameters = GenerateParameters(
+            maxTokens: 32,
+            temperature: 0.0,
+            repetitionPenalty: which == "repetition" ? 1.5 : nil,
+            presencePenalty: which == "presence" ? 0.5 : nil,
+            frequencyPenalty: which == "frequency" ? 0.2 : nil,
+        )
+        var normal: [Int] = []
+        for await g in try generateTokens(
+            input: modelInput, parameters: parameters, context: mainContext)
+        {
+            if let t = g.token { normal.append(t) }
+        }
+        var speculative: [Int] = []
+        for await g in try generateTokens(
+            input: modelInput, parameters: parameters, context: mainContext,
+            draftModel: draftContext.model, numDraftTokens: 8)
+        {
+            if let t = g.token { speculative.append(t) }
+        }
+        #expect(normal == speculative, "\(which) penalty diverges under speculative decoding")
+    }
+
 }


### PR DESCRIPTION
`SpeculativeDecodingTests."Speculative decoding matches default token generation"` fails on a clean
checkout for all three `withLogitProcessor: true` cases (draft sizes 2, 8, 48). All three `false`
cases pass, so the speculative path itself is sound.

Isolated per penalty at `numDraftTokens: 8`, before the fix:

| penalty | matches default |
|---|---|
| `repetitionPenalty` | yes |
| `presencePenalty` | **no** |
| `frequencyPenalty` | **no** |

That split is predicted by the storage, and there turned out to be two causes behind it.

## 1. The throwaway processor copies shared state

`SpeculativeTokenIterator` copies the processor twice per round — `var draftProcessor = processor`
(commented "Copy to discard later") and `if var verifyProcessor = processor`.

`RepetitionContext` holds a `TokenRing`, whose `append` REASSIGNS its `MLXArray` buffer, so a struct
copy is genuinely independent — which is why repetition alone matched.
`PresencePenaltyContext` and `FrequencyPenaltyContext` hold `GeneratedTokenCounts`, a `final class`
mutated in place by `record`. Neither copy discarded anything: the draft loop recorded every
*proposed* token and the verify loop walked all `numDraft + 1` positions, so rejected drafts were
recorded into the real processor and accepted ones were recorded twice.

`LogitProcessor.independentCopy()` is added, defaulting to the ordinary value copy — correct for a
processor whose state is all value types — and overridden by the two penalty contexts and
`PenaltyProcessor` to deep-copy the counts object *and* its array, since `record` writes through an
indexed assignment. Both copy sites now use it.

## 2. `record` silently dropped tokens

Fixing the sharing was not enough, which is what pointed at the second cause.

`record` is handed a token, not the logits, so it cannot know the vocabulary size — and it returned
early when the buffer did not exist:

```swift
guard let counts else { return }   // no logits seen yet, so nothing to count into
```

On the ordinary decode path that is invisible: `process` runs before every `didSample`, so the buffer
exists from step one. On the speculative path the real processor is advanced with `didSample` while
only its throwaway copies ever see logits, so it can be handed many tokens before it sees any.
Instrumented on this test: **64 of 1106 `record` calls were dropped**.

Those tokens are now held and folded in the moment `vector` can size the buffer; `independentCopy`
carries the pending list too.

## Coverage

- `LogitProcessorIndependentCopyTests` covers the copy mechanism directly: recording into a copy no
  longer reaches the original, and the copy still accumulates its own penalty.
- `whichPenaltyBreaksSpeculativeEquivalence` asserts equivalence per penalty, so a regression names
  which one broke rather than only that something did.
- The original parameterised test passes for all six cases.
