### PR TITLE
Qwen3.8: fuse native-MTP verifier MoE rows

### DIFF
--- a/Libraries/MLXLMCommon/Qwen4ExpFusedAffineMoE.swift
+++ b/Libraries/MLXLMCommon/Qwen4ExpFusedAffineMoE.swift
@@ -26,6 +26,10 @@ enum Qwen4ExpFusedAffineMoE {
         inputDimensions: 2048, expertDimensions: 512, routes: 8)
     private static let supportedBits = Set([2, 3, 4, 5, 6])
     private static let supportedGroupSizes = Set([32, 64])
+    /// Decode and native-MTP verification only. A single decode token is one
+    /// row; native MTP verifies the current token plus at most three drafts.
+    /// Larger prompt/prefill batches deliberately stay on the generic path.
+    private static let maximumRows = 4
 
     private static let enabled: Bool = {
         let raw =
@@ -43,8 +47,10 @@ enum Qwen4ExpFusedAffineMoE {
             uint sgid = tid / 32u;
             uint lane = thread_index_in_simdgroup;
             uint m = sgid % EXPERT_DIM;
-            uint k = sgid / EXPERT_DIM;
-            uint e = uint(inds[k]);
+            uint route_row = sgid / EXPERT_DIM;
+            uint k = route_row % ROUTES;
+            uint row = route_row / ROUTES;
+            uint e = uint(inds[row * ROUTES + k]);
             size_t rowoff = size_t(e) * EXPERT_DIM + m;
             constexpr uint G_VALUES_PER_PACK = (G_BITS == 3 || G_BITS == 5) ? 8u : (G_BITS == 6 ? 4u : 32u / G_BITS);
             constexpr uint U_VALUES_PER_PACK = (U_BITS == 3 || U_BITS == 5) ? 8u : (U_BITS == 6 ? 4u : 32u / U_BITS);
@@ -82,7 +88,7 @@ enum Qwen4ExpFusedAffineMoE {
               float qsg = 0.0f;
               float xs = 0.0f;
               for (uint j = 0; j < G_VALUES_PER_PACK; ++j) {
-                float xv = float(x[xbase + j]);
+                float xv = float(x[row * INPUT_DIM + xbase + j]);
                 xs += xv;
                 qsg += xv * float((gwrd >> (G_BITS * j)) & G_CODE_MASK);
               }
@@ -106,7 +112,7 @@ enum Qwen4ExpFusedAffineMoE {
               float qsu = 0.0f;
               float xs = 0.0f;
               for (uint j = 0; j < U_VALUES_PER_PACK; ++j) {
-                float xv = float(x[xbase + j]);
+                float xv = float(x[row * INPUT_DIM + xbase + j]);
                 xs += xv;
                 qsu += xv * float((uwrd >> (U_BITS * j)) & U_CODE_MASK);
               }
@@ -118,10 +124,15 @@ enum Qwen4ExpFusedAffineMoE {
               float g = float(T(gacc));
               float u = float(T(uacc));
               float activated = g / (1.0f + metal::fast::exp(-g)) * u;
-              act[k * EXPERT_DIM + m] = T(activated);
+              act[(row * ROUTES + k) * EXPERT_DIM + m] = T(activated);
             }
             """,
-        ensureRowContiguous: false)
+        // Native MTP supplies lazy/sliced multi-row input, route, and score
+        // views. The kernel indexes those arrays as flat row-major storage, so
+        // accepting arbitrary strides silently reads the wrong tokens/routes.
+        // MLX only materializes inputs that need it; dense single-row decode
+        // remains the same allocation-free contract.
+        ensureRowContiguous: true)
 
     private static let downKernel = MLXFast.metalKernel(
         name: "vmlx_qwen4_q4g64_weighted_down10",
@@ -131,10 +142,11 @@ enum Qwen4ExpFusedAffineMoE {
             uint tid = thread_position_in_grid.x;
             uint sgid = tid / 32u;
             uint lane = thread_index_in_simdgroup;
-            uint d = sgid;
+            uint d = sgid % INPUT_DIM;
+            uint row = sgid / INPUT_DIM;
             float weighted = 0.0f;
             for (uint k = 0; k < ROUTES; ++k) {
-              uint e = uint(inds[k]);
+              uint e = uint(inds[row * ROUTES + k]);
               size_t rowoff = size_t(e) * INPUT_DIM + d;
               constexpr uint VALUES_PER_PACK = (BITS == 3 || BITS == 5) ? 8u : (BITS == 6 ? 4u : 32u / BITS);
               constexpr uint BYTES_PER_PACK = BITS == 5 ? 5u : ((BITS == 3 || BITS == 6) ? 3u : 4u);
@@ -159,7 +171,8 @@ enum Qwen4ExpFusedAffineMoE {
                 } else {
                   wrd = ulong(*reinterpret_cast<const device uint32_t*>(dp));
                 }
-                size_t abase = size_t(k) * EXPERT_DIM + pack_idx * VALUES_PER_PACK;
+                size_t abase = (size_t(row) * ROUTES + k) * EXPERT_DIM
+                    + pack_idx * VALUES_PER_PACK;
                 float qs = 0.0f;
                 float xs = 0.0f;
                 for (uint j = 0; j < VALUES_PER_PACK; ++j) {
@@ -170,11 +183,14 @@ enum Qwen4ExpFusedAffineMoE {
                 acc += sc * qs + bi * xs;
               }
               acc = simd_sum(acc);
-              weighted += float(scores[k]) * acc;
+              weighted += float(scores[row * ROUTES + k]) * acc;
             }
-            if (lane == 0u) out[d] = T(weighted);
+            if (lane == 0u) out[row * INPUT_DIM + d] = T(weighted);
             """,
-        ensureRowContiguous: false)
+        // `act` is dense, but `indices` and `scores` may be strided views from
+        // top-k selection during multi-token verification. This kernel also
+        // indexes them as flat row-major storage.
+        ensureRowContiguous: true)
 
     private static let reportLock = NSLock()
     nonisolated(unsafe) private static var reportedShapes = Set<String>()
@@ -214,14 +230,14 @@ enum Qwen4ExpFusedAffineMoE {
                     + " scores=\(scores.shape):\(scores.dtype):size\(scores.size)\n").utf8))
     }
 
-    private static func reportActivation(shape: Shape) {
+    private static func reportActivation(shape: Shape, rows: Int) {
         reportLock.lock()
         defer { reportLock.unlock() }
-        let label = "\(shape.inputDimensions)x\(shape.expertDimensions):topk\(shape.routes)"
+        let label = "\(shape.inputDimensions)x\(shape.expertDimensions):topk\(shape.routes):rows\(rows)"
         guard reportedShapes.insert(label).inserted else { return }
         FileHandle.standardError.write(
             Data(
-                ("[Qwen4Exp] fused_affine_moe_decode=active rows=1"
+                ("[Qwen4Exp] fused_affine_moe_decode=active rows=\(rows)"
                     + " shape=\(shape.inputDimensions)x\(shape.expertDimensions) topk=\(shape.routes)"
                     + " mixed_q2_q3_q4_q5_q6_g32_g64 input=bfloat16 output=bfloat16"
                     + " affine_metadata=bf16_or_f16 router_scores=bf16_or_f32"
@@ -288,12 +304,17 @@ enum Qwen4ExpFusedAffineMoE {
             // produces F32 scores. The reduction already converts scores to
             // FP32 registers; both are native inputs and neither changes the
             // BF16 activation/result contract.
+            let rows = input.size / shape.inputDimensions
+            let leadingShape = Array(input.shape.dropLast())
             guard input.dtype == .bfloat16,
                 scores.dtype == .bfloat16 || scores.dtype == .float32,
-                input.size == shape.inputDimensions,
+                rows >= 1, rows <= maximumRows,
+                input.size == rows * shape.inputDimensions,
                 input.dim(-1) == shape.inputDimensions,
-                indices.size == shape.routes, indices.dim(-1) == shape.routes,
-                scores.size == shape.routes, scores.dim(-1) == shape.routes
+                indices.size == rows * shape.routes, indices.dim(-1) == shape.routes,
+                scores.size == rows * shape.routes, scores.dim(-1) == shape.routes,
+                Array(indices.shape.dropLast()) == leadingShape,
+                Array(scores.shape.dropLast()) == leadingShape
             else {
                 reportInvocationRejection(input: input, indices: indices, scores: scores)
                 return nil
@@ -317,8 +338,9 @@ enum Qwen4ExpFusedAffineMoE {
                     ("U_GROUP_SIZE", upGroupSize),
                     ("INPUT_DIM", shape.inputDimensions),
                     ("EXPERT_DIM", shape.expertDimensions),
+                    ("ROUTES", shape.routes),
                 ],
-                grid: (32 * shape.expertDimensions * shape.routes, 1, 1),
+                grid: (32 * rows * shape.expertDimensions * shape.routes, 1, 1),
                 threadGroup: (128, 1, 1),
                 outputShapes: [pairShape],
                 outputDTypes: [input.dtype])[0]
@@ -336,12 +358,12 @@ enum Qwen4ExpFusedAffineMoE {
                     ("EXPERT_DIM", shape.expertDimensions),
                     ("ROUTES", shape.routes),
                 ],
-                grid: (32 * shape.inputDimensions, 1, 1),
+                grid: (32 * rows * shape.inputDimensions, 1, 1),
                 threadGroup: (128, 1, 1),
                 outputShapes: [input.shape],
                 outputDTypes: [input.dtype])[0]
 
-            reportActivation(shape: shape)
+            reportActivation(shape: shape, rows: rows)
             return output
         }
     }

--- a/Tests/MLXLMTests/Qwen4ExpFusedAffineMoETests.swift
+++ b/Tests/MLXLMTests/Qwen4ExpFusedAffineMoETests.swift
@@ -164,6 +164,133 @@ struct Qwen4ExpFusedAffineMoETests {
         }
     }
 
+    @Test("native-MTP rows 2 through 4 match independent row-1 decode for every shipped layout")
+    func smallRowIsolationParity() throws {
+        for (comboIndex, combo) in Self.shippedCombos.enumerated() {
+            let seed = UInt64(7001 + comboIndex * 101)
+            let (gate, _) = Self.makeProjection(
+                inputDims: Self.inputDims, outputDims: Self.expertDims,
+                bits: combo.gate.bits, groupSize: combo.gate.group, seed: seed)
+            let (up, _) = Self.makeProjection(
+                inputDims: Self.inputDims, outputDims: Self.expertDims,
+                bits: combo.up.bits, groupSize: combo.up.group, seed: seed + 1)
+            let (down, _) = Self.makeProjection(
+                inputDims: Self.expertDims, outputDims: Self.inputDims,
+                bits: combo.down.bits, groupSize: combo.down.group, seed: seed + 2)
+            let reducer = try #require(
+                Qwen4ExpFusedAffineMoE.makeReducer(gate: gate, up: up, down: down))
+
+            for rows in 2...4 {
+                var inputRows = [MLXArray]()
+                var indexRows = [MLXArray]()
+                var scoreRows = [MLXArray]()
+                var independentOutputs = [MLXArray]()
+
+                for row in 0..<rows {
+                    let rowSeed = seed + UInt64(10 + rows * 10 + row)
+                    let input = MLXRandom.uniform(
+                        low: -1.0, high: 1.0, [1, Self.inputDims],
+                        key: MLXRandom.key(rowSeed)
+                    ).asType(.bfloat16)
+                    let routeValues = (0..<Self.topK).map {
+                        UInt32(($0 * 3 + row * 5) % Self.experts)
+                    }
+                    let indices = MLXArray(routeValues, [1, Self.topK])
+                    let scores = MLX.softmax(
+                        MLXRandom.uniform(
+                            low: 0.0, high: 1.0, [1, Self.topK],
+                            key: MLXRandom.key(rowSeed + 1)
+                        ).asType(.float32), axis: -1)
+
+                    inputRows.append(input)
+                    indexRows.append(indices)
+                    scoreRows.append(scores)
+                    independentOutputs.append(try #require(reducer(input, indices, scores)))
+                }
+
+                let batched = try #require(
+                    reducer(
+                        concatenated(inputRows, axis: 0),
+                        concatenated(indexRows, axis: 0),
+                        concatenated(scoreRows, axis: 0)))
+                let independent = concatenated(independentOutputs, axis: 0)
+                let error = Self.relativeError(batched, independent)
+                print(
+                    "[FusedMoERowParity] combo=\(combo.label) rows=\(rows)"
+                        + " batched_vs_single=\(error)")
+                #expect(
+                    error < 0.001,
+                    "\(combo.label) rows \(rows) crossed row state: relative error \(error)")
+            }
+        }
+    }
+
+    @Test("native-MTP accepts production-shaped non-contiguous row views")
+    func smallNonContiguousRowParity() throws {
+        let seed: UInt64 = 7501
+        let combo = Self.shippedCombos[4] // Qwen3.8 Flash-Next 2L q2/q2/q2-g32.
+        let (gate, _) = Self.makeProjection(
+            inputDims: Self.inputDims, outputDims: Self.expertDims,
+            bits: combo.gate.bits, groupSize: combo.gate.group, seed: seed)
+        let (up, _) = Self.makeProjection(
+            inputDims: Self.inputDims, outputDims: Self.expertDims,
+            bits: combo.up.bits, groupSize: combo.up.group, seed: seed + 1)
+        let (down, _) = Self.makeProjection(
+            inputDims: Self.expertDims, outputDims: Self.inputDims,
+            bits: combo.down.bits, groupSize: combo.down.group, seed: seed + 2)
+        let reducer = try #require(
+            Qwen4ExpFusedAffineMoE.makeReducer(gate: gate, up: up, down: down))
+
+        for rows in 2...4 {
+            let paddedInput = MLXRandom.uniform(
+                low: -1.0, high: 1.0, [1, rows * 2, Self.inputDims],
+                key: MLXRandom.key(seed + UInt64(rows * 10))
+            ).asType(.bfloat16)
+            let input = paddedInput[0..., .stride(by: 2), 0...]
+
+            let routeValues = (0..<(rows * Self.topK * 2)).map {
+                UInt32(($0 * 3 + rows) % Self.experts)
+            }
+            let paddedIndices = MLXArray(routeValues, [1, rows, Self.topK * 2])
+            let indices = paddedIndices[0..., 0..., .stride(by: 2)]
+            let paddedScores = MLX.softmax(
+                MLXRandom.uniform(
+                    low: 0.0, high: 1.0, [1, rows, Self.topK * 2],
+                    key: MLXRandom.key(seed + UInt64(rows * 10 + 1))
+                ).asType(.float32), axis: -1)
+            let scores = paddedScores[0..., 0..., .stride(by: 2)]
+
+            let contiguousResult = try #require(
+                reducer(
+                    MLX.contiguous(input), MLX.contiguous(indices),
+                    MLX.contiguous(scores)))
+            let stridedResult = try #require(reducer(input, indices, scores))
+            let error = Self.relativeError(stridedResult, contiguousResult)
+            #expect(error == 0, "rows \(rows) read a strided view as contiguous: \(error)")
+        }
+    }
+
+    @Test("prefill rows above the native-MTP ceiling stay on the generic path")
+    func largerRowsRejected() throws {
+        let seed: UInt64 = 8001
+        let (gate, _) = Self.makeProjection(
+            inputDims: Self.inputDims, outputDims: Self.expertDims,
+            bits: 4, groupSize: 64, seed: seed)
+        let (up, _) = Self.makeProjection(
+            inputDims: Self.inputDims, outputDims: Self.expertDims,
+            bits: 4, groupSize: 64, seed: seed + 1)
+        let (down, _) = Self.makeProjection(
+            inputDims: Self.expertDims, outputDims: Self.inputDims,
+            bits: 4, groupSize: 64, seed: seed + 2)
+        let reducer = try #require(
+            Qwen4ExpFusedAffineMoE.makeReducer(gate: gate, up: up, down: down))
+        let rows = 5
+        let input = MLXArray.zeros([rows, Self.inputDims], dtype: .bfloat16)
+        let indices = MLXArray.zeros([rows, Self.topK], dtype: .uint32)
+        let scores = MLXArray.ones([rows, Self.topK], dtype: .float32) / Float(Self.topK)
+        #expect(reducer(input, indices, scores) == nil)
+    }
+
     @Test("Ornith 2048x512 top-8 q5 contract matches eager quantized math")
     func ornith35ShapeParity() throws {
         let inputDims = 2048

--- a/docs/benchmarks/QWEN38_FLASH_NEXT_MTP_ROW4_MOE_2026_08_30.md
+++ b/docs/benchmarks/QWEN38_FLASH_NEXT_MTP_ROW4_MOE_2026_08_30.md
@@ -98,4 +98,3 @@ Raw logs, binary hashes, source heads, memory snapshots, and full decoded text
 are preserved under:
 
 `/Users/eric/vmlx-private-evidence/qwen38-count-20260830/c1162b43/`
-

--- a/docs/benchmarks/QWEN38_FLASH_NEXT_MTP_ROW4_MOE_2026_08_30.md
+++ b/docs/benchmarks/QWEN38_FLASH_NEXT_MTP_ROW4_MOE_2026_08_30.md
@@ -1,0 +1,101 @@
+# Qwen3.8 Flash-Next native-MTP row-4 MoE proof (2026-08-30)
+
+## Scope and verdict
+
+Runtime source head: `c1162b43a6144349e630fb13894d495ce74faa7e`
+
+This change is a **PASS** for its bounded claim: native-MTP verification rows
+2 through 4 now use the same fused routed-MoE arithmetic as ordinary row-1
+decode, and fixed depth 3 exceeds 60 tok/s on the exact count workload.
+
+This is **not** proof that native MTP should be forced on globally. A separate,
+pre-existing whole-model staged-verifier parity failure remains reproducible on
+rejection-heavy prose. This change does not enable MTP, change Auto policy, or
+change generation parameters.
+
+## Source trace
+
+Before this change, `Qwen4ExpFusedAffineMoE` accepted exactly one hidden row.
+A depth-3 verifier therefore fell back to generic routed MoE for its four-row
+target forward. The patch:
+
+- supports only rows 1 through 4 (decode plus the current maximum native-MTP
+  verification depth), leaving larger prefill batches on the generic path;
+- indexes input, route, score, activation, and output tensors by row;
+- materializes only non-contiguous input views required by the flat Metal
+  indexing contract;
+- keeps q2/q3/q4/q5/q6 and group-size 32/64 support bounded to the two audited
+  production shapes.
+
+## Focused tests
+
+Command:
+
+```sh
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
+  swift test --filter Qwen4ExpFusedAffineMoETests
+```
+
+Result on `c1162b43`: 6/6 passed.
+
+The suite covers every shipped bit/group layout at rows 2, 3, and 4 against
+independent row-1 execution, production-shaped non-contiguous views, the
+rows-above-4 fallback, Ornith's separate 2048x512 top-8 contract, and invalid
+metadata rejection. Every multi-row-versus-row-1 relative error printed `0.0`.
+
+## Live Release matrix
+
+Bundle: `JANGQ-AI/Qwen3.8-Flash-Next-JANG_2L`
+
+Prompt: `Count from 1 to 200.`
+
+Settings: greedy sampling, 1,024-token cap, fixed native-MTP depth, adaptive
+depth disabled for measurement, mmap weights, no JangPress. The 22-token
+prompt is below the 2,048-token QSA budget, so sparse-QSA changes are not part
+of this measurement.
+
+| Runtime | Depth | tok/s | verifier time | result |
+|---|---:|---:|---:|---|
+| before control (`c1cef3bb`, row-4 generic MoE) | 3 | 33.8 | 22.189 s | exact 1-200, `stop` |
+| `c1162b43`, cold single row | 3 | 68.2 | 9.434 s | exact 1-200, `stop` |
+| `c1162b43`, repeat 1 | 3 | 69.4 | 9.438 s | exact 1-200, `stop` |
+| `c1162b43`, repeat 2 | 3 | 65.8 | 10.009 s | exact 1-200, `stop` |
+| `c1162b43`, repeat 3 | 3 | 62.2 | 10.706 s | exact 1-200, `stop` |
+| `c1162b43` | 2 | 54.1 | 12.914 s | exact 1-200, `stop` |
+| `c1162b43` | 1 | 43.7 | 16.941 s | exact 1-200, `stop` |
+
+Depth-3 repeat median: **65.8 tok/s**. All three measured outputs were the
+same 890-character sequence and byte-matched the expected comma-separated
+integers 1 through 200. Peak physical footprint was 51,376 MiB.
+
+Additional greedy rows on `c1162b43`:
+
+| Workload | AR tok/s | D3 tok/s | visible result |
+|---|---:|---:|---|
+| 250-word tide explanation | 40.1 | 43.3 | coherent, `stop`, no marker leak |
+| Swift binary search | 39.8 | 57.1 | coherent, `stop`, no marker leak |
+
+## Remaining blocker: whole-model greedy parity
+
+AR prose repeats byte-identically, and explicit sequential MTP verification
+matches those AR bytes. Batched staged D3 is deterministic but differs from
+AR. Token-level traces locate the first wrong target decision at generated
+token 231: from the same prefix, staged row-0 selects token `67550` while the
+sequential target selects `10539`. This occurs before staged cache commit, so
+it is not a rollback leak. Other mixed quantized/dense projections still use
+different multi-row and row-1 kernels and can perturb a near-tied argmax.
+
+Therefore:
+
+- do not use this PR to force D3 or change Auto defaults;
+- preserve the existing fail-closed tuning requirement;
+- require a separate whole-model verifier-parity fix and matched AR/D3 proof
+  before making a global policy change.
+
+## Local raw evidence
+
+Raw logs, binary hashes, source heads, memory snapshots, and full decoded text
+are preserved under:
+
+`/Users/eric/vmlx-private-evidence/qwen38-count-20260830/c1162b43/`
+


### PR DESCRIPTION
## Summary

Accelerate Qwen3.8 Flash-Next native-MTP verification by extending the existing fused affine routed-MoE decode path from one hidden row to the bounded verifier shape of one through four rows.

This PR makes **no** change to MTP enablement, Auto policy, reasoning, templates, samplers, or bundle generation config. It is a bounded runtime speed fix; a separate staged-verifier parity issue remains documented below.

## Source trace

Before `c1162b43`, `Qwen4ExpFusedAffineMoE` accepted exactly one row, so a depth-3 verifier's four-row target forward fell back to generic routed MoE. The change:

- admits only rows 1...4, leaving larger/prefill batches on the existing fallback;
- makes input, route, score, activation, and output indexing row-aware;
- materializes non-contiguous row views required by the flat Metal indexing contract;
- remains bounded to the audited Qwen4Exp 2560x640 top-10 and Ornith 2048x512 top-8 shapes and shipped q2/q3/q4/q5/q6, group-32/group-64 layouts.

## Focused correctness tests

Exact runtime source: `c1162b43a6144349e630fb13894d495ce74faa7e`

```sh
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
  swift test --filter Qwen4ExpFusedAffineMoETests
```

Result: **6/6 passed**. Coverage includes:

- rows 2, 3, and 4 against independent row-1 execution;
- every shipped bit/group layout, with reported relative error `0.0`;
- production-shaped non-contiguous views;
- rows greater than 4 taking fallback;
- Ornith's separate top-8 contract;
- invalid metadata rejection.

## Live Release proof

Bundle: `JANGQ-AI/Qwen3.8-Flash-Next-JANG_2L`

Exact prompt: `Count from 1 to 200.`

Greedy, max 1,024 tokens, fixed native-MTP depth, adaptive disabled for the measurement, mmap weights, no JangPress. The 22-token prompt is below the 2,048-token QSA budget, so QSA is inactive in this comparison.

| Runtime | Depth | tok/s | verifier | Result |
|---|---:|---:|---:|---|
| before `c1cef3bb` | 3 | 33.8 | 22.189 s | exact 1...200, `stop` |
| `c1162b43`, cold | 3 | 68.2 | 9.434 s | exact 1...200, `stop` |
| `c1162b43`, repeat 1 | 3 | 69.4 | 9.438 s | exact 1...200, `stop` |
| `c1162b43`, repeat 2 | 3 | 65.8 | 10.009 s | exact 1...200, `stop` |
| `c1162b43`, repeat 3 | 3 | 62.2 | 10.706 s | exact 1...200, `stop` |
| `c1162b43` | 2 | 54.1 | 12.914 s | exact 1...200, `stop` |
| `c1162b43` | 1 | 43.7 | 16.941 s | exact 1...200, `stop` |

D3 sustained median: **65.8 tok/s**. All measured outputs were the same 890-character expected comma-separated sequence. Peak physical footprint was **51,376 MiB**.

Additional greedy rows:

| Workload | AR | D3 | Result |
|---|---:|---:|---|
| 250-word tide explanation | 40.1 tok/s | 43.3 tok/s | coherent `stop`, no marker leak |
| Swift binary search | 39.8 tok/s | 57.1 tok/s | coherent `stop`, no marker leak |

## Explicit non-claim / parity blocker

This PR does **not** establish that D3 should be forced globally.

AR prose repeats byte-identically, and explicit sequential MTP verification matches AR bytes. Batched staged D3 is deterministic but differs from AR. Token traces locate the first divergent target choice at generated token 231: from the same prefix, staged row 0 chooses token `67550`, while sequential target verification chooses `10539`. This is before staged cache commit, exonerating rollback leakage and pointing to remaining whole-model multi-row-versus-row-1 numerical parity outside this MoE wrapper.

Accordingly, this PR preserves the current fail-closed tuning requirement. Default/Auto D3 needs its own parity fix and matched AR/D3 proof.

## Evidence

Durable source/proof record: `docs/benchmarks/QWEN38_FLASH_NEXT_MTP_ROW4_MOE_2026_08_30.md`

Local raw artifacts: `/Users/eric/vmlx-private-evidence/qwen38-count-20260830/c1162b43/`
