### PR TITLE
Qwen3.8: keep staged MTP on a row-equivalent GDN front

### DIFF
--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -1552,6 +1552,16 @@ enum Qwen35Language {
         private func compiledDecodeFront(
             _ inputs: MLXArray, convState: MLXArray
         ) -> [MLXArray]? {
+            // Keep AR decode and multi-token verification on the same native
+            // BF16 affine/conv path. The generic compiled front is not
+            // row-equivalent to that path: a width-1 AR step and a width-N
+            // verifier step can produce different GDN state from the first
+            // linear-attention layer, which breaks speculative-decoding
+            // output equivalence and draft acceptance. Retain it only as an
+            // explicit diagnostic while the native path remains the default.
+            guard ProcessInfo.processInfo.environment[
+                "VMLINUX_QWEN4_EXP_COMPILE_GDN_FRONT"
+            ] == "1" else { return nil }
             guard let fused = ensureFusedDecodeInputProjection(inputs) else { return nil }
             return Qwen4ExpCompiledGDNInputs.callFront(
                 input: inputs,

--- a/Tests/MLXLMTests/Qwen4ExpBF16AffineTests.swift
+++ b/Tests/MLXLMTests/Qwen4ExpBF16AffineTests.swift
@@ -123,6 +123,32 @@ struct Qwen4ExpBF16AffineTests {
         }
     }
 
+    @Test("dense affine output is exactly invariant to verifier row batching")
+    func denseRowBatchingIsExact() {
+        let input = (MLXArray(0 ..< 256, [4, 64]).asType(.float32) / 255)
+            .asType(.bfloat16)
+        let denseWeight =
+            (MLXArray(0 ..< 448, [7, 64]).asType(.float32) / 447) - 0.5
+        let (weight, scales, biases) = quantized(
+            denseWeight.asType(.float16), groupSize: 64, bits: 4, mode: .affine)
+
+        let batched = Qwen4ExpBF16Affine.dense(
+            input, weight, scales: scales, biases: biases,
+            groupSize: 64, bits: 4, mode: .affine)
+        let rowWise = concatenated(
+            (0 ..< 4).map { row in
+                Qwen4ExpBF16Affine.dense(
+                    input[row ..< (row + 1), 0...], weight,
+                    scales: scales, biases: biases,
+                    groupSize: 64, bits: 4, mode: .affine)
+            },
+            axis: 0)
+        MLX.eval(batched, rowWise)
+
+        #expect(batched.shape == rowWise.shape)
+        #expect(abs(batched - rowWise).max().item(Float.self) == 0)
+    }
+
     @Test("gathered routed projection keeps BF16 I/O")
     func gatheredParity() throws {
         let input = (MLXArray(0 ..< 128, [2, 64]).asType(.float32) / 127)

--- a/docs/benchmarks/QWEN38_FLASH_NEXT_MTP_GDN_FRONT_PARITY_2026_08_30.md
+++ b/docs/benchmarks/QWEN38_FLASH_NEXT_MTP_GDN_FRONT_PARITY_2026_08_30.md
@@ -72,6 +72,8 @@ Production-patch evidence:
 - Release `RunBench` product build: PASS.
 - Added a numeric regression asserting exact native BF16 affine output for a
   four-row verifier batch versus four width-1 calls.
+- The `MLXLMTests` target, including that regression source, compiles in
+  Release with `-enable-testing` (283.26 seconds).
 - Local full SwiftPM test execution is currently BLOCKED by unrelated existing
   package failures: `MLXArray.withEvalLockForTesting` is absent in `MLXTests`,
   and the generated Xcode package build fails because

--- a/docs/benchmarks/QWEN38_FLASH_NEXT_MTP_GDN_FRONT_PARITY_2026_08_30.md
+++ b/docs/benchmarks/QWEN38_FLASH_NEXT_MTP_GDN_FRONT_PARITY_2026_08_30.md
@@ -1,0 +1,85 @@
+# Qwen3.8 Flash-Next staged-MTP GDN-front parity
+
+Status: **PARTIAL** until bundle-driven Auto, served API, and Osaurus UI proof
+are complete. The engine-level fixed-depth defect is reproduced and reversed
+on the local `JANGQ-AI/Qwen3.8-Flash-Next-JANG_2L` bundle.
+
+## Defect
+
+Autoregressive width-1 decode entered `Qwen4ExpCompiledGDNInputs.callFront`,
+while the width-4 native-MTP verifier could not enter that function because it
+accepts only `input.dim(1) == 1`. The verifier instead used the native BF16
+affine plus ordinary causal-convolution path. Those two paths were not
+row-equivalent: the first GDN recurrent-state difference appeared in layer 0,
+then propagated through PLE and later layers. This reduced draft acceptance
+and could change greedy output relative to AR.
+
+The staged cache commit itself was exonerated. Replaying the staged `q/k/v/a/b`
+rows as one accepted prefix or as chained width-1 updates produced exact state
+equality in all 36 GDN layers. Starting from the same pre-verify checkpoint,
+however, a true sequential model replay differed from the staged cache at
+layer 0 recurrent slot 1 (`maxdiff=4.172e-07`), proving the mismatch happened
+before cache commit.
+
+Diagnostic evidence:
+
+- `vmlx-private-evidence/qwen38-staged-parity-20260830/267337e6/staged-commit-audit/d3-measurement.log`
+- `vmlx-private-evidence/qwen38-staged-parity-20260830/267337e6/staged-commit-audit/cache-audit.log`
+
+## Fix
+
+The non-equivalent generic compiled GDN front is no longer a production
+default. It remains available only through the explicit diagnostic environment
+variable `VMLINUX_QWEN4_EXP_COMPILE_GDN_FRONT=1`. Default AR and staged-MTP
+verification now share the native BF16 affine/conv path. PLE remains SSD-backed
+through `pread` plus `F_NOCACHE`; this change does not make PLE or n-gram state
+resident.
+
+## Matched engine proof
+
+Release `RunBench`, greedy sampling, identical prompt and output budget, no
+JangPress, no KV-cache substitution. Prompt: count from 1 through 120 and emit
+only the comma-separated sequence. Every arm produced the exact expected
+490-byte sequence and SHA-256
+`37524b0ce6e14373f1bb0b5f0a9f3bc637153beec13eb80bba74bb50d1b86fda`.
+
+| Arm | tok/s | Peak physical footprint | MTP result |
+| --- | ---: | ---: | --- |
+| AR | 37.4 | 48,700 MiB | control |
+| D1 | 33.3 | 51,101 MiB | 490/490 verified inputs committed |
+| D2 | 44.2 | 51,169 MiB | 489/489 verified inputs committed |
+| D3 | 68.6 | 51,195 MiB | 492/492 verified inputs committed |
+
+D3 is 1.83x AR and is the measured winner. All rows ended with `stop`, no
+unclosed reasoning, no loop, and no protocol leakage.
+
+A second code-generation row was also byte-identical between AR and D3:
+
+| Arm | tok/s | Output SHA-256 |
+| --- | ---: | --- |
+| AR | 30.5 | `e5fe77ed8ed443d36f346e7234002ae89a8fce111f78004416a093bed8464ce5` |
+| D3 | 62.6 | `e5fe77ed8ed443d36f346e7234002ae89a8fce111f78004416a093bed8464ce5` |
+
+The D3 code row committed 120 output tokens with 8 rejected drafts handled by
+normal verifier correction; it did not fall back to AR.
+
+Production-patch evidence:
+
+- `vmlx-private-evidence/qwen38-staged-parity-20260830/267337e6/production-patch/`
+
+## Test state and remaining gates
+
+- Release `RunBench` product build: PASS.
+- Added a numeric regression asserting exact native BF16 affine output for a
+  four-row verifier batch versus four width-1 calls.
+- Local full SwiftPM test execution is currently BLOCKED by unrelated existing
+  package failures: `MLXArray.withEvalLockForTesting` is absent in `MLXTests`,
+  and the generated Xcode package build fails because
+  `DistributedModelInventory/main.swift` combines `@main` with top-level code.
+  These are recorded as infrastructure blockers, not test passes.
+- Bundle-driven Auto must consume an updated workload-general measured sidecar
+  and resolve D3 without `VMLX_MTP_TUNING_MEASUREMENT`.
+- The exact repinned Osaurus Release app must prove native Chat and served API
+  D3 telemetry, visible output completion, multi-turn tool continuation,
+  cancellation recovery, and cache restore before the user-facing lane is
+  complete.


### PR DESCRIPTION
## Root cause

Width-1 AR entered the generic compiled GDN front, but width-4 native-MTP verification used the native BF16 affine/conv path. The two paths diverged in layer-0 recurrent state, breaking greedy speculative equivalence and acceptance. The staged cache commit itself was byte-exact when replaying the same q/k/v/a/b.

## Fix

Default AR and staged verification now share the native BF16 path. The non-equivalent compiled front remains available only as the explicit diagnostic `VMLINUX_QWEN4_EXP_COMPILE_GDN_FRONT=1`. PLE remains SSD-backed (`pread` + `F_NOCACHE`). Added a four-row versus row-wise exact affine regression.

## Live Release proof

Exact local `JANGQ-AI/Qwen3.8-Flash-Next-JANG_2L`, greedy, same prompt/output budget, no JangPress:

- AR: 37.4 tok/s, 48,700 MiB peak footprint.
- D1: 33.3 tok/s, 51,101 MiB.
- D2: 44.2 tok/s, 51,169 MiB.
- D3: 68.6 tok/s, 51,195 MiB, 492/492 verifier inputs committed.
- Every arm emitted the exact 1..120 sequence with SHA-256 `37524b0ce6e14373f1bb0b5f0a9f3bc637153beec13eb80bba74bb50d1b86fda` and normal `stop`.
- Independent Swift-code row: AR 30.5 vs D3 62.6 tok/s; byte-identical coherent output SHA-256 `e5fe77ed8ed443d36f346e7234002ae89a8fce111f78004416a093bed8464ce5`.

Evidence and causal trace are documented in `docs/benchmarks/QWEN38_FLASH_NEXT_MTP_GDN_FRONT_PARITY_2026_08_30.md`.

## Build/test truth

- Release `RunBench` product build: PASS on this head.
- Full local SwiftPM test execution is BLOCKED by pre-existing unrelated package failures (`MLXArray.withEvalLockForTesting` missing in `MLXTests`; generated Xcode package build rejects `DistributedModelInventory/main.swift` for `@main` plus top-level code). I am not claiming those suites passed.
- User-facing Auto/API/UI proof is a downstream Osaurus repin gate, not represented by the engine rows above.