### PR TITLE
Qwen3.8 4M: preserve AR-equivalent MTP verifier rows

### DIFF
--- a/Libraries/MLXLMCommon/SwitchLayers.swift
+++ b/Libraries/MLXLMCommon/SwitchLayers.swift
@@ -374,6 +374,20 @@ public class SwitchGLU: Module, SwitchGLULayer {
         return reducer(input, indices, scores)
     }
 
+    /// True only when all three resident affine expert projections use the
+    /// requested packing. Qwen3.8 Flash-Next uses this narrow topology probe
+    /// to distinguish its uniform 4M routed bank from the 2L/4S/6S layouts;
+    /// it does not infer model identity from a bundle name.
+    public func hasUniformAffineQuantization(bits: Int, groupSize: Int) -> Bool {
+        guard let gate = gateProj as? QuantizedSwitchLinear,
+            let up = upProj as? QuantizedSwitchLinear,
+            let down = downProj as? QuantizedSwitchLinear
+        else { return false }
+        return [gate, up, down].allSatisfy {
+            $0.bits == bits && $0.groupSize == groupSize && $0.mode == .affine
+        }
+    }
+
     /// Variant for model graphs that weight each routed activation before its
     /// expert down projection. The score tensor has the same leading shape as
     /// `indices`; sorting keeps scores aligned with the expert dispatch rows.

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -1959,6 +1959,9 @@ enum Qwen35Language {
     }
 
     final class SparseMoeBlock: Module, UnaryLayer {
+        private static let rowIsolationLogLock = NSLock()
+        private nonisolated(unsafe) static var didReportRowIsolation = false
+
         let normTopkProb: Bool
         let numExperts: Int
         let topK: Int
@@ -2064,7 +2067,47 @@ enum Qwen35Language {
                 groupSize: gate.groupSize, bits: gate.bits, mode: gate.mode)
         }
 
+        /// The released 4M Flash-Next routed bank is uniformly affine q4/g64.
+        /// Its greedy AR path evaluates one token at a time, while native MTP
+        /// verifies two to four positions together. Running the complete MoE
+        /// block per row preserves the AR router, expert and shared-expert
+        /// numerical contract instead of merely splitting the final routed
+        /// kernel after width-sensitive decisions have already been made.
+        ///
+        /// This stays deliberately topology-scoped: 2L/4S/6S use different
+        /// routed bit layouts and retain their measured multi-row verifier.
+        func requiresDecodeEquivalentRows(_ x: MLXArray) -> Bool {
+            let rows = x.size / x.dim(-1)
+            guard compileDecodeRegions, (2 ... 4).contains(rows),
+                let affine = switchMLP as? SwitchGLU
+            else { return false }
+            return affine.hasUniformAffineQuantization(bits: 4, groupSize: 64)
+        }
+
+        private func reportDecodeEquivalentRows() {
+            Self.rowIsolationLogLock.lock()
+            defer { Self.rowIsolationLogLock.unlock() }
+            guard !Self.didReportRowIsolation else { return }
+            Self.didReportRowIsolation = true
+            FileHandle.standardError.write(
+                Data(
+                    "[Qwen4Exp] moe_verify_rows=decode_equivalent topology=q4g64\n"
+                        .utf8))
+        }
+
         func callAsFunction(_ x: MLXArray) -> MLXArray {
+            if requiresDecodeEquivalentRows(x) {
+                let rows = x.size / x.dim(-1)
+                let hidden = x.dim(-1)
+                let rowInputs = MLX.split(
+                    x.reshaped(1, rows, hidden), parts: rows, axis: 1)
+                let result = MLX.concatenated(
+                    rowInputs.map { callAsFunction($0) }, axis: 1
+                ).reshaped(x.shape)
+                reportDecodeEquivalentRows()
+                return result
+            }
+
             let inds: MLXArray
             let scores: MLXArray
             if let compiled = compiledRouter(x) {

--- a/Tests/MLXLMTests/Qwen4ExpConfigurationTests.swift
+++ b/Tests/MLXLMTests/Qwen4ExpConfigurationTests.swift
@@ -2,6 +2,7 @@
 
 import Foundation
 import MLX
+import MLXNN
 import Testing
 
 @testable import MLXVLM
@@ -83,6 +84,39 @@ struct Qwen4ExpConfigurationTests {
             "language_model.layers.0.attn_hyper_connection.hc_norm.weight"]?.dtype == .bfloat16)
         #expect(sanitized["language_model.layers.0.linear_attn.A_log"]?.dtype == .float32)
 
+    }
+
+    @Test("4M q4g64 verifier isolates the complete MoE block by decode row")
+    func q4VerifierUsesDecodeEquivalentMoERows() throws {
+        let config = try JSONDecoder().decode(
+            Qwen4ExpConfiguration.self, from: configData(dtype: "bfloat16"))
+        var text = config.base.textConfiguration
+        text.moeIntermediateSize = 64
+        text.sharedExpertIntermediateSize = 64
+        let block = Qwen35Language.SparseMoeBlock(
+            text, layerIdx: 0,
+            allowFusedGateUpCache: false, compileDecodeRegions: true)
+        quantize(model: block, groupSize: 64, bits: 4)
+
+        let values = (0 ..< (4 * 64)).map { Float(($0 % 37) - 18) / 19 }
+        let input = MLXArray(values).reshaped(1, 4, 64).asType(.bfloat16)
+        #expect(block.requiresDecodeEquivalentRows(input))
+
+        let batched = block(input)
+        let rows = MLX.split(input, parts: 4, axis: 1)
+        let independent = MLX.concatenated(rows.map { block($0) }, axis: 1)
+        let error = max(
+            abs(batched.asType(.float32) - independent.asType(.float32)))
+        MLX.eval(error)
+        #expect(error.item(Float.self) == 0)
+
+        for bits in [2, 6] {
+            let nonFourBit = Qwen35Language.SparseMoeBlock(
+                text, layerIdx: 0,
+                allowFusedGateUpCache: false, compileDecodeRegions: true)
+            quantize(model: nonFourBit, groupSize: 64, bits: bits)
+            #expect(!nonFourBit.requiresDecodeEquivalentRows(input))
+        }
     }
 
     @Test("packed affine metadata preserves checkpoint storage dtype")

--- a/docs/benchmarks/QWEN38_FLASH_NEXT_4M_MTP_ROW_PARITY_2026_08_30.md
+++ b/docs/benchmarks/QWEN38_FLASH_NEXT_4M_MTP_ROW_PARITY_2026_08_30.md
@@ -1,0 +1,112 @@
+# Qwen3.8 Flash-Next 4M native-MTP row parity
+
+Status: **engine PASS; Auto/API/Osaurus gates remain separate**.
+
+This change fixes the 4M checkpoint's whole-model greedy-parity failure. It
+does not enable MTP, change sampling, add a bundle-name allowlist, or change
+the SSD-backed PLE/n-gram path.
+
+## Reproduction and source trace
+
+The `JANGQ-AI/Qwen3.8-Flash-Next-JANG_4M` bundle uses a uniform affine q4/g64
+routed expert bank. Greedy AR evaluates one hidden row at a time, while native
+MTP verifies two to four positions together. Before this patch, the complete
+`SparseMoeBlock` made width-sensitive router, routed-expert, shared-expert and
+post-reduction decisions over the verifier block. On a rejection-heavy Swift
+code prompt, AR and D3 were deterministic but different:
+
+| Arm | Tokens | tok/s | Output SHA-256 |
+| --- | ---: | ---: | --- |
+| AR | 257 | 32.4 | `b37a49f464c026df63bbb1efe21e6c78ebd9291be120d4f8811f1336d44b4ccb` |
+| D3 | 315 | 49.8 | `bf2643f855bd0bef688866b1e84e8a4c9e450b30b3f3a5e8f3e99c11ed52246e` |
+
+Disabling only the fused affine routed-MoE path made D3 reproduce the default
+AR bytes, isolating the defect to the MoE width contract. An attempted narrower
+fix that split only the final fused routed kernel passed its synthetic test but
+failed the real model unchanged. That experiment was discarded rather than
+presented as a fix.
+
+The retained change detects the real projection topology from loaded tensor
+types and quantization metadata. Only a `compileDecodeRegions` block whose
+gate, up and down routed projections are all affine q4/g64 uses decode-equivalent
+rows. The complete MoE block then evaluates each verifier position with the
+same `[1,1,H]` contract as AR before concatenating the rows. The 2L, 4S, 6S,
+TurboQuant and non-Qwen4Exp paths do not match that gate and remain unchanged.
+
+## Focused regression
+
+Command:
+
+```sh
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
+  swift test \
+  --scratch-path /Users/eric/vmlx-qwen38-d3-coldstart/.build \
+  --filter q4VerifierUsesDecodeEquivalentMoERows
+```
+
+Result: 1/1 passed. The test quantizes a complete synthetic Qwen4Exp MoE block
+to q4/g64, proves the four-row result is exactly equal to four width-1 calls,
+and proves a 6-bit block does not enter the new path.
+
+## Matched live Release proof
+
+Binary SHA-256:
+`e564b4ae0bd98827b1969b070572d1a93a3f688309f780ead7d73a90a4494f1d`.
+
+Bundle: `JANGQ-AI/Qwen3.8-Flash-Next-JANG_4M`.
+
+Settings: Release `RunBench`, mmap weights, no JangPress, greedy sampling,
+seed 42, warmup 1, fixed D3 for measurement. PLE reported
+`backend=pread-fnocache cache=F_NOCACHE` against 28.832 GiB of SSD-backed rows.
+
+Code prompt:
+`Write a Swift function that returns the first n Fibonacci numbers. Include input validation and a short explanation.`
+
+| Arm | Tokens | tok/s | Stop | Output SHA-256 | Peak footprint |
+| --- | ---: | ---: | --- | --- | ---: |
+| AR | 257 | 34.4 | stop | `b37a49f464c026df63bbb1efe21e6c78ebd9291be120d4f8811f1336d44b4ccb` | 73,913 MiB |
+| D3 | 257 | 51.4 | stop | `b37a49f464c026df63bbb1efe21e6c78ebd9291be120d4f8811f1336d44b4ccb` | 77,222 MiB |
+
+D3 was 1.49x AR. It used 76 target verification calls, accepted drafts at
+all depths, emitted 57 bonus tokens, and used zero AR fallback tokens. Output
+was coherent Swift with no loop, marker leak, or unclosed reasoning.
+
+Sustained count workload, two measured runs after one warmup:
+
+| Run | Headline tok/s | Tail tok/s | Acceptance | Result |
+| --- | ---: | ---: | --- | --- |
+| 0 | 58.5 | 75.4 | 256/256 verifier inputs | exact count prefix, length cap |
+| 1 | 58.2 | 75.3 | 256/256 verifier inputs | exact count prefix, length cap |
+
+The 256-token cap truncates the requested 1-to-120 sequence, so this row is a
+throughput/acceptance measurement, not the coherency proof. The stopped code
+row above is the coherency and byte-parity gate.
+
+Raw local evidence:
+
+`/Users/eric/vmlx-private-evidence/qwen38-4m-row-parity-20260830/`
+
+## Python and accelerator audit boundary
+
+The source-matched Python runtime measured 4S D3 at 88.79 tok/s and 4M D3 at
+74.76 tok/s. Its winning rows did not activate CoreML, ANE, QSA, PLE/GDN,
+affine-MoE pair fusion, RMSNorm fusion, or parallel-read fusion. The Swift 4M
+tail rate of 75.3-75.4 tok/s therefore matches the relevant Python steady-state
+rate; Swift's lower headline includes an approximately one-second first-decode
+materialization cost.
+
+CoreML/ANE is not added by this change. The audited mlx-serve path disables ANE
+on M5 because it was slower and depends on private APIs. Any future TensorOps,
+NAX, NPP, CoreML or ANE path still requires its own real-bundle parity,
+footprint and wall-clock win before production use.
+
+## Remaining gates
+
+- Merge this bounded engine fix before changing the 4M tuning sidecar.
+- Re-run the 4M AR/D1/D2/D3/adaptive matrix on the merged head.
+- Prove bundle-driven Auto resolves D3 without measurement-only environment
+  variables.
+- Repin Osaurus and prove served API plus visible native Chat, multi-turn tools,
+  Stop/continue and cache restore from the exact Release app.
+- Treat the 73-77 GiB footprint as measured truth; MTP speed does not waive the
+  separate memory-footprint work.

--- a/docs/benchmarks/QWEN38_FLASH_NEXT_MTP_ROW4_MOE_2026_08_30.md
+++ b/docs/benchmarks/QWEN38_FLASH_NEXT_MTP_ROW4_MOE_2026_08_30.md
@@ -1,5 +1,11 @@
 # Qwen3.8 Flash-Next native-MTP row-4 MoE proof (2026-08-30)
 
+> Follow-up: the separate 4M whole-model parity blocker described below was
+> subsequently isolated and fixed. See
+> `QWEN38_FLASH_NEXT_4M_MTP_ROW_PARITY_2026_08_30.md` for the retained source
+> change and matched AR/D3 Release proof. The measurements in this document
+> remain the historical 2L row-4-kernel evidence.
+
 ## Scope and verdict
 
 Runtime source head: `c1162b43a6144349e630fb13894d495ce74faa7e`


### PR DESCRIPTION
## Summary

Fix Qwen3.8 Flash-Next 4M native-MTP whole-model greedy parity without changing sampling, Auto policy, model detection by filename, or SSD-backed PLE/ngram behavior.

The 4M routed expert bank is uniformly affine q4/g64. Greedy AR evaluates one hidden row at a time, while native MTP verifies 2-4 positions together. The complete MoE block previously made width-sensitive router, routed-expert, shared-expert, and post-reduction decisions over that multi-row verifier block. This patch topology-detects the 4M bank from the loaded projection types/metadata and evaluates each verifier position through the complete MoE block with the AR `[1,1,H]` contract.

2L/4S/6S and non-Qwen4Exp paths do not match the q4/g64 + decode-region gate and remain unchanged.

## Before reproduction

Bundle: `JANGQ-AI/Qwen3.8-Flash-Next-JANG_4M`

Greedy seed-42 Swift code prompt, Release RunBench:

| Arm | Tokens | tok/s | Output SHA-256 |
| --- | ---: | ---: | --- |
| AR | 257 | 32.4 | `b37a49f464c026df63bbb1efe21e6c78ebd9291be120d4f8811f1336d44b4ccb` |
| D3 | 315 | 49.8 | `bf2643f855bd0bef688866b1e84e8a4c9e450b30b3f3a5e8f3e99c11ed52246e` |

Disabling only the fused affine routed-MoE path made D3 reproduce default-AR bytes. A narrower experimental split of only the final routed kernel passed its synthetic test but did not change the real-model failure; that experiment was reverted and is not part of this PR.

## After live Release proof

Head: `640797db2ad2685e3aaf1e3f67f8b1eb9f9c13c9`

Release RunBench binary SHA-256: `e564b4ae0bd98827b1969b070572d1a93a3f688309f780ead7d73a90a4494f1d`

Same bundle, prompt, greedy sampler, seed, and warmup:

| Arm | Tokens | tok/s | Stop | Output SHA-256 | Peak phys footprint |
| --- | ---: | ---: | --- | --- | ---: |
| AR | 257 | 34.4 | stop | `b37a49f464c026df63bbb1efe21e6c78ebd9291be120d4f8811f1336d44b4ccb` | 73,913 MiB |
| D3 | 257 | 51.4 | stop | `b37a49f464c026df63bbb1efe21e6c78ebd9291be120d4f8811f1336d44b4ccb` | 77,222 MiB |

D3 is 1.49x AR and byte-identical. It recorded 76 verify calls, accepted drafts at depths 1/2/3, emitted 57 bonus tokens, and used zero AR fallback tokens. Output was coherent, stopped naturally, and had no loop, marker leak, or unclosed reasoning.

Sustained count workload after one warmup:

| Run | Headline tok/s | Tail tok/s | Acceptance |
| --- | ---: | ---: | --- |
| 0 | 58.5 | 75.4 | 256/256 verifier inputs |
| 1 | 58.2 | 75.3 | 256/256 verifier inputs |

The count row is length-capped and is used only for throughput/acceptance. The stopped code row above is the coherency/parity proof. Swift tail throughput matches the source-matched Python 4M D3 result (74.76 tok/s).

PLE remained SSD-backed: `backend=pread-fnocache cache=F_NOCACHE`, with 28.832 GiB backing. No JangPress.

Evidence: `/Users/eric/vmlx-private-evidence/qwen38-4m-row-parity-20260830/`

## Tests

- `q4VerifierUsesDecodeEquivalentMoERows`: 1/1 pass, including q2 and q6 negative topology controls.
- `Qwen4ExpConfigurationTests`: 3/3 pass.
- `Qwen4ExpFusedAffineMoETests`: 6/6 pass.
- Release build: pass.
- `git diff --check`: pass.

The focused test quantizes a complete synthetic Qwen4Exp MoE block to q4/g64 and proves a 4-row call is exactly equal to four width-1 calls.

## Accelerator boundary

The source-matched Python winner did not activate CoreML, ANE, QSA, PLE/GDN, affine-MoE pair fusion, RMSNorm fusion, or parallel-read fusion. This PR therefore does not add speculative accelerator paths. Any TensorOps/NAX/NPP/CoreML/ANE change still needs a separate real-bundle parity, footprint, and wall-clock win.

## Remaining separate gates

- Merged-head AR/D1/D2/D3/Auto sweep.
- Bundle-driven Auto-D3 policy and stale 4M tuning handling.
- Osaurus repin plus served API and visible native Chat proof.
- The measured 73-77 GiB footprint remains a separate memory issue; the speed/parity result does not waive it.

Full report: `docs/benchmarks/QWEN38_FLASH_NEXT_4M_MTP_ROW_PARITY_2026_08_30.md`.
