### PR TITLE
Scope Qwen3.8 4M verifier rows to the full trunk

### DIFF
--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -1966,6 +1966,7 @@ enum Qwen35Language {
         let numExperts: Int
         let topK: Int
         let compileDecodeRegions: Bool
+        let decodeEquivalentVerifierRows: Bool
 
         @ModuleInfo(key: "gate") var gate: Linear
         @ModuleInfo(key: "switch_mlp") var switchMLP: Module
@@ -1977,12 +1978,14 @@ enum Qwen35Language {
             _ args: Qwen35Configuration.TextConfiguration,
             layerIdx: Int = -1,
             allowFusedGateUpCache: Bool = true,
-            compileDecodeRegions: Bool = false
+            compileDecodeRegions: Bool = false,
+            decodeEquivalentVerifierRows: Bool = false
         ) {
             self.normTopkProb = args.normTopkProb
             self.numExperts = args.numExperts
             self.topK = args.numExpertsPerTok
             self.compileDecodeRegions = compileDecodeRegions
+            self.decodeEquivalentVerifierRows = decodeEquivalentVerifierRows
 
             _gate.wrappedValue = Linear(args.hiddenSize, args.numExperts, bias: false)
             let weightFormat = args.weightFormat.lowercased()
@@ -2078,7 +2081,8 @@ enum Qwen35Language {
         /// routed bit layouts and retain their measured multi-row verifier.
         func requiresDecodeEquivalentRows(_ x: MLXArray) -> Bool {
             let rows = x.size / x.dim(-1)
-            guard compileDecodeRegions, (2 ... 4).contains(rows),
+            guard decodeEquivalentVerifierRows,
+                compileDecodeRegions, (2 ... 4).contains(rows),
                 let affine = switchMLP as? SwitchGLU
             else { return false }
             return affine.hasUniformAffineQuantization(bits: 4, groupSize: 64)

--- a/Libraries/MLXVLM/Models/Qwen4Exp.swift
+++ b/Libraries/MLXVLM/Models/Qwen4Exp.swift
@@ -92,10 +92,12 @@ public struct Qwen4ExpConfiguration: Codable, Sendable {
     let base: Qwen35Configuration
     let extras: TextExtras
     let jangMetadata: JangMetadata?
+    let quantizationContainer: BaseConfiguration.QuantizationContainer?
 
     enum CodingKeys: String, CodingKey {
         case text = "text_config"
         case jangMetadata = "jang_config"
+        case quantizationContainer = "quantization"
     }
 
     public init(from decoder: Decoder) throws {
@@ -103,6 +105,9 @@ public struct Qwen4ExpConfiguration: Codable, Sendable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         extras = try container.decode(TextExtras.self, forKey: .text)
         jangMetadata = try container.decodeIfPresent(JangMetadata.self, forKey: .jangMetadata)
+        quantizationContainer = try container.decodeIfPresent(
+            BaseConfiguration.QuantizationContainer.self,
+            forKey: .quantizationContainer)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -122,6 +127,29 @@ public struct Qwen4ExpConfiguration: Codable, Sendable {
         case "float32", "fp32", "float": .float32
         default: nil
         }
+    }
+
+    /// The row-equivalent verifier workaround is proven only for the released
+    /// 4M checkpoint's complete routed-expert bank. A local q4 sub-block is not
+    /// enough to identify that topology: 4S is mixed q2/q3/q4, and the private
+    /// MTP head can itself carry q4 tensors. Require every trunk layer's three
+    /// routed projections to resolve to affine q4/g64 from bundle metadata.
+    var hasUniformQ4G64TrunkRoutedExperts: Bool {
+        guard base.textConfiguration.hiddenLayers > 0,
+            let quantization = quantizationContainer?.perLayerQuantization
+        else { return false }
+
+        for layer in 0 ..< base.textConfiguration.hiddenLayers {
+            for projection in ["gate_proj", "up_proj", "down_proj"] {
+                let path = "language_model.layers.\(layer).mlp.switch_mlp.\(projection)"
+                guard let resolved = quantization.quantization(layer: path),
+                    resolved.bits == 4,
+                    resolved.groupSize == 64,
+                    resolved.mode == .affine
+                else { return false }
+            }
+        }
+        return true
     }
 }
 
@@ -1026,7 +1054,8 @@ private final class Qwen4ExpDecoderLayer: Module {
         }
         _mlp.wrappedValue = Qwen35Language.SparseMoeBlock(
             text, layerIdx: layerIndex, allowFusedGateUpCache: false,
-            compileDecodeRegions: true)
+            compileDecodeRegions: true,
+            decodeEquivalentVerifierRows: config.hasUniformQ4G64TrunkRoutedExperts)
         _attentionResidual.wrappedValue = Qwen4ExpGatedResidual(config)
         _mlpResidual.wrappedValue = Qwen4ExpGatedResidual(config)
         if let pleIndex = config.extras.pleLayerIds.firstIndex(of: layerIndex + 1) {
@@ -1153,7 +1182,8 @@ private final class Qwen4ExpMTPDecoderLayer: Module {
         _attention.wrappedValue = Qwen4ExpAttention(config)
         _mlp.wrappedValue = Qwen35Language.SparseMoeBlock(
             config.base.textConfiguration, layerIdx: layerIndex,
-            allowFusedGateUpCache: false, compileDecodeRegions: true)
+            allowFusedGateUpCache: false, compileDecodeRegions: true,
+            decodeEquivalentVerifierRows: false)
         _attentionResidual.wrappedValue = Qwen4ExpGatedResidual(config)
         _mlpResidual.wrappedValue = Qwen4ExpGatedResidual(config)
         super.init()

--- a/Tests/MLXLMTests/Qwen4ExpConfigurationTests.swift
+++ b/Tests/MLXLMTests/Qwen4ExpConfigurationTests.swift
@@ -9,10 +9,28 @@ import Testing
 
 @Suite("qwen4_exp configuration")
 struct Qwen4ExpConfigurationTests {
-    private func configData(dtype: String) -> Data {
-        Data("""
+    private func configData(dtype: String, routedBits: [[Int]]? = nil) -> Data {
+        let quantization: String
+        if let routedBits {
+            var entries: [String] = ["\"group_size\":64", "\"bits\":8"]
+            for (layer, bits) in routedBits.enumerated() {
+                precondition(bits.count == 3)
+                for (projection, bit) in zip(
+                    ["gate_proj", "up_proj", "down_proj"], bits)
+                {
+                    entries.append(
+                        "\"language_model.layers.\(layer).mlp.switch_mlp.\(projection)\":"
+                            + "{\"group_size\":64,\"bits\":\(bit)}")
+                }
+            }
+            quantization = "\"quantization\":{\(entries.joined(separator: ","))},"
+        } else {
+            quantization = ""
+        }
+        return Data("""
             {
               "model_type":"qwen4_exp",
+              \(quantization)
               "text_config":{
                 "model_type":"qwen4_exp_text","dtype":"\(dtype)",
                 "mamba_ssm_dtype":"float32","mtp_num_hidden_layers":1,
@@ -89,13 +107,16 @@ struct Qwen4ExpConfigurationTests {
     @Test("4M q4g64 verifier isolates the complete MoE block by decode row")
     func q4VerifierUsesDecodeEquivalentMoERows() throws {
         let config = try JSONDecoder().decode(
-            Qwen4ExpConfiguration.self, from: configData(dtype: "bfloat16"))
+            Qwen4ExpConfiguration.self,
+            from: configData(dtype: "bfloat16", routedBits: [[4, 4, 4], [4, 4, 4]]))
+        #expect(config.hasUniformQ4G64TrunkRoutedExperts)
         var text = config.base.textConfiguration
         text.moeIntermediateSize = 64
         text.sharedExpertIntermediateSize = 64
         let block = Qwen35Language.SparseMoeBlock(
             text, layerIdx: 0,
-            allowFusedGateUpCache: false, compileDecodeRegions: true)
+            allowFusedGateUpCache: false, compileDecodeRegions: true,
+            decodeEquivalentVerifierRows: config.hasUniformQ4G64TrunkRoutedExperts)
         quantize(model: block, groupSize: 64, bits: 4)
 
         let values = (0 ..< (4 * 64)).map { Float(($0 % 37) - 18) / 19 }
@@ -113,10 +134,34 @@ struct Qwen4ExpConfigurationTests {
         for bits in [2, 6] {
             let nonFourBit = Qwen35Language.SparseMoeBlock(
                 text, layerIdx: 0,
-                allowFusedGateUpCache: false, compileDecodeRegions: true)
+                allowFusedGateUpCache: false, compileDecodeRegions: true,
+                decodeEquivalentVerifierRows: true)
             quantize(model: nonFourBit, groupSize: 64, bits: bits)
             #expect(!nonFourBit.requiresDecodeEquivalentRows(input))
         }
+    }
+
+    @Test("mixed 4S and q2 2L routed layouts never enable 4M verifier rows")
+    func mixedAndLowBitLayoutsDoNotEnableVerifierRows() throws {
+        let mixed = try JSONDecoder().decode(
+            Qwen4ExpConfiguration.self,
+            from: configData(dtype: "bfloat16", routedBits: [[3, 3, 3], [3, 2, 4]]))
+        let lowBit = try JSONDecoder().decode(
+            Qwen4ExpConfiguration.self,
+            from: configData(dtype: "bfloat16", routedBits: [[2, 2, 2], [2, 2, 2]]))
+        #expect(!mixed.hasUniformQ4G64TrunkRoutedExperts)
+        #expect(!lowBit.hasUniformQ4G64TrunkRoutedExperts)
+
+        var text = mixed.base.textConfiguration
+        text.moeIntermediateSize = 64
+        text.sharedExpertIntermediateSize = 64
+        let input = MLXArray.zeros([1, 4, 64], dtype: .bfloat16)
+        let mixedBlock = Qwen35Language.SparseMoeBlock(
+            text, layerIdx: 0, allowFusedGateUpCache: false,
+            compileDecodeRegions: true,
+            decodeEquivalentVerifierRows: mixed.hasUniformQ4G64TrunkRoutedExperts)
+        quantize(model: mixedBlock, groupSize: 64, bits: 4)
+        #expect(!mixedBlock.requiresDecodeEquivalentRows(input))
     }
 
     @Test("packed affine metadata preserves checkpoint storage dtype")

--- a/docs/benchmarks/QWEN38_FLASH_NEXT_4M_MTP_ROW_PARITY_2026_08_30.md
+++ b/docs/benchmarks/QWEN38_FLASH_NEXT_4M_MTP_ROW_PARITY_2026_08_30.md
@@ -26,12 +26,25 @@ fix that split only the final fused routed kernel passed its synthetic test but
 failed the real model unchanged. That experiment was discarded rather than
 presented as a fix.
 
-The retained change detects the real projection topology from loaded tensor
-types and quantization metadata. Only a `compileDecodeRegions` block whose
-gate, up and down routed projections are all affine q4/g64 uses decode-equivalent
-rows. The complete MoE block then evaluates each verifier position with the
-same `[1,1,H]` contract as AR before concatenating the rows. The 2L, 4S, 6S,
-TurboQuant and non-Qwen4Exp paths do not match that gate and remain unchanged.
+The first retained change detected projection topology from each loaded block.
+That was sufficient for the 4M proof but not sufficient to isolate the 4M
+checkpoint: 4S has a mixed q2/q3/q4 routed bank, so an individual q4 block
+could still enter the decode-equivalent path. The private MTP head also uses
+the same `SparseMoeBlock` type and can carry q4 tensors. A follow-up therefore
+moved the selector to the decoded bundle-wide quantization map. Every trunk
+layer's gate, up and down routed projections must resolve to affine q4/g64;
+the decision is passed only to trunk blocks and is explicitly false for the
+MTP head. The complete MoE block then evaluates each verifier position with
+the same `[1,1,H]` contract as AR before concatenating the rows. Mixed 4S,
+q2 2L, TurboQuant and non-Qwen4Exp paths do not match that gate.
+
+The spill was caught by a cross-quant live row: 4S D3 fell from its previous
+~67 tok/s range to 36.9 tok/s while still producing correct bytes. On the
+narrowed selector it returned to 67.4 tok/s (72.0 tail estimate), produced the
+same full-text SHA-256
+`20dbc5d7831d7a43c23bfa2cedb198965012b4d5b722d8c81a47271eb8c58b33`,
+stopped normally, and used zero AR fallback tokens. This correction is why a
+single loaded block's bit layout must never be used as a model-family proxy.
 
 ## Focused regression
 
@@ -44,9 +57,11 @@ DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
   --filter q4VerifierUsesDecodeEquivalentMoERows
 ```
 
-Result: 1/1 passed. The test quantizes a complete synthetic Qwen4Exp MoE block
-to q4/g64, proves the four-row result is exactly equal to four width-1 calls,
-and proves a 6-bit block does not enter the new path.
+Result after the scope correction: 4/4 passed. The suite quantizes a complete
+synthetic Qwen4Exp MoE block to q4/g64, proves the four-row result is exactly
+equal to four width-1 calls, proves 2/6-bit blocks do not enter the new path,
+and proves mixed 4S plus q2 2L model-wide maps cannot enable a locally q4
+block.
 
 ## Matched live Release proof
 


### PR DESCRIPTION
## Summary

Narrows the Qwen3.8 Flash-Next 4M decode-equivalent verifier-row workaround from a per-block q4/g64 probe to the complete trunk topology declared by the bundle.

The first 4M parity fix was correct for 4M but its selector was too broad: 4S has a mixed q2/q3/q4 routed bank, and individual q4 blocks (including the private MTP head) could enter the expensive full-MoE row split. That cut the real 4S count row from about 67 tok/s to 36.9 tok/s while preserving bytes.

## Causal source change

- Decode the existing bundle `quantization` map in `Qwen4ExpConfiguration`.
- Enable row-equivalent verifier execution only when every trunk layer's routed gate/up/down projection resolves to affine q4/g64.
- Pass that decision only to trunk `SparseMoeBlock`s.
- Explicitly keep the private MTP head out of the workaround.
- Keep a runtime q4/g64 assertion inside the selected block.

No model-name/path allowlist, sampling change, MTP activation change, PLE change, or cache-policy change is introduced.

## Focused tests

Exact head: `f5ebc0ccf26671da05bdf2a7217d175c28e49a2d`

- Fresh Release build: PASS; binary SHA-256 `f950ab3c1147ebc2428f8cfa05efbe22feea5cebed90bcd8bd0ca47e58ea56da`.
- `Qwen4ExpConfigurationTests`: 4/4 PASS after preparing and colocating the exact pinned MLX metallib.
- Uniform all-layer q4/g64 enables row-equivalence.
- Mixed q2/q3/q4 (4S shape) and q2 (2L shape) do not.
- A locally q4 block remains disabled unless model-wide metadata authorizes it.
- Four verifier rows remain exactly equal to four independent width-1 calls when authorized.

Pinned native sources: MLX `0c7cf41306ed75fd96b2e0481e74be46fa8dc576`, mlx-c `7bede8f1491384bb580f87d1d510f80cbd53660d`.

## Exact-head live Release proof

Settings for both rows: greedy, seed 42, fixed D3, prompt `Count from 1 to 200.`, one warmup + one measured turn, mmap weights, no JangPress, full decoded text.

| Bundle | Selector | tok/s | tail | D3 accepts | AR fallback | stop | output SHA-256 | peak footprint |
| --- | --- | ---: | ---: | ---: | ---: | --- | --- | ---: |
| Qwen3.8 Flash-Next 4S | OFF | 68.4 | 73.2 | 222/223 | 0 | stop | `20dbc5d7831d7a43c23bfa2cedb198965012b4d5b722d8c81a47271eb8c58b33` | 59,886 MiB |
| Qwen3.8 Flash-Next 4M | ON | 57.9 | 61.7 | 222/223 | 0 | stop | `20dbc5d7831d7a43c23bfa2cedb198965012b4d5b722d8c81a47271eb8c58b33` | 76,776 MiB |

4S before this correction on the same workload was 36.9 tok/s (39.4 tail), so the regression reversal is 1.85x. Both rows emitted exact 1-200 text with no loop, marker leak, unclosed reasoning, or premature finish. PLE remained SSD-backed via `pread-fnocache` / `F_NOCACHE` (20.697 GiB for 4S; 28.832 GiB for 4M).

The 4M row used a temporary symlink fixture over the unchanged bundle files, replacing only the stale blocked tuning sidecar with measured representative D3 metadata so this scope-only PR could exercise the already-proven MTP head without including the separate Auto-policy change. The original bundle was not modified.

Raw local evidence:
`/Users/eric/vmlx-private-evidence/qwen38-auto-d3-20260830/`

## Boundary

This PR fixes the cross-quant performance regression only. Auto-D3 activation, stale 4M tuning supersession, Osaurus repinning, served API proof, and visible native-Chat proof remain separate gates.
