### PR TITLE
Run native MTP when a bounded request cannot reach KV rotation

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -523,18 +523,42 @@ public struct GenerateParameters: Sendable {
             && requestedReasoningBudgetTokens == nil
     }
 
+    /// Resolve parameters that are safe for native MTP, or nil when this
+    /// request must stay autoregressive.
+    ///
+    /// A configured `maxKVSize` normally selects `RotatingKVCache`. Rotation
+    /// cannot be rolled back after a rejected draft overwrites an old slot.
+    /// However, when the complete bounded request (prompt + declared output
+    /// ceiling) fits inside that window, rotation is provably unreachable.
+    /// In that case native MTP may use ordinary unbounded cache objects for
+    /// this request while the declared `maxTokens` keeps the same position
+    /// ceiling. This is important for hosts such as Osaurus, whose memory
+    /// safety policy supplies a large finite window even for a 1K-token run;
+    /// treating the mere presence of that cap as ineligible silently turned
+    /// every such MTP request into plain AR.
+    public func nativeMTPEffectiveParameters(for input: LMInput) -> GenerateParameters? {
+        guard isNativeMTPPenaltyFree, !input.hasMediaContent else { return nil }
+        // NativeMTPTokenIterator needs at least one draft/verify cycle. Treat
+        // one-token probes as ordinary AR here so callers do not select the
+        // exclusive MTP lane only for iterator construction to throw.
+        if let maxTokens, maxTokens <= 1 { return nil }
+
+        var resolved = self
+        if let maxKVSize {
+            guard let maxTokens, maxTokens >= 0 else { return nil }
+            let (requiredPositions, overflow) = input.text.tokens.size.addingReportingOverflow(
+                maxTokens)
+            guard !overflow, requiredPositions <= maxKVSize else { return nil }
+            // Avoid constructing RotatingKVCache when native MTP runs. The
+            // request cannot exceed the original bound because maxTokens is
+            // still enforced by the iterator.
+            resolved.maxKVSize = nil
+        }
+        return resolved
+    }
+
     public func canUseNativeMTP(for input: LMInput) -> Bool {
-        isNativeMTPPenaltyFree
-            && !input.hasMediaContent
-            // A bounded KV window makes attention slots `RotatingKVCache`, a
-            // ring buffer that OVERWRITES evicted positions. Once rotation
-            // wraps, a rejected draft cannot be un-written — rolling back by
-            // decrementing `offset` silently restores nothing. Hybrid stacks
-            // make it worse: Mamba state is updated in place and has no offset
-            // at all. Speculation therefore requires an unbounded window, and
-            // the honest response to a bounded one is to decline rather than
-            // emit subtly wrong text.
-            && maxKVSize == nil
+        nativeMTPEffectiveParameters(for: input) != nil
     }
 }
 

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -397,10 +397,13 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             effectiveParameters.kvMode = policy.kvMode
             effectiveParameters.maxKVSize = policy.maxKVSize
         }
-        guard effectiveParameters.canUseNativeMTP(for: input) else {
+        guard let nativeMTPParameters = effectiveParameters.nativeMTPEffectiveParameters(
+            for: input)
+        else {
             throw NativeMTPRuntimeError.unsupportedSampling(
-                "native MTP is enabled only for text-only requests with no active penalties, no suppress/reasoning-budget processors, and an unbounded KV window; sampled requests run the exact-pq accept path")
+                "native MTP is enabled only for text-only requests with no active penalties or suppress/reasoning-budget processors, and requires either an unbounded KV window or a prompt plus declared output ceiling that fits wholly inside the configured window; sampled requests run the exact-pq accept path")
         }
+        effectiveParameters = nativeMTPParameters
 
         self.model = model
         self.cache = cache ?? model.newCache(parameters: effectiveParameters)

--- a/RunBench/Bench.swift
+++ b/RunBench/Bench.swift
@@ -243,6 +243,12 @@ struct Bench {
         //   BENCH_PERF_SEED    — deterministic stochastic-sampler seed
         //   BENCH_PERF_USE_GENERATION_CONFIG=1 — seed sampling from the
         //     bundle's generation_config.json before explicit env overrides.
+        //   BENCH_PERF_MAX_KV_SIZE — finite request KV window used to verify
+        //     speculative-window eligibility against production caps.
+        //   BENCH_PERF_ALLOCATOR_CACHE_BYTES / MEMORY_LIMIT_FRACTION — load-
+        //     scoped limits matching a production memory-safety plan.
+        //   BENCH_PERF_PERSISTENT_ALLOCATOR_CACHE_BYTES — post-load MLX
+        //     freed-buffer reuse limit for allocator-policy A/B measurements.
         if (env["BENCH_PERF"] ?? "0") == "1" {
             try await runPerfBench(
                 modelPath: modelPath, maxNew: maxNew,
@@ -8407,13 +8413,17 @@ func runPerfBench(
             context = loaded.0
             jangPressRuntime = loaded.1
         } else if nativeMTPRequestedAtLoad {
+            let allocatorCap: ResidentCap = env["BENCH_PERF_ALLOCATOR_CACHE_BYTES"]
+                .flatMap(UInt64.init).map(ResidentCap.absolute) ?? .unlimited
+            let memoryCap: ResidentCap = env["BENCH_PERF_MEMORY_LIMIT_FRACTION"]
+                .flatMap(Double.init).map(ResidentCap.fraction) ?? .unlimited
             let loaded = try await MLXLMCommon.loadModel(
                 from: modelDir,
                 using: #huggingFaceTokenizerLoader(),
                 loadConfiguration: LoadConfiguration(
                     jangPress: .disabled,
-                    maxResidentBytes: .unlimited,
-                    memoryLimit: .unlimited,
+                    maxResidentBytes: allocatorCap,
+                    memoryLimit: memoryCap,
                     useMmapSafetensors: useMmap,
                     nativeMTP: true))
             context = loaded.0
@@ -8431,6 +8441,11 @@ func runPerfBench(
                     from: modelDir, using: #huggingFaceTokenizerLoader())
                 jangPressRuntime = nil
             }
+        }
+        if let persistentAllocatorCap = env["BENCH_PERF_PERSISTENT_ALLOCATOR_CACHE_BYTES"]
+            .flatMap(Int.init)
+        {
+            MLX.Memory.cacheLimit = persistentAllocatorCap
         }
         let rssAfterLoad = currentRSSMiB()
         let footprintAfterLoad = currentPhysFootprintMiB()
@@ -8662,6 +8677,9 @@ func runPerfBench(
             }
             if let nativeMTPDepth = env["BENCH_PERF_NATIVE_MTP_DEPTH"].flatMap(Int.init) {
                 params.draftStrategy = .nativeMTP(depth: nativeMTPDepth)
+            }
+            if let maxKVSize = env["BENCH_PERF_MAX_KV_SIZE"].flatMap(Int.init) {
+                params.maxKVSize = maxKVSize
             }
             switch (env["BENCH_PERF_KV_MODE"] ?? "none").lowercased() {
             case "tq", "tq44", "turboquant":

--- a/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
@@ -1532,14 +1532,26 @@ struct MTPRuntimeFocusedTests {
             .canUseNativeMTP(for: textOnly))
         #expect(!GenerateParameters(maxTokens: 4, temperature: 0.7, repetitionPenalty: 1.05)
             .canUseNativeMTP(for: textOnly))
-        // Media and bounded KV windows stay ineligible regardless of sampling.
+        // Media stays ineligible regardless of sampling.
         #expect(!GenerateParameters(maxTokens: 4, temperature: 0)
             .canUseNativeMTP(for: imageInput))
         #expect(!GenerateParameters(maxTokens: 4, temperature: 0.7)
             .canUseNativeMTP(for: imageInput))
+        // A bounded window is eligible only when prompt + the declared output
+        // ceiling fits. The effective MTP parameters clear maxKVSize so the
+        // iterator constructs rollback-safe, non-rotating caches while
+        // retaining the same maxTokens ceiling.
         var bounded = GenerateParameters(maxTokens: 4, temperature: 0.7)
         bounded.maxKVSize = 1024
+        #expect(bounded.canUseNativeMTP(for: textOnly))
+        #expect(bounded.nativeMTPEffectiveParameters(for: textOnly)?.maxKVSize == nil)
+        bounded.maxKVSize = 6
         #expect(!bounded.canUseNativeMTP(for: textOnly))
+        var unboundedOutput = GenerateParameters(maxTokens: nil, temperature: 0.7)
+        unboundedOutput.maxKVSize = 1024
+        #expect(!unboundedOutput.canUseNativeMTP(for: textOnly))
+        #expect(!GenerateParameters(maxTokens: 1, temperature: 0)
+            .canUseNativeMTP(for: textOnly))
         // The greedy-lossless flag itself still means greedy: it gates the
         // token-identical parity contract, not general eligibility.
         #expect(!GenerateParameters(maxTokens: 4, temperature: 0.7)

--- a/Tests/MLXLMTests/NemotronLightningMTPTests.swift
+++ b/Tests/MLXLMTests/NemotronLightningMTPTests.swift
@@ -171,12 +171,10 @@ struct NemotronLightningMTPTests {
     }
 }
 
-/// Speculation must decline a bounded KV window. `RotatingKVCache` overwrites
-/// evicted positions, so a rejected draft cannot be un-written once rotation
-/// wraps — and on a hybrid stack the Mamba state has no offset to rewind at
-/// all. Declining is the only sound answer; the alternative is subtly wrong
-/// text that no test would catch.
-@Suite("Native MTP requires an unbounded KV window")
+/// Speculation must decline a bounded KV window only when the request can
+/// actually reach rotation. If prompt + maxTokens fits, native MTP constructs
+/// non-rotating caches and retains maxTokens as the original position ceiling.
+@Suite("Native MTP bounded-window safety")
 struct NativeMTPWindowGuardTests {
 
     private func greedy(maxKVSize: Int?) -> GenerateParameters {
@@ -188,10 +186,33 @@ struct NativeMTPWindowGuardTests {
         #expect(greedy(maxKVSize: nil).canUseNativeMTP(for: LMInput(tokens: MLXArray([Int32(1)]))))
     }
 
-    @Test(arguments: [512, 4096, 262_144])
-    func boundedWindowDeclines(_ size: Int) {
-        #expect(!greedy(maxKVSize: size).canUseNativeMTP(for: LMInput(tokens: MLXArray([Int32(1)]))),
-            "maxKVSize \(size) must decline speculation")
+    @Test(arguments: [33, 512, 4096, 262_144])
+    func fittingBoundedWindowUsesNonRotatingCache(_ size: Int) throws {
+        let input = LMInput(tokens: MLXArray([Int32(1)]))
+        let effective = try #require(greedy(maxKVSize: size)
+            .nativeMTPEffectiveParameters(for: input))
+        #expect(effective.maxKVSize == nil)
+        #expect(effective.maxTokens == 32)
+    }
+
+    @Test("a bound below prompt plus output declines")
+    func undersizedBoundDeclines() {
+        let input = LMInput(tokens: MLXArray([Int32(1)]))
+        #expect(!greedy(maxKVSize: 32).canUseNativeMTP(for: input))
+    }
+
+    @Test("a finite bound with no output ceiling declines")
+    func finiteBoundWithoutOutputCeilingDeclines() {
+        let input = LMInput(tokens: MLXArray([Int32(1)]))
+        let parameters = GenerateParameters(maxTokens: nil, maxKVSize: 4096, temperature: 0)
+        #expect(!parameters.canUseNativeMTP(for: input))
+    }
+
+    @Test("a one-token probe stays autoregressive")
+    func oneTokenProbeDeclines() {
+        let input = LMInput(tokens: MLXArray([Int32(1)]))
+        let parameters = GenerateParameters(maxTokens: 1, maxKVSize: 4096, temperature: 0)
+        #expect(!parameters.canUseNativeMTP(for: input))
     }
 }
 


### PR DESCRIPTION
## Problem

Osaurus memory safety supplies a finite `maxKVSize` (65,536 in the live Qwen3.8 Flash-Next row). vMLX treated the mere presence of any finite cap as native-MTP-ineligible. The request was submitted as `native_mtp:d3`, but completion telemetry proved `decodePath=plain mtp=off`; the identical warm served request ran at 32.99 tok/s.

This was a silent dispatch mismatch, not slow MTP.

## Fix

- Resolve a native-MTP-safe parameter copy.
- If `maxKVSize` is finite, require a declared output ceiling and prove `promptTokens + maxTokens <= maxKVSize` with checked addition.
- Clear `maxKVSize` only in the MTP iterator's effective copy, so it constructs rollback-safe non-rotating caches.
- Retain `maxTokens`, preserving the original position ceiling.
- Continue declining media, penalties/processors, overflow, a request that can reach rotation, finite-window requests without an output ceiling, and one-token probes.

No sampler, prompt, reasoning, or output coercion is added.

## Focused tests on `5cff7e20`

- `nativeMTPRequestEligibilityIsPenaltyFreeTextOnly`: 1/1 PASS.
- `NativeMTPWindowGuardTests`: 5/5 PASS, including exact-fit, undersized, no-output-ceiling, and one-token-probe rows.

## Live acceptance

IN PROGRESS on the exact local Osaurus Release harness. The before row is frozen:

- requested/resolved: `native_mtp:d3`
- actual completion: `decodePath=plain mtp=off`
- warm throughput: 32.9904 tok/s
- exact output: 1 through 200
- disk L2 hit: 1; SSM companion hit: 1

The PR will not be merged until the same served request reports actual native-MTP depth/verify/acceptance telemetry and a visible Chat UI row is inspected.
