### PR TITLE
Fix Qwen4Exp long-prefill QSA allocation

### DIFF
--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -607,13 +607,39 @@ public class QSAKVCache: KVCacheSimple {
     /// `updateIndexerKeys` BEFORE `update(keys:values:)` advances `offset`,
     /// matching the reference forward order.
     public private(set) var indexerKeys: MLXArray?
+    /// Derived, normalized, RoPE-applied completed index blocks. This is an
+    /// in-memory decode accelerator only: raw indexer keys remain the durable
+    /// state, so disk/cache restoration can always rebuild it exactly.
+    private var pooledIndexerKeys: MLXArray?
+    private var pooledIndexerCompressRatio: Int?
+
+    public func cachedPooledIndexerKeys(
+        compressRatio: Int, completeBlocks: Int
+    ) -> MLXArray? {
+        guard pooledIndexerCompressRatio == compressRatio,
+            let pooledIndexerKeys,
+            pooledIndexerKeys.dim(1) <= completeBlocks
+        else { return nil }
+        return pooledIndexerKeys
+    }
+
+    public func storePooledIndexerKeys(_ keys: MLXArray, compressRatio: Int) {
+        pooledIndexerKeys = keys
+        pooledIndexerCompressRatio = compressRatio
+    }
+
+    private func invalidatePooledIndexerKeys() {
+        pooledIndexerKeys = nil
+        pooledIndexerCompressRatio = nil
+    }
 
     public func updateIndexerKeys(_ rawKeys: MLXArray) -> MLXArray {
         if let existing = indexerKeys, existing.dim(1) > 0 {
             // Stale rows beyond `offset` (a trim/rollback that happened
             // between forwards) must not survive into the concat.
-            let valid = existing.dim(1) > offset
-                ? existing[0..., ..<offset, 0...] : existing
+            let hadStaleRows = existing.dim(1) > offset
+            let valid = hadStaleRows ? existing[0..., ..<offset, 0...] : existing
+            if hadStaleRows { invalidatePooledIndexerKeys() }
             indexerKeys = concatenated([valid, rawKeys], axis: 1)
         } else {
             indexerKeys = rawKeys
@@ -636,6 +662,7 @@ public class QSAKVCache: KVCacheSimple {
             return s
         }
         set {
+            invalidatePooledIndexerKeys()
             if newValue.count == 3 {
                 super.state = Array(newValue[0 ..< 2])
                 indexerKeys = newValue[2]
@@ -649,6 +676,7 @@ public class QSAKVCache: KVCacheSimple {
     @discardableResult
     public override func trim(_ n: Int) -> Int {
         let trimmed = super.trim(n)
+        if trimmed > 0 { invalidatePooledIndexerKeys() }
         if trimmed > 0, let existing = indexerKeys, existing.dim(1) > offset {
             indexerKeys = existing[0..., ..<offset, 0...]
         }

--- a/Libraries/MLXVLM/Models/Qwen4Exp.swift
+++ b/Libraries/MLXVLM/Models/Qwen4Exp.swift
@@ -894,7 +894,9 @@ private final class Qwen4ExpQSAIndexer: Module {
         super.init()
     }
 
-    func callAsFunction(_ x: MLXArray, cache: QSAKVCache?) -> MLXArray? {
+    func prepare(_ x: MLXArray, cache: QSAKVCache?) -> (
+        query: MLXArray, pooledKeys: MLXArray, past: Int, total: Int
+    )? {
         let B = x.dim(0), S = x.dim(1)
         precondition(B == 1, "qwen4_exp QSA currently supports batch size 1")
         let past = cache?.offset ?? 0
@@ -915,26 +917,50 @@ private final class Qwen4ExpQSAIndexer: Module {
             .transposed(0, 2, 1, 3)
         let blocks = total / extras.indexerCompressRatio
         guard blocks > 0 else { return nil }
-        var pooled = allKeys[0..., ..<(blocks * extras.indexerCompressRatio), 0...]
-            .reshaped(B, blocks, extras.indexerCompressRatio, extras.indexerHeadDim)
-            .asType(.float32).mean(axis: 2).asType(allKeys.dtype)
-        pooled = kNorm(pooled)
+        let ratio = extras.indexerCompressRatio
+        let cachedPooled = cache?.cachedPooledIndexerKeys(
+            compressRatio: ratio, completeBlocks: blocks)
+        let cachedBlocks = cachedPooled?.dim(1) ?? 0
+        var pooled: MLXArray
+        if cachedBlocks == blocks, let cachedPooled {
+            pooled = cachedPooled
+        } else {
+            let rawStart = cachedBlocks * ratio
+            let rawStop = blocks * ratio
+            var appended = allKeys[0..., rawStart ..< rawStop, 0...]
+                .reshaped(B, blocks - cachedBlocks, ratio, extras.indexerHeadDim)
+                .asType(.float32).mean(axis: 2).asType(allKeys.dtype)
+            appended = kNorm(appended)
+            let appended4 = expandedDimensions(appended, axis: 1)
+            let appendedPositions = MLXArray(stride(
+                from: rawStart, to: rawStop, by: ratio))
+                .asType(.int32).reshaped(1, blocks - cachedBlocks)
+            let (appendedCos, appendedSin) = rotary(
+                x: appended4, positionIds: appendedPositions)
+            appended = Qwen35Language.applyMultimodalRotaryPosEmb(
+                q: appended4, k: appended4,
+                cos: appendedCos, sin: appendedSin).0[0..., 0, 0..., 0...]
+            pooled = cachedPooled.map { concatenated([$0, appended], axis: 1) }
+                ?? appended
+            cache?.storePooledIndexerKeys(pooled, compressRatio: ratio)
+        }
         let qPositions = MLXArray(past ..< (past + S)).asType(.int32).reshaped(1, S)
-        let blockPositions = MLXArray(stride(
-            from: 0, to: blocks * extras.indexerCompressRatio,
-            by: extras.indexerCompressRatio)).asType(.int32).reshaped(1, blocks)
         let (qCos, qSin) = rotary(x: query, positionIds: qPositions)
         query = Qwen35Language.applyMultimodalRotaryPosEmb(
             q: query, k: query, cos: qCos, sin: qSin).0
-        let pooled4 = expandedDimensions(pooled, axis: 1)
-        let (kCos, kSin) = rotary(x: pooled4, positionIds: blockPositions)
-        pooled = Qwen35Language.applyMultimodalRotaryPosEmb(
-            q: pooled4, k: pooled4, cos: kCos, sin: kSin).0[0..., 0, 0..., 0...]
-        return Qwen4ExpQSA.selectedTokenMask(
-            query: query, pooledKeys: expandedDimensions(pooled, axis: 1),
-            pastLen: past, compressRatio: extras.indexerCompressRatio,
+        return (query, pooled, past, total)
+    }
+
+    func mask(from prepared: (
+        query: MLXArray, pooledKeys: MLXArray, past: Int, total: Int
+    )) -> MLXArray? {
+        Qwen4ExpQSA.selectedTokenMask(
+            query: prepared.query,
+            pooledKeys: expandedDimensions(prepared.pooledKeys, axis: 1),
+            pastLen: prepared.past,
+            compressRatio: extras.indexerCompressRatio,
             blockTopK: extras.indexerBudget / extras.indexerCompressRatio,
-            keyLen: total)
+            keyLen: prepared.total)
     }
 }
 
@@ -974,7 +1000,7 @@ private final class Qwen4ExpAttention: Module {
     ) -> MLXArray {
         let B = x.dim(0), S = x.dim(1)
         let past = cache?.offset ?? 0
-        let sparseMask = indexer(x, cache: cache)
+        let qsa = indexer.prepare(x, cache: cache)
         let headDim = text.headDim ?? (text.hiddenSize / text.attentionHeads)
         let qg = qProj(x).reshaped(B, S, text.attentionHeads, headDim * 2)
             .split(parts: 2, axis: -1)
@@ -992,6 +1018,29 @@ private final class Qwen4ExpAttention: Module {
         let (cos, sin) = rotary(x: value, positionIds: positions)
         (query, key) = Qwen35Language.applyMultimodalRotaryPosEmb(
             q: query, k: key, cos: cos, sin: sin)
+
+        // Batch-one contiguous text uses exact gathered QSA. Both indexer
+        // scoring and main attention are query-chunked, so neither prefill nor
+        // decode can create a prompt-squared mask. Media/M-RoPE, offset-shifted,
+        // cacheless, and unsupported layouts fail closed to the official mask
+        // path below.
+        if let qsa, let cache, B == 1, explicitPositions == nil, positionOffset == 0 {
+            let (cachedKeys, cachedValues) = cache.update(keys: key, values: value)
+            let output = Qwen4ExpQSA.gatheredAttention(
+                queries: query,
+                keys: cachedKeys,
+                values: cachedValues,
+                indexQueries: qsa.query,
+                pooledIndexKeys: qsa.pooledKeys,
+                pastLen: qsa.past,
+                compressRatio: indexer.extras.indexerCompressRatio,
+                blockTopK: indexer.extras.indexerBudget / indexer.extras.indexerCompressRatio,
+                scale: scale)
+                .transposed(0, 2, 1, 3).reshaped(B, S, -1)
+            return oProj(output * sigmoid(gate))
+        }
+
+        let sparseMask = qsa.flatMap { indexer.mask(from: $0) }
 
         // Pass an explicit pre-update causal mask. Falling through to
         // `attentionWithCacheUpdate`'s cache-derived mask asks the cache for

--- a/Libraries/MLXVLM/Models/Qwen4Exp.swift
+++ b/Libraries/MLXVLM/Models/Qwen4Exp.swift
@@ -1019,12 +1019,16 @@ private final class Qwen4ExpAttention: Module {
         (query, key) = Qwen35Language.applyMultimodalRotaryPosEmb(
             q: query, k: key, cos: cos, sin: sin)
 
-        // Batch-one contiguous text uses exact gathered QSA. Both indexer
-        // scoring and main attention are query-chunked, so neither prefill nor
-        // decode can create a prompt-squared mask. Media/M-RoPE, offset-shifted,
-        // cacheless, and unsupported layouts fail closed to the official mask
-        // path below.
-        if let qsa, let cache, B == 1, explicitPositions == nil, positionOffset == 0 {
+        // Large batch-one contiguous prefill uses exact gathered QSA. Both
+        // indexer scoring and main attention are query-chunked, so prefill
+        // cannot create a prompt-squared mask. Short decode and native-MTP
+        // verification keep the faster exact mask path because their
+        // `[B,T,keyLen]` mask stays bounded. Media/M-RoPE, offset-shifted,
+        // cacheless, and unsupported layouts also use the official path.
+        if let qsa, let cache, B == 1, explicitPositions == nil, positionOffset == 0,
+            Qwen4ExpQSA.shouldUseGatheredAttention(
+                queryTokens: S, keyTokens: qsa.total)
+        {
             let (cachedKeys, cachedValues) = cache.update(keys: key, values: value)
             let output = Qwen4ExpQSA.gatheredAttention(
                 queries: query,

--- a/Libraries/MLXVLM/Models/Qwen4ExpQSA.swift
+++ b/Libraries/MLXVLM/Models/Qwen4ExpQSA.swift
@@ -14,6 +14,22 @@ import Foundation
 import MLX
 
 enum Qwen4ExpQSA {
+    /// Use the gathered implementation only once the exact sparse mask would
+    /// become materially large. Singleton decode and native-MTP verification
+    /// use one to four query rows, so their `[B,T,keyLen]` masks remain small
+    /// even at long context and are substantially faster than gathering K/V.
+    /// Large prefill crosses this bound and stays on the query-chunked path.
+    static func shouldUseGatheredAttention(
+        queryTokens: Int,
+        keyTokens: Int,
+        maxMaskElements: Int = 1_048_576
+    ) -> Bool {
+        guard queryTokens > 0, keyTokens > 0, maxMaskElements >= 0 else {
+            return false
+        }
+        return queryTokens > maxMaskElements / keyTokens
+    }
+
     /// Keep the portable gathered path bounded without turning every prompt
     /// into dozens of tiny dispatches.
     static func queryChunkSize(keyLen: Int) -> Int {

--- a/Libraries/MLXVLM/Models/Qwen4ExpQSA.swift
+++ b/Libraries/MLXVLM/Models/Qwen4ExpQSA.swift
@@ -58,16 +58,33 @@ enum Qwen4ExpQSA {
             .ellipsis, (-blockTopK)...]
         // selectedBlocks: [B, T, blockTopK]
 
-        let tokenIdx = MLXArray((0 ..< keyLen).map(Int32.init))  // [keyLen]
-        let tokenBlocks = floorDivide(tokenIdx, MLXArray(Int32(compressRatio)))
-        let selectedTokens = MLX.any(
-            MLX.equal(
-                tokenBlocks.reshaped(1, 1, 1, keyLen),
-                expandedDimensions(selectedBlocks, axis: -1)),
-            axis: 2)
+        // Mark winners on the compressed block axis, then widen each block to
+        // its raw tokens. Comparing every raw token against every selected
+        // block materializes [B,T,blockTopK,keyLen]: at an 18k prompt with the
+        // production top-k of 512 that exceeds MLX's maximum buffer size.
+        // `putAlong` keeps the largest intermediate at [B,T,keyLen] while
+        // producing the exact same membership mask.
+        let batch = query.dim(0)
+        let blockHits = putAlong(
+            MLXArray.zeros([batch, seqLen, maxCompleteBlocks], dtype: .bool),
+            selectedBlocks,
+            values: MLXArray(true),
+            axis: -1)
+        var selectedTokens = repeated(blockHits, count: compressRatio, axis: -1)
+        let completeKeyLen = maxCompleteBlocks * compressRatio
+        if completeKeyLen < keyLen {
+            selectedTokens = concatenated(
+                [
+                    selectedTokens,
+                    MLXArray.zeros(
+                        [batch, seqLen, keyLen - completeKeyLen], dtype: .bool),
+                ],
+                axis: -1)
+        }
         // selectedTokens: [B, T, keyLen]
 
         // The incomplete tail block up to each query position always attends.
+        let tokenIdx = MLXArray((0 ..< keyLen).map(Int32.init))  // [keyLen]
         let tailStarts = completeCounts * Int32(compressRatio)  // [T]
         let tokenRow = tokenIdx.reshaped(1, 1, keyLen)
         let beforeQueryEnd = MLX.less(tokenRow, queryEnds.reshaped(1, seqLen, 1))

--- a/Libraries/MLXVLM/Models/Qwen4ExpQSA.swift
+++ b/Libraries/MLXVLM/Models/Qwen4ExpQSA.swift
@@ -14,6 +14,166 @@ import Foundation
 import MLX
 
 enum Qwen4ExpQSA {
+    /// Keep the portable gathered path bounded without turning every prompt
+    /// into dozens of tiny dispatches.
+    static func queryChunkSize(keyLen: Int) -> Int {
+        if keyLen <= 4_096 { return 32 }
+        if keyLen <= 16_384 { return 64 }
+        return 128
+    }
+
+    /// Exact QSA attention over only the selected K/V rows.
+    ///
+    /// This is the bounded fallback for the production batch-one text path.
+    /// It never constructs `[B,T,keyLen]` (or the still larger
+    /// `[B,T,topK,keyLen]`) masks: indexer scoring and main attention are both
+    /// query-chunked, and each row gathers at most the configured token budget
+    /// plus the incomplete compressed tail.
+    static func gatheredAttention(
+        queries: MLXArray,
+        keys: MLXArray,
+        values: MLXArray,
+        indexQueries: MLXArray,
+        pooledIndexKeys: MLXArray,
+        pastLen: Int,
+        compressRatio: Int,
+        blockTopK: Int,
+        scale: Float,
+        queryChunk: Int? = nil
+    ) -> MLXArray {
+        let batch = queries.dim(0)
+        let queryHeads = queries.dim(1)
+        let queryTokens = queries.dim(2)
+        let headDim = queries.dim(3)
+        let kvHeads = keys.dim(1)
+        let keyTokens = keys.dim(2)
+        let indexHeads = indexQueries.dim(1)
+        let indexHeadDim = indexQueries.dim(3)
+        let maxBlocks = keyTokens / compressRatio
+
+        precondition(batch == 1, "gathered QSA requires batch size 1")
+        precondition(queryTokens > 0 && pastLen + queryTokens == keyTokens)
+        precondition(keys.shape == values.shape)
+        precondition(keys.dim(0) == batch && keys.dim(3) == headDim)
+        precondition(queryHeads % kvHeads == 0)
+        precondition(indexQueries.shape == [batch, indexHeads, queryTokens, indexHeadDim])
+        precondition(pooledIndexKeys.shape == [batch, maxBlocks, indexHeadDim])
+        precondition(compressRatio > 0 && blockTopK > 0)
+
+        let groups = queryHeads / kvHeads
+        let chunkSize = queryChunk ?? queryChunkSize(keyLen: keyTokens)
+        precondition(chunkSize > 0)
+        let keyRows = keys.transposed(0, 2, 1, 3)
+        let valueRows = values.transposed(0, 2, 1, 3)
+        let pooled4 = expandedDimensions(pooledIndexKeys, axis: 1)
+        var outputs: [MLXArray] = []
+
+        func batchGather(_ source: MLXArray, indices: MLXArray) -> MLXArray {
+            let width = indices.dim(2)
+            let offsets = MLXArray((0 ..< batch).map { Int32($0 * keyTokens) })
+                .reshaped(batch, 1, 1)
+            let flatIndices = (indices.asType(.int32) + offsets).reshaped(-1)
+            let flat = source.reshaped(batch * keyTokens, kvHeads, headDim)
+            return flat.take(flatIndices, axis: 0)
+                .reshaped(batch, indices.dim(1), width, kvHeads, headDim)
+        }
+
+        for start in stride(from: 0, to: queryTokens, by: chunkSize) {
+            let stop = min(start + chunkSize, queryTokens)
+            let chunkTokens = stop - start
+            let queryEnds = MLXArray(
+                (start ..< stop).map { Int32(pastLen + $0 + 1) })
+                .reshaped(1, chunkTokens)
+            let completeCounts = floorDivide(
+                queryEnds, MLXArray(Int32(compressRatio)))
+
+            let chunkIndexQueries = indexQueries[0..., 0..., start ..< stop, 0...]
+            var scores = matmul(
+                chunkIndexQueries.asType(.float32),
+                pooled4.asType(.float32).transposed(0, 1, 3, 2))
+            scores = maximum(scores, MLXArray(Float(0))).sum(axis: 1)
+                / sqrt(Float(indexHeadDim))
+
+            let blockIndices = MLXArray((0 ..< maxBlocks).map(Int32.init))
+                .reshaped(1, 1, maxBlocks)
+            let validBlocks = MLX.less(
+                blockIndices, completeCounts.reshaped(1, chunkTokens, 1))
+            scores = MLX.where(validBlocks, scores, MLXArray(-Float.infinity))
+
+            let selectedWidth = min(maxBlocks, blockTopK)
+            let canonical = MLX.broadcast(
+                MLXArray((0 ..< selectedWidth).map(Int32.init)).reshaped(1, 1, selectedWidth),
+                to: [batch, chunkTokens, selectedWidth])
+            var selectedBlocks = canonical
+            if maxBlocks > blockTopK {
+                let ranked = argPartition(scores, kth: -blockTopK, axis: -1)[
+                    .ellipsis, (-blockTopK)...].asType(.int32)
+                selectedBlocks = MLX.where(
+                    MLX.lessEqual(
+                        completeCounts, MLXArray(Int32(blockTopK)))
+                        .reshaped(batch, chunkTokens, 1),
+                    canonical,
+                    ranked)
+            }
+            selectedBlocks = MLX.sorted(selectedBlocks, axis: -1)
+
+            let selectedCount = MLX.minimum(
+                completeCounts, MLXArray(Int32(blockTopK)))
+            var selectedIndices = (
+                expandedDimensions(selectedBlocks, axis: -1) * Int32(compressRatio)
+                    + MLXArray((0 ..< compressRatio).map(Int32.init))
+                        .reshaped(1, 1, 1, compressRatio)
+            ).reshaped(batch, chunkTokens, selectedWidth * compressRatio)
+            var selectedValid = MLX.broadcast(
+                MLX.less(
+                    MLXArray((0 ..< selectedWidth).map(Int32.init))
+                        .reshaped(1, 1, selectedWidth, 1),
+                    selectedCount.reshaped(batch, chunkTokens, 1, 1)),
+                to: [batch, chunkTokens, selectedWidth, compressRatio])
+                .reshaped(batch, chunkTokens, selectedWidth * compressRatio)
+
+            // The zero-to-three visible tokens after the last complete block
+            // are part of Qwen's published sparse-attention contract.
+            let tailWidth = compressRatio - 1
+            if tailWidth > 0 {
+                let tail = completeCounts.reshaped(batch, chunkTokens, 1)
+                    * Int32(compressRatio)
+                    + MLXArray((0 ..< tailWidth).map(Int32.init)).reshaped(1, 1, tailWidth)
+                let tailValid = MLX.less(
+                    tail, queryEnds.reshaped(batch, chunkTokens, 1))
+                selectedIndices = concatenated([selectedIndices, tail], axis: -1)
+                selectedValid = concatenated([selectedValid, tailValid], axis: -1)
+            }
+
+            let safeIndices = MLX.where(
+                selectedValid, selectedIndices, MLXArray(Int32(0)))
+            let selectedKeys = batchGather(keyRows, indices: safeIndices)
+                .transposed(0, 1, 3, 2, 4)
+            let selectedValues = batchGather(valueRows, indices: safeIndices)
+                .transposed(0, 1, 3, 2, 4)
+
+            let chunkQueries = queries[0..., 0..., start ..< stop, 0...]
+                .transposed(0, 2, 1, 3)
+            let groupedQueries = chunkQueries.reshaped(
+                batch, chunkTokens, kvHeads, groups, headDim)
+            var attentionScores = matmul(
+                groupedQueries.asType(.float32),
+                selectedKeys.asType(.float32).transposed(0, 1, 2, 4, 3)) * scale
+            attentionScores = MLX.where(
+                selectedValid.reshaped(batch, chunkTokens, 1, 1, -1),
+                attentionScores,
+                MLXArray(-Float.infinity))
+            let probabilities = MLX.softmax(
+                attentionScores, axis: -1, precise: true).asType(queries.dtype)
+            let output = matmul(probabilities, selectedValues)
+                .reshaped(batch, chunkTokens, queryHeads, headDim)
+                .transposed(0, 2, 1, 3)
+            outputs.append(output)
+        }
+
+        return concatenated(outputs, axis: 2)
+    }
+
     /// Boolean attention mask [B, 1, T, keyLen] from indexer scores.
     ///
     /// - Parameters:
@@ -38,8 +198,10 @@ enum Qwen4ExpQSA {
         guard maxCompleteBlocks > blockTopK else { return nil }
 
         // ReLU(q·k̄) summed over indexer heads, scaled by sqrt(D).
-        var scores = matmul(query, pooledKeys.transposed(0, 1, 3, 2))
-        scores = maximum(scores.asType(.float32), MLXArray(Float(0))).sum(axis: 1)
+        var scores = matmul(
+            query.asType(.float32),
+            pooledKeys.asType(.float32).transposed(0, 1, 3, 2))
+        scores = maximum(scores, MLXArray(Float(0))).sum(axis: 1)
         scores = scores / sqrt(Float(query.dim(3)))
         // scores: [B, T, numBlocks]
 

--- a/Tests/MLXLMTests/QSAKVCachePersistenceTests.swift
+++ b/Tests/MLXLMTests/QSAKVCachePersistenceTests.swift
@@ -136,3 +136,26 @@ private func makeQSACache(
         #expect((cache[0] as? QSAKVCache)?.indexerKeys != nil)
     }
 }
+
+@Test func qsaDerivedPooledBlocksReuseAndInvalidateSafely() {
+    MLXMetalTestLock.withLock {
+        let cache = makeQSACache(tokens: 16)
+        let first = MLXArray.ones([1, 4, 8]).asType(.bfloat16)
+        cache.storePooledIndexerKeys(first, compressRatio: 4)
+        #expect(cache.cachedPooledIndexerKeys(
+            compressRatio: 4, completeBlocks: 4)?.dim(1) == 4)
+        #expect(cache.cachedPooledIndexerKeys(
+            compressRatio: 4, completeBlocks: 5)?.dim(1) == 4)
+        #expect(cache.cachedPooledIndexerKeys(
+            compressRatio: 2, completeBlocks: 8) == nil)
+
+        _ = cache.trim(1)
+        #expect(cache.cachedPooledIndexerKeys(
+            compressRatio: 4, completeBlocks: 3) == nil)
+
+        cache.storePooledIndexerKeys(first, compressRatio: 4)
+        cache.state = cache.state
+        #expect(cache.cachedPooledIndexerKeys(
+            compressRatio: 4, completeBlocks: 4) == nil)
+    }
+}

--- a/Tests/MLXLMTests/Qwen4ExpQSATests.swift
+++ b/Tests/MLXLMTests/Qwen4ExpQSATests.swift
@@ -24,6 +24,47 @@ struct Qwen4ExpQSATests {
             compressRatio: compressRatio, blockTopK: blockTopK, keyLen: keyLen)
     }
 
+    private func makeReferenceMask(
+        query: MLXArray, pooled: MLXArray,
+        pastLen: Int, compressRatio: Int, blockTopK: Int, keyLen: Int
+    ) -> MLXArray? {
+        let seqLen = query.dim(2)
+        let maxCompleteBlocks = keyLen / compressRatio
+        guard maxCompleteBlocks > blockTopK else { return nil }
+
+        var scores = matmul(query, pooled.transposed(0, 1, 3, 2))
+        scores = maximum(scores.asType(.float32), MLXArray(Float(0))).sum(axis: 1)
+        scores = scores / sqrt(Float(query.dim(3)))
+        let queryEnds = MLXArray((0 ..< seqLen).map { Int32(pastLen + $0 + 1) })
+        let completeCounts = floorDivide(queryEnds, MLXArray(Int32(compressRatio)))
+        let blockIdx = MLXArray((0 ..< maxCompleteBlocks).map(Int32.init))
+        let validBlocks = MLX.less(
+            blockIdx.reshaped(1, 1, maxCompleteBlocks),
+            completeCounts.reshaped(1, seqLen, 1))
+        scores = MLX.where(validBlocks, scores, MLXArray(-Float.infinity))
+        let selectedBlocks = argPartition(scores, kth: -blockTopK, axis: -1)[
+            .ellipsis, (-blockTopK)...]
+        let tokenIdx = MLXArray((0 ..< keyLen).map(Int32.init))
+        let tokenBlocks = floorDivide(tokenIdx, MLXArray(Int32(compressRatio)))
+        let selectedTokens = MLX.any(
+            MLX.equal(
+                tokenBlocks.reshaped(1, 1, 1, keyLen),
+                expandedDimensions(selectedBlocks, axis: -1)),
+            axis: 2)
+        let tailStarts = completeCounts * Int32(compressRatio)
+        let tokenRow = tokenIdx.reshaped(1, 1, keyLen)
+        let beforeQueryEnd = MLX.less(tokenRow, queryEnds.reshaped(1, seqLen, 1))
+        let tail = MLX.logicalAnd(
+            MLX.greaterEqual(tokenRow, tailStarts.reshaped(1, seqLen, 1)),
+            beforeQueryEnd)
+        let useSparse = MLX.greater(completeCounts, MLXArray(Int32(blockTopK)))
+        let mask = MLX.where(
+            useSparse.reshaped(1, seqLen, 1),
+            MLX.logicalOr(selectedTokens, tail),
+            beforeQueryEnd)
+        return expandedDimensions(mask, axis: 1)
+    }
+
     @Test("below the sparse threshold returns nil (dense fallback)")
     func denseFallback() throws {
         try MLXMetalTestLock.withLock {
@@ -87,6 +128,42 @@ struct Qwen4ExpQSATests {
             }
             // 32 % 4 == 0 → no tail; exactly blockTopK complete blocks attend.
             #expect(selectedComplete == blockTopK, "selected \(selectedComplete)")
+        }
+    }
+
+    @Test("block-axis scatter is exactly equivalent to the reference membership mask")
+    func blockAxisScatterParity() throws {
+        try MLXMetalTestLock.withLock {
+            MLXRandom.seed(17)
+            let seqLen = 7, keyLen = 35, compressRatio = 4, blockTopK = 2
+            let query = MLXRandom.normal([1, 3, seqLen, 8])
+            let pooled = MLXRandom.normal([1, 1, keyLen / compressRatio, 8])
+            let actual = try #require(Qwen4ExpQSA.selectedTokenMask(
+                query: query, pooledKeys: pooled, pastLen: keyLen - seqLen,
+                compressRatio: compressRatio, blockTopK: blockTopK, keyLen: keyLen))
+            let reference = try #require(makeReferenceMask(
+                query: query, pooled: pooled, pastLen: keyLen - seqLen,
+                compressRatio: compressRatio, blockTopK: blockTopK, keyLen: keyLen))
+
+            #expect(actual.shape == reference.shape)
+            #expect(actual.asArray(Bool.self) == reference.asArray(Bool.self))
+        }
+    }
+
+    @Test("4K sparse prefill materializes without a topK-expanded token tensor")
+    func longPrefillMembershipIsBounded() throws {
+        try MLXMetalTestLock.withLock {
+            let seqLen = 4_096, compressRatio = 4, blockTopK = 512
+            MLXRandom.seed(23)
+            let query = MLXRandom.normal([1, 4, seqLen, 8])
+            let pooled = MLXRandom.normal([1, 1, seqLen / compressRatio, 8])
+            let mask = try #require(Qwen4ExpQSA.selectedTokenMask(
+                query: query, pooledKeys: pooled, pastLen: 0,
+                compressRatio: compressRatio, blockTopK: blockTopK, keyLen: seqLen))
+
+            #expect(mask.shape == [1, 1, seqLen, seqLen])
+            MLX.eval(mask)
+            #expect(mask[0, 0, seqLen - 1].sum().item(Int.self) >= blockTopK * compressRatio)
         }
     }
 }

--- a/Tests/MLXLMTests/Qwen4ExpQSATests.swift
+++ b/Tests/MLXLMTests/Qwen4ExpQSATests.swift
@@ -2,6 +2,7 @@
 
 import Foundation
 import MLX
+import MLXFast
 import Testing
 
 @testable import MLXVLM
@@ -32,8 +33,9 @@ struct Qwen4ExpQSATests {
         let maxCompleteBlocks = keyLen / compressRatio
         guard maxCompleteBlocks > blockTopK else { return nil }
 
-        var scores = matmul(query, pooled.transposed(0, 1, 3, 2))
-        scores = maximum(scores.asType(.float32), MLXArray(Float(0))).sum(axis: 1)
+        var scores = matmul(
+            query.asType(.float32), pooled.asType(.float32).transposed(0, 1, 3, 2))
+        scores = maximum(scores, MLXArray(Float(0))).sum(axis: 1)
         scores = scores / sqrt(Float(query.dim(3)))
         let queryEnds = MLXArray((0 ..< seqLen).map { Int32(pastLen + $0 + 1) })
         let completeCounts = floorDivide(queryEnds, MLXArray(Int32(compressRatio)))
@@ -164,6 +166,94 @@ struct Qwen4ExpQSATests {
             #expect(mask.shape == [1, 1, seqLen, seqLen])
             MLX.eval(mask)
             #expect(mask[0, 0, seqLen - 1].sum().item(Int.self) >= blockTopK * compressRatio)
+        }
+    }
+
+    @Test("chunked gathered prefill matches the exact sparse-mask reference")
+    func gatheredPrefillParity() throws {
+        try MLXMetalTestLock.withLock {
+            MLXRandom.seed(31)
+            let seqLen = 7, keyLen = 35, pastLen = keyLen - seqLen
+            let ratio = 4, topK = 2, scale: Float = 1 / sqrt(8)
+            let queries = MLXRandom.normal([1, 4, seqLen, 8])
+            let keys = MLXRandom.normal([1, 2, keyLen, 8])
+            let values = MLXRandom.normal([1, 2, keyLen, 8])
+            let indexQueries = MLXRandom.normal([1, 3, seqLen, 8])
+            let pooled = MLXRandom.normal([1, keyLen / ratio, 8])
+            let mask = try #require(Qwen4ExpQSA.selectedTokenMask(
+                query: indexQueries,
+                pooledKeys: expandedDimensions(pooled, axis: 1),
+                pastLen: pastLen,
+                compressRatio: ratio,
+                blockTopK: topK,
+                keyLen: keyLen))
+            let reference = MLXFast.scaledDotProductAttention(
+                queries: queries, keys: keys, values: values,
+                scale: scale, mask: .array(mask))
+            let gathered = Qwen4ExpQSA.gatheredAttention(
+                queries: queries, keys: keys, values: values,
+                indexQueries: indexQueries, pooledIndexKeys: pooled,
+                pastLen: pastLen, compressRatio: ratio, blockTopK: topK,
+                scale: scale, queryChunk: 3)
+
+            MLX.eval(reference, gathered)
+            #expect(gathered.shape == reference.shape)
+            #expect(MLX.allClose(gathered, reference, rtol: 1e-3, atol: 1e-3).item(Bool.self))
+        }
+    }
+
+    @Test("chunked gathered singleton decode matches the exact sparse-mask reference")
+    func gatheredDecodeParity() throws {
+        try MLXMetalTestLock.withLock {
+            MLXRandom.seed(37)
+            let keyLen = 35, ratio = 4, topK = 2
+            let scale: Float = 1 / sqrt(8)
+            let queries = MLXRandom.normal([1, 4, 1, 8])
+            let keys = MLXRandom.normal([1, 2, keyLen, 8])
+            let values = MLXRandom.normal([1, 2, keyLen, 8])
+            let indexQueries = MLXRandom.normal([1, 3, 1, 8])
+            let pooled = MLXRandom.normal([1, keyLen / ratio, 8])
+            let mask = try #require(Qwen4ExpQSA.selectedTokenMask(
+                query: indexQueries,
+                pooledKeys: expandedDimensions(pooled, axis: 1),
+                pastLen: keyLen - 1,
+                compressRatio: ratio,
+                blockTopK: topK,
+                keyLen: keyLen))
+            let reference = MLXFast.scaledDotProductAttention(
+                queries: queries, keys: keys, values: values,
+                scale: scale, mask: .array(mask))
+            let gathered = Qwen4ExpQSA.gatheredAttention(
+                queries: queries, keys: keys, values: values,
+                indexQueries: indexQueries, pooledIndexKeys: pooled,
+                pastLen: keyLen - 1, compressRatio: ratio, blockTopK: topK,
+                scale: scale)
+
+            MLX.eval(reference, gathered)
+            #expect(MLX.allClose(gathered, reference, rtol: 1e-3, atol: 1e-3).item(Bool.self))
+        }
+    }
+
+    @Test("18K production-budget gathered attention evaluates without a quadratic mask")
+    func gatheredLongContextIsBounded() throws {
+        try MLXMetalTestLock.withLock {
+            let keyLen = 18_432, seqLen = 128, ratio = 4, topK = 512
+            MLXRandom.seed(41)
+            let queries = MLXRandom.normal([1, 24, seqLen, 16]).asType(.float16)
+            let keys = MLXRandom.normal([1, 2, keyLen, 16]).asType(.float16)
+            let values = MLXRandom.normal([1, 2, keyLen, 16]).asType(.float16)
+            let indexQueries = MLXRandom.normal([1, 4, seqLen, 8]).asType(.float16)
+            let pooled = MLXRandom.normal([1, keyLen / ratio, 8]).asType(.float16)
+            let output = Qwen4ExpQSA.gatheredAttention(
+                queries: queries, keys: keys, values: values,
+                indexQueries: indexQueries, pooledIndexKeys: pooled,
+                pastLen: keyLen - seqLen,
+                compressRatio: ratio, blockTopK: topK,
+                scale: 1 / sqrt(16))
+
+            MLX.eval(output)
+            #expect(output.shape == [1, 24, seqLen, 16])
+            #expect(MLX.isFinite(output).all().item(Bool.self))
         }
     }
 }

--- a/Tests/MLXLMTests/Qwen4ExpQSATests.swift
+++ b/Tests/MLXLMTests/Qwen4ExpQSATests.swift
@@ -12,6 +12,20 @@ import Testing
 @Suite("qwen4_exp QSA block selection", .serialized)
 struct Qwen4ExpQSATests {
 
+    @Test("gathered routing preserves fast decode and bounds large prefill")
+    func gatheredRoutingThreshold() {
+        #expect(!Qwen4ExpQSA.shouldUseGatheredAttention(
+            queryTokens: 1, keyTokens: 262_144))
+        #expect(!Qwen4ExpQSA.shouldUseGatheredAttention(
+            queryTokens: 4, keyTokens: 131_072))
+        #expect(!Qwen4ExpQSA.shouldUseGatheredAttention(
+            queryTokens: 32, keyTokens: 32))
+        #expect(Qwen4ExpQSA.shouldUseGatheredAttention(
+            queryTokens: 128, keyTokens: 18_432))
+        #expect(Qwen4ExpQSA.shouldUseGatheredAttention(
+            queryTokens: 18_432, keyTokens: 18_432))
+    }
+
     private func makeMask(
         pastLen: Int, seqLen: Int, keyLen: Int,
         compressRatio: Int = 4, blockTopK: Int = 2, heads: Int = 2, dim: Int = 8


### PR DESCRIPTION
## Summary

- replace Qwen4Exp QSA's `[B,T,blockTopK,keyLen]` token-vs-selected-block broadcast with a bounded block-axis scatter and token repeat
- preserve exact sparse selection, incomplete-tail, and causal-mask semantics
- cover non-divisible key lengths and production `block_topk=512` long-prefill materialization

## Production failure fixed

A Qwen3.8-Flash-Next JANG_2L API request at roughly 18-22K prompt tokens attempted a `258,693,367,808` byte MLX allocation, exceeded the `86,586,540,032` byte maximum buffer, and then crashed in `MLXArray.asArray` while the lazy graph was evaluated from `Qwen4ExpPLE.prefetch`.

The old membership expression compared every raw token with every selected block, producing `[B,T,512,keyLen]`. The replacement marks selected compressed blocks in `[B,T,numBlocks]`, repeats each block by the compression ratio, and only materializes the required `[B,T,keyLen]` mask.

## Proof

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --skip-build --filter Qwen4ExpQSATests`
  - 6/6 passed
  - exact old/new Boolean-mask parity passed
  - 4K, `block_topk=512` materialization passed in 0.168s
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --skip-build --filter Qwen4Exp`
  - 38/38 passed
- `git diff --check`

Live packaged-app replay of the crash-sized API row will be attached before merge.
