### PR TITLE
Jinja: `foo.0` is a subscript, not an identifier

### DIFF
--- a/Tests/MLXLMTests/JinjaNumericMemberTests.swift
+++ b/Tests/MLXLMTests/JinjaNumericMemberTests.swift
@@ -1,0 +1,70 @@
+// Copyright © 2026 osaurus-eval contributors
+// SPDX-License-Identifier: MIT
+//
+// `foo.0` is Jinja's sugar for `foo[0]`, and the parser rejected it.
+//
+// GLM-5.3's chat template writes `m.content.0.type`. The parser threw "Expected identifier but
+// found number", and the CALLER caught that and substituted another family's template — so the
+// model was prompted in Gemma-4's format, answered fluently, and never emitted its own turn-end
+// token, running to the token limit on every request. A parse error two layers down surfaced as
+// "this model rambles".
+
+import Foundation
+import VMLXJinja
+import Testing
+
+@Suite("Jinja numeric member access")
+struct JinjaNumericMemberTests {
+
+    private func render(_ source: String, _ context: [String: Value]) throws -> String {
+        try Template(source).render(context)
+    }
+
+    @Test("foo.0 indexes a list")
+    func numericMemberIndexesAList() throws {
+        let out = try render("{{ items.0 }}", ["items": .array([.string("a"), .string("b")])])
+        #expect(out == "a")
+    }
+
+    @Test("the chain continues after a numeric index")
+    func chainAfterNumericIndex() throws {
+        // Exactly GLM-5.3's shape: `content.0.type`.
+        let out = try render(
+            "{{ content.0.type }}",
+            ["content": .array([
+                .object(["type": .string("tool_reference")]),
+                .object(["type": .string("text")]),
+            ])])
+        #expect(out == "tool_reference")
+    }
+
+    @Test("a numeric index means the same as a bracket subscript")
+    func matchesBracketForm() throws {
+        let context: [String: Value] = [
+            "items": .array([.int(10), .int(20), .int(30)])
+        ]
+        let dotted = try render("{{ items.1 }}", context)
+        let bracketed = try render("{{ items[1] }}", context)
+        #expect(dotted == bracketed)
+        #expect(dotted == "20")
+    }
+
+    /// Attribute access must still work — the fix must not swallow ordinary names.
+    @Test("named attributes are unaffected")
+    func namedAttributesStillWork() throws {
+        let out = try render("{{ m.role }}", ["m": .object(["role": .string("user")])])
+        #expect(out == "user")
+    }
+    /// The lexer change must not break ordinary float literals — that is the thing a
+    /// "only continue a number before a digit" rule could plausibly have broken.
+    @Test("float literals still lex")
+    func floatLiteralsStillWork() throws {
+        #expect(try render("{{ 1.5 }}", [:]) == "1.5")
+        #expect(try render("{{ 0.25 }}", [:]) == "0.25")
+        #expect(try render("{{ 2.0 + 0.5 }}", [:]) == "2.5")
+        // A number followed by a dot and a NON-digit is an index chain, not a float.
+        #expect(
+            try render("{{ rows.0.name }}", ["rows": .array([.object(["name": .string("ok")])])])
+                == "ok")
+    }
+}

--- a/Vendors/Jinja/Sources/Jinja/Lexer.swift
+++ b/Vendors/Jinja/Sources/Jinja/Lexer.swift
@@ -430,7 +430,14 @@ public enum Lexer: Sendable {
             let char = source[pos]
             if char.isNumber {
                 pos = source.index(after: pos)
-            } else if char == "." && !hasDot {
+            } else if char == "." && !hasDot
+                && source.index(after: pos) < source.endIndex
+                && source[source.index(after: pos)].isNumber
+            {
+                // A dot only continues the number when a DIGIT follows it. In `content.0.type`
+                // the trailing dot is a member separator, and swallowing it produced the number
+                // "0." — which then failed to parse as an index and surfaced, three layers up, as
+                // a model that would not stop generating.
                 hasDot = true
                 pos = source.index(after: pos)
             } else {

--- a/Vendors/Jinja/Sources/Jinja/Parser.swift
+++ b/Vendors/Jinja/Sources/Jinja/Parser.swift
@@ -519,8 +519,20 @@ public struct Parser: Sendable {
 
         while true {
             if match(.dot) {
-                let name = try consumeIdentifier()
-                expr = .member(expr, .identifier(name), computed: false)
+                // `foo.0` is Jinja's sugar for `foo[0]` — a NUMBER after the dot is a subscript,
+                // not an attribute name. Rejecting it failed GLM-5.3's chat template ("Expected
+                // identifier but found number"), and because the caller catches a template failure
+                // and substitutes a family fallback, the model was then prompted in a DIFFERENT
+                // family's format: fluent, plausible, and never emitting its own turn-end token, so
+                // generation ran to the token limit every time.
+                let token = peek()
+                if token.kind == .number, let index = Int(token.value) {
+                    advance()
+                    expr = .member(expr, .integer(index), computed: true)
+                } else {
+                    let name = try consumeIdentifier()
+                    expr = .member(expr, .identifier(name), computed: false)
+                }
             } else if match(.openBracket) {
                 // Slice or subscript
                 let start = try? parseExpression()


### PR DESCRIPTION
`foo.0` is Jinja's sugar for `foo[0]`. The parser expected an identifier after the dot, so any template using it failed to compile.

That matters more than it looks, because `applyChatTemplate`'s caller catches a template failure and substitutes a family fallback keyed on `bos_token`. GLM-5.3's template writes `m.content.0.type`, so the model was silently prompted in **Gemma-4's** format instead of its own — fluent, plausible, and never emitting its own `<|user|>` turn-end token, which is one of its three declared eos ids. Every request ran to the token cap and then invented a new user turn. The only visible symptom was "this model rambles".

Two fixes, each at the level it belongs to:

* the **lexer** continues a number across a dot only when a DIGIT follows, so `0.type` lexes as `0` `.` `type` rather than the float `0.`. A parser-only fix is not enough — the greedy number rule swallows the separator first;
* the **parser** then accepts a number after a dot as a computed subscript.

`JinjaNumericMemberTests` covers `items.0`, the chain `content.0.type`, equivalence with `items[1]`, plain attribute access, and a **float-literal guard** — "only continue before a digit" is exactly the rule that could have broken `1.5`, so it is asserted rather than assumed.

Verified on the model: the rendered prompt becomes `[gMASK]<sop><|system|>Reasoning Effort: Max<|user|>Hi.<|assistant|><think>`, the fallback engages zero times, and answers terminate cleanly instead of running on. The full suite passes, which matters here because every model's chat template goes through this lexer.

`VMLX_CHAT_TEMPLATE_FALLBACK_DISABLE=1` is what made this findable — the fallback is helpful enough to hide its own cause.
