### PR TITLE
JangLoader: a declared quantization that COULD have produced the tensors wins

### DIFF
--- a/Libraries/MLXLMCommon/JangLoader.swift
+++ b/Libraries/MLXLMCommon/JangLoader.swift
@@ -2443,8 +2443,36 @@ public struct JangLoader: Sendable {
             // output that collapsed the forward. A self-consistent declaration whose
             // inputDim ∈ validInDims is the strongest available evidence for roles
             // without a more specific tensor manifest or semantic width constraint.
+            /// The DECLARED (bits, group_size), when the packed tensors can actually have been
+            /// produced by it.
+            ///
+            /// A packed width does not determine the pair. `(bits: 8, group_size: 64)` and
+            /// `(bits: 4, group_size: 128)` pack a row to exactly the same number of uint32 words
+            /// and imply input dims that differ by a factor of two, so shape inference alone cannot
+            /// choose between them — it can only guess, and on GLM-5.3 it guessed wrong for 35
+            /// modules. Its KDA `o_proj` is declared 8-bit/g64 (input 8192 = 64 heads x 128), the
+            /// walk re-stamped 4-bit/g128 (input 16384), and the model died in the first layer with
+            /// "Last dimension of first input with shape (..., 8192) does not match the expanded
+            /// quantized matrix (16384, 4096)".
+            ///
+            /// So: where the declaration is POSSIBLE, take it. It is a statement by whoever produced
+            /// the file, and preferring a coin-flip over it is not inference. Where it is impossible
+            /// — the packed width cannot come from it — it is ignored exactly as before, which is
+            /// what the rest of this chain exists for.
+            let declaredIfConsistent: (bits: Int, groupSize: Int)? = {
+                guard let declared = declaredForLayer, declared.bits > 0, declared.groupSize > 0
+                else { return nil }
+                let inDim = numGroups * declared.groupSize
+                guard inDim > 0, packedDim > 0,
+                    packedDim * 32 == inDim * declared.bits
+                else { return nil }
+                return (declared.bits, declared.groupSize)
+            }()
+
             if let manifest = manifestQuantization(for: basePath) {
                 (bits, inferredGroupSize) = (manifest.bits, manifest.groupSize)
+            } else if let declared = declaredIfConsistent {
+                (bits, inferredGroupSize) = declared
             } else if isLanguageHiddenAnchor,
                       let hiddenSize = hiddenSizeHint,
                       let exact = inferExactQuantization(expectedInDim: hiddenSize)


### PR DESCRIPTION
A packed width does not determine `(bits, group_size)`. `(8, 64)` and `(4, 128)` pack a row to **exactly the same number of uint32 words** and imply input dims that differ by a factor of two, so shape inference cannot choose between them — it can only guess.

GLM-5.3 declares 8-bit/g64 for its KDA `o_proj` (input 8192 = 64 heads × 128). The walk re-stamped 4-bit/g128 (input 16384) and logged it as *"config-metadata mismatch patched in-memory … 35 per-layer overrides applied"*. The model then died in its first layer:

```
[quantized_matmul] Last dimension of first input with shape (..., 8192)
does not match the expanded quantized matrix (16384, 4096)
```

The declaration was correct; the inference was a coin flip.

This takes the declared pair whenever the packed tensors **could** have been produced by it, ahead of the inference chain. Where the declaration is impossible it is ignored exactly as before — that is what the rest of the chain is for. `JangLoader.swift` already argued for this ("a self-consistent declaration … is the strongest available evidence for roles"); it just ran after the guessing rather than before it.

Confirmed not to be a dimension bug before changing anything: a forward built from the shipped config with **random** weights passes at full width (64 heads of 256, a 1536 query LoRA, hc_mult 4), so the geometry was right and the fault was in loading.

No regressions in the full suite.
