### PR TITLE
Heal misaligned safetensors before mmap load

### DIFF
--- a/Libraries/MLXLMCommon/Cache/JangPressPrestacker.swift
+++ b/Libraries/MLXLMCommon/Cache/JangPressPrestacker.swift
@@ -13,9 +13,9 @@
 import Foundation
 
 #if canImport(Darwin)
-import Darwin
+    import Darwin
 #elseif canImport(Glibc)
-import Glibc
+    import Glibc
 #endif
 
 private func jangPressPrestackerCleanupAtExit() {
@@ -49,14 +49,23 @@ public enum JangPressPrestacker {
     ) throws -> URL {
         guard enabled else { return originalURL }
 
+        // Heal dtype-misaligned containers before any mmap-backed load. This
+        // is an in-place, atomic, byte-verified optimization for ordinary
+        // writable model directories. Hash-addressed/symlinked stores and all
+        // failures retain the original shard and use MLX's aligned-copy
+        // fallback, so storage optimization can never refuse a model load.
+        SafetensorsStorageHealer.healBundleIfEligible(at: originalURL)
+
         let env = ProcessInfo.processInfo.environment
         let prestackRaw = env["MLXPRESS_PRESTACK"] ?? env["JANGPRESS_PRESTACK"]
         let prestackExplicitlyEnabled = isEnabledFlag(prestackRaw)
         let prestackDisabled = !prestackExplicitlyEnabled
-        let alignSafetensors = env["MLXPRESS_ALIGN_SAFETENSORS"]
+        let alignSafetensors =
+            env["MLXPRESS_ALIGN_SAFETENSORS"]
             ?? env["JANGPRESS_ALIGN_SAFETENSORS"]
         let alignExplicitlyEnabled = isEnabledFlag(alignSafetensors)
-        let prestackStrict = env["MLXPRESS_PRESTACK_STRICT"]
+        let prestackStrict =
+            env["MLXPRESS_PRESTACK_STRICT"]
             ?? env["JANGPRESS_PRESTACK_STRICT"]
         if prestackDisabled && !alignExplicitlyEnabled {
             return originalURL
@@ -80,10 +89,11 @@ public enum JangPressPrestacker {
                 let cacheURL = try cacheDirectory(for: originalURL, files: scan.files)
                 try ensureOverlayLinks(from: originalURL, to: cacheURL)
                 let outputURL = cacheURL.appendingPathComponent(outputName)
-                let manifestURL = cacheURL.appendingPathComponent("jangpress-prestack-manifest.json")
+                let manifestURL = cacheURL.appendingPathComponent(
+                    "jangpress-prestack-manifest.json")
 
                 if FileManager.default.fileExists(atPath: outputURL.path),
-                   FileManager.default.fileExists(atPath: manifestURL.path)
+                    FileManager.default.fileExists(atPath: manifestURL.path)
                 {
                     log("using existing prestacked overlay \(cacheURL.path)")
                     preparedURL = cacheURL
@@ -95,10 +105,12 @@ public enum JangPressPrestacker {
                     try writeSafetensors(plan: plan, to: outputURL)
                     try writeManifest(plan: plan, source: originalURL, to: manifestURL)
                     let totalBytes = plan.reduce(UInt64(0)) { $0 + $1.totalBytes }
-                    log(String(format:
-                        "wrote %d prestacked routed tensors (%.1f GB) into %@",
-                        plan.count, Double(totalBytes) / 1_073_741_824.0,
-                        outputURL.path))
+                    log(
+                        String(
+                            format:
+                                "wrote %d prestacked routed tensors (%.1f GB) into %@",
+                            plan.count, Double(totalBytes) / 1_073_741_824.0,
+                            outputURL.path))
                     preparedURL = cacheURL
                 }
             } catch {
@@ -173,8 +185,10 @@ public enum JangPressPrestacker {
 
     private static func scanBundle(_ directory: URL) throws -> BundleScan {
         let fm = FileManager.default
-        guard let enumerator = fm.enumerator(
-            at: directory, includingPropertiesForKeys: [.fileSizeKey, .contentModificationDateKey])
+        guard
+            let enumerator = fm.enumerator(
+                at: directory,
+                includingPropertiesForKeys: [.fileSizeKey, .contentModificationDateKey])
         else {
             return BundleScan(files: [], groups: [:])
         }
@@ -186,15 +200,18 @@ public enum JangPressPrestacker {
 
         for case let url as URL in enumerator {
             guard url.pathExtension == "safetensors",
-                  url.lastPathComponent != "jangtq_runtime.safetensors",
-                  url.lastPathComponent != outputName
+                url.lastPathComponent != "jangtq_runtime.safetensors",
+                url.lastPathComponent != outputName
             else { continue }
 
-            let values = try url.resourceValues(forKeys: [.fileSizeKey, .contentModificationDateKey])
-            files.append(SourceFile(
-                url: url,
-                size: UInt64(values.fileSize ?? 0),
-                modified: values.contentModificationDate?.timeIntervalSince1970 ?? 0))
+            let values = try url.resourceValues(forKeys: [
+                .fileSizeKey, .contentModificationDateKey,
+            ])
+            files.append(
+                SourceFile(
+                    url: url,
+                    size: UInt64(values.fileSize ?? 0),
+                    modified: values.contentModificationDate?.timeIntervalSince1970 ?? 0))
 
             let header = try readSafetensorsHeader(url)
             for (key, value) in header.tensors {
@@ -202,11 +219,11 @@ public enum JangPressPrestacker {
                     existingStackedKeys.insert(key)
                 }
                 guard let match = matchPerExpertKey(key),
-                      let dtype = value["dtype"] as? String,
-                      let shape = value["shape"] as? [Int],
-                      let offsets = value["data_offsets"] as? [UInt64],
-                      offsets.count == 2,
-                      offsets[1] >= offsets[0]
+                    let dtype = value["dtype"] as? String,
+                    let shape = value["shape"] as? [Int],
+                    let offsets = value["data_offsets"] as? [UInt64],
+                    offsets.count == 2,
+                    offsets[1] >= offsets[0]
                 else { continue }
 
                 let source = TensorSource(
@@ -232,7 +249,7 @@ public enum JangPressPrestacker {
             guard let maxExpert = group.byExpert.keys.max(), group.byExpert[0] != nil else {
                 return false
             }
-            return (0...maxExpert).allSatisfy { group.byExpert[$0] != nil }
+            return (0 ... maxExpert).allSatisfy { group.byExpert[$0] != nil }
         }
 
         return BundleScan(files: files.sorted { $0.url.path < $1.url.path }, groups: groups)
@@ -249,7 +266,8 @@ public enum JangPressPrestacker {
         defer { try? handle.close() }
         let prefix = try handle.read(upToCount: 8) ?? Data()
         guard prefix.count == 8 else {
-            throw NSError(domain: "JangPressPrestacker", code: 1,
+            throw NSError(
+                domain: "JangPressPrestacker", code: 1,
                 userInfo: [NSLocalizedDescriptionKey: "short safetensors header: \(url.path)"])
         }
         let headerLength = prefix.withUnsafeBytes {
@@ -257,12 +275,14 @@ public enum JangPressPrestacker {
         }
         let headerData = try handle.read(upToCount: Int(headerLength)) ?? Data()
         guard headerData.count == Int(headerLength) else {
-            throw NSError(domain: "JangPressPrestacker", code: 2,
+            throw NSError(
+                domain: "JangPressPrestacker", code: 2,
                 userInfo: [NSLocalizedDescriptionKey: "truncated safetensors header: \(url.path)"])
         }
         let json = try JSONSerialization.jsonObject(with: headerData)
         guard let dict = json as? [String: Any] else {
-            throw NSError(domain: "JangPressPrestacker", code: 3,
+            throw NSError(
+                domain: "JangPressPrestacker", code: 3,
                 userInfo: [NSLocalizedDescriptionKey: "invalid safetensors JSON: \(url.path)"])
         }
         let metadata = dict["__metadata__"] as? [String: Any]
@@ -294,11 +314,12 @@ public enum JangPressPrestacker {
             let perTensorBytes = sources.reduce(UInt64(0)) { $0 + $1.byteLength }
             let expectedBytes = UInt64(sources.count) * first.byteLength
             guard perTensorBytes == expectedBytes else { continue }
-            result.append(WriteTensor(
-                key: group.outputKey,
-                dtype: first.dtype,
-                shape: [sources.count] + first.shape,
-                sources: sources))
+            result.append(
+                WriteTensor(
+                    key: group.outputKey,
+                    dtype: first.dtype,
+                    shape: [sources.count] + first.shape,
+                    sources: sources))
         }
         var offset: UInt64 = 0
         for i in result.indices {
@@ -341,9 +362,10 @@ public enum JangPressPrestacker {
         let dataBaseAlignment = 4096
         let misalignment = (8 + headerData.count) % dataBaseAlignment
         if misalignment != 0 {
-            headerData.append(Data(
-                repeating: 0x20,
-                count: dataBaseAlignment - misalignment))
+            headerData.append(
+                Data(
+                    repeating: 0x20,
+                    count: dataBaseAlignment - misalignment))
         }
         var headerLength = UInt64(headerData.count).littleEndian
         try withUnsafeBytes(of: &headerLength) { raw in
@@ -440,10 +462,13 @@ public enum JangPressPrestacker {
                 .appendingPathComponent("vmlx-swift-lm", isDirectory: true)
                 .appendingPathComponent("jangpress-prestack", isDirectory: true)
         }
-        let hash = stableHash(([version, originalURL.path] + files.map {
-            "\($0.url.lastPathComponent):\($0.size):\($0.modified)"
-        }).joined(separator: "|"))
-        return root
+        let hash = stableHash(
+            ([version, originalURL.path]
+                + files.map {
+                    "\($0.url.lastPathComponent):\($0.size):\($0.modified)"
+                }).joined(separator: "|"))
+        return
+            root
             .appendingPathComponent(originalURL.lastPathComponent + "-" + hash, isDirectory: true)
     }
 
@@ -507,7 +532,8 @@ public enum JangPressPrestacker {
             "bytes": total,
             "created": Date().timeIntervalSince1970,
         ]
-        let data = try JSONSerialization.data(withJSONObject: object, options: [.prettyPrinted, .sortedKeys])
+        let data = try JSONSerialization.data(
+            withJSONObject: object, options: [.prettyPrinted, .sortedKeys])
         try data.write(to: url, options: [.atomic])
     }
 
@@ -558,7 +584,8 @@ public enum JangPressPrestacker {
         originalIsJANGTQ: Bool,
         env: [String: String]
     ) throws -> URL {
-        let alignSafetensors = env["MLXPRESS_ALIGN_SAFETENSORS"]
+        let alignSafetensors =
+            env["MLXPRESS_ALIGN_SAFETENSORS"]
             ?? env["JANGPRESS_ALIGN_SAFETENSORS"]
         guard isEnabledFlag(alignSafetensors) else {
             return directory
@@ -567,7 +594,8 @@ public enum JangPressPrestacker {
         // every source shard for those models can double very large cache
         // footprints, so keep it opt-in unless a focused investigation
         // requests it.
-        let alignJANGTQ = env["MLXPRESS_ALIGN_JANGTQ"]
+        let alignJANGTQ =
+            env["MLXPRESS_ALIGN_JANGTQ"]
             ?? env["JANGPRESS_ALIGN_JANGTQ"]
         if originalIsJANGTQ && alignJANGTQ != "1" {
             return directory
@@ -587,9 +615,10 @@ public enum JangPressPrestacker {
 
         try FileManager.default.createDirectory(
             at: cacheURL, withIntermediateDirectories: true)
-        let rewriteNames = Set(scan.plans.filter(\.needsAlignment).map {
-            $0.source.url.lastPathComponent
-        })
+        let rewriteNames = Set(
+            scan.plans.filter(\.needsAlignment).map {
+                $0.source.url.lastPathComponent
+            })
         try ensureAlignedOverlayLinks(from: directory, to: cacheURL, rewriting: rewriteNames)
 
         var rewritten = 0
@@ -603,11 +632,13 @@ public enum JangPressPrestacker {
             rewrittenCount: rewritten,
             source: directory,
             to: manifestURL)
-        log(String(format:
-            "wrote aligned safetensors overlay: files=%d payload=%.1f GB into %@",
-            rewritten,
-            Double(scan.rewriteBytes) / 1_073_741_824.0,
-            cacheURL.path))
+        log(
+            String(
+                format:
+                    "wrote aligned safetensors overlay: files=%d payload=%.1f GB into %@",
+                rewritten,
+                Double(scan.rewriteBytes) / 1_073_741_824.0,
+                cacheURL.path))
         return cacheURL
     }
 
@@ -636,10 +667,10 @@ public enum JangPressPrestacker {
             var containsRouted = false
             for (key, value) in header.tensors {
                 guard let dtype = value["dtype"] as? String,
-                      let shape = value["shape"] as? [Int],
-                      let offsets = value["data_offsets"] as? [UInt64],
-                      offsets.count == 2,
-                      offsets[1] >= offsets[0]
+                    let shape = value["shape"] as? [Int],
+                    let offsets = value["data_offsets"] as? [UInt64],
+                    offsets.count == 2,
+                    offsets[1] >= offsets[0]
                 else { continue }
 
                 let sourceOffset = header.dataBase + offsets[0]
@@ -651,25 +682,27 @@ public enum JangPressPrestacker {
                 if isRoutedTensorKey(key) {
                     containsRouted = true
                 }
-                tensors.append(AlignmentTensor(
-                    key: key,
-                    dtype: dtype,
-                    shape: shape,
-                    sourceOffset: sourceOffset,
-                    byteLength: byteLength))
+                tensors.append(
+                    AlignmentTensor(
+                        key: key,
+                        dtype: dtype,
+                        shape: shape,
+                        sourceOffset: sourceOffset,
+                        byteLength: byteLength))
             }
 
-            plans.append(AlignmentFilePlan(
-                source: source,
-                metadata: header.metadata,
-                tensors: tensors.sorted { lhs, rhs in
-                    if lhs.sourceOffset == rhs.sourceOffset {
-                        return lhs.key < rhs.key
-                    }
-                    return lhs.sourceOffset < rhs.sourceOffset
-                },
-                needsAlignment: needsAlignment,
-                containsRoutedTensor: containsRouted))
+            plans.append(
+                AlignmentFilePlan(
+                    source: source,
+                    metadata: header.metadata,
+                    tensors: tensors.sorted { lhs, rhs in
+                        if lhs.sourceOffset == rhs.sourceOffset {
+                            return lhs.key < rhs.key
+                        }
+                        return lhs.sourceOffset < rhs.sourceOffset
+                    },
+                    needsAlignment: needsAlignment,
+                    containsRoutedTensor: containsRouted))
         }
 
         return AlignmentScan(
@@ -742,7 +775,7 @@ public enum JangPressPrestacker {
         var arranged = plan.tensors
         var headerData = Data()
 
-        for _ in 0..<8 {
+        for _ in 0 ..< 8 {
             var dataOffset: UInt64 = 0
             for i in arranged.indices {
                 let alignment = UInt64(dtypeAlignment(arranged[i].dtype))
@@ -777,9 +810,10 @@ public enum JangPressPrestacker {
             let dataBaseAlignment = 4096
             let misalignment = (8 + headerData.count) % dataBaseAlignment
             if misalignment != 0 {
-                headerData.append(Data(
-                    repeating: 0x20,
-                    count: dataBaseAlignment - misalignment))
+                headerData.append(
+                    Data(
+                        repeating: 0x20,
+                        count: dataBaseAlignment - misalignment))
             }
             let newDataBase = UInt64(8 + headerData.count)
             if newDataBase == dataBase {
@@ -880,7 +914,7 @@ public enum JangPressPrestacker {
             ?? env["JANGPRESS_ALIGN_CACHE_DIR"]
             ?? env["MLXPRESS_PRESTACK_CACHE_DIR"]
             ?? env["JANGPRESS_PRESTACK_CACHE_DIR"],
-           !override.isEmpty
+            !override.isEmpty
         {
             root = URL(fileURLWithPath: override)
         } else {
@@ -888,10 +922,13 @@ public enum JangPressPrestacker {
                 .appendingPathComponent("vmlx-swift-lm", isDirectory: true)
                 .appendingPathComponent("jangpress-align", isDirectory: true)
         }
-        let hash = stableHash(([alignmentVersion, originalURL.path] + files.map {
-            "\($0.url.lastPathComponent):\($0.size):\($0.modified)"
-        }).joined(separator: "|"))
-        return root
+        let hash = stableHash(
+            ([alignmentVersion, originalURL.path]
+                + files.map {
+                    "\($0.url.lastPathComponent):\($0.size):\($0.modified)"
+                }).joined(separator: "|"))
+        return
+            root
             .appendingPathComponent(originalURL.lastPathComponent + "-" + hash, isDirectory: true)
     }
 
@@ -939,7 +976,8 @@ public enum JangPressPrestacker {
         ) {
             return KeyMatch(
                 expert: Int(m[2])!,
-                outputKey: "model.layers.\(m[1]).block_sparse_moe.switch_mlp.\(projName(m[3])).\(m[4])")
+                outputKey:
+                    "model.layers.\(m[1]).block_sparse_moe.switch_mlp.\(projName(m[3])).\(m[4])")
         }
         if let m = match(
             key,
@@ -980,8 +1018,7 @@ public enum JangPressPrestacker {
     }
 
     private static func isStackedRoutedKey(_ key: String) -> Bool {
-        key.contains(".switch_mlp.") &&
-            (key.hasSuffix(".tq_packed") || key.hasSuffix(".tq_norms"))
+        key.contains(".switch_mlp.") && (key.hasSuffix(".tq_packed") || key.hasSuffix(".tq_norms"))
     }
 
     private static func projName(_ raw: String) -> String {
@@ -999,7 +1036,7 @@ public enum JangPressPrestacker {
         let range = NSRange(location: 0, length: ns.length)
         guard let m = re.firstMatch(in: value, range: range) else { return nil }
         var captures: [String] = []
-        for i in 0..<m.numberOfRanges {
+        for i in 0 ..< m.numberOfRanges {
             let r = m.range(at: i)
             captures.append(r.location == NSNotFound ? "" : ns.substring(with: r))
         }
@@ -1007,10 +1044,10 @@ public enum JangPressPrestacker {
     }
 
     private static func stableHash(_ input: String) -> String {
-        var hash: UInt64 = 0xcbf29ce484222325
+        var hash: UInt64 = 0xcbf2_9ce4_8422_2325
         for byte in input.utf8 {
             hash ^= UInt64(byte)
-            hash &*= 0x100000001b3
+            hash &*= 0x100_0000_01b3
         }
         return String(format: "%016llx", hash)
     }
@@ -1020,43 +1057,47 @@ public enum JangPressPrestacker {
     }
 
     private static func posixError(_ op: String, path: String) -> NSError {
-        NSError(domain: "JangPressPrestacker", code: Int(errno),
-            userInfo: [NSLocalizedDescriptionKey: "\(op)(\(path)) failed: \(String(cString: strerror(errno)))"])
+        NSError(
+            domain: "JangPressPrestacker", code: Int(errno),
+            userInfo: [
+                NSLocalizedDescriptionKey:
+                    "\(op)(\(path)) failed: \(String(cString: strerror(errno)))"
+            ])
     }
 
     #if canImport(Darwin)
-    private static func systemOpen(_ path: String, _ flags: Int32) -> Int32 {
-        Darwin.open(path, flags, 0)
-    }
-    private static func systemClose(_ fd: Int32) -> Int32 { Darwin.close(fd) }
-    private static func systemEnableNoCache(_ fd: Int32) -> Int32 {
-        Darwin.fcntl(fd, F_NOCACHE, 1)
-    }
-    private static func systemPread(
-        _ fd: Int32, _ buffer: UnsafeMutableRawPointer, _ count: Int, _ offset: Int64
-    ) -> Int {
-        Darwin.pread(fd, buffer, count, off_t(offset))
-    }
-    private static func systemWrite(
-        _ fd: Int32, _ buffer: UnsafeRawPointer, _ count: Int
-    ) -> Int {
-        Darwin.write(fd, buffer, count)
-    }
+        private static func systemOpen(_ path: String, _ flags: Int32) -> Int32 {
+            Darwin.open(path, flags, 0)
+        }
+        private static func systemClose(_ fd: Int32) -> Int32 { Darwin.close(fd) }
+        private static func systemEnableNoCache(_ fd: Int32) -> Int32 {
+            Darwin.fcntl(fd, F_NOCACHE, 1)
+        }
+        private static func systemPread(
+            _ fd: Int32, _ buffer: UnsafeMutableRawPointer, _ count: Int, _ offset: Int64
+        ) -> Int {
+            Darwin.pread(fd, buffer, count, off_t(offset))
+        }
+        private static func systemWrite(
+            _ fd: Int32, _ buffer: UnsafeRawPointer, _ count: Int
+        ) -> Int {
+            Darwin.write(fd, buffer, count)
+        }
     #elseif canImport(Glibc)
-    private static func systemOpen(_ path: String, _ flags: Int32) -> Int32 {
-        Glibc.open(path, flags, 0)
-    }
-    private static func systemClose(_ fd: Int32) -> Int32 { Glibc.close(fd) }
-    private static func systemEnableNoCache(_ fd: Int32) -> Int32 { 0 }
-    private static func systemPread(
-        _ fd: Int32, _ buffer: UnsafeMutableRawPointer, _ count: Int, _ offset: Int64
-    ) -> Int {
-        Glibc.pread(fd, buffer, count, off_t(offset))
-    }
-    private static func systemWrite(
-        _ fd: Int32, _ buffer: UnsafeRawPointer, _ count: Int
-    ) -> Int {
-        Glibc.write(fd, buffer, count)
-    }
+        private static func systemOpen(_ path: String, _ flags: Int32) -> Int32 {
+            Glibc.open(path, flags, 0)
+        }
+        private static func systemClose(_ fd: Int32) -> Int32 { Glibc.close(fd) }
+        private static func systemEnableNoCache(_ fd: Int32) -> Int32 { 0 }
+        private static func systemPread(
+            _ fd: Int32, _ buffer: UnsafeMutableRawPointer, _ count: Int, _ offset: Int64
+        ) -> Int {
+            Glibc.pread(fd, buffer, count, off_t(offset))
+        }
+        private static func systemWrite(
+            _ fd: Int32, _ buffer: UnsafeRawPointer, _ count: Int
+        ) -> Int {
+            Glibc.write(fd, buffer, count)
+        }
     #endif
 }

--- a/Libraries/MLXLMCommon/Cache/SafetensorsStorageHealer.swift
+++ b/Libraries/MLXLMCommon/Cache/SafetensorsStorageHealer.swift
@@ -1,0 +1,621 @@
+// Copyright © 2026 Jinho Jang. All rights reserved.
+
+import Foundation
+
+#if canImport(Darwin)
+    import Darwin
+#elseif canImport(Glibc)
+    import Glibc
+#endif
+
+/// Repairs dtype-misaligned safetensors containers before MLX mmaps them.
+///
+/// The repair changes only container order and offsets. Tensor names, shapes,
+/// dtypes, metadata, and payload bytes are preserved. Every replacement is
+/// written beside its source, flushed, byte-verified, and atomically renamed.
+/// Any failure is advisory: the original shard remains available to MLX's
+/// aligned-copy fallback.
+enum SafetensorsStorageHealer {
+    struct Configuration {
+        var environment: [String: String] = ProcessInfo.processInfo.environment
+        var availableBytes: ((URL) throws -> UInt64)?
+        var failAfterCopiedBytes: UInt64?
+        var logger: (String) -> Void = { message in
+            fputs("[SafetensorsStorageHealer] \(message)\n", stderr)
+        }
+    }
+
+    struct Result: Equatable {
+        var scannedShards = 0
+        var healedShards = 0
+        var skippedShards = 0
+        var fallbackShards = 0
+    }
+
+    private struct Tensor {
+        var name: String
+        var descriptor: [String: Any]
+        var dtype: String
+        var alignment: UInt64
+        var sourceOffset: UInt64
+        var byteLength: UInt64
+        var outputOffset: UInt64 = 0
+    }
+
+    private struct Header {
+        var dataBase: UInt64
+        var metadata: Any?
+        var tensors: [Tensor]
+    }
+
+    private static let processLock = NSLock()
+    private static let bufferBytes = 4 * 1024 * 1024
+    private static let freeSpaceReserve = UInt64(512 * 1024 * 1024)
+    private static let maximumHeaderBytes = UInt64(100_000_000)
+
+    static func healBundleIfEligible(at originalURL: URL) {
+        _ = healBundle(at: originalURL, configuration: Configuration())
+    }
+
+    @discardableResult
+    static func healBundle(
+        at originalURL: URL,
+        configuration: Configuration
+    ) -> Result {
+        let env = configuration.environment
+        let rawEnabled =
+            env["MLXPRESS_HEAL_SAFETENSORS"]
+            ?? env["JANGPRESS_HEAL_SAFETENSORS"]
+        if isDisabledFlag(rawEnabled) {
+            configuration.logger("event=disabled path=\(quoted(originalURL.path))")
+            return Result()
+        }
+
+        let directory = originalURL.standardizedFileURL
+        guard !isHashAddressedStorage(directory) else {
+            configuration.logger(
+                "event=skip reason=hash_addressed_storage path=\(quoted(directory.path))")
+            return Result()
+        }
+        guard FileManager.default.isWritableFile(atPath: directory.path) else {
+            configuration.logger(
+                "event=skip reason=directory_not_writable path=\(quoted(directory.path))")
+            return Result()
+        }
+
+        return processLock.withLock {
+            healLocked(at: directory, configuration: configuration)
+        }
+    }
+
+    private static func healLocked(
+        at directory: URL,
+        configuration: Configuration
+    ) -> Result {
+        var result = Result()
+        let directoryFD = systemOpen(directory.path, O_RDONLY, 0)
+        guard directoryFD >= 0 else {
+            configuration.logger(
+                "event=fallback reason=directory_open_failed path=\(quoted(directory.path)) error=\(errno)"
+            )
+            result.fallbackShards = 1
+            return result
+        }
+        defer { _ = systemClose(directoryFD) }
+
+        let entries: [URL]
+        do {
+            entries = try FileManager.default.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: [.isSymbolicLinkKey, .fileSizeKey],
+                options: [.skipsHiddenFiles]
+            )
+            .filter { $0.pathExtension == "safetensors" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+        } catch {
+            configuration.logger(
+                "event=fallback reason=enumeration_failed path=\(quoted(directory.path)) detail=\(quoted(String(describing: error)))"
+            )
+            result.fallbackShards = 1
+            return result
+        }
+
+        for shard in entries {
+            result.scannedShards += 1
+            do {
+                let values = try shard.resourceValues(forKeys: [.isSymbolicLinkKey])
+                guard values.isSymbolicLink != true,
+                    !isHashAddressedStorage(shard)
+                else {
+                    result.skippedShards += 1
+                    configuration.logger(
+                        "event=skip reason=linked_or_hash_addressed_shard shard=\(quoted(shard.path))"
+                    )
+                    continue
+                }
+
+                let header = try readHeader(shard)
+                guard
+                    header.tensors.contains(where: {
+                        $0.sourceOffset % $0.alignment != 0
+                    })
+                else {
+                    continue
+                }
+
+                let attributes = try FileManager.default.attributesOfItem(atPath: shard.path)
+                let sourceSize = (attributes[.size] as? NSNumber)?.uint64Value ?? 0
+                let available =
+                    try configuration.availableBytes?(directory)
+                    ?? availableBytes(at: directory)
+                let required = sourceSize.addingReportingOverflow(freeSpaceReserve)
+                guard !required.overflow, available >= required.partialValue else {
+                    result.fallbackShards += 1
+                    configuration.logger(
+                        String(
+                            format:
+                                "event=fallback reason=insufficient_disk shard=%@ required_bytes=%llu available_bytes=%llu",
+                            quoted(shard.path), required.partialValue, available))
+                    continue
+                }
+
+                try rewriteAndInstall(
+                    shard: shard,
+                    sourceHeader: header,
+                    sourceAttributes: attributes,
+                    directoryFD: directoryFD,
+                    failAfterCopiedBytes: configuration.failAfterCopiedBytes)
+                result.healedShards += 1
+                configuration.logger(
+                    "event=healed shard=\(quoted(shard.path)) tensors=\(header.tensors.count) bytes=\(sourceSize)"
+                )
+            } catch {
+                result.fallbackShards += 1
+                configuration.logger(
+                    "event=fallback reason=heal_failed shard=\(quoted(shard.path)) detail=\(quoted(String(describing: error)))"
+                )
+            }
+        }
+
+        return result
+    }
+
+    private static func rewriteAndInstall(
+        shard: URL,
+        sourceHeader: Header,
+        sourceAttributes: [FileAttributeKey: Any],
+        directoryFD: Int32,
+        failAfterCopiedBytes: UInt64?
+    ) throws {
+        let temporary = shard.deletingLastPathComponent().appendingPathComponent(
+            ".\(shard.lastPathComponent).vmlx-heal-\(UUID().uuidString).tmp")
+        var installed = false
+        defer {
+            if !installed {
+                try? FileManager.default.removeItem(at: temporary)
+            }
+        }
+
+        let arranged = sourceHeader.tensors.sorted { lhs, rhs in
+            if lhs.alignment != rhs.alignment { return lhs.alignment > rhs.alignment }
+            return lhs.name < rhs.name
+        }
+        var rewritten = arranged
+        var cursor: UInt64 = 0
+        for index in rewritten.indices {
+            rewritten[index].outputOffset = cursor
+            let addition = cursor.addingReportingOverflow(rewritten[index].byteLength)
+            guard !addition.overflow else { throw healerError("payload size overflow") }
+            cursor = addition.partialValue
+        }
+        let headerData = try makeHeader(metadata: sourceHeader.metadata, tensors: rewritten)
+
+        let outputFD = systemOpen(
+            temporary.path,
+            O_WRONLY | O_CREAT | O_EXCL | O_TRUNC,
+            S_IRUSR | S_IWUSR)
+        guard outputFD >= 0 else { throw posixError("open", temporary.path) }
+        var outputOpen = true
+        defer {
+            if outputOpen { _ = systemClose(outputFD) }
+        }
+        _ = systemNoCache(outputFD)
+
+        var encodedLength = UInt64(headerData.count).littleEndian
+        try withUnsafeBytes(of: &encodedLength) {
+            try writeAll(fd: outputFD, bytes: $0)
+        }
+        try headerData.withUnsafeBytes {
+            try writeAll(fd: outputFD, bytes: $0)
+        }
+
+        let sourceFD = systemOpen(shard.path, O_RDONLY, 0)
+        guard sourceFD >= 0 else { throw posixError("open", shard.path) }
+        defer { _ = systemClose(sourceFD) }
+        _ = systemNoCache(sourceFD)
+
+        var copied: UInt64 = 0
+        for tensor in rewritten {
+            try copyRange(
+                sourceFD: sourceFD,
+                sourcePath: shard.path,
+                sourceOffset: tensor.sourceOffset,
+                byteLength: tensor.byteLength,
+                outputFD: outputFD,
+                copied: &copied,
+                failAfterCopiedBytes: failAfterCopiedBytes)
+        }
+        guard systemFsync(outputFD) == 0 else {
+            throw posixError("fsync", temporary.path)
+        }
+        guard systemClose(outputFD) == 0 else {
+            outputOpen = false
+            throw posixError("close", temporary.path)
+        }
+        outputOpen = false
+
+        if let permissions = (sourceAttributes[.posixPermissions] as? NSNumber)?.uint16Value {
+            try FileManager.default.setAttributes(
+                [.posixPermissions: NSNumber(value: permissions)],
+                ofItemAtPath: temporary.path)
+        }
+
+        let outputHeader = try readHeader(temporary)
+        try verifyDescriptorsAndPayloads(
+            sourceURL: shard,
+            sourceHeader: sourceHeader,
+            outputURL: temporary,
+            outputHeader: outputHeader)
+
+        let currentAttributes = try FileManager.default.attributesOfItem(atPath: shard.path)
+        guard sameSourceIdentity(sourceAttributes, currentAttributes) else {
+            throw healerError("source changed during heal")
+        }
+
+        guard systemRename(temporary.path, shard.path) == 0 else {
+            throw posixError("rename", shard.path)
+        }
+        installed = true
+        // The shard itself is already durable. Directory fsync is best effort
+        // because some filesystems reject fsync on directory descriptors.
+        _ = systemFsync(directoryFD)
+    }
+
+    private static func readHeader(_ url: URL) throws -> Header {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        let prefix = try handle.read(upToCount: 8) ?? Data()
+        guard prefix.count == 8 else { throw healerError("truncated length") }
+        let headerLength = prefix.withUnsafeBytes {
+            UInt64(littleEndian: $0.loadUnaligned(as: UInt64.self))
+        }
+        guard headerLength > 0, headerLength <= maximumHeaderBytes else {
+            throw healerError("invalid header length \(headerLength)")
+        }
+        let rawHeader = try handle.read(upToCount: Int(headerLength)) ?? Data()
+        guard rawHeader.count == Int(headerLength) else {
+            throw healerError("truncated header")
+        }
+        let object = try JSONSerialization.jsonObject(with: rawHeader)
+        guard let dictionary = object as? [String: Any] else {
+            throw healerError("header is not an object")
+        }
+
+        let fileSize = try FileManager.default.attributesOfItem(atPath: url.path)[.size]
+        let size = (fileSize as? NSNumber)?.uint64Value ?? 0
+        let dataBase = 8 + headerLength
+        var tensors: [Tensor] = []
+        for (name, rawDescriptor) in dictionary where name != "__metadata__" {
+            guard let descriptor = rawDescriptor as? [String: Any],
+                let dtype = descriptor["dtype"] as? String,
+                let alignment = dtypeAlignment(dtype),
+                descriptor["shape"] is [NSNumber],
+                let offsets = descriptor["data_offsets"] as? [NSNumber],
+                offsets.count == 2
+            else {
+                throw healerError("invalid descriptor for \(name)")
+            }
+            let start = offsets[0].uint64Value
+            let end = offsets[1].uint64Value
+            guard end >= start,
+                (end - start) % alignment == 0,
+                dataBase <= size,
+                end <= size - dataBase
+            else {
+                throw healerError("invalid payload range for \(name)")
+            }
+            tensors.append(
+                Tensor(
+                    name: name,
+                    descriptor: descriptor,
+                    dtype: dtype,
+                    alignment: alignment,
+                    sourceOffset: dataBase + start,
+                    byteLength: end - start))
+        }
+
+        let bySource = tensors.sorted { $0.sourceOffset < $1.sourceOffset }
+        var expectedOffset = dataBase
+        for tensor in bySource {
+            guard tensor.sourceOffset == expectedOffset else {
+                throw healerError("non-contiguous payload at \(tensor.name)")
+            }
+            expectedOffset += tensor.byteLength
+        }
+        guard expectedOffset == size else {
+            throw healerError("payload does not cover file")
+        }
+        return Header(
+            dataBase: dataBase,
+            metadata: dictionary["__metadata__"],
+            tensors: tensors)
+    }
+
+    private static func makeHeader(metadata: Any?, tensors: [Tensor]) throws -> Data {
+        var object: [String: Any] = [:]
+        for tensor in tensors {
+            var descriptor = tensor.descriptor
+            descriptor["data_offsets"] = [
+                tensor.outputOffset,
+                tensor.outputOffset + tensor.byteLength,
+            ]
+            object[tensor.name] = descriptor
+        }
+        if let metadata { object["__metadata__"] = metadata }
+        var encoded = try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+        let maximumAlignment = max(UInt64(8), tensors.map(\.alignment).max() ?? 8)
+        let remainder = UInt64(8 + encoded.count) % maximumAlignment
+        if remainder != 0 {
+            encoded.append(Data(repeating: 0x20, count: Int(maximumAlignment - remainder)))
+        }
+        return encoded
+    }
+
+    private static func verifyDescriptorsAndPayloads(
+        sourceURL: URL,
+        sourceHeader: Header,
+        outputURL: URL,
+        outputHeader: Header
+    ) throws {
+        guard sourceHeader.tensors.count == outputHeader.tensors.count,
+            jsonEqual(sourceHeader.metadata, outputHeader.metadata)
+        else { throw healerError("header verification failed") }
+
+        let outputByName = Dictionary(
+            uniqueKeysWithValues:
+                outputHeader.tensors.map { ($0.name, $0) })
+        let sourceFD = systemOpen(sourceURL.path, O_RDONLY, 0)
+        guard sourceFD >= 0 else { throw posixError("open", sourceURL.path) }
+        defer { _ = systemClose(sourceFD) }
+        let outputFD = systemOpen(outputURL.path, O_RDONLY, 0)
+        guard outputFD >= 0 else { throw posixError("open", outputURL.path) }
+        defer { _ = systemClose(outputFD) }
+        _ = systemNoCache(sourceFD)
+        _ = systemNoCache(outputFD)
+
+        for source in sourceHeader.tensors {
+            guard let output = outputByName[source.name],
+                output.dtype == source.dtype,
+                output.byteLength == source.byteLength,
+                output.sourceOffset % output.alignment == 0,
+                descriptorsEqual(source.descriptor, output.descriptor)
+            else { throw healerError("descriptor verification failed for \(source.name)") }
+            try compareRanges(
+                lhsFD: sourceFD,
+                lhsOffset: source.sourceOffset,
+                rhsFD: outputFD,
+                rhsOffset: output.sourceOffset,
+                byteLength: source.byteLength)
+        }
+    }
+
+    private static func copyRange(
+        sourceFD: Int32,
+        sourcePath: String,
+        sourceOffset: UInt64,
+        byteLength: UInt64,
+        outputFD: Int32,
+        copied: inout UInt64,
+        failAfterCopiedBytes: UInt64?
+    ) throws {
+        let buffer = UnsafeMutableRawPointer.allocate(byteCount: bufferBytes, alignment: 4096)
+        defer { buffer.deallocate() }
+        var remaining = byteLength
+        var offset = sourceOffset
+        while remaining > 0 {
+            if let limit = failAfterCopiedBytes, copied >= limit {
+                throw healerError("injected interrupted write")
+            }
+            var count = min(UInt64(bufferBytes), remaining)
+            if let limit = failAfterCopiedBytes {
+                count = min(count, limit - copied)
+                if count == 0 { throw healerError("injected interrupted write") }
+            }
+            let read = systemPread(sourceFD, buffer, Int(count), Int64(offset))
+            guard read > 0 else { throw posixError("pread", sourcePath) }
+            try writeAll(fd: outputFD, pointer: buffer, count: read)
+            remaining -= UInt64(read)
+            offset += UInt64(read)
+            copied += UInt64(read)
+        }
+    }
+
+    private static func compareRanges(
+        lhsFD: Int32,
+        lhsOffset: UInt64,
+        rhsFD: Int32,
+        rhsOffset: UInt64,
+        byteLength: UInt64
+    ) throws {
+        let lhs = UnsafeMutableRawPointer.allocate(byteCount: bufferBytes, alignment: 4096)
+        let rhs = UnsafeMutableRawPointer.allocate(byteCount: bufferBytes, alignment: 4096)
+        defer {
+            lhs.deallocate()
+            rhs.deallocate()
+        }
+        var remaining = byteLength
+        var lhsCursor = lhsOffset
+        var rhsCursor = rhsOffset
+        while remaining > 0 {
+            let count = Int(min(UInt64(bufferBytes), remaining))
+            let lhsRead = systemPread(lhsFD, lhs, count, Int64(lhsCursor))
+            let rhsRead = systemPread(rhsFD, rhs, count, Int64(rhsCursor))
+            guard lhsRead == count, rhsRead == count,
+                memcmp(lhs, rhs, count) == 0
+            else { throw healerError("payload byte verification failed") }
+            remaining -= UInt64(count)
+            lhsCursor += UInt64(count)
+            rhsCursor += UInt64(count)
+        }
+    }
+
+    private static func writeAll(fd: Int32, bytes: UnsafeRawBufferPointer) throws {
+        guard let base = bytes.baseAddress else { return }
+        try writeAll(fd: fd, pointer: base, count: bytes.count)
+    }
+
+    private static func writeAll(fd: Int32, pointer: UnsafeRawPointer, count: Int) throws {
+        var written = 0
+        while written < count {
+            let result = systemWrite(fd, pointer.advanced(by: written), count - written)
+            guard result > 0 else { throw posixError("write", "fd=\(fd)") }
+            written += result
+        }
+    }
+
+    private static func availableBytes(at directory: URL) throws -> UInt64 {
+        let attributes = try FileManager.default.attributesOfFileSystem(forPath: directory.path)
+        guard let number = attributes[.systemFreeSize] as? NSNumber else {
+            throw healerError("free disk capacity unavailable")
+        }
+        return number.uint64Value
+    }
+
+    private static func sameSourceIdentity(
+        _ lhs: [FileAttributeKey: Any],
+        _ rhs: [FileAttributeKey: Any]
+    ) -> Bool {
+        let lhsSize = (lhs[.size] as? NSNumber)?.uint64Value
+        let rhsSize = (rhs[.size] as? NSNumber)?.uint64Value
+        let lhsDate = lhs[.modificationDate] as? Date
+        let rhsDate = rhs[.modificationDate] as? Date
+        return lhsSize == rhsSize && lhsDate == rhsDate
+    }
+
+    private static func descriptorsEqual(_ lhs: [String: Any], _ rhs: [String: Any]) -> Bool {
+        var lhs = lhs
+        var rhs = rhs
+        lhs.removeValue(forKey: "data_offsets")
+        rhs.removeValue(forKey: "data_offsets")
+        return jsonEqual(lhs, rhs)
+    }
+
+    private static func jsonEqual(_ lhs: Any?, _ rhs: Any?) -> Bool {
+        switch (lhs, rhs) {
+        case (nil, nil): return true
+        case (let lhs?, let rhs?):
+            guard JSONSerialization.isValidJSONObject(["value": lhs]),
+                JSONSerialization.isValidJSONObject(["value": rhs]),
+                let lhsData = try? JSONSerialization.data(
+                    withJSONObject: ["value": lhs], options: [.sortedKeys]),
+                let rhsData = try? JSONSerialization.data(
+                    withJSONObject: ["value": rhs], options: [.sortedKeys])
+            else { return false }
+            return lhsData == rhsData
+        default: return false
+        }
+    }
+
+    private static func dtypeAlignment(_ dtype: String) -> UInt64? {
+        switch dtype {
+        case "C128": return 16
+        case "F64", "I64", "U64", "C64": return 8
+        case "F32", "I32", "U32": return 4
+        case "F16", "BF16", "I16", "U16": return 2
+        case "BOOL", "U8", "I8", "F8_E5M2", "F8_E4M3", "F8_E4M3FN",
+            "F8_E4M3FNUZ", "F8_E5M2FNUZ", "F8_E8M0":
+            return 1
+        default: return nil
+        }
+    }
+
+    private static func isHashAddressedStorage(_ url: URL) -> Bool {
+        let path = url.standardizedFileURL.path.lowercased()
+        if path.contains("/.cache/huggingface/hub/")
+            || path.contains("/huggingface/hub/models--")
+        {
+            return true
+        }
+        let components = url.standardizedFileURL.pathComponents.map { $0.lowercased() }
+        guard components.contains(where: { $0.hasPrefix("models--") }) else { return false }
+        return components.contains("blobs") || components.contains("snapshots")
+    }
+
+    private static func isDisabledFlag(_ raw: String?) -> Bool {
+        guard let raw = raw?.lowercased() else { return false }
+        return raw == "0" || raw == "false" || raw == "no" || raw == "off"
+    }
+
+    private static func quoted(_ value: String) -> String {
+        let escaped =
+            value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        return "\"" + escaped + "\""
+    }
+
+    private static func healerError(_ message: String) -> Error {
+        NSError(
+            domain: "SafetensorsStorageHealer",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: message])
+    }
+
+    private static func posixError(_ operation: String, _ path: String) -> Error {
+        NSError(
+            domain: NSPOSIXErrorDomain,
+            code: Int(errno),
+            userInfo: [
+                NSLocalizedDescriptionKey:
+                    "\(operation) failed for \(path): \(String(cString: strerror(errno)))"
+            ])
+    }
+
+    #if canImport(Darwin)
+        private static func systemOpen(_ path: String, _ flags: Int32, _ mode: mode_t) -> Int32 {
+            Darwin.open(path, flags, mode)
+        }
+        private static func systemClose(_ fd: Int32) -> Int32 { Darwin.close(fd) }
+        private static func systemWrite(_ fd: Int32, _ pointer: UnsafeRawPointer, _ count: Int)
+            -> Int
+        {
+            Darwin.write(fd, pointer, count)
+        }
+        private static func systemPread(
+            _ fd: Int32, _ pointer: UnsafeMutableRawPointer, _ count: Int, _ offset: Int64
+        ) -> Int { Darwin.pread(fd, pointer, count, offset) }
+        private static func systemFsync(_ fd: Int32) -> Int32 { Darwin.fsync(fd) }
+        private static func systemRename(_ source: String, _ destination: String) -> Int32 {
+            Darwin.rename(source, destination)
+        }
+        private static func systemNoCache(_ fd: Int32) -> Int32 { Darwin.fcntl(fd, F_NOCACHE, 1) }
+    #elseif canImport(Glibc)
+        private static func systemOpen(_ path: String, _ flags: Int32, _ mode: mode_t) -> Int32 {
+            Glibc.open(path, flags, mode)
+        }
+        private static func systemClose(_ fd: Int32) -> Int32 { Glibc.close(fd) }
+        private static func systemWrite(_ fd: Int32, _ pointer: UnsafeRawPointer, _ count: Int)
+            -> Int
+        {
+            Glibc.write(fd, pointer, count)
+        }
+        private static func systemPread(
+            _ fd: Int32, _ pointer: UnsafeMutableRawPointer, _ count: Int, _ offset: Int64
+        ) -> Int { Glibc.pread(fd, pointer, count, offset) }
+        private static func systemFsync(_ fd: Int32) -> Int32 { Glibc.fsync(fd) }
+        private static func systemRename(_ source: String, _ destination: String) -> Int32 {
+            Glibc.rename(source, destination)
+        }
+        private static func systemNoCache(_ fd: Int32) -> Int32 { 0 }
+    #endif
+}

--- a/Libraries/MLXLMCommon/ModelFactory.swift
+++ b/Libraries/MLXLMCommon/ModelFactory.swift
@@ -2,14 +2,15 @@
 
 import Foundation
 import MLX
+
 #if canImport(Cmlx)
-import Cmlx
+    import Cmlx
 #endif
 
 #if canImport(Darwin)
-import Darwin
+    import Darwin
 #elseif canImport(Glibc)
-import Glibc
+    import Glibc
 #endif
 
 /// File patterns required to resolve a tokenizer without downloading model weights.
@@ -608,17 +609,20 @@ public func loadModel(
         applyPlainDeepseekV4ProcessMemoryLimitsIfNeeded(facts: facts)
     if loadConfiguration.useMmapSafetensors && !useMmapSafetensors {
         let reason = "DeepSeek V4 affine JANG selected resident safetensors for production decode"
-        FileHandle.standardError.write(Data(
-            "[Load] \(reason)\n".utf8))
+        FileHandle.standardError.write(
+            Data(
+                "[Load] \(reason)\n".utf8))
     }
     if loadConfiguration.memoryLimit != memoryLimit {
-        FileHandle.standardError.write(Data(
-            "[Load] DeepSeek V4 affine JANG uses RAM admission instead of the decode-throttling MLX memory limit\n"
-                .utf8))
+        FileHandle.standardError.write(
+            Data(
+                "[Load] DeepSeek V4 affine JANG uses RAM admission instead of the decode-throttling MLX memory limit\n"
+                    .utf8))
     }
 
     // 2. Resolve JangPress policy → concrete options.
-    let resolvedOptions: JangPressLoadOptions = facts.requiresResidentSafetensors
+    let resolvedOptions: JangPressLoadOptions =
+        facts.requiresResidentSafetensors
         ? .disabled
         : loadConfiguration.jangPress.resolve(facts: facts)
 
@@ -657,11 +661,13 @@ public func loadModel(
     //     size" rejection (the original 847a8c7 crash condition). See
     //     docs/WIRED-LIMIT-INVESTIGATION-2026-05-03.md.
     if dsv4NativeAllocatorCeiling == nil,
-        let rawCap = memoryLimit
-        .applyAsCacheLimitInt(physicalMemory: facts.physicalMemory)
+        let rawCap =
+            memoryLimit
+            .applyAsCacheLimitInt(physicalMemory: facts.physicalMemory)
     {
         let workingSetCap = MLX.GPU.maxRecommendedWorkingSetBytes() ?? Int.max
-        let safeCap = max(1 * 1024 * 1024 * 1024,  // never below 1 GB
+        let safeCap = max(
+            1 * 1024 * 1024 * 1024,  // never below 1 GB
             min(rawCap, workingSetCap))
         MLX.Memory.memoryLimit = safeCap
     }
@@ -674,8 +680,10 @@ public func loadModel(
     //    whole-shard mmap loader, then use cold-page advice and OS
     //    compression/reclaim instead of a large stacked cache overlay.
     //    Active-expert pread streaming is an explicit fallback/diagnostic
-    //    path only. Alignment overlays remain separately gated by
-    //    MLXPRESS_ALIGN_* / JANGPRESS_ALIGN_*.
+    //    path only. Before mmap, ordinary writable model directories are
+    //    automatically healed when a safetensors shard has dtype-misaligned
+    //    offsets. The older side-copy alignment overlay remains separately
+    //    gated by MLXPRESS_ALIGN_* / JANGPRESS_ALIGN_*.
     let loadDirectory = try JangPressPrestacker.prepareBundleIfNeeded(
         originalURL: directory,
         enabled: useMmapSafetensors)
@@ -689,10 +697,12 @@ public func loadModel(
     // proved that wrapping every tensor span as its own Metal buffer increases
     // load time without lowering Activity Monitor footprint; the real blocker
     // is model sanitize replacing routed mmap tensors with full stacked banks.
-    let tensorBuffersRaw = ProcessInfo.processInfo.environment["MLXPRESS_MMAP_TENSOR_BUFFERS"]
+    let tensorBuffersRaw =
+        ProcessInfo.processInfo.environment["MLXPRESS_MMAP_TENSOR_BUFFERS"]
         ?? ProcessInfo.processInfo.environment["JANGPRESS_MMAP_TENSOR_BUFFERS"]
         ?? ""
-    let useTensorMmapBuffers = useMmapSafetensors
+    let useTensorMmapBuffers =
+        useMmapSafetensors
         && resolvedOptions.enabled
         && resolvedOptions.backend == .mmap
         && ["1", "true", "on", "yes"].contains(tensorBuffersRaw.lowercased())
@@ -824,65 +834,65 @@ private func withMmapSafetensorsEnv<R>(
     startColdPercent: Int?,
     _ body: () async throws -> R
 ) async throws -> R {
-#if canImport(Darwin) || canImport(Glibc)
-    let mmapKey = "MLX_SAFETENSORS_MMAP"
-    let vmlxMmapKey = "VMLX_MMAP_SAFETENSORS"
-    let tensorKey = "MLX_SAFETENSORS_MMAP_TENSOR_BUFFERS"
-    let startColdKey = "MLX_SAFETENSORS_MMAP_START_COLD"
-    let coldPctKey = "MLX_SAFETENSORS_MMAP_COLD_PCT"
-    let priorMmap = getenv(mmapKey).map { String(cString: $0) }
-    let priorVmlxMmap = getenv(vmlxMmapKey).map { String(cString: $0) }
-    let priorTensor = getenv(tensorKey).map { String(cString: $0) }
-    let priorStartCold = getenv(startColdKey).map { String(cString: $0) }
-    let priorColdPct = getenv(coldPctKey).map { String(cString: $0) }
-    if enabled {
-        setenv(mmapKey, "1", 1)
-        setenv(vmlxMmapKey, "1", 1)
-        if tensorBuffers {
-            setenv(tensorKey, "1", 1)
-        }
-        if let startColdPercent, startColdPercent > 0 {
-            setenv(startColdKey, "1", 1)
-            setenv(
-                coldPctKey,
-                String(max(0, min(100, startColdPercent))),
-                1)
-        }
-    } else {
-        unsetenv(mmapKey)
-        unsetenv(vmlxMmapKey)
-        unsetenv(tensorKey)
-        unsetenv(startColdKey)
-        unsetenv(coldPctKey)
-    }
-    defer {
-        if let priorMmap {
-            setenv(mmapKey, priorMmap, 1)
+    #if canImport(Darwin) || canImport(Glibc)
+        let mmapKey = "MLX_SAFETENSORS_MMAP"
+        let vmlxMmapKey = "VMLX_MMAP_SAFETENSORS"
+        let tensorKey = "MLX_SAFETENSORS_MMAP_TENSOR_BUFFERS"
+        let startColdKey = "MLX_SAFETENSORS_MMAP_START_COLD"
+        let coldPctKey = "MLX_SAFETENSORS_MMAP_COLD_PCT"
+        let priorMmap = getenv(mmapKey).map { String(cString: $0) }
+        let priorVmlxMmap = getenv(vmlxMmapKey).map { String(cString: $0) }
+        let priorTensor = getenv(tensorKey).map { String(cString: $0) }
+        let priorStartCold = getenv(startColdKey).map { String(cString: $0) }
+        let priorColdPct = getenv(coldPctKey).map { String(cString: $0) }
+        if enabled {
+            setenv(mmapKey, "1", 1)
+            setenv(vmlxMmapKey, "1", 1)
+            if tensorBuffers {
+                setenv(tensorKey, "1", 1)
+            }
+            if let startColdPercent, startColdPercent > 0 {
+                setenv(startColdKey, "1", 1)
+                setenv(
+                    coldPctKey,
+                    String(max(0, min(100, startColdPercent))),
+                    1)
+            }
         } else {
             unsetenv(mmapKey)
-        }
-        if let priorVmlxMmap {
-            setenv(vmlxMmapKey, priorVmlxMmap, 1)
-        } else {
             unsetenv(vmlxMmapKey)
-        }
-        if let priorTensor {
-            setenv(tensorKey, priorTensor, 1)
-        } else {
             unsetenv(tensorKey)
-        }
-        if let priorStartCold {
-            setenv(startColdKey, priorStartCold, 1)
-        } else {
             unsetenv(startColdKey)
-        }
-        if let priorColdPct {
-            setenv(coldPctKey, priorColdPct, 1)
-        } else {
             unsetenv(coldPctKey)
         }
-    }
-#endif
+        defer {
+            if let priorMmap {
+                setenv(mmapKey, priorMmap, 1)
+            } else {
+                unsetenv(mmapKey)
+            }
+            if let priorVmlxMmap {
+                setenv(vmlxMmapKey, priorVmlxMmap, 1)
+            } else {
+                unsetenv(vmlxMmapKey)
+            }
+            if let priorTensor {
+                setenv(tensorKey, priorTensor, 1)
+            } else {
+                unsetenv(tensorKey)
+            }
+            if let priorStartCold {
+                setenv(startColdKey, priorStartCold, 1)
+            } else {
+                unsetenv(startColdKey)
+            }
+            if let priorColdPct {
+                setenv(coldPctKey, priorColdPct, 1)
+            } else {
+                unsetenv(coldPctKey)
+            }
+        }
+    #endif
     return try await body()
 }
 
@@ -892,49 +902,52 @@ private func adviseCanonicalMmapRoutedExpertsIfAvailable(
     mmapEnabled: Bool
 ) -> Int64? {
     guard mmapEnabled,
-          options.enabled,
-          options.backend == .mmap,
-          options.compressPct > 0
+        options.enabled,
+        options.backend == .mmap,
+        options.compressPct > 0
     else { return nil }
 
-#if canImport(Cmlx)
-    guard let adviseRouted = lookupSafetensorsMmapAdviseRouted() else {
+    #if canImport(Cmlx)
+        guard let adviseRouted = lookupSafetensorsMmapAdviseRouted() else {
+            return nil
+        }
+
+        let advised = adviseRouted(
+            0,  // 0 = cold advice; C++ defaults to MADV_DONTNEED and can be env-selected.
+            Int32(max(0, min(100, options.compressPct))))
+
+        let env = ProcessInfo.processInfo.environment
+        if advised > 0,
+            env["MLXPRESS_DEBUG"] == "1"
+                || env["JANGPRESS_DEBUG"] == "1"
+                || env["MLX_SAFETENSORS_MMAP_DEBUG"] == "1"
+        {
+            FileHandle.standardError.write(
+                Data(
+                    "[MLXPress] advised \(advised) canonical mmap routed bytes cold (pct=\(options.compressPct))\n"
+                        .utf8))
+        }
+        return advised
+    #else
         return nil
-    }
-
-    let advised = adviseRouted(
-        0,  // 0 = cold advice; C++ defaults to MADV_DONTNEED and can be env-selected.
-        Int32(max(0, min(100, options.compressPct))))
-
-    let env = ProcessInfo.processInfo.environment
-    if advised > 0,
-       (env["MLXPRESS_DEBUG"] == "1"
-        || env["JANGPRESS_DEBUG"] == "1"
-        || env["MLX_SAFETENSORS_MMAP_DEBUG"] == "1")
-    {
-        FileHandle.standardError.write(Data(
-            "[MLXPress] advised \(advised) canonical mmap routed bytes cold (pct=\(options.compressPct))\n".utf8))
-    }
-    return advised
-#else
-    return nil
-#endif
+    #endif
 }
 
 #if canImport(Cmlx)
-private typealias SafetensorsMmapAdviseRoutedFn = @convention(c) (
-    Int32,
-    Int32
-) -> Int64
+    private typealias SafetensorsMmapAdviseRoutedFn =
+        @convention(c) (
+            Int32,
+            Int32
+        ) -> Int64
 
-private func lookupSafetensorsMmapAdviseRouted() -> SafetensorsMmapAdviseRoutedFn? {
-    guard let handle = dlopen(nil, RTLD_NOW),
-          let symbol = dlsym(handle, "mlx_safetensors_mmap_advise_routed")
-    else {
-        return nil
+    private func lookupSafetensorsMmapAdviseRouted() -> SafetensorsMmapAdviseRoutedFn? {
+        guard let handle = dlopen(nil, RTLD_NOW),
+            let symbol = dlsym(handle, "mlx_safetensors_mmap_advise_routed")
+        else {
+            return nil
+        }
+        return unsafeBitCast(symbol, to: SafetensorsMmapAdviseRoutedFn.self)
     }
-    return unsafeBitCast(symbol, to: SafetensorsMmapAdviseRoutedFn.self)
-}
 #endif
 
 /// Protocol for types that can provide ModelFactory instances.

--- a/Tests/MLXLMTests/JangPressSafetensorsAlignmentTests.swift
+++ b/Tests/MLXLMTests/JangPressSafetensorsAlignmentTests.swift
@@ -2,182 +2,254 @@
 
 import Foundation
 import Testing
+
 @testable import MLXLMCommon
 
-#if canImport(Darwin)
-import Darwin
-#elseif canImport(Glibc)
-import Glibc
-#endif
-
-@Suite("JangPress safetensors alignment overlay", .serialized)
+@Suite("Safetensors storage heal-on-load", .serialized)
 struct JangPressSafetensorsAlignmentTests {
+    @Test("dense and routed tensors heal in place with identical named payloads")
+    func healsAllModelFamiliesInPlace() throws {
+        let bundle = try Self.makeDirectory()
+        defer { try? FileManager.default.removeItem(at: bundle) }
+        let shard = bundle.appendingPathComponent("model.safetensors")
+        try Self.writeUnalignedFixture(shard)
+        let before = try Self.readFixture(shard)
 
-    @Test("routed safetensors with unaligned data base is rewritten into aligned overlay")
-    func routedUnalignedBundleGetsAlignedOverlay() throws {
-        let bundle = try Self.makeBundleDir()
-        let cache = try Self.makeBundleDir(prefix: "jpress-align-cache")
-        defer {
-            try? FileManager.default.removeItem(at: bundle)
-            try? FileManager.default.removeItem(at: cache)
-        }
-        try Self.writeSafetensors(
+        let result = SafetensorsStorageHealer.healBundle(
+            at: bundle, configuration: Self.configuration())
+
+        #expect(result.scannedShards == 1)
+        #expect(result.healedShards == 1)
+        #expect(result.fallbackShards == 0)
+        let after = try Self.readFixture(shard)
+        #expect(after.metadata == before.metadata)
+        #expect(after.payloads == before.payloads)
+        #expect(after.unalignedCount == 0)
+        #expect(try Self.temporaryFiles(in: bundle).isEmpty)
+    }
+
+    @Test("second load is a no-op after the one-time heal")
+    func secondLoadDoesNotRewrite() throws {
+        let bundle = try Self.makeDirectory()
+        defer { try? FileManager.default.removeItem(at: bundle) }
+        let shard = bundle.appendingPathComponent("model.safetensors")
+        try Self.writeUnalignedFixture(shard)
+        _ = SafetensorsStorageHealer.healBundle(
+            at: bundle, configuration: Self.configuration())
+        let first = try Data(contentsOf: shard)
+
+        let result = SafetensorsStorageHealer.healBundle(
+            at: bundle, configuration: Self.configuration())
+
+        #expect(result.scannedShards == 1)
+        #expect(result.healedShards == 0)
+        #expect(result.fallbackShards == 0)
+        #expect(try Data(contentsOf: shard) == first)
+    }
+
+    @Test("insufficient transient disk advises and leaves the original intact")
+    func diskShortageFallsBackWithoutMutation() throws {
+        let bundle = try Self.makeDirectory()
+        defer { try? FileManager.default.removeItem(at: bundle) }
+        let shard = bundle.appendingPathComponent("model.safetensors")
+        try Self.writeUnalignedFixture(shard)
+        let before = try Data(contentsOf: shard)
+        var configuration = Self.configuration()
+        configuration.availableBytes = { _ in 0 }
+
+        let result = SafetensorsStorageHealer.healBundle(
+            at: bundle, configuration: configuration)
+
+        #expect(result.healedShards == 0)
+        #expect(result.fallbackShards == 1)
+        #expect(try Data(contentsOf: shard) == before)
+        #expect(try Self.temporaryFiles(in: bundle).isEmpty)
+    }
+
+    @Test("an interrupted stream never replaces the original shard")
+    func interruptedWriteLeavesOriginalIntact() throws {
+        let bundle = try Self.makeDirectory()
+        defer { try? FileManager.default.removeItem(at: bundle) }
+        let shard = bundle.appendingPathComponent("model.safetensors")
+        try Self.writeUnalignedFixture(shard)
+        let before = try Data(contentsOf: shard)
+        var configuration = Self.configuration()
+        configuration.failAfterCopiedBytes = 1
+
+        let result = SafetensorsStorageHealer.healBundle(
+            at: bundle, configuration: configuration)
+
+        #expect(result.healedShards == 0)
+        #expect(result.fallbackShards == 1)
+        #expect(try Data(contentsOf: shard) == before)
+        #expect(try Self.temporaryFiles(in: bundle).isEmpty)
+    }
+
+    @Test("Hugging Face hash-addressed snapshots are never rewritten")
+    func hashAddressedStorageIsExempt() throws {
+        let root = try Self.makeDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let snapshot = root.appendingPathComponent(
+            ".cache/huggingface/hub/models--owner--model/snapshots/revision")
+        try FileManager.default.createDirectory(
+            at: snapshot, withIntermediateDirectories: true)
+        let shard = snapshot.appendingPathComponent("model.safetensors")
+        try Self.writeUnalignedFixture(shard)
+        let before = try Data(contentsOf: shard)
+
+        let result = SafetensorsStorageHealer.healBundle(
+            at: snapshot, configuration: Self.configuration())
+
+        #expect(result.scannedShards == 0)
+        #expect(result.healedShards == 0)
+        #expect(try Data(contentsOf: shard) == before)
+    }
+
+    @Test("symlinked blob shards are skipped even in a plain directory")
+    func symlinkShardIsExempt() throws {
+        let root = try Self.makeDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let bundle = root.appendingPathComponent("bundle")
+        try FileManager.default.createDirectory(at: bundle, withIntermediateDirectories: true)
+        let blob = root.appendingPathComponent("blob.safetensors")
+        try Self.writeUnalignedFixture(blob)
+        let before = try Data(contentsOf: blob)
+        try FileManager.default.createSymbolicLink(
             at: bundle.appendingPathComponent("model.safetensors"),
-            tensorName: "model.layers.0.mlp.experts.0.gate_proj.weight")
-        try Data("{}".utf8).write(to: bundle.appendingPathComponent("config.json"))
+            withDestinationURL: blob)
 
-        let priorCache = getenv("JANGPRESS_ALIGN_CACHE_DIR").map { String(cString: $0) }
-        let priorAlign = getenv("JANGPRESS_ALIGN_SAFETENSORS").map { String(cString: $0) }
-        setenv("JANGPRESS_ALIGN_CACHE_DIR", cache.path, 1)
-        setenv("JANGPRESS_ALIGN_SAFETENSORS", "1", 1)
-        defer { Self.restoreEnv("JANGPRESS_ALIGN_CACHE_DIR", priorCache) }
-        defer { Self.restoreEnv("JANGPRESS_ALIGN_SAFETENSORS", priorAlign) }
+        let result = SafetensorsStorageHealer.healBundle(
+            at: bundle, configuration: Self.configuration())
+
+        #expect(result.scannedShards == 1)
+        #expect(result.skippedShards == 1)
+        #expect(result.healedShards == 0)
+        #expect(try Data(contentsOf: blob) == before)
+    }
+
+    @Test("the production JangPress hook heals before returning the mmap directory")
+    func productionLoadHookHealsByDefault() throws {
+        let bundle = try Self.makeDirectory()
+        defer { try? FileManager.default.removeItem(at: bundle) }
+        let shard = bundle.appendingPathComponent("model.safetensors")
+        try Self.writeUnalignedFixture(shard)
+        let saved = Self.saveAndUnset([
+            "MLXPRESS_HEAL_SAFETENSORS", "JANGPRESS_HEAL_SAFETENSORS",
+            "MLXPRESS_PRESTACK", "JANGPRESS_PRESTACK",
+            "MLXPRESS_ALIGN_SAFETENSORS", "JANGPRESS_ALIGN_SAFETENSORS",
+        ])
+        defer { Self.restore(saved) }
 
         let prepared = try JangPressPrestacker.prepareBundleIfNeeded(
-            originalURL: bundle,
-            enabled: true)
+            originalURL: bundle, enabled: true)
 
-        #expect(prepared.path != bundle.path)
-        let alignedShard = prepared.appendingPathComponent("model.safetensors")
-        #expect(FileManager.default.fileExists(atPath: alignedShard.path))
-        #expect(FileManager.default.fileExists(
-            atPath: prepared.appendingPathComponent("config.json").path))
-
-        let header = try Self.readHeader(alignedShard)
-        #expect(header.dataBase % 4096 == 0)
-        for (_, item) in header.tensors {
-            let dtype = item["dtype"] as! String
-            let offsets = item["data_offsets"] as! [UInt64]
-            let absolute = header.dataBase + offsets[0]
-            #expect(absolute % UInt64(Self.dtypeAlignment(dtype)) == 0)
-        }
-
-        let payload = try Data(contentsOf: alignedShard)
-        #expect(payload.suffix(6) == Data([1, 2, 3, 4, 5, 6]))
+        #expect(prepared.standardizedFileURL == bundle.standardizedFileURL)
+        #expect(try Self.readFixture(shard).unalignedCount == 0)
     }
 
-    @Test("dense unaligned safetensors are not copied by JangPress aligner")
-    func denseUnalignedBundleIsLeftAlone() throws {
-        let bundle = try Self.makeBundleDir()
-        let cache = try Self.makeBundleDir(prefix: "jpress-align-cache")
-        defer {
-            try? FileManager.default.removeItem(at: bundle)
-            try? FileManager.default.removeItem(at: cache)
-        }
-        try Self.writeSafetensors(
-            at: bundle.appendingPathComponent("model.safetensors"),
-            tensorName: "model.layers.0.input_layernorm.weight")
+    @Test("resident/non-mmap loads do not mutate model storage")
+    func disabledMmapDoesNotHeal() throws {
+        let bundle = try Self.makeDirectory()
+        defer { try? FileManager.default.removeItem(at: bundle) }
+        let shard = bundle.appendingPathComponent("model.safetensors")
+        try Self.writeUnalignedFixture(shard)
+        let before = try Data(contentsOf: shard)
 
-        let priorCache = getenv("JANGPRESS_ALIGN_CACHE_DIR").map { String(cString: $0) }
-        setenv("JANGPRESS_ALIGN_CACHE_DIR", cache.path, 1)
-        defer { Self.restoreEnv("JANGPRESS_ALIGN_CACHE_DIR", priorCache) }
+        _ = try JangPressPrestacker.prepareBundleIfNeeded(
+            originalURL: bundle, enabled: false)
 
-        let prepared = try JangPressPrestacker.prepareBundleIfNeeded(
-            originalURL: bundle,
-            enabled: true)
-        #expect(prepared.path == bundle.resolvingSymlinksInPath().path)
+        #expect(try Data(contentsOf: shard) == before)
     }
 
-    @Test("alignment overlay is opt-in when env is unset")
-    func alignmentOverlayIsOffByDefault() throws {
-        let bundle = try Self.makeBundleDir()
-        let cache = try Self.makeBundleDir(prefix: "jpress-align-cache")
-        defer {
-            try? FileManager.default.removeItem(at: bundle)
-            try? FileManager.default.removeItem(at: cache)
-        }
-        try Self.writeSafetensors(
-            at: bundle.appendingPathComponent("model.safetensors"),
-            tensorName: "model.layers.0.mlp.experts.0.gate_proj.weight")
-
-        let priorCache = getenv("JANGPRESS_ALIGN_CACHE_DIR").map { String(cString: $0) }
-        let priorAlign = getenv("JANGPRESS_ALIGN_SAFETENSORS").map { String(cString: $0) }
-        setenv("JANGPRESS_ALIGN_CACHE_DIR", cache.path, 1)
-        unsetenv("JANGPRESS_ALIGN_SAFETENSORS")
-        defer { Self.restoreEnv("JANGPRESS_ALIGN_CACHE_DIR", priorCache) }
-        defer { Self.restoreEnv("JANGPRESS_ALIGN_SAFETENSORS", priorAlign) }
-
-        let prepared = try JangPressPrestacker.prepareBundleIfNeeded(
-            originalURL: bundle,
-            enabled: true)
-        #expect(prepared.path == bundle.resolvingSymlinksInPath().path)
+    private static func configuration() -> SafetensorsStorageHealer.Configuration {
+        SafetensorsStorageHealer.Configuration(
+            environment: [:],
+            availableBytes: { _ in UInt64.max },
+            failAfterCopiedBytes: nil,
+            logger: { _ in })
     }
 
-    private static func makeBundleDir(prefix: String = "jpress-align") throws -> URL {
-        let dir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("\(prefix)-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        return dir
+    private static func makeDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vmlx-heal-test-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory, withIntermediateDirectories: true)
+        return directory
     }
 
-    private static func writeSafetensors(at url: URL, tensorName: String) throws {
+    private static func writeUnalignedFixture(_ url: URL) throws {
         let header: [String: Any] = [
-            tensorName: [
-                "dtype": "U32",
-                "shape": [1],
-                "data_offsets": [0, 4],
+            "__metadata__": ["format": "pt", "proof": "payloads-unchanged"],
+            "model.layers.0.input_layernorm.weight": [
+                "dtype": "BF16", "shape": [1], "data_offsets": [0, 2],
             ],
-            "model.layers.0.post_attention_layernorm.weight": [
-                "dtype": "BF16",
-                "shape": [1],
-                "data_offsets": [4, 6],
+            "model.layers.0.mlp.experts.0.gate_proj.weight": [
+                "dtype": "U32", "shape": [1], "data_offsets": [2, 6],
             ],
         ]
-        var headerData = try JSONSerialization.data(
-            withJSONObject: header,
-            options: [.sortedKeys])
-        while (8 + headerData.count) % 4 == 0 {
-            headerData.append(0x20)
+        var encoded = try JSONSerialization.data(
+            withJSONObject: header, options: [.sortedKeys])
+        while (8 + encoded.count) % 2 != 0 || (8 + encoded.count + 2) % 4 == 0 {
+            encoded.append(0x20)
         }
 
-        var data = Data()
-        var headerLength = UInt64(headerData.count).littleEndian
-        data.append(contentsOf: withUnsafeBytes(of: &headerLength) { Array($0) })
-        data.append(headerData)
-        data.append(contentsOf: [1, 2, 3, 4, 5, 6])
-        try data.write(to: url)
+        var output = Data()
+        var length = UInt64(encoded.count).littleEndian
+        output.append(contentsOf: withUnsafeBytes(of: &length) { Array($0) })
+        output.append(encoded)
+        output.append(contentsOf: [0xA1, 0xA2, 0xB1, 0xB2, 0xB3, 0xB4])
+        try output.write(to: url)
     }
 
-    private struct Header {
-        var dataBase: UInt64
-        var tensors: [String: [String: Any]]
+    private struct FixtureRead {
+        var metadata: [String: String]
+        var payloads: [String: Data]
+        var unalignedCount: Int
     }
 
-    private static func readHeader(_ url: URL) throws -> Header {
-        let handle = try FileHandle(forReadingFrom: url)
-        defer { try? handle.close() }
-        let prefix = try handle.read(upToCount: 8) ?? Data()
-        let headerLength = prefix.withUnsafeBytes {
+    private static func readFixture(_ url: URL) throws -> FixtureRead {
+        let data = try Data(contentsOf: url)
+        let headerLength = data.prefix(8).withUnsafeBytes {
             UInt64(littleEndian: $0.loadUnaligned(as: UInt64.self))
         }
-        let headerData = try handle.read(upToCount: Int(headerLength)) ?? Data()
-        let json = try JSONSerialization.jsonObject(with: headerData)
-        let object = json as! [String: Any]
-        var tensors: [String: [String: Any]] = [:]
-        for (key, value) in object where key != "__metadata__" {
-            var item = value as! [String: Any]
-            if let offsets = item["data_offsets"] as? [NSNumber] {
-                item["data_offsets"] = offsets.map { $0.uint64Value }
-            }
-            tensors[key] = item
+        let dataBase = 8 + Int(headerLength)
+        let headerData = data.subdata(in: 8 ..< dataBase)
+        let object = try JSONSerialization.jsonObject(with: headerData) as! [String: Any]
+        let metadata = object["__metadata__"] as! [String: String]
+        var payloads: [String: Data] = [:]
+        var unaligned = 0
+        for (name, raw) in object where name != "__metadata__" {
+            let descriptor = raw as! [String: Any]
+            let offsets = (descriptor["data_offsets"] as! [NSNumber]).map(\.intValue)
+            let dtype = descriptor["dtype"] as! String
+            let alignment = dtype == "U32" ? 4 : 2
+            if (dataBase + offsets[0]) % alignment != 0 { unaligned += 1 }
+            payloads[name] = data.subdata(
+                in: (dataBase + offsets[0]) ..< (dataBase + offsets[1]))
         }
-        return Header(dataBase: 8 + headerLength, tensors: tensors)
+        return FixtureRead(
+            metadata: metadata, payloads: payloads, unalignedCount: unaligned)
     }
 
-    private static func dtypeAlignment(_ dtype: String) -> Int {
-        switch dtype {
-        case "F64", "I64", "U64", "C64": return 8
-        case "F32", "I32", "U32": return 4
-        case "F16", "BF16", "I16", "U16": return 2
-        default: return 1
-        }
+    private static func temporaryFiles(in directory: URL) throws -> [URL] {
+        try FileManager.default.contentsOfDirectory(
+            at: directory, includingPropertiesForKeys: nil
+        )
+        .filter { $0.lastPathComponent.contains(".vmlx-heal-") }
     }
 
-    private static func restoreEnv(_ key: String, _ value: String?) {
-        if let value {
-            setenv(key, value, 1)
-        } else {
+    private static func saveAndUnset(_ keys: [String]) -> [String: String?] {
+        var result: [String: String?] = [:]
+        for key in keys {
+            result[key] = getenv(key).map { String(cString: $0) }
             unsetenv(key)
+        }
+        return result
+    }
+
+    private static func restore(_ values: [String: String?]) {
+        for (key, value) in values {
+            if let value { setenv(key, value, 1) } else { unsetenv(key) }
         }
     }
 }

--- a/docs/SAFETENSORS-HEAL-ON-LOAD-2026-08-31.md
+++ b/docs/SAFETENSORS-HEAL-ON-LOAD-2026-08-31.md
@@ -1,0 +1,34 @@
+# Safetensors heal-on-load checkpoint — 2026-08-31
+
+## Scope
+
+Existing bundles with dtype-misaligned safetensors offsets are repaired before
+the mmap-backed loader opens them. Tensor payload bytes and logical descriptors
+are preserved; only container order and offsets change.
+
+## Safety contract
+
+- Repair is enabled by default for ordinary writable model directories.
+- Each affected shard is streamed to an adjacent temporary file, flushed,
+  fully byte-verified tensor-by-tensor, and installed by atomic rename.
+- The original shard is re-stat'd before replacement. An interrupted write,
+  disk-capacity failure, read-only directory, malformed header, or any other
+  repair error leaves the original available to MLX's copy-on-load fallback.
+- Hugging Face hash-addressed stores and symlinked blob shards are not mutated.
+- Repairs happen before mmap and are a no-op on subsequent loads.
+
+## Current proof
+
+| Gate | Evidence | Status |
+| --- | --- | --- |
+| Focused Swift tests | `JangPressSafetensorsAlignmentTests`, 8 tests under the Xcode Swift toolchain | PASS |
+| Byte preservation | Dense and routed fixtures plus full source/output payload comparison in the installer | PASS |
+| Atomic fallback | Injected interrupted stream retains original and cleans the temporary file | PASS |
+| Disk fallback | Injected insufficient capacity returns fallback without mutation | PASS |
+| Hash-store protection | HF snapshot and symlinked blob fixtures remain unchanged | PASS |
+| Production hook | `JangPressPrestacker.prepareBundleIfNeeded` repairs before mmap preparation | PASS |
+| Real model families | Qwen, Gemma, Laguna, Nemo, and Raptor short multi-turn matrix | PENDING |
+
+The checkpoint is not merge- or release-ready until the real-model matrix
+records output, load/warmup behavior, token/s, physical footprint, and crash
+status.


### PR DESCRIPTION
## Summary
- repair dtype-misaligned safetensors in ordinary writable model directories before mmap
- stream one shard at a time to an adjacent temp, fsync, fully byte-verify, and atomically rename
- never refuse loading: insufficient disk, read-only/hash-addressed storage, malformed files, or interrupted repair retain the original copy-on-load fallback
- skip Hugging Face hash-addressed and symlink blob storage

## Current proof
- Xcode Swift focused suite: `JangPressSafetensorsAlignmentTests` 8/8 passed
- production release CLI built successfully
- exhaustive read-only scan: 922 local shards, 194 misaligned across 41 directories, zero unsupported dtypes, zero malformed containers
- real Gemma clone: 2 affected shards healed; second load no-op; original unchanged; footprint 1.05 GB fallback vs 367 MB healed post-load growth
- real Nemotron Omni clone: six affected shards (~20.3 GB) healed; repair+load+two-turn run ~18s; alpha/beta at 115/122 tok/s; ~2.1 GB post-load footprint growth
- aligned Raptor: alpha/beta at 140/148 tok/s
- aligned Laguna: alpha/beta at 112/111 tok/s

## Known separate issues
- local Gemma E2B bundle emits repeated `<pad>` both before repair (copy fallback) and after repair; repair is not causal, but that model row remains a correctness failure
- standalone `mlxpress` does not link/register the VLM factory for `qwen4_exp`; Qwen runtime proof remains an Osaurus/VLM-route follow-up
