### PR TITLE
Fix growing tool-loop cache boundaries

### DIFF
--- a/Libraries/MLXLMCommon/Cache/DiskCache.swift
+++ b/Libraries/MLXLMCommon/Cache/DiskCache.swift
@@ -123,6 +123,15 @@ public final class DiskCache: @unchecked Sendable {
     /// an inherited file before it can take the fast path.
     private var validatedFiles: [String: ValidatedFileFingerprint] = [:]
 
+    /// Trace-only identity of the most recent boundary written by this cache
+    /// instance. Growing agent loops can store N tokens and immediately probe N
+    /// tokens under a different hash on the next turn; counts alone hide where
+    /// the prompt stopped being a prefix. Retain the IDs only while explicit
+    /// cache tracing is enabled so the miss log can report the first divergent
+    /// token without changing cache selection or normal-process memory use.
+    private var traceLastStoredTokens: [Int]?
+    private var traceLastStoredHash: String?
+
     /// Thread-safe copy of current disk-cache counters.
     public func snapshotStats() -> DiskCacheStats {
         lock.lock()
@@ -269,6 +278,10 @@ public final class DiskCache: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         stores += 1
+        if ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1" {
+            traceLastStoredTokens = tokens
+            traceLastStoredHash = hash
+        }
 
         // A normal warm request fetches an L2 entry and then publishes the
         // same prompt boundary again at completion. Rewriting it used to
@@ -394,6 +407,23 @@ public final class DiskCache: @unchecked Sendable {
                     ("[vmlx][cache/disk-fetch] noFile count=\(tokens.count) "
                         + "hash=\(hash.prefix(12)) modelKey=\(modelKey ?? "nil") "
                         + "salt=\(mediaSalt.map { String($0.prefix(12)) } ?? "nil")\n").utf8))
+                if let stored = traceLastStoredTokens,
+                   stored.count == tokens.count,
+                   let storedHash = traceLastStoredHash,
+                   storedHash != hash
+                {
+                    var index = 0
+                    while index < tokens.count, stored[index] == tokens[index] {
+                        index += 1
+                    }
+                    let storedID = index < stored.count ? String(stored[index]) : "end"
+                    let requestedID = index < tokens.count ? String(tokens[index]) : "end"
+                    FileHandle.standardError.write(Data(
+                        ("[vmlx][cache/key-divergence] count=\(tokens.count) "
+                            + "storedHash=\(storedHash.prefix(12)) fetchHash=\(hash.prefix(12)) "
+                            + "firstDiff=\(index) storedToken=\(storedID) fetchToken=\(requestedID)\n")
+                            .utf8))
+                }
             }
             return nil
         }

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -2165,12 +2165,13 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.promptCacheSnapshot = makePromptBoundaryCacheSnapshot(from: self.cache)
     }
 
-    /// The hybrid cross-turn reuse boundary: the index of the LAST turn-start
-    /// token (`<|im_start|>` / `<start_of_turn>`), i.e. the end of the prompt
-    /// once its trailing generation prompt is stripped. The next chat turn
-    /// replaces that generation prompt with the assistant's reply, so the
-    /// full-prompt key never matches again, but this boundary does — it is what
-    /// gives hybrid models cross-turn prefix reuse at all.
+    /// The hybrid cross-turn reuse boundary. Prefer the canonical history
+    /// boundary derived from the exact active chat template (including the
+    /// assistant-continuation LCP proof); fall back to the model-load suffix
+    /// heuristic only for raw/benchmark inputs that carry no canonical chat
+    /// boundaries. The next chat turn replaces the generation prompt with the
+    /// assistant's reply, so the full-prompt key never matches again, but this
+    /// boundary does — it is what gives hybrid models cross-turn prefix reuse.
     ///
     /// Returns `nil` when the boundary cannot pay for itself: dense models reuse
     /// via the post-answer boundary, media inputs are excluded, and with every
@@ -2181,12 +2182,16 @@ public struct TokenIterator: TokenIteratorProtocol {
         promptTokenIds: [Int],
         input: LMInput
     ) -> Int? {
+        let heuristicBoundary = coordinator?.genPromptSuffixTokens.first
+            .flatMap { promptTokenIds.lastIndex(of: $0) }
+        let canonicalBoundary = input.cachePrefixTokenCounts
+            .filter { $0 > 0 && $0 < promptTokenIds.count }
+            .max()
         guard ProcessInfo.processInfo.environment["VMLX_HYBRID_STRIPPED_STORE"] != "0",
             let coordinator,
             coordinator.isHybrid,
             coordinator.canPersistBoundaries,
-            let turnStartTok = coordinator.genPromptSuffixTokens.first,
-            let stripAt = promptTokenIds.lastIndex(of: turnStartTok),
+            let stripAt = canonicalBoundary ?? heuristicBoundary,
             stripAt > 0, stripAt < promptTokenIds.count,
             input.canCaptureHybridStripBoundary(
                 promptTokenIds: promptTokenIds,

--- a/Libraries/MLXLMCommon/Tokenizer.swift
+++ b/Libraries/MLXLMCommon/Tokenizer.swift
@@ -250,6 +250,63 @@ public func canonicalChatCacheBoundaries(
         return exactPrefixBoundary(messages: Array(messages.dropLast()))
     }
 
+    /// Prove that the newest history boundary survives the next assistant
+    /// continuation, rather than only proving that a no-generation render is
+    /// a prefix of the CURRENT prompt.
+    ///
+    /// Some templates rewrite the separator immediately before the assistant
+    /// rail when an assistant/tool message is materialised. Raptor/Qwen-shaped
+    /// tool history exposed the concrete failure: the current user prompt ended
+    /// in `\n<role>assistant`, while the next structured tool-call render used
+    /// `<role>assistant` at that same position. The old boundary included the
+    /// newline, so an otherwise identical growing prompt missed its just-written
+    /// SSD entry and fell back to the static system prefix.
+    ///
+    /// Render two divergent future assistant messages and retain only the LCP
+    /// shared by both renders AND the active prompt. Divergent contents prove
+    /// the boundary contains no assistant-controlled payload; comparison with
+    /// the active prompt preserves the exact-token KV invariant. This is
+    /// template-derived and model-family agnostic.
+    func assistantContinuationStableBoundary() -> Int? {
+        guard !messages.isEmpty else { return nil }
+
+        func renderProbe(_ content: String) -> [Int]? {
+            var probeMessages = messages
+            probeMessages.append(["role": "assistant", "content": content])
+            return try? controllable.applyChatTemplate(
+                messages: probeMessages,
+                tools: tools,
+                additionalContext: additionalContext,
+                addGenerationPrompt: false)
+        }
+
+        guard let probeA = renderProbe("0"),
+              let probeB = renderProbe("z"),
+              !probeA.isEmpty,
+              !probeB.isEmpty
+        else {
+            return nil
+        }
+
+        let limit = min(probeA.count, probeB.count, promptTokens.count)
+        var boundary = 0
+        while boundary < limit,
+              probeA[boundary] == probeB[boundary],
+              probeA[boundary] == promptTokens[boundary]
+        {
+            boundary += 1
+        }
+
+        guard boundary > 0,
+              boundary < probeA.count,
+              boundary < probeB.count,
+              boundary < promptTokens.count
+        else {
+            return nil
+        }
+        return boundary
+    }
+
     /// Intermediate turn-aligned rungs between the stable prefix and the
     /// newest history boundary.
     ///
@@ -292,7 +349,8 @@ public func canonicalChatCacheBoundaries(
         return rungs
     }
 
-    let historyTop = exactPrefixBoundary(messages: messages)
+    let historyTop = assistantContinuationStableBoundary()
+        ?? exactPrefixBoundary(messages: messages)
         ?? trailingContinuationBoundary()
     let history = historyTop.map { [$0] + historyLadder(below: $0) } ?? []
     let all = Array(Set(stable + history)).sorted()

--- a/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
@@ -263,8 +263,8 @@ struct BatchEngineGrowingChatCacheSourceTests {
         #expect(source.contains("coordinator.hasValidatedDiskEntry("))
     }
 
-    @Test("token iterator drains MLX around cache store before completion info")
-    func tokenIteratorDrainsMLXAroundCacheStoreBeforeCompletionInfo() throws {
+    @Test("token iterator publishes info early but finishes only after cache store drain")
+    func tokenIteratorFinishesOnlyAfterCacheStoreDrain() throws {
         let source = try String(
             contentsOfFile: "Libraries/MLXLMCommon/Evaluate.swift",
             encoding: .utf8)
@@ -273,31 +273,28 @@ struct BatchEngineGrowingChatCacheSourceTests {
 
         let onEnd = try #require(task.range(of: "handler.onGenerationEnd(emit: continuation.yield)"))
         let store = try #require(task.range(of: "iterator.storeCacheAfterGeneration("))
+        let info = try #require(task.range(
+            of: "handler.infoEvent(info)",
+            range: onEnd.upperBound..<store.lowerBound))
         let preStoreSync = try #require(task.range(
             of: "Stream().synchronize()",
-            range: onEnd.upperBound..<store.lowerBound))
+            range: info.upperBound..<store.lowerBound))
         let postStoreSync = try #require(task.range(
             of: "Stream().synchronize()",
             range: store.upperBound..<task.endIndex))
         let advisorDrain = try #require(task.range(
             of: "MLXPressCanonicalExpertAdvisor.shared.waitUntilIdle()",
             range: postStoreSync.upperBound..<task.endIndex))
-        let info = try #require(task.range(
-            of: "handler.infoEvent(info)",
-            range: advisorDrain.upperBound..<task.endIndex))
         let finish = try #require(task.range(
             of: "continuation.finish()",
-            range: info.upperBound..<task.endIndex))
+            range: advisorDrain.upperBound..<task.endIndex))
 
-        #expect(onEnd.lowerBound < preStoreSync.lowerBound)
+        #expect(onEnd.lowerBound < info.lowerBound)
+        #expect(info.lowerBound < preStoreSync.lowerBound)
         #expect(preStoreSync.lowerBound < store.lowerBound)
         #expect(store.lowerBound < postStoreSync.lowerBound)
         #expect(postStoreSync.lowerBound < advisorDrain.lowerBound)
-        #expect(advisorDrain.lowerBound < info.lowerBound)
-        #expect(info.lowerBound < finish.lowerBound)
-        #expect(task.range(
-            of: "handler.infoEvent(info)",
-            range: onEnd.upperBound..<store.lowerBound) == nil)
+        #expect(advisorDrain.lowerBound < finish.lowerBound)
     }
 
     @Test("token iterator materializes disk cache restores before prefill")

--- a/Tests/MLXLMCommonFocusedTests/CanonicalChatCacheBoundariesTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/CanonicalChatCacheBoundariesTests.swift
@@ -249,6 +249,84 @@ struct CanonicalChatCacheBoundariesTests {
         }
     }
 
+    /// Raptor/Qwen-shaped separator rewrite: an open generation rail carries a
+    /// newline before `<role>`, while materialising the assistant continuation
+    /// removes that newline. A no-generation render alone therefore publishes
+    /// one token too far into history.
+    private struct RewrittenAssistantSeparatorTokenizer: GenerationPromptControllableTokenizer {
+        var bosToken: String? { nil }
+        var eosToken: String? { nil }
+        var unknownToken: String? { nil }
+
+        func encode(text: String, addSpecialTokens: Bool) -> [Int] { [] }
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String { "" }
+        func convertTokenToId(_ token: String) -> Int? { nil }
+        func convertIdToToken(_ id: Int) -> String? { nil }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] {
+            try applyChatTemplate(
+                messages: messages, tools: tools,
+                additionalContext: additionalContext, addGenerationPrompt: true)
+        }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?,
+            addGenerationPrompt: Bool
+        ) throws -> [Int] {
+            var result = [1]
+            for message in messages {
+                switch message["role"] as? String {
+                case "system": result.append(10)
+                case "user": result.append(30)
+                case "assistant":
+                    result.append(157_151) // <role>
+                    let content = message["content"] as? String ?? ""
+                    result.append(content.first == "0" ? 60 : 61)
+                default: result.append(50)
+                }
+            }
+            if addGenerationPrompt {
+                result.append(198) // newline present only on the open rail
+                result.append(157_151)
+                result.append(40)
+            } else if messages.last?["role"] as? String == "user" {
+                result.append(198)
+            }
+            return result
+        }
+    }
+
+    @Test("history boundary excludes a separator rewritten by the next assistant continuation")
+    func rewrittenAssistantSeparatorIsExcludedFromHistoryBoundary() throws {
+        let tokenizer = RewrittenAssistantSeparatorTokenizer()
+        let messages: [[String: any Sendable]] = [
+            ["role": "system", "content": "rules"],
+            ["role": "user", "content": "read two files"],
+        ]
+        let prompt = try tokenizer.applyChatTemplate(
+            messages: messages, tools: tools, additionalContext: nil,
+            addGenerationPrompt: true)
+        let boundaries = canonicalChatCacheBoundaries(
+            tokenizer: tokenizer,
+            messages: messages,
+            tools: tools,
+            additionalContext: nil,
+            promptTokens: prompt)
+
+        #expect(prompt == [1, 10, 30, 198, 157_151, 40])
+        // The old no-generation boundary was 4 and included token 198. The
+        // future structured assistant render has <role> at index 3, so only
+        // the first three tokens are cross-turn stable.
+        #expect(boundaries.all.contains(3))
+        #expect(!boundaries.all.contains(4))
+    }
+
     @Test("a trailing assistant continuation still publishes a history boundary")
     func trailingAssistantContinuationPublishesHistoryBoundary() {
         let tokenizer = ContinuationRailTokenizer()


### PR DESCRIPTION
## Summary
- derive the newest reusable history boundary from an exact chat-template continuation proof instead of assuming the current no-generation render stays stable
- use canonical template boundaries for hybrid AR, native MTP, and batched cache stores, retaining the model-load suffix heuristic only for raw inputs without canonical chat metadata
- add trace-only first-divergent-token diagnostics for equal-length cache-key misses
- update the terminal-order source contract: completion metadata may be early, but the stream cannot finish until cache persistence and MLX/advisor drains complete

## Source evidence
The reproduced miss stored and fetched the same token count but diverged at the final boundary token: stored newline token 198 vs next-render `<role>` token 157151. The new continuation LCP excludes that template-rewritten separator without model-ID or token-ID special casing.

## Tests
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcrun swift test --filter CanonicalChatCacheBoundariesTests` — 12/12 passed
- `... swift test --skip-build --filter CacheStoreBudgetTests` — 17/17 passed
- `... swift test --filter BatchEngineGrowingChatCacheSourceTests` — all 27 selected source assertions passed; standalone runner printed a missing default metallib message after the source-only checks
- Osaurus Release app compiled successfully against this checkout

## Live proof status
PARTIAL: the rebuilt Osaurus app is open for the manual growing multi-file/tool-loop run. Do not merge solely from this description until its trace shows the newly stored canonical boundary is restored on successive tool steps and prefill no longer falls back to the static prefix.