### PR TITLE
DeepseekV3 MoE: cast router scores back before applying to expert outputs

### DIFF
--- a/Libraries/MLXLLM/Models/DeepseekV3.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV3.swift
@@ -352,7 +352,14 @@ class DeepseekV3MoE: Module, UnaryLayer {
         let (indices, scores) = gate(x)
         JangPressCanonicalExpertAdvisor.shared.observe(layer: layerIdx, indices: indices)
         var y = switchMLP(x, indices)
-        y = (y * scores[.ellipsis, .newAxis]).sum(axis: -2)
+        // Router scores are float32 for numerical stability; cast back
+        // before applying so the f32 does not leak into the residual
+        // stream. Without the cast every layer past firstKDenseReplace ran
+        // — and cached KV — in float32 (observed live on a deepseek_v3 MoE
+        // bundle: 46/48 layers' disk cache entries stored F32 at exactly
+        // twice the bf16 size), doubling decode compute, KV bandwidth, and
+        // disk cache footprint.
+        y = (y * scores[.ellipsis, .newAxis].asType(y.dtype)).sum(axis: -2)
 
         if let shared = sharedExperts {
             y = y + shared(x)

--- a/Tests/MLXLMTests/DeepseekV3MoEDtypeTests.swift
+++ b/Tests/MLXLMTests/DeepseekV3MoEDtypeTests.swift
@@ -1,0 +1,75 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// DeepseekV3 MoE dtype-preservation gate. The router computes its scores
+// in float32 for numerical stability; applying them to the expert
+// outputs without casting back promoted the entire residual stream to
+// float32 from the first MoE layer on. Every downstream matmul and every
+// cached KV then ran at twice the bf16 cost — observed live on a
+// deepseek_v3 MoE bundle whose disk cache stored 46/48 layers' KV as F32
+// at exactly 2x the bf16 entry size (1880 KB/token), with only the
+// first_k_dense_replace layers still bf16. The expert mix must return
+// the input dtype.
+
+import Foundation
+import MLX
+import MLXRandom
+import XCTest
+
+@testable import MLXLLM
+
+final class DeepseekV3MoEDtypeTests: XCTestCase {
+
+    private static let minimalConfigJSON = """
+        {
+          "model_type": "deepseek_v3",
+          "hidden_size": 64,
+          "num_hidden_layers": 2,
+          "intermediate_size": 128,
+          "num_attention_heads": 4,
+          "num_key_value_heads": 2,
+          "rms_norm_eps": 1e-6,
+          "vocab_size": 100,
+          "max_position_embeddings": 2048,
+          "rope_theta": 10000.0,
+          "q_lora_rank": 16,
+          "kv_lora_rank": 16,
+          "qk_nope_head_dim": 8,
+          "qk_rope_head_dim": 8,
+          "v_head_dim": 8,
+          "moe_intermediate_size": 32,
+          "first_k_dense_replace": 1,
+          "moe_layer_freq": 1,
+          "n_routed_experts": 4,
+          "num_experts_per_tok": 2,
+          "topk_group": 1,
+          "n_group": 1,
+          "routed_scaling_factor": 1.0
+        }
+        """
+
+    func testMoEOutputPreservesBF16InputDtype() throws {
+        let config = try JSONDecoder().decode(
+            DeepseekV3Configuration.self,
+            from: Data(Self.minimalConfigJSON.utf8))
+        let moe = DeepseekV3MoE(config: config, layerIdx: 1)
+
+        // Freshly initialized modules carry float32 weights; cast them to
+        // bf16 so the module matches a real loaded bundle, where the leak
+        // was the f32 router scores, not the weights.
+        let bf16Params = ModuleParameters.unflattened(
+            moe.parameters().flattened().map { ($0.0, $0.1.asType(.bfloat16)) }
+        )
+        try moe.update(parameters: bf16Params, verify: [.noUnusedKeys])
+
+        let x = MLXRandom.normal([1, 3, 64]).asType(.bfloat16)
+        let y = moe(x)
+        eval(y)
+
+        XCTAssertEqual(
+            y.dtype, .bfloat16,
+            "MoE expert mix must preserve the residual-stream dtype; an f32 "
+                + "result means the router scores leaked into the residual "
+                + "and every downstream layer (and its cached KV) runs f32")
+    }
+}


### PR DESCRIPTION
## Problem

`MoEGate` computes routing scores in float32 for numerical stability, and `DeepseekV3MoE` multiplied the bf16 expert outputs by those f32 scores without casting back. Dtype promotion (bf16 × f32 → f32) then carried float32 into the residual stream from the first MoE layer on: every downstream matmul, every cached K/V, and every disk cache entry past `first_k_dense_replace` ran at twice the bf16 cost.

## Evidence

Live disk-cache forensics on a deepseek_v3 MoE bundle (Kanana-2-30B-A3B, 48 layers, `first_k_dense_replace` dense head): cache entries store 46/48 layers' K/V as `F32 (1, 32, N, 192/128)` at exactly **1880 KB/token — twice the bf16 size** — while only the leading dense layers remain BF16, matching the promotion point exactly. 38% of a 135 GB production cache directory was f32 KV.

Cost: ~2× decode compute for the whole MoE stack, 2× KV bandwidth at decode, 2× disk cache footprint for every deepseek_v3-arch bundle (DeepSeek-V3, Kimi K2.x, Kanana, and derivatives).

## Fix

Cast the selected scores to the expert-output dtype at the point of application; routing math (sigmoid, group top-k, normalization) stays float32. One expression changed.

## Test

`DeepseekV3MoEDtypeTests` constructs `DeepseekV3MoE` from a minimal config, casts its parameters to bf16 to match a loaded bundle, and asserts the expert mix preserves the input dtype — fails on the old expression by bf16×f32 promotion, passes with the cast.