### PR TITLE
mHC: the cached region key names every quantity the region depends on

### DIFF
--- a/Libraries/MLXLLM/Models/DeepseekV4MathHelpers.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV4MathHelpers.swift
@@ -515,7 +515,12 @@ public enum DeepseekV4Math {
         eps: Float,
         normEps: Float
     ) -> (x: MLXArray, post: MLXArray, comb: MLXArray) {
-        let key = "\(hcMult)|\(hiddenSize)|\(iters)|\(eps)"
+        // `normEps` belongs in the key. The cached region is a function of all FIVE quantities, but
+        // the key named only four — so two families agreeing on hcMult/hiddenSize/iters/eps and
+        // differing only in the norm epsilon would collide, and the second one silently gets the
+        // first one's region. DSV4 alone cannot expose this: it derives both epsilons from a
+        // configuration that always makes them equal, so its key is unambiguous by accident.
+        let key = "\(hcMult)|\(hiddenSize)|\(iters)|\(eps)|\(normEps)"
         hcPreCompiledLock.lock()
         var region = hcPreCompiledCache[key]
         if region == nil {


### PR DESCRIPTION
> **Stacked on #381 — merge that first.** `normEps` does not exist without it, so until #381 lands
> GitHub shows this PR's diff as containing #381's commit too. The change belonging to *this* PR is
> six lines in `DeepseekV4MathHelpers.swift`.

`hyperConnectionRegion` caches by

```swift
let key = "\(hcMult)|\(hiddenSize)|\(iters)|\(eps)"
```

but the region it returns is a function of **five** quantities — the norm epsilon is not named. Two
families agreeing on the first four and differing only in `normEps` collide, and the second silently
receives the first one's region.

## Why it survived

It is not reachable from DeepSeek V4 alone. DSV4 derives both epsilons from a configuration that
always makes them equal, so its key is unambiguous *by accident* rather than by construction. The
collision needs two callers with different norm epsilons, which only exists once a second family
uses this type — which is exactly what is coming.

## Why it is a separate PR

#381 fixes **which epsilon the norm uses**. This fixes **what the cache key names**. They arrived in
the same working branch because the change that introduces `normEps` is also the change that makes
the key incomplete — but they are separate defects with separate arguments, and one can be right
while the other is wrong.

I originally shipped both under #381's commit message. That message talks about an epsilon; a
reviewer reading it would have had no reason to look for a cache-key change, and no way to accept
one and reject the other. Splitting it is the point.

## Verification

Builds on upstream `main` + #358 + #381, and #381's oracle tests still pass. There is no test for
the collision itself: reproducing it needs two families with different norm epsilons instantiated
against the same cache, and the second family does not exist in this repo yet. Stating that plainly
rather than adding a test that cannot fail today.
