### PR TITLE
Native MTP: abandon the prefetched verify before stats finalize

### DIFF
--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -1024,6 +1024,15 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     /// Idempotent: `storeCacheAfterGeneration` calls it as a backstop for
     /// callers that never ran the loop's early-finalize step.
     mutating func finalizeGenerationStats(generatedTokenIds: [Int]) {
+        // Generation is over by the time stats finalize; roll back any
+        // unconsumed prefetched verify NOW so (a) the `abandoned` counter on
+        // the summary line below is truthful — the early-finalize call the
+        // generate loop makes to stop the host spinner printed before
+        // `storeCacheAfterGeneration`'s abandon ran, reporting 0 for a
+        // mid-generation Stop that really did abandon one — and (b) the
+        // speculative rows leave the attention lanes at the earliest safe
+        // point. Idempotent; the store-path call remains as the backstop.
+        abandonPendingVerify()
         guard !generationStatsFinalized else { return }
         generationStatsFinalized = true
         let accepted = acceptedByDepth


### PR DESCRIPTION
Telemetry-truth follow-up to #386, found by the post-merge interaction audit (Stop-button mid-generation): the early finalizeGenerationStats call prints the summary line before storeCacheAfterGeneration's abandon runs, so a cancelled generation with one outstanding prefetch reported `abandoned=0`. Abandon now also runs at finalize time (idempotent, strictly earlier); the store-path call remains as a backstop.

Live proof: Stop pressed at 312/1128 tokens with prefetch in flight (submit=80/consumed=79), follow-up turn restored the stored boundary and continued the count exactly (…314-320, 56 tok/s) — the audit table for the whole interaction surface (Stop, tool chains, sampled/media/B>1 exclusions, gate disengagement) is in #383.