### PR TITLE
MTP inspector: union the index weight_map with safetensors header names

### DIFF
--- a/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
+++ b/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
@@ -1855,11 +1855,22 @@ public enum MTPBundleInspector {
     }
 
     private static func loadTensorNames(from directory: URL) throws -> [String] {
+        // The index, when present, is a fast path — but it must never VETO
+        // tensors that are physically in the shards. Observed live
+        // (Qwen3.8-27B-JANG_4D): the stamping pipeline wrote 31 `mtp.*`
+        // tensors into the safetensors but omitted every one of them from
+        // `model.safetensors.index.json`'s 2,348-entry weight_map, so an
+        // index-only read reported `tensors=0 metadata_only_missing_weights`
+        // and refused both auto and manual MTP for a bundle whose head is
+        // complete. Union the index keys with the header scan; headers cost
+        // one small read per shard and this runs only at load-time
+        // inspection.
+        var names: Set<String> = []
         let indexURL = directory.appendingPathComponent("model.safetensors.index.json")
         if let index = try loadJSONObjectIfExists(indexURL),
             let weightMap = index["weight_map"] as? [String: Any]
         {
-            return Array(weightMap.keys)
+            names.formUnion(weightMap.keys)
         }
 
         let contents =
@@ -1869,11 +1880,10 @@ public enum MTPBundleInspector {
                 options: [.skipsHiddenFiles])) ?? []
         let safetensors = contents.filter { $0.pathExtension == "safetensors" }
 
-        var names: [String] = []
         for file in safetensors {
-            names.append(contentsOf: try safetensorsHeaderNames(file))
+            names.formUnion(try safetensorsHeaderNames(file))
         }
-        return names
+        return Array(names)
     }
 
     private struct NativeMTPTuningDocument: Decodable {


### PR DESCRIPTION
## Problem

`MTPBundleInspector.loadTensorNames` returns `model.safetensors.index.json` weight_map keys **exclusively** whenever an index file exists — the safetensors header scan only runs when the index is absent. An index that omits tensors physically present in the shards therefore becomes a veto on MTP (and vision) evidence.

This is not hypothetical. On `Qwen3.8-27B-JANG_4D`, a stamping pass rewrote the index on 2026-08-31 22:53 with **2,348 entries and zero of the 31 `mtp.*` tensors** that live in `model-mtp-of-00005.safetensors` (the mtp shard's name doesn't match the `model-NNNNN-of-MMMMM` pattern the index generator globbed). Result on an engine at current main:

```
MTP-PLAN model=qwen3.8-27b-jang_4d nativeMTP=false strategy=none
  reason=Manual MTP depth requires complete MTP tensor evidence in the bundle
  status=mtp: metadata_only_missing_weights, layers=1, tensors=0, tuning=d2
```

The same bundle engaged depth-3 MTP the day before the index rewrite — which is how the corruption was isolated (the pre-rewrite bundle had no index at all, so the inspector fell through to the header scan).

## Fix

Union the index weight_map keys with the per-shard safetensors header names. The union can only add physically-present tensors.

- **Cost:** one 8-byte-length + JSON-header read per shard, once per load-time inspection. No tensor data is touched.
- **Order:** the sole caller (`inspect`) uses the names only for prefix filtering and counting, so the Set-order change is inconsequential.
- **Consumers audited:** base weight loading and MTP-head loading both enumerate shard files from the filesystem (`Load.swift` glob), not the index — a plan approved on header evidence always finds its weights. `hasCompleteDeepseekV4AffinePrestackedIndex` (LoadConfiguration) reads the index directly and is untouched. Vision-tensor detection gains the same protection for free.

## Proof (live, broken index deliberately installed)

Rebuilt osaurus preview against this branch, restored the corrupt 2,348-entry index, launched the app, and ran a chat turn on the 27B (mtp force_on d1):

```
MTP-PLAN model=qwen3.8-27b-jang_4d nativeMTP=true strategy=native_mtp:d1·greedy-when-active
  status=mtp: preserved_enabled, layers=1, tensors=31, tuning=d2, speculative=on
STEP-MTP   depth=1 active=1 verifyCalls=24 acceptedByDepth=2/22 avgCommitted=1.92
  verifier=input_capture_staged cacheMode=private-mtp+verifier-prefix-commit
STEP-STATS promptTokens=3116 promptMs=10 genTokens=46 genTps=33.5 stop=stop
```

Inspection → plan → head weight load → live speculative decode, all with the corrupt index in place. A library-wide scan found no other bundle with index-vs-header divergence; the 27B's index has also been repaired on disk (backup kept), so shipped index-first builds keep working until this lands.