### PR TITLE
Hybrid cache: stop persisting recurrent-state copies the restore path never applies

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -1810,7 +1810,9 @@ public actor BatchEngine {
                         coordinator.setHybrid(
                             true,
                             requiresRecurrentSSMCompanion:
-                                topology.requiresRecurrentSSMCompanionState)
+                                topology.requiresRecurrentSSMCompanionState,
+                            requiresSeparateRecurrentPayload:
+                                topology.requiresSeparateRecurrentPayloadState)
                         Self.logger.info(
                             "Coordinator flipped to isHybrid=true on first hybrid slot admission"
                         )

--- a/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
@@ -103,6 +103,7 @@ public final class CacheCoordinator: @unchecked Sendable {
     /// hybrid topology that owns its companion tensors inside the v2 layer
     /// payload and therefore sets this false.
     private var _requiresRecurrentSSMCompanion: Bool = false
+    private var _requiresSeparateRecurrentPayload: Bool = false
 
     /// 2026-05-04 (DSV4 SWA/CSA/HSA correctness pass):
     /// Whether the model has hybrid pool caches (DeepseekV4 SWA+CSA+HSA)
@@ -215,12 +216,20 @@ public final class CacheCoordinator: @unchecked Sendable {
     ///     then requires a sidecar rather than accepting a false disk hit.
     public func setHybrid(
         _ isHybrid: Bool,
-        requiresRecurrentSSMCompanion: Bool? = nil
+        requiresRecurrentSSMCompanion: Bool? = nil,
+        requiresSeparateRecurrentPayload: Bool? = nil
     ) {
         lock.withLock {
             _isHybrid = isHybrid
             _requiresRecurrentSSMCompanion = isHybrid
                 ? (requiresRecurrentSSMCompanion ?? true)
+                : false
+            // Callers that don't know the payload topology inherit the
+            // companion flag — the conservative pre-split behavior (persist
+            // and require the separate recurrent payload).
+            _requiresSeparateRecurrentPayload = isHybrid
+                ? (requiresSeparateRecurrentPayload
+                    ?? _requiresRecurrentSSMCompanion)
                 : false
         }
     }
@@ -234,6 +243,16 @@ public final class CacheCoordinator: @unchecked Sendable {
     /// SSM/GDN snapshot at the exact matched prompt boundary.
     public var requiresRecurrentSSMCompanion: Bool {
         lock.withLock { _requiresRecurrentSSMCompanion }
+    }
+
+    /// Whether stores must persist recurrent state as a separate payload
+    /// (folded `ssm_*` + companion sidecar) because the v2 layer
+    /// serialization cannot round-trip it natively (ArraysCache/GDN).
+    /// MambaCache state round-trips in-file, so topologies without an
+    /// ArraysCache layer skip both extra copies. See
+    /// `ModelCacheTopologySnapshot.requiresSeparateRecurrentPayloadState`.
+    public var requiresSeparateRecurrentPayload: Bool {
+        lock.withLock { _requiresSeparateRecurrentPayload }
     }
 
     /// Whether a prompt-boundary store has any tier to land in. With both tiers
@@ -472,13 +491,17 @@ public final class CacheCoordinator: @unchecked Sendable {
             if !(states?.isEmpty ?? true) {
                 return true
             }
-            // Mamba/ArraysCache topologies require the separately keyed
-            // prompt-boundary sidecar. A generic format-v2 marker is not
-            // evidence that every recurrent layer is complete (ArraysCache
-            // is intentionally serialized as `.skip`). ZAYA CCA is topology-
-            // classified with this flag false because its v2 layer payload
-            // atomically owns KV + conv + previous-hidden state.
-            return !requiresRecurrentSSMCompanion
+            // ArraysCache topologies require the separately keyed
+            // prompt-boundary sidecar: v2 has no LayerKind for GDN state, so
+            // a format-v2 marker is not evidence those layers are complete.
+            // MambaCache state round-trips in the v2 payload itself
+            // (`mamba_{i}_state0/1`, applied by deserializeV2), so those
+            // topologies accept a v2 entry without any companion — matching
+            // the store side, which no longer persists the redundant copies
+            // for them. ZAYA CCA is topology-classified with this flag false
+            // because its v2 layer payload atomically owns KV + conv +
+            // previous-hidden state.
+            return !requiresSeparateRecurrentPayload
                 && diskArrays.map { TQDiskSerializer.formatVersion(of: $0) >= 2 } == true
         }
 
@@ -975,6 +998,7 @@ public final class CacheCoordinator: @unchecked Sendable {
         // see `isPagedIncompatible` above). Recurrent-only/state-only caches
         // must not publish token hashes without any restorable KV payload;
         // doing so would suppress the valid typed disk fallback on fetch.
+        var publishedPagedPayload = false
         if !isPagedIncompatible,
            hasPagedKVPayload,
            hasRequiredPagedCompanion,
@@ -985,6 +1009,7 @@ public final class CacheCoordinator: @unchecked Sendable {
                 layerData: blockLayerData,
                 boundaryCompanionData: pagedBoundaryCompanion,
                 mediaSalt: mediaSalt)
+            publishedPagedPayload = true
         }
 
         // Build the disk payload before entering the linked-store transaction.
@@ -1000,12 +1025,25 @@ public final class CacheCoordinator: @unchecked Sendable {
         // disk persistence for sliding-window models (Gemma3/Gemma4
         // SWA layers, Mistral4 with maxKVSize, MiMoV2Flash, BaichuanM1,
         // Qwen3.5-VL inherited sliding layers).
+        // Persist the separate recurrent payload (folded `ssm_*` + companion
+        // sidecar) only when something actually consumes it:
+        //  - ArraysCache/GDN topologies — the v2 layer serialization has no
+        //    LayerKind for that state, so the companion is its only carrier;
+        //  - a hybrid boundary that just published a PAGED payload — paged
+        //    blocks carry KV only, and the tier-1 hit path rejects hybrid
+        //    hits without `fetchCompleteSSMStates`.
+        // For disk-only MambaCache hybrids, the state round-trips in-file as
+        // `mamba_{i}_state0/1`; the extra copies tripled the recurrent bytes
+        // per stored boundary (~+300MB each on Qwen3.8-27B) without the
+        // restore path ever applying them.
+        let persistSeparateRecurrentPayload =
+            isHybrid && (requiresSeparateRecurrentPayload || publishedPagedPayload)
         var diskArrays: [String: MLXArray]?
         if diskCache != nil {
             if let cache {
                 let arrays = TQDiskSerializer.serialize(
                     cache: cache,
-                    ssmStates: isHybrid ? ssmStates : nil)
+                    ssmStates: persistSeparateRecurrentPayload ? ssmStates : nil)
                 if !arrays.isEmpty {
                     diskArrays = arrays
                 }
@@ -1031,7 +1069,7 @@ public final class CacheCoordinator: @unchecked Sendable {
         storePersistentBoundary(
             tokens: promptTokens,
             diskArrays: diskArrays,
-            ssmStates: isHybrid ? ssmStates : nil,
+            ssmStates: persistSeparateRecurrentPayload ? ssmStates : nil,
             mediaSalt: mediaSalt)
     }
 

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1852,7 +1852,9 @@ public struct TokenIterator: TokenIteratorProtocol {
                     coordinator.setHybrid(
                         true,
                         requiresRecurrentSSMCompanion:
-                            topology.requiresRecurrentSSMCompanionState)
+                            topology.requiresRecurrentSSMCompanionState,
+                        requiresSeparateRecurrentPayload:
+                            topology.requiresSeparateRecurrentPayloadState)
                     Self.logger.info(
                         "TokenIterator: coordinator flipped to isHybrid=true"
                     )

--- a/Libraries/MLXLMCommon/ModelContainer.swift
+++ b/Libraries/MLXLMCommon/ModelContainer.swift
@@ -84,6 +84,26 @@ public struct ModelCacheTopologySnapshot: Codable, Sendable, Equatable {
         mambaLayerCount > 0 || arraysLayerCount > 0
     }
 
+    /// Whether any recurrent state needs a SEPARATELY persisted payload
+    /// (folded `ssm_*` arrays + the `ssm_companion` sidecar) because the v2
+    /// disk layer serialization cannot round-trip it natively.
+    ///
+    /// Only ArraysCache (GatedDeltaNet linear-attention) state is in that
+    /// position: v2 has no `LayerKind` for it, so `restoreFromDiskArrays`
+    /// leaves those layers at their initial value and the companion is the
+    /// sole carrier. MambaCache state round-trips in-file as
+    /// `mamba_{i}_state0/1` and is restored by `deserializeV2` directly —
+    /// measured live on Qwen3.8-27B (48 mamba layers), the companion copies
+    /// added ~300MB per stored boundary that the restore path never applied.
+    ///
+    /// This is deliberately narrower than
+    /// ``requiresRecurrentSSMCompanionState``, which also encodes
+    /// path-dependence semantics (exact-boundary persistence and stable
+    /// boundary re-derive policy) that apply to Mamba topologies too.
+    public var requiresSeparateRecurrentPayloadState: Bool {
+        arraysLayerCount > 0
+    }
+
     public var requiresDiskBackedCoordinatorRestore: Bool {
         requiresSSMCompanionState
             || rotatingKVLayerCount > 0
@@ -306,7 +326,8 @@ public final class ModelContainer: Sendable {
         let coordinator = CacheCoordinator(config: config)
         coordinator.setHybrid(
             isHybrid,
-            requiresRecurrentSSMCompanion: topology.requiresRecurrentSSMCompanionState)
+            requiresRecurrentSSMCompanion: topology.requiresRecurrentSSMCompanionState,
+            requiresSeparateRecurrentPayload: topology.requiresSeparateRecurrentPayloadState)
         coordinator.setGenPromptSuffixTokens(await computeGenPromptSuffixTokens())
 
         _cacheCoordinator.withLock { $0 = coordinator }

--- a/Libraries/MLXLMCommon/SpecDec/DFlash2TokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/DFlash2TokenIterator.swift
@@ -414,7 +414,9 @@ struct DFlash2TokenIterator: TokenIteratorProtocol {
                 let topology = ModelCacheTopologySnapshot(cache: self.cache)
                 coordinator.setHybrid(
                     true,
-                    requiresRecurrentSSMCompanion: topology.requiresRecurrentSSMCompanionState)
+                    requiresRecurrentSSMCompanion: topology.requiresRecurrentSSMCompanionState,
+                    requiresSeparateRecurrentPayload:
+                        topology.requiresSeparateRecurrentPayloadState)
             }
             if !coordinator.isPagedIncompatible, cacheCannotUsePagedCoordinatorRestore(self.cache) {
                 if cacheCanUsePagedWithRotatingCompanion(self.cache) {

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -543,7 +543,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 coordinator.setHybrid(
                     true,
                     requiresRecurrentSSMCompanion:
-                        topology.requiresRecurrentSSMCompanionState)
+                        topology.requiresRecurrentSSMCompanionState,
+                    requiresSeparateRecurrentPayload:
+                        topology.requiresSeparateRecurrentPayloadState)
             }
             if !coordinator.isPagedIncompatible,
                cacheCannotUsePagedCoordinatorRestore(self.cache)

--- a/Tests/MLXLMCommonFocusedTests/CacheCoordinatorTopologyFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/CacheCoordinatorTopologyFocusedTests.swift
@@ -974,6 +974,100 @@ struct CacheCoordinatorTopologyFocusedTests {
         }
     }
 
+    @Test("mamba round-trip topology stores no separate recurrent payload")
+    func mambaRoundTripTopologySkipsSeparateRecurrentPayload() {
+        FocusedMLXTestSupport.withLock {
+        let tmp = makeTempDir("mamba-no-separate-payload")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let coordinator = makeCoordinator(
+            usePagedCache: false,
+            enableDiskCache: true,
+            diskCacheDir: tmp,
+            modelKey: "mamba-no-separate-payload-focused")
+        coordinator.setHybrid(
+            true,
+            requiresRecurrentSSMCompanion: true,
+            requiresSeparateRecurrentPayload: false)
+
+        let tokens = Array(501...512)
+        let cache = makeNemotronOmniCache(tokenCount: tokens.count, populated: true)
+
+        coordinator.storeAfterGeneration(
+            promptTokens: tokens,
+            perLayerData: [],
+            ssmStates: extractSSMStates(from: cache),
+            cache: cache)
+
+        // No companion sidecar and no folded `ssm_*` copy — the mamba state
+        // lives in the v2 payload as `mamba_{i}_state0/1` only.
+        #expect(coordinator.ssmStateCache.fetchEntry(
+            tokens: tokens,
+            boundary: tokens.count,
+            requireComplete: false) == nil)
+
+        switch coordinator.fetch(tokens: tokens + [513]) {
+        case .hit(let matched, let remaining, let detail, let blocks, let ssm, let arrays):
+            #expect(matched == tokens.count)
+            #expect(remaining == [513])
+            #expect(detail == .disk)
+            #expect(blocks.isEmpty)
+            #expect(ssm == nil)
+            guard let arrays else {
+                Issue.record("disk hit should carry the v2 payload")
+                return
+            }
+            #expect(arrays["__ssm_count__"] == nil)
+            #expect(!arrays.keys.contains { $0.hasPrefix("ssm_") })
+            #expect(arrays.keys.contains { $0.hasPrefix("mamba_") })
+        case .miss:
+            Issue.record(
+                "mamba hybrid v2 entry must be accepted without a recurrent companion")
+        }
+        }
+    }
+
+    @Test("separate-payload topology still persists and requires the companion")
+    func separatePayloadTopologyKeepsCompanion() {
+        FocusedMLXTestSupport.withLock {
+        let tmp = makeTempDir("arrays-separate-payload")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let coordinator = makeCoordinator(
+            usePagedCache: false,
+            enableDiskCache: true,
+            diskCacheDir: tmp,
+            modelKey: "arrays-separate-payload-focused")
+        coordinator.setHybrid(
+            true,
+            requiresRecurrentSSMCompanion: true,
+            requiresSeparateRecurrentPayload: true)
+
+        let tokens = Array(601...612)
+        let cache = makeNemotronOmniCache(tokenCount: tokens.count, populated: true)
+        let states = extractSSMStates(from: cache)
+
+        coordinator.storeAfterGeneration(
+            promptTokens: tokens,
+            perLayerData: [],
+            ssmStates: states,
+            cache: cache)
+
+        #expect(coordinator.ssmStateCache.fetchEntry(
+            tokens: tokens,
+            boundary: tokens.count,
+            requireComplete: false) != nil)
+
+        switch coordinator.fetch(tokens: tokens + [613]) {
+        case .hit(let matched, _, let detail, _, let ssm, let arrays):
+            #expect(matched == tokens.count)
+            #expect(detail == .disk)
+            #expect(ssm?.count == states.count)
+            #expect(arrays?["__ssm_count__"] != nil)
+        case .miss:
+            Issue.record("separate-payload hybrid should hit with its companion")
+        }
+        }
+    }
+
     @Test("dynamic reasoning scope isolates every coordinator hash tier")
     func dynamicReasoningScopeIsolatesCoordinatorHashTiers() {
         let tokens = [101, 102, 103, 104]

--- a/Tests/MLXLMTests/DeepseekV3MoEDtypeTests.swift
+++ b/Tests/MLXLMTests/DeepseekV3MoEDtypeTests.swift
@@ -13,6 +13,7 @@
 
 import Foundation
 import MLX
+import MLXNN
 import MLXRandom
 import XCTest
 


### PR DESCRIPTION
## Problem

Every stored prompt boundary for a MambaCache hybrid carries the recurrent state **three times**:

1. `mamba_{i}_state0/1` in the v2 payload — authoritative, applied by `deserializeV2`;
2. a folded `ssm_*` copy in the same file — only ever read to re-populate the companion store;
3. the `ssm_companion` sidecar file — fetched for validation, then **not applied**: the apply is gated on `fmtV < 2 || cacheHasArraysState`, and live tracing on Qwen3.8-27B (48× MambaCache + 16× KVCacheSimple) prints `willRestore=false`.

Measured on a fresh cache root (one short chat turn, preview build):
- 64-token boundary: **297MB** (149MB of it dead copies) + 154MB companion
- 3.1k boundary: **488MB** vs 341MB
- save time 0.11–0.12s per record, ~9–13 records per turn ⇒ ~3GB written for one Q&A turn
- the real box's `~/.osaurus/cache/kv_v2` sits at **87GB for 57 entries** in this shape

## Fix

Split the topology signal: the existing `requiresRecurrentSSMCompanionState` (mamba ‖ arrays) keeps its path-dependence semantics untouched (exact-boundary policy, stable-boundary re-derive, N-1 seeds); a new narrow `requiresSeparateRecurrentPayloadState` (**arrays only** — ArraysCache/GDN has no v2 LayerKind, so the companion is its only carrier) gates the storage question. Stores fold `ssm_*`/persist the companion only when the narrow flag is set **or the boundary just published a paged payload** (the tier-1 paged hit path requires `fetchCompleteSSMStates`, so paged/batch setups keep their companion). The fetch gate accepts v2 entries without a companion exactly for the topologies whose restore never applied it.

## Interaction audit

- **Paged tier**: hybrid paged hits reject without a companion → companion still persisted whenever a paged payload was published for the boundary.
- **BatchEngine exact-full-hit N-1 seed**: for mamba topologies the disk seed no longer exists; that path takes its existing correct full-prefill rollback (trade-off documented in the commit; the N-1 KV entry still carries the state in-file for a follow-up).
- **ArraysCache families** (FalconH1, BailingHybrid, …): narrow flag true, behavior byte-identical to before.
- **Old entries**: still readable — folded `ssm_*` reads and companion fetches are unchanged on the read side.
- Unchanged: `shouldPersistExactPromptBoundary`, `shouldForceStableBoundaryRederive`, ZAYA CCA classification.

## Proof

- **Unit**: 44/44 focused coordinator tests pass, incl. 2 new ones — mamba topology stores no `ssm_*`/companion and its v2 entry is accepted and restored without one; separate-payload topology still persists **and** requires the companion.
- **Live** (osaurus preview, fresh cache root, Qwen3.8-27B): companion files **0** (was 1/boundary); entry sizes/save times as above (−30%/−50% bytes, −70% save latency); app restart restores from the slim entry (`cacheRestore completed=2969/2970 detail=disk`), growing-turn boundary hit at `promptMs=10`, TTFT **0.59s** restored vs 4.33s cold; three consecutive restored-state generations coherent at 28–34 tok/s with MTP d1 active.
- **Structural equivalence**: for mamba topologies the restore applies the same `mamba_{i}_*` arrays before and after this change (`willRestore=false` both) — the restored cache state is bit-identical; only never-applied bytes stopped being written.

Also fixes the missing `MLXNN` import in `DeepseekV3MoEDtypeTests` that broke the whole SwiftPM test build.