### PR TITLE
Add an auxiliary cache-prompt intent that never persists boundaries

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -3213,7 +3213,12 @@ public actor BatchEngine {
         // ring buffer + 5-tuple metaState via `.rotating` LayerKind. The
         // `mediaSalt` is passed through so the stored key matches the key
         // the next fetch will look for (VL multi-turn cache hits).
-        if reason != .cancelled, let coordinator = cacheCoordinator {
+        if reason != .cancelled,
+            // Auxiliary (title/suggestion/summary) prompts never store a
+            // boundary — see `CachePromptIntent.auxiliary`.
+            slot.originalInput.cachePromptIntent != .auxiliary,
+            let coordinator = cacheCoordinator
+        {
             let promptTokens = slot.cachePromptTokenIds
             let hasHybridPool = slot.cache.contains { $0 is HybridPoolCache }
             let promptCacheSnapshot = slot.promptCacheSnapshot

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -2823,6 +2823,10 @@ public struct TokenIterator: TokenIteratorProtocol {
         guard let coordinator = cacheCoordinator, !promptTokenIds.isEmpty else {
             return
         }
+        // Auxiliary (title/suggestion/summary) prompts embed per-turn content
+        // and never prefix a future request — persisting their boundaries is
+        // pure write cost. They may restore; they never store.
+        guard originalInput.cachePromptIntent != .auxiliary else { return }
 
         var sharedPromptRederivedStates: [Int: [MLXArray]]?
         let sharedPromptAdditionalBoundaries = Array(Set(

--- a/Libraries/MLXLMCommon/LanguageModel.swift
+++ b/Libraries/MLXLMCommon/LanguageModel.swift
@@ -45,9 +45,17 @@ public struct LMInput {
     /// exact warmup checkpoint can replay the previous tool turn after a
     /// reasoning-mode change even though its token prefix matches. No warmup
     /// path may cache the throwaway decoded tokens.
+    /// ``auxiliary`` marks internal utility generations — chat titles,
+    /// follow-up suggestions, summaries — whose prompt embeds per-turn
+    /// content and is therefore never an exact prefix of any future request.
+    /// Persisting their boundaries is pure write cost: measured live, one
+    /// osaurus chat turn wrote six ~150MB hybrid boundary records for its
+    /// title/suggestion prompts alone. Auxiliary requests still RESTORE
+    /// whatever prefix the cache already holds; they just never store one.
     public enum CachePromptIntent: Sendable, Equatable {
         case generation
         case reusablePrefixWarmup
+        case auxiliary
     }
 
     /// Correctness policy for restoring a persisted prompt prefix.
@@ -274,6 +282,22 @@ public struct LMInput {
             cachePromptIntent: cachePromptIntent,
             cacheRestorePolicy: cacheRestorePolicy,
             toolSchemas: schemas)
+    }
+
+    /// Return an otherwise-identical input with an explicit prompt intent.
+    public func withCachePromptIntent(_ intent: CachePromptIntent) -> LMInput {
+        LMInput(
+            text: text,
+            image: image,
+            video: video,
+            audio: audio,
+            mediaTokenIds: mediaTokenIds,
+            cacheScopeSalt: cacheScopeSalt,
+            cachePrefixTokenCounts: cachePrefixTokenCounts,
+            cacheStablePrefixTokenCounts: cacheStablePrefixTokenCounts,
+            cachePromptIntent: intent,
+            cacheRestorePolicy: cacheRestorePolicy,
+            toolSchemas: toolSchemas)
     }
 
     /// Return an otherwise-identical input with an explicit restore policy.

--- a/Libraries/MLXLMCommon/SpecDec/DFlash2TokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/DFlash2TokenIterator.swift
@@ -1310,6 +1310,9 @@ struct DFlash2TokenIterator: TokenIteratorProtocol {
         // Never persist a cache that still carries unverified draft rows.
         abandonInFlightVerify()
         guard let coordinator = cacheCoordinator, !promptTokenIds.isEmpty else { return }
+        // Auxiliary (title/suggestion/summary) prompts never store a
+        // boundary — see `CachePromptIntent.auxiliary`.
+        guard originalInput.cachePromptIntent != .auxiliary else { return }
         defer {
             promptCacheSnapshot = nil
             hybridStripSnapshot = nil

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -827,6 +827,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         releaseCompiledVerify()
         if let coordinator = cacheCoordinator,
            !promptTokenIds.isEmpty,
+           // Auxiliary (title/suggestion/summary) prompts never store a
+           // boundary — see `CachePromptIntent.auxiliary`.
+           originalInput.cachePromptIntent != .auxiliary,
            let promptCacheSnapshot
         {
             // Shared with the solo and batched engines — see the note there.


### PR DESCRIPTION
## Problem

Internal utility generations (chat titles, follow-up suggestions, memory distillation, transcript cleanup) embed per-turn content in their prompts — their token streams are never an exact prefix of any future request. Persisting their prompt boundaries is pure write cost. Measured live on a MambaCache hybrid: one osaurus chat turn wrote **six ~150MB boundary records** for its title/suggestion prompts alone — about half the turn's remaining store volume even after #390.

## Change

- New `CachePromptIntent.auxiliary`: documented as restore-allowed, store-forbidden.
- Early-out of store-after-generation in all four engines (solo `TokenIterator`, `BatchEngine.finishSlot`, `NativeMTPTokenIterator`, `DFlash2TokenIterator`). The spec-dec iterators keep their verify rollback/release calls ahead of the guard — those are correctness cleanup, not persistence.
- `LMInput.withCachePromptIntent(_:)` helper mirroring `withCacheRestorePolicy` so hosts can mark a prepared input.

No behavior change for any existing caller — the case must be explicitly requested (osaurus side threads it from `CoreModelService`, whose callers are exactly the four utility services; PR to follow after this lands).

## Proof (live A/B, osaurus preview wired to this branch, fresh cache root, Qwen3.8-27B)

- store-phase records for one chat turn: **12 → 6** — every 144–239-token title/suggestion boundary record eliminated;
- the auto-title ('Why the Sky is Blue') and all four follow-up suggestions still generated normally (`STEP-STATS promptTokens=149 genTokens=5`, `promptTokens=188 genTokens=43`), main reply decoded at 42 tok/s;
- remaining stores are exactly the useful set: warm-up boundaries + main-turn exact/N-1/post-gen.