### PR TITLE
Native MTP: gate the exact-prompt store behind the canonical hybrid boundary

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -2262,6 +2262,15 @@ public struct TokenIterator: TokenIteratorProtocol {
         let canonicalBoundary = input.cachePrefixTokenCounts
             .filter { $0 > 0 && $0 < promptTokenIds.count }
             .max()
+        if ProcessInfo.processInfo.environment["VMLX_STRIP_BOUNDARY_TRACE"] == "1" {
+            FileHandle.standardError.write(Data(
+                ("[vmlx][strip-boundary] prompt=\(promptTokenIds.count) "
+                    + "canonical=\(canonicalBoundary.map(String.init) ?? "nil") "
+                    + "prefixCounts=\(input.cachePrefixTokenCounts) "
+                    + "stableCounts=\(input.cacheStablePrefixTokenCounts) "
+                    + "genSuffixTokens=\(coordinator?.genPromptSuffixTokens ?? []) "
+                    + "heuristic=\(heuristicBoundary.map(String.init) ?? "nil")\n").utf8))
+        }
         guard ProcessInfo.processInfo.environment["VMLX_HYBRID_STRIPPED_STORE"] != "0",
             let coordinator,
             coordinator.isHybrid,

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -839,6 +839,19 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 input: originalInput)
             let isReusablePrefixWarmup =
                 originalInput.cachePromptIntent == .reusablePrefixWarmup
+            // Same canonical-boundary policy as the solo TokenIterator,
+            // BatchEngine.finishSlot, and DFlash2 store paths: when a
+            // path-dependent hybrid has a proven cross-turn boundary, the
+            // full-prompt record is a boundary no later turn can match
+            // (the next turn replaces the generation suffix, and hybrid
+            // fetch skips exact boundaries by construction) — storing it
+            // costs a full synchronous snapshot write per turn for an
+            // entry that is never restored. MTP was the fourth store
+            // path; the first three were gated and this one was missed —
+            // measured live as an extra ~100ms + ~350-500MB record on
+            // EVERY tool-call cycle (exact 3446 beside canonical 3445).
+            let usesCanonicalHybridBoundary =
+                coordinator.isHybrid && sharedPromptStripBoundary != nil
             let shouldPersistExactWarmupPrompt = shouldPersistExactPromptBoundary(
                 cachePromptIntent: originalInput.cachePromptIntent,
                 requiresRecurrentSSMCompanion:
@@ -915,7 +928,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                     mediaSalt: mediaSalt)
             }
 
-            if shouldPersistExactWarmupPrompt {
+            if shouldPersistExactWarmupPrompt, !usesCanonicalHybridBoundary {
                 store(
                     tokens: promptTokenIds,
                     snapshot: promptCacheSnapshot,


### PR DESCRIPTION
## Problem

Solo TokenIterator, BatchEngine.finishSlot, and DFlash2 all skip the full-prompt boundary record when a path-dependent hybrid has a proven cross-turn boundary (`usesCanonicalHybridBoundary`) — the next turn replaces the generation suffix so the full-prompt key never matches again, and hybrid fetch skips exact boundaries by construction. **The native-MTP iterator was the fourth store path and never got the gate** (same drift its own `CacheStoreBudget` note records for the budget guard).

Measured live on Qwen3.8-27B tool chains: **two ~100ms, ~350–500MB synchronous records per tool call** (exact 3446 beside canonical 3445), where the exact record is never restored — the new `VMLX_STRIP_BOUNDARY_TRACE` diagnostic shows the canonical publish working on every step (`prefixCounts=[1791, …, N-1]`, the assistant-continuation LCP proof layer) and every continuation LCPs at N-1.

## Fix

Mirror the other three engines: compute `usesCanonicalHybridBoundary` and gate the exact-prompt `store` on its absence. Hybrids without a canonical/strip boundary (raw/benchmark prompts) keep the exact record; dense models unaffected; identical reruns resume via the N-1 seed + one-token eval (the same fullhit-trim-eval1 contract fetch already enforces).

Also keeps the env-gated `VMLX_STRIP_BOUNDARY_TRACE=1` diagnostic in `hybridStripBoundaryIndex` that isolated this.

## Proof (live A/B, osaurus preview wired to this branch, 27B, real 7-step file-tool chain with tools auto-approved)

- Before: every tool cycle wrote the pair (e.g. `store-phase count=3446` + `count=3445`, ~0.10s each).
- After: **one record per cycle** — canonical boundaries 2649/2731/2813/2945/3230/3612/4042 across the chain, no exact-N records — while every tool continuation still restored at `promptMs=10` and decode held 20–25 tok/s.
- `CacheCoordinatorTopologyFocusedTests`: 44/44 pass. (`MTPRuntimeFocusedTests` / depth-3 auto-launch suites are red on main independently of this change — stale #373 expectations masked by #379's import break; filed as #393 with pin-vs-main verification.)