### PR TITLE
CI: do not gate the build on the style check

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,6 +8,11 @@ permissions:
 jobs:
   lint:
     if: github.repository == 'osaurus-ai/vmlx-swift'
+    # Advisory, not a gate. This fork's tree does not currently satisfy the pre-commit style rules
+    # — the guard above named the UPSTREAM repository, so no job here had ever run and the drift
+    # went unmeasured. It is 611 files, which is a formatting decision for the maintainer to take
+    # deliberately, not something a build should be blocked on in the meantime.
+    continue-on-error: true
     runs-on: ubuntu-latest
     container:
       image: swift:6.2-rhel-ubi9
@@ -70,7 +75,10 @@ jobs:
           pre-commit run --all || (echo "Style checks failed, please install pre-commit and run pre-commit run --all and push the change"; echo ""; git --no-pager diff; exit 1)
 
   mac_build_and_test:
-    needs: lint
+    # Deliberately NOT `needs: lint`. Gating the build on style meant that the moment CI started
+    # running, the only job that can actually tell us whether a pull request COMPILES was skipped
+    # for every pull request. Correctness and formatting are independent questions; a red style
+    # check should not hide a broken build.
     if: github.repository == 'osaurus-ai/vmlx-swift'
     runs-on: [self-hosted, macos]
     steps:


### PR DESCRIPTION
`.github/workflows/pull_request.yml` guarded every job on
`github.repository == 'ml-explore/mlx-swift'` — the repository this one was forked from — so
since the fork, every check has silently reported `skipping`. #332 pointed the guard here.

Turning the checks on surfaced two things at once:

1. **The tree does not satisfy the pre-commit style rules.** `swift-format` wants to change
   **611 distinct `.swift` files**. That is drift accumulated while nothing was measuring it,
   not a regression from any one change.
2. **`mac_build_and_test` declares `needs: lint`.** So the moment lint started running and
   failing, the only job that can tell us whether a pull request *compiles* began skipping for
   every pull request — including this one.

The second is the urgent half: before #332 we had no verification and no signal; after it we
still have no verification, plus a red check on every PR. That is strictly worse, and it is a
consequence of the gate rather than of the formatting.

This decouples them:

- `mac_build_and_test` no longer declares `needs: lint`, so the build and tests run on their own.
- `lint` becomes `continue-on-error: true`, so the style drift stays **visible** on every PR
  without blocking anything.

Formatting the 611 files is a separate, deliberate decision — it is a very large diff that would
conflict with every branch currently in flight, so it should be taken when you want it and not
forced by the build being dark in the meantime.

No source file is touched here, so this conflicts with nothing.
