### PR TITLE
Tool dispatch ends the turn: early stop instead of drain-to-EOS

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -154,10 +154,25 @@ private func debugDumpReasoningPrompt(
 private final class BatchStreamTerminationState: @unchecked Sendable {
     private let lock = NSLock()
     private var completed = false
+    private var toolCallEmitted = false
 
     func markCompleted() {
         lock.lock()
         completed = true
+        lock.unlock()
+    }
+
+    /// Record that the bridge surfaced a parsed `.toolCall` to the consumer.
+    /// A consumer that terminates AFTER this point has everything it needs —
+    /// the dispatched tool defines the turn's end — so termination routes to
+    /// ``BatchEngine/finishEarly(_:)`` (natural `.stop`, boundary stores run)
+    /// instead of ``BatchEngine/cancel(_:)`` (stores skipped). Without this,
+    /// a host that stops consuming at tool dispatch either loses the
+    /// boundary store or must drain the model's post-tool-call prose to EOS
+    /// at full decode cost (measured up to maxTokens=16384 of zombie decode).
+    func markToolCallEmitted() {
+        lock.lock()
+        toolCallEmitted = true
         lock.unlock()
     }
 
@@ -166,6 +181,13 @@ private final class BatchStreamTerminationState: @unchecked Sendable {
         let shouldCancel = !completed
         lock.unlock()
         return shouldCancel
+    }
+
+    func didEmitToolCall() -> Bool {
+        lock.lock()
+        let value = toolCallEmitted
+        lock.unlock()
+        return value
     }
 }
 
@@ -752,8 +774,16 @@ public actor BatchEngine {
         continuation.onTermination = {
             @Sendable [requestId, engineRef, terminationState] _ in
             guard terminationState.shouldCancelOnTermination() else { return }
+            let toolDispatch = terminationState.didEmitToolCall()
             Task {
-                await engineRef.cancel(requestId)
+                if toolDispatch {
+                    // The consumer stopped at tool dispatch: finish the slot
+                    // with a natural `.stop` so boundary stores run and the
+                    // tool continuation restores instead of re-prefilling.
+                    await engineRef.finishEarly(requestId)
+                } else {
+                    await engineRef.cancel(requestId)
+                }
             }
         }
 
@@ -848,6 +878,9 @@ public actor BatchEngine {
                         let tail = stopMatcher.flush()
                         if !tail.isEmpty { continuation.yield(.chunk(tail)) }
                     }
+                    // From here on, consumer termination means "tool
+                    // dispatched" — route it to finishEarly, not cancel.
+                    terminationState.markToolCallEmitted()
                     continuation.yield(event)
                 case .toolCallProgress:
                     continuation.yield(event)
@@ -1505,6 +1538,38 @@ public actor BatchEngine {
         if let idx = activeSlots.firstIndex(where: { $0.id == id }) {
             var slot = activeSlots[idx]
             finishSlot(&slot, reason: .cancelled)
+            slot.isFinished = true
+            activeSlots[idx] = slot
+        }
+    }
+
+    /// Finish a specific request early with a natural `.stop`.
+    ///
+    /// The consumer has everything it needs from this generation — the
+    /// canonical case is a parsed tool call that has already been
+    /// dispatched — and every further decode step is waste. Unlike
+    /// ``cancel(_:)``, this goes through the normal ``finishSlot`` path:
+    /// prompt-boundary stores run and the stream closes with `.stop`, so
+    /// the tool continuation restores the persisted boundary instead of
+    /// re-prefilling. Requests still in the wait queue have generated
+    /// nothing and are removed exactly as ``cancel(_:)`` removes them.
+    public func finishEarly(_ id: BatchRequestID) {
+        if let idx = waitQueue.firstIndex(where: { $0.id == id }) {
+            let request = waitQueue.remove(at: idx)
+            request.continuation.yield(.info(GenerateCompletionInfo(
+                promptTokenCount: request.input.text.tokens.size,
+                generationTokenCount: 0,
+                promptTime: 0,
+                generationTime: 0,
+                stopReason: .cancelled
+            )))
+            request.continuation.finish()
+            return
+        }
+
+        if let idx = activeSlots.firstIndex(where: { $0.id == id }) {
+            var slot = activeSlots[idx]
+            finishSlot(&slot, reason: .stop)
             slot.isFinished = true
             activeSlots[idx] = slot
         }

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -4610,9 +4610,15 @@ private func generateLoopTask<Handler: TokenLoopHandler>(
             )
 
             while let token = iterator.next() {
-                // Check for cancellation on every loop iteration.
+                // Check for cancellation on every loop iteration. A consumer
+                // that stops after the handler surfaced a parsed tool call is
+                // not abandoning the turn — the dispatched tool defines its
+                // end — so that termination is a natural `.stop`, not a
+                // `.cancelled`. This is what lets hosts stop consuming at
+                // tool dispatch instead of draining the model's post-tool
+                // prose to EOS (measured up to maxTokens of zombie decode).
                 if Task.isCancelled {
-                    stopReason = .cancelled
+                    stopReason = handler.emittedToolCall ? .stop : .cancelled
                     break
                 }
 
@@ -4640,9 +4646,12 @@ private func generateLoopTask<Handler: TokenLoopHandler>(
                     // Distinguish "downstream consumer terminated the
                     // stream" from "library-internal stop-sequence
                     // match" — the latter should report `stopReason =
-                    // .stop`, not `.cancelled`.
+                    // .stop`, not `.cancelled`. A consumer that stops
+                    // after an emitted tool call is likewise a natural
+                    // `.stop`: the dispatched tool ends the turn.
                     stopReason =
-                        (handler.stopSequenceHit || handler.haltedOnRepetition)
+                        (handler.stopSequenceHit || handler.haltedOnRepetition
+                            || handler.emittedToolCall)
                         ? .stop : .cancelled
                     break
                 }
@@ -4651,7 +4660,7 @@ private func generateLoopTask<Handler: TokenLoopHandler>(
 
             if stopReason == nil {
                 if Task.isCancelled {
-                    stopReason = .cancelled
+                    stopReason = handler.emittedToolCall ? .stop : .cancelled
                 } else if let maxTokens = iterator.maxTokens, tokenCount >= maxTokens {
                     stopReason = .length
                 } else {


### PR DESCRIPTION
## Problem

When a host dispatches a parsed tool call, everything decoded afterward is discarded — the public stream already terminated at the call and post-tool prose is suppressed by design. But consumer termination mapped to `.cancelled` (which skips boundary stores on the batched path), so hosts protected the store by **draining to EOS**: up to `maxTokens` of dead decode at full GPU cost while the executed tool's continuation waited on the generation lease.

## Change

- **`generateLoopTask`** (solo, native-MTP, and DFlash2 engines all run through it): consumer termination / task cancellation after the handler emitted a tool call resolves to **`.stop`** — the dispatched tool defines the turn's end. Non-tool Stop-button semantics unchanged (`.cancelled`, per the #2388 contract).
- **`BatchEngine.finishEarly(_:)`** — the natural-stop sibling of `cancel(_:)` for active slots: `finishSlot(reason: .stop)`, boundary stores run.
- **Batched bridge**: records surfacing a `.toolCall` (`markToolCallEmitted`) and routes consumer termination to `finishEarly` instead of `cancel` from that point on.

Opt-in by construction: a host that keeps draining behaves exactly as before; a host that stops consuming at dispatch gets the early stop with stores intact.

## Proof (live, Qwen3.8-27B, force_on d3, identical multi-call prompt, quiet machine)

| leg | dispatch-step genTokens | decode time |
|-----|------------------------|-------------|
| before (drain-to-EOS) | 5,383 | 263.7s |
| after (early stop) | **3,492** | **153.9s** |

~110 seconds of post-dispatch decode eliminated on one step. Two earlier contended-machine samples show the same dominance (3,764 vs 2,674). Run-to-run token variance is thinking-length (adaptive AR-fallback samples at temperature); every after-sample is below every before-sample. After the early stop: `==GEN STREAM-DRAINED` → `LEASE-RELEASED` 32ms apart, full `STEP-MTP` summary finalized, boundary stored, and the tool continuation restored at `promptMs=10`. The fixed build's multi-step agent loop ran normally on non-dispatch turns (natural stops, 10ms continuations).