### PR TITLE
Evaluate: the strip-boundary trace must type-check

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -134,7 +134,7 @@ public struct GenerateParameters: Sendable {
 
     /// Runtime accelerator selection for generation.
     ///
-    /// Defaults to `VMLINUX_ACCELERATOR` when present, otherwise `.metal`.
+    /// Defaults to `VMLX_ACCELERATOR` when present, otherwise `.metal`.
     /// `ane-coreml` is a fail-closed request: it is accepted only when the
     /// selected runtime surface has a validated Core ML island. Text decode
     /// currently has no such island, so it stays on MLX/Metal.
@@ -2263,13 +2263,17 @@ public struct TokenIterator: TokenIteratorProtocol {
             .filter { $0 > 0 && $0 < promptTokenIds.count }
             .max()
         if ProcessInfo.processInfo.environment["VMLX_STRIP_BOUNDARY_TRACE"] == "1" {
-            FileHandle.standardError.write(Data(
-                ("[vmlx][strip-boundary] prompt=\(promptTokenIds.count) "
-                    + "canonical=\(canonicalBoundary.map(String.init) ?? "nil") "
-                    + "prefixCounts=\(input.cachePrefixTokenCounts) "
-                    + "stableCounts=\(input.cacheStablePrefixTokenCounts) "
-                    + "genSuffixTokens=\(coordinator?.genPromptSuffixTokens ?? []) "
-                    + "heuristic=\(heuristicBoundary.map(String.init) ?? "nil")\n").utf8))
+            // Appended in steps rather than as one `+` chain. Six interpolations joined by `+`
+            // inside a `Data(...)` call gives the type checker an overload search it cannot finish:
+            // `error: unable to type-check this expression in reasonable time`. Each `+=` here is
+            // independently trivial to check.
+            var trace = "[vmlx][strip-boundary] prompt=\(promptTokenIds.count) "
+            trace += "canonical=\(canonicalBoundary.map(String.init) ?? "nil") "
+            trace += "prefixCounts=\(input.cachePrefixTokenCounts) "
+            trace += "stableCounts=\(input.cacheStablePrefixTokenCounts) "
+            trace += "genSuffixTokens=\(coordinator?.genPromptSuffixTokens ?? []) "
+            trace += "heuristic=\(heuristicBoundary.map(String.init) ?? "nil")\n"
+            FileHandle.standardError.write(Data(trace.utf8))
         }
         guard ProcessInfo.processInfo.environment["VMLX_HYBRID_STRIPPED_STORE"] != "0",
             let coordinator,


### PR DESCRIPTION
`main` does not currently compile under Swift 6.4:

```
Libraries/MLXLMCommon/Evaluate.swift:2268:35: error: the compiler is unable to type-check this
expression in reasonable time; try breaking up the expression into distinct sub-expressions
```

The `VMLX_STRIP_BOUNDARY_TRACE` diagnostic added in #394 builds its line by joining six
interpolated segments with `+`, inside a `Data(...)` call:

```swift
FileHandle.standardError.write(Data(
    ("[vmlx][strip-boundary] prompt=\(promptTokenIds.count) "
        + "canonical=\(canonicalBoundary.map(String.init) ?? "nil") "
        …
```

Every `+` is an overload the type checker must resolve, and with six interpolations feeding one
argument the search does not terminate in the allowed budget. It is a checker limit rather than a
mistake in the logic — the expression is perfectly well-formed.

Appending in steps makes each statement independently trivial:

```swift
var trace = "[vmlx][strip-boundary] prompt=\(promptTokenIds.count) "
trace += "canonical=\(canonicalBoundary.map(String.init) ?? "nil") "
…
FileHandle.standardError.write(Data(trace.utf8))
```

The emitted string is byte-identical and the trace stays behind the same environment variable.

Verified by building the full package against `main` at `209aac3e0`: it fails before this change and
succeeds after.

Worth noting how this reached `main`: the pull-request workflow guarded every job on
`github.repository == 'ml-explore/mlx-swift'`, so no check had run on this repository since the fork.
#332 pointed the guard here and #395 stopped the build being gated behind the style job, so a
compile break like this should be visible on the PR from now on — provided a macOS runner picks the
job up.
