### PR TITLE
Tests: two source guards that drifted from the code they pin

### DIFF
--- a/Tests/MLXLMTests/ChatSessionRuntimeWiringSourceCoverageTests.swift
+++ b/Tests/MLXLMTests/ChatSessionRuntimeWiringSourceCoverageTests.swift
@@ -16,7 +16,16 @@ struct ChatSessionRuntimeWiringSourceCoverageTests {
     @Test("streamMap passes container cache coordinator into TokenIterator")
     func streamMapPassesCacheCoordinatorIntoTokenIterator() throws {
         let source = try Self.source("Libraries/MLXLMCommon/ChatSession.swift")
-        #expect(source.contains("let cacheCoordinator = model.cacheCoordinator"))
+        // The coordinator is taken from the CONTAINER and then suppressed when the KV cache is
+        // already populated — a refinement added after this test was written, which renamed the
+        // binding and left the old literal (`let cacheCoordinator = model.cacheCoordinator`)
+        // nowhere in the file. The subject is unchanged: the container's coordinator reaches
+        // `TokenIterator`. Pin that, including the suppression, rather than one stale spelling.
+        #expect(source.contains("let containerCacheCoordinator = model.cacheCoordinator"))
+        #expect(
+            source.contains(
+                "let cacheCoordinator = kvCacheIsPopulated ? nil : containerCacheCoordinator"),
+            "a populated KV cache must not also be handed the container coordinator")
         #expect(source.contains("cacheCoordinator: cacheCoordinator"))
         #expect(source.contains("let iterator = try TokenIterator("))
     }

--- a/Tests/MLXLMTests/MiMoV2FlashRuntimeTests.swift
+++ b/Tests/MLXLMTests/MiMoV2FlashRuntimeTests.swift
@@ -145,7 +145,20 @@ struct MiMoV2FlashRuntimeTests {
         #expect(source.contains("let firstSimple = cache.first { $0 is KVCacheSimple }"))
         #expect(source.contains("if let simpleCache = cache[i] as? KVCacheSimple"))
         #expect(source.contains("TurboQuantKVCache.fromSimpleCache"))
-        #expect(source.contains("RotatingKVCache, DeepseekV4Cache, MambaCache, CacheList: skip"))
+        // The skip list gained `ZayaMoEPlaceholderCache` and the comment wrapped, so the old
+        // one-line literal stopped matching text that is present and correct. Match against
+        // whitespace-collapsed source, and name the types individually so ADDING a skipped cache
+        // does not break the test while REMOVING one still does.
+        let flat = source.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+        for skipped in [
+            "RotatingKVCache", "DeepseekV4Cache", "MambaCache", "CacheList",
+            "ZayaMoEPlaceholderCache",
+        ] {
+            #expect(
+                flat.contains("\(skipped),") || flat.contains("\(skipped):"),
+                "\(skipped) must stay in the TurboQuant skip list")
+        }
+        #expect(flat.contains("ZayaMoEPlaceholderCache: skip."))
 
         let topology = ModelCacheTopologySnapshot(cache: [
             TurboQuantKVCache(),


### PR DESCRIPTION
Two source-text guards that broke when the code they pin improved. Both fail on a clean checkout.

**`ChatSessionRuntimeWiringSourceCoverageTests`** wants
`let cacheCoordinator = model.cacheCoordinator`. The coordinator is now taken from the container as
`containerCacheCoordinator` and then suppressed when the KV cache is already populated
(`kvCacheIsPopulated ? nil : containerCacheCoordinator`) — a refinement that left the old literal
nowhere in the file. The subject is unchanged, so this pins the current binding including the
suppression, which is a stronger statement than the one it replaces.

**`MiMoV2FlashRuntimeTests`** wants a single-line skip-list comment,
`RotatingKVCache, DeepseekV4Cache, MambaCache, CacheList: skip`. The list gained
`ZayaMoEPlaceholderCache` and the comment wrapped across two lines. Now matched against
whitespace-collapsed source and per type, so ADDING a skipped cache cannot break the test while
REMOVING one still does.

---

**Both of these are failing on `main` right now.** Verified by running them against a clean checkout
before touching anything:

| suite | pristine `main` | with this change |
|---|---|---|
| `ChatSessionRuntimeWiringSourceCoverage` | 4 tests, **1 issue** | 4 tests, pass |
| `MiMoV2FlashRuntime` | 7 tests, **1 issue** | 7 tests, pass |

Neither failure is a defect in the code they describe — the code got *better* in both cases, and the
guards were pinned to the older spelling. A source-scanning guard has that failure mode built in: it
asserts on text, so any improvement to the text it names breaks it, and it cannot tell the difference
between "the property I protect is gone" and "the property moved".

That is also why they went unnoticed. `.github/workflows/pull_request.yml` guarded every job on
`github.repository == 'ml-explore/mlx-swift'` — the repository this one was forked from — so no check
had run here since the fork. #332 pointed the guard at this repository and #395 stopped the build
being gated behind the style job; these two suites are what that turned up.

Both fixes narrow what is pinned to the invariant rather than the phrasing: the container coordinator
must reach `TokenIterator` and must be suppressed when the KV cache is populated; and each named cache
type must stay in the TurboQuant skip list, matched against whitespace-collapsed source so that ADDING
a skipped type cannot break the test while REMOVING one still does.
