### PR TITLE
mHC oracle: assert the final stream collapse is a mean

### DIFF
--- a/Tests/MLXLMTests/HyperConnectionEpsilonOracleTests.swift
+++ b/Tests/MLXLMTests/HyperConnectionEpsilonOracleTests.swift
@@ -159,4 +159,39 @@ struct HyperConnectionEpsilonOracleTests {
             #expect(d < Self.tolerance, "the bracketed block output differs from the reference by \(d)")
         }
     }
+
+    /// The final collapse across streams is a MEAN, not a sum.
+    ///
+    /// The fixture has carried `reducedMean` all along; this is the assertion that consumes it. It was
+    /// written alongside the two above and could not travel with them, because it needs
+    /// `Glm5NextLanguageModel` and GLM-5.3 was not upstream yet. It is now.
+    ///
+    /// Worth stating separately because a sum is the natural guess — the streams were summed on the
+    /// way in, so summing them on the way out looks symmetric — and it is wrong. The negative is
+    /// asserted directly rather than left implicit: a sum differs from the mean by exactly `hcMult`
+    /// here, so if the two were ever close enough to be confused, this test would be proving nothing
+    /// and says so.
+    @Test("the final stream collapse is an unweighted mean, not a sum")
+    func reduceIsAMean() throws {
+        let f = Self.fixture
+        try MLXMetalTestLock.withLock {
+            let after = MLXArray(
+                Self.flatten(f.out.afterBlock),
+                [f.shape.B, f.shape.L, f.shape.hc, f.shape.hidden])
+            let reduced = Glm5NextLanguageModel.reduceHyperConnectionStream(after)
+            eval(reduced)
+
+            #expect(reduced.shape == [f.shape.B, f.shape.L, f.shape.hidden])
+            let expected = Self.flatten(f.out.reducedMean)
+            let d = Self.maxAbsDiff(reduced, expected)
+            #expect(d < 1e-5, "the reduce differs from the reference mean by \(d)")
+
+            let sumInstead = after.sum(axis: -2)
+            let dSum = Self.maxAbsDiff(sumInstead, expected)
+            #expect(
+                dSum > 0.1,
+                "a sum is indistinguishable from the mean here (\(dSum)); the test proves nothing")
+        }
+    }
+
 }


### PR DESCRIPTION
`HyperConnectionEpsilonOracleTests` embeds a fixture with a `reducedMean` field that no test reads.
This adds the assertion that reads it.

The three assertions were written together against `scripts/glm5-hc-oracle.py`, which transcribes
GLM-5.3's `modeling_glm5_next.py`. Two of them — `collapse` and `expand` — went upstream with the
epsilon fix. The third could not: it calls `Glm5NextLanguageModel.reduceHyperConnectionStream`, and
GLM-5.3 was not in the tree yet. That constraint is gone, so the fixture and the assertion are
reunited.

It earns a separate test because the wrong answer is the intuitive one. The streams are summed on the
way *in*, so summing them on the way *out* reads as symmetric — and the reference takes an unweighted
mean. Nothing else in the suite would notice the difference: shapes are identical either way, and the
model still produces fluent text with a residual scaled by `hcMult`.

The negative is asserted rather than assumed:

```swift
let sumInstead = after.sum(axis: -2)
#expect(dSum > 0.1, "a sum is indistinguishable from the mean here (\(dSum)); the test proves nothing")
```

so if a future fixture ever made the two comparable, this reports that it has stopped discriminating
instead of passing quietly.

Verified on current `main`: all three assertions in the suite pass.
