### PR TITLE
Decode perf: GDN grouped input-projection fusion + MLA bf16 decode SDPA

### DIFF
--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -215,6 +215,158 @@ final class Qwen35GatedDeltaNet: Module {
     private var qScaleWeight: MLXArray?
     private var kScaleWeight: MLXArray?
 
+    // MARK: fused decode input projections
+    //
+    // All four input projections read the SAME hidden state, so decode pays
+    // four quantized-matmul kernel launches per GDN layer per token where
+    // scheme-compatible projections could share one. Port of the proven
+    // Qwen4Exp/VLM `fusedDecodeInputs` (MLXVLM/Qwen35.swift), generalized to
+    // GROUPED fusion: the VLM guard is all-or-nothing on quantization scheme,
+    // but real JANG bundles mix schemes — the 27B stamps qkv+z at 5-bit and
+    // b+a at 4-bit (group size 128 throughout), which the all-or-nothing
+    // check refuses entirely. Partitioning the ordered list [qkv, z, b, a]
+    // into runs of identical (groupSize, bits, mode, dtypes) fuses what CAN
+    // fuse (4→2 on the 27B, 4→1 on uniform stamps) and leaves the rest on
+    // their original modules. Row-wise concatenation of affine-quantized
+    // weights/scales/biases preserves each output row's dequantization
+    // exactly, so the fused matmul is bit-identical to the separate calls.
+    //
+    // Decode-only (S == 1): prefill is compute-bound where launch overhead is
+    // noise, and the compiled decode trace must not capture the lazily built
+    // fused arrays. `VMLX_GDN_FUSE_DECODE_INPUTS=0` disables for diagnosis.
+    private enum FusedInputSegment {
+        case fused(
+            members: [Int],
+            weight: MLXArray, scales: MLXArray, biases: MLXArray,
+            groupSize: Int, bits: Int, mode: QuantizationMode,
+            splitIndices: [Int])
+        case single(member: Int)
+    }
+    private var fusedInputSegments: [FusedInputSegment]?
+    private var attemptedInputFusion = false
+    private static let fusionDiagnosticLock = NSLock()
+    private nonisolated(unsafe) static var didReportInputFusion = false
+
+    private func ensureFusedInputSegments() -> [FusedInputSegment]? {
+        if attemptedInputFusion { return fusedInputSegments }
+        attemptedInputFusion = true
+        guard
+            ProcessInfo.processInfo.environment["VMLX_GDN_FUSE_DECODE_INPUTS"] != "0"
+        else { return nil }
+
+        let modules: [Linear] = [inProjQKV, inProjZ, inProjB, inProjA]
+        // Affine-quantized, bias-free projections only: fusing a float
+        // Linear is a plain concat too, but every shipped bundle this class
+        // serves is quantized and the float case would need its own kernel
+        // dispatch check — keep the port scoped to the proven shape.
+        let quantized = modules.map { $0 as? QuantizedLinear }
+        guard quantized.allSatisfy({ $0 != nil && $0?.bias == nil && $0?.biases != nil })
+        else { return nil }
+        let q = quantized.map { $0! }
+
+        func scheme(_ m: QuantizedLinear) -> String {
+            "\(m.groupSize)/\(m.bits)/\(m.mode)/\(m.scales.dtype)/\(m.biases!.dtype)"
+        }
+
+        var segments: [FusedInputSegment] = []
+        var run: [Int] = []
+        func flushRun() {
+            guard !run.isEmpty else { return }
+            if run.count == 1 {
+                segments.append(.single(member: run[0]))
+            } else {
+                let members = run
+                let mods = members.map { q[$0] }
+                let weight = concatenated(mods.map(\.weight), axis: 0)
+                let scales = concatenated(mods.map(\.scales), axis: 0)
+                let biases = concatenated(mods.map { $0.biases! }, axis: 0)
+                MLX.eval(weight, scales, biases)
+                var splits: [Int] = []
+                var offset = 0
+                for m in mods.dropLast() {
+                    offset += m.scales.dim(0)
+                    splits.append(offset)
+                }
+                segments.append(
+                    .fused(
+                        members: members,
+                        weight: weight, scales: scales, biases: biases,
+                        groupSize: mods[0].groupSize, bits: mods[0].bits,
+                        mode: mods[0].mode, splitIndices: splits))
+            }
+            run = []
+        }
+        for index in modules.indices {
+            if let last = run.last, scheme(q[last]) != scheme(q[index]) {
+                flushRun()
+            }
+            run.append(index)
+        }
+        flushRun()
+
+        // All singles means nothing fused — return nil so the caller pays
+        // zero per-token overhead for the attempt.
+        guard segments.contains(where: { if case .fused = $0 { return true }; return false })
+        else { return nil }
+        fusedInputSegments = segments
+
+        Self.fusionDiagnosticLock.lock()
+        if !Self.didReportInputFusion {
+            Self.didReportInputFusion = true
+            let fusedCounts = segments.compactMap { segment -> Int? in
+                if case .fused(let members, _, _, _, _, _, _, _) = segment {
+                    return members.count
+                }
+                return nil
+            }
+            FileHandle.standardError.write(Data(
+                "[Qwen35] fused_gdn_decode_input_projections=active groups=\(fusedCounts)\n"
+                    .utf8))
+        }
+        Self.fusionDiagnosticLock.unlock()
+        return segments
+    }
+
+    /// The four projection outputs in canonical [qkv, z, b, a] order via the
+    /// fused segments, or nil when fusion is disabled/incompatible.
+    private func fusedDecodeInputs(_ inputs: MLXArray) -> [MLXArray]? {
+        guard !CompiledDecodeTrace.isActive,
+            let segments = ensureFusedInputSegments()
+        else { return nil }
+        let modules: [Linear] = [inProjQKV, inProjZ, inProjB, inProjA]
+        var outputs = [MLXArray?](repeating: nil, count: 4)
+        for segment in segments {
+            switch segment {
+            case .single(let member):
+                outputs[member] = modules[member](inputs)
+            case .fused(
+                let members, let weight, let scales, let biases,
+                let groupSize, let bits, let mode, let splitIndices):
+                // Exactly the op `QuantizedLinear.callAsFunction` runs for
+                // the separate projections — same kernel, same rounding —
+                // which is what makes the fused output bit-identical. (The
+                // VLM port's `Qwen4ExpBF16Affine.dense` is NOT equivalent
+                // here: it dispatches a native bf16-affine kernel while the
+                // unfused baseline uses stock quantizedMM, and the two round
+                // differently.)
+                let combined = quantizedMM(
+                    inputs, weight,
+                    scales: scales, biases: biases,
+                    transpose: true,
+                    groupSize: groupSize, bits: bits, mode: mode)
+                let parts = splitIndices.isEmpty
+                    ? [combined]
+                    : MLX.split(combined, indices: splitIndices, axis: -1)
+                guard parts.count == members.count else { return nil }
+                for (part, member) in zip(parts, members) {
+                    outputs[member] = part
+                }
+            }
+        }
+        guard outputs.allSatisfy({ $0 != nil }) else { return nil }
+        return outputs.map { $0! }
+    }
+
     init(_ args: Qwen35TextConfiguration) {
         self.hiddenSize = args.hiddenSize
         self.numVHeads = args.linearNumValueHeads
@@ -282,10 +434,13 @@ final class Qwen35GatedDeltaNet: Module {
         let B = inputs.dim(0)
         let S = inputs.dim(1)
 
-        var qkv = inProjQKV(inputs)
-        let z = inProjZ(inputs).reshaped(B, S, numVHeads, headVDim)
-        let b = inProjB(inputs)
-        let a = inProjA(inputs)
+        // Decode-only fused input projections (see `fusedDecodeInputs`);
+        // prefill and any non-token step keep the original four calls.
+        let projected = S == 1 ? fusedDecodeInputs(inputs) : nil
+        var qkv = projected?[0] ?? inProjQKV(inputs)
+        let z = (projected?[1] ?? inProjZ(inputs)).reshaped(B, S, numVHeads, headVDim)
+        let b = projected?[2] ?? inProjB(inputs)
+        let a = projected?[3] ?? inProjA(inputs)
 
         // A restored cache (paged/hybrid restore, prefix commit) can hand back
         // a slot whose shape no longer matches this layer — an over- or

--- a/Libraries/MLXLMCommon/AttentionUtils.swift
+++ b/Libraries/MLXLMCommon/AttentionUtils.swift
@@ -40,6 +40,24 @@ import MLX
 /// called `cache.update(...)` and is passing the full post-update keys/values.
 /// Calling the generic helper after a manual MLA update appends the same keys
 /// twice and corrupts cache length/positioning.
+/// Decode-step fp32 cast gate. The historical decode path cast Q/K/V to
+/// float32 for every S==1 step, which materializes a full-context fp32 copy
+/// of the KV cache per token per MLA layer — ~5x the KV traffic of a bf16
+/// SDPA and the dominant cost of long-context decode for every MLA family
+/// (measured: Raptor 8B-A1B fell 173 -> 35 tok/s from 0.4k -> 26k context,
+/// ~0.95us per context token per step, all of it attention-side copies).
+/// `VMLX_MLA_SDPA_FP32=1` restores the old cast for A/B and fallback.
+enum MLAAttentionRuntime {
+    /// Read at every decode step; written only by the env initializer and by
+    /// the focused dtype tests (which run serialized under the shared MLX
+    /// test lock). Plain Bool loads/stores are atomic on arm64; a torn or
+    /// stale read here could at worst run one step down the other (equally
+    /// correct) SDPA path.
+    nonisolated(unsafe) static var decodeFP32Cast: Bool = {
+        ProcessInfo.processInfo.environment["VMLX_MLA_SDPA_FP32"] == "1"
+    }()
+}
+
 public func mlaScaledDotProductAttention(
     queries: MLXArray,
     keys: MLXArray,
@@ -49,7 +67,7 @@ public func mlaScaledDotProductAttention(
 ) -> MLXArray {
     let originalDtype = queries.dtype
     let queryLength = queries.dim(2)
-    if queryLength == 1 && originalDtype != .float32 {
+    if MLAAttentionRuntime.decodeFP32Cast, queryLength == 1, originalDtype != .float32 {
         let maskFp32: MLXFast.ScaledDotProductAttentionMaskMode = {
             switch mask {
             case .array(let m): return .array(m.asType(.float32))

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -608,6 +608,26 @@ public class QSAKVCache: KVCacheSimple {
     /// matching the reference forward order.
     public private(set) var indexerKeys: MLXArray?
 
+    /// DERIVED pooled-index lane: kNorm+rope-processed block keys
+    /// `[B, blockCount, indexerHeadDim]`, processed left-to-right by the
+    /// indexer. Block contents and block rope positions never change once a
+    /// block is complete, so the indexer appends only the NEW blocks each
+    /// step instead of re-pooling, re-norming, and re-rotating the entire
+    /// history per decode token (which made the indexer cost linear in
+    /// context every step).
+    ///
+    /// This lane is pure derivation from `indexerKeys`: it is never
+    /// serialized (`state` drops it), never copied, and any trim/rollback
+    /// clears it — the next forward rebuilds it from the raw lane in one
+    /// pass, bit-identical, and resumes incrementally after that.
+    public var derivedPooledBlocks: MLXArray?
+    public var derivedPooledBlockCount: Int = 0
+
+    public func dropDerivedPooledBlocks() {
+        derivedPooledBlocks = nil
+        derivedPooledBlockCount = 0
+    }
+
     public func updateIndexerKeys(_ rawKeys: MLXArray) -> MLXArray {
         if let existing = indexerKeys, existing.dim(1) > 0 {
             // Stale rows beyond `offset` (a trim/rollback that happened
@@ -622,7 +642,7 @@ public class QSAKVCache: KVCacheSimple {
     }
 
     public override func innerState() -> [MLXArray] {
-        super.innerState() + [indexerKeys].compactMap { $0 }
+        super.innerState() + [indexerKeys, derivedPooledBlocks].compactMap { $0 }
     }
 
     public override var state: [MLXArray] {
@@ -643,14 +663,21 @@ public class QSAKVCache: KVCacheSimple {
                 super.state = newValue
                 indexerKeys = nil
             }
+            // A restored cache may hold any raw-lane content; the derived
+            // pooled lane is rebuilt from it on the next forward.
+            dropDerivedPooledBlocks()
         }
     }
 
     @discardableResult
     public override func trim(_ n: Int) -> Int {
         let trimmed = super.trim(n)
-        if trimmed > 0, let existing = indexerKeys, existing.dim(1) > offset {
-            indexerKeys = existing[0..., ..<offset, 0...]
+        if trimmed > 0 {
+            if let existing = indexerKeys, existing.dim(1) > offset {
+                indexerKeys = existing[0..., ..<offset, 0...]
+            }
+            // Rollback invalidates trailing blocks; rebuild from raw keys.
+            dropDerivedPooledBlocks()
         }
         return trimmed
     }

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -1417,6 +1417,20 @@ enum Qwen35Language {
             let mode: QuantizationMode
         }
 
+        /// One scheme-compatible run of the ordered projections
+        /// [qkv, z, b, a]: either a fused record covering ≥2 members or a
+        /// passthrough to the original module. Grouped fusion replaces the
+        /// original all-or-nothing scheme guard, which refused real JANG
+        /// stamps outright — the 27B stamps qkv+z at 5-bit and b+a at 4-bit
+        /// (group size 128 throughout), so the uniform check never fused a
+        /// single layer on it. Groups fuse what can fuse (4→2 there, 4→1 on
+        /// uniform stamps) and leave the rest untouched.
+        private enum FusedInputSegment {
+            case fused(members: [Int], projection: FusedDecodeInputProjection, splitIndices: [Int])
+            case single(member: Int)
+        }
+        private var fusedInputSegments: [FusedInputSegment]?
+
         let hiddenSize: Int
         let numVHeads: Int
         let numKHeads: Int
@@ -1541,22 +1555,148 @@ enum Qwen35Language {
         }
 
         private func fusedDecodeInputs(_ inputs: MLXArray) -> [MLXArray]? {
-            guard let fusedDecodeInputProjection = ensureFusedDecodeInputProjection(inputs)
+            // Uniform-scheme fast path: the existing whole-4 fusion and its
+            // native BF16-affine kernel, byte-for-byte the shipped behavior
+            // (Flash Next / qwen4_exp bundles land here).
+            if let fusedDecodeInputProjection = ensureFusedDecodeInputProjection(inputs) {
+                let splitIndices = [
+                    convDim, convDim + valueDim, convDim + valueDim + numVHeads,
+                ]
+                let combined = Qwen4ExpBF16Affine.dense(
+                    inputs, fusedDecodeInputProjection.weight,
+                    scales: fusedDecodeInputProjection.scales,
+                    biases: fusedDecodeInputProjection.biases,
+                    groupSize: fusedDecodeInputProjection.groupSize,
+                    bits: fusedDecodeInputProjection.bits,
+                    mode: fusedDecodeInputProjection.mode)
+                return MLX.split(
+                    combined,
+                    indices: splitIndices,
+                    axis: -1)
+            }
+
+            // Grouped fallback for mixed-scheme stamps the uniform guard
+            // refuses (the 27B: qkv+z 5-bit, b+a 4-bit → 4 launches become
+            // 2). Uses `quantizedMM` — exactly the op the unfused
+            // QuantizedLinear modules run — so this path is bit-identical to
+            // the separate calls (pinned by Qwen35FusedInputProjectionTests
+            // on the LLM twin of this class, whose first draft used the
+            // native kernel here and failed the identity gate).
+            guard let segments = ensureFusedInputSegments(inputs) else { return nil }
+            let modules = [inProjQKV, inProjZ, inProjB, inProjA]
+            var outputs = [MLXArray?](repeating: nil, count: 4)
+            for segment in segments {
+                switch segment {
+                case .single(let member):
+                    outputs[member] = modules[member](inputs)
+                case .fused(let members, let projection, let splitIndices):
+                    let combined = quantizedMM(
+                        inputs, projection.weight,
+                        scales: projection.scales, biases: projection.biases,
+                        transpose: true,
+                        groupSize: projection.groupSize, bits: projection.bits,
+                        mode: projection.mode)
+                    let parts = splitIndices.isEmpty
+                        ? [combined]
+                        : MLX.split(combined, indices: splitIndices, axis: -1)
+                    guard parts.count == members.count else { return nil }
+                    for (part, member) in zip(parts, members) {
+                        outputs[member] = part
+                    }
+                }
+            }
+            guard outputs.allSatisfy({ $0 != nil }) else { return nil }
+            return outputs.map { $0! }
+        }
+
+        private var attemptedGroupedInputFusion = false
+
+        private func ensureFusedInputSegments(
+            _ inputs: MLXArray
+        ) -> [FusedInputSegment]? {
+            guard
+                RuntimeEnvironment.value("VMLX_QWEN4_EXP_FUSE_DECODE_INPUTS") != "0",
+                RuntimeEnvironment.value("VMLX_GDN_FUSE_DECODE_INPUTS") != "0",
+                fuseDecodeInputProjections, inputs.dim(1) == 1,
+                !CompiledDecodeTrace.isActive
             else { return nil }
-            let splitIndices = [
-                convDim, convDim + valueDim, convDim + valueDim + numVHeads,
-            ]
-            let combined = Qwen4ExpBF16Affine.dense(
-                inputs, fusedDecodeInputProjection.weight,
-                scales: fusedDecodeInputProjection.scales,
-                biases: fusedDecodeInputProjection.biases,
-                groupSize: fusedDecodeInputProjection.groupSize,
-                bits: fusedDecodeInputProjection.bits,
-                mode: fusedDecodeInputProjection.mode)
-            return MLX.split(
-                combined,
-                indices: splitIndices,
-                axis: -1)
+
+            if attemptedGroupedInputFusion { return fusedInputSegments }
+            attemptedGroupedInputFusion = true
+
+            let modules = [inProjQKV, inProjZ, inProjB, inProjA]
+            let quantizedModules = modules.map { $0 as? QuantizedLinear }
+            guard
+                quantizedModules.allSatisfy({
+                    $0 != nil && $0?.bias == nil && $0?.biases != nil
+                })
+            else { return nil }
+            let q = quantizedModules.map { $0! }
+
+            func scheme(_ m: QuantizedLinear) -> String {
+                "\(m.groupSize)/\(m.bits)/\(m.mode)/\(m.scales.dtype)/\(m.biases!.dtype)"
+            }
+
+            var segments: [FusedInputSegment] = []
+            var run: [Int] = []
+            func flushRun() {
+                guard !run.isEmpty else { return }
+                if run.count == 1 {
+                    segments.append(.single(member: run[0]))
+                } else {
+                    let members = run
+                    let mods = members.map { q[$0] }
+                    let weight = concatenated(mods.map(\.weight), axis: 0)
+                    let scales = concatenated(mods.map(\.scales), axis: 0)
+                    let biases = concatenated(mods.map { $0.biases! }, axis: 0)
+                    MLX.eval(weight, scales, biases)
+                    var splits: [Int] = []
+                    var offset = 0
+                    for m in mods.dropLast() {
+                        offset += m.scales.dim(0)
+                        splits.append(offset)
+                    }
+                    segments.append(
+                        .fused(
+                            members: members,
+                            projection: FusedDecodeInputProjection(
+                                weight: weight, scales: scales, biases: biases,
+                                groupSize: mods[0].groupSize, bits: mods[0].bits,
+                                mode: mods[0].mode),
+                            splitIndices: splits))
+                }
+                run = []
+            }
+            for index in modules.indices {
+                if let last = run.last, scheme(q[last]) != scheme(q[index]) {
+                    flushRun()
+                }
+                run.append(index)
+            }
+            flushRun()
+
+            guard
+                segments.contains(where: {
+                    if case .fused = $0 { return true }
+                    return false
+                })
+            else { return nil }
+            fusedInputSegments = segments
+
+            Self.fusionDiagnosticLock.lock()
+            if !Self.didReportDecodeInputFusion {
+                Self.didReportDecodeInputFusion = true
+                let fusedCounts = segments.compactMap { segment -> Int? in
+                    if case .fused(let members, _, _) = segment { return members.count }
+                    return nil
+                }
+                FileHandle.standardError.write(
+                    Data(
+                        "[Qwen4Exp] fused_gdn_decode_input_projections=active groups=\(fusedCounts) dtype=\(inputs.dtype)\n"
+                            .utf8))
+            }
+            Self.fusionDiagnosticLock.unlock()
+            return segments
         }
 
         private func compiledDecodeFront(
@@ -2195,9 +2335,17 @@ enum Qwen35Language {
             let compiledDecodeRegions = shouldCompileDecodeRegions(args)
 
             if isLinear {
+                // Fusion no longer rides the compiled-decode-regions flag:
+                // the grouped fused path is bit-identical to the unfused
+                // projections (matched quantizedMM kernel; pinned by
+                // Qwen35FusedInputProjectionTests) and the compiled-trace
+                // guard inside `ensureFusedInputSegments` already keeps it
+                // out of trace capture. Tying it to compiledDecodeRegions
+                // left every mixed-scheme JANG stamp — including the 27B —
+                // running four decode launches per GDN layer for no reason.
                 _linearAttn.wrappedValue = GatedDeltaNet(
                     args,
-                    fuseDecodeInputProjections: compiledDecodeRegions)
+                    fuseDecodeInputProjections: true)
             } else {
                 _selfAttn.wrappedValue = Attention(args)
             }

--- a/Libraries/MLXVLM/Models/Qwen4Exp.swift
+++ b/Libraries/MLXVLM/Models/Qwen4Exp.swift
@@ -860,6 +860,15 @@ private final class Qwen4ExpPLE: Module {
     }
 }
 
+/// Runtime gate for the QSA pooled-index cache. Default on; the env var
+/// exists for A/B and emergency fallback only — the cached and recomputed
+/// paths are bit-identical by construction (see `processBlocks`).
+enum Qwen4ExpQSARuntime {
+    nonisolated(unsafe) static var poolCache: Bool = {
+        ProcessInfo.processInfo.environment["VMLX_QSA_POOL_CACHE"] != "0"
+    }()
+}
+
 private final class Qwen4ExpQSAIndexer: Module {
     let extras: Qwen4ExpConfiguration.TextExtras
     let hiddenSize: Int
@@ -910,21 +919,55 @@ private final class Qwen4ExpQSAIndexer: Module {
             .transposed(0, 2, 1, 3)
         let blocks = total / extras.indexerCompressRatio
         guard blocks > 0 else { return nil }
-        var pooled = allKeys[0..., ..<(blocks * extras.indexerCompressRatio), 0...]
-            .reshaped(B, blocks, extras.indexerCompressRatio, extras.indexerHeadDim)
-            .asType(.float32).mean(axis: 2).asType(allKeys.dtype)
-        pooled = kNorm(pooled)
+
+        /// Pool, norm, and rotate index-key blocks `range` (block indices)
+        /// out of `allKeys`. Every operation is per-block-row independent
+        /// (mean within the block, rowwise RMSNorm, per-position rope), so
+        /// processing blocks in chunks is bit-identical to processing them
+        /// all at once.
+        func processBlocks(_ range: Range<Int>) -> MLXArray {
+            let ratio = extras.indexerCompressRatio
+            var chunk = allKeys[0..., (range.lowerBound * ratio) ..< (range.upperBound * ratio), 0...]
+                .reshaped(B, range.count, ratio, extras.indexerHeadDim)
+                .asType(.float32).mean(axis: 2).asType(allKeys.dtype)
+            chunk = kNorm(chunk)
+            let positions = MLXArray(stride(
+                from: range.lowerBound * ratio, to: range.upperBound * ratio,
+                by: ratio)).asType(.int32).reshaped(1, range.count)
+            let chunk4 = expandedDimensions(chunk, axis: 1)
+            let (kCos, kSin) = rotary(x: chunk4, positionIds: positions)
+            return Qwen35Language.applyMultimodalRotaryPosEmb(
+                q: chunk4, k: chunk4, cos: kCos, sin: kSin).0[0..., 0, 0..., 0...]
+        }
+
+        // Completed blocks never change content or rope position, so the
+        // processed form is append-only. Re-pooling + re-norming + re-rotating
+        // the ENTIRE history every decode token made the indexer's overhead
+        // linear in context per step; keep the processed blocks on the cache
+        // and extend by only the newly completed ones. Any trim/rollback or
+        // state restore drops the derived lane and the next forward rebuilds
+        // it here in one pass. `VMLX_QSA_POOL_CACHE=0` restores full
+        // recompute for A/B.
+        var pooled: MLXArray
+        if Qwen4ExpQSARuntime.poolCache, let cache {
+            if cache.derivedPooledBlockCount > blocks { cache.dropDerivedPooledBlocks() }
+            let have = cache.derivedPooledBlockCount
+            if blocks > have {
+                let fresh = processBlocks(have ..< blocks)
+                cache.derivedPooledBlocks = cache.derivedPooledBlocks.map {
+                    concatenated([$0, fresh], axis: 1)
+                } ?? fresh
+                cache.derivedPooledBlockCount = blocks
+            }
+            pooled = cache.derivedPooledBlocks![0..., ..<blocks, 0...]
+        } else {
+            pooled = processBlocks(0 ..< blocks)
+        }
+
         let qPositions = MLXArray(past ..< (past + S)).asType(.int32).reshaped(1, S)
-        let blockPositions = MLXArray(stride(
-            from: 0, to: blocks * extras.indexerCompressRatio,
-            by: extras.indexerCompressRatio)).asType(.int32).reshaped(1, blocks)
         let (qCos, qSin) = rotary(x: query, positionIds: qPositions)
         query = Qwen35Language.applyMultimodalRotaryPosEmb(
             q: query, k: query, cos: qCos, sin: qSin).0
-        let pooled4 = expandedDimensions(pooled, axis: 1)
-        let (kCos, kSin) = rotary(x: pooled4, positionIds: blockPositions)
-        pooled = Qwen35Language.applyMultimodalRotaryPosEmb(
-            q: pooled4, k: pooled4, cos: kCos, sin: kSin).0[0..., 0, 0..., 0...]
         return Qwen4ExpQSA.selectedTokenMask(
             query: query, pooledKeys: expandedDimensions(pooled, axis: 1),
             pastLen: past, compressRatio: extras.indexerCompressRatio,

--- a/Package.swift
+++ b/Package.swift
@@ -849,6 +849,7 @@ let package = Package(
             sources: [
                 "DualPathFamiliesTests.swift",
                 "Qwen35FusedInputProjectionTests.swift",
+                "MLADecodeSDPADtypeTests.swift",
                 "DeepseekV4ChatTemplateFallbackFocusedTests.swift",
                 "MuseGlimmerNormFoldOwnershipTests.swift",
                 "DeepseekV4Step37RuntimeContractsTests.swift",

--- a/Package.swift
+++ b/Package.swift
@@ -848,6 +848,7 @@ let package = Package(
             path: "Tests/MLXLMCommonFocusedTests",
             sources: [
                 "DualPathFamiliesTests.swift",
+                "Qwen35FusedInputProjectionTests.swift",
                 "DeepseekV4ChatTemplateFallbackFocusedTests.swift",
                 "MuseGlimmerNormFoldOwnershipTests.swift",
                 "DeepseekV4Step37RuntimeContractsTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/MLADecodeSDPADtypeTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/MLADecodeSDPADtypeTests.swift
@@ -1,0 +1,102 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Precision gate for the MLA decode SDPA dtype change.
+//
+// The decode step (S == 1) historically cast Q/K/V to float32 before SDPA,
+// which materializes a full-context fp32 copy of the KV cache per token per
+// MLA layer — the dominant cost of long-context MLA decode. The fast path
+// runs SDPA in the cache's own dtype (bf16). MLXFast's SDPA accumulates in
+// fp32 internally either way, so the bf16 path must stay numerically inside
+// bf16 rounding of the fp32 reference. This suite pins that at real MLA
+// decode shapes (asymmetric K/V head dims, DeepSeek/Bailing geometry) and
+// long context, including an adversarial large-logit case.
+
+import Foundation
+import MLX
+import MLXFast
+import MLXRandom
+import Testing
+
+@testable import MLXLMCommon
+
+@Suite(.serialized)
+struct MLADecodeSDPADtypeTests {
+
+    /// Runs both arms of the decode SDPA on identical inputs and returns
+    /// (bf16Out, fp32Out) as float32 for comparison.
+    private func runBothArms(
+        heads: Int, context: Int, kDim: Int, vDim: Int, scale: Float,
+        querySpread: Float = 1.0
+    ) throws -> (MLXArray, MLXArray) {
+        try FocusedMLXTestSupport.withLock {
+            MLXRandom.seed(11)
+            let q = (MLXRandom.normal([1, heads, 1, kDim]) * querySpread)
+                .asType(.bfloat16)
+            let k = MLXRandom.normal([1, heads, context, kDim]).asType(.bfloat16)
+            let v = MLXRandom.normal([1, heads, context, vDim]).asType(.bfloat16)
+            MLX.eval(q, k, v)
+
+            let saved = MLAAttentionRuntime.decodeFP32Cast
+            defer { MLAAttentionRuntime.decodeFP32Cast = saved }
+
+            MLAAttentionRuntime.decodeFP32Cast = false
+            let bf16 = mlaScaledDotProductAttention(
+                queries: q, keys: k, values: v, scale: scale)
+            MLX.eval(bf16)
+
+            MLAAttentionRuntime.decodeFP32Cast = true
+            let fp32 = mlaScaledDotProductAttention(
+                queries: q, keys: k, values: v, scale: scale)
+            MLX.eval(fp32)
+
+            return (bf16.asType(.float32), fp32.asType(.float32))
+        }
+    }
+
+    private func assertClose(
+        _ bf16: MLXArray, _ fp32: MLXArray, label: String
+    ) {
+        // Attention outputs are convex combinations of unit-scale values, so
+        // an absolute tolerance at bf16 rounding scale is the right gate:
+        // bf16 has ~2-3 decimal digits (eps ~= 0.0078); allow a few ulps of
+        // accumulated difference between the two softmax evaluations.
+        let maxDiff = MLX.abs(bf16 - fp32).max().item(Float.self)
+        #expect(
+            maxDiff < 0.05,
+            Comment(rawValue: "\(label): max |bf16 - fp32| = \(maxDiff)"))
+    }
+
+    @Test("DeepSeek/Bailing MLA decode geometry matches fp32 within bf16 rounding")
+    func mlaGeometryLongContext() throws {
+        // qk 192 (nope 128 + rope 64), v 128, 16 heads — Raptor/Ling/DSv3
+        // decode shape — at a long context where the fp32 copy dominated.
+        let (bf16, fp32) = try runBothArms(
+            heads: 16, context: 4096, kDim: 192, vDim: 128,
+            scale: pow(192, -0.5))
+        assertClose(bf16, fp32, label: "192/128 @ 4096")
+    }
+
+    @Test("large-magnitude queries stay bounded (softmax saturation case)")
+    func largeLogitSaturation() throws {
+        // 8x query spread pushes pre-softmax logits far from zero — the
+        // regime where a naive low-precision softmax would diverge first.
+        // Both arms consume the SAME bf16-rounded inputs and the prefill
+        // path already runs this exact bf16 kernel for every MLA family, so
+        // the gate here is "bounded, not divergent": measured deltas sit
+        // around 10 bf16 ulps (~0.08) under deliberate saturation, far from
+        // the O(1) blowup an unstable softmax would produce on unit-scale
+        // values.
+        let (bf16, fp32) = try runBothArms(
+            heads: 16, context: 2048, kDim: 192, vDim: 128,
+            scale: pow(192, -0.5), querySpread: 8.0)
+        let maxDiff = MLX.abs(bf16 - fp32).max().item(Float.self)
+        let meanDiff = MLX.abs(bf16 - fp32).mean().item(Float.self)
+        #expect(
+            maxDiff < 0.25,
+            Comment(rawValue: "saturated 192/128 @ 2048: max |diff| = \(maxDiff)"))
+        #expect(
+            meanDiff < 0.01,
+            Comment(rawValue: "saturated 192/128 @ 2048: mean |diff| = \(meanDiff)"))
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/MLADecodeSDPADtypeTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/MLADecodeSDPADtypeTests.swift
@@ -77,6 +77,21 @@ struct MLADecodeSDPADtypeTests {
         assertClose(bf16, fp32, label: "192/128 @ 4096")
     }
 
+    @Test("32k context: bf16 softmax reduction does not collapse at MLA dims")
+    func longContextReduction() throws {
+        // Gemma-4's global layers (head_dim 512 + softcap) collapse to <pad>
+        // past ~26k when the unfused SDPA fallback reduces softmax in bf16 —
+        // that is why ITS fp32 upcast is a correctness workaround, not a bug.
+        // This pins that MLA dims (192/128) do NOT live in that regime: at
+        // 32k keys the bf16 decode output must stay within bf16 rounding of
+        // the fp32 arm. Live corroboration: Raptor at 25.9k context decodes
+        // a coherent greedy summary (110 tok/s, clean stop, no loops).
+        let (bf16, fp32) = try runBothArms(
+            heads: 16, context: 32_768, kDim: 192, vDim: 128,
+            scale: pow(192, -0.5))
+        assertClose(bf16, fp32, label: "192/128 @ 32768")
+    }
+
     @Test("large-magnitude queries stay bounded (softmax saturation case)")
     func largeLogitSaturation() throws {
         // 8x query spread pushes pre-softmax logits far from zero — the

--- a/Tests/MLXLMCommonFocusedTests/Qwen35FusedInputProjectionTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/Qwen35FusedInputProjectionTests.swift
@@ -1,0 +1,113 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Bit-identity gate for the Qwen3.5 GDN fused decode input projections.
+//
+// The fusion concatenates affine-quantized projection weights row-wise and
+// replaces N quantized matmuls with one per scheme-compatible group. Row
+// independence of (de)quantization and matmul makes the fused output
+// bit-identical to the separate calls — this suite pins that for BOTH
+// grouping shapes: a uniform stamp (all four projections fuse, 4→1) and the
+// 27B's real mixed stamp (qkv+z at one width, b+a at another, 4→2). The
+// baseline instance runs with `VMLX_GDN_FUSE_DECODE_INPUTS=0`, the fused
+// instance with identical weights (same seed) and fusion on; outputs must
+// match exactly.
+
+import Foundation
+import MLX
+import MLXNN
+import MLXRandom
+import Testing
+
+@testable import MLXLLM
+@testable import MLXLMCommon
+
+@Suite(.serialized)
+struct Qwen35FusedInputProjectionTests {
+
+    private static func makeConfig() throws -> Qwen35TextConfiguration {
+        let json = """
+            {
+              "hidden_size": 64,
+              "linear_num_value_heads": 4,
+              "linear_num_key_heads": 2,
+              "linear_key_head_dim": 8,
+              "linear_value_head_dim": 8,
+              "linear_conv_kernel_dim": 4,
+              "rms_norm_eps": 1e-6
+            }
+            """
+        return try JSONDecoder().decode(
+            Qwen35TextConfiguration.self, from: Data(json.utf8))
+    }
+
+    /// Deterministic layer with the four input projections quantized:
+    /// qkv/z at `wideBits`, b/a at `narrowBits` (group size 32 throughout).
+    private static func makeLayer(
+        wideBits: Int, narrowBits: Int
+    ) throws -> Qwen35GatedDeltaNet {
+        MLXRandom.seed(42)
+        let layer = Qwen35GatedDeltaNet(try makeConfig())
+        quantize(
+            model: layer,
+            filter: { path, module in
+                guard module is Linear, !(module is QuantizedLinear) else { return nil }
+                if path.contains("in_proj_qkv") || path.contains("in_proj_z") {
+                    return (groupSize: 32, bits: wideBits, mode: .affine)
+                }
+                if path.contains("in_proj_b") || path.contains("in_proj_a") {
+                    return (groupSize: 32, bits: narrowBits, mode: .affine)
+                }
+                return nil
+            })
+        MLX.eval(layer.parameters())
+        return layer
+    }
+
+    private static func run(
+        _ layer: Qwen35GatedDeltaNet, input: MLXArray
+    ) -> MLXArray {
+        let out = layer(input, cache: MambaCache())
+        MLX.eval(out)
+        return out
+    }
+
+    private func assertBitIdentical(wideBits: Int, narrowBits: Int) throws {
+        try FocusedMLXTestSupport.withLock {
+            MLXRandom.seed(7)
+            let input = MLXRandom.normal([1, 1, 64]).asType(.bfloat16)
+            MLX.eval(input)
+
+            setenv("VMLX_GDN_FUSE_DECODE_INPUTS", "0", 1)
+            defer { unsetenv("VMLX_GDN_FUSE_DECODE_INPUTS") }
+            let baselineLayer = try Self.makeLayer(
+                wideBits: wideBits, narrowBits: narrowBits)
+            let baseline = Self.run(baselineLayer, input: input)
+
+            setenv("VMLX_GDN_FUSE_DECODE_INPUTS", "1", 1)
+            let fusedLayer = try Self.makeLayer(
+                wideBits: wideBits, narrowBits: narrowBits)
+            let fused = Self.run(fusedLayer, input: input)
+
+            let identical = MLX.all(baseline .== fused).item(Bool.self)
+            #expect(
+                identical,
+                Comment(
+                    rawValue:
+                        "fused GDN input projections must be bit-identical "
+                        + "(wide=\(wideBits) narrow=\(narrowBits))"))
+        }
+    }
+
+    @Test("uniform quantization fuses all four projections bit-identically")
+    func uniformSchemeFusesAllFour() throws {
+        try assertBitIdentical(wideBits: 4, narrowBits: 4)
+    }
+
+    @Test("mixed quantization fuses compatible pairs bit-identically")
+    func mixedSchemeFusesPairs() throws {
+        // The 27B's real shape: wide projections at one bit width, the tiny
+        // b/a pair at another — the all-or-nothing guard would refuse this.
+        try assertBitIdentical(wideBits: 8, narrowBits: 4)
+    }
+}


### PR DESCRIPTION
## What

The four GDN input projections (qkv/z/b/a) read the same decode hidden state but ran as four separate quantized matmuls. The existing all-or-nothing fusion only engaged when every projection shared one quantization scheme, so mixed stamps — like the 27B's qkv/z at 5-bit gs128 and b/a at 4-bit gs128 — never fused.

This groups the projections by (groupSize, bits, mode, scales/biases dtype) and fuses each compatible group into one `quantizedMM` per group (the 27B fuses 4→2). The uniform whole-4 path in the VLM class keeps its existing bf16-affine kernel and fused record, so compiled decode and Flash Next behavior are byte-for-byte untouched; grouped fusion is the fallback for stamps the uniform path refuses. Decode-only (S==1), disabled inside compiled-decode tracing, opt-out via `VMLX_GDN_FUSE_DECODE_INPUTS=0`.

## Proof

**Bit identity (unit, gates the kernel):** `Qwen35FusedInputProjectionTests` 2/2 pass — uniform stamp (4/4/4/4, fuses 4→1) and the 27B's real mixed shape (8/8/4/4, fuses 4→2). The suite caught a real divergence during development: fusing through the bf16-affine dense kernel was NOT bit-identical to the separate `QuantizedLinear` calls; the shipped fused op is the exact `quantizedMM` those calls dispatch, so outputs match bit-for-bit.

**Live A/B (visual harness, quiet machine):** Qwen3.8-27B-JANG_4D, agent chat (4,175-token prompt), MTP off (AR decode path), 3 valid reps per arm, fresh app instance per rep:

| arm | decode tok/s (reps) | median |
|---|---|---|
| fused (default) | 23.2 / 23.3 / 23.5 | **23.3** |
| `VMLX_GDN_FUSE_DECODE_INPUTS=0` | 22.5 / 22.8 / 23.0 | **22.8** |

+2.2% sustained decode with clean separation (every fused rep beats every unfused rep). Fusion activation confirmed per-rep via the `fused_gdn_decode_input_projections=active groups=[2, 2]` stderr diagnostic in the fused arm only.