### PR TITLE
JangLoader: the chat-template shim must survive a symlinked bundle

### DIFF
--- a/Libraries/MLXLMCommon/JangLoader.swift
+++ b/Libraries/MLXLMCommon/JangLoader.swift
@@ -1414,8 +1414,17 @@ public struct JangLoader: Sendable {
                 options: [.prettyPrinted, .sortedKeys])
             try rewrittenSidecar.write(to: shimDir.appendingPathComponent("chat_template.json"))
 
-            let entries = (try? fileManager.contentsOfDirectory(
-                at: directory, includingPropertiesForKeys: nil)) ?? []
+            // RESOLVED, and the failure is not swallowed. `contentsOfDirectory(at:)` THROWS on a URL
+            // naming a symlink to a directory ("couldn't be opened"), so a `try? … ?? []` here yields
+            // an empty list and leaves a shim holding only the files rewritten above. The load then
+            // fails as a MISSING TOKENIZER — which says nothing about the symlinked bundle that
+            // caused it, and sends you looking for a file that is present.
+            //
+            // A shim that cannot be populated is worse than no shim, so fall back to the bundle
+            // itself, exactly as the `catch` below does.
+            guard let entries = try? fileManager.contentsOfDirectory(
+                at: directory.resolvingSymlinksInPath(), includingPropertiesForKeys: nil)
+            else { return directory }
             let rewrittenTemplateFiles: Set<String> = [
                 "tokenizer_config.json",
                 "chat_template.jinja",
@@ -1665,8 +1674,17 @@ public struct JangLoader: Sendable {
                 to: shimDir.appendingPathComponent("tokenizer_config.json"))
             // Symlink all OTHER files — tokenizer.json especially is often
             // large and we don't want to duplicate it.
-            let entries = (try? fileManager.contentsOfDirectory(
-                at: directory, includingPropertiesForKeys: nil)) ?? []
+            // RESOLVED, and the failure is not swallowed. `contentsOfDirectory(at:)` THROWS on a URL
+            // naming a symlink to a directory ("couldn't be opened"), so a `try? … ?? []` here yields
+            // an empty list and leaves a shim holding only the files rewritten above. The load then
+            // fails as a MISSING TOKENIZER — which says nothing about the symlinked bundle that
+            // caused it, and sends you looking for a file that is present.
+            //
+            // A shim that cannot be populated is worse than no shim, so fall back to the bundle
+            // itself, exactly as the `catch` below does.
+            guard let entries = try? fileManager.contentsOfDirectory(
+                at: directory.resolvingSymlinksInPath(), includingPropertiesForKeys: nil)
+            else { return directory }
             for entry in entries where entry.lastPathComponent != "tokenizer_config.json" {
                 let dest = shimDir.appendingPathComponent(entry.lastPathComponent)
                 // Some tokenizer caches already contain symlinks — follow them


### PR DESCRIPTION
## Symptom

A model bundle reached through a symlinked directory fails to load:

```
$ osaurus-eval prompt --model cais/HarmBench-Llama-2-13b-cls-Jang_6M …
Error: Required configuration file missing: tokenizer.json
```

The file is present and readable:

```
$ ls -l ~/Library/MLModels/cais/HarmBench-Llama-2-13b-cls-Jang_6M/tokenizer.json
-rw-r--r--  1 rcfa  staff  3619013  tokenizer.json
```

The same bundle loads fine through its real path. Only the symlink fails.

## Cause

`FileManager.contentsOfDirectory(at:includingPropertiesForKeys:)` **throws** on a URL that names a
symlink to a directory:

```
real dir       contentsOfDirectory -> 35 entries, tokenizer.json present=true
symlinked dir  contentsOfDirectory THREW: The file "…" couldn't be opened.
```

Both chat-template shims in `JangLoader` enumerate the bundle that way and wrote the result as
`(try? …) ?? []`. So the throw became an empty list: nothing was symlinked into the shim, and the
shim — holding only the files it had just rewritten — was handed to the tokenizer loader.

The reported file really is missing, in the shim. That is why the message is so misleading: it names
a file that is plainly present in the bundle you asked for, and says nothing about the temporary
directory it is actually describing, or about the symlink that produced it.

Only bundles that take the shim path are affected, which is why this is not universal — a bundle
needing no chat-template rewrite loads through a symlink without trouble.

## Fix

Resolve the directory before enumerating, and stop discarding the failure:

```swift
guard let entries = try? fileManager.contentsOfDirectory(
    at: directory.resolvingSymlinksInPath(), includingPropertiesForKeys: nil)
else { return directory }
```

`resolvingSymlinksInPath()` is already the idiom elsewhere in this file. The `guard` matters
independently of symlinks: a shim that cannot be populated is strictly worse than no shim, since it
hides a complete bundle behind a directory missing everything the loader needs. Falling back to the
bundle is what the surrounding `catch` already does.

## Verified

`cais/HarmBench-Llama-2-13b-cls-Jang_6M` (a symlink into another namespace), a freshly created
absolute symlink, and the real path: the first two fail before this change and all three answer
after it.

No test ships with this. Exercising it needs a bundle whose `tokenizer_config.json` triggers the
shim, reached through a symlink — a fixture rather than a unit test, and I would rather say that
than add one that passes without covering the path.
