### PR TITLE
SafetensorsStorageHealer: enumerate through a symlinked bundle

### DIFF
--- a/Libraries/MLXLMCommon/Cache/SafetensorsStorageHealer.swift
+++ b/Libraries/MLXLMCommon/Cache/SafetensorsStorageHealer.swift
@@ -105,8 +105,12 @@ enum SafetensorsStorageHealer {
 
         let entries: [URL]
         do {
+            // RESOLVED: `contentsOfDirectory(at:)` throws on a URL naming a symlink to a
+            // directory, so a bundle reached through one would enumerate to nothing and take the
+            // fallback below — the healer silently declining to do its job on exactly the bundles
+            // an operator has deduplicated by symlinking between namespaces.
             entries = try FileManager.default.contentsOfDirectory(
-                at: directory,
+                at: directory.resolvingSymlinksInPath(),
                 includingPropertiesForKeys: [.isSymbolicLinkKey, .fileSizeKey],
                 options: [.skipsHiddenFiles]
             )


### PR DESCRIPTION
Follow-on to #402, same cause one site further on.

`FileManager.contentsOfDirectory(at:)` throws on a URL naming a symlink to a directory. The healer
enumerates the bundle that way, so a bundle reached through a symlink produced:

```
[SafetensorsStorageHealer] event=fallback reason=enumeration_failed path=".../cais/HarmBench-…"
```

and the healer took its fallback path — declining to scan exactly the bundles an operator has
deduplicated by symlinking between namespaces. This one is less severe than #402 because it *reports*
the failure and degrades rather than erroring, but the effect is still silent in practice: the log
line names an enumeration failure, not the symlink that caused it, and shard healing simply does not
happen.

Fixed by resolving the directory before enumerating, as #402 does for the chat-template shims.

Verified: loading a symlinked bundle emits the fallback line before this change and none after.
