### PR TITLE
Qwen3VL: reorder vision rows to placeholder order before the pooled scatter

### DIFF
--- a/Libraries/MLXVLM/Models/Qwen3VL.swift
+++ b/Libraries/MLXVLM/Models/Qwen3VL.swift
@@ -1754,6 +1754,82 @@ public final class Qwen3VL: Module, VLMModel, KVCacheDimensionProvider {
         return indices
     }
 
+    /// Permutation that reorders vision feature rows from batch order
+    /// (image rows first, then video rows — the order `prepare`
+    /// concatenates pixels in) to PLACEHOLDER order (conversation order).
+    ///
+    /// The pooled scatter over `imageMask .|| videoMask` assumes those two
+    /// orders agree, and they do not: a chat whose earlier turn carried a
+    /// video and whose current turn carries an image has video placeholders
+    /// FIRST, so the pooled scatter lays the image's rows onto the video's
+    /// pads and vice versa — the blocks swap, silently, because the total
+    /// element count still matches (same defect fixed in Qwen35.swift; this
+    /// model additionally re-applies the rows per deepstack layer, so the
+    /// permutation is computed once and applied to every row batch).
+    ///
+    /// Returns `nil` when only one media kind is present — one kind cannot
+    /// mis-order, and the fast path stays untouched.
+    private func placeholderOrderPermutation(
+        inputIds: MLXArray,
+        imageTokenIndex: Int,
+        videoTokenIndex: Int,
+        imageRowCount: Int,
+        totalRows: Int
+    ) throws -> MLXArray? {
+        guard imageRowCount > 0, totalRows > imageRowCount else { return nil }
+        let flatIds = inputIds.flattened()
+        let imagePositions = nonZero((flatIds .== MLXArray(imageTokenIndex)).asType(.bool))
+        let videoPositions = nonZero((flatIds .== MLXArray(videoTokenIndex)).asType(.bool))
+        guard imagePositions.count == imageRowCount,
+            videoPositions.count == totalRows - imageRowCount
+        else {
+            throw Qwen3VLError.featureTokenMismatch(
+                expected: imagePositions.count + videoPositions.count, actual: totalRows)
+        }
+        return MLXArray(
+            Self.placeholderOrderPermutation(
+                imagePositions: imagePositions,
+                videoPositions: videoPositions,
+                imageRowCount: imageRowCount))
+    }
+
+    /// Pure core of the reordering: walk the combined placeholder positions
+    /// in ascending (conversation) order; each position consumes the next
+    /// row of its kind's queue. Rows [0, imageRowCount) are the image batch,
+    /// the rest the video batch.
+    static func placeholderOrderPermutation(
+        imagePositions: [Int],
+        videoPositions: [Int],
+        imageRowCount: Int
+    ) -> [UInt32] {
+        let totalRows = imagePositions.count + videoPositions.count
+        var permutation = [UInt32](repeating: 0, count: totalRows)
+        var imageNext = 0
+        var videoNext = imageRowCount
+        var imageIdx = 0
+        var videoIdx = 0
+        for slot in 0 ..< totalRows {
+            let takeImage: Bool
+            if imageIdx == imagePositions.count {
+                takeImage = false
+            } else if videoIdx == videoPositions.count {
+                takeImage = true
+            } else {
+                takeImage = imagePositions[imageIdx] < videoPositions[videoIdx]
+            }
+            if takeImage {
+                permutation[slot] = UInt32(imageNext)
+                imageNext += 1
+                imageIdx += 1
+            } else {
+                permutation[slot] = UInt32(videoNext)
+                videoNext += 1
+                videoIdx += 1
+            }
+        }
+        return permutation
+    }
+
     private func combinedFrames(
         imageFrames: [THW]?,
         videoFrames: [THW]?
@@ -1815,7 +1891,24 @@ public final class Qwen3VL: Module, VLMModel, KVCacheDimensionProvider {
             let splits = framesList.map { $0.product / (mergeSize * mergeSize) }
             let splitIndices = cumulativeSplitIndices(from: splits)
             let featureSlices = visionHidden.split(indices: splitIndices)
-            let flattenedFeatures = concatenated(featureSlices).asType(textEmbeds.dtype)
+            var flattenedFeatures = concatenated(featureSlices).asType(textEmbeds.dtype)
+
+            // Rows arrive image-batch-first; placeholders sit in conversation
+            // order. Reorder rows to placeholder order ONCE so the pooled
+            // scatter below — and every per-layer deepstack application of
+            // the same rows — lands each block on its own medium's pads.
+            let imageRowCount = (imageFrames ?? []).reduce(0) {
+                $0 + $1.product / (mergeSize * mergeSize)
+            }
+            let rowPermutation = try placeholderOrderPermutation(
+                inputIds: inputIds,
+                imageTokenIndex: config.imageTokenIndex,
+                videoTokenIndex: config.videoTokenIndex,
+                imageRowCount: imageRowCount,
+                totalRows: flattenedFeatures.dim(0))
+            if let rowPermutation {
+                flattenedFeatures = flattenedFeatures[rowPermutation]
+            }
 
             let (mergedEmbeds, mask) = try mergeInputIdsWithImageFeatures(
                 imageFeatures: flattenedFeatures,
@@ -1831,7 +1924,13 @@ public final class Qwen3VL: Module, VLMModel, KVCacheDimensionProvider {
                 deepstackEmbeds = deepstackOutputs.map { layerFeatures in
                     let splitIndices = cumulativeSplitIndices(from: splits)
                     let slices = layerFeatures.split(indices: splitIndices)
-                    let concatenatedSlices = concatenated(slices).asType(textEmbeds.dtype)
+                    var concatenatedSlices = concatenated(slices).asType(textEmbeds.dtype)
+                    // Same batch-order rows, same placeholder-order pads:
+                    // applyDeepstack adds these rows at visualMask positions
+                    // per layer, so they need the same reordering.
+                    if let rowPermutation {
+                        concatenatedSlices = concatenatedSlices[rowPermutation]
+                    }
                     return concatenatedSlices
                 }
             }

--- a/Package.swift
+++ b/Package.swift
@@ -908,6 +908,7 @@ let package = Package(
                 "VLGrowingConversationReuseTests.swift",
                 "VLMediaTokenDeclarationReachabilityTests.swift",
                 "Apertus1p5PrefixNormalisationTests.swift",
+                "Qwen3VLFeatureOrderTests.swift",
                 "NemotronHOmniPreEncodedAudioTests.swift",
                 "NemotronHJANGTQDispatchFocusedTests.swift",
                 "MTPRuntimeFocusedTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/Qwen3VLFeatureOrderTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/Qwen3VLFeatureOrderTests.swift
@@ -1,0 +1,49 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Pins the Qwen3VL vision-feature reordering: feature rows arrive
+// image-batch-first (the order `prepare` concatenates pixels), while
+// placeholders sit in conversation order. The permutation must map each
+// placeholder slot to the next row of ITS kind — the pooled scatter and
+// every per-layer deepstack application then land each block on its own
+// medium's pads. Video-before-image across turns is the exact shape that
+// silently swapped the two blocks (same defect fixed in Qwen35.swift).
+
+import Testing
+
+@testable import MLXVLM
+
+struct Qwen3VLFeatureOrderTests {
+
+    @Test("video placeholders before image placeholders pull video rows first")
+    func videoFirstConversationOrder() {
+        // Conversation: video turn (pads at 10,11,12) then image turn
+        // (pads at 20,21). Rows: image batch = [0,1], video batch = [2,3,4].
+        let perm = Qwen3VL.placeholderOrderPermutation(
+            imagePositions: [20, 21],
+            videoPositions: [10, 11, 12],
+            imageRowCount: 2)
+        // Slots 0-2 are the video pads -> video rows 2,3,4;
+        // slots 3-4 are the image pads -> image rows 0,1.
+        #expect(perm == [2, 3, 4, 0, 1])
+    }
+
+    @Test("image-first conversation is the identity permutation")
+    func imageFirstIsIdentity() {
+        let perm = Qwen3VL.placeholderOrderPermutation(
+            imagePositions: [5, 6],
+            videoPositions: [30, 31, 32],
+            imageRowCount: 2)
+        #expect(perm == [0, 1, 2, 3, 4])
+    }
+
+    @Test("interleaved kinds consume each queue in placeholder order")
+    func interleavedKinds() {
+        // img, vid, img, vid conversation order.
+        let perm = Qwen3VL.placeholderOrderPermutation(
+            imagePositions: [1, 8],
+            videoPositions: [4, 12],
+            imageRowCount: 2)
+        #expect(perm == [0, 2, 1, 3])
+    }
+}


### PR DESCRIPTION
## What

Qwen3VL (qwen3_vl / Qwen3-VL family) carries the same media-order defect that was fixed for the qwen3_5 family in #298: feature rows arrive image-batch-first (`prepare` concatenates image pixels before video pixels) while placeholders sit in conversation order, and the pooled scatter over `imageMask .|| videoMask` assumes those orders agree. A video turn followed by an image turn silently swaps the two blocks (total element count still matches). Qwen3VL additionally re-applies the SAME rows once per deepstack layer (`applyDeepstack` adds them at `visualMask` positions), so a per-kind scatter split would not be enough.

Fix: compute one permutation mapping batch order → placeholder order and apply it to the merged features AND every deepstack layer's rows. Single-kind inputs return nil and keep the existing fast path untouched; per-kind count mismatches still throw.

## Proof

`Qwen3VLFeatureOrderTests` 3/3 on this branch (post-rebase onto main): video-before-image pulls video rows first, image-first is the identity, interleaved kinds consume each queue in placeholder order. MLXVLM builds clean.

## Note

Originally opened carrying the full #298 chain by mistake (#298 already merged Aug 22 and shipped in 0.24.3); rebased to exactly this one commit.