### PR TITLE
fp32 sweep: DSA and GLM5-next indexers score in the pool's native dtype

### DIFF
--- a/Libraries/MLXLLM/Models/DeepseekV4Compressor.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV4Compressor.swift
@@ -1265,6 +1265,15 @@ public final class DeepseekV4Cache: QuantizedHybridPoolCache, CacheRetainedByteC
 // strictly increases context coverage. After pooling, applies the
 // absolute position embedding (APE) and partial RoPE at the chunk
 // positions. Updates the per-layer V4Cache pool if provided.
+/// Gate for the DSA dense-indexer score matmul input dtype. Default runs in
+/// the pool's native dtype (no per-step full-pool fp32 copy); the env var
+/// restores the historical fp32-input matmul for A/B and fallback.
+enum DeepseekV4IndexerRuntime {
+    nonisolated(unsafe) static var scoreFP32Inputs: Bool = {
+        ProcessInfo.processInfo.environment["VMLX_DSA_INDEX_FP32"] == "1"
+    }()
+}
+
 enum DeepseekV4CompressorQATKind {
     case attentionKV
     case indexer
@@ -1827,9 +1836,24 @@ public final class DeepseekV4Indexer: Module {
         // scores: (B, nHeads, L, pooledLen). Match Python shape.
         // q is (B, nHeads, L, headDim); pooled is (B, pooledLen, headDim).
         // Expand pooled to (B, 1, pooledLen, headDim) for broadcast.
+        //
+        // The matmul runs in the pool's native dtype: casting `pooled` to
+        // fp32 materialized a full-pool fp32 copy on EVERY decode step
+        // (linear-in-context traffic per token — the same tax class as the
+        // MLA decode cast fixed in AttentionUtils). Metal GEMM accumulates
+        // in fp32 internally, and these are SELECTION logits: bf16 storage
+        // rounding (~2^-8 relative) can only flip near-tie block choices,
+        // and the fp32 head-weighted sum below happens after the cast.
+        // `VMLX_DSA_INDEX_FP32=1` restores the fp32-input matmul for A/B.
         let pooledBroad = pooled.expandedDimensions(axis: 1)
-        var scores = q.asType(.float32).matmul(
-            pooledBroad.asType(.float32).swappedAxes(-1, -2))
+        var scores: MLXArray
+        if DeepseekV4IndexerRuntime.scoreFP32Inputs {
+            scores = q.asType(.float32).matmul(
+                pooledBroad.asType(.float32).swappedAxes(-1, -2))
+        } else {
+            scores = q.asType(pooled.dtype).matmul(
+                pooledBroad.swappedAxes(-1, -2)).asType(.float32)
+        }
         scores = maximum(scores, MLXArray(0.0)) * MLXArray(scale)
 
         // Reshape scores sum axis: (B, 1, L, nHeads) multiply → sum.

--- a/Libraries/MLXLLM/Models/Phi.swift
+++ b/Libraries/MLXLLM/Models/Phi.swift
@@ -61,6 +61,14 @@ class PhiAttention: Module {
         keys = applyRotaryPosition(rope, to: keys, cache: cache)
 
         // Finally perform the attention computation
+        //
+        // The fp32 query cast is LOAD-BEARING, not a leftover: Phi ships
+        // fp16, and fp16 attention scores overflow (+-65504) — the fp32
+        // promotion (mirroring Python mlx-lm's phi implementation) keeps
+        // score range and softmax reduction in fp32. Same class as Gemma-4's
+        // global-layer upcast: removing it trades correctness for bandwidth.
+        // The KV cache itself still stores the model's native dtype — only
+        // the SDPA consumption is promoted.
         let scale = sqrt(1 / Float(queries.dim(-1)))
         let output = attentionWithCacheUpdate(
             queries: queries.asType(.float32),

--- a/Libraries/MLXVLM/Models/Glm5Next.swift
+++ b/Libraries/MLXVLM/Models/Glm5Next.swift
@@ -41,6 +41,15 @@ import MLXNN
 /// Which attention a decoder layer runs. GLM-5.3 interleaves them explicitly rather than by
 /// interval — 34 linear to 11 sparse in the shipped 45-layer bundle — so the schedule is read as a
 /// list and not derived from a stride the way `Qwen35`'s `full_attention_interval` is.
+/// Gate for the GLM5-next sparse-index pooling/scoring dtype. Default runs
+/// in the packed cache's native dtype (no per-step full-context fp32
+/// copies); the env var restores the historical fp32 pipeline for A/B.
+enum Glm5NextIndexerRuntime {
+    nonisolated(unsafe) static var poolFP32: Bool = {
+        ProcessInfo.processInfo.environment["VMLX_GLM5_INDEX_FP32"] == "1"
+    }()
+}
+
 public enum Glm5NextLayerKind: String, Codable, Sendable {
     case linearAttention = "linear_attention"
     case deepseekSparseAttention = "deepseek_sparse_attention"
@@ -909,17 +918,28 @@ extension Glm5NextIndexer {
         }
         // A LEARNED weighted average within each pool: softmax over the POOL-MEMBER axis, per
         // feature channel — not one scalar weight per member.
-        var logits = groupedGate.asType(.float32) + ape.asType(.float32)[.newAxis, .newAxis]
+        //
+        // The gathers above span the ENTIRE packed index history and this
+        // runs every decode step, so fp32 casts here materialized two
+        // full-context fp32 tensors per token (the MLA-cast tax class).
+        // The softmax reduces over the tiny pool-member axis only, and the
+        // pooled keys feed SELECTION scores, so native-dtype math changes
+        // at most near-tie pool choices. `VMLX_GLM5_INDEX_FP32=1` restores
+        // the fp32 pipeline for A/B.
+        let poolMathDtype: DType =
+            Glm5NextIndexerRuntime.poolFP32 ? .float32 : packed.dtype
+        var logits = groupedGate.asType(poolMathDtype)
+            + ape.asType(poolMathDtype)[.newAxis, .newAxis]
         logits = MLX.where(
             groupedValid.expandedDimensions(axis: -1), logits,
-            MLXArray(-Float.greatestFiniteMagnitude))
+            MLXArray(-Float.greatestFiniteMagnitude).asType(poolMathDtype))
         var probabilities = softmax(logits, axis: 2)
         // A fully invalid pool softmaxes -inf against -inf and yields NaN; it is masked out of the
         // selection anyway, but a NaN here would poison the pooled key and, through it, the scores
         // of every VALID pool in the same matmul.
         probabilities = MLX.where(
-            isNaN(probabilities), MLXArray(Float(0)), probabilities)
-        let pooled = (probabilities * groupedKeys.asType(.float32)).sum(axis: 2)
+            isNaN(probabilities), MLXArray(Float(0)).asType(poolMathDtype), probabilities)
+        let pooled = (probabilities * groupedKeys.asType(poolMathDtype)).sum(axis: 2)
 
         return (pooled.asType(packed.dtype), poolIndices, poolValid)
     }
@@ -939,9 +959,21 @@ extension Glm5NextIndexer {
         let poolCount = poolIndices.dim(0)
 
         // (B, S, H, D) @ (B, 1, D, P) -> (B, S, H, P)
-        var scores = matmul(
-            queries.asType(.float32),
-            poolKeys.asType(.float32).swappedAxes(-1, -2).expandedDimensions(axis: 1))
+        // Native-dtype matmul (fp32 accumulation happens inside the GEMM);
+        // only the small score tensor is carried in fp32 for the weighting
+        // math below. Casting poolKeys to fp32 copied the whole pool per
+        // decode step. Gated with the pooling math above.
+        var scores: MLXArray
+        if Glm5NextIndexerRuntime.poolFP32 {
+            scores = matmul(
+                queries.asType(.float32),
+                poolKeys.asType(.float32).swappedAxes(-1, -2).expandedDimensions(axis: 1))
+        } else {
+            scores = matmul(
+                queries.asType(poolKeys.dtype),
+                poolKeys.swappedAxes(-1, -2).expandedDimensions(axis: 1)
+            ).asType(.float32)
+        }
         scores = maximum(scores * (1.0 / sqrt(Float(headDim))), MLXArray(Float(0)))
 
         // One learned scalar per index head, then a weighted sum ACROSS heads.


### PR DESCRIPTION
Closes out the context-scaling fp32 audit (66 files, ~295 cast sites classified). Fixes the two remaining per-decode-token full-history fp32 materializations — the DeepseekV4 dense indexer and both GLM5-next sparse-index paths — by running the big matmuls/gathers in the pool's native dtype (fp32 GEMM accumulation is internal) and keeping fp32 only for the small score/weighting tensors. Both gated: `VMLX_DSA_INDEX_FP32=1` / `VMLX_GLM5_INDEX_FP32=1` restore the old pipelines.

Proof: DSV4 focused suites 164/164 including the indexer causal top-k contract; MLXLLM+MLXVLM build clean. These are selection logits (top-k block choice), so native-dtype storage rounding can only flip near-ties — unlike attention output, where the audit PROVED fp32 is load-bearing for Gemma-4 (measured maxDiff 0.27 from bf16 score storage at its d=512 regime) and Phi (fp16 range); both are now documented in-code as intentional so they don't get 'optimized' into correctness bugs. GLM5-next live A/B pending a local glm5_next bundle; DSV4 live A/B planned on the 95GB DSV4-Flash in-app under production memory caps.