### PR TITLE
GLM-5.3: load the affine bank resident, not mapped

### DIFF
--- a/Libraries/MLXLMCommon/Cache/LoadConfiguration.swift
+++ b/Libraries/MLXLMCommon/Cache/LoadConfiguration.swift
@@ -621,12 +621,34 @@ public struct LoadBundleFacts: Sendable, Equatable {
             && isRouted
     }
 
+    /// GLM-5.3 (`glm5_next`) needs the same resident treatment DSV4 does, and for the same reason:
+    /// a routed affine bank far larger than the page cache will hold.
+    ///
+    /// Measured on a 95 GB bundle / 128 GB machine. Mapped, it sits at 60-74 GB file-backed with
+    /// free memory pinned near zero and the kernel evicting and re-reading continuously — `sys`
+    /// runs ~37x `user`, i.e. the model spends its life faulting rather than computing.
+    ///
+    /// This is NOT "mmap is bad": mmap is what lets a model LARGER than RAM run at all. It is that
+    /// a bundle which fits resident should be resident, because file-backed pages are evictable and
+    /// macOS drops them eagerly, while anonymous pages are not. 95 GB of 128 GB fits.
+    public var isGlm5NextAffineJANG: Bool {
+        let type = modelType?.lowercased() ?? ""
+        let format = weightFormat?.lowercased() ?? ""
+        let declaresAffine = format.isEmpty || format == "affine" || format == "jang"
+        return (type == "glm5_next" || type == "glm5_next_text")
+            && !hasJangTQRuntime
+            && declaresAffine
+            && isRouted
+            && (numRoutedExperts ?? 0) >= 128
+    }
+
     /// Plain split-expert DSV4 currently requires a resident compute bank.
     /// Qwen4Exp must retain the caller's mmap choice: its 61+ GiB packed bank
     /// is valid mixed-dtype MLX input, while its PLE/ngram tensors already stay
     /// in the model-owned exact-row SSD reader.
     public var requiresResidentSafetensors: Bool {
-        isPlainDeepseekV4AffineJANG && !hasPrestackedAffineRoutedExperts
+        (isPlainDeepseekV4AffineJANG && !hasPrestackedAffineRoutedExperts)
+            || isGlm5NextAffineJANG
     }
 
     public func resolveMmapSafetensors(requested: Bool) -> Bool {


### PR DESCRIPTION
## Symptom

GLM-5.3 (`glm5_next`, 95 GB JANG bundle) generates at a fraction of a token per second on a 128 GB
machine, with `sys` time roughly **37x** `user` — the process is faulting, not computing.

## Cause

The bundle is memory-mapped, and at 95 GB on 128 GB it cannot stay mapped. Sampled during a run:

```
file-backed  60-74 GB      free  ~0.1 GB
```

macOS drops file-backed pages eagerly under pressure, so the mapping is evicted and re-read
continuously. Loaded resident instead, the same bundle sits in anonymous memory, which the kernel
cannot simply drop:

```
                 mapped        resident
file-backed      62-67 GB      6.8 GB
anonymous        25-27 GB     67.3 GB
```

## Measured

Same command both ways — `run --benchmark gsm8k --limit 3 --max-tokens 256`:

| load mode | result |
|---|---|
| mapped | **did not complete 3 items in 5640s** |
| resident | **completed 3/3 in 2698s** |

## Fix

`requiresResidentSafetensors` already carries exactly this exception for plain split-expert DSV4
("currently requires a resident compute bank"). GLM-5.3 matches the same shape — routed affine bank,
≥128 experts, no JANGTQ runtime — so this adds a sibling predicate rather than a new mechanism.

To be explicit about what this does *not* claim: mmap is what lets a model **larger** than RAM run at
all, and nothing here changes that. The claim is narrower — a bundle that **fits** resident should be
resident, because the eviction asymmetry between file-backed and anonymous pages turns "fits, mapped"
into continuous re-reading.

## Not the whole story

GLM-5.3 is still slow in absolute terms after this change: 3 gsm8k items at 5-shot with thinking on
took 2698 s. The load mode was costing more than everything else combined, but it is not the only
thing wrong, and I would rather land the measured half than hold it while chasing the rest.
