### PR TITLE
Quantized modules return the activation dtype: end the silent fp32 promotion cascade

### DIFF
--- a/Libraries/MLXLLM/Models/BailingHybrid.swift
+++ b/Libraries/MLXLLM/Models/BailingHybrid.swift
@@ -680,7 +680,12 @@ class BailingLinearAttention: Module {
             cache?.offset += L
         }
 
-        let flat = output.transposed(0, 2, 1, 3).reshaped(B, L, -1)
+        // The GLA recurrence intentionally runs and stores its STATE in fp32
+        // (fp16-overflow fix above); the layer OUTPUT has no such need, and
+        // returning it fp32 promoted the residual stream — and through it
+        // every downstream attention layer's KV cache — to fp32 on bf16
+        // bundles. Cast the output lane back; the state lane stays fp32.
+        let flat = output.transposed(0, 2, 1, 3).reshaped(B, L, -1).asType(x.dtype)
         let gated = gNorm(flat) * sigmoid(gProj(x))
         return dense(gated)
     }

--- a/Libraries/MLXLLM/Models/DeepseekV3JANGTQ.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV3JANGTQ.swift
@@ -381,7 +381,7 @@ final class DeepseekV3JANGTQMoE: Module, UnaryLayer {
             }
         } else {
             y = switchMLP(routeInput, indices)
-            y = (y * scores[.ellipsis, .newAxis]).sum(axis: -2)
+            y = (y * scores.asType(y.dtype)[.ellipsis, .newAxis]).sum(axis: -2)
         }
 
         if let shared = sharedExperts {

--- a/Libraries/MLXLLM/Models/DeepseekV4JANGTQ.swift
+++ b/Libraries/MLXLLM/Models/DeepseekV4JANGTQ.swift
@@ -87,7 +87,7 @@ final class DeepseekV4MoEJANGTQ: Module, UnaryLayer {
             y = streaming.reduced(x, indices: indices, scores: scores)
         } else {
             y = switchMLP(x, indices)
-            y = (y * scores[.ellipsis, .newAxis]).sum(axis: -2)
+            y = (y * scores.asType(y.dtype)[.ellipsis, .newAxis]).sum(axis: -2)
         }
         y = y + sharedExperts(x)
         return y

--- a/Libraries/MLXLLM/Models/GLM4MOE.swift
+++ b/Libraries/MLXLLM/Models/GLM4MOE.swift
@@ -216,7 +216,7 @@ class GLM4MoE: Module, UnaryLayer {
         let (inds, scores) = gate(x)
         JangPressCanonicalExpertAdvisor.shared.observe(layer: layerIdx, indices: inds)
         var y = switchMLP(x, inds)
-        y = (y * scores[.ellipsis, .newAxis]).sum(axis: -2).asType(y.dtype)
+        y = (y * scores.asType(y.dtype)[.ellipsis, .newAxis]).sum(axis: -2).asType(y.dtype)
         if let sharedExperts {
             y = y + sharedExperts(x)
         }

--- a/Libraries/MLXLLM/Models/GLM4MOELite.swift
+++ b/Libraries/MLXLLM/Models/GLM4MOELite.swift
@@ -411,7 +411,7 @@ class GLM4MoELiteMoE: Module, UnaryLayer {
         let (inds, scores) = gate(x)
         JangPressCanonicalExpertAdvisor.shared.observe(layer: layerIdx, indices: inds)
         var y = switchMLP(x, inds)
-        y = (y * scores[.ellipsis, .newAxis]).sum(axis: -2).asType(y.dtype)
+        y = (y * scores.asType(y.dtype)[.ellipsis, .newAxis]).sum(axis: -2).asType(y.dtype)
         if let sharedExperts {
             y = y + sharedExperts(x)
         }

--- a/Libraries/MLXLLM/Models/Hy3.swift
+++ b/Libraries/MLXLLM/Models/Hy3.swift
@@ -471,7 +471,7 @@ class Hy3MoE: Module, UnaryLayer {
             routed = streaming.reduced(x, indices: indices, scores: scores)
         } else {
             let y = switchMLP(x, indices)
-            routed = (y * scores[.ellipsis, .newAxis]).sum(axis: -2)
+            routed = (y * scores.asType(y.dtype)[.ellipsis, .newAxis]).sum(axis: -2)
         }
         return routed + sharedExperts(x)
     }
@@ -508,7 +508,7 @@ class Hy3AffineMoE: Module, UnaryLayer {
         let (indices, scores) = gate(x)
         JangPressCanonicalExpertAdvisor.shared.observe(layer: layerIdx, indices: indices)
         let y = switchMLP(x, indices)
-        let routed = (y * scores[.ellipsis, .newAxis]).sum(axis: -2)
+        let routed = (y * scores.asType(y.dtype)[.ellipsis, .newAxis]).sum(axis: -2)
         return routed + sharedExperts(x)
     }
 }

--- a/Libraries/MLXLLM/Models/Jamba.swift
+++ b/Libraries/MLXLLM/Models/Jamba.swift
@@ -366,7 +366,7 @@ class JambaSparseMoeBlock: Module {
         scores = MLX.softmax(scores, axis: -1, precise: true)
 
         let y = switchMLP(x, inds)
-        return (y * scores[.ellipsis, .newAxis]).sum(axis: -2)
+        return (y * scores.asType(y.dtype)[.ellipsis, .newAxis]).sum(axis: -2)
     }
 }
 

--- a/Libraries/MLXLLM/Models/MiMoV2Flash.swift
+++ b/Libraries/MLXLLM/Models/MiMoV2Flash.swift
@@ -320,7 +320,7 @@ class MiMoV2FlashMoE: Module, UnaryLayer {
         let (inds, scores) = gate(x)
         JangPressCanonicalExpertAdvisor.shared.observe(layer: layerIdx, indices: inds)
         var y = switchMLP(x, inds)
-        y = (y * scores[.ellipsis, .newAxis]).sum(axis: -2).asType(y.dtype)
+        y = (y * scores.asType(y.dtype)[.ellipsis, .newAxis]).sum(axis: -2).asType(y.dtype)
         if let sharedExperts {
             y = y + sharedExperts(x)
         }

--- a/Libraries/MLXLLM/Models/MiniMax.swift
+++ b/Libraries/MLXLLM/Models/MiniMax.swift
@@ -140,7 +140,7 @@ class MiniMaxSparseMoeBlock: Module {
         scores = scores.asType(x.dtype)
 
         let y = switchMLP(x, inds)
-        return (y * scores[.ellipsis, .newAxis]).sum(axis: -2)
+        return (y * scores.asType(y.dtype)[.ellipsis, .newAxis]).sum(axis: -2)
     }
 }
 

--- a/Libraries/MLXLLM/Models/MiniMaxJANGTQ.swift
+++ b/Libraries/MLXLLM/Models/MiniMaxJANGTQ.swift
@@ -209,7 +209,7 @@ private class MiniMaxJANGTQSparseMoeBlock: Module {
             return streaming.reduced(x, indices: inds, scores: scores)
         }
         let y = switchMLP(x, inds)
-        return (y * scores[.ellipsis, .newAxis]).sum(axis: -2)
+        return (y * scores.asType(y.dtype)[.ellipsis, .newAxis]).sum(axis: -2)
     }
 }
 

--- a/Libraries/MLXLLM/Models/Mixtral.swift
+++ b/Libraries/MLXLLM/Models/Mixtral.swift
@@ -126,7 +126,7 @@ private class MixtralSparseMoeBlock: Module {
         let scores = MLX.softmax(MLX.takeAlong(gates, inds, axis: -1), axis: -1, precise: true)
         JangPressCanonicalExpertAdvisor.shared.observe(layer: layerIdx, indices: inds)
         let y = switchMLP(x, inds)
-        return (y * scores[.ellipsis, .newAxis]).sum(axis: -2)
+        return (y * scores.asType(y.dtype)[.ellipsis, .newAxis]).sum(axis: -2)
     }
 }
 

--- a/Libraries/MLXLLM/Models/NemotronH.swift
+++ b/Libraries/MLXLLM/Models/NemotronH.swift
@@ -915,7 +915,7 @@ internal class NemotronHMoE: Module, UnaryLayer, NemotronHMixer {
             y = weighted
         } else {
             y = layer(expertInput, inds)
-            y = (y * scores[.ellipsis, .newAxis]).sum(axis: -2).asType(y.dtype)
+            y = (y * scores.asType(y.dtype)[.ellipsis, .newAxis]).sum(axis: -2).asType(y.dtype)
         }
         if profile {
             MLX.eval(y)

--- a/Libraries/MLXLLM/Models/NemotronHJANGTQ.swift
+++ b/Libraries/MLXLLM/Models/NemotronHJANGTQ.swift
@@ -73,7 +73,7 @@ internal final class NemotronHJANGTQSwitchMLP: Module, NemotronHSwitchMLPLayer {
     ///   - `indices` : `(B, T, K)` — expert ids per token
     ///   - return    : `(B, T, K, hidden)` — per-(token, expert) outputs.
     ///                 The caller (`NemotronHMoE.callAsFunction`) does
-    ///                 `(y * scores[.ellipsis, .newAxis]).sum(axis: -2)`
+    ///                 `(y * scores.asType(y.dtype)[.ellipsis, .newAxis]).sum(axis: -2)`
     ///                 to reduce over the K dim.
     ///
     /// We bypass `TurboQuantSwitchLinear.callAsFunction(_:_:)` and call

--- a/Libraries/MLXLLM/Models/OlmoE.swift
+++ b/Libraries/MLXLLM/Models/OlmoE.swift
@@ -123,7 +123,7 @@ class OlmoeSparseMoeBlock: Module, UnaryLayer {
         }
 
         let y = switchMLP(x, inds)
-        return (y * scores[.ellipsis, .newAxis]).sum(axis: -2)
+        return (y * scores.asType(y.dtype)[.ellipsis, .newAxis]).sum(axis: -2)
     }
 }
 

--- a/Libraries/MLXLLM/Models/PhiMoE.swift
+++ b/Libraries/MLXLLM/Models/PhiMoE.swift
@@ -145,7 +145,7 @@ class PhiMoESparseMoeBlock: Module {
         JangPressCanonicalExpertAdvisor.shared.observe(layer: layerIdx, indices: inds)
 
         let y = switchMLP(x, inds)
-        return (y * scores[.ellipsis, .newAxis]).sum(axis: -2)
+        return (y * scores.asType(y.dtype)[.ellipsis, .newAxis]).sum(axis: -2)
     }
 }
 

--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -358,8 +358,12 @@ final class Qwen35GatedDeltaNet: Module {
                     ? [combined]
                     : MLX.split(combined, indices: splitIndices, axis: -1)
                 guard parts.count == members.count else { return nil }
+                // Pin to the activation dtype: f16 JANG scales promote
+                // quantizedMM to fp32; the unfused QuantizedLinear reference
+                // pins the same way, so bit-identity is preserved.
                 for (part, member) in zip(parts, members) {
-                    outputs[member] = part
+                    outputs[member] = part.dtype == inputs.dtype
+                        ? part : part.asType(inputs.dtype)
                 }
             }
         }
@@ -890,7 +894,7 @@ final class Qwen35SparseMoeBlock: Module, UnaryLayer {
         }
 
         let y = switchMLP(x, inds)
-        let combined = (y * scores[.ellipsis, .newAxis]).sum(axis: -2)
+        let combined = (y * scores.asType(y.dtype)[.ellipsis, .newAxis]).sum(axis: -2)
 
         let sharedY = sharedExpert(x)
         let gatedSharedY = compiledSigmoidGate(sharedExpertGate(x), sharedY)

--- a/Libraries/MLXLLM/Models/Qwen35JANGTQ.swift
+++ b/Libraries/MLXLLM/Models/Qwen35JANGTQ.swift
@@ -534,7 +534,7 @@ final class Qwen35JANGTQSparseMoeBlock: Module, UnaryLayer {
             combined = streaming.reduced(x, indices: inds, scores: scores)
         } else {
             let y = switchMLP(x, inds)
-            combined = (y * scores[.ellipsis, .newAxis]).sum(axis: -2)
+            combined = (y * scores.asType(y.dtype)[.ellipsis, .newAxis]).sum(axis: -2)
         }
 
         let sharedY = sharedExpert(x)

--- a/Libraries/MLXLLM/Models/Qwen3MoE.swift
+++ b/Libraries/MLXLLM/Models/Qwen3MoE.swift
@@ -148,7 +148,7 @@ class Qwen3MoESparseMoeBlock: Module, UnaryLayer {
         }
 
         let y = switchMLP(x, inds)
-        return (y * scores[.ellipsis, .newAxis]).sum(axis: -2)
+        return (y * scores.asType(y.dtype)[.ellipsis, .newAxis]).sum(axis: -2)
     }
 }
 

--- a/Libraries/MLXLLM/Models/Qwen3Next.swift
+++ b/Libraries/MLXLLM/Models/Qwen3Next.swift
@@ -394,7 +394,7 @@ final class Qwen3NextSparseMoeBlock: Module {
         }
 
         let y = switchMLP(x, inds)
-        let combined = (y * scores[.ellipsis, .newAxis]).sum(axis: -2)
+        let combined = (y * scores.asType(y.dtype)[.ellipsis, .newAxis]).sum(axis: -2)
 
         var sharedY = sharedExpert(x)
         sharedY = sigmoid(sharedExpertGate(x)) * sharedY

--- a/Libraries/MLXLMCommon/AffineStreamingSwitchGLU.swift
+++ b/Libraries/MLXLMCommon/AffineStreamingSwitchGLU.swift
@@ -435,7 +435,10 @@ public final class AffineStreamingSwitchGLU: Module {
         }
 
         let result = chunks.count == 1 ? chunks[0] : concatenated(chunks, axis: 0)
-        return result.reshaped(x.shape)
+        // This path REQUIRES f16 scales, so gatherQuantizedMM promotes bf16
+        // activations to fp32 (promote_types) and the whole MoE block leaked
+        // fp32 into the residual stream. Pin to the activation dtype.
+        return result.reshaped(x.shape).asType(x.dtype)
     }
 
     private func expert(_ index: Int) -> AffineStreamingExpertCatalog.ExpertArrays {

--- a/Libraries/MLXLMCommon/SwitchLayers.swift
+++ b/Libraries/MLXLMCommon/SwitchLayers.swift
@@ -644,6 +644,27 @@ public class QuantizedSwitchLinear: SwitchLinear, Quantized {
             result = result + MLX.expandedDimensions(bias[indices], axis: -2)
         }
 
+        // Same contract as QuantizedLinear: gatherQuantizedMM types its
+        // output as promote_types(x, scales) — f16 JANG scales against bf16
+        // activations promote every expert output to fp32, which then flows
+        // through the MoE reduce into the residual stream and every KV cache
+        // behind it. Pin back to the activation dtype (fp32 accumulation
+        // still happens inside the kernel). VMLX_QUANTIZED_OUTPUT_PROMOTE=1
+        // restores the historical propagation.
+        if !SwitchLayerRuntime.propagatePromotedOutput, result.dtype != x.dtype,
+            x.dtype == .bfloat16 || x.dtype == .float16
+        {
+            result = result.asType(x.dtype)
+        }
+
         return result
     }
+}
+
+/// Mirrors `QuantizedRuntime` in MLXNN (module boundaries in different
+/// packages, same env contract).
+enum SwitchLayerRuntime {
+    nonisolated(unsafe) static var propagatePromotedOutput: Bool = {
+        ProcessInfo.processInfo.environment["VMLX_QUANTIZED_OUTPUT_PROMOTE"] == "1"
+    }()
 }

--- a/Libraries/MLXLMCommon/TurboQuantSwitchLinear.swift
+++ b/Libraries/MLXLMCommon/TurboQuantSwitchLinear.swift
@@ -97,7 +97,11 @@ public class TurboQuantSwitchLinear: Module {
             batchTokens: batch, K: K,
             inFeatures: inFeatures, outFeatures: outFeatures, bits: bits
         )
-        return y.reshaped(indices.shape + [outFeatures])
+        // The TQ kernel declares fp32 outputs (accumulator dtype). The GLU
+        // sibling casts back to the activation dtype; this single-projection
+        // class was the outlier and leaked fp32 into the residual stream of
+        // any JANGTQ model using a standalone projection.
+        return y.reshaped(indices.shape + [outFeatures]).asType(x.dtype)
     }
 }
 

--- a/Libraries/MLXVLM/Models/DeepseekOCRLanguage.swift
+++ b/Libraries/MLXVLM/Models/DeepseekOCRLanguage.swift
@@ -222,7 +222,7 @@ private class DeepseekOCRMoE: Module, UnaryLayer {
     func callAsFunction(_ x: MLXArray) -> MLXArray {
         let (inds, scores) = gate(x)
         var y = switchMLP(x, inds)
-        y = (y * scores[.ellipsis, .newAxis]).sum(axis: -2)
+        y = (y * scores.asType(y.dtype)[.ellipsis, .newAxis]).sum(axis: -2)
         if let shared = sharedExperts {
             y = y + shared(x)
         }

--- a/Libraries/MLXVLM/Models/Glm4vMoe.swift
+++ b/Libraries/MLXVLM/Models/Glm4vMoe.swift
@@ -339,7 +339,7 @@ private enum Glm4vMoeLanguage {
             let (inds, scores) = gate(x)
             JangPressCanonicalExpertAdvisor.shared.observe(layer: layerIdx, indices: inds)
             var y = switchMLP(x, inds)
-            y = (y * scores[.ellipsis, .newAxis]).sum(axis: -2).asType(y.dtype)
+            y = (y * scores.asType(y.dtype)[.ellipsis, .newAxis]).sum(axis: -2).asType(y.dtype)
             if let sharedExperts {
                 y = y + sharedExperts(x)
             }

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -1600,8 +1600,15 @@ enum Qwen35Language {
                         ? [combined]
                         : MLX.split(combined, indices: splitIndices, axis: -1)
                     guard parts.count == members.count else { return nil }
+                    // Pin to the activation dtype: f16 JANG scales promote
+                    // quantizedMM to fp32 (the unfused QuantizedLinear
+                    // reference now pins the same way, so bit-identity with
+                    // the fallback path is preserved). Without this the fp32
+                    // qkv/z/b/a flowed into the GDN recurrence and tripped
+                    // the compiled_gdn_tail dtype gate.
                     for (part, member) in zip(parts, members) {
-                        outputs[member] = part
+                        outputs[member] = part.dtype == inputs.dtype
+                            ? part : part.asType(inputs.dtype)
                     }
                 }
             }
@@ -1815,7 +1822,14 @@ enum Qwen35Language {
                 kNormed = front[4]
                 v = front[5]
                 convInput = front[6]
-                if let cache, convKernelSize > 1 { cache[0] = front[6] }
+                if let cache, convKernelSize > 1 {
+                    // The compiled front can emit a promoted fp32 conv tail
+                    // (f16-scale bundles); the conv-state CACHE lane must
+                    // stay in the activation dtype or every later step pays
+                    // 2x state traffic and re-promotes the conv input.
+                    let tail = front[6]
+                    cache[0] = tail.dtype == inputs.dtype ? tail : tail.asType(inputs.dtype)
+                }
             } else {
                 let fusedInputs = fusedDecodeInputs(inputs)
                 var mixedQKV = fusedInputs?[0] ?? inProjQKV(inputs)
@@ -2285,7 +2299,7 @@ enum Qwen35Language {
             } else if let turbo = switchMLP as? TurboQuantSwitchGLU {
                 let y = turbo(x, inds)
                 routed = nil
-                eagerCombined = (y * scores[.ellipsis, .newAxis]).sum(axis: -2)
+                eagerCombined = (y * scores.asType(y.dtype)[.ellipsis, .newAxis]).sum(axis: -2)
             } else if let affine = switchMLP as? SwitchGLU {
                 if let combined = affine.qwen4ExpReduced(
                     x, indices: inds, scores: scores)

--- a/Package.swift
+++ b/Package.swift
@@ -850,6 +850,7 @@ let package = Package(
                 "DualPathFamiliesTests.swift",
                 "Qwen35FusedInputProjectionTests.swift",
                 "MLADecodeSDPADtypeTests.swift",
+                "NoContextScalingFP32CastSourceTests.swift",
                 "DeepseekV4ChatTemplateFallbackFocusedTests.swift",
                 "MuseGlimmerNormFoldOwnershipTests.swift",
                 "DeepseekV4Step37RuntimeContractsTests.swift",

--- a/Source/MLXNN/Quantized.swift
+++ b/Source/MLXNN/Quantized.swift
@@ -3,6 +3,19 @@
 import Foundation
 import MLX
 
+/// Runtime gate for quantized-module output dtype. MLX types quantized
+/// matmul/dequant outputs as `promote_types(activation, scales)`; JANG
+/// bundles stamp f16 scales, so bf16 models silently promote to fp32 and
+/// the fp32 propagates model-wide (fp32 residual stream, doubled KV caches,
+/// refused fused-decode gates). The default pins module outputs back to the
+/// activation dtype; `VMLX_QUANTIZED_OUTPUT_PROMOTE=1` restores the
+/// historical propagation for A/B and fallback.
+enum QuantizedRuntime {
+    nonisolated(unsafe) static var propagatePromotedOutput: Bool = {
+        ProcessInfo.processInfo.environment["VMLX_QUANTIZED_OUTPUT_PROMOTE"] == "1"
+    }()
+}
+
 /// Protocol for layers that can be quantized
 public protocol Quantizable {
 
@@ -359,6 +372,7 @@ open class QuantizedLinear: Linear, Quantized {
     }
 
     open override func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let inputDType = x.dtype
         var x = quantizedMM(
             x,
             weight,
@@ -371,6 +385,19 @@ open class QuantizedLinear: Linear, Quantized {
         )
         if let bias {
             x = x + bias
+        }
+        // MLX types quantizedMM output as promote_types(x, scales): bf16
+        // activations against the f16 scales JANG bundles stamp promote to
+        // FLOAT32, and without this pin the fp32 silently propagates through
+        // the whole layer stack — fp32 residual stream, fp32 K/V projections
+        // (doubling every KV cache and disk-cache entry), and fused/compiled
+        // decode regions refusing their dtype gates. fp32 stays where it
+        // belongs: inside the matmul as the accumulator. The env var
+        // restores the historical promote-and-propagate behavior for A/B.
+        if !QuantizedRuntime.propagatePromotedOutput, x.dtype != inputDType,
+            inputDType == .bfloat16 || inputDType == .float16
+        {
+            x = x.asType(inputDType)
         }
         return x
     }

--- a/Tests/MLXLMCommonFocusedTests/NoContextScalingFP32CastSourceTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NoContextScalingFP32CastSourceTests.swift
@@ -1,0 +1,89 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Source guard: no model runtime may cast cached keys/values (or any other
+// full-context tensor consumed per decode step) to float32.
+//
+// The pattern this pins against is inherited from upstream mlx-swift /
+// mlx-lm ports: an `asType(.float32)` on post-cache-update K/V materializes
+// a full-context fp32 copy of the KV cache on EVERY decode token (~5x the
+// native-dtype traffic) and was measured as the dominant long-context decode
+// cost for every MLA family (Raptor 8B-A1B 173 -> 35 tok/s from 0.4k -> 26k
+// ctx; fixed in #401 with a 2.4x recovery at 26k) plus the DSA/GLM5/QSA
+// indexer variants of the same tax (#401/#405).
+//
+// The guard is an allowlist, not a ban: three sites keep fp32 deliberately,
+// each with an in-code comment explaining why removing it is a CORRECTNESS
+// regression, not an optimization:
+//   - Phi.swift: fp16 score range (+-65504) protection, upstream-mirrored.
+//   - Gemma4.swift (VLM): bf16 score STORAGE loses winner margins at its
+//     d=512/scale-1.0 regime (measured maxDiff 0.27 vs fp32); needs an
+//     mlx-fork sdpa_vector kernel, not a Swift-side dtype change.
+//   - AttentionUtils.swift: the env-gated MLA fallback arm itself.
+// A new legitimate exception must be added HERE with the same justification
+// standard, not slipped past the guard.
+
+import Foundation
+import Testing
+
+@Suite("No context-scaling fp32 casts in model runtimes")
+struct NoContextScalingFP32CastSourceTests {
+
+    private static func repoRoot() -> URL {
+        var url = URL(fileURLWithPath: #filePath)
+        for _ in 0..<3 { url.deleteLastPathComponent() }
+        return url
+    }
+
+    /// Files allowed to contain `asType(.float32)` applied to a
+    /// cache-consumption identifier, with the reason pinned above.
+    private static let allowedFiles: Set<String> = [
+        "Phi.swift",
+        "Gemma4.swift",  // MLXVLM — global-layer upcast, load-bearing
+        "AttentionUtils.swift",  // env-gated fp32 fallback arm
+        "DeepseekV4Compressor.swift",  // VMLX_DSA_INDEX_FP32 fallback arm only
+        "Glm5Next.swift",  // VMLX_GLM5_INDEX_FP32 fallback arm only
+    ]
+
+    /// Identifiers that name post-cache-update, context-length tensors in
+    /// the model runtimes. A fp32 cast applied directly to one of these is
+    /// the exact tax pattern this guard exists to block.
+    private static let cacheIdentifiers = [
+        "cachedKeys", "cachedValues",
+        "cK", "cV",
+        "allKeys",
+        "pooledBroad", "poolKeys", "groupedKeys",
+    ]
+
+    @Test("model sources never cast cached K/V or pooled history to fp32")
+    func noCacheFP32Casts() throws {
+        let fm = FileManager.default
+        let root = Self.repoRoot()
+        var offenders: [String] = []
+        for dir in ["Libraries/MLXLLM/Models", "Libraries/MLXVLM/Models"] {
+            let base = root.appendingPathComponent(dir)
+            guard let files = try? fm.contentsOfDirectory(atPath: base.path) else { continue }
+            for file in files where file.hasSuffix(".swift") {
+                if Self.allowedFiles.contains(file) { continue }
+                let path = base.appendingPathComponent(file).path
+                guard let source = try? String(contentsOfFile: path, encoding: .utf8) else {
+                    continue
+                }
+                for line in source.split(separator: "\n", omittingEmptySubsequences: false) {
+                    guard line.contains("asType(.float32)") else { continue }
+                    for ident in Self.cacheIdentifiers
+                    where line.contains("\(ident).asType(.float32)") {
+                        offenders.append("\(dir)/\(file): \(line.trimmingCharacters(in: .whitespaces))")
+                    }
+                }
+            }
+        }
+        #expect(
+            offenders.isEmpty,
+            Comment(rawValue:
+                "fp32 cast on a cache-consumption tensor (the long-context decode "
+                + "tax fixed in #401/#405). Either run in the cache's native dtype "
+                + "or document a correctness justification and add the file to the "
+                + "allowlist in this guard:\n" + offenders.joined(separator: "\n")))
+    }
+}


### PR DESCRIPTION
Deep audit result (all runtime/inference code, explicit casts + implicit promotions + loaders + cache writes): MLX types quantized outputs as `promote_types(activation, scales)`; JANG bundles stamp **f16** scales, so bf16 models silently ran fp32 activation paths — doubling KV caches/disk entries and silently disqualifying five compiled-decode regions. Full mechanism, fix inventory, remaining loader-side work, and proof in the commit message. Highlights: activation-dtype pin at the QuantizedLinear/QuantizedSwitchLinear boundaries (env fallback `VMLX_QUANTIZED_OUTPUT_PROMOTE=1`), DeepseekV3's score-cast pattern applied to 21 MoE reducers, GDN grouped-fallback/conv-tail/TQ/streaming-GLU/BailingHybrid pins, and a repo-wide source guard with a justified fp32 allowlist. Focused suite: failing set identical to clean main (zero new failures); bit-identity and dtype gates all green.