### PR TITLE
JANG-affine preserve branches: pin quantized-embedding output to bf16

### DIFF
--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -1075,6 +1075,34 @@ public func loadWeights(
             shouldSkip: isJANGTQNative ? isJANGTQParameterKey : { _ in false })
     }
 
+    // The Gemma-4 / DSV4-prestacked preserve branches keep f16 affine
+    // metadata file-backed (correct: materializing the scale banks costs
+    // gigabytes and can alter logits), but `dequantized` types embedding
+    // output from the SCALES dtype — so the quantized EMBEDDING seeded f16
+    // into a bf16 stream and the first mixed op promoted the whole
+    // activation path to fp32 (doubled KV caches, refused fused-decode
+    // gates). Pin only the embedding OUTPUT to bf16: the dequant math still
+    // reads the exact file-backed f16 metadata; qwen4_exp bundles are
+    // excluded because their native-module swap already handles this.
+    if preserveJANGAffineMmapDtypes,
+        !shouldUseQwen4ExpNativeBF16Affine(modelDirectory: modelDirectory)
+    {
+        var pinned = 0
+        for (_, module) in model.leafModules().flattened() {
+            if let embedding = module as? QuantizedEmbedding,
+                embedding.scales.dtype == .float16
+            {
+                embedding.outputDType = .bfloat16
+                pinned += 1
+            }
+        }
+        if pinned > 0 {
+            FileHandle.standardError.write(Data(
+                "[Load] jang_affine_preserve embedding_output_dtype=bfloat16 modules=\(pinned)\n"
+                    .utf8))
+        }
+    }
+
     if shouldPreserveQwen4ExpJANGAffineMmapDtypes(modelDirectory: modelDirectory) {
         let flat = Dictionary(uniqueKeysWithValues: model.parameters().flattened())
         var count = 0

--- a/Source/MLXNN/Quantized.swift
+++ b/Source/MLXNN/Quantized.swift
@@ -239,19 +239,35 @@ open class QuantizedEmbedding: Embedding, Quantized {
         self.freeze()
     }
 
+    /// When set, embedding lookups (and the tied lm-head projection) are cast
+    /// to this dtype on the way out. `dequantized` types its output from the
+    /// SCALES dtype, so a bundle that keeps f16 affine metadata file-backed
+    /// (Gemma-4 / DSV4 prestacked mmap preserves) seeds f16 into a bf16
+    /// model's stream — the first mixed op then promotes to fp32 and the
+    /// whole activation path degrades. The loader sets this for those
+    /// bundles; the dequant math itself still uses the exact f16 metadata.
+    public var outputDType: DType? = nil
+
     open override func callAsFunction(_ x: MLXArray) -> MLXArray {
         let s = x.shape
         let x = x.flattened()
-        let out = dequantized(
+        var out = dequantized(
             weight[x], scales: scales[x], biases: biases == nil ? nil : biases![x],
             groupSize: groupSize, bits: bits, mode: mode)
+        if let outputDType, out.dtype != outputDType {
+            out = out.asType(outputDType)
+        }
         return out.reshaped(s + [-1])
     }
 
     open override func asLinear(_ x: MLXArray) -> MLXArray {
-        quantizedMM(
+        var out = quantizedMM(
             x, weight, scales: scales, biases: biases, transpose: true, groupSize: groupSize,
             bits: bits, mode: mode)
+        if let outputDType, out.dtype != outputDType {
+            out = out.asType(outputDType)
+        }
+        return out
     }
 }
 


### PR DESCRIPTION
Closes the last audited fp32 seed: preserve-branch bundles (Gemma-4 jang_affine mmap, DSV4 prestacked) keep f16 scales file-backed, and a QUANTIZED embedding's dequant output takes the scales dtype — f16 into a bf16 stream, promoted to fp32 at the first mixed op. #407 pinned the linear boundaries; this pins the embedding OUTPUT (exact f16 metadata still used for the math). Live verification on gemma-4-12B under mmap preserve: coherent output at parity speed (38.2 tok/s), zero fp32 diagnostics — and the honest scope note that this particular bundle ships an unquantized f16 dense embedding, so the pin engages on the quantized-embedding class (DSV4 prestacked). Guard suites green.