### PR TITLE
GLM-5.3: register its processor, not only its model

### DIFF
--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -98,11 +98,11 @@ private func create<C: Codable, P>(
         @escaping (
             C,
             any Tokenizer
-        ) -> P
+        ) throws -> P
 ) -> (Data, any Tokenizer) throws -> P {
     { data, tokenizer in
         let configuration = try JSONDecoder.json5().decode(C.self, from: data)
-        return processorInit(configuration, tokenizer)
+        return try processorInit(configuration, tokenizer)
     }
 }
 
@@ -224,6 +224,8 @@ public enum VLMProcessorTypeRegistry {
     public static let shared: ProcessorTypeRegistry = .init(creators: [
         "MuseGlimmerProcessor": create(
             MuseGlimmerProcessorConfiguration.self, MuseGlimmerProcessor.init),
+        "Glm5NextProcessor": create(
+            Glm5NextProcessorConfiguration.self, Glm5NextProcessor.init),
         "PaliGemmaProcessor": create(
             PaliGemmaProcessorConfiguration.self, PaliGemmaProcessor.init),
         "Qwen2VLProcessor": create(


### PR DESCRIPTION
`glm5_next` is in `VLMModelFactory`'s model table; `Glm5NextProcessor` is not in `ProcessorTypeRegistry`.
The bundle declares `processor_class: "Glm5NextProcessor"`, so loading the family reads its 95 GB of
weights and then fails at the last step:

```
Error: Unsupported processor type: Glm5NextProcessor
```

The prediction is already in the tree. `Glm5NextProcessor`'s registry initialiser is documented as:

> registering the model without registering this left the family loading its 95 GB of weights and
> then failing with "Unsupported processor type" — a table filled in on one side only.

So the initialiser was written for a registry entry that never landed. This adds it.

One supporting change: that initialiser `throws` — it resolves the image/video ids from the
vocabulary via `convertTokenToId`, and their absence is a genuine failure rather than something to
paper over. `create` accepted only a non-throwing initialiser, so it is widened to accept a throwing
one. Swift allows a non-throwing function wherever a throwing one is expected, so all existing
registrations compile unchanged and no bespoke closure is needed next to the table.

Verified: the family loads and generates after this change, and fails with the error above before it.
