### PR TITLE
GLM-5.3: uncap the resident pools, as DSV4 already is

### DIFF
--- a/Libraries/MLXLMCommon/Cache/LoadConfiguration.swift
+++ b/Libraries/MLXLMCommon/Cache/LoadConfiguration.swift
@@ -661,8 +661,22 @@ public struct LoadBundleFacts: Sendable, Equatable {
     /// and collapses throughput. Hosts must perform their normal pre-load RAM
     /// admission check instead of silently throttling a successfully admitted
     /// model.
+    /// Families whose resident bank is larger than the default cap, so a cap would force MLX to
+    /// destroy and rebuild decode intermediates every token.
+    ///
+    /// Measured on GLM-5.3: the bundle is 95 GB and the default cap is 0.70 x 128 GB = 89.6 GB, so
+    /// the model does not fit under its own allowance. A decode profile is then dominated by
+    /// `MetalAllocator::malloc` and `IOGPUResourceCreate` — buffer churn through IOKit — rather
+    /// than by any matmul, and generation runs at 0.38 tok/s.
+    ///
+    /// One property for both caps deliberately: they are the same decision about the same bundle,
+    /// and a family added to one list and not the other is exactly how this reached production.
+    public var requiresUncappedResidentPools: Bool {
+        isPlainDeepseekV4AffineJANG || isGlm5NextAffineJANG
+    }
+
     public func resolveMLXMemoryLimit(requested: ResidentCap) -> ResidentCap {
-        isPlainDeepseekV4AffineJANG ? .unlimited : requested
+        requiresUncappedResidentPools ? .unlimited : requested
     }
 
     /// Plain affine DSV4 must also keep MLX's freed-buffer reuse pool
@@ -672,7 +686,7 @@ public struct LoadBundleFacts: Sendable, Equatable {
     /// the same throughput-collapse mechanism as the total MLX memory limit
     /// above, so RAM admission remains the owning safety gate for both caps.
     public func resolveMLXAllocatorCacheLimit(requested: ResidentCap) -> ResidentCap {
-        isPlainDeepseekV4AffineJANG ? .unlimited : requested
+        requiresUncappedResidentPools ? .unlimited : requested
     }
 }
 


### PR DESCRIPTION
`ResidentCap.default` is `.fraction(0.70)` — **89.6 GB** on a 128 GB machine. The GLM-5.3 bundle is
**95 GB**, so the model is larger than the allowance it is given and MLX cannot keep its decode
intermediates.

`resolveMLXAllocatorCacheLimit` already spells out the consequence, for DSV4:

> a small profile cap forces the large routed decode intermediates to be destroyed and rebuilt every
> token. That is the same throughput-collapse mechanism as the total MLX memory limit above.

GLM-5.3 has the same shape — routed affine bank, ≥128 experts — and was added to
`requiresResidentSafetensors` (#406) without being added to either cap. This adds it, and collapses
the two family tests into one `requiresUncappedResidentPools`, because they are the same decision
about the same bundle and splitting them is how the omission happened.

## Measured, and deliberately not oversold

| | s/token | tok/s |
|---|---|---|
| before | 2.66 | 0.38 |
| after | 2.44 | 0.41 |

**~1.1x — real but small, and not the main cost.** A decode profile taken *after* this change still
has `MetalAllocator::malloc` (17 samples) and `IOGPUResourceCreate` (9) at the top — higher than
before — so buffer churn continues irrespective of the cache limit. Something allocates per step for
another reason. Landing the inconsistency fix on its own terms rather than letting it look like a
performance answer it is not.
