### PR TITLE
Safetensors healer is opt-in: don't rewrite a user's original model files by default (#2604)

### DIFF
--- a/Libraries/MLXLMCommon/Cache/SafetensorsStorageHealer.swift
+++ b/Libraries/MLXLMCommon/Cache/SafetensorsStorageHealer.swift
@@ -66,8 +66,18 @@ enum SafetensorsStorageHealer {
         let rawEnabled =
             env["MLXPRESS_HEAL_SAFETENSORS"]
             ?? env["JANGPRESS_HEAL_SAFETENSORS"]
-        if isDisabledFlag(rawEnabled) {
-            configuration.logger("event=disabled path=\(quoted(originalURL.path))")
+        // Default OFF (opt-in). The realignment rewrites the user's ORIGINAL
+        // model shards in place — payload-preserving and atomic, but it still
+        // changes the file bytes, which breaks HF-hash verification and
+        // cross-engine comparison of the local directory (osaurus#2604). It
+        // is only a mmap optimization: MLX's aligned-copy fallback loads the
+        // misaligned tensors correctly without it, so declining to heal never
+        // blocks a load. We do not modify a user's files for a perf
+        // optimization unless they explicitly opt in via
+        // MLXPRESS_HEAL_SAFETENSORS=1 (or JANGPRESS_HEAL_SAFETENSORS=1).
+        guard isEnabledFlag(rawEnabled) else {
+            configuration.logger(
+                "event=disabled reason=opt_in_required path=\(quoted(originalURL.path))")
             return Result()
         }
 
@@ -558,6 +568,13 @@ enum SafetensorsStorageHealer {
     private static func isDisabledFlag(_ raw: String?) -> Bool {
         guard let raw = raw?.lowercased() else { return false }
         return raw == "0" || raw == "false" || raw == "no" || raw == "off"
+    }
+
+    /// Explicit opt-in for the in-place realignment. Unset / empty / any
+    /// non-truthy value keeps the healer OFF (originals untouched).
+    private static func isEnabledFlag(_ raw: String?) -> Bool {
+        guard let raw = raw?.lowercased() else { return false }
+        return raw == "1" || raw == "true" || raw == "yes" || raw == "on"
     }
 
     private static func quoted(_ value: String) -> String {

--- a/Tests/MLXLMTests/JangPressSafetensorsAlignmentTests.swift
+++ b/Tests/MLXLMTests/JangPressSafetensorsAlignmentTests.swift
@@ -127,8 +127,32 @@ struct JangPressSafetensorsAlignmentTests {
         #expect(try Data(contentsOf: blob) == before)
     }
 
-    @Test("the production JangPress hook heals before returning the mmap directory")
-    func productionLoadHookHealsByDefault() throws {
+    @Test("the production hook does NOT rewrite the user's shards without opt-in (#2604)")
+    func productionLoadHookDoesNotHealWithoutOptIn() throws {
+        let bundle = try Self.makeDirectory()
+        defer { try? FileManager.default.removeItem(at: bundle) }
+        let shard = bundle.appendingPathComponent("model.safetensors")
+        try Self.writeUnalignedFixture(shard)
+        let before = try Data(contentsOf: shard)
+        let saved = Self.saveAndUnset([
+            "MLXPRESS_HEAL_SAFETENSORS", "JANGPRESS_HEAL_SAFETENSORS",
+            "MLXPRESS_PRESTACK", "JANGPRESS_PRESTACK",
+            "MLXPRESS_ALIGN_SAFETENSORS", "JANGPRESS_ALIGN_SAFETENSORS",
+        ])
+        defer { Self.restore(saved) }
+
+        let prepared = try JangPressPrestacker.prepareBundleIfNeeded(
+            originalURL: bundle, enabled: true)
+
+        // Default: the original file is byte-for-byte untouched; MLX loads it
+        // through its aligned-copy fallback instead. No storage mutation.
+        #expect(prepared.standardizedFileURL == bundle.standardizedFileURL)
+        #expect(try Data(contentsOf: shard) == before)
+        #expect(try Self.temporaryFiles(in: bundle).isEmpty)
+    }
+
+    @Test("opt-in MLXPRESS_HEAL_SAFETENSORS=1 heals the shard in place")
+    func productionLoadHookHealsWhenOptedIn() throws {
         let bundle = try Self.makeDirectory()
         defer { try? FileManager.default.removeItem(at: bundle) }
         let shard = bundle.appendingPathComponent("model.safetensors")
@@ -139,6 +163,7 @@ struct JangPressSafetensorsAlignmentTests {
             "MLXPRESS_ALIGN_SAFETENSORS", "JANGPRESS_ALIGN_SAFETENSORS",
         ])
         defer { Self.restore(saved) }
+        setenv("MLXPRESS_HEAL_SAFETENSORS", "1", 1)
 
         let prepared = try JangPressPrestacker.prepareBundleIfNeeded(
             originalURL: bundle, enabled: true)
@@ -162,8 +187,11 @@ struct JangPressSafetensorsAlignmentTests {
     }
 
     private static func configuration() -> SafetensorsStorageHealer.Configuration {
+        // The healer is opt-in (default OFF so it never rewrites a user's
+        // original shards). These tests exercise the healing LOGIC, so they
+        // explicitly enable it.
         SafetensorsStorageHealer.Configuration(
-            environment: [:],
+            environment: ["MLXPRESS_HEAL_SAFETENSORS": "1"],
             availableBytes: { _ in UInt64.max },
             failAfterCopiedBytes: nil,
             logger: { _ in })


### PR DESCRIPTION
Fixes osaurus#2604 (model files altered/rewritten). The in-place safetensors realignment (the `.vmlx-heal-UID.tmp` rename) ran by default and rewrote the user's ORIGINAL `model.safetensors` — payload-preserving and byte-verified, but it changes the file bytes, breaking HF-hash verification and cross-engine comparison of the local directory.

It is only a mmap optimization (MLX's aligned-copy fallback loads misaligned tensors correctly without it), so it now defaults OFF and runs only with `MLXPRESS_HEAL_SAFETENSORS=1`. The careful healing machinery (atomic rename, byte-verify, source-identity check, hash-addressed/symlink/non-writable skips, fallback) is unchanged — only the default gate flips, matching the "don't modify user files for an optimization without consent" principle.

**config.json note:** a full search found NO production code (vmlx or osaurus) that writes config.json back to a model directory — the float re-normalization the issue also mentions is not from our load path (likely a separate conversion/download tool). Called out so the issue can be answered accurately.

Tests 9/9: the in-place heal is now explicitly opted in; new guards pin that the production hook leaves the shard byte-for-byte untouched by default and heals only when opted in.