### PR TITLE
GLM-5.3: build the MTP head only when the host asks for it

### DIFF
--- a/Libraries/MLXVLM/Models/Glm5Next.swift
+++ b/Libraries/MLXVLM/Models/Glm5Next.swift
@@ -390,6 +390,13 @@ public enum Glm5NextCheckpointKeys {
 
     /// Weights for a tower that was not built. Dropping them is what makes a narrowed construction
     /// loadable at all: MLX refuses keys with no matching module.
+    /// The decoder-layer index a key belongs to, or nil if it names no layer.
+    static func decoderLayerIndex(_ key: String) -> Int? {
+        guard let range = key.range(of: "layers.") else { return nil }
+        let digits = key[range.upperBound...].prefix { $0.isNumber }
+        return digits.isEmpty ? nil : Int(digits)
+    }
+
     public static func isVisionKey(_ key: String) -> Bool {
         key.hasPrefix("model.visual.") || key.hasPrefix("visual.")
             || key.hasPrefix("model.vision_tower.") || key.hasPrefix("vision_tower.")
@@ -439,12 +446,18 @@ public enum Glm5NextCheckpointKeys {
     }
 
     /// Apply the policy. `keepVision` is the plan's answer, not a guess from the key set.
+    /// - Parameter dropLayersFrom: when non-nil, discard weights for decoder layers at or above
+    ///   this index. That is how an MTP-carrying bundle loads with the head switched off: the keys
+    ///   are dropped here rather than left unclaimed, which `verify: [.noUnusedKeys]` would reject.
     public static func sanitize(
-        _ weights: [String: MLXArray], keepVision: Bool
+        _ weights: [String: MLXArray], keepVision: Bool, dropLayersFrom: Int? = nil
     ) -> [String: MLXArray] {
         var out = [String: MLXArray](minimumCapacity: weights.count)
         for (key, value) in weights {
             if !keepVision, isVisionKey(key) { continue }
+            if let floor = dropLayersFrom, let index = decoderLayerIndex(key), index >= floor {
+                continue
+            }
             // Torch conv layout [O, I, …] -> MLX [O, …, I]. `patch_embed.proj` is 5-D and
             // `downsample` is 4-D; a bundle already converted is left alone, which is what the
             // trailing-dimension check decides.
@@ -469,6 +482,26 @@ public enum Glm5NextCheckpointKeys {
         }
         return out
     }
+}
+
+/// Whether this load builds GLM-5.3's multi-token-prediction head.
+///
+/// `num_nextn_predict_layers` is `1` in BOTH shipped bundles, but only the `-MTP` bundle carries
+/// layer 45's weights. Building the head from the config alone therefore allocated a 288-expert MoE
+/// that no checkpoint key binds to: three DENSE, UNQUANTIZED `switch_mlp` projections at 4.83 GB
+/// each. Nothing read them — the backbone forward runs `layers.prefix(numDecoderLayers)` and
+/// `multiTokenPredictionLayer` has no callers — but 14.5 GB of resident parameters pushed the
+/// process past MLX's allocator GC threshold (`0.95 * recommendedMaxWorkingSetSize`, which no cap
+/// can raise). Above it `MetalAllocator::malloc` releases the buffer cache on EVERY allocation, so
+/// buffer reuse stops entirely.
+///
+/// `verify: [.noUnusedKeys]` cannot catch this: it asserts that no checkpoint KEY went unclaimed,
+/// and a module that receives no weights consumes no keys.
+///
+/// Fail-closed, matching `nemotronHNativeMTPEnabled()`: with no host request the head is never
+/// built and costs nothing. `LoadConfiguration.nativeMTP` is how a host asks for it.
+internal func glm5NextNativeMTPEnabled() -> Bool {
+    NativeMTPActivation.isExplicitlyRequested
 }
 
 // MARK: - Linear attention
@@ -2304,7 +2337,10 @@ public final class Glm5NextLanguageModel: Module {
     public init(_ config: Glm5NextTextConfiguration) throws {
         let schedule = try config.validatedSchedule()
         self.numDecoderLayers = config.numHiddenLayers
-        self.numMTPLayers = max(0, config.numNextnPredictLayers)
+        // Gated, not config-driven: see `glm5NextNativeMTPEnabled()`. A bundle that declares an
+        // MTP layer but ships no weights for it must not allocate one.
+        self.numMTPLayers =
+            glm5NextNativeMTPEnabled() ? max(0, config.numNextnPredictLayers) : 0
         self.usesHyperConnections = config.mhc
         self.hcMult = config.hcMult
 
@@ -2675,7 +2711,10 @@ public class Glm5Next: Module, ModalityBearing, ModelComponentMapping {
     /// Applies the bundle's key policy, asking the PLAN whether the tower exists rather than
     /// inferring it from which keys happen to be present.
     public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
-        Glm5NextCheckpointKeys.sanitize(weights, keepVision: plan.builds(.visionTower))
+        Glm5NextCheckpointKeys.sanitize(
+            weights, keepVision: plan.builds(.visionTower),
+            dropLayersFrom: glm5NextNativeMTPEnabled()
+                ? nil : config.textConfig.numHiddenLayers)
     }
 
     /// The linear-attention layers, in decoder order. Built lazily by `buildLinearAttentionLayers`


### PR DESCRIPTION
## What

`Glm5NextLanguageModel.init` built GLM-5.3's multi-token-prediction head from
`config.num_nextn_predict_layers`, which is `1` in **both** shipped bundles — but only
`GLM-5.3-Flash-JANG-MTP` actually ships layer 45's weights.

On the plain bundle nothing binds to that layer, so its 288-expert MoE stayed **dense and
unquantized**: three `switch_mlp` projections at 4.83 GB each. Every real layer's equivalent is
`uint32 [288, 4096, 192]` at 906 MB.

## Why it hurt

`MetalAllocator::malloc` releases cached buffers whenever
`active + cache + size >= gc_limit_`, and `gc_limit_ = min(block_limit_, 0.95 *
recommendedMaxWorkingSetSize)` — clamped by the device, so no `memoryLimit` / `cacheLimit`
setting can raise it. On a 128 GB M4 Max that is 109.68 GB. The phantom layer put `active` at
117.25 GB, making the condition true on *every* allocation: the entire cache was flushed each
time and buffer reuse stopped.

Measured on `JANGQ-AI/GLM-5.3-Flash-JANG`, gsm8k, `--no-thinking --max-tokens 256`:

| | params held | tensors | headroom vs `gc_limit_` | cache samples | tok/s |
|---|---|---|---|---|---|
| before | 117.25 GB | 2969 | −7.57 GB | **0 / 40** | 0.346 |
| after | 102.38 GB | 2941 | +7.29 GB | **40 / 40** | 0.537 |

2941 is exactly the bundle's tensor count. The baseline row was produced by reverting only the
two-line gate, so the comparison isolates this change.

## Why `verify: [.noUnusedKeys]` did not catch it

That check asserts no checkpoint KEY went unclaimed. A module that receives no weights consumes
no keys, so it raises no complaint. The inverse question — did every parameter come from
somewhere? — is never asked. A cheap post-load invariant (parameter count and bytes must match
the bundle, modulo declared drops) would have flagged this on the first load; happy to follow up
with that separately if it is wanted.

## The fix

1. Gate construction on `NativeMTPActivation.isExplicitlyRequested` — the per-load task-local the
   host sets from `LoadConfiguration.nativeMTP` — matching `nemotronHNativeMTPEnabled()`'s
   fail-closed pattern.
2. Drop layer `>= num_hidden_layers` keys in `sanitize` when the head is off. Without this half,
   the `-MTP` bundle's now-unclaimed layer-45 keys trip `verify: [.noUnusedKeys]`. Verified: that
   bundle loads cleanly with the head off (102.51 GB -> 100.04 GB).

Safety: the MTP layer is excluded from the forward pass (`layers.prefix(numDecoderLayers)`) and
`multiTokenPredictionLayer` has no callers in the tree, so with the head off nothing changes
numerically.

## Note

GLM-5.3's MTP head is currently unreachable through the host path regardless:
`NativeMTPAutoDecodePolicy` gates on `isSupportedQwenMTPModelType`, which accepts only `qwen*`
model types, and GLM-5.3 is `glm5_next`. So the fail-closed branch is the only one this family
takes today. Filed separately as #413.

**Resolved since drafting (2026-09-03):** the slow decode noted while this was a draft is now
understood and is unrelated to this change. The host created no `WiredMemoryTicket`, so the
weights were never wired; with one ticket GLM-5.3 went 0.06 → 9 tok/s and DeepSeek-V4-Flash
0.7 → 31 tok/s on the same binary. Filed separately. This PR stands on its own: it removes 14.5 GB
of never-read parameters and the allocator cliff they caused, and is a strict prerequisite for the
wired-memory sizing to fit under the working-set ceiling on a 128 GB machine.
