### PR TITLE
GLM-5.3: guard the fresh-cache copy so first generation stops crashing

### DIFF
--- a/Libraries/MLXVLM/Models/Glm5Next.swift
+++ b/Libraries/MLXVLM/Models/Glm5Next.swift
@@ -809,7 +809,13 @@ public final class Glm5NextIndexedKVCache: KVCache {
             // The packed buffer is the ONLY optional trailing entry, so its presence is decided by
             // the count rather than by position — restoring it into the KV slots would corrupt both.
             let kvCount = kv.state.count
-            kv.state = Array(newValue.prefix(kvCount))
+            let kvPortion = Array(newValue.prefix(kvCount))
+            // Same empty guard as `copy()`: the inner setter traps on a count
+            // that is not exactly 2, and an empty restore (fresh snapshot)
+            // yields no KV arrays.
+            if !kvPortion.isEmpty {
+                kv.state = kvPortion
+            }
             indexerPacked = newValue.count > kvCount ? newValue[kvCount] : nil
         }
     }
@@ -839,7 +845,17 @@ public final class Glm5NextIndexedKVCache: KVCache {
 
     public func copy() -> any KVCache {
         let copy = Glm5NextIndexedKVCache()
-        copy.kv.state = kv.state.map(Self.owned)
+        // The inner KVCacheSimple's state setter requires EXACTLY [keys,
+        // values] and traps on any other count. A fresh cache (no tokens yet)
+        // yields an EMPTY state, so restore it only when present — the same
+        // guard `KVCacheSimple.copy()` and `DeepseekV4Compressor` already use.
+        // Without it, snapshotting a fresh cache at the prompt boundary (the
+        // very first generation) round-tripped `[]` through the setter and
+        // trapped, crashing the app before any token was produced.
+        let innerState = kv.state
+        if !innerState.isEmpty {
+            copy.kv.state = innerState.map(Self.owned)
+        }
         copy.kv.metaState = kv.metaState
         copy.kv.offset = kv.offset
         copy.indexerPacked = indexerPacked.map(Self.owned)

--- a/Tests/MLXLMTests/Glm5NextCacheCopyTests.swift
+++ b/Tests/MLXLMTests/Glm5NextCacheCopyTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import MLX
+import MLXLMCommon
+@testable import MLXVLM
+import Testing
+
+/// Regression for the GLM-5.3 (`glm5_next`) first-generation crash: snapshotting
+/// a FRESH cache at the prompt boundary called `Glm5NextIndexedKVCache.copy()`,
+/// which round-tripped the inner `KVCacheSimple`'s EMPTY state through a setter
+/// that traps unless it receives exactly `[keys, values]`. The app crashed
+/// (EXC_BREAKPOINT in `KVCacheSimple.state.setter`) before producing a token.
+/// Every other cache's `copy()` already guards the empty case; GLM-5.3's did
+/// not. These tests pin that a fresh cache copies (and restores) without a trap.
+@Suite("GLM-5.3 indexed KV cache copy", .serialized)
+struct Glm5NextCacheCopyTests {
+    @Test("copy() of a FRESH (empty) cache does not trap in the inner state setter")
+    func copyOfFreshCacheDoesNotTrap() {
+        let cache = Glm5NextIndexedKVCache()
+
+        // The crash path: makePromptBoundaryCacheSnapshot -> copy() on a cache
+        // with no tokens yet.
+        let copy = cache.copy() as! Glm5NextIndexedKVCache
+
+        #expect(copy.offset == 0)
+        #expect(copy.state.isEmpty)
+        #expect(copy.indexerPacked == nil)
+    }
+
+    @Test("a populated cache still round-trips keys, values, and the indexer buffer")
+    func copyOfPopulatedCachePreservesState() {
+        let cache = Glm5NextIndexedKVCache()
+
+        // Shape [B, H, L, D]: one head, four positions, small head dim.
+        let keys = MLXArray(0..<32, [1, 1, 4, 8]).asType(.float32)
+        let values = MLXArray(100..<132, [1, 1, 4, 8]).asType(.float32)
+        _ = cache.update(keys: keys, values: values)
+
+        #expect(cache.offset == 4)
+        #expect(cache.state.count == 2)
+
+        let copy = cache.copy() as! Glm5NextIndexedKVCache
+        #expect(copy.offset == 4)
+        #expect(copy.state.count == 2)
+
+        let originalKeys = cache.state[0]
+        let copiedKeys = copy.state[0]
+        #expect(copiedKeys.shape == originalKeys.shape)
+        #expect(allClose(copiedKeys, originalKeys, atol: 0).all().item(Bool.self))
+    }
+
+    @Test("assigning an empty state to a fresh cache does not trap")
+    func emptyStateRestoreDoesNotTrap() {
+        let cache = Glm5NextIndexedKVCache()
+        cache.state = []
+        #expect(cache.offset == 0)
+        #expect(cache.state.isEmpty)
+    }
+}

--- a/Tests/MLXLMTests/Glm5NextProcessorRegistrationTests.swift
+++ b/Tests/MLXLMTests/Glm5NextProcessorRegistrationTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import MLXLMCommon
+@testable import MLXVLM
+import Testing
+
+/// Regression for the GLM-5.3 (`glm5_next`) load/retry loop: the model was
+/// registered in the VLM TYPE registry but its processor was NOT registered in
+/// `VLMProcessorTypeRegistry`, so the family loaded its ~95 GB of weights and
+/// then failed every generation with "Unsupported processor type:
+/// Glm5NextProcessor" — which surfaced to users as an endless load/evict loop
+/// (RAM sawtooth), no crash, no logged error. This asserts the processor is
+/// registered so that never regresses.
+@Suite("GLM-5.3 processor registration", .serialized)
+struct Glm5NextProcessorRegistrationTests {
+    /// Minimal GLM-5.3 tokenizer stand-in: the processor's initialiser only
+    /// requires `<|image|>` to resolve; the image/video delimiters are optional.
+    struct ImageTokenTokenizer: MLXLMCommon.Tokenizer {
+        var bosToken: String? = nil
+        var eosToken: String? = nil
+        var eosTokenId: Int? = 154_820
+        var unknownToken: String? = nil
+        var unknownTokenId: Int? = nil
+
+        func encode(text: String, addSpecialTokens: Bool = true) -> [Int] {
+            text.utf8.map { Int($0) }
+        }
+
+        func decode(tokenIds: [Int], skipSpecialTokens: Bool) -> String {
+            tokenIds.map(String.init).joined(separator: " ")
+        }
+
+        func convertTokenToId(_ token: String) -> Int? {
+            switch token {
+            case "<|image|>": return 154_854
+            case "<|begin_of_image|>": return 154_830
+            case "<|end_of_image|>": return 154_831
+            case "<|video|>": return 154_855
+            default: return nil
+            }
+        }
+
+        func convertIdToToken(_ id: Int) -> String? { String(id) }
+
+        func applyChatTemplate(
+            messages: [[String: any Sendable]],
+            tools: [[String: any Sendable]]?,
+            additionalContext: [String: any Sendable]?
+        ) throws -> [Int] {
+            encode(text: "user:Describe.")
+        }
+    }
+
+    static func processorConfigurationData() -> Data {
+        """
+        {
+          "image_processor": {
+            "image_mean": [0.48145466, 0.4578275, 0.40821073],
+            "image_std": [0.26862954, 0.26130258, 0.27577711],
+            "patch_size": 14,
+            "merge_size": 2,
+            "temporal_patch_size": 2,
+            "min_image_tokens": 4,
+            "max_image_tokens": 16384
+          },
+          "video_processor": {
+            "image_mean": [0.48145466, 0.4578275, 0.40821073],
+            "image_std": [0.26862954, 0.26130258, 0.27577711],
+            "patch_size": 14,
+            "merge_size": 2,
+            "temporal_patch_size": 2,
+            "min_image_tokens": 4,
+            "max_image_tokens": 16384,
+            "fps": 2
+          }
+        }
+        """.data(using: .utf8)!
+    }
+
+    @Test("VLM processor registry recognizes Glm5NextProcessor (no 'Unsupported processor type' loop)")
+    func registryRecognizesGlm5NextProcessor() async throws {
+        let processor = try await VLMProcessorTypeRegistry.shared.createModel(
+            configuration: Self.processorConfigurationData(),
+            processorType: "Glm5NextProcessor",
+            tokenizer: ImageTokenTokenizer())
+
+        #expect(processor is Glm5NextProcessor)
+    }
+
+    @Test("The glm5_next model type is served by the VLM factory")
+    func vlmFactoryKnowsGlm5Next() {
+        #expect(VLMTypeRegistry.supportedModelTypes.contains("glm5_next"))
+    }
+}


### PR DESCRIPTION
## Problem

Loading **GLM-5.3** (`glm5_next`) and sending the **first message** crashed the app with `EXC_BREAKPOINT` before a single token — reproduced live in the dev app:

```
_assertionFailure
KVCacheSimple.state.setter            (KVCache.swift:541  "state must have exactly 2 arrays")
Glm5NextIndexedKVCache.copy()         (Glm5Next.swift:842)
makePromptBoundaryCacheSnapshot(from:)
TokenIterator.prepare(input:windowSize:)
```

`KVCacheSimple.state`'s getter returns `[]` for an empty cache, but its setter `fatalError`s on any count other than exactly `[keys, values]`. `Glm5NextIndexedKVCache.copy()` did `copy.kv.state = kv.state.map(owned)` **unconditionally**, so snapshotting a **fresh** cache at the prompt boundary (the very first generation, before any token is cached) round-tripped `[]` through that setter and trapped.

## Fix

Add the empty guard every other cache already uses — `KVCacheSimple.copy()` (line 587) and `DeepseekV4Compressor` (line 987) both wrap the assignment in `if !state.isEmpty`. **Audited every other `KVCache.copy()` and model cache: `Glm5NextIndexedKVCache` was the only one missing it.** Also guarded the `state` setter (an empty restore hit the same trap).

## Proof

Before: the dev app crashed at `Glm5Next.swift:842` on the first GLM-5.3 message (crash report captured). After (this fix, built into the dev app): the same flow **survives the prompt-boundary snapshot and no longer crashes** — the process stays alive through prefill.

## Tests

- `Glm5NextCacheCopyTests` — fresh-cache copy (the crash path), populated round-trip, empty-state restore. 3/3.
- `Glm5NextProcessorRegistrationTests` — pins that the VLM processor registry knows `Glm5NextProcessor` (the sibling load-loop fix landed as #410 with no regression test). 2/2.