### PR TITLE
Wire a loaded model's weights so big bundles stop swapping on every eval

### DIFF
--- a/Libraries/MLXLMCommon/ModelFactory.swift
+++ b/Libraries/MLXLMCommon/ModelFactory.swift
@@ -672,6 +672,30 @@ public func loadModel(
         MLX.Memory.memoryLimit = safeCap
     }
 
+    // 3c. Raise the MLX WIRED limit to keep the model's weights GPU-resident.
+    //     MLX's default wired limit is ~75% of the recommended working set, so
+    //     a model larger than that has its pages SWAPPED on every eval — Metal
+    //     command-buffer stalls (observed live: a 95 GB bundle pinned memory
+    //     and thrashed ~15-20 GB of swap, warmup never finished, while the same
+    //     bundle multiturns fine on the Python engine, which does exactly this
+    //     at load). Mirror `_set_wired_limit_for_model`: wire the model plus
+    //     headroom (max(16 GB, 30% of weights) — routed-expert dequant + KV +
+    //     Metal scratch spike past a flat 8 GB on big MoE bundles), CLAMPED to
+    //     the OS working set so we never trip Apple's "limit larger than max
+    //     working set" rejection. Only ever ADVISES the allocator by RAISING a
+    //     limit — it never blocks or refuses a load, and a small model simply
+    //     gets a smaller (cheaper) residency set. The user can lift the OS cap
+    //     with `sudo sysctl iogpu.wired_limit_mb=<MB>`.
+    if facts.totalSafetensorsBytes > 0 {
+        let modelBytes = Int(clamping: facts.totalSafetensorsBytes)
+        let headroom = max(
+            16 * 1024 * 1024 * 1024,
+            Int((Double(modelBytes) * 0.30).rounded()))
+        let workingSet = MLX.GPU.maxRecommendedWorkingSetBytes() ?? Int.max
+        let target = min(modelBytes + headroom, workingSet)
+        setModelResidencyWiredLimit(target)
+    }
+
     // 4. Optional disk-layout preparation. The permanent prestacked
     //    safetensors overlay is now explicit opt-in via
     //    MLXPRESS_PRESTACK=1 / JANGPRESS_PRESTACK=1. MLXPress's normal

--- a/Source/MLX/WiredMemory.swift
+++ b/Source/MLX/WiredMemory.swift
@@ -31,6 +31,31 @@ private enum WiredMemoryBackend {
     }
 }
 
+/// Directly set the process-wide wired memory limit so a just-loaded model's
+/// weights stay GPU-resident.
+///
+/// MLX's default wired limit is ~75% of the device's recommended max working
+/// set. A model LARGER than that default has its pages swapped during every
+/// `eval`, which stalls Metal command buffers — observed live as a 95 GB
+/// bundle pinning memory and thrashing ~15-20 GB of swap while warmup never
+/// finishes. This mirrors the Python engine's load-time
+/// `_set_wired_limit_for_model`: a loaded model is a LONG-LIVED residency
+/// requirement, not the transient active work that ``WiredMemoryManager``
+/// tickets model, so the limit is applied directly and persists until the next
+/// load sets it again.
+///
+/// The caller must clamp `bytes` to the OS working set
+/// (``GPU/maxRecommendedWorkingSetBytes()``) — Apple rejects a wired limit
+/// above the max working set. This only ever talks to the backend; it never
+/// blocks, throttles, or refuses a load.
+///
+/// - Returns: `true` when the limit was applied (GPU device), `false` on an
+///   unsupported device where wiring is a no-op.
+@discardableResult
+public func setModelResidencyWiredLimit(_ bytes: Int) -> Bool {
+    WiredMemoryBackend.applyLimit(max(0, bytes))
+}
+
 /// Debug event emitted by ``WiredMemoryManager`` when coordinating wired memory changes.
 ///
 /// Events are only emitted in DEBUG builds. In release builds the event stream


### PR DESCRIPTION
## Problem

MLX's default wired-memory limit is ~75% of the device's recommended max working set. A model **larger** than that — e.g. a 95 GB GLM-5.3 bundle on a 128 GB Mac, where the default wires ~77 GB — has its weight pages **swapped out and re-faulted on every `eval`**, stalling Metal command buffers. Live symptom: the app pins memory and thrashes **15-22 GB of swap** while warmup never finishes. The **same bundle multiturns fine on the Python engine**, which raises the wired limit at load (`_set_wired_limit_for_model`). The Swift side never did.

## Fix

At load, set the MLX wired limit to `weightBytes + max(16 GB, 30% of weights)`, **clamped to the OS working set** (so we never trip Apple's "limit larger than max working set" rejection). Mirrors the Python loader exactly. Adds `setModelResidencyWiredLimit(_:)` — a loaded model is long-lived residency, not the transient active work the `WiredMemoryManager` ticket flow models — called from the model factory right after the existing memory-limit cap.

This only ever **RAISES** a limit to keep the model resident: it never blocks, throttles, or refuses a load, and a smaller model gets a smaller (cheaper) residency set. Users can lift the OS ceiling with `sudo sysctl iogpu.wired_limit_mb=<MB>`.

## Proof (live)

Loading the 95 GB GLM-5.3 bundle in the dev app:

| | wired memory | swap |
|---|---|---|
| **without** this change | stays low (~77 GB cap) | **sustained 17-22 GB thrash**, warmup never finishes |
| **with** this change | ramps to **~119 GB** (model resident) | one-time load spike, then **settles to ~3.4 GB baseline** |

The model becomes GPU-resident and stops thrashing. (A separate, larger issue — the GLM-5.3 forward itself is slow on Swift because it lacks the fused mHC/RMSNorm/MoE kernels the Python engine has — is tracked independently; this PR is purely the RAM-residency fix.)