### PR TITLE
MLXArray._updateInternal: serialize the in-place ctx swap on evalLock (fixes qwen4_exp Buffer::raw_ptr crash)

### DIFF
--- a/Source/MLX/MLXArray.swift
+++ b/Source/MLX/MLXArray.swift
@@ -570,7 +570,20 @@ public final class MLXArray {
     /// Note: this is an implementation detail and only visible because of the need to call it from
     /// other `mlx-swift` modules.
     public func _updateInternal(_ array: MLXArray) {
-        mlx_array_set(&self.ctx, array.ctx)
+        // Replacing `ctx` releases the previous backing `array::Data`, whose
+        // buffer another thread may be copying out of under `evalLock` (every
+        // host read — `asArray`, `item`, `asData` — holds `evalLock` across the
+        // realized copy). In-place cache updates (`ArraysCache` subscript
+        // setter → here) run on the decode thread with no lock, so without
+        // serializing this swap a concurrent host read frees the buffer
+        // mid-copy and dereferences a dangling `MTL::Buffer` in
+        // `Buffer::raw_ptr()` — the production EXC_BAD_ACCESS behind Sentry
+        // APPLE-MACOS-1ZE (qwen4_exp PLE reads its recurrent slot every decode
+        // step). `evalLock` is recursive, so nested updates issued while eval
+        // or compile already holds it stay safe.
+        evalLock.withLock {
+            mlx_array_set(&self.ctx, array.ctx)
+        }
     }
 
     /// Internal function for copying the backing `mlx::core::array` context.

--- a/Tests/MLXTests/MLXArrayInPlaceUpdateRaceTests.swift
+++ b/Tests/MLXTests/MLXArrayInPlaceUpdateRaceTests.swift
@@ -1,0 +1,73 @@
+@testable import MLX
+import Dispatch
+import Testing
+
+/// Regression for the production EXC_BAD_ACCESS in
+/// `mlx::core::allocator::Buffer::raw_ptr` (Sentry APPLE-MACOS-1ZE, qwen4_exp).
+///
+/// Mechanism: `Qwen4ExpPLE.prefetch` host-reads a cache-resident slot array
+/// (`cache[2].asArray`) on every decode step, while the recurrent cache updates
+/// that SAME persistent slot array in place through the `ArraysCache` subscript
+/// setter → `MLXArray._updateInternal` → `mlx_array_set`, which frees the old
+/// `ctx`/buffer. Host reads hold `evalLock` across the realized copy; before the
+/// fix the in-place update did NOT, so a concurrent update freed the buffer
+/// mid-copy and the reader dereferenced a dangling `MTL::Buffer`.
+///
+/// The reproduction is deterministic on an unfixed build (crashes 8/8): a large
+/// array makes the host copy span milliseconds, `cacheLimit = 0` releases the
+/// freed buffer immediately instead of recycling it, and the writer issues the
+/// bare ctx swap (no `eval`, so it never takes `evalLock` and can run while a
+/// reader holds it mid-copy). The fix serializes `_updateInternal` on `evalLock`;
+/// with it the reader and the freeing swap can no longer overlap.
+@Suite("MLXArray in-place update vs host read race")
+struct MLXArrayInPlaceUpdateRaceTests {
+
+    private final class Box: @unchecked Sendable {
+        let array: MLXArray
+        init(_ array: MLXArray) { self.array = array }
+    }
+
+    @Test("host-reading an array while it is updated in place must not crash")
+    func inPlaceUpdateDuringHostReadIsSafe() {
+        let savedLimit = Memory.cacheLimit
+        Memory.cacheLimit = 0
+        defer { Memory.cacheLimit = savedLimit }
+
+        let size = 2_000_000          // ~8 MB Int32 backing -> multi-ms copy window
+        let iterations = 4000
+        let readerThreads = 3
+
+        let box = Box(MLXArray(Array(Int32(0) ..< Int32(size))))
+        MLX.eval(box.array)
+
+        let group = DispatchGroup()
+
+        // Writer: bare ctx swap, freeing the old buffer with no evalLock. It must
+        // NOT eval `fresh` first — taking evalLock there would serialize against
+        // the reader's locked host copy and hide the race (the production shape
+        // is the recurrent cache updating the slot with no lock).
+        group.enter()
+        DispatchQueue.global(qos: .userInitiated).async {
+            for index in 0 ..< iterations {
+                let base = Int32(truncatingIfNeeded: index)
+                let fresh = MLXArray((0 ..< Int32(size)).map { base &+ $0 }) + base
+                box.array._updateInternal(fresh)
+            }
+            group.leave()
+        }
+
+        // Readers: host-read the same array (exactly as Qwen4ExpPLE.prefetch does).
+        for _ in 0 ..< readerThreads {
+            group.enter()
+            DispatchQueue.global(qos: .userInitiated).async {
+                for _ in 0 ..< iterations {
+                    _ = box.array.asArray(Int32.self)
+                }
+                group.leave()
+            }
+        }
+
+        group.wait()
+        #expect(box.array.size == size)
+    }
+}


### PR DESCRIPTION
## The crash (Sentry APPLE-MACOS-1ZE)

Production `EXC_BAD_ACCESS` in `mlx::core::allocator::Buffer::raw_ptr`, only on **qwen4_exp**:
```
raw_ptr (allocator.cpp:28) <- mlx_array_data_uint8 (array.cpp:503)
  <- MLXArray.asArray (MLXArray+Bytes.swift:137) <- withEvaluatedHostAccess
  <- Qwen4ExpPLE.prefetch (Qwen4Exp.swift:677)
```

## Root cause (traced, not assumed)

- `_updateInternal` swaps `ctx` via `mlx_array_set`, which **frees the previous backing buffer**. It took **no lock**.
- Every host read holds `evalLock` across the realized copy (the prior fix, #347).
- `Qwen4ExpPLE.prefetch` host-reads its recurrent cache slot (`cache[2].asArray`) **every decode step**, while the recurrent state updates that **same** slot **in place** through the `ArraysCache` subscript setter → `_updateInternal`. No other model host-reads a cache-resident array on the decode path — which is exactly why only qwen4_exp crashed.
- `evalLock` (held by the reader) did not cover the unlocked in-place update, so a concurrent update frees the buffer mid-copy → the reader walks a dangling `MTL::Buffer`.
- The MLX Metal allocator is mutex-safe, so this is **not** allocator corruption; and the whole path is first-party (crash site, prior guard #347, and the in-place setter are all our own commits) — **not a third-party contributor**.

#347 ("Serialize evaluated MLX host reads through backing copy") closed read-vs-eval/clearCache but not **read-vs-in-place-update**, because the update side never took the lock. This PR closes that last window.

## Fix

Wrap the `mlx_array_set` swap in `_updateInternal` in `evalLock.withLock`. `evalLock` is an `NSRecursiveLock`, so nested updates during eval/compile stay safe. Cache-slot updates are tiny (token ids), so the added serialization is negligible on the decode path.

## Proof (deterministic reproduction + control)

Standalone harness racing `_updateInternal` (bare ctx swap, no lock) against `asArray` on the same array, `cacheLimit = 0` so the freed buffer is released immediately:

| build | result |
|---|---|
| **unfixed** | **8/8 SIGSEGV** in `Buffer::raw_ptr` |
| **fixed**   | **0/8**, clean exit |

lldb caught both sides simultaneously: crashing thread in `raw_ptr` ← `mlx_array_data_uint8` ← `asArray` (identical to the Sentry stack), and a second thread in `MetalAllocator::free` → `shared_ptr __on_zero_shared` → `array::Data` destroy — the concurrent free of the very buffer being read.

Adds `MLXArrayInPlaceUpdateRaceTests` encoding that race as a regression guard.