### PR TITLE
Wired-limit: only wire a model when it fits a safe physical-RAM reserve (fixes osaurus#2612 + 16GB orchestrator spawn refusal)

### DIFF
--- a/Libraries/MLXLMCommon/ModelFactory.swift
+++ b/Libraries/MLXLMCommon/ModelFactory.swift
@@ -686,14 +686,22 @@ public func loadModel(
     //     limit — it never blocks or refuses a load, and a small model simply
     //     gets a smaller (cheaper) residency set. The user can lift the OS cap
     //     with `sudo sysctl iogpu.wired_limit_mb=<MB>`.
+    //     SAFETY: wired pages can't be reclaimed, so this only RAISES the limit
+    //     when the whole model fits inside a safe physical-RAM reserve. On a
+    //     constrained Mac where the model is a large fraction of RAM it leaves
+    //     the swappable default instead of wiring the machine into a
+    //     memory-pressure panic (osaurus#2612). See `modelResidencyWiredTarget`.
     if facts.totalSafetensorsBytes > 0 {
         let modelBytes = Int(clamping: facts.totalSafetensorsBytes)
-        let headroom = max(
-            16 * 1024 * 1024 * 1024,
-            Int((Double(modelBytes) * 0.30).rounded()))
         let workingSet = MLX.GPU.maxRecommendedWorkingSetBytes() ?? Int.max
-        let target = min(modelBytes + headroom, workingSet)
-        setModelResidencyWiredLimit(target)
+        let physical = Int(clamping: facts.physicalMemory)
+        if let target = modelResidencyWiredTarget(
+            modelBytes: modelBytes,
+            workingSet: workingSet,
+            physicalMemory: physical)
+        {
+            setModelResidencyWiredLimit(target)
+        }
     }
 
     // 4. Optional disk-layout preparation. The permanent prestacked

--- a/Source/MLX/WiredMemory.swift
+++ b/Source/MLX/WiredMemory.swift
@@ -56,6 +56,56 @@ public func setModelResidencyWiredLimit(_ bytes: Int) -> Bool {
     WiredMemoryBackend.applyLimit(max(0, bytes))
 }
 
+/// Compute the model-residency wired-limit target for a just-loaded model, or
+/// `nil` to leave the OS/MLX default untouched.
+///
+/// Wired pages cannot be reclaimed — not swapped, not compressed — so wiring a
+/// model that leaves a constrained Mac too little headroom removes the OS's
+/// only relief valve under memory pressure. Raising the residency limit to the
+/// full working set did exactly that: on 16 GB Macs, models that ran fine
+/// before began flickering, freezing, and triggering kernel restarts
+/// (osaurus#2612), with much higher resident RAM.
+///
+/// This policy reserves a generous slice of PHYSICAL RAM for the OS plus the
+/// decode transients (KV cache, Metal scratch) that must stay reclaimable, and
+/// only raises the wired limit when the whole model fits inside that safe
+/// ceiling — precisely the case the residency raise was meant to help (a large
+/// bundle on a Mac with room to spare, which would otherwise swap its pages on
+/// every `eval`). When the model is a large fraction of RAM it returns `nil`:
+/// the pages stay swappable, which is slower under pressure but never panics —
+/// the pre-residency default that constrained Macs relied on.
+///
+/// The reserve scales with the machine (a fraction, floored at a flat minimum)
+/// so large Macs still get the residency win while small Macs stay safe.
+///
+/// - Parameters:
+///   - modelBytes: on-disk weight size of the model.
+///   - workingSet: Metal's recommended max working set; Apple rejects a wired
+///     limit above this. Pass `Int.max` when unknown (non-Metal backends).
+///   - physicalMemory: total installed RAM in bytes.
+/// - Returns: a byte target for ``setModelResidencyWiredLimit(_:)``, or `nil`
+///   to leave the default (the safe choice on a constrained Mac).
+public func modelResidencyWiredTarget(
+    modelBytes: Int,
+    workingSet: Int,
+    physicalMemory: Int
+) -> Int? {
+    guard modelBytes > 0, physicalMemory > 0 else { return nil }
+    let gib = 1024 * 1024 * 1024
+    let headroom = max(16 * gib, Int((Double(modelBytes) * 0.30).rounded()))
+    // Keep at least this much PHYSICAL RAM reclaimable for the OS + decode
+    // transients. 35% of RAM, floored at 8 GB — enough for the OS, the app,
+    // and a model's KV/scratch spike on the small end; scales up on big Macs.
+    let osReserve = max(8 * gib, physicalMemory / 100 * 35)
+    let safeCeiling = max(0, physicalMemory - osReserve)
+    let target = min(modelBytes + headroom, workingSet, safeCeiling)
+    // Only raise when the whole model fits wired inside the safe ceiling.
+    // Otherwise leave the default: the model stays swappable (safe), instead of
+    // wiring a machine into a memory-pressure panic.
+    guard target >= modelBytes else { return nil }
+    return target
+}
+
 /// Debug event emitted by ``WiredMemoryManager`` when coordinating wired memory changes.
 ///
 /// Events are only emitted in DEBUG builds. In release builds the event stream

--- a/Tests/MLXTests/ModelResidencyWiredTargetTests.swift
+++ b/Tests/MLXTests/ModelResidencyWiredTargetTests.swift
@@ -1,0 +1,84 @@
+import Testing
+
+@testable import MLX
+
+/// Regression guard for osaurus#2612: raising the model-residency wired limit to
+/// the full working set wired non-reclaimable memory a constrained Mac needed,
+/// causing flickering, freezes, and kernel restarts on 16 GB machines.
+///
+/// `modelResidencyWiredTarget` must never return a target that fails to leave a
+/// safe reclaim reserve of PHYSICAL RAM, and must decline (return nil) when the
+/// model is a large fraction of RAM.
+@Suite("Model-residency wired-limit policy")
+struct ModelResidencyWiredTargetTests {
+    private static let gib = 1024 * 1024 * 1024
+    private func gb(_ n: Double) -> Int { Int(n * Double(Self.gib)) }
+
+    // Reserve mirrors the policy: 35% of physical RAM, floored at 8 GB.
+    private func osReserve(physical: Int) -> Int { max(8 * Self.gib, physical / 100 * 35) }
+
+    @Test("16 GB Mac: a ~9 GB model is NOT wired (the #2612 regression)")
+    func constrainedMacDeclinesLargeModel() {
+        // Old code returned min(9GB+headroom, workingSet) = the full ~10.6 GB
+        // working set here, wiring the machine into a panic. Must be nil now.
+        let target = modelResidencyWiredTarget(
+            modelBytes: gb(9), workingSet: gb(10.6), physicalMemory: gb(16))
+        #expect(target == nil)
+    }
+
+    @Test("16 GB Mac: a ~5 GB model wires, but leaves a safe reserve")
+    func constrainedMacWiresSmallModelSafely() {
+        let physical = gb(16)
+        let target = modelResidencyWiredTarget(
+            modelBytes: gb(5), workingSet: gb(10.6), physicalMemory: physical)
+        #expect(target != nil)
+        if let target {
+            #expect(physical - target >= osReserve(physical: physical))  // reclaim reserve preserved
+            #expect(target <= gb(10.6))                                   // never above working set
+            #expect(target >= gb(5))                                      // whole model fits wired
+        }
+    }
+
+    @Test("128 GB Mac: a 76 GB model IS wired (the residency win is kept)")
+    func spaciousMacWiresLargeModel() {
+        let physical = gb(128)
+        let target = modelResidencyWiredTarget(
+            modelBytes: gb(76), workingSet: gb(96), physicalMemory: physical)
+        #expect(target != nil)
+        if let target {
+            #expect(target >= gb(76))
+            #expect(physical - target >= osReserve(physical: physical))
+            #expect(target <= gb(96))
+        }
+    }
+
+    @Test("128 GB Mac: a 101 GB bundle that can't fit safely is declined")
+    func spaciousMacDeclinesOversizeModel() {
+        let target = modelResidencyWiredTarget(
+            modelBytes: gb(101), workingSet: gb(96), physicalMemory: gb(128))
+        #expect(target == nil)
+    }
+
+    @Test("invariant: any returned target preserves the reclaim reserve")
+    func returnedTargetAlwaysLeavesReserve() {
+        let physicals = [gb(8), gb(16), gb(24), gb(32), gb(64), gb(96), gb(128), gb(192)]
+        let models = [gb(2), gb(5), gb(9), gb(14), gb(30), gb(48), gb(76), gb(101), gb(140)]
+        for physical in physicals {
+            let workingSet = physical * 3 / 4  // rough Metal working-set fraction
+            for modelBytes in models {
+                guard let target = modelResidencyWiredTarget(
+                    modelBytes: modelBytes, workingSet: workingSet, physicalMemory: physical)
+                else { continue }
+                #expect(physical - target >= osReserve(physical: physical))
+                #expect(target <= workingSet)
+                #expect(target >= modelBytes)
+            }
+        }
+    }
+
+    @Test("zero/invalid inputs leave the default")
+    func invalidInputsDecline() {
+        #expect(modelResidencyWiredTarget(modelBytes: 0, workingSet: gb(96), physicalMemory: gb(128)) == nil)
+        #expect(modelResidencyWiredTarget(modelBytes: gb(5), workingSet: gb(10), physicalMemory: 0) == nil)
+    }
+}


### PR DESCRIPTION
## Root cause (one change, two user-facing regressions)

**Control via the release pins:** 0.24.3 (worked) pins vmlx `1315fdcb`; **0.24.4 (broke) pins `5a63b9be` = #417.** Both regressions below appeared exactly when #417 shipped.

#417 raised the model-residency wired limit to `min(model+headroom, workingSet)` — i.e. the **full working set** on a constrained Mac. Wired pages can't be reclaimed (not swapped, not compressed), so on a 16 GB Mac loading a ~9 GB model it wired ~10.6 GB, leaving the OS + decode transients no relief valve.

1. **osaurus#2612 — flickering, freezes, kernel restarts on 16 GB Macs**, with much higher resident RAM. Direct consequence of wiring the working set.
2. **0.24.4 local-orchestrator spawn refusal on 16 GB** (`spawn_agent ... no free capacity for a child run`). osaurus's RAM-safety preflight (`ChatResidencyHandoff.availableMemoryBytes`) derives free RAM from the system `wire_count`; an over-wired model makes it report ~0 free and **correctly** refuse every child. The preflight was right — the wiring ate the RAM.

## Fix

Gate the raise behind a pure, testable `modelResidencyWiredTarget(modelBytes:workingSet:physicalMemory:)`:
- Reserve **35% of physical RAM (floor 8 GB)** for the OS + KV/Metal-scratch that must stay reclaimable.
- Only wire when the **whole model** fits inside that safe ceiling. Otherwise return `nil` → leave the swappable default (slower under pressure, never panics) — the pre-#417 behavior constrained Macs relied on.
- Big Macs keep the residency win: 128 GB / 76 GB model still wires (leaves 44.8 GB).

| profile | OLD (#417) wired | NEW |
|---|---|---|
| 16 GB + 9 GB model | 10.6 GB (panic) | **nil (safe default)** |
| 16 GB + 5 GB model | 10.6 GB | 8.0 GB (leaves 8 GB) |
| 128 GB + 76 GB model | 96 GB | 83.2 GB (leaves 44.8 GB) |
| 128 GB + 101 GB bundle | 96 GB | nil (safe) |

## Tests

`ModelResidencyWiredTargetTests` asserts the reclaim-reserve invariant across machine profiles and that **a 16 GB + 9 GB model is declined** — the exact regression the old formula shipped. Policy math verified standalone (all cases pass). Compiles clean (MLXLMCommon).

Aligns with the project rule: an estimate may advise, never starve the machine.