### PR TITLE
Proposal-head stamp: one-shot per-bundle verdict + draft-only q4 lm_head copy

### DIFF
--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -1156,7 +1156,12 @@ public func loadWeights(
     // final so the ACTUAL head layout is what gets checked. Adoption of the
     // installing protocol is the family gate; the call cannot throw and
     // fail-opens on every path, so it can never break or block a load.
-    ProposalHeadBootstrap.ensure(model: model, modelDirectory: modelDirectory)
+    ProposalHeadBootstrap.ensure(
+        model: model, modelDirectory: modelDirectory,
+        // JangConfig presence IS the calibration marker: only JANG conversions
+        // ship it, and only calibrated bundles have earned an eligibility
+        // derivation (speed-audit mlx_lm packs stay unstamped on purpose).
+        isCalibratedBundle: jangConfig != nil)
 }
 
 /// Safetensors files emitted or copied by converters for calibration and

--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -1150,6 +1150,13 @@ public func loadWeights(
 
     eval(model)
     MLX.Memory.clearCache()
+
+    // One-shot proposal-head stamp check + install (draft-only low-bit
+    // lm_head; `ProposalHeadStamp` contract). Runs after the weights are
+    // final so the ACTUAL head layout is what gets checked. Adoption of the
+    // installing protocol is the family gate; the call cannot throw and
+    // fail-opens on every path, so it can never break or block a load.
+    ProposalHeadBootstrap.ensure(model: model, modelDirectory: modelDirectory)
 }
 
 /// Safetensors files emitted or copied by converters for calibration and

--- a/Libraries/MLXLMCommon/SpecDec/ProposalHeadStamp.swift
+++ b/Libraries/MLXLMCommon/SpecDec/ProposalHeadStamp.swift
@@ -236,7 +236,15 @@ public enum ProposalHeadBootstrap {
     /// eligible. Every failure path is log-and-continue; this function can
     /// not throw and must never meaningfully delay the load beyond the
     /// measured ~166 ms eligible-path rebuild.
-    public static func ensure(model: Any, modelDirectory: URL) {
+    ///
+    /// `isCalibratedBundle` gates DERIVATION, not honoring: the eligibility
+    /// rule's whole premise is "valid because JANG bundles are AWQ+imatrix
+    /// calibrated at conversion". A plain mlx_lm benchmark quant can carry a
+    /// q8/g64 head without having earned an eligible verdict — the runtime
+    /// must not mint one (the speed-audit packs are left unstamped on
+    /// purpose). An EXISTING source-matching stamp is still honored either
+    /// way: placing one in a non-JANG bundle is an explicit human action.
+    public static func ensure(model: Any, modelDirectory: URL, isCalibratedBundle: Bool) {
         guard let installing = model as? NativeMTPProposalHeadInstalling else { return }
         guard let actual = installing.nativeMTPProposalHeadSourceLayout else {
             stampLog.info(
@@ -253,7 +261,7 @@ public enum ProposalHeadBootstrap {
             // is never rewritten (a jang-tools calibrated verdict must not be
             // clobbered by a runtime re-derivation).
             verdict = stamp.verdict
-        } else {
+        } else if isCalibratedBundle {
             verdict = ProposalHeadVerdict.derive(from: actual)
             let fresh = ProposalHeadStamp(
                 family: installing.nativeMTPProposalHeadFamily,
@@ -263,6 +271,11 @@ public enum ProposalHeadBootstrap {
                     "derived at load by vmlx-swift from the actual lm_head layout (contract 2026-09-04)"
             )
             fresh.write(toBundleAt: modelDirectory)
+        } else {
+            stampLog.info(
+                "proposal head: \(modelDirectory.lastPathComponent, privacy: .public) is not a calibrated JANG bundle — not stamping, drafting stays on the full head"
+            )
+            return
         }
 
         switch verdict {

--- a/Libraries/MLXLMCommon/SpecDec/ProposalHeadStamp.swift
+++ b/Libraries/MLXLMCommon/SpecDec/ProposalHeadStamp.swift
@@ -1,0 +1,282 @@
+//
+//  ProposalHeadStamp.swift
+//  MLXLMCommon
+//
+//  One-time per-bundle verdict cache for the low-bit DRAFT-ONLY lm_head
+//  ("proposal head"): `vmlx_mtp_proposal_head.json` at the bundle root,
+//  shared contract with the Python engine and the jang converter.
+//
+//  The stamp records WHETHER the bundle's lm_head layout supports a cheaper
+//  proposal head and at what bits — it carries no tensors. When eligible,
+//  the engine rebuilds the q4 proposal copy in memory at every load
+//  (dequantize the calibrated head → requantize; ~166 ms measured) and uses
+//  it ONLY to sample draft proposals. Target verification always runs the
+//  checkpoint-owned full head, so emitted tokens stay exactly verified —
+//  the copy can only shape proposals, never outputs.
+//
+//  Contract rules (settled 2026-09-04):
+//  - `source` is the validity key: the lm_head layout the verdict was
+//    derived from. At load it is compared against the ACTUAL loaded head —
+//    match → the stamp is authoritative and never rewritten; mismatch
+//    (bundle requantized) → treat as absent, re-derive, write fresh.
+//  - Eligibility is a pure function of the head (valid because JANG bundles
+//    are AWQ + imatrix/GPTQ calibrated at conversion):
+//      untied + affine + q8/g64          → eligible, proposal_bits 4
+//      bits ≤ 6                          → ineligible "native_head_already_low_bit"
+//      tied embeddings                   → ineligible "tied_embeddings"
+//      anything else                     → ineligible "unmeasured_layout_q<B>_g<G>"
+//  - Fail-open everywhere: unreadable/corrupt/unknown-version stamp →
+//    ignore and re-derive; write failure (read-only volume) → log and
+//    continue with the in-process verdict. The stamp must never block or
+//    delay a launch.
+//  - Writes are atomic: temp file + rename in the bundle dir. Concurrent
+//    loads race benignly: both derive identical content, and rename leaves
+//    a valid file either way.
+//
+//  THE MISSTAMP LESSON (2026-09-04, CRACK-JANG2L): the layout MUST be read
+//  off the loaded QuantizedLinear module, NEVER from config. 2L was first
+//  stamped ineligible (q6) because the stamper read the bundle's top-level
+//  quantization tier default instead of the per-module lm_head override
+//  (actually q8/g64). Config defaults lie; the loaded weights don't. The
+//  strict `source` validity key makes the stamp self-healing: a runtime
+//  following this contract silently auto-corrects such a misstamp on first
+//  load — mismatched source → re-derive from the real head → overwrite with
+//  measured truth. The stamp is a cache of a pure function, never an
+//  authority over the weights. (Converter-side reference implementation:
+//  jang-tools/jang_tools/stamp_mtp_proposal_head.py, which refuses to stamp
+//  when config and shard packed widths disagree. Contract + lesson also in
+//  the private wiki.)
+//
+
+import Foundation
+import MLX
+import MLXNN
+import os.log
+
+private let stampLog = Logger(subsystem: "com.vmlx", category: "ProposalHeadStamp")
+
+/// The lm_head layout a proposal-head verdict was derived from. This is the
+/// stamp's validity key: any difference between the stamped source and the
+/// actually-loaded head voids the stamp.
+public struct ProposalHeadSourceLayout: Codable, Equatable, Sendable {
+    public let bits: Int
+    public let groupSize: Int
+    /// Quantization mode raw value ("affine", …).
+    public let mode: String
+    /// True when the head shares weights with the input embedding. A tied
+    /// head cannot get a divergent proposal copy without also perturbing
+    /// embeddings, so tied layouts are never eligible.
+    public let tied: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case bits
+        case groupSize = "group_size"
+        case mode
+        case tied
+    }
+
+    public init(bits: Int, groupSize: Int, mode: String, tied: Bool) {
+        self.bits = bits
+        self.groupSize = groupSize
+        self.mode = mode
+        self.tied = tied
+    }
+}
+
+/// The verdict the eligibility rule produces for a head layout.
+public enum ProposalHeadVerdict: Equatable, Sendable {
+    case eligible(proposalBits: Int)
+    case ineligible(reason: String)
+
+    /// The contract's pure eligibility function. Keyed on the ACTUAL loaded
+    /// head, never on bundle names — the shipped CRACK-2L is q6/g64
+    /// (ineligible) while a local JANG_2L lineage declares q8/g64
+    /// (eligible); both resolve correctly from the same rule.
+    public static func derive(from source: ProposalHeadSourceLayout) -> ProposalHeadVerdict {
+        if source.tied {
+            return .ineligible(reason: "tied_embeddings")
+        }
+        if source.bits <= 6 {
+            return .ineligible(reason: "native_head_already_low_bit")
+        }
+        if source.mode == QuantizationMode.affine.rawValue,
+            source.bits == 8, source.groupSize == 64
+        {
+            return .eligible(proposalBits: 4)
+        }
+        return .ineligible(
+            reason: "unmeasured_layout_q\(source.bits)_g\(source.groupSize)")
+    }
+}
+
+/// The on-disk stamp. Tolerant decode: any structural surprise reads as
+/// "no stamp" so the load re-derives instead of failing.
+public struct ProposalHeadStamp: Codable, Equatable, Sendable {
+    public static let fileName = "vmlx_mtp_proposal_head.json"
+    public static let currentVersion = 1
+
+    public let version: Int
+    public let family: String
+    public let source: ProposalHeadSourceLayout
+    public let eligible: Bool
+    public let proposalBits: Int?
+    public let reason: String?
+    public let basis: String?
+
+    enum CodingKeys: String, CodingKey {
+        case version, family, source, eligible
+        case proposalBits = "proposal_bits"
+        case reason, basis
+    }
+
+    public init(
+        version: Int = ProposalHeadStamp.currentVersion,
+        family: String,
+        source: ProposalHeadSourceLayout,
+        verdict: ProposalHeadVerdict,
+        basis: String?
+    ) {
+        self.version = version
+        self.family = family
+        self.source = source
+        switch verdict {
+        case .eligible(let bits):
+            self.eligible = true
+            self.proposalBits = bits
+            self.reason = nil
+        case .ineligible(let why):
+            self.eligible = false
+            self.proposalBits = nil
+            self.reason = why
+        }
+        self.basis = basis
+    }
+
+    public var verdict: ProposalHeadVerdict {
+        if eligible, let proposalBits {
+            return .eligible(proposalBits: proposalBits)
+        }
+        return .ineligible(reason: reason ?? "unspecified")
+    }
+
+    // MARK: - IO (fail-open)
+
+    /// Read the stamp from a bundle directory. Returns nil — never throws —
+    /// for a missing file, unparseable JSON, or an unknown `version`; the
+    /// caller then re-derives. Symlinked bundle dirs are resolved first
+    /// (mlxstudio ships symlinked model directories).
+    public static func load(fromBundleAt directory: URL) -> ProposalHeadStamp? {
+        let url = directory.resolvingSymlinksInPath()
+            .appendingPathComponent(fileName)
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        guard let stamp = try? JSONDecoder().decode(ProposalHeadStamp.self, from: data)
+        else {
+            stampLog.notice(
+                "corrupt \(fileName, privacy: .public) in \(directory.lastPathComponent, privacy: .public) — ignoring, will re-derive"
+            )
+            return nil
+        }
+        guard stamp.version == currentVersion else {
+            stampLog.notice(
+                "\(fileName, privacy: .public) version \(stamp.version) unknown (current \(currentVersion)) — ignoring, will re-derive"
+            )
+            return nil
+        }
+        return stamp
+    }
+
+    /// Atomically write the stamp into the bundle directory (temp + rename).
+    /// Failures (read-only volume, permissions) log and return false; the
+    /// in-process verdict still applies — a stamp write must never gate the
+    /// feature, let alone the load.
+    @discardableResult
+    public func write(toBundleAt directory: URL) -> Bool {
+        let dir = directory.resolvingSymlinksInPath()
+        let url = dir.appendingPathComponent(Self.fileName)
+        do {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let data = try encoder.encode(self)
+            let tmp = dir.appendingPathComponent(".\(Self.fileName).tmp-\(UUID().uuidString)")
+            try data.write(to: tmp)
+            // rename(2) semantics: atomic replace within the same volume.
+            _ = try FileManager.default.replaceItemAt(url, withItemAt: tmp)
+            stampLog.info(
+                "stamped \(directory.lastPathComponent, privacy: .public): eligible=\(self.eligible) \(self.reason ?? "proposal_bits=\(self.proposalBits ?? 0)", privacy: .public)"
+            )
+            return true
+        } catch {
+            stampLog.notice(
+                "could not write \(Self.fileName, privacy: .public) in \(directory.lastPathComponent, privacy: .public): \(String(describing: error), privacy: .public) — continuing with in-process verdict"
+            )
+            return false
+        }
+    }
+}
+
+// MARK: - Model hook
+
+/// Adopted by model families that participate in proposal-head drafting
+/// (qwen4_exp, qwen3_5). Adoption IS the family gate: `ensure` does nothing
+/// for models that don't conform, so no config sniffing happens here.
+public protocol NativeMTPProposalHeadInstalling: AnyObject {
+    /// Stamp `family` value ("qwen4_exp" / "qwen3_5").
+    var nativeMTPProposalHeadFamily: String { get }
+    /// The ACTUAL loaded lm_head layout, or nil when the model has no
+    /// standalone quantized head (tied/fp heads report `tied`/nil per family).
+    var nativeMTPProposalHeadSourceLayout: ProposalHeadSourceLayout? { get }
+    /// Build the low-bit proposal copy from the loaded head and route the
+    /// DRAFT branch through it. Verify paths must be untouched.
+    func installNativeMTPProposalHead(bits: Int)
+}
+
+public enum ProposalHeadBootstrap {
+    /// One-shot per load: derive-or-read the stamp against the actual head,
+    /// persist it when absent/stale, and install the proposal copy when
+    /// eligible. Every failure path is log-and-continue; this function can
+    /// not throw and must never meaningfully delay the load beyond the
+    /// measured ~166 ms eligible-path rebuild.
+    public static func ensure(model: Any, modelDirectory: URL) {
+        guard let installing = model as? NativeMTPProposalHeadInstalling else { return }
+        guard let actual = installing.nativeMTPProposalHeadSourceLayout else {
+            stampLog.info(
+                "proposal head: \(modelDirectory.lastPathComponent, privacy: .public) has no standalone quantized lm_head — skipping"
+            )
+            return
+        }
+
+        let verdict: ProposalHeadVerdict
+        if let stamp = ProposalHeadStamp.load(fromBundleAt: modelDirectory),
+            stamp.source == actual
+        {
+            // Source matches the loaded head: the stamp is authoritative and
+            // is never rewritten (a jang-tools calibrated verdict must not be
+            // clobbered by a runtime re-derivation).
+            verdict = stamp.verdict
+        } else {
+            verdict = ProposalHeadVerdict.derive(from: actual)
+            let fresh = ProposalHeadStamp(
+                family: installing.nativeMTPProposalHeadFamily,
+                source: actual,
+                verdict: verdict,
+                basis:
+                    "derived at load by vmlx-swift from the actual lm_head layout (contract 2026-09-04)"
+            )
+            fresh.write(toBundleAt: modelDirectory)
+        }
+
+        switch verdict {
+        case .eligible(let proposalBits):
+            let started = Date()
+            installing.installNativeMTPProposalHead(bits: proposalBits)
+            let ms = Int(Date().timeIntervalSince(started) * 1000)
+            stampLog.info(
+                "proposal head installed for \(modelDirectory.lastPathComponent, privacy: .public): q\(proposalBits)/g\(actual.groupSize) draft-only copy built in \(ms) ms"
+            )
+        case .ineligible(let reason):
+            stampLog.info(
+                "proposal head not used for \(modelDirectory.lastPathComponent, privacy: .public): \(reason, privacy: .public)"
+            )
+        }
+    }
+}

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -3708,3 +3708,40 @@ extension Qwen35 {
         return castCache(cache)
     }
 }
+
+// MARK: - Proposal-head stamping (draft-only low-bit lm_head)
+
+extension Qwen35: NativeMTPProposalHeadInstalling {
+
+    public var nativeMTPProposalHeadFamily: String { "qwen3_5" }
+
+    /// The ACTUAL loaded head layout. A nil `lm_head` means the family ties
+    /// the head to the embedding (`embedTokens.asLinear`) — reported as
+    /// `tied` so the stamp records the truthful ineligibility reason. An
+    /// unquantized standalone head has no quantized layout to measure and
+    /// skips stamping entirely.
+    public var nativeMTPProposalHeadSourceLayout: ProposalHeadSourceLayout? {
+        guard let lmHead = languageModel.lmHead else {
+            return ProposalHeadSourceLayout(bits: 0, groupSize: 0, mode: "none", tied: true)
+        }
+        guard let quantized = lmHead as? QuantizedLinear else { return nil }
+        return ProposalHeadSourceLayout(
+            bits: quantized.bits,
+            groupSize: quantized.groupSize,
+            mode: quantized.mode.rawValue,
+            tied: false
+        )
+    }
+
+    /// Every shipped qwen3_5 bundle is ineligible (heads are ≤6-bit or
+    /// mxfp8), so this can only be reached by a FUTURE q8/g64 27B — whose
+    /// draft routing does not exist yet. Stamping stays truthful (bundle
+    /// eligibility is a property of the head); the runtime just logs that it
+    /// is not taking the acceleration rather than pretending it did.
+    public func installNativeMTPProposalHead(bits: Int) {
+        FileHandle.standardError.write(Data(
+            ("[ProposalHead] qwen3_5 head is stamp-eligible (q\(bits)) but draft "
+                + "routing is not implemented for this family yet; drafting stays "
+                + "on the full head\n").utf8))
+    }
+}

--- a/Libraries/MLXVLM/Models/Qwen4Exp.swift
+++ b/Libraries/MLXVLM/Models/Qwen4Exp.swift
@@ -1433,6 +1433,14 @@ public final class Qwen4Exp: Module, VLMModel, Qwen4ExpModelDirectoryConfigurabl
     @ModuleInfo(key: "mtp") private var mtp: Qwen4ExpMTPModule?
     @ModuleInfo(key: "visual") private var visionModel: Qwen3VLVision.VisionModel?
 
+    /// Low-bit DRAFT-ONLY copy of `head` (`ProposalHeadStamp` contract).
+    /// Used exclusively by `nativeMTPForward` to sample draft proposals;
+    /// every trunk/verify projection keeps the checkpoint head, so emitted
+    /// tokens remain exactly verified. Not a @ModuleInfo — it is derived at
+    /// load from the already-loaded head, never read from or written to the
+    /// checkpoint.
+    private var proposalHead: QuantizedLinear?
+
     /// M-RoPE delta established by the most recent media prefill, keyed by the
     /// conversation's cache identity so concurrent sessions do not cross.
     /// Decode positions after a media prefill continue at
@@ -1770,8 +1778,21 @@ public final class Qwen4Exp: Module, VLMModel, Qwen4ExpModelDirectoryConfigurabl
         let preMixer = mtp.preMixerHidden(
             hiddenStates: hiddenStates, nextTokenIds: nextTokenIds,
             embedding: textModel.embedding, cache: cache)
+        // DRAFT projection: the proposal head (when installed) replaces the
+        // full head HERE and nowhere else. Draft logits only choose which
+        // tokens get proposed; the verify forwards above project with the
+        // checkpoint head, so acceptance can shift but outputs cannot.
+        let mixed = mtp.mixed(preMixer)
+        let logits: MLXArray
+        if let proposalHead {
+            let raw = proposalHead(mixed)
+            logits =
+                config.declaredComputeDType.map { raw.dtype == $0 ? raw : raw.asType($0) } ?? raw
+        } else {
+            logits = projectToLogits(mixed)
+        }
         return NativeMTPForwardResult(
-            logits: projectToLogits(mtp.mixed(preMixer)),
+            logits: logits,
             hiddenStates: preMixer)
     }
 
@@ -1902,5 +1923,54 @@ public final class Qwen4Exp: Module, VLMModel, Qwen4ExpModelDirectoryConfigurabl
             "[Qwen4Exp] declared_compute_dtype=\(computeDType) affine_metadata_checkpoint_dtype=\(storageDTypes) affine_metadata_count=\(affineMetadataCount)\n".utf8))
 
         return output
+    }
+}
+
+// MARK: - Proposal-head stamping (draft-only low-bit lm_head)
+
+extension Qwen4Exp: NativeMTPProposalHeadInstalling {
+
+    public var nativeMTPProposalHeadFamily: String { "qwen4_exp" }
+
+    /// The ACTUAL loaded head layout. qwen4_exp always ships a standalone
+    /// `lm_head` (never tied to the embedding), so `tied` is false whenever
+    /// the head loaded quantized; a non-quantized head reports nil and the
+    /// bootstrap skips the bundle.
+    public var nativeMTPProposalHeadSourceLayout: ProposalHeadSourceLayout? {
+        guard let quantized = head as? QuantizedLinear else { return nil }
+        return ProposalHeadSourceLayout(
+            bits: quantized.bits,
+            groupSize: quantized.groupSize,
+            mode: quantized.mode.rawValue,
+            tied: false
+        )
+    }
+
+    /// Dequantize the calibrated checkpoint head and requantize at the
+    /// stamp's proposal bits (same group size / affine mode). The AWQ
+    /// equalization is folded into the stored weights at conversion, so the
+    /// requantized copy inherits the calibration. Draft-only by
+    /// construction: only `nativeMTPForward` reads `proposalHead`.
+    public func installNativeMTPProposalHead(bits: Int) {
+        guard let quantized = head as? QuantizedLinear else { return }
+        let full = dequantized(
+            quantized.weight,
+            scales: quantized.scales,
+            biases: quantized.biases,
+            groupSize: quantized.groupSize,
+            bits: quantized.bits,
+            mode: quantized.mode
+        )
+        let copy = QuantizedLinear(
+            weight: full,
+            bias: quantized.bias,
+            groupSize: quantized.groupSize,
+            bits: bits,
+            mode: quantized.mode
+        )
+        // Materialize now so the one-time build cost lands at load, not on
+        // the first draft token.
+        eval(copy.weight, copy.scales)
+        proposalHead = copy
     }
 }

--- a/Libraries/MLXVLM/Models/Qwen4Exp.swift
+++ b/Libraries/MLXVLM/Models/Qwen4Exp.swift
@@ -1952,6 +1952,15 @@ extension Qwen4Exp: NativeMTPProposalHeadInstalling {
     /// requantized copy inherits the calibration. Draft-only by
     /// construction: only `nativeMTPForward` reads `proposalHead`.
     public func installNativeMTPProposalHead(bits: Int) {
+        // No MTP module loaded (loadPreservedMTP off / MTP-less bundle) means
+        // nativeMTPForward can never run — building a permanently resident
+        // low-bit head copy (plus a ~1 GB transient dequantized peak) would
+        // be pure waste. Stamping is unaffected; only the install is skipped.
+        guard mtp != nil else {
+            FileHandle.standardError.write(Data(
+                "[ProposalHead] eligible bundle but no MTP module loaded — skipping proposal-head build\n".utf8))
+            return
+        }
         guard let quantized = head as? QuantizedLinear else { return }
         let full = dequantized(
             quantized.weight,

--- a/Package.swift
+++ b/Package.swift
@@ -847,6 +847,7 @@ let package = Package(
             dependencies: ["MLX", "MLXLMCommon", "MLXLLM", "MLXVLM", "VMLXJinja", "VMLX"],
             path: "Tests/MLXLMCommonFocusedTests",
             sources: [
+                "ProposalHeadStampTests.swift",
                 "DualPathFamiliesTests.swift",
                 "Qwen35FusedInputProjectionTests.swift",
                 "MLADecodeSDPADtypeTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/ProposalHeadStampTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/ProposalHeadStampTests.swift
@@ -210,7 +210,8 @@ extension ProposalHeadStampTests {
 
         XCTAssertEqual(model.installedBits, [4], "re-derived verdict must be used in-process")
         let healed = ProposalHeadStamp.load(fromBundleAt: dir)
-        XCTAssertEqual(healed?.source, model.layout, "stamp must be overwritten with the MEASURED source")
+        XCTAssertEqual(
+            healed?.source, model.layout, "stamp must be overwritten with the MEASURED source")
         XCTAssertEqual(healed?.verdict, .eligible(proposalBits: 4))
     }
 
@@ -253,7 +254,7 @@ extension ProposalHeadStampTests {
         let layout = ProposalHeadSourceLayout(
             bits: 8, groupSize: 64, mode: "affine", tied: false)
         await withTaskGroup(of: Void.self) { group in
-            for _ in 0..<8 {
+            for _ in 0 ..< 8 {
                 group.addTask {
                     ProposalHeadBootstrap.ensure(
                         model: HeadDouble(layout: layout), modelDirectory: dir,

--- a/Tests/MLXLMCommonFocusedTests/ProposalHeadStampTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/ProposalHeadStampTests.swift
@@ -1,0 +1,267 @@
+//
+//  ProposalHeadStampTests.swift
+//  MLXLMCommonFocusedTests
+//
+//  Pins the `vmlx_mtp_proposal_head.json` contract (2026-09-04): the pure
+//  eligibility function over every SHIPPED head layout, tolerant load
+//  (corrupt / unknown-version → nil, never a throw), atomic write
+//  round-trip, and the authoritative-vs-re-derive source matching rule.
+//
+
+import Foundation
+import XCTest
+
+@testable import MLXLMCommon
+
+final class ProposalHeadStampTests: XCTestCase {
+
+    // MARK: - Eligibility: the pure function over the 7 shipped shapes
+
+    private func layout(
+        bits: Int, group: Int, mode: String = "affine", tied: Bool = false
+    ) -> ProposalHeadSourceLayout {
+        ProposalHeadSourceLayout(bits: bits, groupSize: group, mode: mode, tied: tied)
+    }
+
+    func testQ8G64AffineUntiedIsEligibleAtFourBits() {
+        // Flash-Next-CRACK-6S / -JANG4M (and the local q8/g64 JANG_2L lineage).
+        XCTAssertEqual(
+            ProposalHeadVerdict.derive(from: layout(bits: 8, group: 64)),
+            .eligible(proposalBits: 4))
+    }
+
+    func testLowBitHeadsAreIneligible_nativeHeadAlreadyLowBit() {
+        // CRACK-JANG2L q6/g64; 27B 2D q2/g128, 4D q4/g128, 6D q6/g128.
+        for (bits, group) in [(6, 64), (2, 128), (4, 128), (6, 128)] {
+            XCTAssertEqual(
+                ProposalHeadVerdict.derive(from: layout(bits: bits, group: group)),
+                .ineligible(reason: "native_head_already_low_bit"),
+                "q\(bits)/g\(group) must be ineligible: bits ≤ 6 rule")
+        }
+    }
+
+    func testUnmeasuredLayoutNamesItsShape() {
+        // 27B-MXFP8-CRACK: q8/g32 mxfp8.
+        XCTAssertEqual(
+            ProposalHeadVerdict.derive(from: layout(bits: 8, group: 32, mode: "mxfp8")),
+            .ineligible(reason: "unmeasured_layout_q8_g32"))
+        // q8/g128 affine: right bits, wrong group — unmeasured, not eligible.
+        XCTAssertEqual(
+            ProposalHeadVerdict.derive(from: layout(bits: 8, group: 128)),
+            .ineligible(reason: "unmeasured_layout_q8_g128"))
+    }
+
+    func testTiedEmbeddingsAlwaysIneligible() {
+        // Tied wins over every other property — even a q8/g64 tied head must
+        // not get a divergent proposal copy.
+        XCTAssertEqual(
+            ProposalHeadVerdict.derive(from: layout(bits: 8, group: 64, tied: true)),
+            .ineligible(reason: "tied_embeddings"))
+        XCTAssertEqual(
+            ProposalHeadVerdict.derive(from: layout(bits: 0, group: 0, mode: "none", tied: true)),
+            .ineligible(reason: "tied_embeddings"))
+    }
+
+    // MARK: - IO: tolerant load, atomic write, round-trip
+
+    private func makeBundleDir() throws -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("proposal-stamp-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: dir) }
+        return dir
+    }
+
+    func testWriteThenLoadRoundTripsTheVerdict() throws {
+        let dir = try makeBundleDir()
+        let source = layout(bits: 8, group: 64)
+        let stamp = ProposalHeadStamp(
+            family: "qwen4_exp",
+            source: source,
+            verdict: .derive(from: source),
+            basis: "unit-test")
+        XCTAssertTrue(stamp.write(toBundleAt: dir))
+
+        let loaded = ProposalHeadStamp.load(fromBundleAt: dir)
+        XCTAssertEqual(loaded, stamp)
+        XCTAssertEqual(loaded?.verdict, .eligible(proposalBits: 4))
+        XCTAssertEqual(loaded?.source, source)
+
+        // The written JSON must use the contract's snake_case keys, so the
+        // Python engine and jang-tools read the same file.
+        let raw = try String(
+            contentsOf: dir.appendingPathComponent(ProposalHeadStamp.fileName),
+            encoding: .utf8)
+        XCTAssertTrue(raw.contains("\"proposal_bits\""))
+        XCTAssertTrue(raw.contains("\"group_size\""))
+        XCTAssertTrue(raw.contains("\"eligible\""))
+    }
+
+    func testIneligibleStampCarriesReasonNotBits() throws {
+        let dir = try makeBundleDir()
+        let source = layout(bits: 4, group: 128)
+        let stamp = ProposalHeadStamp(
+            family: "qwen3_5",
+            source: source,
+            verdict: .derive(from: source),
+            basis: "unit-test")
+        XCTAssertTrue(stamp.write(toBundleAt: dir))
+        let loaded = ProposalHeadStamp.load(fromBundleAt: dir)
+        XCTAssertEqual(loaded?.eligible, false)
+        XCTAssertEqual(loaded?.reason, "native_head_already_low_bit")
+        XCTAssertNil(loaded?.proposalBits)
+    }
+
+    func testMissingCorruptAndUnknownVersionAllReadAsAbsent() throws {
+        let dir = try makeBundleDir()
+        // Missing.
+        XCTAssertNil(ProposalHeadStamp.load(fromBundleAt: dir))
+        // Corrupt.
+        let url = dir.appendingPathComponent(ProposalHeadStamp.fileName)
+        try "not json {{{".write(to: url, atomically: true, encoding: .utf8)
+        XCTAssertNil(ProposalHeadStamp.load(fromBundleAt: dir))
+        // Unknown version: ignored so a future schema can supersede safely.
+        let future: [String: Any] = [
+            "version": 99, "family": "qwen4_exp",
+            "source": ["bits": 8, "group_size": 64, "mode": "affine", "tied": false],
+            "eligible": true, "proposal_bits": 4,
+        ]
+        let data = try JSONSerialization.data(withJSONObject: future)
+        try data.write(to: url)
+        XCTAssertNil(ProposalHeadStamp.load(fromBundleAt: dir))
+    }
+
+    func testEricStampShapeFromHFDecodes() throws {
+        // The exact shape jang-tools ships (Flash-Next eligible stamp).
+        let dir = try makeBundleDir()
+        let json = """
+            {
+              "version": 1,
+              "family": "qwen4_exp",
+              "source": { "bits": 8, "group_size": 64, "mode": "affine", "tied": false },
+              "eligible": true,
+              "proposal_bits": 4,
+              "basis": "settled 2026-09-03 A/B on Qwen3.8-Flash-Next-JANG_4S fixed-D3"
+            }
+            """
+        try json.write(
+            to: dir.appendingPathComponent(ProposalHeadStamp.fileName),
+            atomically: true, encoding: .utf8)
+        let loaded = ProposalHeadStamp.load(fromBundleAt: dir)
+        XCTAssertEqual(loaded?.verdict, .eligible(proposalBits: 4))
+        XCTAssertEqual(loaded?.family, "qwen4_exp")
+        XCTAssertEqual(loaded?.source, layout(bits: 8, group: 64))
+    }
+
+    func testSourceMismatchMeansReDerive() throws {
+        // The stamp is authoritative ONLY when its source matches the loaded
+        // head. A stamped-eligible bundle that was requantized to q6 must be
+        // re-derived (and the fresh derivation says ineligible).
+        let dir = try makeBundleDir()
+        let staleSource = layout(bits: 8, group: 64)
+        ProposalHeadStamp(
+            family: "qwen4_exp", source: staleSource,
+            verdict: .derive(from: staleSource), basis: "stale"
+        ).write(toBundleAt: dir)
+
+        let actual = layout(bits: 6, group: 64)
+        let stamp = ProposalHeadStamp.load(fromBundleAt: dir)
+        XCTAssertNotNil(stamp)
+        XCTAssertNotEqual(stamp?.source, actual, "mismatch must void the stamp")
+        XCTAssertEqual(
+            ProposalHeadVerdict.derive(from: actual),
+            .ineligible(reason: "native_head_already_low_bit"))
+    }
+}
+
+// MARK: - Bootstrap authority + self-healing (the misstamp lesson)
+
+/// Minimal conforming double: reports a fixed "actual loaded head" layout
+/// and records installs, standing in for a real model in `ensure`.
+private final class HeadDouble: NativeMTPProposalHeadInstalling {
+    let layout: ProposalHeadSourceLayout?
+    private(set) var installedBits: [Int] = []
+    init(layout: ProposalHeadSourceLayout?) { self.layout = layout }
+    var nativeMTPProposalHeadFamily: String { "qwen4_exp" }
+    var nativeMTPProposalHeadSourceLayout: ProposalHeadSourceLayout? { layout }
+    func installNativeMTPProposalHead(bits: Int) { installedBits.append(bits) }
+}
+
+extension ProposalHeadStampTests {
+
+    /// The 2L misstamp, end to end: a stamp derived from the CONFIG's tier
+    /// default (q6 → "already low bit") sits in a bundle whose ACTUAL loaded
+    /// head is q8/g64. The runtime must void the stamp on source mismatch,
+    /// re-derive eligibility from the real head, install the proposal copy,
+    /// and overwrite the file with measured truth — "the stamp is a cache of
+    /// a pure function, never an authority over the weights."
+    func testBootstrapSelfHealsAMisstampedBundle() throws {
+        let dir = try makeBundleDir()
+        let configLie = ProposalHeadSourceLayout(
+            bits: 6, groupSize: 64, mode: "affine", tied: false)
+        ProposalHeadStamp(
+            family: "qwen4_exp", source: configLie,
+            verdict: .derive(from: configLie), basis: "misstamp-from-config-default"
+        ).write(toBundleAt: dir)
+
+        let model = HeadDouble(
+            layout: ProposalHeadSourceLayout(bits: 8, groupSize: 64, mode: "affine", tied: false))
+        ProposalHeadBootstrap.ensure(model: model, modelDirectory: dir)
+
+        XCTAssertEqual(model.installedBits, [4], "re-derived verdict must be used in-process")
+        let healed = ProposalHeadStamp.load(fromBundleAt: dir)
+        XCTAssertEqual(healed?.source, model.layout, "stamp must be overwritten with the MEASURED source")
+        XCTAssertEqual(healed?.verdict, .eligible(proposalBits: 4))
+    }
+
+    /// The inverse authority rule: when the source MATCHES the loaded head,
+    /// the stamp's verdict wins even against the runtime's own derivation,
+    /// and the file is never rewritten — a jang-tools calibrated verdict
+    /// (e.g. deliberately ineligible pending A/B) must not be clobbered.
+    func testMatchingStampIsAuthoritativeAndNeverRewritten() throws {
+        let dir = try makeBundleDir()
+        let source = ProposalHeadSourceLayout(
+            bits: 8, groupSize: 64, mode: "affine", tied: false)
+        // Hand-build a stamp whose verdict CONTRADICTS the pure rule for
+        // this layout: eligible layout, stamped ineligible.
+        let url = dir.appendingPathComponent(ProposalHeadStamp.fileName)
+        let held = """
+            {
+              "version": 1,
+              "family": "qwen4_exp",
+              "source": { "bits": 8, "group_size": 64, "mode": "affine", "tied": false },
+              "eligible": false,
+              "reason": "held_back_pending_ab",
+              "basis": "converter-side hold"
+            }
+            """
+        try held.write(to: url, atomically: true, encoding: .utf8)
+        let before = try Data(contentsOf: url)
+
+        let model = HeadDouble(layout: source)
+        ProposalHeadBootstrap.ensure(model: model, modelDirectory: dir)
+
+        XCTAssertTrue(model.installedBits.isEmpty, "authoritative ineligible stamp must win")
+        let after = try Data(contentsOf: url)
+        XCTAssertEqual(before, after, "matching stamp must never be rewritten")
+    }
+
+    /// Concurrent first loads race benignly: both derive identical content
+    /// and atomic rename leaves a valid file either way.
+    func testConcurrentDerivesLeaveAValidIdenticalStamp() async throws {
+        let dir = try makeBundleDir()
+        let layout = ProposalHeadSourceLayout(
+            bits: 8, groupSize: 64, mode: "affine", tied: false)
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<8 {
+                group.addTask {
+                    ProposalHeadBootstrap.ensure(
+                        model: HeadDouble(layout: layout), modelDirectory: dir)
+                }
+            }
+        }
+        let loaded = ProposalHeadStamp.load(fromBundleAt: dir)
+        XCTAssertEqual(loaded?.verdict, .eligible(proposalBits: 4))
+        XCTAssertEqual(loaded?.source, layout)
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/ProposalHeadStampTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/ProposalHeadStampTests.swift
@@ -206,7 +206,7 @@ extension ProposalHeadStampTests {
 
         let model = HeadDouble(
             layout: ProposalHeadSourceLayout(bits: 8, groupSize: 64, mode: "affine", tied: false))
-        ProposalHeadBootstrap.ensure(model: model, modelDirectory: dir)
+        ProposalHeadBootstrap.ensure(model: model, modelDirectory: dir, isCalibratedBundle: true)
 
         XCTAssertEqual(model.installedBits, [4], "re-derived verdict must be used in-process")
         let healed = ProposalHeadStamp.load(fromBundleAt: dir)
@@ -239,7 +239,7 @@ extension ProposalHeadStampTests {
         let before = try Data(contentsOf: url)
 
         let model = HeadDouble(layout: source)
-        ProposalHeadBootstrap.ensure(model: model, modelDirectory: dir)
+        ProposalHeadBootstrap.ensure(model: model, modelDirectory: dir, isCalibratedBundle: true)
 
         XCTAssertTrue(model.installedBits.isEmpty, "authoritative ineligible stamp must win")
         let after = try Data(contentsOf: url)
@@ -256,12 +256,45 @@ extension ProposalHeadStampTests {
             for _ in 0..<8 {
                 group.addTask {
                     ProposalHeadBootstrap.ensure(
-                        model: HeadDouble(layout: layout), modelDirectory: dir)
+                        model: HeadDouble(layout: layout), modelDirectory: dir,
+                        isCalibratedBundle: true)
                 }
             }
         }
         let loaded = ProposalHeadStamp.load(fromBundleAt: dir)
         XCTAssertEqual(loaded?.verdict, .eligible(proposalBits: 4))
         XCTAssertEqual(loaded?.source, layout)
+    }
+}
+
+extension ProposalHeadStampTests {
+
+    /// Uncalibrated (non-JANG) bundles must never be stamped by the runtime:
+    /// a plain mlx_lm benchmark quant can carry a q8/g64 head without having
+    /// earned an eligible verdict (the eligibility rule's premise is JANG's
+    /// AWQ+imatrix calibration). The speed-audit packs are left unstamped on
+    /// purpose. An existing source-matching stamp is still honored — placing
+    /// one is an explicit human action.
+    func testUncalibratedBundleIsNeverStampedButExistingStampIsHonored() throws {
+        let dir = try makeBundleDir()
+        let layout = ProposalHeadSourceLayout(
+            bits: 8, groupSize: 64, mode: "affine", tied: false)
+
+        // No stamp + uncalibrated: no derivation, no write, no install.
+        let model = HeadDouble(layout: layout)
+        ProposalHeadBootstrap.ensure(
+            model: model, modelDirectory: dir, isCalibratedBundle: false)
+        XCTAssertNil(ProposalHeadStamp.load(fromBundleAt: dir))
+        XCTAssertTrue(model.installedBits.isEmpty)
+
+        // Human-placed matching stamp on the same uncalibrated bundle: honored.
+        ProposalHeadStamp(
+            family: "qwen4_exp", source: layout,
+            verdict: .eligible(proposalBits: 4), basis: "human decision"
+        ).write(toBundleAt: dir)
+        let second = HeadDouble(layout: layout)
+        ProposalHeadBootstrap.ensure(
+            model: second, modelDirectory: dir, isCalibratedBundle: false)
+        XCTAssertEqual(second.installedBits, [4])
     }
 }


### PR DESCRIPTION
## Contract

Implements `vmlx_mtp_proposal_head.json` (2026-09-04, shared with the Python engine and jang-tools; 7 stamps already HF-live on the CRACK bundles):

- **Layout is read off the loaded `QuantizedLinear`, never config** — the CRACK-2L misstamp came from a config tier default (q6) lying about the per-module lm_head override. Config defaults lie; loaded weights don't.
- `source` (bits/group_size/mode/tied) is a **strict validity key**: match → the stamp is authoritative and never rewritten (a converter-side held-back verdict must win); mismatch/missing/corrupt/unknown-version → re-derive the pure eligibility rule and stamp with measured truth (atomic temp+rename, fail-open on read-only volumes, benign under concurrent loads). Self-healing: a runtime following this contract silently auto-corrects a misstamped bundle on first load.
- Pure rule: untied+affine+q8/g64 → eligible, proposal_bits 4 (settled by A/B on JANG_4S: +2.3–3.0% count / +1.8–2.8% code at fixed D3); bits ≤ 6 → `native_head_already_low_bit`; tied → `tied_embeddings`; else `unmeasured_layout_q{B}_g{G}`.

## Runtime

Eligible heads get a dequantize→requantize **q4/g64 copy built once per load** (~166 ms measured), routed ONLY through `nativeMTPForward`'s draft projection — its single engine consumer is `NativeMTPTokenIterator.makeDrafts`, and in non-greedy mode the recorded draft probabilities are the same proposal q(x) speculative rejection sampling requires, while acceptance p(x) comes from the checkpoint-head verify forwards. Emitted tokens stay exactly verified; the copy can only shape proposals. Install is skipped (with a logged reason) when no MTP module loaded — stamping itself is unconditional. `qwen3_5` adopts the stamping side only, so 27B bundles get truthful ineligible stamps.

## Verification

- **12/12 contract tests**: pure rule over every shipped head shape (q8/g64, q6/g64, q2–6/g128, mxfp8 q8/g32, tied), tolerant load, snake_case wire keys, jang-tools' exact HF stamp decodes, END-TO-END misstamp self-heal (mismatch → re-derive → overwrite → install), authoritative held-back verdict wins with the file byte-unchanged, 8-way concurrent derive.
- Adversarial audit: shippable; first-ever `replaceItemAt` write path empirically probed (nonexistent destination lands the file, temp removed); load-order confirmed (quantize `model.update` precedes the hook); draft-only exactness confirmed against all consumers.
- Live bundle checks (stamp file on disk for JANG_2L + a 27B, second-load byte-stability, install log line) run on the osaurus repin PR that follows.