### PR TITLE
MTP original layout, calibrated draft sidecar, adaptive depth to d5, AR-safety governor, verify tile

### DIFF
--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -122,6 +122,28 @@ private func modelIndexContainsPreservedMTPWeight(at modelDirectory: URL) -> Boo
     return weightMap.keys.contains(where: isPreservedMTPWeightKey)
 }
 
+/// The unique shard file names `model.safetensors.index.json` maps weights
+/// into, or nil when the bundle has no readable index (single-file and
+/// legacy bundles keep the directory-scan path). Entries that try to escape
+/// the bundle (absolute paths, `..`) are dropped — weight_map values are
+/// plain file names by contract, and a hostile index must not become a
+/// file-system probe.
+func indexedShardFileNames(at modelDirectory: URL) -> [String]? {
+    let indexURL = modelDirectory.appendingPathComponent("model.safetensors.index.json")
+    guard let data = try? Data(contentsOf: indexURL),
+        let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+        let weightMap = json["weight_map"] as? [String: Any]
+    else { return nil }
+    var names: Set<String> = []
+    for value in weightMap.values {
+        guard let name = value as? String, !name.isEmpty,
+            !name.hasPrefix("/"), !name.contains("..")
+        else { continue }
+        names.insert(name)
+    }
+    return names.isEmpty ? nil : names.sorted()
+}
+
 private func loadJangConfigSanitizeMetadata(at modelDirectory: URL) -> [String: String] {
     guard let url = JangLoader.findConfigPath(at: modelDirectory),
         let data = try? Data(contentsOf: url),
@@ -241,6 +263,62 @@ public func loadWeights(
                 continue
             }
             allShardURLs.append(url)
+        }
+        // FINAL bundle-layout contract (2026-09-04, JANG bundles): when the
+        // bundle ships `model.safetensors.index.json`, the index IS the load
+        // manifest — load exactly the files its weight_map names, nothing
+        // else. Discovery-by-glob is what let withdrawn artifacts (a
+        // dedicated `mtp-00001-*` shard, an interim root-level draft-head
+        // sidecar) leak into `model.update()` as duplicate/unknown keys and
+        // fail loads the index itself defines as complete. An extra file the
+        // index does not mention must never fail — or even affect — a load;
+        // the calibrated draft sidecar lives in `mtp_draft/` for exactly
+        // that reason. Named runtime overlays (`jangtq_stacked`,
+        // `jangpress-prestacked`) are deliberate artifacts, not indexed
+        // weights, so they keep their exact-path opt-in. Gated to JANG
+        // bundles: stock community bundles keep the historical glob and are
+        // untouched by this contract.
+        if jangConfig != nil,
+            let indexedNames = indexedShardFileNames(at: modelDirectory)
+        {
+            var selected: [URL] = []
+            var missing: [String] = []
+            for name in indexedNames {
+                let url = modelDirectory.appendingPathComponent(name)
+                if FileManager.default.fileExists(atPath: url.path) {
+                    selected.append(url)
+                } else {
+                    missing.append(name)
+                }
+            }
+            if !missing.isEmpty {
+                let message =
+                    "model.safetensors.index.json references \(missing.count) "
+                    + "file(s) that are not in \(modelDirectory.path): "
+                    + missing.sorted().joined(separator: ", ")
+                    + ". The bundle layout is incomplete or superseded — "
+                    + "re-download the bundle."
+                FileHandle.standardError.write(Data("[loadWeights] \(message)\n".utf8))
+                throw TruncatedSafetensorsError(description: message)
+            }
+            for overlay in ["jangtq_stacked.safetensors", "jangpress-prestacked.safetensors"] {
+                if overlay == "jangtq_stacked.safetensors" && skipDSV4Sidecar { continue }
+                let url = modelDirectory.appendingPathComponent(overlay)
+                if FileManager.default.fileExists(atPath: url.path),
+                    !selected.contains(where: { $0.lastPathComponent == overlay })
+                {
+                    selected.append(url)
+                }
+            }
+            let droppedCount = allShardURLs.filter { url in
+                !selected.contains(where: { $0.path == url.path })
+            }.count
+            if droppedCount > 0 {
+                FileHandle.standardError.write(Data(
+                    ("[loadWeights] index-manifest load: ignoring \(droppedCount) "
+                        + "non-indexed safetensors file(s) in the bundle\n").utf8))
+            }
+            allShardURLs = selected
         }
         // Detect mixed `model-NNNNN-of-MMMMM.safetensors` sets: parse
         // the trailing `MMMMM` total and group by it. >1 distinct total

--- a/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
+++ b/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
@@ -1866,19 +1866,39 @@ public enum MTPBundleInspector {
         // one small read per shard and this runs only at load-time
         // inspection.
         var names: Set<String> = []
+        var indexedFiles: Set<String> = []
         let indexURL = directory.appendingPathComponent("model.safetensors.index.json")
         if let index = try loadJSONObjectIfExists(indexURL),
             let weightMap = index["weight_map"] as? [String: Any]
         {
             names.formUnion(weightMap.keys)
+            indexedFiles.formUnion(weightMap.values.compactMap { $0 as? String })
         }
 
-        let contents =
-            (try? FileManager.default.contentsOfDirectory(
-                at: directory,
-                includingPropertiesForKeys: [.isRegularFileKey],
-                options: [.skipsHiddenFiles])) ?? []
-        let safetensors = contents.filter { $0.pathExtension == "safetensors" }
+        // Header scan scope follows the FINAL layout contract (2026-09-04):
+        // with an index present, only the files the index maps into are
+        // inspection-worthy — a stray tensor file the index doesn't mention
+        // (withdrawn `mtp-00001-*` shard, an interim root-level draft-head
+        // sidecar, the deliberate `mtp_draft/` artifact) must never make a
+        // bundle LOOK like it has loadable MTP weights the loader will not
+        // load. The header union itself stays: the index can omit tensors
+        // that are physically in its own shards (observed live on
+        // Qwen3.8-27B-JANG_4D, 31 `mtp.*` tensors missing from a 2,348-entry
+        // weight_map), and detection must not refuse a complete head over
+        // that. Index-less bundles keep the full directory scan.
+        let safetensors: [URL]
+        if !indexedFiles.isEmpty {
+            safetensors = indexedFiles.sorted().map {
+                directory.appendingPathComponent($0)
+            }.filter { FileManager.default.fileExists(atPath: $0.path) }
+        } else {
+            let contents =
+                (try? FileManager.default.contentsOfDirectory(
+                    at: directory,
+                    includingPropertiesForKeys: [.isRegularFileKey],
+                    options: [.skipsHiddenFiles])) ?? []
+            safetensors = contents.filter { $0.pathExtension == "safetensors" }
+        }
 
         for file in safetensors {
             names.formUnion(try safetensorsHeaderNames(file))

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -106,12 +106,11 @@ public struct NativeMTPGenerationStats: Sendable, Equatable {
     /// Draft depth actually in effect at the start of generation (`depth=`).
     ///
     /// This is the REQUESTED depth after the policy cap, not the raw request:
-    /// the iterator clamps to `VMLX_MTP_DEPTH_CAP` (default `2` — the D2
-    /// ceiling; depths past 2 only ever won on a deterministic counting
-    /// prompt, and Nemotron measured D3 at 0.48x on real prose). A host that
-    /// asks for `.nativeMTP(depth: 3)` therefore sees `depth == 2` here —
-    /// which is the point of surfacing it, since that gap is otherwise
-    /// invisible without reading stderr.
+    /// the iterator clamps to `VMLX_MTP_DEPTH_CAP` (default `3` since the
+    /// staged verifier's measured D3 win — see the cap-site comment; the D2
+    /// ceiling era is over). A host that asks past the cap sees the clamped
+    /// value here — which is the point of surfacing it, since that gap is
+    /// otherwise invisible without reading stderr.
     public let depth: Int
 
     /// Draft depth in effect at end of generation, after any adaptive

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -2177,10 +2177,22 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             adaptiveWindow.removeFirst(adaptiveWindow.count - Self.adaptiveWindowSize)
         }
 
+        // The safety warmup exists for the lazy-repair verifier (an
+        // unaccepted row could reach committed state). Under the STAGED
+        // verifier that corruption class is structurally gone — the
+        // verify-cycle gate already skips warmup there — yet this
+        // acceptance verdict still ran after `hybridWarmupCycleCount` staged
+        // cycles, and one low-acceptance prose generation wrote a PERMANENT
+        // negative memo that turned every later generation in the process
+        // into pure AR (live 2026-09-04: `hybrid_warmup_memo`, verifyCalls=0,
+        // 324/325 tokens AR). Speculation economics under staged verify are
+        // the AR-safety governor's job (windowed, reversible) — never a
+        // one-shot permanent verdict.
         if usesHybridMambaCache,
            speculativeSampler.isGreedy,
            processor == nil,
            !hybridSafetyWarmupComplete,
+           stagedVerifierCommitCount == 0,
            verifyCalls >= Self.hybridWarmupCycleCount
         {
             let acceptedTokens = acceptedByDepth.reduce(0) { partial, item in

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -369,6 +369,10 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private(set) var mtpForwardCount = 0
     private(set) var autoregressiveFallbackTokenCount = 0
     private(set) var adaptiveDepthDownshiftCount = 0
+    /// Hard ceiling for adaptive promotion — the resolved depth cap, which
+    /// may exceed the REQUESTED depth (the request is a starting point, not
+    /// a lid, since 2026-09-04). See the depth-policy comment in `init`.
+    private let adaptiveDepthCeiling: Int
     private(set) var seedMainForwardTime: TimeInterval = 0
     private(set) var verifyMainForwardTime: TimeInterval = 0
     private(set) var replayMainForwardTime: TimeInterval = 0
@@ -407,6 +411,25 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private var hybridSafetyWarmupComplete = false
     private var adaptiveWindow: [AdaptiveCycle] = []
     private var adaptiveFallbackReason: String?
+    /// Timestamp of the previous adaptive cycle's bookkeeping; diffs give
+    /// per-cycle wall time for wall-clock depth pricing.
+    private var lastAdaptiveCycleTimestamp: TimeInterval?
+    /// Measured committed-tokens-per-second per depth (EMA, α = 0.5),
+    /// recorded each time a full window evaluates at that depth. Wall-clock
+    /// truth for the controller: acceptance floors alone kept a d3 window at
+    /// 0.65 acceptance pinned at d3 even when its throughput measurably lost
+    /// to d2 (Eric, 2026-09-04: "d3 is slower than d2 sometimes").
+    private var measuredThroughputByDepth: [Int: Double] = [:]
+    /// Windows evaluated at the current depth since the level above was last
+    /// throughput-probed; after `upperProbeCooldownWindows`, the stale upper
+    /// measurement is dropped so the climb can be re-attempted (prompt
+    /// character changes mid-generation — a table after prose).
+    private var windowsSinceUpperProbe = 0
+    private static let upperProbeCooldownWindows = 8
+    /// A lower depth must beat the current one by this factor before the
+    /// wall-clock rule demotes — hysteresis so measurement noise doesn't
+    /// oscillate the depth.
+    private static let wallClockDemoteFactor = 1.05
     private(set) var nativeMTPStats: NativeMTPGenerationStats?
     private var generationStatsFinalized = false
     private let iteratorStartTime = Date.timeIntervalSinceReferenceDate
@@ -418,6 +441,14 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private struct AdaptiveCycle {
         let depth: Int
         let accepted: Int
+        /// Tokens this cycle actually delivered (accepted drafts + the
+        /// verifier's own token) — the numerator of wall-clock pricing.
+        let committed: Int
+        /// Wall seconds since the previous cycle's bookkeeping — drafting,
+        /// verify, sampling, cache commit, everything the user waits on.
+        /// 0 for the first cycle of a generation (no predecessor to diff
+        /// against); throughput sums skip those.
+        let wallSeconds: Double
     }
 
     init(
@@ -473,21 +504,21 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         self.sampler = effectiveParameters.sampler()
         self.speculativeSampler = SpeculativeSamplingController(parameters: effectiveParameters)
         self.maxTokens = effectiveParameters.maxTokens
-        // Depth policy: D3 is the ceiling. The old D2 cap was calibrated on
-        // the lazy-repair/sequential verifier, where every rejection cost a
-        // checkpoint restore + full replay forward (Nemotron D3 0.48x, the
-        // Python depth-3 prose figure 14% slower than AR). Under the staged
-        // verifier those numbers no longer describe this code: 2026-08-19 on
-        // Qwen3.8-27B-JANG_4D, D3 measured 28.4 tok/s vs D2 27.5 vs plain
-        // 16.5, byte-identical output, 3.13 committed tokens per verify.
-        // A default cap below what a measured tuning artifact requests is a
-        // silent clamp on the host's explicit choice — the same bug this
-        // comment already records for the cap=1 era. The adaptive controller
-        // still downshifts unprofitable depth at runtime; benchmarks can
-        // override via VMLX_MTP_DEPTH_CAP.
+        // Depth policy (2026-09-04): the REQUESTED depth is the STARTING
+        // depth; the hard cap is 5 and the adaptive controller may promote
+        // past the request up to that cap when a full acceptance window
+        // clears the top floor with margin — near-perfect-acceptance shapes
+        // (counting, enumeration, tables) earn d4/d5 at runtime instead of
+        // being pinned to their start. History: the D2 cap era was
+        // calibrated on the lazy-repair verifier (Nemotron D3 0.48x); the
+        // staged verifier re-measured D3 as a win (27B_4D: 28.4 vs 16.5
+        // plain, byte-identical), and the same acceptance-priced controller
+        // that downshifts unprofitable depth governs every step above the
+        // start. Benchmarks can still override via VMLX_MTP_DEPTH_CAP.
         let depthCap =
             ProcessInfo.processInfo.environment["VMLX_MTP_DEPTH_CAP"]
-            .flatMap(Int.init).map { Swift.max($0, 1) } ?? 3
+            .flatMap(Int.init).map { Swift.max($0, 1) } ?? 5
+        self.adaptiveDepthCeiling = depthCap
         self.depth = Swift.min(requestedDepth, depthCap)
         self.currentDepth = Swift.min(requestedDepth, depthCap)
         self.verifierModeSetting = effectiveParameters.draftStrategy?.nativeMTPVerifierMode
@@ -771,7 +802,10 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             ProcessInfo.processInfo.environment["VMLX_MTP_COMPILED_VERIFY"] == "1"
         {
             let promptOffset = self.cache.map(\.offset).max() ?? promptTokenIds.count
-            let bufferLength = promptOffset + (self.maxTokens ?? 4096) + self.depth + 8
+            // Sized by the promotion CEILING, not the starting depth — the
+            // adaptive controller may climb past the request mid-generation.
+            let bufferLength =
+                promptOffset + (self.maxTokens ?? 4096) + self.adaptiveDepthCeiling + 8
             self.cache = self.cache.map { layer in
                 // Never promote QSAKVCache: the qwen4_exp indexer needs the
                 // concrete type for its raw-key lane (osaurus#2525).
@@ -1877,7 +1911,15 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             }
             return
         }
-        adaptiveWindow.append(AdaptiveCycle(depth: currentDepth, accepted: accepted))
+        let now = Date.timeIntervalSinceReferenceDate
+        let cycleWall = lastAdaptiveCycleTimestamp.map { now - $0 } ?? 0
+        lastAdaptiveCycleTimestamp = now
+        adaptiveWindow.append(
+            AdaptiveCycle(
+                depth: currentDepth,
+                accepted: accepted,
+                committed: accepted + 1,
+                wallSeconds: Swift.max(0, cycleWall)))
         if adaptiveWindow.count > Self.adaptiveWindowSize {
             adaptiveWindow.removeFirst(adaptiveWindow.count - Self.adaptiveWindowSize)
         }
@@ -1972,10 +2014,65 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         // the sample budget before any demote judgment.
         let inRestoredGraceWindow =
             restoredPrefixStart && verifyCalls < 4 * Self.adaptiveWindowSize
-        if currentDepth >= 3, acceptanceRatio < depthThreeFloor, !inRestoredGraceWindow {
+
+        // WALL-CLOCK pricing (2026-09-04). Acceptance floors are a proxy;
+        // what the user feels is committed tokens per second. Record this
+        // window's measured throughput for the current depth, then demote
+        // when a LOWER depth's remembered throughput beats it with margin —
+        // even at healthy acceptance. This is the fix for "d3 is slower
+        // than d2 sometimes": drafting more per token does not pay when the
+        // acceptance decay + per-row verify cost eat the extra drafts.
+        let timedSamples = activeSamples.filter { $0.wallSeconds > 0 }
+        let windowWall = timedSamples.reduce(0.0) { $0 + $1.wallSeconds }
+        if windowWall > 0, timedSamples.count >= Self.adaptiveMinimumSamplesPerDepth {
+            let committed = timedSamples.reduce(0) { $0 + $1.committed }
+            let throughput = Double(committed) / windowWall
+            measuredThroughputByDepth[currentDepth] =
+                measuredThroughputByDepth[currentDepth].map { 0.5 * $0 + 0.5 * throughput }
+                ?? throughput
+            windowsSinceUpperProbe += 1
+            if windowsSinceUpperProbe >= Self.upperProbeCooldownWindows {
+                // The level above was measured in a different stretch of the
+                // generation; forget it so the climb can be re-attempted.
+                measuredThroughputByDepth[currentDepth + 1] = nil
+                windowsSinceUpperProbe = 0
+            }
+            if currentDepth > 1, !inRestoredGraceWindow,
+                let lower = measuredThroughputByDepth[currentDepth - 1],
+                lower > throughput * Self.wallClockDemoteFactor
+            {
+                currentDepth -= 1
+                adaptiveDepthDownshiftCount += 1
+                adaptiveWindow.removeAll(keepingCapacity: true)
+                lastAdaptiveCycleTimestamp = nil
+                windowsSinceUpperProbe = 0
+                mtpCache = model.makeNativeMTPCache()
+                mtpCacheRefreshCount += 1
+                return
+            }
+        }
+
+        // Above the measured d3 regime, price each level one step at a time:
+        // a d5 window that stops paying drops to d4, not to d2 — the deep
+        // levels exist only because acceptance earned them, and one soft
+        // window shouldn't forfeit the whole climb.
+        if currentDepth >= 4, acceptanceRatio < depthThreeFloor, !inRestoredGraceWindow {
+            currentDepth -= 1
+            adaptiveDepthDownshiftCount += 1
+            adaptiveWindow.removeAll(keepingCapacity: true)
+            lastAdaptiveCycleTimestamp = nil
+            windowsSinceUpperProbe = 0
+            mtpCache = model.makeNativeMTPCache()
+            mtpCacheRefreshCount += 1
+            return
+        }
+
+        if currentDepth == 3, acceptanceRatio < depthThreeFloor, !inRestoredGraceWindow {
             currentDepth = 2
             adaptiveDepthDownshiftCount += 1
             adaptiveWindow.removeAll(keepingCapacity: true)
+            lastAdaptiveCycleTimestamp = nil
+            windowsSinceUpperProbe = 0
             mtpCache = model.makeNativeMTPCache()
             mtpCacheRefreshCount += 1
             return
@@ -1988,6 +2085,8 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             currentDepth = 1
             adaptiveDepthDownshiftCount += 1
             adaptiveWindow.removeAll(keepingCapacity: true)
+            lastAdaptiveCycleTimestamp = nil
+            windowsSinceUpperProbe = 0
             mtpCache = model.makeNativeMTPCache()
             mtpCacheRefreshCount += 1
             return
@@ -2002,22 +2101,35 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             return
         }
 
-        // Re-arm. The controller could historically only demote, so a single
-        // cold window — a restored prefix arriving with a cold aligned-head
-        // cache — pinned the whole session below its configured depth. When a
-        // full window at the CURRENT depth clears the floor of the depth
-        // above with margin, promote one level; the window reset re-prices
-        // the new depth on fresh samples.
-        if currentDepth < depth {
+        // Promote. Historically bounded by the REQUESTED depth (recovery
+        // only); since 2026-09-04 the request is a STARTING depth and a full
+        // window that clears the floor of the level above with margin climbs
+        // toward `adaptiveDepthCeiling` — near-perfect-acceptance shapes
+        // (counting, enumeration) ride to d4/d5 while ordinary prose, whose
+        // acceptance sits under the floors, never leaves its start. Only the
+        // staged verifier earns the extended ceiling: the lazy-repair
+        // verifier keeps the old recover-to-request bound (its rejection
+        // cost model was never re-measured above d3).
+        let promotionCeiling = staged ? adaptiveDepthCeiling : depth
+        if currentDepth < promotionCeiling {
             let nextFloor: Double
             switch currentDepth {
             case 1: nextFloor = depthTwoFloor
             default: nextFloor = depthThreeFloor
             }
-            if acceptanceRatio >= nextFloor + Self.adaptivePromotionMargin {
+            // Don't re-climb to a level whose measured wall-clock already
+            // lost to this one (the cooldown above forgets it eventually so
+            // a changed prompt regime can re-probe).
+            let upperKnownWorse =
+                measuredThroughputByDepth[currentDepth + 1].map { upper in
+                    measuredThroughputByDepth[currentDepth].map { upper < $0 } ?? false
+                } ?? false
+            if acceptanceRatio >= nextFloor + Self.adaptivePromotionMargin, !upperKnownWorse {
                 currentDepth += 1
                 adaptiveDepthPromotionCount += 1
                 adaptiveWindow.removeAll(keepingCapacity: true)
+                lastAdaptiveCycleTimestamp = nil
+                windowsSinceUpperProbe = 0
             }
         }
     }

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -165,6 +165,10 @@ public struct NativeMTPGenerationStats: Sendable, Equatable {
     /// line printing `adaptiveFallback=none`; a non-`nil` reason is printed
     /// verbatim (`adaptiveFallback=`).
     public let adaptiveFallbackReason: String?
+    /// AR-safety governor: how many times the request paused speculation for
+    /// losing to AR on a window, and how many resume probes won.
+    public let arSafetyTrips: Int
+    public let arSafetyResumes: Int
 
     /// Verifier mode used for this generation (`verifierMode=`).
     public let verifierMode: String
@@ -186,7 +190,9 @@ public struct NativeMTPGenerationStats: Sendable, Equatable {
         adaptiveDownshifts: Int,
         adaptiveFallbackReason: String?,
         verifierMode: String,
-        cacheMode: String
+        cacheMode: String,
+        arSafetyTrips: Int = 0,
+        arSafetyResumes: Int = 0
     ) {
         self.depth = depth
         self.activeDepth = activeDepth
@@ -202,6 +208,8 @@ public struct NativeMTPGenerationStats: Sendable, Equatable {
         self.adaptiveFallbackReason = adaptiveFallbackReason
         self.verifierMode = verifierMode
         self.cacheMode = cacheMode
+        self.arSafetyTrips = arSafetyTrips
+        self.arSafetyResumes = arSafetyResumes
     }
 }
 
@@ -408,6 +416,49 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private(set) var acceptanceProbabilitySum = 0.0
     private(set) var acceptanceProbabilityCount = 0
     private var forceAutoregressiveFallback = false
+
+    // MARK: AR-safety governor state (windowed, context-scaled, REVERSIBLE)
+    //
+    // Runs every cycle regardless of depth policy (fixed or adaptive): if a
+    // WINDOWED MTP ms/token exceeds a context-scaled AR baseline, the request
+    // pauses speculation and decodes AR "instantaneously"; while paused it
+    // measures the live AR step cost and periodically PROBES a resume at the
+    // starting depth, keeping MTP only if the probe window beats live AR.
+    // Design + audit trail: docs/internal/MTP-AR-SAFETY-GOVERNOR-SWIFT-2026-09-04.md
+    // (Swift port of vmlx-private-evidence MTP-ONFLY-AR-FALLBACK-PLAN, plus
+    // the reversible Phase 2 the Python plan deferred).
+    private struct ARSafetySample {
+        let emitted: Int
+        let wall: TimeInterval
+        let verifyTotal: TimeInterval
+    }
+    private var arSafetyRing: [ARSafetySample] = []
+    private var arSafetyEmittedTotal = 0
+    /// Wall of one TRUE single-token AR step measured after eval — the first
+    /// decode cycle runs AR precisely to capture this (the seed forward is
+    /// prompt-sized here, not an AR step; the lazy-eval trap is avoided by
+    /// timing after `MLX.eval`).
+    private var arSafetySeedStepSec: TimeInterval?
+    /// First MTP cycle's verify-forward wall; verify growth over it tracks
+    /// AR's own context growth (context-fair baseline).
+    private var arSafetyFirstVerifySec: TimeInterval?
+    private var arSafetyPaused = false
+    /// Live AR step cost at the CURRENT context, EMA over paused steps.
+    private var arSafetyLiveStepSec: TimeInterval?
+    private var arSafetyTokensSincePause = 0
+    private var arSafetyResumeInterval = NativeMTPTokenIterator.arSafetyResumeIntervalStart
+    private var arSafetyProbeCyclesRemaining = 0
+    private(set) var arSafetyTrips = 0
+    private(set) var arSafetyResumes = 0
+    private static let arSafetyWindow = 16
+    private static let arSafetyMargin = 1.25
+    private static let arSafetyProbeWindow = 8
+    private static let arSafetyResumeIntervalStart = 24
+    private static let arSafetyResumeIntervalMax = 192
+    /// `VMLX_NATIVE_MTP_AR_SAFETY=0` disables the governor (measurement
+    /// hatch, like the adaptive one). Default ON.
+    private static let arSafetyDisabled =
+        ProcessInfo.processInfo.environment["VMLX_NATIVE_MTP_AR_SAFETY"] == "0"
     private var hybridSafetyWarmupComplete = false
     private var adaptiveWindow: [AdaptiveCycle] = []
     private var adaptiveFallbackReason: String?
@@ -830,7 +881,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             pendingTokens.removeAll(keepingCapacity: true)
             pendingIndex = 0
             do {
-                if forceAutoregressiveFallback {
+                if forceAutoregressiveFallback || arSafetyPaused
+                    || (!Self.arSafetyDisabled && arSafetySeedStepSec == nil)
+                {
                     try generateAutoregressiveToken()
                 } else {
                     try verifyCycle()
@@ -1144,10 +1197,12 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             adaptiveDownshifts: adaptiveDepthDownshiftCount,
             adaptiveFallbackReason: adaptiveFallbackReason,
             verifierMode: verifierMode,
-            cacheMode: "private-mtp+verifier-prefix-commit")
+            cacheMode: "private-mtp+verifier-prefix-commit",
+            arSafetyTrips: arSafetyTrips,
+            arSafetyResumes: arSafetyResumes)
         let line = String(
             format:
-                "[NativeMTP] depth=%d activeDepth=%d verifyCalls=%d outputTokens=%d arFallbackTokens=%d acceptedByDepth=%@ bonus=%d rejected=%d residualCorrection=%d prefixCommit=%d rollbackRepair=%d mtpCacheRefresh=%d targetForwards=%d verifyInputTokens=%d repairForwards=%d seedMainForwards=%d verifyMainForwards=%d replayMainForwards=%d mtpForwards=%d avgCommittedPerVerify=%.2f avgAcceptP=%.3f adaptiveDownshifts=%d adaptiveFallback=%@ targetVerifySec=%.3f verifyGpuWaitSec=%.3f seedMainSec=%.3f verifyMainSec=%.3f replayMainSec=%.3f mtpDraftSec=%.3f samplingSec=%.3f cacheCommitSec=%.3f materializeSyncSec=%.3f cacheStateSec=%.3f iteratorWallSec=%.3f gdnReplayCalls=%d gdnReplayStates=%d gdnReplaySec=%.3f prefetch[submit=%d,consumed=%d,abandoned=%d] phaseDiag=%@ samplingMode=%@ verifierMode=%@ cacheMode=private-mtp+verifier-prefix-commit\n",
+                "[NativeMTP] depth=%d activeDepth=%d verifyCalls=%d outputTokens=%d arFallbackTokens=%d acceptedByDepth=%@ bonus=%d rejected=%d residualCorrection=%d prefixCommit=%d rollbackRepair=%d mtpCacheRefresh=%d targetForwards=%d verifyInputTokens=%d repairForwards=%d seedMainForwards=%d verifyMainForwards=%d replayMainForwards=%d mtpForwards=%d avgCommittedPerVerify=%.2f avgAcceptP=%.3f adaptiveDownshifts=%d adaptiveFallback=%@ targetVerifySec=%.3f verifyGpuWaitSec=%.3f seedMainSec=%.3f verifyMainSec=%.3f replayMainSec=%.3f mtpDraftSec=%.3f samplingSec=%.3f cacheCommitSec=%.3f materializeSyncSec=%.3f cacheStateSec=%.3f iteratorWallSec=%.3f gdnReplayCalls=%d gdnReplayStates=%d gdnReplaySec=%.3f prefetch[submit=%d,consumed=%d,abandoned=%d] phaseDiag=%@ samplingMode=%@ verifierMode=%@ cacheMode=private-mtp+verifier-prefix-commit arSafety[trips=%d,resumes=%d,paused=%d]\n",
             depth,
             currentDepth,
             verifyCalls,
@@ -1190,7 +1245,10 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             verifyPrefetchAbandonedCount,
             phaseSummary,
             speculativeSampler.isGreedy ? "greedy" : "exact-pq",
-            verifierMode)
+            verifierMode,
+            arSafetyTrips,
+            arSafetyResumes,
+            arSafetyPaused ? 1 : 0)
         FileHandle.standardError.write(Data(line.utf8))
     }
 
@@ -1589,6 +1647,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
 
         verifyCalls += 1
         acceptedByDepth[accepted, default: 0] += 1
+        arSafetyAfterVerifyCycle(accepted: accepted)
         recordAdaptiveCycle(accepted: accepted)
         if Self.traceEnabled {
             let requestedIDs = recordMaterializeSync { requested.map { $0.item(Int.self) } }
@@ -1899,7 +1958,187 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private static let adaptiveDisabledForMeasurement =
         ProcessInfo.processInfo.environment["VMLX_NATIVE_MTP_DISABLE_ADAPTIVE"] == "1"
 
+    // MARK: - AR-safety governor
+
+    /// The pure decision: does a windowed MTP ms/token lose to the
+    /// context-scaled AR baseline? Mirrors the Python engine's
+    /// `_native_mtp_windowed_ar_verdict` exactly so both runtimes trip on the
+    /// same arithmetic. nil = MTP holds. Guards: zero/negative deltas never
+    /// divide; `firstVerifyMs <= 0` disables context scaling (baseline stays
+    /// the seed AR step).
+    struct ARSafetyVerdict: Equatable {
+        let mtpMsPerToken: Double
+        let arBaselineMs: Double
+    }
+
+    static func windowedARVerdict(
+        arStepMs: Double,
+        firstVerifyMs: Double,
+        windowCycles: Int,
+        deltaEmitted: Int,
+        deltaWallMs: Double,
+        deltaVerifyMs: Double,
+        margin: Double
+    ) -> ARSafetyVerdict? {
+        guard arStepMs > 0, windowCycles > 0, deltaEmitted > 0, deltaWallMs > 0 else {
+            return nil
+        }
+        var scale = 1.0
+        if firstVerifyMs > 0 {
+            let verifyAvgMs = deltaVerifyMs / Double(windowCycles)
+            scale = Swift.max(1.0, verifyAvgMs / firstVerifyMs)
+        }
+        let baseline = arStepMs * scale
+        let mtpMsPerToken = deltaWallMs / Double(deltaEmitted)
+        guard mtpMsPerToken > baseline * margin else { return nil }
+        return ARSafetyVerdict(mtpMsPerToken: mtpMsPerToken, arBaselineMs: baseline)
+    }
+
+    private var arSafetyWindowForRequest: Int {
+        // Restored prefixes start with a cold aligned-head cache: dilute the
+        // judgement window the same 4× the adaptive gates use.
+        restoredPrefixStart ? 4 * Self.arSafetyWindow : Self.arSafetyWindow
+    }
+
+    /// After every verify cycle (any depth policy): sample, then either
+    /// judge a resume probe or run the windowed trip test.
+    private mutating func arSafetyAfterVerifyCycle(accepted: Int) {
+        guard !Self.arSafetyDisabled, !forceAutoregressiveFallback else { return }
+        arSafetyEmittedTotal += accepted + 1
+        let now = Date.timeIntervalSinceReferenceDate
+        arSafetyRing.append(
+            ARSafetySample(
+                emitted: arSafetyEmittedTotal, wall: now, verifyTotal: targetVerifyTime))
+        let window = arSafetyProbeCyclesRemaining > 0
+            ? Self.arSafetyProbeWindow : arSafetyWindowForRequest
+        if arSafetyRing.count > window + 1 {
+            arSafetyRing.removeFirst(arSafetyRing.count - (window + 1))
+        }
+        if arSafetyFirstVerifySec == nil, arSafetyRing.count >= 2 {
+            let d = arSafetyRing[1].verifyTotal - arSafetyRing[0].verifyTotal
+            if d > 0 { arSafetyFirstVerifySec = d }
+        }
+        guard arSafetyRing.count == window + 1,
+            let oldest = arSafetyRing.first, let newest = arSafetyRing.last
+        else { return }
+        let deltaEmitted = newest.emitted - oldest.emitted
+        let deltaWallMs = (newest.wall - oldest.wall) * 1000
+        let deltaVerifyMs = (newest.verifyTotal - oldest.verifyTotal) * 1000
+
+        if arSafetyProbeCyclesRemaining > 0 {
+            arSafetyProbeCyclesRemaining -= 1
+            guard arSafetyProbeCyclesRemaining == 0 else { return }
+            // Probe verdict against the LIVE AR cost measured while paused
+            // (already at the current context — no scaling needed). MTP must
+            // WIN outright to stay; otherwise pause again with backoff.
+            let liveArMs = (arSafetyLiveStepSec ?? arSafetySeedStepSec ?? 0) * 1000
+            let mtpMsPerToken = deltaEmitted > 0 ? deltaWallMs / Double(deltaEmitted) : .infinity
+            if liveArMs > 0, mtpMsPerToken >= liveArMs {
+                arSafetyPause(
+                    reason: String(
+                        format: "ar_safety_probe_lost(mtp=%.1fms/tok live_ar=%.1fms)",
+                        mtpMsPerToken, liveArMs))
+                arSafetyResumeInterval = Swift.min(
+                    arSafetyResumeInterval * 2, Self.arSafetyResumeIntervalMax)
+            } else {
+                arSafetyResumes += 1
+                arSafetyResumeInterval = Self.arSafetyResumeIntervalStart
+                FileHandle.standardError.write(Data(String(
+                    format: "[NativeMTP] ar_safety resumed: mtp=%.1fms/tok live_ar=%.1fms depth=%d\n",
+                    mtpMsPerToken, liveArMs, currentDepth).utf8))
+            }
+            return
+        }
+
+        // Warmup: judge only once the window is full of post-warmup cycles.
+        guard verifyCalls >= window, let seed = arSafetySeedStepSec else { return }
+        if let verdict = Self.windowedARVerdict(
+            arStepMs: seed * 1000,
+            firstVerifyMs: (arSafetyFirstVerifySec ?? 0) * 1000,
+            windowCycles: window,
+            deltaEmitted: deltaEmitted,
+            deltaWallMs: deltaWallMs,
+            deltaVerifyMs: deltaVerifyMs,
+            margin: Self.arSafetyMargin)
+        {
+            arSafetyPause(
+                reason: String(
+                    format: "ar_safety_windowed(mtp=%.1fms/tok ar=%.1fms depth=%d)",
+                    verdict.mtpMsPerToken, verdict.arBaselineMs, currentDepth))
+        }
+    }
+
+    private mutating func arSafetyPause(reason: String) {
+        arSafetyPaused = true
+        arSafetyTrips += 1
+        arSafetyTokensSincePause = 0
+        arSafetyProbeCyclesRemaining = 0
+        arSafetyRing.removeAll(keepingCapacity: true)
+        adaptiveWindow.removeAll(keepingCapacity: true)
+        lastAdaptiveCycleTimestamp = nil
+        adaptiveFallbackReason = reason
+        drafts.removeAll(keepingCapacity: true)
+        draftProbabilities.removeAll(keepingCapacity: true)
+        FileHandle.standardError.write(Data("[NativeMTP] ar_safety paused: \(reason)\n".utf8))
+    }
+
+    /// After every AR step: capture the seed AR cost on the very first
+    /// decode step, track live AR cost while paused, and start a resume
+    /// probe on schedule. Resuming = fresh head cache + drafts from THIS
+    /// step's hidden, so the next cycle is a real verify at the start depth.
+    private mutating func arSafetyAfterARStep(
+        stepSec: TimeInterval, hidden: MLXArray, nextToken: MLXArray
+    ) {
+        guard !Self.arSafetyDisabled, !forceAutoregressiveFallback else { return }
+        if arSafetySeedStepSec == nil {
+            arSafetySeedStepSec = stepSec
+            arSafetyStartSpeculating(hidden: hidden, nextToken: nextToken, probe: false)
+            return
+        }
+        guard arSafetyPaused else { return }
+        arSafetyLiveStepSec = arSafetyLiveStepSec.map { 0.7 * $0 + 0.3 * stepSec } ?? stepSec
+        arSafetyTokensSincePause += 1
+        guard arSafetyTokensSincePause >= arSafetyResumeInterval else { return }
+        arSafetyPaused = false
+        arSafetyStartSpeculating(hidden: hidden, nextToken: nextToken, probe: true)
+    }
+
+    private mutating func arSafetyStartSpeculating(
+        hidden: MLXArray, nextToken: MLXArray, probe: Bool
+    ) {
+        // Same re-prime the depth controller uses on every depth change: a
+        // fresh head cache, drafts from the current hidden. Drafts are only
+        // proposals — verification owns every emitted token — so a cold head
+        // cache can only cost acceptance, never correctness.
+        mtpCache = model.makeNativeMTPCache()
+        mtpCacheRefreshCount += 1
+        currentDepth = depth
+        arSafetyRing.removeAll(keepingCapacity: true)
+        arSafetyProbeCyclesRemaining = probe ? Self.arSafetyProbeWindow : 0
+        let draftStart = Date.timeIntervalSinceReferenceDate
+        let draftBatch = Self.makeDrafts(
+            model: model,
+            hidden: hidden,
+            nextToken: nextToken,
+            mtpCache: mtpCache,
+            depth: currentDepth,
+            sampler: sampler,
+            speculativeSampler: speculativeSampler,
+            processor: processor)
+        drafts = draftBatch.tokens
+        draftProbabilities = draftBatch.probabilities
+        headChainPairs = Self.alignedHeadCacheEnabled
+            ? Swift.max(0, draftBatch.tokens.count - 1) : 0
+        mtpForwardCount += draftBatch.forwardCount
+        materializeSyncTime += draftBatch.materializeSyncTime
+        mtpDraftTime += Date.timeIntervalSinceReferenceDate - draftStart
+    }
+
     private mutating func recordAdaptiveCycle(accepted: Int) {
+        // While the AR-safety governor holds the request in AR (or is
+        // probing a resume) the depth controller must not also act: one
+        // decision per window, one owner.
+        if arSafetyPaused || arSafetyProbeCyclesRemaining > 0 { return }
         if Self.adaptiveDisabledForMeasurement {
             // The hatch must not leave the safety warmup permanently
             // incomplete: that silently priced EVERY cycle as a sequential
@@ -2174,6 +2413,14 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         pendingTokens.append(tokenID)
         autoregressiveFallbackTokenCount += 1
         nextMain = sample.token
+        // Any drafts made before this AR step were built for the previous
+        // position; they are stale now.
+        drafts.removeAll(keepingCapacity: true)
+        draftProbabilities.removeAll(keepingCapacity: true)
+        arSafetyAfterARStep(
+            stepSec: elapsed,
+            hidden: Self.lastHidden(output.hiddenStates),
+            nextToken: sample.token)
     }
 
     private mutating func verifyCycleSequential(primary: MLXArray) throws {
@@ -2294,6 +2541,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
 
         acceptedByDepth[accepted, default: 0] += 1
+        arSafetyAfterVerifyCycle(accepted: accepted)
         recordAdaptiveCycle(accepted: accepted)
         prefixCommitCount += 1
 

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -450,6 +450,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     /// prompt-sized here, not an AR step; the lazy-eval trap is avoided by
     /// timing after `MLX.eval`).
     private var arSafetySeedStepSec: TimeInterval?
+    private var arSafetySeedFirstSampleSec: TimeInterval?
     /// First MTP cycle's verify-forward wall; verify growth over it tracks
     /// AR's own context growth (context-fair baseline).
     private var arSafetyFirstVerifySec: TimeInterval?
@@ -2105,8 +2106,16 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     ) {
         guard !Self.arSafetyDisabled, !forceAutoregressiveFallback else { return }
         if arSafetySeedStepSec == nil {
-            arSafetySeedStepSec = stepSec
-            arSafetyStartSpeculating(hidden: hidden, nextToken: nextToken, probe: false)
+            // The very first decode step carries graph/kernel warm-up and
+            // reads high (a lenient, never over-eager baseline — but lenient
+            // enough that a prose regime at ~AR speed never tripped). Take
+            // the MIN of two consecutive true AR steps as the seed.
+            if let first = arSafetySeedFirstSampleSec {
+                arSafetySeedStepSec = Swift.min(first, stepSec)
+                arSafetyStartSpeculating(hidden: hidden, nextToken: nextToken, probe: false)
+            } else {
+                arSafetySeedFirstSampleSec = stepSec
+            }
             return
         }
         guard arSafetyPaused else { return }
@@ -2366,6 +2375,20 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
 
         if currentDepth == 1, acceptanceRatio < depthOneFloor, !inRestoredGraceWindow {
+            // Under the staged verifier with the governor on, "d1 doesn't
+            // pay" is a REVERSIBLE verdict: pause to AR and let the governor's
+            // probes bring MTP back when the regime changes. Live (4M prose,
+            // build #4): this irreversible fallback fired on 6/8 prose gens
+            // BEFORE the governor could act, locking 55–366 AR tokens per
+            // turn — the "never recovers" behaviour the governor exists to
+            // end. The lazy-repair verifier keeps the irreversible fallback.
+            if staged, !Self.arSafetyDisabled {
+                arSafetyPause(
+                    reason: String(
+                        format: "adaptive_accept_ratio=%.2f_depth=1_paused",
+                        acceptanceRatio))
+                return
+            }
             enableAutoregressiveFallback(
                 reason: String(
                     format: "adaptive_accept_ratio=%.2f_depth=%d",

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -381,6 +381,13 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     /// stats line): which rule moved the depth, how often.
     private var adaptiveWallClockDemotes = 0
     private var adaptiveAcceptanceDemotes = 0
+    /// Oscillation brake: how many times each depth has been demoted FROM
+    /// in this generation. Live on 4M prose (2026-09-04): d3 start →
+    /// 12 downshifts over 414 cycles — acceptance demoted, the margin gate
+    /// promoted straight back, each hop cold-starting the head cache. A
+    /// level demoted twice is closed for the rest of the generation.
+    private var adaptiveDemotedFromCount: [Int: Int] = [:]
+    private static let adaptiveMaxDemotesPerLevel = 2
     /// Hard ceiling for adaptive promotion — the resolved depth cap, which
     /// may exceed the REQUESTED depth (the request is a starting point, not
     /// a lid, since 2026-09-04). See the depth-policy comment in `init`.
@@ -2287,6 +2294,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 let lower = measuredThroughputByDepth[currentDepth - 1],
                 lower > throughput * Self.wallClockDemoteFactor
             {
+                adaptiveDemotedFromCount[currentDepth, default: 0] += 1
                 currentDepth -= 1
                 adaptiveDepthDownshiftCount += 1
                 adaptiveWallClockDemotes += 1
@@ -2304,6 +2312,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         // levels exist only because acceptance earned them, and one soft
         // window shouldn't forfeit the whole climb.
         if currentDepth >= 4, acceptanceRatio < depthThreeFloor, !inRestoredGraceWindow {
+            adaptiveDemotedFromCount[currentDepth, default: 0] += 1
             currentDepth -= 1
             adaptiveDepthDownshiftCount += 1
             adaptiveAcceptanceDemotes += 1
@@ -2316,6 +2325,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
 
         if currentDepth == 3, acceptanceRatio < depthThreeFloor, !inRestoredGraceWindow {
+            adaptiveDemotedFromCount[3, default: 0] += 1
             currentDepth = 2
             adaptiveDepthDownshiftCount += 1
             adaptiveAcceptanceDemotes += 1
@@ -2331,6 +2341,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             // A failing D2 downshifts to D1 first — D1's breakeven is far
             // lower, so "D2 doesn't pay" is not evidence that speculation
             // itself doesn't.
+            adaptiveDemotedFromCount[2, default: 0] += 1
             currentDepth = 1
             adaptiveDepthDownshiftCount += 1
             adaptiveAcceptanceDemotes += 1
@@ -2374,7 +2385,12 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 measuredThroughputByDepth[currentDepth + 1].map { upper in
                     measuredThroughputByDepth[currentDepth].map { upper < $0 } ?? false
                 } ?? false
-            if acceptanceRatio >= nextFloor + Self.adaptivePromotionMargin, !upperKnownWorse {
+            let upperClosed =
+                adaptiveDemotedFromCount[currentDepth + 1, default: 0]
+                >= Self.adaptiveMaxDemotesPerLevel
+            if acceptanceRatio >= nextFloor + Self.adaptivePromotionMargin,
+                !upperKnownWorse, !upperClosed
+            {
                 currentDepth += 1
                 adaptiveDepthPromotionCount += 1
                 adaptiveWindow.removeAll(keepingCapacity: true)

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -377,6 +377,10 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private(set) var mtpForwardCount = 0
     private(set) var autoregressiveFallbackTokenCount = 0
     private(set) var adaptiveDepthDownshiftCount = 0
+    /// Per-rule audit counters for the depth controller (printed on the
+    /// stats line): which rule moved the depth, how often.
+    private var adaptiveWallClockDemotes = 0
+    private var adaptiveAcceptanceDemotes = 0
     /// Hard ceiling for adaptive promotion — the resolved depth cap, which
     /// may exceed the REQUESTED depth (the request is a starting point, not
     /// a lid, since 2026-09-04). See the depth-policy comment in `init`.
@@ -1202,7 +1206,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             arSafetyResumes: arSafetyResumes)
         let line = String(
             format:
-                "[NativeMTP] depth=%d activeDepth=%d verifyCalls=%d outputTokens=%d arFallbackTokens=%d acceptedByDepth=%@ bonus=%d rejected=%d residualCorrection=%d prefixCommit=%d rollbackRepair=%d mtpCacheRefresh=%d targetForwards=%d verifyInputTokens=%d repairForwards=%d seedMainForwards=%d verifyMainForwards=%d replayMainForwards=%d mtpForwards=%d avgCommittedPerVerify=%.2f avgAcceptP=%.3f adaptiveDownshifts=%d adaptiveFallback=%@ targetVerifySec=%.3f verifyGpuWaitSec=%.3f seedMainSec=%.3f verifyMainSec=%.3f replayMainSec=%.3f mtpDraftSec=%.3f samplingSec=%.3f cacheCommitSec=%.3f materializeSyncSec=%.3f cacheStateSec=%.3f iteratorWallSec=%.3f gdnReplayCalls=%d gdnReplayStates=%d gdnReplaySec=%.3f prefetch[submit=%d,consumed=%d,abandoned=%d] phaseDiag=%@ samplingMode=%@ verifierMode=%@ cacheMode=private-mtp+verifier-prefix-commit arSafety[trips=%d,resumes=%d,paused=%d]\n",
+                "[NativeMTP] depth=%d activeDepth=%d verifyCalls=%d outputTokens=%d arFallbackTokens=%d acceptedByDepth=%@ bonus=%d rejected=%d residualCorrection=%d prefixCommit=%d rollbackRepair=%d mtpCacheRefresh=%d targetForwards=%d verifyInputTokens=%d repairForwards=%d seedMainForwards=%d verifyMainForwards=%d replayMainForwards=%d mtpForwards=%d avgCommittedPerVerify=%.2f avgAcceptP=%.3f adaptiveDownshifts=%d adaptiveFallback=%@ targetVerifySec=%.3f verifyGpuWaitSec=%.3f seedMainSec=%.3f verifyMainSec=%.3f replayMainSec=%.3f mtpDraftSec=%.3f samplingSec=%.3f cacheCommitSec=%.3f materializeSyncSec=%.3f cacheStateSec=%.3f iteratorWallSec=%.3f gdnReplayCalls=%d gdnReplayStates=%d gdnReplaySec=%.3f prefetch[submit=%d,consumed=%d,abandoned=%d] phaseDiag=%@ samplingMode=%@ verifierMode=%@ cacheMode=private-mtp+verifier-prefix-commit arSafety[trips=%d,resumes=%d,paused=%d] depthMoves[promotions=%d,wallclockDemotes=%d,acceptanceDemotes=%d]\n",
             depth,
             currentDepth,
             verifyCalls,
@@ -1248,7 +1252,10 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             verifierMode,
             arSafetyTrips,
             arSafetyResumes,
-            arSafetyPaused ? 1 : 0)
+            arSafetyPaused ? 1 : 0,
+            adaptiveDepthPromotionCount,
+            adaptiveWallClockDemotes,
+            adaptiveAcceptanceDemotes)
         FileHandle.standardError.write(Data(line.utf8))
     }
 
@@ -2282,6 +2289,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             {
                 currentDepth -= 1
                 adaptiveDepthDownshiftCount += 1
+                adaptiveWallClockDemotes += 1
                 adaptiveWindow.removeAll(keepingCapacity: true)
                 lastAdaptiveCycleTimestamp = nil
                 windowsSinceUpperProbe = 0
@@ -2298,6 +2306,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         if currentDepth >= 4, acceptanceRatio < depthThreeFloor, !inRestoredGraceWindow {
             currentDepth -= 1
             adaptiveDepthDownshiftCount += 1
+            adaptiveAcceptanceDemotes += 1
             adaptiveWindow.removeAll(keepingCapacity: true)
             lastAdaptiveCycleTimestamp = nil
             windowsSinceUpperProbe = 0
@@ -2309,6 +2318,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         if currentDepth == 3, acceptanceRatio < depthThreeFloor, !inRestoredGraceWindow {
             currentDepth = 2
             adaptiveDepthDownshiftCount += 1
+            adaptiveAcceptanceDemotes += 1
             adaptiveWindow.removeAll(keepingCapacity: true)
             lastAdaptiveCycleTimestamp = nil
             windowsSinceUpperProbe = 0
@@ -2323,6 +2333,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             // itself doesn't.
             currentDepth = 1
             adaptiveDepthDownshiftCount += 1
+            adaptiveAcceptanceDemotes += 1
             adaptiveWindow.removeAll(keepingCapacity: true)
             lastAdaptiveCycleTimestamp = nil
             windowsSinceUpperProbe = 0

--- a/Libraries/MLXLMCommon/SpecDec/ProposalHeadStamp.swift
+++ b/Libraries/MLXLMCommon/SpecDec/ProposalHeadStamp.swift
@@ -48,6 +48,7 @@
 //  the private wiki.)
 //
 
+import CryptoKit
 import Foundation
 import MLX
 import MLXNN
@@ -109,6 +110,45 @@ public enum ProposalHeadVerdict: Equatable, Sendable {
     }
 }
 
+/// A calibrated draft-head sidecar the stamp may declare: pre-quantized
+/// q4/g64 lm_head tensors produced by the converter's imatrix-weighted
+/// refit (measurably better proposal quality than the runtime's RTN
+/// requantize). The artifact is OPTIONAL sugar on top of the verdict:
+/// runtimes unaware of it — and any load where the file is missing, the
+/// sha256 mismatches, or the tensors don't fit the head — keep the RTN
+/// rebuild. Fail-open, silently.
+public struct ProposalHeadDraftArtifact: Codable, Equatable, Sendable {
+    /// Bundle-relative path of the safetensors sidecar. The final layout
+    /// puts it in a SUBFOLDER (`mtp_draft/…`) so the bundle root stays free
+    /// of tensor files that are not model shards.
+    public let file: String
+    /// Hex sha256 of the sidecar file; a mismatch voids the artifact.
+    public let sha256: String
+    public let bits: Int?
+    public let groupSize: Int?
+    public let mode: String?
+    public let acceptanceValidated: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case file, sha256, bits
+        case groupSize = "group_size"
+        case mode
+        case acceptanceValidated = "acceptance_validated"
+    }
+
+    public init(
+        file: String, sha256: String, bits: Int? = nil, groupSize: Int? = nil,
+        mode: String? = nil, acceptanceValidated: Bool? = nil
+    ) {
+        self.file = file
+        self.sha256 = sha256
+        self.bits = bits
+        self.groupSize = groupSize
+        self.mode = mode
+        self.acceptanceValidated = acceptanceValidated
+    }
+}
+
 /// The on-disk stamp. Tolerant decode: any structural surprise reads as
 /// "no stamp" so the load re-derives instead of failing.
 public struct ProposalHeadStamp: Codable, Equatable, Sendable {
@@ -122,11 +162,16 @@ public struct ProposalHeadStamp: Codable, Equatable, Sendable {
     public let proposalBits: Int?
     public let reason: String?
     public let basis: String?
+    /// Converter-shipped calibrated draft sidecar (see
+    /// ``ProposalHeadDraftArtifact``). Runtime-derived stamps never carry
+    /// one — only the converter can attest a calibrated artifact.
+    public let draftArtifact: ProposalHeadDraftArtifact?
 
     enum CodingKeys: String, CodingKey {
         case version, family, source, eligible
         case proposalBits = "proposal_bits"
         case reason, basis
+        case draftArtifact = "draft_artifact"
     }
 
     public init(
@@ -134,7 +179,8 @@ public struct ProposalHeadStamp: Codable, Equatable, Sendable {
         family: String,
         source: ProposalHeadSourceLayout,
         verdict: ProposalHeadVerdict,
-        basis: String?
+        basis: String?,
+        draftArtifact: ProposalHeadDraftArtifact? = nil
     ) {
         self.version = version
         self.family = family
@@ -150,6 +196,7 @@ public struct ProposalHeadStamp: Codable, Equatable, Sendable {
             self.reason = why
         }
         self.basis = basis
+        self.draftArtifact = draftArtifact
     }
 
     public var verdict: ProposalHeadVerdict {
@@ -225,9 +272,12 @@ public protocol NativeMTPProposalHeadInstalling: AnyObject {
     /// The ACTUAL loaded lm_head layout, or nil when the model has no
     /// standalone quantized head (tied/fp heads report `tied`/nil per family).
     var nativeMTPProposalHeadSourceLayout: ProposalHeadSourceLayout? { get }
-    /// Build the low-bit proposal copy from the loaded head and route the
-    /// DRAFT branch through it. Verify paths must be untouched.
-    func installNativeMTPProposalHead(bits: Int)
+    /// Build the low-bit proposal copy and route the DRAFT branch through
+    /// it. When `calibratedDraft` is non-nil it carries the sha-verified
+    /// converter sidecar tensors — install those verbatim; otherwise rebuild
+    /// by RTN (dequantize the loaded head → requantize). Verify paths must
+    /// be untouched either way.
+    func installNativeMTPProposalHead(bits: Int, calibratedDraft: ProposalHeadCalibratedDraft?)
 }
 
 public enum ProposalHeadBootstrap {
@@ -254,6 +304,7 @@ public enum ProposalHeadBootstrap {
         }
 
         let verdict: ProposalHeadVerdict
+        var honoredStamp: ProposalHeadStamp?
         if let stamp = ProposalHeadStamp.load(fromBundleAt: modelDirectory),
             stamp.source == actual
         {
@@ -261,6 +312,7 @@ public enum ProposalHeadBootstrap {
             // is never rewritten (a jang-tools calibrated verdict must not be
             // clobbered by a runtime re-derivation).
             verdict = stamp.verdict
+            honoredStamp = stamp
         } else if isCalibratedBundle {
             verdict = ProposalHeadVerdict.derive(from: actual)
             let fresh = ProposalHeadStamp(
@@ -281,15 +333,116 @@ public enum ProposalHeadBootstrap {
         switch verdict {
         case .eligible(let proposalBits):
             let started = Date()
-            installing.installNativeMTPProposalHead(bits: proposalBits)
+            // The calibrated sidecar is only ever declared by an HONORED
+            // stamp — a runtime re-derivation cannot attest calibration.
+            var calibratedDraft: ProposalHeadCalibratedDraft?
+            if let artifact = honoredStamp?.draftArtifact {
+                calibratedDraft = ProposalHeadCalibratedDraft.loadVerified(
+                    artifact: artifact,
+                    bundleDirectory: modelDirectory,
+                    expectedBits: proposalBits,
+                    expectedGroupSize: actual.groupSize)
+            }
+            installing.installNativeMTPProposalHead(
+                bits: proposalBits, calibratedDraft: calibratedDraft)
             let ms = Int(Date().timeIntervalSince(started) * 1000)
+            let origin = calibratedDraft != nil ? "sidecar, sha-verified" : "RTN rebuild"
             stampLog.info(
-                "proposal head installed for \(modelDirectory.lastPathComponent, privacy: .public): q\(proposalBits)/g\(actual.groupSize) draft-only copy built in \(ms) ms"
+                "proposal head installed for \(modelDirectory.lastPathComponent, privacy: .public): q\(proposalBits)/g\(actual.groupSize) draft-only copy ready in \(ms) ms (origin: \(origin, privacy: .public))"
             )
         case .ineligible(let reason):
             stampLog.info(
                 "proposal head not used for \(modelDirectory.lastPathComponent, privacy: .public): \(reason, privacy: .public)"
             )
         }
+    }
+}
+
+// MARK: - Calibrated draft sidecar
+
+/// Pre-quantized draft-head tensors loaded from a stamp's `draft_artifact`
+/// sidecar, sha256-verified. Consumed by the family install hook in place
+/// of the RTN dequant→requant rebuild.
+public struct ProposalHeadCalibratedDraft {
+    public let weight: MLXArray
+    public let scales: MLXArray
+    public let biases: MLXArray?
+    public let bits: Int
+    public let groupSize: Int
+
+    /// Load + verify a declared sidecar. ANY failure — traversal-unsafe or
+    /// missing file, sha256 mismatch, unreadable tensors, layout fields that
+    /// contradict the verdict — returns nil so the caller silently keeps the
+    /// RTN rebuild. This function must never throw and never block a load on
+    /// anything but the one-pass hash of the artifact itself.
+    public static func loadVerified(
+        artifact: ProposalHeadDraftArtifact,
+        bundleDirectory: URL,
+        expectedBits: Int,
+        expectedGroupSize: Int
+    ) -> ProposalHeadCalibratedDraft? {
+        func reject(_ why: String) -> ProposalHeadCalibratedDraft? {
+            stampLog.info(
+                "draft artifact rejected (\(why, privacy: .public)) — keeping RTN rebuild")
+            return nil
+        }
+        // Declared layout, when present, must agree with the verdict.
+        if let bits = artifact.bits, bits != expectedBits {
+            return reject("declared bits \(bits) != verdict q\(expectedBits)")
+        }
+        if let group = artifact.groupSize, group != expectedGroupSize {
+            return reject("declared group \(group) != head group \(expectedGroupSize)")
+        }
+        if let mode = artifact.mode, mode != QuantizationMode.affine.rawValue {
+            return reject("declared mode \(mode) unsupported")
+        }
+        // Bundle-relative path only; the stamp must not become a probe.
+        guard !artifact.file.hasPrefix("/"), !artifact.file.contains("..") else {
+            return reject("unsafe artifact path")
+        }
+        let url = bundleDirectory.resolvingSymlinksInPath()
+            .appendingPathComponent(artifact.file)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            return reject("missing \(artifact.file)")
+        }
+        guard let digest = sha256Hex(of: url) else {
+            return reject("unreadable \(artifact.file)")
+        }
+        guard digest == artifact.sha256.lowercased() else {
+            return reject("sha256 mismatch for \(artifact.file)")
+        }
+        guard let arrays = try? MLX.loadArrays(url: url) else {
+            return reject("unparseable safetensors \(artifact.file)")
+        }
+        guard let weight = arrays["lm_head.weight"],
+            let scales = arrays["lm_head.scales"]
+        else {
+            return reject("missing lm_head.weight/scales tensors")
+        }
+        return ProposalHeadCalibratedDraft(
+            weight: weight,
+            scales: scales,
+            biases: arrays["lm_head.biases"],
+            bits: expectedBits,
+            groupSize: expectedGroupSize)
+    }
+
+    /// Streaming sha256 of a file (8 MiB chunks), lowercase hex. nil when
+    /// the file cannot be read.
+    static func sha256Hex(of url: URL) -> String? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+        var hasher = SHA256()
+        while true {
+            let chunk: Data?
+            do {
+                chunk = try handle.read(upToCount: 8 * 1024 * 1024)
+            } catch {
+                return nil
+            }
+            guard let chunk, !chunk.isEmpty else { break }
+            hasher.update(data: chunk)
+        }
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
     }
 }

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -3738,7 +3738,9 @@ extension Qwen35: NativeMTPProposalHeadInstalling {
     /// draft routing does not exist yet. Stamping stays truthful (bundle
     /// eligibility is a property of the head); the runtime just logs that it
     /// is not taking the acceleration rather than pretending it did.
-    public func installNativeMTPProposalHead(bits: Int) {
+    public func installNativeMTPProposalHead(
+        bits: Int, calibratedDraft: ProposalHeadCalibratedDraft?
+    ) {
         FileHandle.standardError.write(Data(
             ("[ProposalHead] qwen3_5 head is stamp-eligible (q\(bits)) but draft "
                 + "routing is not implemented for this family yet; drafting stays "

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -1305,13 +1305,25 @@ enum Qwen35Language {
             let B = x.dim(0)
             let L = x.dim(1)
 
-            let qProjOutput = qProj(x)
+            // Verify-tile (workplan W2a): at verify width (1 < L < tile,
+            // B == 1) each projection re-streams its full weight per row
+            // through the qmv kernel; zero-padding M to the tile streams it
+            // once. The pad is sliced off before q/k norms, RoPE, and the
+            // KV cache write, so the cache only ever sees the real rows.
+            // Off unless VMLX_MTP_VERIFY_TILE is set.
+            let qProjOutput = Qwen4ExpVerifyTile.padded(
+                x, family: Qwen4ExpVerifyTile.Family.qwen35
+            ) { qProj($0) }
             let qSplit = qProjOutput.reshaped(B, L, numAttentionHeads, -1).split(parts: 2, axis: -1)
             var queries = qSplit[0]
             let gate = qSplit[1].reshaped(B, L, -1)
 
-            var keys = kProj(x)
-            var values = vProj(x)
+            var keys = Qwen4ExpVerifyTile.padded(
+                x, family: Qwen4ExpVerifyTile.Family.qwen35
+            ) { kProj($0) }
+            var values = Qwen4ExpVerifyTile.padded(
+                x, family: Qwen4ExpVerifyTile.Family.qwen35
+            ) { vProj($0) }
 
             queries = qNorm(queries).transposed(0, 2, 1, 3)
             keys = kNorm(keys.reshaped(B, L, numKeyValueHeads, -1)).transposed(0, 2, 1, 3)
@@ -1382,7 +1394,10 @@ enum Qwen35Language {
             .transposed(0, 2, 1, 3)
             .reshaped(B, L, -1)
 
-            return oProj(compiledSigmoidMultiply(output, gate))
+            return Qwen4ExpVerifyTile.padded(
+                compiledSigmoidMultiply(output, gate),
+                family: Qwen4ExpVerifyTile.Family.qwen35
+            ) { oProj($0) }
         }
     }
 
@@ -1442,9 +1457,11 @@ enum Qwen35Language {
         let convDim: Int
         let fuseDecodeInputProjections: Bool
         /// Verify-tile (workplan W2a) opt-in. GatedDeltaNet is shared across
-        /// the qwen3_5 VLM family; only qwen4_exp passes `true`, keeping the
-        /// experiment family-scoped. See `Qwen4ExpVerifyTile`.
+        /// the qwen3_5 VLM family; each trunk that opts in passes `true`
+        /// plus its own `verifyTileFamily` tag so the one-shot activation
+        /// log names the family that engaged. See `Qwen4ExpVerifyTile`.
         let verifyTilePadding: Bool
+        let verifyTileFamily: String
         private var attemptedDecodeInputFusion = false
         private var fusedDecodeInputProjection: FusedDecodeInputProjection?
 
@@ -1464,7 +1481,8 @@ enum Qwen35Language {
             _ args: Qwen35Configuration.TextConfiguration,
             outputGateSigmoid: Bool = false,
             fuseDecodeInputProjections: Bool = false,
-            verifyTilePadding: Bool = false
+            verifyTilePadding: Bool = false,
+            verifyTileFamily: String = Qwen4ExpVerifyTile.Family.qwen4Exp
         ) {
             self.hiddenSize = args.hiddenSize
             self.numVHeads = args.linearNumValueHeads
@@ -1477,6 +1495,7 @@ enum Qwen35Language {
             self.convDim = keyDim * 2 + valueDim
             self.fuseDecodeInputProjections = fuseDecodeInputProjections
             self.verifyTilePadding = verifyTilePadding
+            self.verifyTileFamily = verifyTileFamily
 
             precondition(
                 numVHeads % numKHeads == 0,
@@ -1976,12 +1995,12 @@ enum Qwen35Language {
         }
 
         /// Verify-tile M-pad for this layer's row-independent projections; a
-        /// no-op unless this instance opted in (qwen4_exp only).
+        /// no-op unless this instance opted in (qwen4_exp and qwen3_5 do).
         private func verifyTiled(
             _ x: MLXArray, _ body: (MLXArray) -> MLXArray
         ) -> MLXArray {
             guard verifyTilePadding else { return body(x) }
-            return Qwen4ExpVerifyTile.padded(x) { body($0) }
+            return Qwen4ExpVerifyTile.padded(x, family: verifyTileFamily) { body($0) }
         }
 
         private func verifyTiledOutput(
@@ -1989,7 +2008,9 @@ enum Qwen35Language {
             _ body: (MLXArray, MLXArray) -> MLXArray
         ) -> MLXArray {
             guard verifyTilePadding else { return body(x, gate) }
-            return Qwen4ExpVerifyTile.padded(x, gate) { body($0, $1) }
+            return Qwen4ExpVerifyTile.padded(x, gate, family: verifyTileFamily) {
+                body($0, $1)
+            }
         }
 
         /// Commit for the STAGED (compile-compatible) verify: the forward
@@ -2389,9 +2410,14 @@ enum Qwen35Language {
                 // out of trace capture. Tying it to compiledDecodeRegions
                 // left every mixed-scheme JANG stamp — including the 27B —
                 // running four decode launches per GDN layer for no reason.
+                // Verify-tile (workplan W2a): pad the GDN's verify-width
+                // projections to the NAX qmm tile. Off unless
+                // VMLX_MTP_VERIFY_TILE is set; see `Qwen4ExpVerifyTile`.
                 _linearAttn.wrappedValue = GatedDeltaNet(
                     args,
-                    fuseDecodeInputProjections: true)
+                    fuseDecodeInputProjections: true,
+                    verifyTilePadding: true,
+                    verifyTileFamily: Qwen4ExpVerifyTile.Family.qwen35)
             } else {
                 _selfAttn.wrappedValue = Attention(args)
             }
@@ -2738,6 +2764,23 @@ enum Qwen35Language {
         fileprivate var precomputedPositionIds: MLXArray? = nil
         fileprivate var ropeDeltas: MLXArray? = nil
 
+        /// The LM-head projection (untied `lm_head` or the tied embedding),
+        /// with verify-tile M-padding (workplan W2a): at verify width every
+        /// head row costs a full qmv stream of the hidden x vocab weight;
+        /// padding M to the NAX tile streams it once for all rows and the
+        /// padded rows are sliced away before the logits leave. Off unless
+        /// VMLX_MTP_VERIFY_TILE is set.
+        fileprivate func headLogits(_ hidden: MLXArray) -> MLXArray {
+            Qwen4ExpVerifyTile.padded(
+                hidden, family: Qwen4ExpVerifyTile.Family.qwen35
+            ) { input in
+                if let lmHead {
+                    return lmHead(input)
+                }
+                return model.embedTokens.asLinear(input)
+            }
+        }
+
         init(_ config: Qwen35Configuration) {
             self.config = config
             self.textConfig = config.textConfiguration
@@ -2914,11 +2957,7 @@ enum Qwen35Language {
                 positionIds: positionIds
             )
 
-            if let lmHead {
-                out = lmHead(out)
-            } else {
-                out = model.embedTokens.asLinear(out)
-            }
+            out = headLogits(out)
 
             return LMOutput(logits: out)
         }
@@ -2973,12 +3012,7 @@ enum Qwen35Language {
                 positionIds: positionIds,
                 captureLayerIDs: captureLayerIDs,
                 recordPrefixCommitStates: recordPrefixCommitStates)
-            let logits: MLXArray
-            if let lmHead {
-                logits = lmHead(hidden)
-            } else {
-                logits = model.embedTokens.asLinear(hidden)
-            }
+            let logits = headLogits(hidden)
             return (logits, captured)
         }
 
@@ -3008,19 +3042,13 @@ enum Qwen35Language {
             let logits: MLXArray
             if NativeMTPPhaseDiagnostics.enabled {
                 let start = Date.timeIntervalSinceReferenceDate
-                if let lmHead {
-                    logits = lmHead(model.norm(hidden))
-                } else {
-                    logits = model.embedTokens.asLinear(model.norm(hidden))
-                }
+                logits = headLogits(model.norm(hidden))
                 MLX.eval(logits)
                 NativeMTPPhaseDiagnostics.record(
                     "vlm_lm_head",
                     seconds: Date.timeIntervalSinceReferenceDate - start)
-            } else if let lmHead {
-                logits = lmHead(model.norm(hidden))
             } else {
-                logits = model.embedTokens.asLinear(model.norm(hidden))
+                logits = headLogits(model.norm(hidden))
             }
             return NativeMTPForwardResult(logits: logits, hiddenStates: hidden)
         }
@@ -3046,12 +3074,7 @@ enum Qwen35Language {
                     seconds: Date.timeIntervalSinceReferenceDate - blockStart)
 
                 let headStart = Date.timeIntervalSinceReferenceDate
-                let logits: MLXArray
-                if let lmHead {
-                    logits = lmHead(mtp.norm(hidden))
-                } else {
-                    logits = model.embedTokens.asLinear(mtp.norm(hidden))
-                }
+                let logits = headLogits(mtp.norm(hidden))
                 MLX.eval(logits)
                 NativeMTPPhaseDiagnostics.record(
                     "vlm_mtp_lm_head",
@@ -3063,12 +3086,7 @@ enum Qwen35Language {
                 nextTokenIds: nextTokenIds,
                 embedTokens: model.embedTokens,
                 cache: cache)
-            let logits: MLXArray
-            if let lmHead {
-                logits = lmHead(mtp.norm(hidden))
-            } else {
-                logits = model.embedTokens.asLinear(mtp.norm(hidden))
-            }
+            let logits = headLogits(mtp.norm(hidden))
             return NativeMTPForwardResult(logits: logits, hiddenStates: hidden)
         }
 

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -1441,6 +1441,10 @@ enum Qwen35Language {
         let convKernelSize: Int
         let convDim: Int
         let fuseDecodeInputProjections: Bool
+        /// Verify-tile (workplan W2a) opt-in. GatedDeltaNet is shared across
+        /// the qwen3_5 VLM family; only qwen4_exp passes `true`, keeping the
+        /// experiment family-scoped. See `Qwen4ExpVerifyTile`.
+        let verifyTilePadding: Bool
         private var attemptedDecodeInputFusion = false
         private var fusedDecodeInputProjection: FusedDecodeInputProjection?
 
@@ -1459,7 +1463,8 @@ enum Qwen35Language {
         init(
             _ args: Qwen35Configuration.TextConfiguration,
             outputGateSigmoid: Bool = false,
-            fuseDecodeInputProjections: Bool = false
+            fuseDecodeInputProjections: Bool = false,
+            verifyTilePadding: Bool = false
         ) {
             self.hiddenSize = args.hiddenSize
             self.numVHeads = args.linearNumValueHeads
@@ -1471,6 +1476,7 @@ enum Qwen35Language {
             self.convKernelSize = args.linearConvKernelDim
             self.convDim = keyDim * 2 + valueDim
             self.fuseDecodeInputProjections = fuseDecodeInputProjections
+            self.verifyTilePadding = verifyTilePadding
 
             precondition(
                 numVHeads % numKHeads == 0,
@@ -1832,11 +1838,11 @@ enum Qwen35Language {
                 }
             } else {
                 let fusedInputs = fusedDecodeInputs(inputs)
-                var mixedQKV = fusedInputs?[0] ?? inProjQKV(inputs)
-                z = (fusedInputs?[1] ?? inProjZ(inputs)).reshaped(
+                var mixedQKV = fusedInputs?[0] ?? verifyTiled(inputs) { inProjQKV($0) }
+                z = (fusedInputs?[1] ?? verifyTiled(inputs) { inProjZ($0) }).reshaped(
                     B, S, numVHeads, headVDim)
-                b = fusedInputs?[2] ?? inProjB(inputs)
-                a = fusedInputs?[3] ?? inProjA(inputs)
+                b = fusedInputs?[2] ?? verifyTiled(inputs) { inProjB($0) }
+                a = fusedInputs?[3] ?? verifyTiled(inputs) { inProjA($0) }
 
                 if let mask {
                     mixedQKV = MLX.where(mask[.ellipsis, .newAxis], mixedQKV, 0)
@@ -1955,9 +1961,35 @@ enum Qwen35Language {
                 }
             }
 
-            if let tail = compiledDecodeTail(out, gate: z) { return tail }
-            out = norm(out, gate: z)
-            return outProj(out.reshaped(B, S, -1))
+            // Verify-tile (workplan W2a): norm-with-gate is rowwise and
+            // outProj is a row-independent matmul, so the whole output stage
+            // may run at padded M and be sliced back afterwards. All cache
+            // and staging writes above already saw only the real rows.
+            return verifyTiledOutput(out, gate: z) { paddedOut, paddedGate in
+                if let tail = compiledDecodeTail(paddedOut, gate: paddedGate) {
+                    return tail
+                }
+                let normed = norm(paddedOut, gate: paddedGate)
+                return outProj(
+                    normed.reshaped(normed.dim(0), normed.dim(1), -1))
+            }
+        }
+
+        /// Verify-tile M-pad for this layer's row-independent projections; a
+        /// no-op unless this instance opted in (qwen4_exp only).
+        private func verifyTiled(
+            _ x: MLXArray, _ body: (MLXArray) -> MLXArray
+        ) -> MLXArray {
+            guard verifyTilePadding else { return body(x) }
+            return Qwen4ExpVerifyTile.padded(x) { body($0) }
+        }
+
+        private func verifyTiledOutput(
+            _ x: MLXArray, gate: MLXArray,
+            _ body: (MLXArray, MLXArray) -> MLXArray
+        ) -> MLXArray {
+            guard verifyTilePadding else { return body(x, gate) }
+            return Qwen4ExpVerifyTile.padded(x, gate) { body($0, $1) }
         }
 
         /// Commit for the STAGED (compile-compatible) verify: the forward

--- a/Libraries/MLXVLM/Models/Qwen4Exp.swift
+++ b/Libraries/MLXVLM/Models/Qwen4Exp.swift
@@ -903,7 +903,7 @@ private final class Qwen4ExpQSAIndexer: Module {
         let B = x.dim(0), S = x.dim(1)
         precondition(B == 1, "qwen4_exp QSA currently supports batch size 1")
         let past = cache?.offset ?? 0
-        let qk = projection(x)
+        let qk = Qwen4ExpVerifyTile.padded(x) { projection($0) }
         let split = MLX.split(
             qk, indices: [extras.indexerNHeads * extras.indexerHeadDim], axis: -1)
         let rawKeys = split[1]
@@ -1015,13 +1015,21 @@ private final class Qwen4ExpAttention: Module {
         let past = cache?.offset ?? 0
         let sparseMask = indexer(x, cache: cache)
         let headDim = text.headDim ?? (text.hiddenSize / text.attentionHeads)
-        let qg = qProj(x).reshaped(B, S, text.attentionHeads, headDim * 2)
+        // Verify-tile (workplan W2a): the projections are row-independent
+        // weight matmuls, so their M dimension may be padded to the NAX tile
+        // and sliced back before any reshape, rope, cache, or SDPA touches
+        // the rows. Off by default; see `Qwen4ExpVerifyTile`.
+        let qg = Qwen4ExpVerifyTile.padded(x) { qProj($0) }
+            .reshaped(B, S, text.attentionHeads, headDim * 2)
             .split(parts: 2, axis: -1)
         var query = qNorm(qg[0]).transposed(0, 2, 1, 3)
         let gate = qg[1].reshaped(B, S, -1)
-        var key = kNorm(kProj(x).reshaped(B, S, text.kvHeads, headDim))
-            .transposed(0, 2, 1, 3)
-        let value = vProj(x).reshaped(B, S, text.kvHeads, headDim).transposed(0, 2, 1, 3)
+        var key = kNorm(
+            Qwen4ExpVerifyTile.padded(x) { kProj($0) }
+                .reshaped(B, S, text.kvHeads, headDim)
+        ).transposed(0, 2, 1, 3)
+        let value = Qwen4ExpVerifyTile.padded(x) { vProj($0) }
+            .reshaped(B, S, text.kvHeads, headDim).transposed(0, 2, 1, 3)
         // Media prefill passes explicit 3-channel M-RoPE positions from
         // getRopeIndex; decode after media continues from past + ropeDelta.
         // Text-only keeps the sequential cache-offset positions (offset 0).
@@ -1054,7 +1062,7 @@ private final class Qwen4ExpAttention: Module {
             queries: query, keys: key, values: value, cache: cache,
             scale: scale, mask: mask)
             .transposed(0, 2, 1, 3).reshaped(B, S, -1)
-        return oProj(output * sigmoid(gate))
+        return Qwen4ExpVerifyTile.padded(output * sigmoid(gate)) { oProj($0) }
     }
 }
 
@@ -1084,7 +1092,8 @@ private final class Qwen4ExpDecoderLayer: Module {
         if isLinear {
             _linearAttention.wrappedValue = Qwen35Language.GatedDeltaNet(
                 text, outputGateSigmoid: config.extras.outputGateType == "sigmoid",
-                fuseDecodeInputProjections: true)
+                fuseDecodeInputProjections: true,
+                verifyTilePadding: true)
         } else {
             _attention.wrappedValue = Qwen4ExpAttention(config)
         }
@@ -1723,7 +1732,10 @@ public final class Qwen4Exp: Module, VLMModel, Qwen4ExpModelDirectoryConfigurabl
     }
 
     private func projectToLogits(_ headInput: MLXArray) -> MLXArray {
-        let logits = head(headInput)
+        // Verify-tile (workplan W2a): at verify width every lm_head row costs
+        // a full qmv stream of the 5120x248320 head; padding M to the NAX
+        // tile streams it once for all rows. Off by default.
+        let logits = Qwen4ExpVerifyTile.padded(headInput) { head($0) }
         let result: MLXArray
         guard let computeDType = config.declaredComputeDType,
             logits.dtype != computeDType

--- a/Libraries/MLXVLM/Models/Qwen4Exp.swift
+++ b/Libraries/MLXVLM/Models/Qwen4Exp.swift
@@ -1,5 +1,6 @@
 // Copyright © 2026 Apple Inc.
 
+import CryptoKit
 import Foundation
 import MLX
 import MLXLMCommon
@@ -1946,12 +1947,17 @@ extension Qwen4Exp: NativeMTPProposalHeadInstalling {
         )
     }
 
-    /// Dequantize the calibrated checkpoint head and requantize at the
-    /// stamp's proposal bits (same group size / affine mode). The AWQ
-    /// equalization is folded into the stored weights at conversion, so the
-    /// requantized copy inherits the calibration. Draft-only by
-    /// construction: only `nativeMTPForward` reads `proposalHead`.
-    public func installNativeMTPProposalHead(bits: Int) {
+    /// Install the draft-only proposal head. Preferred source is the
+    /// converter's sha-verified calibrated sidecar (imatrix-weighted refit —
+    /// measurably lower weighted NMSE than RTN); fallback is the RTN
+    /// rebuild: dequantize the calibrated checkpoint head and requantize at
+    /// the stamp's proposal bits (same group size / affine mode — the AWQ
+    /// equalization is folded into the stored weights, so even the RTN copy
+    /// inherits calibration). Draft-only by construction: only
+    /// `nativeMTPForward` reads `proposalHead`.
+    public func installNativeMTPProposalHead(
+        bits: Int, calibratedDraft: ProposalHeadCalibratedDraft?
+    ) {
         // No MTP module loaded (loadPreservedMTP off / MTP-less bundle) means
         // nativeMTPForward can never run — building a permanently resident
         // low-bit head copy (plus a ~1 GB transient dequantized peak) would
@@ -1962,6 +1968,16 @@ extension Qwen4Exp: NativeMTPProposalHeadInstalling {
             return
         }
         guard let quantized = head as? QuantizedLinear else { return }
+
+        if let draft = calibratedDraft,
+            let copy = calibratedProposalHead(from: draft, matching: quantized)
+        {
+            eval(copy.weight, copy.scales)
+            proposalHead = copy
+            logProposalHeadDigestIfRequested(copy, origin: "sidecar")
+            return
+        }
+
         let full = dequantized(
             quantized.weight,
             scales: quantized.scales,
@@ -1981,5 +1997,69 @@ extension Qwen4Exp: NativeMTPProposalHeadInstalling {
         // the first draft token.
         eval(copy.weight, copy.scales)
         proposalHead = copy
+        logProposalHeadDigestIfRequested(copy, origin: "rtn")
+    }
+
+    /// `VMLX_PROPOSAL_HEAD_DIGEST=1`: log sha256 of the INSTALLED packed
+    /// tensors so a harness can byte-compare them against the sidecar file's
+    /// tensor payloads offline. RTN produces different q4 codes than the
+    /// imatrix-weighted refit, so digest equality with the sidecar is hard
+    /// proof the calibrated head is live (and inequality proves RTN). Debug
+    /// aid only — costs one hash pass, gated off by default.
+    private func logProposalHeadDigestIfRequested(_ copy: QuantizedLinear, origin: String) {
+        guard ProcessInfo.processInfo.environment["VMLX_PROPOSAL_HEAD_DIGEST"] == "1"
+        else { return }
+        func digest(_ array: MLXArray) -> String {
+            let data = array.asData(access: .copy).data
+            var hasher = SHA256()
+            hasher.update(data: data)
+            return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+        }
+        FileHandle.standardError.write(Data(
+            ("[ProposalHead] digest origin=\(origin) "
+                + "weight=\(digest(copy.weight)) "
+                + "scales=\(digest(copy.scales)) "
+                + "biases=\(copy.biases.map(digest) ?? "none")\n").utf8))
+    }
+
+    /// Adopt the sidecar tensors verbatim as the proposal head, but only
+    /// when their shapes actually describe THIS head (out rows equal, packed
+    /// q-bits column arithmetic consistent with the head's input width).
+    /// A shape surprise silently yields nil → the RTN rebuild proceeds.
+    private func calibratedProposalHead(
+        from draft: ProposalHeadCalibratedDraft, matching head: QuantizedLinear
+    ) -> QuantizedLinear? {
+        let inFeatures = head.scales.dim(1) * head.groupSize
+        let outFeatures = head.scales.dim(0)
+        func rejected(_ why: String) -> QuantizedLinear? {
+            FileHandle.standardError.write(Data(
+                "[ProposalHead] calibrated sidecar shape rejected (\(why)) — RTN rebuild\n".utf8))
+            return nil
+        }
+        guard draft.weight.ndim == 2, draft.scales.ndim == 2 else {
+            return rejected("tensor rank")
+        }
+        guard draft.weight.dim(0) == outFeatures, draft.scales.dim(0) == outFeatures else {
+            return rejected(
+                "out rows \(draft.weight.dim(0)) vs head \(outFeatures)")
+        }
+        guard draft.scales.dim(1) * draft.groupSize == inFeatures else {
+            return rejected(
+                "group cols \(draft.scales.dim(1))×g\(draft.groupSize) vs in \(inFeatures)")
+        }
+        guard draft.weight.dim(1) * 32 == inFeatures * draft.bits else {
+            return rejected(
+                "packed cols \(draft.weight.dim(1)) vs q\(draft.bits) over in \(inFeatures)")
+        }
+        let copy = QuantizedLinear(
+            weight: draft.weight,
+            bias: head.bias,
+            scales: draft.scales,
+            biases: draft.biases,
+            groupSize: draft.groupSize,
+            bits: draft.bits,
+            mode: head.mode
+        )
+        return copy
     }
 }

--- a/Libraries/MLXVLM/Models/Qwen4ExpVerifyTile.swift
+++ b/Libraries/MLXVLM/Models/Qwen4ExpVerifyTile.swift
@@ -26,10 +26,18 @@ import MLXLMCommon
 /// Gate: `VMLX_MTP_VERIFY_TILE=<rows>` (16 recommended; 8 stays BELOW the
 /// qmv→qmm floor for the large trunk matmuls on M5-class devices and only
 /// helps if the floor is lower on the running device), `off`/`0`/unset
-/// disables. Family-scoped: only qwen4_exp call sites consult this, and the
-/// shared GatedDeltaNet participates only when constructed with
-/// `verifyTilePadding: true` (which only Qwen4Exp passes).
+/// disables. Family-scoped by call site: qwen4_exp (QSA q/k/v/o + indexer,
+/// GDN, lm_head) and qwen3_5 (attention q/k/v/o, GDN, lm_head) each pass
+/// their own `family` tag so the one-shot activation log names the trunk
+/// that engaged; the shared GatedDeltaNet participates only when constructed
+/// with `verifyTilePadding: true`. Routed MoE never consults this.
 enum Qwen4ExpVerifyTile {
+    /// Activation-log tags. One line per family per process.
+    enum Family {
+        static let qwen4Exp = "Qwen4Exp"
+        static let qwen35 = "Qwen35"
+    }
+
     /// Rows to pad verify-width matmuls to; `nil` = disabled (the default).
     /// Read once from the environment; mutable ONLY so focused tests can
     /// exercise the padded path without process-level env plumbing.
@@ -52,16 +60,15 @@ enum Qwen4ExpVerifyTile {
     }
 
     private static let activationLogLock = NSLock()
-    private nonisolated(unsafe) static var didReportActivation = false
+    private nonisolated(unsafe) static var reportedFamilies: Set<String> = []
 
-    private static func reportActivation(tile: Int) {
+    private static func reportActivation(tile: Int, family: String) {
         activationLogLock.lock()
         defer { activationLogLock.unlock() }
-        guard !didReportActivation else { return }
-        didReportActivation = true
+        guard reportedFamilies.insert(family).inserted else { return }
         FileHandle.standardError.write(
             Data(
-                "[Qwen4Exp] verify_tile=\(tile) path=m-pad\n".utf8))
+                "[\(family)] verify_tile=\(tile) path=m-pad\n".utf8))
     }
 
     /// Runs `body` — a row-independent weight matmul over the axis-1 rows of
@@ -70,7 +77,8 @@ enum Qwen4ExpVerifyTile {
     /// when the gate is off, `S == 1` (AR decode: qmv IS the right kernel),
     /// `S >= tile` (prefill / already at the tile), or batch > 1.
     static func padded(
-        _ x: MLXArray, tile: Int? = rows, _ body: (MLXArray) -> MLXArray
+        _ x: MLXArray, tile: Int? = rows, family: String = Family.qwen4Exp,
+        _ body: (MLXArray) -> MLXArray
     ) -> MLXArray {
         guard let tile, x.ndim >= 2, x.dim(0) == 1 else { return body(x) }
         let s = x.dim(1)
@@ -80,7 +88,7 @@ enum Qwen4ExpVerifyTile {
         let out = body(
             concatenated(
                 [x, MLXArray.zeros(padShape, dtype: x.dtype)], axis: 1))
-        reportActivation(tile: tile)
+        reportActivation(tile: tile, family: family)
         return out[0..., ..<s]
     }
 
@@ -89,6 +97,7 @@ enum Qwen4ExpVerifyTile {
     /// the result is sliced back to the real rows.
     static func padded(
         _ x: MLXArray, _ gate: MLXArray, tile: Int? = rows,
+        family: String = Family.qwen4Exp,
         _ body: (MLXArray, MLXArray) -> MLXArray
     ) -> MLXArray {
         guard let tile, x.ndim >= 2, x.dim(0) == 1, gate.ndim >= 2,
@@ -103,7 +112,7 @@ enum Qwen4ExpVerifyTile {
         let out = body(
             concatenated([x, MLXArray.zeros(xPad, dtype: x.dtype)], axis: 1),
             concatenated([gate, MLXArray.zeros(gatePad, dtype: gate.dtype)], axis: 1))
-        reportActivation(tile: tile)
+        reportActivation(tile: tile, family: family)
         return out[0..., ..<s]
     }
 }

--- a/Libraries/MLXVLM/Models/Qwen4ExpVerifyTile.swift
+++ b/Libraries/MLXVLM/Models/Qwen4ExpVerifyTile.swift
@@ -1,0 +1,109 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXLMCommon
+
+/// MTP verify-tile M-padding (workplan W2a).
+///
+/// Native MTP verify forwards run `depth + 1` rows (2–6). MLX only takes the
+/// NAX qmm tile path when `M >= get_qmv_batch_limit` — 10–12 for this trunk's
+/// K/N on an M5 Max (`Source/Cmlx/mlx/mlx/backend/metal/quantized.cpp:87`,
+/// dispatch at `:1406-1425`); below the limit every row runs the qmv vector
+/// kernel, which re-streams the full dense weight per row. Zero-padding ONLY
+/// the M dimension of row-independent weight matmuls up to the tile turns
+/// those S weight passes into one 64-row NAX M-tile pass, so the extra verify
+/// rows become ~free where weight streaming dominates.
+///
+/// Safety: the pad wraps pure matmuls (QKV/out projections, GDN input/output
+/// projections, lm_head) and the padded rows are sliced away before ANY cache
+/// write, norm-state recording, or attention interaction — KV/GDN caches and
+/// emitted logits only ever see the real rows. The real rows' values are
+/// mathematically exact (rows of a linear map are independent); the kernel
+/// switch (qmv → qmm/NAX) can shift low-order bits versus the unpadded path,
+/// which is why the gate defaults OFF and exists for a measured A/B.
+///
+/// Gate: `VMLX_MTP_VERIFY_TILE=<rows>` (16 recommended; 8 stays BELOW the
+/// qmv→qmm floor for the large trunk matmuls on M5-class devices and only
+/// helps if the floor is lower on the running device), `off`/`0`/unset
+/// disables. Family-scoped: only qwen4_exp call sites consult this, and the
+/// shared GatedDeltaNet participates only when constructed with
+/// `verifyTilePadding: true` (which only Qwen4Exp passes).
+enum Qwen4ExpVerifyTile {
+    /// Rows to pad verify-width matmuls to; `nil` = disabled (the default).
+    /// Read once from the environment; mutable ONLY so focused tests can
+    /// exercise the padded path without process-level env plumbing.
+    nonisolated(unsafe) static var rows: Int? = parse(
+        RuntimeEnvironment.value("VMLX_MTP_VERIFY_TILE"))
+
+    static func parse(_ raw: String?) -> Int? {
+        guard
+            let raw = raw?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased(),
+            !raw.isEmpty, raw != "off", raw != "0"
+        else { return nil }
+        guard let value = Int(raw), (2 ... 64).contains(value) else {
+            FileHandle.standardError.write(
+                Data(
+                    ("[Qwen4Exp] verify_tile: ignoring VMLX_MTP_VERIFY_TILE=\(raw) "
+                        + "(expected 2-64, or off)\n").utf8))
+            return nil
+        }
+        return value
+    }
+
+    private static let activationLogLock = NSLock()
+    private nonisolated(unsafe) static var didReportActivation = false
+
+    private static func reportActivation(tile: Int) {
+        activationLogLock.lock()
+        defer { activationLogLock.unlock() }
+        guard !didReportActivation else { return }
+        didReportActivation = true
+        FileHandle.standardError.write(
+            Data(
+                "[Qwen4Exp] verify_tile=\(tile) path=m-pad\n".utf8))
+    }
+
+    /// Runs `body` — a row-independent weight matmul over the axis-1 rows of
+    /// a `[1, S, *]` activation — with S zero-padded up to `tile`, then
+    /// slices the result back to the original S rows. Falls through untouched
+    /// when the gate is off, `S == 1` (AR decode: qmv IS the right kernel),
+    /// `S >= tile` (prefill / already at the tile), or batch > 1.
+    static func padded(
+        _ x: MLXArray, tile: Int? = rows, _ body: (MLXArray) -> MLXArray
+    ) -> MLXArray {
+        guard let tile, x.ndim >= 2, x.dim(0) == 1 else { return body(x) }
+        let s = x.dim(1)
+        guard s > 1, s < tile else { return body(x) }
+        var padShape = x.shape
+        padShape[1] = tile - s
+        let out = body(
+            concatenated(
+                [x, MLXArray.zeros(padShape, dtype: x.dtype)], axis: 1))
+        reportActivation(tile: tile)
+        return out[0..., ..<s]
+    }
+
+    /// Two-input form for the GDN output stage, where the projection consumes
+    /// the scan output and its gate together. Both are padded on axis 1 and
+    /// the result is sliced back to the real rows.
+    static func padded(
+        _ x: MLXArray, _ gate: MLXArray, tile: Int? = rows,
+        _ body: (MLXArray, MLXArray) -> MLXArray
+    ) -> MLXArray {
+        guard let tile, x.ndim >= 2, x.dim(0) == 1, gate.ndim >= 2,
+            gate.dim(0) == 1, gate.dim(1) == x.dim(1)
+        else { return body(x, gate) }
+        let s = x.dim(1)
+        guard s > 1, s < tile else { return body(x, gate) }
+        var xPad = x.shape
+        xPad[1] = tile - s
+        var gatePad = gate.shape
+        gatePad[1] = tile - s
+        let out = body(
+            concatenated([x, MLXArray.zeros(xPad, dtype: x.dtype)], axis: 1),
+            concatenated([gate, MLXArray.zeros(gatePad, dtype: gate.dtype)], axis: 1))
+        reportActivation(tile: tile)
+        return out[0..., ..<s]
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -848,6 +848,7 @@ let package = Package(
             path: "Tests/MLXLMCommonFocusedTests",
             sources: [
                 "ProposalHeadStampTests.swift",
+                "NativeMTPARSafetyTests.swift",
                 "DualPathFamiliesTests.swift",
                 "Qwen35FusedInputProjectionTests.swift",
                 "MLADecodeSDPADtypeTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/NativeMTPARSafetyTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NativeMTPARSafetyTests.swift
@@ -1,0 +1,80 @@
+//
+//  NativeMTPARSafetyTests.swift
+//  MLXLMCommonFocusedTests
+//
+//  Pins the AR-safety governor's pure decision arithmetic — a 1:1 port of
+//  the Python engine's tests/test_native_mtp_ar_safety.py so both runtimes
+//  trip on the same numbers: fast MTP holds, slow MTP trips, long-context
+//  growth does NOT false-trip, and the div-by-small/empty guards.
+//
+
+import XCTest
+
+@testable import MLXLMCommon
+
+final class NativeMTPARSafetyTests: XCTestCase {
+
+    private typealias V = NativeMTPTokenIterator
+
+    func testFastMTPHolds() {
+        // MTP at 5ms/tok, AR seed 10ms, no context growth -> MTP is 2x faster.
+        XCTAssertNil(
+            V.windowedARVerdict(
+                arStepMs: 10, firstVerifyMs: 12, windowCycles: 16,
+                deltaEmitted: 32, deltaWallMs: 160, deltaVerifyMs: 12 * 16, margin: 1.25))
+    }
+
+    func testSlowMTPTrips() {
+        // MTP at 20ms/tok vs AR 10ms (flat context) -> 2x slower, must trip.
+        let v = V.windowedARVerdict(
+            arStepMs: 10, firstVerifyMs: 12, windowCycles: 16,
+            deltaEmitted: 16, deltaWallMs: 320, deltaVerifyMs: 12 * 16, margin: 1.25)
+        XCTAssertNotNil(v)
+        XCTAssertEqual(v?.mtpMsPerToken ?? 0, 20, accuracy: 1e-6)
+        XCTAssertEqual(v?.arBaselineMs ?? 0, 10, accuracy: 1e-6)
+    }
+
+    func testLongContextDoesNotFalseTrip() {
+        // Verify doubled (24 vs 12) -> AR baseline scales to 20; MTP at 18
+        // is still worth it (18 < 20 * 1.25). A stale short-context baseline
+        // WOULD have tripped (18 > 10 * 1.25) — the context-fairness fix.
+        XCTAssertNil(
+            V.windowedARVerdict(
+                arStepMs: 10, firstVerifyMs: 12, windowCycles: 16,
+                deltaEmitted: 16, deltaWallMs: 288, deltaVerifyMs: 24 * 16, margin: 1.25))
+        XCTAssertNotNil(
+            V.windowedARVerdict(
+                arStepMs: 10, firstVerifyMs: 0, windowCycles: 16,
+                deltaEmitted: 16, deltaWallMs: 288, deltaVerifyMs: 24 * 16, margin: 1.25),
+            "no scaling -> stale baseline -> trips")
+    }
+
+    func testContextScaledSlowStillTrips() {
+        // Even with context growth (baseline 20), MTP at 30ms/tok loses.
+        let v = V.windowedARVerdict(
+            arStepMs: 10, firstVerifyMs: 12, windowCycles: 16,
+            deltaEmitted: 16, deltaWallMs: 480, deltaVerifyMs: 24 * 16, margin: 1.25)
+        XCTAssertEqual(v?.mtpMsPerToken ?? 0, 30, accuracy: 1e-6)
+        XCTAssertEqual(v?.arBaselineMs ?? 0, 20, accuracy: 1e-6)
+    }
+
+    func testGuardsNeverDivide() {
+        for (emitted, wall, ar, cycles) in [(0, 100.0, 10.0, 16), (16, 0.0, 10.0, 16),
+                                            (16, 100.0, 0.0, 16), (16, 100.0, 10.0, 0)] {
+            XCTAssertNil(
+                V.windowedARVerdict(
+                    arStepMs: ar, firstVerifyMs: 12, windowCycles: cycles,
+                    deltaEmitted: emitted, deltaWallMs: wall, deltaVerifyMs: 192, margin: 1.25),
+                "emitted=\(emitted) wall=\(wall) ar=\(ar) cycles=\(cycles) must not judge")
+        }
+    }
+
+    func testContextScaleNeverMakesBaselineCheaper() {
+        // Verify got FASTER than the first cycle (cache warmed): scale clamps
+        // at 1.0 so the baseline never drops below the seed AR step.
+        let v = V.windowedARVerdict(
+            arStepMs: 10, firstVerifyMs: 12, windowCycles: 16,
+            deltaEmitted: 16, deltaWallMs: 320, deltaVerifyMs: 6 * 16, margin: 1.25)
+        XCTAssertEqual(v?.arBaselineMs ?? 0, 10, accuracy: 1e-6)
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/ProposalHeadStampTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/ProposalHeadStampTests.swift
@@ -181,10 +181,14 @@ final class ProposalHeadStampTests: XCTestCase {
 private final class HeadDouble: NativeMTPProposalHeadInstalling {
     let layout: ProposalHeadSourceLayout?
     private(set) var installedBits: [Int] = []
+    private(set) var installedDrafts: [ProposalHeadCalibratedDraft?] = []
     init(layout: ProposalHeadSourceLayout?) { self.layout = layout }
     var nativeMTPProposalHeadFamily: String { "qwen4_exp" }
     var nativeMTPProposalHeadSourceLayout: ProposalHeadSourceLayout? { layout }
-    func installNativeMTPProposalHead(bits: Int) { installedBits.append(bits) }
+    func installNativeMTPProposalHead(bits: Int, calibratedDraft: ProposalHeadCalibratedDraft?) {
+        installedBits.append(bits)
+        installedDrafts.append(calibratedDraft)
+    }
 }
 
 extension ProposalHeadStampTests {
@@ -297,5 +301,174 @@ extension ProposalHeadStampTests {
         ProposalHeadBootstrap.ensure(
             model: second, modelDirectory: dir, isCalibratedBundle: false)
         XCTAssertEqual(second.installedBits, [4])
+    }
+}
+
+// MARK: - Calibrated draft sidecar (draft_artifact, 2026-09-04 final layout)
+
+extension ProposalHeadStampTests {
+
+    private var ericFullStampJSON: String {
+        """
+        {
+         "version": 1,
+         "family": "qwen4_exp",
+         "source": { "bits": 8, "group_size": 64, "mode": "affine", "tied": false },
+         "eligible": true,
+         "proposal_bits": 4,
+         "basis": "settled 2026-09-03 A/B on Qwen3.8-Flash-Next-JANG_4S fixed-D3",
+         "draft_artifact": {
+          "file": "mtp_draft/vmlx_mtp_proposal_head.safetensors",
+          "sha256": "b05e7c98c4985c85a91518892ed78a62f017d73c1b8007382fa1bf343de4dc3f",
+          "bits": 4,
+          "group_size": 64,
+          "mode": "affine",
+          "method": "imatrix-weighted affine ALS refit",
+          "imatrix": "q38fn-calib/capture/diag.safetensors lm_head.diag",
+          "weighted_nmse": { "rtn_q4": 0.0043, "calibrated_q4": 0.0023 },
+          "acceptance_validated": false,
+          "notes": "fall back to RTN on mismatch"
+         }
+        }
+        """
+    }
+
+    /// The exact shipped stamp (extra artifact fields and all) decodes, the
+    /// verdict is unchanged, and the artifact's contract fields surface.
+    func testShippedDraftArtifactStampDecodes() throws {
+        let dir = try makeBundleDir()
+        try ericFullStampJSON.write(
+            to: dir.appendingPathComponent(ProposalHeadStamp.fileName),
+            atomically: true, encoding: .utf8)
+        let stamp = ProposalHeadStamp.load(fromBundleAt: dir)
+        XCTAssertEqual(stamp?.verdict, .eligible(proposalBits: 4))
+        let artifact = try XCTUnwrap(stamp?.draftArtifact)
+        XCTAssertEqual(artifact.file, "mtp_draft/vmlx_mtp_proposal_head.safetensors")
+        XCTAssertEqual(
+            artifact.sha256,
+            "b05e7c98c4985c85a91518892ed78a62f017d73c1b8007382fa1bf343de4dc3f")
+        XCTAssertEqual(artifact.bits, 4)
+        XCTAssertEqual(artifact.groupSize, 64)
+        XCTAssertEqual(artifact.acceptanceValidated, false)
+    }
+
+    /// A stamp WITHOUT the artifact block still decodes (artifact nil) and a
+    /// runtime-derived stamp never invents one.
+    func testArtifactlessStampDecodesAndRuntimeStampCarriesNone() throws {
+        let dir = try makeBundleDir()
+        let source = ProposalHeadSourceLayout(
+            bits: 8, groupSize: 64, mode: "affine", tied: false)
+        ProposalHeadStamp(
+            family: "qwen4_exp", source: source,
+            verdict: .derive(from: source), basis: "unit-test"
+        ).write(toBundleAt: dir)
+        let loaded = ProposalHeadStamp.load(fromBundleAt: dir)
+        XCTAssertNil(loaded?.draftArtifact)
+        let raw = try String(
+            contentsOf: dir.appendingPathComponent(ProposalHeadStamp.fileName),
+            encoding: .utf8)
+        XCTAssertFalse(raw.contains("draft_artifact"))
+    }
+
+    /// Escape-shaped artifact paths must be rejected before any I/O.
+    func testDraftArtifactRejectsUnsafePaths() {
+        for path in ["/etc/passwd", "../outside.safetensors", "a/../../b.safetensors"] {
+            let artifact = ProposalHeadDraftArtifact(file: path, sha256: "00")
+            XCTAssertNil(
+                ProposalHeadCalibratedDraft.loadVerified(
+                    artifact: artifact,
+                    bundleDirectory: FileManager.default.temporaryDirectory,
+                    expectedBits: 4, expectedGroupSize: 64),
+                "\(path) must be rejected")
+        }
+    }
+
+    /// Missing file and sha mismatch both silently void the artifact.
+    func testDraftArtifactMissingFileAndShaMismatchFallBack() throws {
+        let dir = try makeBundleDir()
+        // Missing file.
+        XCTAssertNil(
+            ProposalHeadCalibratedDraft.loadVerified(
+                artifact: ProposalHeadDraftArtifact(
+                    file: "mtp_draft/vmlx_mtp_proposal_head.safetensors", sha256: "ab"),
+                bundleDirectory: dir, expectedBits: 4, expectedGroupSize: 64))
+        // Present but wrong hash.
+        let sub = dir.appendingPathComponent("mtp_draft", isDirectory: true)
+        try FileManager.default.createDirectory(at: sub, withIntermediateDirectories: true)
+        let file = sub.appendingPathComponent("vmlx_mtp_proposal_head.safetensors")
+        try Data("not the artifact".utf8).write(to: file)
+        XCTAssertNil(
+            ProposalHeadCalibratedDraft.loadVerified(
+                artifact: ProposalHeadDraftArtifact(
+                    file: "mtp_draft/vmlx_mtp_proposal_head.safetensors",
+                    sha256: String(repeating: "0", count: 64)),
+                bundleDirectory: dir, expectedBits: 4, expectedGroupSize: 64))
+    }
+
+    /// Declared layout fields that contradict the verdict void the artifact
+    /// without touching the file system.
+    func testDraftArtifactLayoutContradictionsFallBack() {
+        let dir = FileManager.default.temporaryDirectory
+        XCTAssertNil(
+            ProposalHeadCalibratedDraft.loadVerified(
+                artifact: ProposalHeadDraftArtifact(
+                    file: "mtp_draft/x.safetensors", sha256: "ab", bits: 8),
+                bundleDirectory: dir, expectedBits: 4, expectedGroupSize: 64))
+        XCTAssertNil(
+            ProposalHeadCalibratedDraft.loadVerified(
+                artifact: ProposalHeadDraftArtifact(
+                    file: "mtp_draft/x.safetensors", sha256: "ab", groupSize: 128),
+                bundleDirectory: dir, expectedBits: 4, expectedGroupSize: 64))
+        XCTAssertNil(
+            ProposalHeadCalibratedDraft.loadVerified(
+                artifact: ProposalHeadDraftArtifact(
+                    file: "mtp_draft/x.safetensors", sha256: "ab", mode: "mxfp4"),
+                bundleDirectory: dir, expectedBits: 4, expectedGroupSize: 64))
+    }
+
+    /// The streaming hasher agrees with a known digest.
+    func testSha256HexMatchesKnownVector() throws {
+        let dir = try makeBundleDir()
+        let file = dir.appendingPathComponent("v.bin")
+        try Data("abc".utf8).write(to: file)
+        XCTAssertEqual(
+            ProposalHeadCalibratedDraft.sha256Hex(of: file),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
+    }
+}
+
+// MARK: - Index-manifest shard selection (final layout, 2026-09-04)
+
+extension ProposalHeadStampTests {
+
+    /// weight_map file values are the load manifest: unique, sorted, and
+    /// escape-shaped entries dropped.
+    func testIndexedShardFileNamesSelectsExactlyTheMappedFiles() throws {
+        let dir = try makeBundleDir()
+        let index: [String: Any] = [
+            "weight_map": [
+                "model.embed_tokens.weight": "model-00001-of-00002.safetensors",
+                "mtp.layers.0.weight": "model-00002-of-00002.safetensors",
+                "lm_head.weight": "model-00002-of-00002.safetensors",
+                "evil": "../outside.safetensors",
+                "evil2": "/abs.safetensors",
+            ]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: index)
+        try data.write(to: dir.appendingPathComponent("model.safetensors.index.json"))
+        XCTAssertEqual(
+            indexedShardFileNames(at: dir),
+            ["model-00001-of-00002.safetensors", "model-00002-of-00002.safetensors"])
+    }
+
+    /// No index (or an unreadable one) means no manifest — the caller keeps
+    /// the legacy directory-scan path.
+    func testIndexedShardFileNamesNilWithoutAnIndex() throws {
+        let dir = try makeBundleDir()
+        XCTAssertNil(indexedShardFileNames(at: dir))
+        try "corrupt {".write(
+            to: dir.appendingPathComponent("model.safetensors.index.json"),
+            atomically: true, encoding: .utf8)
+        XCTAssertNil(indexedShardFileNames(at: dir))
     }
 }

--- a/Tests/MLXLMTests/Qwen4ExpVerifyTileTests.swift
+++ b/Tests/MLXLMTests/Qwen4ExpVerifyTileTests.swift
@@ -1,0 +1,193 @@
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import Testing
+
+@testable import MLXVLM
+
+/// Workplan W2a: verify-tile M-padding must be inert by default, must only
+/// engage for 1 < S < tile at batch 1, and must return exactly the real
+/// rows' values — padded rows are a kernel-shape vehicle, never data.
+@Suite("Qwen4Exp verify-tile M padding", .serialized)
+struct Qwen4ExpVerifyTileTests {
+    @Test("gate parses off/absent/invalid to disabled and 2-64 to rows")
+    func gateParsing() {
+        #expect(Qwen4ExpVerifyTile.parse(nil) == nil)
+        #expect(Qwen4ExpVerifyTile.parse("") == nil)
+        #expect(Qwen4ExpVerifyTile.parse("off") == nil)
+        #expect(Qwen4ExpVerifyTile.parse("OFF") == nil)
+        #expect(Qwen4ExpVerifyTile.parse("0") == nil)
+        #expect(Qwen4ExpVerifyTile.parse("1") == nil)
+        #expect(Qwen4ExpVerifyTile.parse("65") == nil)
+        #expect(Qwen4ExpVerifyTile.parse("banana") == nil)
+        #expect(Qwen4ExpVerifyTile.parse("8") == 8)
+        #expect(Qwen4ExpVerifyTile.parse(" 16 ") == 16)
+        #expect(Qwen4ExpVerifyTile.parse("64") == 64)
+    }
+
+    @Test("pads only 1 < S < tile at batch 1, slices back to real rows")
+    func paddingScope() throws {
+        try MLXMetalTestLock.withLock {
+            var seenRows: [Int] = []
+            func run(batch: Int, s: Int, tile: Int?) -> Bool {
+                let x = MLXArray(0 ..< (batch * s * 4), [batch, s, 4])
+                    .asType(.float32)
+                let y = Qwen4ExpVerifyTile.padded(x, tile: tile) { inner in
+                    seenRows.append(inner.dim(1))
+                    return inner * 2
+                }
+                #expect(y.shape == [batch, s, 4])
+                return allClose(y, x * 2).item(Bool.self)
+            }
+            // Verify width: padded to the tile, values exact after the slice.
+            #expect(run(batch: 1, s: 4, tile: 16))
+            #expect(seenRows.last == 16)
+            // AR decode width: untouched.
+            #expect(run(batch: 1, s: 1, tile: 16))
+            #expect(seenRows.last == 1)
+            // At/above the tile (prefill): untouched.
+            #expect(run(batch: 1, s: 16, tile: 16))
+            #expect(seenRows.last == 16)
+            #expect(run(batch: 1, s: 40, tile: 16))
+            #expect(seenRows.last == 40)
+            // Batch > 1: untouched.
+            #expect(run(batch: 2, s: 4, tile: 16))
+            #expect(seenRows.last == 4)
+            // Gate off: untouched.
+            #expect(run(batch: 1, s: 4, tile: nil))
+            #expect(seenRows.last == 4)
+        }
+    }
+
+    @Test("padded quantized matmul rows match the unpadded rows")
+    func quantizedRowEquivalence() throws {
+        try MLXMetalTestLock.withLock {
+            let k = 512
+            let n = 1024
+            let s = 4
+            let x =
+                (MLXArray(0 ..< (s * k), [1, s, k]).asType(.float32)
+                / Float(s * k) - 0.5).asType(.bfloat16)
+            let dense =
+                (MLXArray(0 ..< (n * k), [n, k]).asType(.float32)
+                % 97 / 96 - 0.5).asType(.float16)
+            let (weight, scales, biases) = quantized(
+                dense, groupSize: 64, bits: 4, mode: .affine)
+
+            func project(_ input: MLXArray) -> MLXArray {
+                quantizedMM(
+                    input, weight, scales: scales, biases: biases,
+                    transpose: true, groupSize: 64, bits: 4, mode: .affine)
+            }
+
+            let direct = project(x)
+            let tiled = Qwen4ExpVerifyTile.padded(x, tile: 16) { project($0) }
+            #expect(tiled.shape == direct.shape)
+            #expect(
+                allClose(
+                    tiled.asType(.float32), direct.asType(.float32),
+                    rtol: 1e-2, atol: 1e-2
+                ).item(Bool.self))
+        }
+    }
+
+    @Test("two-input form pads both arrays and slices the projected result")
+    func gatedOutputEquivalence() throws {
+        try MLXMetalTestLock.withLock {
+            let s = 3
+            let x = MLXArray(0 ..< (s * 8), [1, s, 2, 4]).asType(.float32) / 24
+            let gate = MLXArray(0 ..< (s * 8), [1, s, 2, 4]).asType(.float32) / 48
+            var seenRows: Int? = nil
+            let result = Qwen4ExpVerifyTile.padded(x, gate, tile: 8) { out, g in
+                seenRows = out.dim(1)
+                #expect(g.dim(1) == out.dim(1))
+                return (out * sigmoid(g)).reshaped(out.dim(0), out.dim(1), -1)
+            }
+            #expect(seenRows == 8)
+            #expect(result.shape == [1, s, 8])
+            let expected = (x * sigmoid(gate)).reshaped(1, s, -1)
+            #expect(allClose(result, expected).item(Bool.self))
+        }
+    }
+
+    @Test("GDN verify-width forward matches padded vs unpadded")
+    func gdnVerifyForwardEquivalence() throws {
+        let text = try JSONDecoder.json5().decode(
+            Qwen35Configuration.self,
+            from: """
+                {
+                  "model_type": "qwen3_5_moe",
+                  "text_config": {
+                    "model_type": "qwen3_5_moe_text",
+                    "hidden_size": 32,
+                    "num_hidden_layers": 4,
+                    "intermediate_size": 64,
+                    "num_attention_heads": 4,
+                    "num_key_value_heads": 2,
+                    "linear_num_value_heads": 4,
+                    "linear_num_key_heads": 2,
+                    "linear_key_head_dim": 8,
+                    "linear_value_head_dim": 8,
+                    "linear_conv_kernel_dim": 2,
+                    "head_dim": 8,
+                    "full_attention_interval": 4,
+                    "vocab_size": 100,
+                    "rms_norm_eps": 1e-6,
+                    "rope_parameters": {
+                      "rope_type": "default",
+                      "rope_theta": 100000.0,
+                      "partial_rotary_factor": 0.25,
+                      "mrope_section": [1, 1, 1]
+                    }
+                  },
+                  "vocab_size": 100
+                }
+                """.data(using: .utf8)!
+        ).textConfiguration
+        try MLXMetalTestLock.withLock {
+            let gdn = Qwen35Language.GatedDeltaNet(
+                text, outputGateSigmoid: true,
+                fuseDecodeInputProjections: true,
+                verifyTilePadding: true)
+            let input =
+                (MLXArray(0 ..< (4 * 32), [1, 4, 32]).asType(.float32)
+                    / 128 - 0.5)
+
+            let saved = Qwen4ExpVerifyTile.rows
+            defer { Qwen4ExpVerifyTile.rows = saved }
+
+            Qwen4ExpVerifyTile.rows = nil
+            let baseCache = MambaCache()
+            let base = gdn(input, cache: baseCache)
+
+            Qwen4ExpVerifyTile.rows = 16
+            let tiledCache = MambaCache()
+            let tiled = gdn(input, cache: tiledCache)
+            eval(base, tiled)
+
+            #expect(tiled.shape == base.shape)
+            #expect(
+                allClose(tiled, base, rtol: 1e-4, atol: 1e-5).item(Bool.self))
+            // Padded rows must never reach the cache: identical committed
+            // shapes and offsets either way.
+            #expect(tiledCache.offset == baseCache.offset)
+            #expect(tiledCache[0]?.shape == baseCache[0]?.shape)
+            #expect(tiledCache[1]?.shape == baseCache[1]?.shape)
+        }
+    }
+
+    @Test("mismatched gate rows fall through unpadded")
+    func mismatchedGateRows() throws {
+        try MLXMetalTestLock.withLock {
+            let x = MLXArray(0 ..< 12, [1, 3, 4]).asType(.float32)
+            let gate = MLXArray(0 ..< 8, [1, 2, 4]).asType(.float32)
+            var seenRows: Int? = nil
+            _ = Qwen4ExpVerifyTile.padded(x, gate, tile: 8) { out, _ in
+                seenRows = out.dim(1)
+                return out
+            }
+            #expect(seenRows == 3)
+        }
+    }
+}

--- a/Tests/MLXLMTests/Qwen4ExpVerifyTileTests.swift
+++ b/Tests/MLXLMTests/Qwen4ExpVerifyTileTests.swift
@@ -190,4 +190,224 @@ struct Qwen4ExpVerifyTileTests {
             #expect(seenRows == 3)
         }
     }
+
+    // MARK: - qwen3_5 (Qwen3.8-27B JANG family)
+
+    /// Tiny DENSE qwen3_5 text trunk: 4 layers, layer 4 full attention, the
+    /// rest GatedDeltaNet; untied lm_head. Mirrors the 27B layout in kind
+    /// (GDN + gated attention + Linear head), not in size.
+    private func tinyDenseQwen35Configuration() throws -> Qwen35Configuration {
+        try JSONDecoder.json5().decode(
+            Qwen35Configuration.self,
+            from: """
+                {
+                  "model_type": "qwen3_5",
+                  "text_config": {
+                    "model_type": "qwen3_5_text",
+                    "hidden_size": 32,
+                    "num_hidden_layers": 4,
+                    "intermediate_size": 64,
+                    "num_attention_heads": 4,
+                    "num_key_value_heads": 2,
+                    "linear_num_value_heads": 4,
+                    "linear_num_key_heads": 2,
+                    "linear_key_head_dim": 8,
+                    "linear_value_head_dim": 8,
+                    "linear_conv_kernel_dim": 2,
+                    "head_dim": 8,
+                    "full_attention_interval": 4,
+                    "vocab_size": 100,
+                    "tie_word_embeddings": false,
+                    "rms_norm_eps": 1e-6,
+                    "rope_parameters": {
+                      "rope_type": "default",
+                      "rope_theta": 100000.0,
+                      "partial_rotary_factor": 0.25,
+                      "mrope_section": [1, 1, 1]
+                    }
+                  },
+                  "vision_config": {
+                    "model_type": "qwen3_vl",
+                    "depth": 1,
+                    "hidden_size": 16,
+                    "intermediate_size": 32,
+                    "out_hidden_size": 32,
+                    "num_heads": 4,
+                    "patch_size": 2,
+                    "spatial_merge_size": 2,
+                    "temporal_patch_size": 1,
+                    "num_position_embeddings": 32
+                  },
+                  "vocab_size": 100,
+                  "image_token_id": 98,
+                  "video_token_id": 97
+                }
+                """.data(using: .utf8)!)
+    }
+
+    @Test("qwen3_5 GDN (family-tagged) verify-width forward matches padded vs unpadded")
+    func qwen35GDNVerifyForwardEquivalence() throws {
+        let text = try tinyDenseQwen35Configuration().textConfiguration
+        try MLXMetalTestLock.withLock {
+            // Exactly what Qwen35Language.DecoderLayer constructs for a
+            // linear layer.
+            let gdn = Qwen35Language.GatedDeltaNet(
+                text,
+                fuseDecodeInputProjections: true,
+                verifyTilePadding: true,
+                verifyTileFamily: Qwen4ExpVerifyTile.Family.qwen35)
+            #expect(gdn.verifyTileFamily == "Qwen35")
+            let input =
+                (MLXArray(0 ..< (5 * 32), [1, 5, 32]).asType(.float32)
+                    / 160 - 0.5)
+
+            let saved = Qwen4ExpVerifyTile.rows
+            defer { Qwen4ExpVerifyTile.rows = saved }
+
+            Qwen4ExpVerifyTile.rows = nil
+            let baseCache = MambaCache()
+            let base = gdn(input, cache: baseCache)
+
+            Qwen4ExpVerifyTile.rows = 16
+            let tiledCache = MambaCache()
+            let tiled = gdn(input, cache: tiledCache)
+            eval(base, tiled)
+
+            #expect(tiled.shape == base.shape)
+            #expect(
+                allClose(tiled, base, rtol: 1e-4, atol: 1e-5).item(Bool.self))
+            #expect(tiledCache.offset == baseCache.offset)
+            #expect(tiledCache[0]?.shape == baseCache[0]?.shape)
+            #expect(tiledCache[1]?.shape == baseCache[1]?.shape)
+        }
+    }
+
+    @Test("qwen3_5 attention: prefill then verify width, padded vs unpadded")
+    func qwen35AttentionVerifyForwardEquivalence() throws {
+        let text = try tinyDenseQwen35Configuration().textConfiguration
+        try MLXMetalTestLock.withLock {
+            let attention = Qwen35Language.Attention(text)
+            let prefill =
+                (MLXArray(0 ..< (20 * 32), [1, 20, 32]).asType(.float32)
+                    / 640 - 0.5)
+            // 5 rows: 1 < S < 16, and not a divisor of the tile.
+            let verify =
+                (MLXArray(0 ..< (5 * 32), [1, 5, 32]).asType(.float32)
+                    / 160 - 0.25)
+
+            let saved = Qwen4ExpVerifyTile.rows
+            defer { Qwen4ExpVerifyTile.rows = saved }
+
+            // The mask the DecoderLayer hands the attention: built from the
+            // cache offset BEFORE the K/V update, exactly like the model.
+            func mask(_ h: MLXArray, _ cache: KVCache) -> MLXArray? {
+                if case .array(let m) = createAttentionMask(
+                    h: h, cache: cache, returnArray: true)
+                {
+                    return m
+                }
+                return nil
+            }
+
+            func run(rows: Int?) -> (MLXArray, KVCacheSimple) {
+                let cache = KVCacheSimple()
+                Qwen4ExpVerifyTile.rows = nil
+                _ = attention(
+                    prefill, mask: mask(prefill, cache), cache: cache, positionIds: nil)
+                Qwen4ExpVerifyTile.rows = rows
+                let out = attention(
+                    verify, mask: mask(verify, cache), cache: cache, positionIds: nil)
+                eval(out)
+                return (out, cache)
+            }
+
+            let (base, baseCache) = run(rows: nil)
+            let (tiled, tiledCache) = run(rows: 16)
+
+            #expect(tiled.shape == [1, 5, 32])
+            #expect(tiled.shape == base.shape)
+            #expect(
+                allClose(tiled, base, rtol: 1e-4, atol: 1e-5).item(Bool.self))
+            // The KV cache only ever sees the real rows: 20 + 5, never 20 + 16.
+            #expect(baseCache.offset == 25)
+            #expect(tiledCache.offset == baseCache.offset)
+            #expect(tiledCache.state.map(\.shape) == baseCache.state.map(\.shape))
+            #expect(
+                allClose(
+                    tiledCache.state[0][.ellipsis, ..<25, 0...],
+                    baseCache.state[0][.ellipsis, ..<25, 0...],
+                    rtol: 1e-4, atol: 1e-5
+                ).item(Bool.self))
+        }
+    }
+
+    @Test("qwen3_5 model: verify-width logits and caches match padded vs unpadded")
+    func qwen35ModelVerifyLogitsEquivalence() throws {
+        let config = try tinyDenseQwen35Configuration()
+        try MLXMetalTestLock.withLock {
+            let model = Qwen35(config)
+            // Untied head: the lm_head Linear is what the 27B stamps carry.
+            #expect(
+                model.parameters().flattened().contains { key, _ in
+                    key.hasSuffix("lm_head.weight")
+                })
+            let prefill = MLXArray(Array(1 ..< 21))[.newAxis, .ellipsis]
+            let verify = MLXArray([7, 3, 9, 4, 11])[.newAxis, .ellipsis]
+
+            let saved = Qwen4ExpVerifyTile.rows
+            defer { Qwen4ExpVerifyTile.rows = saved }
+
+            func run(rows: Int?) -> (MLXArray, [any KVCache]) {
+                let cache = model.newCache(parameters: nil)
+                Qwen4ExpVerifyTile.rows = nil
+                let prefillLogits = model(prefill, cache: cache)
+                eval(prefillLogits)
+                Qwen4ExpVerifyTile.rows = rows
+                let logits = model(verify, cache: cache)
+                eval(logits)
+                return (logits, cache)
+            }
+
+            let (base, baseCache) = run(rows: nil)
+            let (tiled, tiledCache) = run(rows: 16)
+
+            #expect(tiled.shape == [1, 5, 100])
+            #expect(tiled.shape == base.shape)
+            #expect(
+                allClose(tiled, base, rtol: 1e-4, atol: 1e-5).item(Bool.self))
+            #expect(baseCache.count == 4)
+            for (layer, (b, t)) in zip(baseCache, tiledCache).enumerated() {
+                #expect(t.offset == b.offset, "layer \(layer) offset")
+                #expect(b.offset == 25, "layer \(layer) committed rows")
+                #expect(
+                    t.state.map(\.shape) == b.state.map(\.shape),
+                    "layer \(layer) state shapes")
+            }
+        }
+    }
+
+    @Test("qwen3_5 model: S == 1 decode and prefill never pad")
+    func qwen35ScopeNeverPadsDecodeOrPrefill() throws {
+        let config = try tinyDenseQwen35Configuration()
+        try MLXMetalTestLock.withLock {
+            let model = Qwen35(config)
+            let saved = Qwen4ExpVerifyTile.rows
+            defer { Qwen4ExpVerifyTile.rows = saved }
+            Qwen4ExpVerifyTile.rows = 16
+
+            let cache = model.newCache(parameters: nil)
+            // Prefill at S >= tile: untouched by construction; the verify
+            // gate is on the whole time, so the only thing keeping the pad
+            // out is the scope rule.
+            let prefillLogits = model(MLXArray(Array(1 ..< 17))[.newAxis, .ellipsis], cache: cache)
+            eval(prefillLogits)
+            #expect(prefillLogits.shape == [1, 16, 100])
+            #expect(cache.allSatisfy { $0.offset == 16 })
+            // AR decode: S == 1, untouched.
+            let decodeLogits = model(MLXArray([5])[.newAxis, .ellipsis], cache: cache)
+            eval(decodeLogits)
+            #expect(decodeLogits.shape == [1, 1, 100])
+            #expect(cache.allSatisfy { $0.offset == 17 })
+        }
+    }
 }


### PR DESCRIPTION
Restores the ORIGINAL Flash-Next bundle layout and lands the depth/governor round for native MTP (Qwen3.8 Flash-Next `qwen4_exp` and Qwen3.8-27B `qwen3_5`).

**Loading / detection (JANG bundles)** — `model.safetensors.index.json` is the load manifest: exactly the files weight_map names are loaded; an extra file the index does not mention never fails (or affects) a load; a missing indexed file fails with a re-download message. Detection scans weight_map keys + headers of indexed shards only. Non-JANG / index-less bundles keep the historical directory scan.

**Calibrated draft head** — the stamp's `draft_artifact` (file + sha256) loads the converter's imatrix-calibrated q4/g64 sidecar (`mtp_draft/vmlx_mtp_proposal_head.safetensors`), sha256-verified and shape-validated against the actual head; ANY failure silently keeps the RTN rebuild. Origin is logged; `VMLX_PROPOSAL_HEAD_DIGEST=1` logs installed-tensor digests.

**Depth** — the requested depth (explicit 1/2/3 or the family cold-start d3) is the STARTING depth; cap 3→5; the adaptive controller promotes on acceptance-margin windows, prices depth by wall-clock (per-depth committed tok/s EMA, >5% demote), demotes one level at a time above d3, and brakes oscillation (a level demoted twice stays closed). Stats line gains `depthMoves[...]`.

**AR-safety governor** — every cycle, fixed or adaptive, both families: windowed MTP ms/token vs a context-scaled AR baseline (seed AR step × verify growth, ×1.25) → pause to AR; live AR cost measured while paused; resume probes at the starting depth with backoff; MTP stays only if the probe beats live AR. Reversible (head-cache re-prime = the existing depth-change path). `VMLX_NATIVE_MTP_AR_SAFETY=0` hatch. Pure verdict ported 1:1 from the Python engine with its tests.

**Warmup memo** — the staged verifier never runs the warmup acceptance verdict, so one low-acceptance generation can no longer write a permanent negative memo that turns the rest of the process into AR.

**Verify tile (opt-in, default OFF)** — `VMLX_MTP_VERIFY_TILE=<2..64>` pads verify-width matmuls (attention/GDN projections, lm_head) to the NAX qmm tile for qwen4_exp and qwen3_5; floor on M5 Max (`applegpu_g17s`) is 10/12/18 so use 16. Measured +6% engine decode at d5 on 4M; outputs not bit-identical → stays opt-in.

Tests: ProposalHeadStampTests 21/21, NativeMTPARSafetyTests 6/6, Qwen4ExpVerifyTileTests (qwen4_exp + qwen3_5) 33/33 with adjacent suites.

Live proof (dev build, JANG_4M, this Mac) — receipt in the private docs/internal tree: sidecar origin + digests byte-equal (3/3); temp-0 sidecar-vs-RTN byte-identical; zero-config depth 3 → climbs to 5 on counting (5.4–5.75 committed/verify), engine 47–60 tok/s vs 31.6 AR; prose d3 churn measured (the brake/governor target); popup/readout/variating/2L/27B/governor rows in progress on build #4 (pin c8a4b66b). Lint red = pre-existing repo-wide swift-format 603 staleness (#420/#421 merged the same); no self-hosted mac runner registered.