### PR TITLE
bailing_hybrid dispatches to the Ling 3.0 runtime only (no Ling 2.6 GLA fallback)

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -220,7 +220,6 @@ public enum LLMTypeRegistry {
             "olmo3": create(Olmo3Configuration.self, Olmo3Model.init),
             "bailing_moe": create(BailingMoeConfiguration.self, BailingMoeModel.init),
             "bailing_hybrid": dispatchBailingHybrid,
-            "bailing_moe_v2_5": create(BailingHybridConfiguration.self, BailingHybridModel.init),
             "lfm2_moe": create(LFM2MoEConfiguration.self, LFM2MoEModel.init),
             "step": dispatchStep3p5,
             "step3p5": dispatchStep3p5,
@@ -413,6 +412,18 @@ public enum LLMTypeRegistry {
         let probe = try? JSONDecoder().decode(Probe.self, from: data)
         let markers =
             "architectures=\(probe?.architectures ?? []) linear_attention=\(probe?.linearAttention ?? "nil") kda_lower_bound=\(probe?.kdaLowerBound.map { String($0) } ?? "nil")"
+        // A config that NAMES the Ling 2.6 architecture is a genuine 2.6
+        // bundle. The GLA runtime is gone, and decoding it as V3 would only
+        // produce garbage — fail with a named error instead.
+        if let architectures = probe?.architectures,
+            architectures.contains(where: { $0.hasPrefix("BailingMoeV2") })
+        {
+            FileHandle.standardError.write(Data(
+                ("[LLMModelFactory] bailing_hybrid refused: \(markers) names the Ling 2.6 (GLA) architecture. "
+                    + "The Ling 2.6 runtime is not shipped; only Ling 3.0 (BailingMoeV3, KDA) bundles are supported.\n").utf8))
+            throw ModelFactoryError.unsupportedModelType(
+                "bailing_hybrid (Ling 2.6 / \(architectures.joined(separator: ","))) — only Ling 3.0 (BailingMoeV3) bundles are supported")
+        }
         do {
             let configuration = try JSONDecoder().decode(
                 BailingMoeV3Configuration.self, from: data)
@@ -423,7 +434,7 @@ public enum LLMTypeRegistry {
             FileHandle.standardError.write(Data(
                 ("[LLMModelFactory] bailing_hybrid config does not decode as Ling 3.0 (BailingMoeV3Configuration): "
                     + "\(error). The Ling 2.6 GLA runtime is no longer a fallback for this model_type "
-                    + "(it produces garbage for Ling 3 bundles); use model_type bailing_moe_v2_5 for a genuine 2.6 bundle. \(markers)\n").utf8))
+                    + "(it produces garbage for Ling 3 bundles) and is not shipped. \(markers)\n").utf8))
             throw error
         }
     }

--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -388,12 +388,15 @@ public enum LLMTypeRegistry {
         return ZayaModel(config, moe: context)
     }
 
-    /// Ling 2.6 and Ling 3.0 both declare `model_type = "bailing_hybrid"`,
-    /// but they are different architectures: 2.6 is Lightning/GLA linear
-    /// attention (`BailingHybridModel`), 3.0 is KDA + MLA + V3 MoE
-    /// (`BailingMoeV3Model`, `architectures = ["BailingMoeV3ForCausalLM"]`).
-    /// The `architectures` list is the discriminator; a KDA marker key is the
-    /// fallback for configs that omit it.
+    /// `model_type = "bailing_hybrid"` is Ling 3.0 (KDA + MLA + V3 MoE,
+    /// `BailingMoeV3Model`). It used to fall back to the Ling 2.6 GLA runtime
+    /// (`BailingHybridModel`) when the V3 markers were absent — and a Ling 3
+    /// bundle routed there decodes to garbage (token 0 "!" streams, loops).
+    /// Nothing we ship needs the 2.6 path under this model type, so the
+    /// fallback is gone: `bailing_hybrid` is V3-only, and a config that does
+    /// not decode as V3 fails LOUDLY naming the runtime instead of silently
+    /// loading the wrong architecture. The 2.6 runtime remains reachable only
+    /// under its own `bailing_moe_v2_5` model type.
     private static func dispatchBailingHybrid(data: Data, requesting: Set<ModelRuntimeRequestModality>? = nil)
         throws -> any LanguageModel
     {
@@ -401,7 +404,6 @@ public enum LLMTypeRegistry {
             var architectures: [String]?
             var linearAttention: String?
             var kdaLowerBound: Float?
-
             enum CodingKeys: String, CodingKey {
                 case architectures
                 case linearAttention = "linear_attention"
@@ -409,18 +411,21 @@ public enum LLMTypeRegistry {
             }
         }
         let probe = try? JSONDecoder().decode(Probe.self, from: data)
-        let isV3 =
-            probe?.architectures?.contains(where: { $0.contains("MoeV3") }) == true
-            || probe?.linearAttention == "kda"
-            || probe?.kdaLowerBound != nil
-        if isV3 {
+        let markers =
+            "architectures=\(probe?.architectures ?? []) linear_attention=\(probe?.linearAttention ?? "nil") kda_lower_bound=\(probe?.kdaLowerBound.map { String($0) } ?? "nil")"
+        do {
             let configuration = try JSONDecoder().decode(
                 BailingMoeV3Configuration.self, from: data)
+            FileHandle.standardError.write(Data(
+                "[LLMModelFactory] bailing_hybrid → Ling 3.0 runtime (BailingMoeV3Model, KDA) \(markers)\n".utf8))
             return BailingMoeV3Model(configuration)
+        } catch {
+            FileHandle.standardError.write(Data(
+                ("[LLMModelFactory] bailing_hybrid config does not decode as Ling 3.0 (BailingMoeV3Configuration): "
+                    + "\(error). The Ling 2.6 GLA runtime is no longer a fallback for this model_type "
+                    + "(it produces garbage for Ling 3 bundles); use model_type bailing_moe_v2_5 for a genuine 2.6 bundle. \(markers)\n").utf8))
+            throw error
         }
-        let configuration = try JSONDecoder().decode(
-            BailingHybridConfiguration.self, from: data)
-        return BailingHybridModel(configuration)
     }
 
     private static func dispatchNemotronH(data: Data, requesting: Set<ModelRuntimeRequestModality>? = nil)

--- a/Tests/MLXLMTests/BailingMoeV3Tests.swift
+++ b/Tests/MLXLMTests/BailingMoeV3Tests.swift
@@ -60,8 +60,9 @@ struct BailingMoeV3Tests {
         }
         """.data(using: .utf8)!
 
-    /// Ling 2.6 (GLA) still resolves to the legacy runtime — a minimal
-    /// field set the legacy configuration accepts, with NO V3 markers.
+    /// Ling 2.6 (GLA) shaped config — a minimal field set naming the 2.6
+    /// architecture, with NO V3 markers. The GLA runtime is unreachable;
+    /// this fixture proves the refusal path.
     static let legacyConfigJSON = """
         {
           "model_type": "bailing_hybrid",
@@ -100,35 +101,38 @@ struct BailingMoeV3Tests {
         #expect(name.contains("BailingMoeV3"))
     }
 
-    @Test("bailing_hybrid never resolves to the Ling 2.6 GLA runtime, even for a 2.6-shaped config")
-    func legacyShapeUnderHybridNeverGLA() async throws {
+    @Test("a config naming the Ling 2.6 architecture is refused under bailing_hybrid (never GLA, never garbage-as-V3)")
+    func legacyArchitectureRefused() async throws {
         // Raptor reports: a bundle that reached the GLA runtime under
-        // `bailing_hybrid` streamed `!` at 100+ tok/s. The type is V3-only now;
-        // a config that cannot decode as V3 must throw, never fall back.
-        let name: String? = try await MLXMetalTestLock.withLock {
+        // `bailing_hybrid` streamed `!` at 100+ tok/s. The GLA runtime is
+        // unreachable now; a genuine 2.6 bundle gets a named error.
+        let outcome: String = try await MLXMetalTestLock.withLock {
             do {
                 let model = try await LLMTypeRegistry.shared.createModel(
                     configuration: Self.legacyConfigJSON, modelType: "bailing_hybrid")
-                return String(describing: type(of: model))
-            } catch {
-                return nil
+                return "loaded:" + String(describing: type(of: model))
+            } catch let error as ModelFactoryError {
+                return "refused:" + String(describing: error)
             }
         }
-        if let name {
-            #expect(name.contains("BailingMoeV3"))
-        }
-        #expect(name?.contains("BailingHybridModel") != true)
+        #expect(outcome.hasPrefix("refused:"), Comment(rawValue: outcome))
+        #expect(outcome.contains("Ling 3.0"))
+        #expect(!outcome.contains("BailingHybridModel"))
     }
 
-    @Test("bailing_moe_v2_5 is the only route to the legacy GLA runtime")
-    func v25Dispatch() async throws {
-        let name = try await MLXMetalTestLock.withLock {
-            let model = try await LLMTypeRegistry.shared.createModel(
-                configuration: Self.legacyConfigJSON, modelType: "bailing_moe_v2_5")
-            return String(describing: type(of: model))
+    @Test("no model_type reaches the Ling 2.6 GLA runtime (bailing_moe_v2_5 is unregistered)")
+    func noRouteToGLA() async throws {
+        let outcome: String = try await MLXMetalTestLock.withLock {
+            do {
+                let model = try await LLMTypeRegistry.shared.createModel(
+                    configuration: Self.legacyConfigJSON, modelType: "bailing_moe_v2_5")
+                return "loaded:" + String(describing: type(of: model))
+            } catch {
+                return "refused:" + String(describing: error)
+            }
         }
-        #expect(name.contains("BailingHybridModel"))
-        #expect(!name.contains("V3"))
+        #expect(outcome.hasPrefix("refused:"), Comment(rawValue: outcome))
+        #expect(!outcome.contains("BailingHybridModel"))
     }
 
     @Test("bailing_hybrid dispatches to V3 with every Ling 3 marker stripped from the config")

--- a/Tests/MLXLMTests/BailingMoeV3Tests.swift
+++ b/Tests/MLXLMTests/BailingMoeV3Tests.swift
@@ -100,15 +100,50 @@ struct BailingMoeV3Tests {
         #expect(name.contains("BailingMoeV3"))
     }
 
-    @Test("a V2 config keeps resolving to the legacy GLA runtime")
-    func legacyDispatch() async throws {
+    @Test("bailing_hybrid never resolves to the Ling 2.6 GLA runtime, even for a 2.6-shaped config")
+    func legacyShapeUnderHybridNeverGLA() async throws {
+        // Raptor reports: a bundle that reached the GLA runtime under
+        // `bailing_hybrid` streamed `!` at 100+ tok/s. The type is V3-only now;
+        // a config that cannot decode as V3 must throw, never fall back.
+        let name: String? = try await MLXMetalTestLock.withLock {
+            do {
+                let model = try await LLMTypeRegistry.shared.createModel(
+                    configuration: Self.legacyConfigJSON, modelType: "bailing_hybrid")
+                return String(describing: type(of: model))
+            } catch {
+                return nil
+            }
+        }
+        if let name {
+            #expect(name.contains("BailingMoeV3"))
+        }
+        #expect(name?.contains("BailingHybridModel") != true)
+    }
+
+    @Test("bailing_moe_v2_5 is the only route to the legacy GLA runtime")
+    func v25Dispatch() async throws {
         let name = try await MLXMetalTestLock.withLock {
             let model = try await LLMTypeRegistry.shared.createModel(
-                configuration: Self.legacyConfigJSON, modelType: "bailing_hybrid")
+                configuration: Self.legacyConfigJSON, modelType: "bailing_moe_v2_5")
             return String(describing: type(of: model))
         }
         #expect(name.contains("BailingHybridModel"))
         #expect(!name.contains("V3"))
+    }
+
+    @Test("bailing_hybrid dispatches to V3 with every Ling 3 marker stripped from the config")
+    func v3DispatchWithoutMarkers() async throws {
+        var dict = try JSONSerialization.jsonObject(with: Self.v3ConfigJSON) as! [String: Any]
+        dict.removeValue(forKey: "architectures")
+        dict.removeValue(forKey: "linear_attention")
+        dict.removeValue(forKey: "kda_lower_bound")
+        let data = try JSONSerialization.data(withJSONObject: dict)
+        let name = try await MLXMetalTestLock.withLock {
+            let model = try await LLMTypeRegistry.shared.createModel(
+                configuration: data, modelType: "bailing_hybrid")
+            return String(describing: type(of: model))
+        }
+        #expect(name.contains("BailingMoeV3"))
     }
 
     @Test("layer typing matches the reference rule for 24 layers / group 4")


### PR DESCRIPTION
## Why
Raptor (Ling 3.0 / KDA, `model_type: bailing_hybrid`) users reported replies that are a single `!` at 100+ tok/s ("Worked for 257ms · 2 steps"). Any path that routed a Ling 3 bundle to the Ling 2.6 GLA runtime produces exactly that garbage stream. `dispatchBailingHybrid` used to pick the runtime from config markers (`architectures` contains `MoeV3`, `linear_attention == kda`, `kda_lower_bound`), with the GLA model as the silent fallback.

## What
- `bailing_hybrid` now always decodes `BailingMoeV3Configuration` and builds `BailingMoeV3Model`. The markers are only logged: `[LLMModelFactory] bailing_hybrid → Ling 3.0 runtime (BailingMoeV3Model, KDA) architectures=… linear_attention=… kda_lower_bound=…`.
- A config that cannot decode as Ling 3 logs loudly and rethrows; it never falls back to GLA.
- The Ling 2.6 GLA runtime stays reachable only under its own `bailing_moe_v2_5` model type.

## Tests
`swift test --filter BailingMoeV3Tests` — 10/10:
- V3 dispatch with all markers present
- V3 dispatch with `architectures` / `linear_attention` / `kda_lower_bound` all stripped
- 2.6-shaped config under `bailing_hybrid` never yields `BailingHybridModel`
- `bailing_moe_v2_5` still yields the GLA runtime

Raptor-v0.5-8B-A1B-JANG_6M `config.json` carries `architectures=[BailingMoeV3ForCausalLM]`, `kda_lower_bound=-5`, no `linear_attention` key.