### PR TITLE
Native MTP: AR-safety governor to spec (8+8 cycles, 16/32/64 probes, 10% hysteresis, no ping-pong, median guard) + post-generation tail timers

### DIFF
--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -464,9 +464,12 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private(set) var arSafetyResumes = 0
     private static let arSafetyWindow = 16
     private static let arSafetyMargin = 1.25
-    private static let arSafetyProbeWindow = 8
-    private static let arSafetyResumeIntervalStart = 24
-    private static let arSafetyResumeIntervalMax = 192
+    private static let arSafetyProbeWindow = 6
+    private static let arSafetyResumeIntervalStart = 64
+    private static let arSafetyResumeIntervalMax = 512
+    /// A probe that lost by this factor or more is a clear regime signal:
+    /// back off ×4 instead of ×2.
+    private static let arSafetyClearLossFactor = 1.3
     /// `VMLX_NATIVE_MTP_AR_SAFETY=0` disables the governor (measurement
     /// hatch, like the adaptive one). Default ON.
     private static let arSafetyDisabled =
@@ -1068,7 +1071,8 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                     {
                         continue
                     }
-                    if let boundarySnapshot = cacheSnapshotForBoundary(
+                    let tBoundary = Date()
+                    let boundarySnapshotOpt = cacheSnapshotForBoundary(
                         tokens: boundaryTokens,
                         promptSnapshot: promptCacheSnapshot,
                         allowDiskBackedRederive: shouldForceStableBoundaryRederive(
@@ -1076,7 +1080,10 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                             isReusablePrefixWarmup: isReusablePrefixWarmup,
                             requiresRecurrentSSMCompanion:
                                 coordinator.requiresRecurrentSSMCompanion))
-                    {
+                    if ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1" {
+                        print("[vmlx][gen/tail/derive] label=history-boundary tokens=\(boundaryTokens.count) snapshot=\(Date().timeIntervalSince(tBoundary))s stable=\(isStableBoundary)")
+                    }
+                    if let boundarySnapshot = boundarySnapshotOpt {
                         store(
                             tokens: boundaryTokens,
                             snapshot: boundarySnapshot,
@@ -1103,11 +1110,15 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                     // loop can't store this boundary (no allowDiskBackedRederive),
                     // and `stripAt` routinely coincides with a prefix-count entry.
                     let strippedTokens = Array(promptTokenIds.prefix(stripAt))
-                    if let strippedSnapshot = cacheSnapshotForBoundary(
+                    let tStrip = Date()
+                    let strippedSnapshotOpt = cacheSnapshotForBoundary(
                         tokens: strippedTokens,
                         promptSnapshot: promptCacheSnapshot,
                         allowDiskBackedRederive: true)
-                    {
+                    if ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1" {
+                        print("[vmlx][gen/tail/derive] label=gen-suffix-stripped tokens=\(strippedTokens.count) snapshot=\(Date().timeIntervalSince(tStrip))s")
+                    }
+                    if let strippedSnapshot = strippedSnapshotOpt {
                         store(
                             tokens: strippedTokens,
                             snapshot: strippedSnapshot,
@@ -2071,8 +2082,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                     reason: String(
                         format: "ar_safety_probe_lost(mtp=%.1fms/tok live_ar=%.1fms)",
                         mtpMsPerToken, liveArMs))
+                let clearLoss = liveArMs > 0 && mtpMsPerToken >= liveArMs * Self.arSafetyClearLossFactor
                 arSafetyResumeInterval = Swift.min(
-                    arSafetyResumeInterval * 2, Self.arSafetyResumeIntervalMax)
+                    arSafetyResumeInterval * (clearLoss ? 4 : 2), Self.arSafetyResumeIntervalMax)
             } else {
                 arSafetyResumes += 1
                 arSafetyResumeInterval = Self.arSafetyResumeIntervalStart

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -959,8 +959,13 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 cachePrefixTokenCounts + [sharedPromptStripBoundary].compactMap { $0 }
             ))
 
-            func store(tokens: [Int], snapshot: [KVCache], label _: String) {
+            func store(tokens: [Int], snapshot: [KVCache], label: String) {
                 guard !tokens.isEmpty else { return }
+                // Post-generation tail breakdown (VMLX_CACHE_FETCH_TRACE=1): live
+                // 2026-09-04 the whole 9.5–15 s "hang at the last letters" was
+                // this store; name the step that costs it.
+                let trace = ProcessInfo.processInfo.environment["VMLX_CACHE_FETCH_TRACE"] == "1"
+                let t0 = Date()
                 // Same guard as the other store paths: saving a cache materialises
                 // it several times over at the memory high-water mark, and a
                 // prefix-cache entry is only ever a speed-up for a later request —
@@ -970,6 +975,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 guard CacheStoreBudget.canStore(snapshot) else { return }
                 let cacheSnapshot = snapshot.map { $0.copy() }
                 MLX.eval(cacheSnapshot)
+                let tCopy = Date()
                 let requiresDiskBackedRestore =
                     cacheRequiresDiskBackedCoordinatorRestore(cacheSnapshot)
                 let perLayerData = requiresDiskBackedRestore
@@ -1015,9 +1021,21 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                         persistCapturedStatesToDisk: false,
                         prefillStepSize: cacheInitParameters.prefillStepSize)
                 }()
+                let tSSM = Date()
                 let diskStoreCache = makeDiskStoreCache(
                     fromPromptBoundary: cacheSnapshot,
                     parameters: cacheInitParameters)
+                let tDisk = Date()
+                defer {
+                    if trace {
+                        print(
+                            "[vmlx][gen/tail/store] label=\(label) tokens=\(tokens.count)"
+                                + " copyEval=\(tCopy.timeIntervalSince(t0))s"
+                                + " layerData+ssm=\(tSSM.timeIntervalSince(tCopy))s"
+                                + " diskCachePrep=\(tDisk.timeIntervalSince(tSSM))s"
+                                + " coordinatorStore=\(Date().timeIntervalSince(tDisk))s")
+                    }
+                }
                 coordinator.storeAfterGeneration(
                     promptTokens: tokens,
                     perLayerData: perLayerData,

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -438,7 +438,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     // Design + audit trail: docs/internal/MTP-AR-SAFETY-GOVERNOR-SWIFT-2026-09-04.md
     // (Swift port of vmlx-private-evidence MTP-ONFLY-AR-FALLBACK-PLAN, plus
     // the reversible Phase 2 the Python plan deferred).
-    private struct ARSafetySample {
+    struct ARSafetySample {
         let emitted: Int
         let wall: TimeInterval
         let verifyTotal: TimeInterval
@@ -460,13 +460,25 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private var arSafetyTokensSincePause = 0
     private var arSafetyResumeInterval = NativeMTPTokenIterator.arSafetyResumeIntervalStart
     private var arSafetyProbeCyclesRemaining = 0
+    /// True while a kept re-entry is speculating: a trip in that state backs
+    /// the resume interval off further instead of resetting it.
+    private var arSafetyReentered = false
     private(set) var arSafetyTrips = 0
     private(set) var arSafetyResumes = 0
-    private static let arSafetyWindow = 16
+    /// Judged every verify cycle over the last `arSafetyWindow` cycles once
+    /// `arSafetyWarmupCycles` have run: earliest trip = cycle 16 (~0.65 s at
+    /// d3), a later drop is caught within ~8 cycles (~0.3 s).
+    private static let arSafetyWindow = 8
+    private static let arSafetyWarmupCycles = 8
     private static let arSafetyMargin = 1.25
     private static let arSafetyProbeWindow = 6
-    private static let arSafetyResumeIntervalStart = 64
-    private static let arSafetyResumeIntervalMax = 512
+    /// Re-probe after 16, 32, 64… AR tokens (×2 per lost probe, ×4 on a
+    /// clear loss); a kept re-entry that trips again backs off further.
+    private static let arSafetyResumeIntervalStart = 16
+    private static let arSafetyResumeIntervalMax = 4096
+    /// A probe is kept only when MTP beats the live AR cost by this factor
+    /// (10% hysteresis) so a re-entry cannot ride the noise floor.
+    private static let arSafetyReentryHysteresis = 1.10
     /// A probe that lost by this factor or more is a clear regime signal:
     /// back off ×4 instead of ×2.
     private static let arSafetyClearLossFactor = 1.3
@@ -2039,9 +2051,26 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     }
 
     private var arSafetyWindowForRequest: Int {
-        // Restored prefixes start with a cold aligned-head cache: dilute the
-        // judgement window the same 4× the adaptive gates use.
-        restoredPrefixStart ? 4 * Self.arSafetyWindow : Self.arSafetyWindow
+        // A restored prefix starts with a cold aligned-head cache, but the
+        // 8-cycle warmup already excludes those cycles from the judgement
+        // window; no extra dilution (a 4× window hid real losses for ~2.6 s).
+        Self.arSafetyWindow
+    }
+
+    /// Median per-cycle ms/token over the ring. A single stalled cycle
+    /// (allocator hiccup, page-in) can push the window MEAN over the margin;
+    /// the median must agree before a trip counts as a sustained loss.
+    static func medianCycleMsPerToken(_ ring: [ARSafetySample]) -> Double? {
+        var perCycle: [Double] = []
+        perCycle.reserveCapacity(Swift.max(ring.count - 1, 0))
+        for (a, b) in zip(ring, ring.dropFirst()) {
+            let emitted = b.emitted - a.emitted
+            guard emitted > 0 else { continue }
+            perCycle.append((b.wall - a.wall) * 1000 / Double(emitted))
+        }
+        guard !perCycle.isEmpty else { return nil }
+        let sorted = perCycle.sorted()
+        return sorted[sorted.count / 2]
     }
 
     /// After every verify cycle (any depth policy): sample, then either
@@ -2077,7 +2106,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             // WIN outright to stay; otherwise pause again with backoff.
             let liveArMs = (arSafetyLiveStepSec ?? arSafetySeedStepSec ?? 0) * 1000
             let mtpMsPerToken = deltaEmitted > 0 ? deltaWallMs / Double(deltaEmitted) : .infinity
-            if liveArMs > 0, mtpMsPerToken >= liveArMs {
+            if liveArMs > 0, mtpMsPerToken * Self.arSafetyReentryHysteresis >= liveArMs {
                 arSafetyPause(
                     reason: String(
                         format: "ar_safety_probe_lost(mtp=%.1fms/tok live_ar=%.1fms)",
@@ -2087,7 +2116,11 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                     arSafetyResumeInterval * (clearLoss ? 4 : 2), Self.arSafetyResumeIntervalMax)
             } else {
                 arSafetyResumes += 1
-                arSafetyResumeInterval = Self.arSafetyResumeIntervalStart
+                arSafetyReentered = true
+                // The interval is NOT reset here: a re-entry that trips again
+                // backs off from where it was (no ping-pong); it resets only
+                // when the generation ends.
+                adaptiveFallbackReason = nil
                 FileHandle.standardError.write(Data(String(
                     format: "[NativeMTP] ar_safety resumed: mtp=%.1fms/tok live_ar=%.1fms depth=%d\n",
                     mtpMsPerToken, liveArMs, currentDepth).utf8))
@@ -2095,8 +2128,11 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             return
         }
 
-        // Warmup: judge only once the window is full of post-warmup cycles.
-        guard verifyCalls >= window, let seed = arSafetySeedStepSec else { return }
+        // Warmup: judge only once `arSafetyWarmupCycles` have run AND the
+        // window is full of post-warmup cycles (earliest trip = cycle 16).
+        guard verifyCalls >= Self.arSafetyWarmupCycles + window,
+            let seed = arSafetySeedStepSec
+        else { return }
         if let verdict = Self.windowedARVerdict(
             arStepMs: seed * 1000,
             firstVerifyMs: (arSafetyFirstVerifySec ?? 0) * 1000,
@@ -2104,7 +2140,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             deltaEmitted: deltaEmitted,
             deltaWallMs: deltaWallMs,
             deltaVerifyMs: deltaVerifyMs,
-            margin: Self.arSafetyMargin)
+            margin: Self.arSafetyMargin),
+            let median = Self.medianCycleMsPerToken(arSafetyRing),
+            median > verdict.arBaselineMs * Self.arSafetyMargin
         {
             arSafetyPause(
                 reason: String(
@@ -2116,6 +2154,12 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private mutating func arSafetyPause(reason: String) {
         arSafetyPaused = true
         arSafetyTrips += 1
+        if arSafetyReentered {
+            // A kept re-entry lost again: back off further (spec: no ping-pong).
+            arSafetyReentered = false
+            arSafetyResumeInterval = Swift.min(
+                arSafetyResumeInterval * 2, Self.arSafetyResumeIntervalMax)
+        }
         arSafetyTokensSincePause = 0
         arSafetyProbeCyclesRemaining = 0
         arSafetyRing.removeAll(keepingCapacity: true)

--- a/Tests/MLXLMCommonFocusedTests/NativeMTPARSafetyTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NativeMTPARSafetyTests.swift
@@ -77,4 +77,38 @@ final class NativeMTPARSafetyTests: XCTestCase {
             deltaEmitted: 16, deltaWallMs: 320, deltaVerifyMs: 6 * 16, margin: 1.25)
         XCTAssertEqual(v?.arBaselineMs ?? 0, 10, accuracy: 1e-6)
     }
+
+    // MARK: median guard (one stalled cycle must not trip the window)
+
+    private func ring(_ cycleMs: [Double], emittedPerCycle: Int = 4) -> [V.ARSafetySample] {
+        var out = [V.ARSafetySample(emitted: 0, wall: 0, verifyTotal: 0)]
+        var wall = 0.0, emitted = 0
+        for ms in cycleMs {
+            wall += ms / 1000; emitted += emittedPerCycle
+            out.append(V.ARSafetySample(emitted: emitted, wall: wall, verifyTotal: 0))
+        }
+        return out
+    }
+
+    func testMedianIgnoresSingleStallCycle() {
+        // 7 healthy cycles at 10 ms/tok, one 400 ms/tok stall: the MEAN is
+        // ~59 ms/tok (would trip against a 25 ms AR step × 1.25), the median
+        // stays at 10 ms/tok → no trip.
+        let r = ring([40, 40, 40, 40, 1600, 40, 40, 40])
+        XCTAssertEqual(V.medianCycleMsPerToken(r) ?? -1, 10, accuracy: 1e-9)
+    }
+
+    func testMedianTripsOnSustainedLoss() {
+        // Every cycle costs 45 ms/tok against a 25 ms AR step → median agrees.
+        let r = ring(Array(repeating: 180, count: 8))
+        XCTAssertEqual(V.medianCycleMsPerToken(r) ?? -1, 45, accuracy: 1e-9)
+        XCTAssertGreaterThan(V.medianCycleMsPerToken(r)!, 25 * 1.25)
+    }
+
+    func testMedianGuardsEmptyAndZeroEmission() {
+        XCTAssertNil(V.medianCycleMsPerToken([]))
+        XCTAssertNil(V.medianCycleMsPerToken([V.ARSafetySample(emitted: 0, wall: 0, verifyTotal: 0)]))
+        let flat = [V.ARSafetySample(emitted: 3, wall: 0, verifyTotal: 0), V.ARSafetySample(emitted: 3, wall: 1, verifyTotal: 0)]
+        XCTAssertNil(V.medianCycleMsPerToken(flat))
+    }
 }


### PR DESCRIPTION
## Governor (native MTP must never net below AR)
Brings the Swift AR-safety valve to the agreed behaviour:
- **Judge cadence**: 8-cycle warmup, then an 8-cycle window judged every verify cycle → earliest trip at cycle 16 (~0.65 s at d3), a later drop caught within ~8 cycles (~0.3 s). The 4× restored-prefix window is gone (the warmup already excludes the cold-head cycles; the wide window hid real losses for ~2.6 s).
- **Median guard**: a trip needs the per-cycle median ms/token to agree with the window mean, so one stalled cycle (allocator/page-in) cannot false-trip.
- **Turning back**: after a trip the request keeps measuring live AR and re-probes after 16, 32, 64… AR tokens (×2 per lost probe, ×4 on a clear loss). A probe is kept only when MTP beats live AR by 10% (`arSafetyReentryHysteresis`), re-entering at the **configured** depth (unchanged: `currentDepth = depth`).
- **No ping-pong**: a kept re-entry that trips again backs the interval off further instead of resetting it; the resumed state clears `adaptiveFallbackReason` so stats no longer report a stale pause reason after recovery.
- `arSafety[trips,resumes,paused]` stats unchanged.

## Tail timers
- `[vmlx][gen/tail/store]` per-step breakdown (copy/eval, layerData+ssm, disk prep, coordinator store) and `[vmlx][gen/tail/derive]` (history-boundary / gen-suffix-stripped snapshot) under `VMLX_CACHE_FETCH_TRACE=1`, for the last-letters-hang investigation.

## Tests
`swift test --filter NativeMTPARSafetyTests` — 9/9 (windowed verdict 1:1 with the Python reference + median guard: single stall ignored, sustained loss trips, empty/zero-emission guards).

Live proof on the osaurus dev build follows in the repin PR.