### PR TITLE
Cache restore: fail closed when attention and recurrent offsets disagree with the matched boundary (Raptor '!' / Ornith loops)

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -2034,10 +2034,12 @@ public actor BatchEngine {
                 {
                     var restored = false
                     var retainedDiskRestore = false
+                    var restoredTokenCount = 0
                     if !blocks.isEmpty {
                         let restoredTokens = restoreLayerData(from: blocks, into: slot.cache)
                         coordinator.release(blocks: blocks)
                         if restoredTokens > 0 {
+                            restoredTokenCount = restoredTokens
                             if let ssm = ssmStates {
                                 restoreSSMStates(
                                     ssm, into: slot.cache, boundary: matchedTokens)
@@ -2102,6 +2104,7 @@ public actor BatchEngine {
                             return count
                         }
                         if diskRestored > 0 {
+                            restoredTokenCount = diskRestored
                             // 2026-04-27 fix: materialize restored cache state
                             // in its own command buffer BEFORE prefill builds
                             // its forward graph. Disk restore produces lazy
@@ -2135,6 +2138,19 @@ public actor BatchEngine {
                         }
                     }
 
+                    // Fail closed: attention offsets come from the restored KV
+                    // tensors, recurrent offsets from the matched boundary. A
+                    // hybrid whose two halves disagree must rebuild and full-prefill.
+                    if restored,
+                        !validateRestoredCacheBoundary(
+                            slot.cache, matchedTokens: matchedTokens,
+                            restoredTokens: restoredTokenCount, detail: detail.rawValue)
+                    {
+                        restored = false
+                        retainedDiskRestore = false
+                        slot.cache = context.model.newCache(parameters: slot.parameters)
+                        inputForPrepare = slot.originalInput
+                    }
                     if restored {
                         if usesPostPrepareAlias {
                             slot.cachePromptTokenIds = tokenIds

--- a/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
@@ -136,6 +136,46 @@ func makeDiskStoreCache(
         kvMode: parameters.kvMode)
 }
 
+/// Fail-closed validation of a coordinator cache restore.
+///
+/// A hit restores two independently derived lengths: attention layers take
+/// their offset from the restored KV tensors (`restoreLayerData` /
+/// `restoreFromDiskArrays`), recurrent layers (MambaCache — KDA on Ling 3 /
+/// Raptor, Gated DeltaNet on Qwen 3.5 / Ornith) take theirs from the matched
+/// boundary (`restoreSSMStates(boundary:)` or the record's
+/// `__mamba_i_offset__`). Nothing used to check that they agree: attention
+/// then runs over M tokens while the recurrent state summarises N ≠ M, the
+/// hybrid's two halves desynchronise, and the logits degenerate (token id 0
+/// `!` on Raptor, verbatim loops on Ornith) — the dots3 `cached_tokens % 256`
+/// class of bug, hidden behind a `restoredTokens > 0` liveness check.
+///
+/// The real invariant is `offset == matchedTokens` for EVERY layer, and
+/// `restoredTokens == matchedTokens`. A restore that violates it is refused
+/// and the caller rebuilds the cache and full-prefills; a refused entry costs
+/// one prefill, an accepted one costs correctness for the whole continuation.
+public func validateRestoredCacheBoundary(
+    _ cache: [any KVCache],
+    matchedTokens: Int,
+    restoredTokens: Int,
+    detail: String = ""
+) -> Bool {
+    let offsets = cache.map(\.offset)
+    let consistent =
+        matchedTokens > 0
+        && restoredTokens == matchedTokens
+        && offsets.allSatisfy { $0 == matchedTokens }
+    if !consistent {
+        let unique = Array(Set(offsets)).sorted()
+        let message =
+            "[vmlx][cache/restore] REFUSED offset/key mismatch detail=\(detail) "
+            + "matched=\(matchedTokens) restored=\(restoredTokens) offsets=\(unique)"
+        // Always visible: a refused restore is the difference between one
+        // extra prefill and a whole corrupted continuation.
+        FileHandle.standardError.write(Data((message + "\n").utf8))
+    }
+    return consistent
+}
+
 /// True when any cache layer carries path-dependent non-KV recurrent state.
 ///
 /// Paged KV blocks store attention KV tensors only. Mamba, linear-attention

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1897,10 +1897,12 @@ public struct TokenIterator: TokenIteratorProtocol {
                     let ssmStates, let diskArrays):
                 var restored = false
                 var retainedDiskRestore = false
+                var restoredTokenCount = 0
                 if !blocks.isEmpty {
                     let restoredTokens = restoreLayerData(from: blocks, into: self.cache)
                     coordinator.release(blocks: blocks)
                     if restoredTokens > 0 {
+                        restoredTokenCount = restoredTokens
                         if let ssm = ssmStates {
                             restoreSSMStates(
                                 ssm, into: self.cache, boundary: matchedTokens)
@@ -1970,6 +1972,7 @@ public struct TokenIterator: TokenIteratorProtocol {
                         return count
                     }
                     if diskRestored > 0 {
+                        restoredTokenCount = diskRestored
                         restored = true
                         Self.logger.info(
                             "Cache \(detail.rawValue) hit: restored \(diskRestored) tokens from disk, prefilling \(remainingTokens.count) remaining"
@@ -1977,6 +1980,19 @@ public struct TokenIterator: TokenIteratorProtocol {
                     }
                 }
 
+                // Fail closed: attention offsets come from the restored KV
+                // tensors, recurrent offsets from the matched boundary. A
+                // hybrid whose two halves disagree must rebuild and full-prefill.
+                if restored,
+                    !validateRestoredCacheBoundary(
+                        self.cache, matchedTokens: matchedTokens,
+                        restoredTokens: restoredTokenCount, detail: detail.rawValue)
+                {
+                    restored = false
+                    retainedDiskRestore = false
+                    self.cache = self.model.newCache(parameters: effectiveParameters)
+                    inputForPrepare = input
+                }
                 if restored {
                     if cacheLookupUsesPostPrepareAlias {
                         self.promptTokenIds = cacheLookupTokenIds

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -684,10 +684,12 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 let ssmStates, let diskArrays):
                 var restored = false
                 var retainedDiskRestore = false
+                var restoredTokenCount = 0
                 if !blocks.isEmpty {
                     let restoredTokens = restoreLayerData(from: blocks, into: self.cache)
                     coordinator.release(blocks: blocks)
                     if restoredTokens > 0 {
+                        restoredTokenCount = restoredTokens
                         if let ssm = ssmStates {
                             restoreSSMStates(
                                 ssm, into: self.cache, boundary: matchedTokens)
@@ -699,6 +701,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 if let diskArrays, !restored {
                     let diskRestored = restoreFromDiskArrays(diskArrays, into: &self.cache)
                     if diskRestored > 0 {
+                        restoredTokenCount = diskRestored
                         let cacheHasArraysState = self.cache.contains {
                             String(describing: type(of: $0)).contains("Arrays")
                         }
@@ -714,6 +717,19 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                     }
                 }
 
+                // Fail closed: attention offsets come from the restored KV
+                // tensors, recurrent offsets from the matched boundary. A
+                // hybrid whose two halves disagree must rebuild and full-prefill.
+                if restored,
+                    !validateRestoredCacheBoundary(
+                        self.cache, matchedTokens: matchedTokens,
+                        restoredTokens: restoredTokenCount, detail: "native-mtp")
+                {
+                    restored = false
+                    retainedDiskRestore = false
+                    self.cache = model.newCache(parameters: effectiveParameters)
+                    inputForPrepare = input
+                }
                 if restored {
                     if cacheLookupUsesPostPrepareAlias {
                         self.promptTokenIds = cacheLookupTokenIds

--- a/Package.swift
+++ b/Package.swift
@@ -849,6 +849,7 @@ let package = Package(
             sources: [
                 "ProposalHeadStampTests.swift",
                 "NativeMTPARSafetyTests.swift",
+                "HybridRestoreBoundaryInvariantTests.swift",
                 "DualPathFamiliesTests.swift",
                 "Qwen35FusedInputProjectionTests.swift",
                 "MLADecodeSDPADtypeTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/HybridRestoreBoundaryInvariantTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/HybridRestoreBoundaryInvariantTests.swift
@@ -1,0 +1,305 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Hybrid restore boundary invariant.
+//
+// A coordinator cache hit restores TWO independently derived lengths:
+//
+//   * attention layers — `restoreLayerData(from:into:)` sets each KV layer's
+//     offset from the restored tensor's sequence dim and returns that as
+//     `restoredTokens`;
+//   * recurrent layers — `restoreSSMStates(_:into:boundary:)` sets every
+//     MambaCache / ArraysCache offset to the coordinator's `matchedTokens`.
+//
+// The apply sites (Evaluate / BatchEngine / NativeMTPTokenIterator, plus the
+// disk-array paths right after each) only checked `restoredTokens > 0`. When
+// the two lengths disagree, attention runs over M tokens while KDA / GDN
+// state summarises N != M — the hybrid's two halves desynchronise and the
+// logits degenerate (token id 0 `!` on Raptor / Ling 3, verbatim loops on
+// Ornith / qwen3_5).
+//
+// The invariant is: after a restore, `restoredTokens == matchedTokens` AND
+// every layer's `offset == matchedTokens`. `validateRestoredCacheBoundary`
+// is the fail-closed check; a violation makes the caller rebuild the cache
+// and full-prefill.
+//
+// 37 is used throughout on purpose: it is not a multiple of 16 (the block
+// size used here) nor of 64 / 256 (KV step sizes), so a padded/aligned
+// buffer cannot masquerade as the logical offset.
+
+import Foundation
+import MLX
+@testable import MLXLMCommon
+import Testing
+
+@Suite("Hybrid restore boundary invariant", .serialized)
+struct HybridRestoreBoundaryInvariantTests {
+
+    // MARK: - Fixtures
+
+    private static let kvHeads = 2
+    private static let headDim = 8
+
+    /// A KVCacheSimple whose logical offset is exactly `offset`.
+    ///
+    /// Goes through the `state` setter (the same seam `restoreLayerData`
+    /// uses), which derives `offset` from `keys.dim(2)`.
+    private func makeKV(offset: Int, fill: Float = 1) -> KVCacheSimple {
+        let cache = KVCacheSimple()
+        guard offset > 0 else { return cache }
+        let keys = MLXArray.ones([1, Self.kvHeads, offset, Self.headDim], dtype: .bfloat16) * fill
+        let values = MLXArray.ones([1, Self.kvHeads, offset, Self.headDim], dtype: .bfloat16) * (fill / 2)
+        MLX.eval(keys, values)
+        cache.state = [keys, values]
+        return cache
+    }
+
+    /// A MambaCache with populated conv/ssm slots and logical offset `offset`.
+    private func makeMamba(offset: Int) -> MambaCache {
+        let mamba = MambaCache()
+        let conv = MLXArray.ones([1, 4, 8], dtype: .float32)
+        let ssm = MLXArray.ones([1, 2, 8, 8], dtype: .float32) * Float(2)
+        MLX.eval(conv, ssm)
+        mamba.state = [conv, ssm]
+        mamba.offset = offset
+        return mamba
+    }
+
+    /// `[KVCacheSimple, MambaCache, KVCacheSimple]` — the smallest hybrid
+    /// shape with a recurrent layer sandwiched between two attention layers,
+    /// so a per-layer walk must visit both kinds on either side of it.
+    private func makeHybridCache(kv0: Int, mamba: Int, kv2: Int) -> [any KVCache] {
+        [makeKV(offset: kv0), makeMamba(offset: mamba), makeKV(offset: kv2)]
+    }
+
+    /// Paged blocks carrying `tokenCount` tokens in total for the 2 KV-bearing
+    /// layers of `makeHybridCache`, split into `blockSize`-token blocks (last
+    /// block partial). Mirrors what `CacheCoordinator.fetch` hands back.
+    private func makeBlocks(tokenCount: Int, blockSize: Int) -> [CacheBlock] {
+        var blocks: [CacheBlock] = []
+        var start = 0
+        var blockId = 0
+        while start < tokenCount {
+            let n = min(blockSize, tokenCount - start)
+            let block = CacheBlock(blockId: blockId, blockSize: blockSize)
+            block.tokenIds = Array(start ..< (start + n))
+            var layers: [(keys: MLXArray, values: MLXArray)?] = []
+            for layer in 0 ..< 2 {
+                let keys = MLXArray.ones([1, Self.kvHeads, n, Self.headDim], dtype: .bfloat16)
+                    * Float(layer + 1)
+                let values = MLXArray.ones([1, Self.kvHeads, n, Self.headDim], dtype: .bfloat16)
+                    * Float(start + 1)
+                MLX.eval(keys, values)
+                layers.append((keys: keys, values: values))
+            }
+            block.cacheData = layers
+            blocks.append(block)
+            start += n
+            blockId += 1
+        }
+        return blocks
+    }
+
+    private func offsets(_ cache: [any KVCache]) -> [Int] {
+        cache.map(\.offset)
+    }
+
+    // MARK: - 1. Pure helper contract
+
+    @Test("all layers at 37 with restoredTokens 37 is a valid restore")
+    func consistentRestoreIsValid() {
+        FocusedMLXTestSupport.withLock {
+            let cache = makeHybridCache(kv0: 37, mamba: 37, kv2: 37)
+            // Fixture sanity: the check below must not pass vacuously.
+            #expect(offsets(cache) == [37, 37, 37])
+            #expect(
+                validateRestoredCacheBoundary(cache, matchedTokens: 37, restoredTokens: 37),
+                "a fully consistent restore must be accepted")
+        }
+    }
+
+    @Test("one KV layer at 36 while matched is 37 is refused")
+    func shortKVLayerIsRefused() {
+        FocusedMLXTestSupport.withLock {
+            let cache = makeHybridCache(kv0: 37, mamba: 37, kv2: 36)
+            #expect(offsets(cache) == [37, 37, 36])
+            #expect(
+                !validateRestoredCacheBoundary(cache, matchedTokens: 37, restoredTokens: 37),
+                "an attention layer one token short of the boundary must refuse")
+
+            // Same defect on the FIRST KV layer — the one whose tensor seeds
+            // `restoredTokens` in the disk path — must also refuse, even when
+            // restoredTokens happens to agree with matchedTokens.
+            let cacheFirst = makeHybridCache(kv0: 36, mamba: 37, kv2: 37)
+            #expect(
+                !validateRestoredCacheBoundary(cacheFirst, matchedTokens: 37, restoredTokens: 37))
+        }
+    }
+
+    @Test("MambaCache at 38 while attention is at 37 is refused (the production desync shape)")
+    func recurrentLayerAheadIsRefused() {
+        FocusedMLXTestSupport.withLock {
+            let cache = makeHybridCache(kv0: 37, mamba: 38, kv2: 37)
+            #expect(offsets(cache) == [37, 38, 37])
+            #expect(
+                !validateRestoredCacheBoundary(cache, matchedTokens: 37, restoredTokens: 37),
+                "a recurrent layer ahead of the attention boundary must refuse")
+
+            // And the mirror image: attention at the boundary, mamba behind.
+            let behind = makeHybridCache(kv0: 37, mamba: 36, kv2: 37)
+            #expect(
+                !validateRestoredCacheBoundary(behind, matchedTokens: 37, restoredTokens: 37),
+                "a recurrent layer behind the attention boundary must refuse")
+        }
+    }
+
+    @Test("restoredTokens 36 with every offset at 37 is refused")
+    func restoredCountDisagreeingWithOffsetsIsRefused() {
+        FocusedMLXTestSupport.withLock {
+            let cache = makeHybridCache(kv0: 37, mamba: 37, kv2: 37)
+            #expect(offsets(cache) == [37, 37, 37])
+            #expect(
+                !validateRestoredCacheBoundary(cache, matchedTokens: 37, restoredTokens: 36),
+                "restoredTokens must equal matchedTokens even when every layer offset agrees")
+            // matchedTokens itself disagreeing with a self-consistent cache
+            // is the same refusal from the other side.
+            #expect(
+                !validateRestoredCacheBoundary(cache, matchedTokens: 36, restoredTokens: 36),
+                "a cache at 37 must not be accepted as a 36-token restore")
+        }
+    }
+
+    @Test("a zero-token restore is never valid")
+    func zeroTokenRestoreIsRefused() {
+        FocusedMLXTestSupport.withLock {
+            let cache = makeHybridCache(kv0: 0, mamba: 0, kv2: 0)
+            #expect(offsets(cache) == [0, 0, 0])
+            // `restoredTokens > 0` was the old liveness check; the invariant
+            // helper must not turn "nothing restored" into an accepted hit.
+            #expect(!validateRestoredCacheBoundary(cache, matchedTokens: 0, restoredTokens: 0))
+        }
+    }
+
+    // MARK: - 2. Desync reproduced through the real restore helpers
+
+    @Test("restoreLayerData(37 tokens) + restoreSSMStates(boundary: 40) is exactly the production desync and is refused")
+    func realHelpersProduceDesyncThatIsRefused() {
+        FocusedMLXTestSupport.withLock {
+            let blockSize = 16
+            let blocks = makeBlocks(tokenCount: 37, blockSize: blockSize)
+            #expect(blocks.count == 3, "37 tokens at block size 16 must be 16+16+5")
+            #expect(blocks.last?.tokenCount == 5, "last block must be PARTIAL — 37 % 16 != 0")
+
+            let target = makeHybridCache(kv0: 0, mamba: 0, kv2: 0)
+            let restoredTokens = restoreLayerData(from: blocks, into: target)
+            #expect(restoredTokens == 37, "block restore must report the block token total")
+            #expect(target[0].offset == 37)
+            #expect(target[2].offset == 37)
+            #expect(target[1].offset == 0, "restoreLayerData must not touch the recurrent layer")
+
+            // The SSM companion is applied at a DIFFERENT boundary than the
+            // blocks covered. This is the coordinator-side shape of the bug:
+            // `matchedTokens` drives the recurrent offsets, the block tensors
+            // drive the attention offsets, and nothing reconciled them.
+            let companion = extractSSMStates(from: [makeMamba(offset: 40)])
+            #expect(companion.count == 2)
+            restoreSSMStates(companion, into: target, boundary: 40)
+            #expect(target[1].offset == 40, "restoreSSMStates(boundary:) seats the recurrent offset from the boundary")
+            #expect(offsets(target) == [37, 40, 37], "this IS the desync: attention at 37, recurrent at 40")
+
+            // Both views of the boundary must refuse this cache.
+            #expect(
+                !validateRestoredCacheBoundary(target, matchedTokens: 40, restoredTokens: restoredTokens),
+                "matched=40 vs restored=37 must be refused")
+            #expect(
+                !validateRestoredCacheBoundary(target, matchedTokens: 37, restoredTokens: restoredTokens),
+                "matched=37 with a recurrent layer at 40 must be refused")
+        }
+    }
+
+    @Test("restoreLayerData(37 tokens) + restoreSSMStates(boundary: 37) is accepted")
+    func realHelpersAtTheSameBoundaryAreAccepted() {
+        FocusedMLXTestSupport.withLock {
+            // Control for the previous test: identical path, boundary agrees.
+            let blocks = makeBlocks(tokenCount: 37, blockSize: 16)
+            let target = makeHybridCache(kv0: 0, mamba: 0, kv2: 0)
+            let restoredTokens = restoreLayerData(from: blocks, into: target)
+            #expect(restoredTokens == 37)
+            let companion = extractSSMStates(from: [makeMamba(offset: 37)])
+            restoreSSMStates(companion, into: target, boundary: 37)
+            #expect(offsets(target) == [37, 37, 37])
+            #expect(
+                validateRestoredCacheBoundary(target, matchedTokens: 37, restoredTokens: restoredTokens),
+                "the same helpers at an agreeing boundary must be accepted — otherwise every hybrid hit would be refused")
+        }
+    }
+
+    @Test("restoreLayerData over blocks whose tensors are one token short of tokenIds is refused")
+    func blockTensorShorterThanTokenIdsIsRefused() {
+        FocusedMLXTestSupport.withLock {
+            // `restoreLayerData` returns SUM(tokenIds.count) but sets the
+            // attention offset from the TENSOR length. A block whose KV
+            // tensor lost a token (the disk-array analogue is a truncated
+            // `kv_{i}_keys`) reports 37 restored while the layers sit at 36.
+            let blocks = makeBlocks(tokenCount: 37, blockSize: 16)
+            let last = blocks[blocks.count - 1]
+            let n = last.tokenCount
+            last.cacheData = last.cacheData?.map { entry -> (keys: MLXArray, values: MLXArray)? in
+                guard let entry else { return nil }
+                return (
+                    keys: entry.keys[.ellipsis, ..<(n - 1), 0...],
+                    values: entry.values[.ellipsis, ..<(n - 1), 0...]
+                )
+            }
+
+            let target = makeHybridCache(kv0: 0, mamba: 0, kv2: 0)
+            let restoredTokens = restoreLayerData(from: blocks, into: target)
+            #expect(restoredTokens == 37, "tokenIds still total 37")
+            #expect(target[0].offset == 36, "tensor length drives the attention offset")
+            #expect(target[2].offset == 36)
+            restoreSSMStates(extractSSMStates(from: [makeMamba(offset: 37)]), into: target, boundary: 37)
+            #expect(offsets(target) == [36, 37, 36])
+            #expect(
+                !validateRestoredCacheBoundary(target, matchedTokens: 37, restoredTokens: restoredTokens),
+                "attention offsets 36 under a 37-token boundary must be refused")
+        }
+    }
+
+    // MARK: - 3. The invariant is wired at every apply site
+
+    /// The helper existing is not the fix; the fix is every coordinator-hit
+    /// apply site consulting it. This is the one test in the file that fails
+    /// BEFORE the product change (the sites only checked `restoredTokens > 0`)
+    /// and passes after.
+    @Test("every coordinator-hit apply site consults validateRestoredCacheBoundary")
+    func applySitesConsultTheInvariant() throws {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let libraries = root.appendingPathComponent("Libraries/MLXLMCommon")
+
+        let helpers = try String(
+            contentsOf: libraries.appendingPathComponent("Cache/CacheHelpers.swift"),
+            encoding: .utf8)
+        #expect(
+            helpers.contains("public func validateRestoredCacheBoundary("),
+            "CacheHelpers.swift must declare the public fail-closed helper")
+
+        let applySites = [
+            "Evaluate.swift",
+            "BatchEngine/BatchEngine.swift",
+            "SpecDec/NativeMTPTokenIterator.swift",
+        ]
+        for relative in applySites {
+            let source = try String(
+                contentsOf: libraries.appendingPathComponent(relative), encoding: .utf8)
+            // Each of these files restores blocks and/or disk arrays on a
+            // coordinator hit; a site that never names the helper still
+            // accepts a desynchronised restore on `restoredTokens > 0` alone.
+            #expect(
+                source.contains("validateRestoredCacheBoundary("),
+                "\(relative) applies a coordinator cache hit but never validates the restored boundary")
+        }
+    }
+}

--- a/Tests/MLXLMTests/HybridRestoreBoundaryRoundTripTests.swift
+++ b/Tests/MLXLMTests/HybridRestoreBoundaryRoundTripTests.swift
@@ -1,0 +1,265 @@
+// Copyright © 2026 Apple Inc.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import Testing
+
+@testable import MLXLLM
+
+/// End-to-end disk-tier round trip on the tiny synthetic Ling 3.0 model
+/// (BailingMoeV3: MLA attention on `KVCacheSimple` + KDA on `MambaCache`).
+///
+/// `HybridRestoreBoundaryInvariantTests` (MLXLMCommonFocusedTests) pins
+/// `validateRestoredCacheBoundary` against hand-built caches. This suite runs
+/// the REAL pipeline — model prefill, `TQDiskSerializer.serialize` (v2),
+/// `restoreFromDiskArrays`, the validator, then the suffix prefill — and
+/// proves two things:
+///
+/// 1. A partial hit (same 37-token prefix, 5-token suffix) restored from a
+///    v2 record reproduces one-shot prefill: every offset, the last-position
+///    logits, and every recurrent state.
+/// 2. A record whose two halves disagree (recurrent offset tampered, or one
+///    attention layer's KV truncated) is refused by the validator.
+///
+/// 37 is deliberately not a multiple of any step/page size (16, 64, 256): the
+/// dots3 `cached_tokens % 256` corruption was invisible at aligned lengths.
+@Suite("Hybrid restore boundary round trip (Ling 3 tiny)", .serialized)
+struct HybridRestoreBoundaryRoundTripTests {
+
+    static let prefixLength = 37
+    static let suffixLength = 5
+    static var totalLength: Int { prefixLength + suffixLength }  // 42
+
+    /// Deterministic prompt ids in `0..<vocab_size` (128 on the fixture).
+    /// A fixed LCG rather than `MLXRandom` so the ids do not depend on the
+    /// MLX RNG stream that model init also draws from.
+    private static func promptTokens(count: Int, seed: UInt64 = 0x5EED_2026) -> [Int32] {
+        var s = seed
+        return (0 ..< count).map { _ in
+            s = s &* 6_364_136_223_846_793_005 &+ 1_442_695_040_888_963_407
+            return Int32((s >> 33) % 128)
+        }
+    }
+
+    private struct Fixture {
+        let model: BailingMoeV3Model
+        let tokens: MLXArray  // [42] int32
+        let mambaIndices: [Int]
+        let attentionIndices: [Int]
+
+        private typealias T = HybridRestoreBoundaryRoundTripTests
+
+        var prefix: MLXArray { tokens[0 ..< T.prefixLength].reshaped(1, T.prefixLength) }
+        var suffix: MLXArray {
+            tokens[T.prefixLength ..< T.totalLength].reshaped(1, T.suffixLength)
+        }
+        var whole: MLXArray { tokens.reshaped(1, T.totalLength) }
+    }
+
+    /// Must be called under `MLXMetalTestLock`.
+    private static func makeFixture() throws -> Fixture {
+        MLXRandom.seed(11)
+        let config = try JSONDecoder().decode(
+            BailingMoeV3Configuration.self, from: BailingMoeV3Tests.v3ConfigJSON)
+        let model = BailingMoeV3Model(config)
+        MLX.eval(model.parameters())
+
+        let probe = model.newCache(parameters: nil)
+        let mamba = probe.indices.filter { probe[$0] is MambaCache }
+        let attention = probe.indices.filter { probe[$0] is KVCacheSimple }
+        // Fail closed: the hybrid shape is the whole point of the test.
+        try #require(!mamba.isEmpty, "fixture has no MambaCache layers")
+        try #require(!attention.isEmpty, "fixture has no KVCacheSimple layers")
+        try #require(mamba.count + attention.count == probe.count)
+
+        return Fixture(
+            model: model,
+            tokens: MLXArray(promptTokens(count: totalLength)),
+            mambaIndices: mamba,
+            attentionIndices: attention)
+    }
+
+    /// Prefill the 37-token prefix into a fresh cache and serialize it as a
+    /// v2 disk record (Mamba topology, no `ssmStates` companion).
+    private static func prefixRecord(_ fx: Fixture) throws -> [String: MLXArray] {
+        let cache = fx.model.newCache(parameters: nil)
+        let out = fx.model(fx.prefix, cache: cache)
+        MLX.eval(out)
+        MLX.eval(cache.flatMap(\.state))
+        for (i, layer) in cache.enumerated() {
+            try #require(layer.offset == prefixLength, "prefill: layer \(i) offset \(layer.offset)")
+        }
+        let record = TQDiskSerializer.serialize(cache: cache, ssmStates: nil)
+
+        // The record must actually carry both halves, or the round trip below
+        // would compare a miss against a miss.
+        try #require(TQDiskSerializer.formatVersion(of: record) >= 2)
+        for m in fx.mambaIndices {
+            try #require(record["mamba_\(m)_state0"] != nil, "missing mamba_\(m)_state0")
+            let off = try #require(record["__mamba_\(m)_offset__"], "missing __mamba_\(m)_offset__")
+            #expect(off.shape == [1] && off.dtype == .int32, "offset meta shape \(off.shape) \(off.dtype)")
+            #expect(off[0].item(Int32.self) == Int32(prefixLength))
+        }
+        for a in fx.attentionIndices {
+            let keys = try #require(record["kv_\(a)_keys"], "missing kv_\(a)_keys")
+            try #require(record["kv_\(a)_values"] != nil, "missing kv_\(a)_values")
+            #expect(keys.dim(2) == prefixLength, "kv_\(a)_keys seq dim \(keys.dim(2))")
+        }
+        return record
+    }
+
+    private static func maxAbsDiff(_ a: MLXArray, _ b: MLXArray) -> Float {
+        abs(a.asType(.float32) - b.asType(.float32)).max().item(Float.self)
+    }
+
+    // MARK: - (a) partial hit reproduces one-shot prefill
+
+    @Test("disk-tier partial hit (37 + 5) reproduces one-shot prefill of 42")
+    func roundTripPartialHitMatchesOneShot() throws {
+        try MLXMetalTestLock.withLock {
+            let fx = try Self.makeFixture()
+
+            // One shot: fresh cache, 42 tokens in a single prefill.
+            let oneShotCache = fx.model.newCache(parameters: nil)
+            let oneShot = fx.model(fx.whole, cache: oneShotCache)
+            MLX.eval(oneShot)
+            MLX.eval(oneShotCache.flatMap(\.state))
+            let oneShotLast = oneShot[0, Self.totalLength - 1]
+            for (i, layer) in oneShotCache.enumerated() {
+                #expect(layer.offset == Self.totalLength, "one-shot: layer \(i) offset \(layer.offset)")
+            }
+            // Non-empty baseline: random-init logits must not be degenerate.
+            try #require(abs(oneShotLast.asType(.float32)).max().item(Float.self) > 0)
+            var oneShotStates: [Int: [MLXArray]] = [:]
+            for m in fx.mambaIndices {
+                let s = oneShotCache[m].state
+                try #require(s.count == 2, "one-shot: mamba layer \(m) has \(s.count) slots")
+                oneShotStates[m] = s
+            }
+
+            // Cached: prefill A, serialize (v2), restore into a fresh cache.
+            let record = try Self.prefixRecord(fx)
+            var restoredCache = fx.model.newCache(parameters: nil)
+            let restoredTokens = restoreFromDiskArrays(record, into: &restoredCache)
+            MLX.eval(restoredCache.flatMap(\.state))
+
+            #expect(restoredTokens == Self.prefixLength, "restore returned \(restoredTokens)")
+            #expect(
+                validateRestoredCacheBoundary(
+                    restoredCache, matchedTokens: Self.prefixLength,
+                    restoredTokens: restoredTokens, detail: "round-trip"),
+                "validator refused a consistent restore")
+            for (i, layer) in restoredCache.enumerated() {
+                #expect(layer.offset == Self.prefixLength, "restored: layer \(i) offset \(layer.offset)")
+            }
+
+            // Continue with the suffix through the restored cache.
+            let step = fx.model(fx.suffix, cache: restoredCache)
+            MLX.eval(step)
+            MLX.eval(restoredCache.flatMap(\.state))
+            for (i, layer) in restoredCache.enumerated() {
+                #expect(layer.offset == Self.totalLength, "after suffix: layer \(i) offset \(layer.offset)")
+            }
+
+            // Same tolerance as BailingMoeV3Tests.cachedDecodeParity.
+            let stepLast = step[0, Self.suffixLength - 1]
+            let logitDiff = Self.maxAbsDiff(oneShotLast, stepLast)
+            #expect(logitDiff < 2e-2, "restored-path logits diverged from one-shot: \(logitDiff)")
+
+            // Every recurrent state must match one-shot slot for slot.
+            for m in fx.mambaIndices {
+                let restored = restoredCache[m].state
+                let reference = try #require(oneShotStates[m])
+                try #require(restored.count == reference.count, "mamba layer \(m) slot count")
+                for (slot, (r, o)) in zip(restored, reference).enumerated() {
+                    #expect(r.shape == o.shape, "mamba layer \(m) slot \(slot) shape \(r.shape) vs \(o.shape)")
+                    let scale = max(1, abs(o.asType(.float32)).max().item(Float.self))
+                    let diff = Self.maxAbsDiff(r, o)
+                    #expect(
+                        diff <= 2e-2 * scale,
+                        "mamba layer \(m) slot \(slot) state diverged: \(diff) (scale \(scale))")
+                }
+            }
+        }
+    }
+
+    // MARK: - (b) desynchronised records are refused
+
+    @Test("a record whose recurrent offset is 38 against 37 attention tokens is refused")
+    func tamperedRecurrentOffsetIsRefused() throws {
+        try MLXMetalTestLock.withLock {
+            let fx = try Self.makeFixture()
+            var record = try Self.prefixRecord(fx)
+
+            // Same shape/dtype `metaInt32` writes (1-element 1D int32) so the
+            // deserializer's `readMetaInt32` accepts it as a valid offset.
+            let tampered = fx.mambaIndices[0]
+            record["__mamba_\(tampered)_offset__"] = MLXArray([Int32(Self.prefixLength + 1)])
+
+            var cache = fx.model.newCache(parameters: nil)
+            let restoredTokens = restoreFromDiskArrays(record, into: &cache)
+
+            // What the code does today: the deserializer trusts a readable
+            // offset and `restoreMambaLayer` seats it verbatim, while
+            // `totalTokens` comes from the attention keys (37). So restore
+            // reports 37 and leaves the tampered layer at 38 — exactly the
+            // production desync shape — and ONLY the validator catches it.
+            #expect(restoredTokens == Self.prefixLength, "restore returned \(restoredTokens)")
+            #expect(cache[tampered].offset == Self.prefixLength + 1)
+            for a in fx.attentionIndices {
+                #expect(cache[a].offset == Self.prefixLength)
+            }
+            #expect(
+                !validateRestoredCacheBoundary(
+                    cache, matchedTokens: Self.prefixLength,
+                    restoredTokens: restoredTokens, detail: "tampered-recurrent-offset"),
+                "validator accepted a recurrent layer at 38 against a 37-token match")
+        }
+    }
+
+    @Test("a record with one attention layer's KV truncated to 36 tokens is refused")
+    func truncatedKVIsRefused() throws {
+        try MLXMetalTestLock.withLock {
+            let fx = try Self.makeFixture()
+            let record = try Self.prefixRecord(fx)
+            let firstAttention = try #require(fx.attentionIndices.first)
+
+            // Truncate each attention layer in turn. Truncating the FIRST one
+            // also shrinks the restore count (36 != 37); truncating a later
+            // one leaves the count at 37 and is caught only by the per-layer
+            // offset check. Both properties must refuse.
+            for victim in fx.attentionIndices {
+                var damaged = record
+                let keys = try #require(damaged["kv_\(victim)_keys"])
+                let values = try #require(damaged["kv_\(victim)_values"])
+                // KVCacheSimple layout is [B, H, T, D]; slice the T axis the
+                // same way `KVCacheSimple.state` does.
+                let shorter = Self.prefixLength - 1
+                damaged["kv_\(victim)_keys"] = keys[.ellipsis, ..<shorter, 0...]
+                damaged["kv_\(victim)_values"] = values[.ellipsis, ..<shorter, 0...]
+
+                var cache = fx.model.newCache(parameters: nil)
+                let restoredTokens = restoreFromDiskArrays(damaged, into: &cache)
+
+                // What the code does today: `totalTokens` is seeded from the
+                // first `.standard` layer's key length, so it is 36 only when
+                // the first attention layer is the truncated one.
+                let expectedCount = victim == firstAttention
+                    ? Self.prefixLength - 1 : Self.prefixLength
+                #expect(
+                    restoredTokens == expectedCount,
+                    "victim \(victim): restore returned \(restoredTokens), expected \(expectedCount)")
+                #expect(cache[victim].offset == Self.prefixLength - 1, "victim \(victim) offset \(cache[victim].offset)")
+                for m in fx.mambaIndices {
+                    #expect(cache[m].offset == Self.prefixLength, "mamba \(m) offset \(cache[m].offset)")
+                }
+                #expect(
+                    !validateRestoredCacheBoundary(
+                        cache, matchedTokens: Self.prefixLength,
+                        restoredTokens: restoredTokens, detail: "truncated-kv-\(victim)"),
+                    "validator accepted attention layer \(victim) at 36 against a 37-token match")
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Defect
On a coordinator cache hit the engine restores two independently derived lengths and never checks that they agree:
- attention layers: offset from the restored KV tensors (`restoreLayerData` / `restoreFromDiskArrays`)
- recurrent layers (`MambaCache`: KDA on Ling 3 / Raptor, Gated DeltaNet on Qwen 3.5 / Ornith): offset from the matched boundary (`restoreSSMStates(boundary:)` / `__mamba_i_offset__`)

The apply sites in `Evaluate.swift`, `BatchEngine.swift` and `NativeMTPTokenIterator.swift` only checked `restoredTokens > 0`. A row whose halves disagree seats a desynchronised hybrid cache: attention runs over M tokens while the recurrent state summarises N ≠ M, and the logits degenerate — token id 0 (`!`) on Raptor, verbatim loops on Ornith. Same class as the dots3 `cached_tokens % 256` bug: the real invariant is `offset == matched boundary` for every layer; a liveness check at a nominally aligned boundary is vacuous.

## Fix
`validateRestoredCacheBoundary(_:matchedTokens:restoredTokens:detail:)` (CacheHelpers.swift): `restoredTokens == matchedTokens` and every layer's `offset == matchedTokens`, else log `[vmlx][cache/restore] REFUSED offset/key mismatch detail=… matched=… restored=… offsets=…`, rebuild the cache and full-prefill. Applied at the solo, batch and native-MTP restore sites; the block-diffusion iterator already had the equivalent check. Mirrors the store-side `REFUSED offset/key mismatch` guard, so a poisoned row can neither be written nor consumed. A refused entry costs one prefill; an accepted one costs the whole continuation.

## Tests
Unit tests for the helper and a tiny-KDA-model round trip (partial hit at a non-block-aligned length, tampered offsets refused) follow in this PR.

## Live
Control on the osaurus dev build (Raptor-v0.5-8B-A1B-JANG_6M): cache off 8/8 coherent; cache on 8/8 coherent across partial disk restores at 3136→9050 tokens and a 5-turn tool-step flow (15 HIT / 7 MISS / 0 REFUSED). The user-reported shape involves stale rows from earlier builds; the guard makes any such row a refused restore instead of a corrupted reply.