### PR TITLE
Non-finite logits probe (VMLX_LOGITS_NAN_TRACE=1) + JangLoader top-level reasoning/tools/chat stamps (Raptor)

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -1864,7 +1864,8 @@ public final class LLMModelFactory: ModelFactory {
         var eosTokenIds = ModelTokenConfigurationResolver.resolvedEOSTokenIds(
             baseConfig: baseConfig,
             configurationData: configData,
-            generationConfig: generationConfig)
+            generationConfig: generationConfig,
+            jangStopTokenIds: earlyJangConfig?.chat?.stopTokenIds)
         if baseConfig.modelType == "deepseek_v4" {
             // DSV4's Python runtime treats EOS plus both role-boundary
             // sentinels as hard stops: {1, 128803, 128804}. The public

--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -1911,7 +1911,12 @@ public actor BatchEngine {
                 }
             }
 
-            let slot = BatchSlot(from: request, cache: cache, stopTokenIDs: stopTokenIDs)
+            var slot = BatchSlot(from: request, cache: cache, stopTokenIDs: stopTokenIDs)
+            if NaNLogitsTrace.isEnabled {
+                slot.nanTrace = NaNLogitsTrace(
+                    slot: request.id.description,
+                    model: context.configuration.name)
+            }
             slot.continuation.yield(.prefillProgress(PrefillProgress(
                 stage: .queued,
                 completedUnitCount: 0,
@@ -3262,6 +3267,7 @@ public actor BatchEngine {
     /// future cache reuse.
     private func finishSlot(_ liveSlot: inout BatchSlot, reason: GenerateStopReason) {
         let slot = liveSlot
+        slot.nanTrace?.finish(totalSteps: slot.generatedTokenCount)
         defer {
             // Cache stores are synchronous. Drop the sole retained prompt/seed
             // snapshot as soon as they finish instead of holding it until the

--- a/Libraries/MLXLMCommon/BatchEngine/BatchScheduler.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchScheduler.swift
@@ -155,21 +155,35 @@ struct BatchSlot {
     /// `BucketHandle` holding shared `[B, H, maxLen, D]` buffers.
     var compiledForward: (@Sendable ([MLXArray]) -> [MLXArray])?
 
+    /// `VMLX_LOGITS_NAN_TRACE=1` diagnostic (see ``NaNLogitsTrace``).
+    /// `nil` when the flag is off. Set by the engine at slot admission,
+    /// finished in `finishSlot`.
+    var nanTrace: NaNLogitsTrace?
+
     // MARK: - Sampling
 
     /// Sample a token from logits, applying processor and sampler.
     ///
     /// Returns the sampled token as an `MLXArray` scalar.
     mutating func sampleToken(from logits: MLXArray) -> MLXArray {
+        // Diagnostic only: the raw `[1, V]` row before any processor rewrite.
+        let rawRow = nanTrace != nil ? logits : nil
         var logits = logits
+        let token: MLXArray
         if var proc = processor {
             logits = proc.process(logits: logits)
-            let token = sampler.sample(logits: logits)
+            token = sampler.sample(logits: logits)
             proc.didSample(token: token)
             self.processor = proc
-            return token
+        } else {
+            token = sampler.sample(logits: logits)
         }
-        return sampler.sample(logits: logits)
+        if let rawRow, let nanTrace {
+            nanTrace.observe(
+                rawRow, site: "batch", step: generatedTokenCount,
+                sampled: { token.item(Int.self) })
+        }
+        return token
     }
 }
 

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1592,6 +1592,10 @@ public struct TokenIterator: TokenIteratorProtocol {
     private var compiledMambaOffsets: [(index: Int, base: Int)] = []
     private var compiledStepCount = 0
 
+    /// `VMLX_LOGITS_NAN_TRACE=1` diagnostic (see ``NaNLogitsTrace``). Created
+    /// lazily on the first sample so the flag-off path costs one `Bool` read.
+    private var nanTrace: NaNLogitsTrace?
+
     // Multi-tier cache coordinator (skeleton integration)
     let cacheCoordinator: CacheCoordinator?
 
@@ -2613,16 +2617,40 @@ public struct TokenIterator: TokenIteratorProtocol {
 
     mutating func convertToToken(logits: MLXArray) -> MLXArray {
         var logits = logits[0..., -1, 0...]
+        // Diagnostic only (`VMLX_LOGITS_NAN_TRACE=1`): keep the raw model
+        // row so the probe below reports what the model produced, before
+        // any processor rewrites it. Sampling behaviour is unchanged.
+        let rawRow = NaNLogitsTrace.isEnabled ? logits : nil
 
         if var processor {
             logits = processor.process(logits: logits)
             let y = sampler.sample(logits: logits)
             processor.didSample(token: y)
             self.processor = processor
+            if let rawRow { probeNonFiniteLogits(rawRow, sampled: y) }
             return y
         }
 
-        return sampler.sample(logits: logits)
+        let y = sampler.sample(logits: logits)
+        if let rawRow { probeNonFiniteLogits(rawRow, sampled: y) }
+        return y
+    }
+
+    /// `VMLX_LOGITS_NAN_TRACE=1` only. Reports the first non-finite
+    /// last-position row of this generation to stderr; never alters `sampled`.
+    private mutating func probeNonFiniteLogits(_ row: MLXArray, sampled: MLXArray) {
+        if nanTrace == nil {
+            nanTrace = NaNLogitsTrace(model: String(describing: type(of: model)))
+        }
+        nanTrace?.observe(
+            row,
+            site: compiledForward != nil ? "solo-compiled" : "solo",
+            step: tokenCount,
+            sampled: { sampled.item(Int.self) })
+    }
+
+    public mutating func finalizeGenerationStats(generatedTokenIds: [Int]) {
+        nanTrace?.finish(totalSteps: tokenCount)
     }
 
     // Whether cache quantization is needed (skip the function call entirely when not)

--- a/Libraries/MLXLMCommon/GenerationConfigFile.swift
+++ b/Libraries/MLXLMCommon/GenerationConfigFile.swift
@@ -154,6 +154,26 @@ public enum ModelTokenConfigurationResolver {
         return eosTokenIds
     }
 
+    /// Same as ``resolvedEOSTokenIds(baseConfig:configurationData:generationConfig:)``
+    /// plus the JANG bundle's `chat.stop_token_ids`, which are ADDED to (never
+    /// replace) the config / generation_config declaration. Raptor stamps
+    /// `<|role_end|>` (156895) there and nowhere else.
+    public static func resolvedEOSTokenIds(
+        baseConfig: BaseConfiguration,
+        configurationData: Data,
+        generationConfig: GenerationConfigFile?,
+        jangStopTokenIds: [Int]?
+    ) -> Set<Int> {
+        var eosTokenIds = resolvedEOSTokenIds(
+            baseConfig: baseConfig,
+            configurationData: configurationData,
+            generationConfig: generationConfig)
+        if let jangStopTokenIds {
+            eosTokenIds.formUnion(jangStopTokenIds)
+        }
+        return eosTokenIds
+    }
+
     private struct TextConfigTokens: Codable {
         let eosTokenIds: IntOrIntArray?
 

--- a/Libraries/MLXLMCommon/JangLoader.swift
+++ b/Libraries/MLXLMCommon/JangLoader.swift
@@ -795,6 +795,12 @@ public struct JangChatConfig: Sendable, Equatable {
     public let samplingDefaults: JangChatSamplingDefaults?
     public let templateKwargsDefaults: ChatTemplateKwargsDefaults?
 
+    /// Extra end-of-turn token ids from `chat.stop_token_ids`. Raptor
+    /// (Ling 3 / KDA) stamps `[156895]` (`<|role_end|>`), which is NOT in
+    /// the bundle's `eos_token_id`; the factories union these into
+    /// `ModelConfiguration.eosTokenIds` so the turn actually terminates.
+    public let stopTokenIds: [Int]?
+
     public init(
         encoder: String? = nil,
         hasTokenizerChatTemplate: Bool? = nil,
@@ -806,7 +812,8 @@ public struct JangChatConfig: Sendable, Equatable {
         reasoning: JangChatReasoning? = nil,
         toolCalling: JangChatToolCalling? = nil,
         samplingDefaults: JangChatSamplingDefaults? = nil,
-        templateKwargsDefaults: ChatTemplateKwargsDefaults? = nil
+        templateKwargsDefaults: ChatTemplateKwargsDefaults? = nil,
+        stopTokenIds: [Int]? = nil
     ) {
         self.encoder = encoder
         self.hasTokenizerChatTemplate = hasTokenizerChatTemplate
@@ -819,6 +826,7 @@ public struct JangChatConfig: Sendable, Equatable {
         self.toolCalling = toolCalling
         self.samplingDefaults = samplingDefaults
         self.templateKwargsDefaults = templateKwargsDefaults
+        self.stopTokenIds = stopTokenIds
     }
 }
 
@@ -1832,6 +1840,14 @@ public struct JangLoader: Sendable {
                 branchingBudget: cDict["branching_budget"] as? Int,
                 blockSize: cDict["block_size"] as? Int
             )
+        } else if let synthesized = topLevelStampCapabilities(json) {
+            // Raptor-era (Ling 3 / KDA) bundles carry the stamp as top-level
+            // `reasoning` / `tools` / `vision` / `audio` blocks and no
+            // `capabilities` block at all. Without this the loader read
+            // nothing and every parser fell back to the model_type
+            // heuristic. The names round-trip through the same
+            // `fromCapabilityName` paths as a `capabilities` stamp would.
+            capabilities = synthesized
         } else {
             capabilities = nil
         }
@@ -1842,13 +1858,29 @@ public struct JangLoader: Sendable {
         let modelFamily =
             (json["model_family"] as? String) ?? capabilities?.family
 
+        // Top-level `reasoning` / `tools` blocks (Raptor-era). They feed
+        // the `chat` sub-blocks below only where the `chat` block itself
+        // says nothing, so DSV4-era bundles are untouched.
+        let topLevelReasoning = json["reasoning"] as? [String: Any]
+        let topLevelTools = json["tools"] as? [String: Any]
+
         // New `chat` block — see JangChatConfig doc. Only present
         // on DSV4-era bundles; older bundles return nil here and
         // the runtime falls back to `capabilities` + model_type
         // heuristics. Parsed defensively (every field optional) so
         // partial adoption doesn't break loaders.
+        // A bundle with top-level `reasoning` / `tools` but no `chat` block
+        // still gets a `chat` so the derived sub-blocks have somewhere to live.
+        let chatDict: [String: Any]?
+        if let explicit = json["chat"] as? [String: Any] {
+            chatDict = explicit
+        } else if topLevelReasoning != nil || topLevelTools != nil {
+            chatDict = [String: Any]()
+        } else {
+            chatDict = nil
+        }
         let chat: JangChatConfig?
-        if let chDict = json["chat"] as? [String: Any] {
+        if let chDict = chatDict {
             // reasoning subblock
             let reasoning: JangChatReasoning?
             if let rDict = chDict["reasoning"] as? [String: Any] {
@@ -1863,6 +1895,14 @@ public struct JangLoader: Sendable {
                         rDict["reasoning_effort_levels"]),
                     dropEarlierReasoning: rDict["drop_earlier_reasoning"] as? Bool
                 )
+            } else if let rDict = topLevelReasoning {
+                // Raptor-era top-level `reasoning` block: `default` is
+                // `"on"` / `"off"`, which is the `default_mode`
+                // `"thinking"` / `"chat"` pair the factories already read.
+                reasoning = JangChatReasoning(
+                    supported: rDict["supported"] as? Bool,
+                    defaultMode: topLevelReasoningDefaultMode(rDict)
+                )
             } else { reasoning = nil }
 
             // tool_calling subblock
@@ -1876,6 +1916,11 @@ public struct JangLoader: Sendable {
                     invokeBlock: tDict["invoke_block"] as? String,
                     parameterBlock: tDict["parameter_block"] as? String,
                     toolOutputTag: tDict["tool_output_tag"] as? String
+                )
+            } else if let tDict = topLevelTools {
+                toolCalling = JangChatToolCalling(
+                    supported: tDict["supported"] as? Bool,
+                    parser: tDict["parser"] as? String
                 )
             } else { toolCalling = nil }
 
@@ -1903,8 +1948,25 @@ public struct JangLoader: Sendable {
             if let defaults = chDict["template_kwargs_defaults"] as? [String: Any] {
                 templateKwargsDefaults = ChatTemplateKwargsDefaults(
                     enableThinking: defaults["enable_thinking"] as? Bool)
+            } else if let rDict = topLevelReasoning,
+                let enableThinking = topLevelReasoningDefaultEnableThinking(rDict)
+            {
+                // `reasoning.default: "on"` is the bundle-authored template
+                // default (`enable_thinking`), the same knob
+                // `chat.template_kwargs_defaults.enable_thinking` carries.
+                templateKwargsDefaults = ChatTemplateKwargsDefaults(
+                    enableThinking: enableThinking)
             } else {
                 templateKwargsDefaults = nil
+            }
+
+            // `chat.stop_token_ids` — extra end-of-turn ids beyond the
+            // bundle's `eos_token_id` (Raptor stamps `<|role_end|>`).
+            let stopTokenIds: [Int]?
+            if let ids = chDict["stop_token_ids"] as? [Int], !ids.isEmpty {
+                stopTokenIds = ids
+            } else {
+                stopTokenIds = nil
             }
 
             chat = JangChatConfig(
@@ -1919,7 +1981,8 @@ public struct JangLoader: Sendable {
                 reasoning: reasoning,
                 toolCalling: toolCalling,
                 samplingDefaults: sampling,
-                templateKwargsDefaults: templateKwargsDefaults
+                templateKwargsDefaults: templateKwargsDefaults,
+                stopTokenIds: stopTokenIds
             )
         } else {
             chat = nil
@@ -1938,6 +2001,49 @@ public struct JangLoader: Sendable {
             modelFamily: modelFamily,
             chat: chat
         )
+    }
+
+    /// Synthesize a `JangCapabilities` from Raptor-era top-level
+    /// `reasoning` / `tools` / `vision` / `audio` blocks. Returns `nil` when
+    /// neither `reasoning` nor `tools` is present, so pre-stamp bundles keep
+    /// `capabilities == nil` and the model_type heuristics exactly as before.
+    /// Only used when the bundle has no `capabilities` block.
+    static func topLevelStampCapabilities(_ json: [String: Any]) -> JangCapabilities? {
+        let reasoning = json["reasoning"] as? [String: Any]
+        let tools = json["tools"] as? [String: Any]
+        guard reasoning != nil || tools != nil else { return nil }
+        let vision = json["vision"] as? [String: Any]
+        let audio = json["audio"] as? [String: Any]
+        return JangCapabilities(
+            reasoningParser: reasoning?["parser"] as? String,
+            toolParser: tools?["parser"] as? String,
+            thinkInTemplate: reasoning?["think_in_template"] as? Bool,
+            supportsTools: tools?["supported"] as? Bool,
+            supportsThinking: reasoning?["supported"] as? Bool,
+            supportsVision: vision?["supported"] as? Bool,
+            supportsAudio: audio?["supported"] as? Bool
+        )
+    }
+
+    /// `reasoning.default` (`"on"` / `"off"`) → the `chat.reasoning.default_mode`
+    /// vocabulary (`"thinking"` / `"chat"`) `llmDefaultAdditionalContext` reads.
+    static func topLevelReasoningDefaultMode(_ reasoning: [String: Any]) -> String? {
+        switch topLevelReasoningDefaultEnableThinking(reasoning) {
+        case true?: return "thinking"
+        case false?: return "chat"
+        case nil: return nil
+        }
+    }
+
+    /// `reasoning.default` (`"on"` / `"off"` / bool) → `enable_thinking`.
+    static func topLevelReasoningDefaultEnableThinking(_ reasoning: [String: Any]) -> Bool? {
+        if let flag = reasoning["default"] as? Bool { return flag }
+        guard let raw = reasoning["default"] as? String else { return nil }
+        switch raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "on", "true", "thinking": return true
+        case "off", "false", "chat": return false
+        default: return nil
+        }
     }
 
     private static func parseMXTQBits(_ value: Any?) -> [String: Int] {

--- a/Libraries/MLXLMCommon/NaNLogitsTrace.swift
+++ b/Libraries/MLXLMCommon/NaNLogitsTrace.swift
@@ -30,7 +30,7 @@ public final class NaNLogitsTrace: @unchecked Sendable {
         ProcessInfo.processInfo.environment["VMLX_LOGITS_NAN_TRACE"] == "1"
 
     private static let globalLock = NSLock()
-    private static var generationsWithNonFinite = 0
+    nonisolated(unsafe) private static var generationsWithNonFinite = 0  // guarded by globalLock
 
     /// Process-wide count of generations that saw at least one non-finite
     /// row. Exposed for tests.

--- a/Libraries/MLXLMCommon/NaNLogitsTrace.swift
+++ b/Libraries/MLXLMCommon/NaNLogitsTrace.swift
@@ -1,0 +1,134 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+import MLX
+
+/// Diagnostic probe for non-finite (NaN / ±inf) logits rows at the AR decode
+/// sampling sites. **Observation only — never a guard.** It does not touch
+/// the logits, the sampler, or the sampled token; it only reports.
+///
+/// Enabled by `VMLX_LOGITS_NAN_TRACE=1`. When the flag is off every call site
+/// short-circuits on a cached `Bool` and no MLX work is scheduled.
+///
+/// Background: `TopPSampler` returns token id 0 (`!` on Ling 3 / KDA
+/// vocabularies) for a NaN / −inf row, and users see `!!!!` streams on
+/// Raptor. This trace answers "did the last-position row go non-finite
+/// mid-decode, at which step, and what did the sampler return?".
+///
+/// Output (stderr), first occurrence per generation:
+///
+///     [vmlx][nan-logits] site=<solo|solo-compiled|batch|mtp> step=<n> slot=<id or -> model=<key> nan=<count> inf=<count> sampled=<token id>
+///
+/// and once at the end of a generation that saw at least one such row:
+///
+///     [vmlx][nan-logits] summary generations-with-nonfinite=<process total> steps=<rows this generation> ...
+public final class NaNLogitsTrace: @unchecked Sendable {
+
+    /// Cached once per process. Call sites gate on this before doing any work.
+    public static let isEnabled: Bool =
+        ProcessInfo.processInfo.environment["VMLX_LOGITS_NAN_TRACE"] == "1"
+
+    private static let globalLock = NSLock()
+    private static var generationsWithNonFinite = 0
+
+    /// Process-wide count of generations that saw at least one non-finite
+    /// row. Exposed for tests.
+    public static var generationsWithNonFiniteCount: Int {
+        globalLock.lock()
+        defer { globalLock.unlock() }
+        return generationsWithNonFinite
+    }
+
+    public let slot: String
+    public let model: String
+
+    private let lock = NSLock()
+    private var nonFiniteSteps = 0
+    private var firstStep: Int?
+    private var firstSite: String?
+    private var totalNaN = 0
+    private var totalInf = 0
+    private var finished = false
+
+    /// Returns `nil` when the trace flag is off so call sites can hold an
+    /// optional and skip the probe entirely.
+    public init?(slot: String = "-", model: String) {
+        guard Self.isEnabled else { return nil }
+        self.slot = slot
+        self.model = model
+    }
+
+    /// Count NaN and ±inf entries in `rows` (any shape; typically the
+    /// `[1, V]` last-position row, or the `[1, K, V]` verify slab). One
+    /// `eval` for both reductions. Returns `nil` when everything is finite.
+    public static func nonFiniteCounts(_ rows: MLXArray) -> (nan: Int, inf: Int)? {
+        let nanCount = sum(isNaN(rows)).asType(.int32)
+        let infCount = sum(isInf(rows)).asType(.int32)
+        eval(nanCount, infCount)
+        let nan = nanCount.item(Int.self)
+        let inf = infCount.item(Int.self)
+        if nan == 0 && inf == 0 { return nil }
+        return (nan, inf)
+    }
+
+    /// Probe `rows`; when non-finite, record it (printing on the first
+    /// occurrence for this generation). `sampled` is only evaluated when the
+    /// row is non-finite, so a finite row never forces a token readback.
+    public func observe(
+        _ rows: MLXArray,
+        site: String,
+        step: Int,
+        role: String? = nil,
+        sampled: () -> Int
+    ) {
+        guard let counts = Self.nonFiniteCounts(rows) else { return }
+        record(site: site, step: step, nan: counts.nan, inf: counts.inf, role: role,
+               sampled: sampled())
+    }
+
+    /// Record an already-counted non-finite row.
+    public func record(
+        site: String, step: Int, nan: Int, inf: Int, role: String? = nil, sampled: Int
+    ) {
+        lock.lock()
+        nonFiniteSteps += 1
+        totalNaN += nan
+        totalInf += inf
+        let isFirst = firstStep == nil
+        if isFirst {
+            firstStep = step
+            firstSite = site
+        }
+        lock.unlock()
+
+        guard isFirst else { return }
+        Self.globalLock.lock()
+        Self.generationsWithNonFinite += 1
+        Self.globalLock.unlock()
+
+        var line =
+            "[vmlx][nan-logits] site=\(site) step=\(step) slot=\(slot) model=\(model) nan=\(nan) inf=\(inf) sampled=\(sampled)"
+        if let role { line += " role=\(role)" }
+        FileHandle.standardError.write(Data((line + "\n").utf8))
+    }
+
+    /// Emit the per-generation summary once. Silent when the generation
+    /// never saw a non-finite row.
+    public func finish(totalSteps: Int) {
+        lock.lock()
+        guard !finished else { lock.unlock(); return }
+        finished = true
+        let steps = nonFiniteSteps
+        let first = firstStep
+        let site = firstSite ?? "-"
+        let nan = totalNaN
+        let inf = totalInf
+        lock.unlock()
+        guard steps > 0 else { return }
+
+        let line =
+            "[vmlx][nan-logits] summary generations-with-nonfinite=\(Self.generationsWithNonFiniteCount) steps=\(steps) site=\(site) slot=\(slot) model=\(model) first-step=\(first ?? -1) nan=\(nan) inf=\(inf) total-steps=\(totalSteps)\n"
+        FileHandle.standardError.write(Data(line.utf8))
+    }
+}

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -242,6 +242,14 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     var tokenCount = 0
     var promptPrefillTime: TimeInterval = 0
 
+    /// `VMLX_LOGITS_NAN_TRACE=1` diagnostic (see ``NaNLogitsTrace``);
+    /// `nil` when the flag is off. Probes the backbone (target) logits at
+    /// every site that samples a committed token: chunk verify, rollback
+    /// repair, sequential verify, and the AR fallback. Draft-head logits
+    /// are not probed — a non-finite draft is rejected by verify anyway and
+    /// probing them would drain the draft pipeline once per level.
+    private var nanTrace: NaNLogitsTrace?
+
     private var pendingTokens: [Int] = []
     private var pendingIndex = 0
     private var nextMain: MLXArray?
@@ -575,6 +583,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         effectiveParameters = nativeMTPParameters
 
         self.model = model
+        self.nanTrace = NaNLogitsTrace(model: String(describing: type(of: model)))
         self.cache = cache ?? model.newCache(parameters: effectiveParameters)
         self.mtpCache = model.makeNativeMTPCache()
         self.cacheCoordinator = cacheCoordinator
@@ -1208,6 +1217,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         abandonPendingVerify()
         guard !generationStatsFinalized else { return }
         generationStatsFinalized = true
+        nanTrace?.finish(totalSteps: tokenCount)
         let accepted = acceptedByDepth
             .sorted { $0.key < $1.key }
             .map { "\($0.key):\($0.value)" }
@@ -1632,6 +1642,13 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
         materializeSyncTime += verifyDecision.materializeSyncTime
         samplingTime += Date.timeIntervalSinceReferenceDate - sampleStart
+        if let nanTrace {
+            // Whole verify slab `[1, K+1, V]`: every row is a decode position.
+            let next = verifyDecision.nextToken
+            nanTrace.observe(
+                verifier.logits, site: "mtp", step: tokenCount, role: "verify",
+                sampled: { next.item(Int.self) })
+        }
 
         var accepted = verifyDecision.accepted
         var nextVerifiedToken = verifyDecision.nextToken
@@ -1762,6 +1779,12 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 .token
             recordMaterializeSync {
                 MLX.eval(nextVerifiedToken)
+            }
+            if let nanTrace {
+                let sampled = nextVerifiedToken
+                nanTrace.observe(
+                    repaired.logits[0..., -1, 0...], site: "mtp", step: tokenCount,
+                    role: "repair", sampled: { sampled.item(Int.self) })
             }
             repairedHiddenForNextMTP =
                 repaired.hiddenStates[0..., accepted ..< (accepted + 1), 0...]
@@ -2562,6 +2585,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         samplingTime += Date.timeIntervalSinceReferenceDate - sampleStart
 
         let tokenID = recordMaterializeSync { sample.token.item(Int.self) }
+        nanTrace?.observe(
+            output.logits[0..., -1, 0...], site: "mtp", step: tokenCount, role: "ar",
+            sampled: { tokenID })
         pendingTokens.append(tokenID)
         autoregressiveFallbackTokenCount += 1
         nextMain = sample.token
@@ -2598,6 +2624,22 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             targetForwardCount += 1
             verifyMainForwardCount += 1
             verifyInputTokenCount += 1
+
+            // Diagnostic only: logits are already materialized here, so the
+            // count is cheap; the sampled id is whichever token this
+            // iteration appends (every branch below appends exactly one
+            // before `continue`/`break`), read in the deferred report.
+            let nonFinite = nanTrace == nil
+                ? nil : NaNLogitsTrace.nonFiniteCounts(verifier.logits[0..., -1, 0...])
+            let stepForReport = tokenCount
+            defer {
+                if let nonFinite, let nanTrace {
+                    nanTrace.record(
+                        site: "mtp", step: stepForReport, nan: nonFinite.nan,
+                        inf: nonFinite.inf, role: "verify-seq",
+                        sampled: pendingTokens.last ?? -1)
+                }
+            }
 
             hiddenForNextMTP = Self.lastHidden(verifier.hiddenStates)
 

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -635,7 +635,8 @@ public final class VLMModelFactory: ModelFactory {
         var eosTokenIds = ModelTokenConfigurationResolver.resolvedEOSTokenIds(
             baseConfig: baseConfig,
             configurationData: mergedConfigData,
-            generationConfig: generationConfig)
+            generationConfig: generationConfig,
+            jangStopTokenIds: earlyJangConfig?.chat?.stopTokenIds)
         if baseConfig.modelType == "deepseek_v4" {
             eosTokenIds.formUnion([1, 128803, 128804])
         }

--- a/Package.swift
+++ b/Package.swift
@@ -849,6 +849,7 @@ let package = Package(
             sources: [
                 "ProposalHeadStampTests.swift",
                 "NativeMTPARSafetyTests.swift",
+                "RaptorTopLevelStampTests.swift",
                 "HybridRestoreBoundaryInvariantTests.swift",
                 "DualPathFamiliesTests.swift",
                 "Qwen35FusedInputProjectionTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/RaptorTopLevelStampTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/RaptorTopLevelStampTests.swift
@@ -1,0 +1,299 @@
+//
+//  RaptorTopLevelStampTests.swift
+//  MLXLMCommonFocusedTests
+//
+//  Raptor-v0.5-8B-A1B (Ling 3 / KDA) ships a `jang_config.json` whose stamp
+//  lives in top-level `reasoning` / `tools` / `chat` blocks and has NO
+//  `capabilities` block. Before the top-level fallback, `JangLoader.parseConfig`
+//  read nothing from it: the parsers fell back to the model_type heuristic,
+//  `chat.stop_token_ids` (`<|role_end|>` = 156895) never reached the stop set,
+//  and the bundle-authored "reasoning on" default was lost.
+//
+//  These tests pin:
+//    - the synthesized stamps resolve through `fromCapabilityName` to the SAME
+//      parsers the `bailing_hybrid` model_type heuristic produced (no
+//      behaviour change for the parsers, only a change of source);
+//    - 156895 lands in the resolved EOS set alongside config.json's eos id;
+//    - `reasoning.default = "on"` becomes the `enable_thinking` default the
+//      factories already read from `chat`.
+//
+
+import Foundation
+import XCTest
+
+@testable import MLXLLM
+@testable import MLXLMCommon
+
+final class RaptorTopLevelStampTests: XCTestCase {
+
+    /// Verbatim copy of
+    /// `Raptor-v0.5-8B-A1B-JANG_6M/jang_config.json` (2026-09-04).
+    private static let raptorJangConfig = #"""
+    {
+      "chat": {
+        "sampling_defaults": {
+          "temperature": 0.7,
+          "top_p": 0.95,
+          "top_k": 20,
+          "repetition_penalty": 1.05,
+          "source": "bundle generation_config.json (source-validated profile)",
+          "mode": "default"
+        },
+        "stop_token_ids": [
+          156895
+        ],
+        "context_length": {
+          "native": 131072
+        },
+        "role_framing": {
+          "style": "bailing_v3",
+          "note": "NOT ChatML: turns are <role>SYSTEM|HUMAN|ASSISTANT</role> ... <|role_end|>."
+        }
+      },
+      "reasoning": {
+        "supported": true,
+        "parser": "bailing_v3",
+        "default": "on",
+        "think_in_template": true,
+        "enable_kwarg": "enable_thinking",
+        "think_open_id": 156903,
+        "think_close_id": 156904,
+        "off_is_prefilled_closed_block": true,
+        "off_prefill": "<think></think>",
+        "preserve_thinking_supported": true,
+        "preserve_thinking_default": true,
+        "preserve_thinking_transport": "template_constant",
+        "note": "Reasoning is ON by default UPSTREAM: the template sets thinking_option='on' when neither enable_thinking nor thinking_option is passed, and injects 'detailed thinking on' into the SYSTEM turn. Verified empirically. preserved_thinking is HARDCODED true in the template (line 16) — it is not a caller kwarg, so history <think> blocks are always retained, which also improves prefix-cache reuse."
+      },
+      "tools": {
+        "supported": true,
+        "parser": "bailing_v3_xml_arg",
+        "dialect": "xml_arg",
+        "mlx_lm_autodetected": false,
+        "tool_open_id": 156896,
+        "tool_close_id": 156897,
+        "schema_direction": "json_in_xml_out",
+        "call_format": "<tool_call>{function-name}\\n<arg_key>{k}</arg_key>\\n<arg_value>{v}</arg_value>\\n...\\n</tool_call>",
+        "note": "ASYMMETRIC: tool SCHEMAS are injected as JSON inside <tools>, but tool CALLS come back as XML key/value pairs with a BARE function name on the first line — not a JSON object. No Hermes/Qwen-style JSON parser matches. Values are emitted raw when the argument is a string and tojson otherwise, so a parser must round-trip both. Ship a Ling3 parser or tool calling silently does not work."
+      },
+      "vision": {
+        "supported": false
+      },
+      "audio": {
+        "supported": false
+      },
+      "runtime": {
+        "model_type": "bailing_hybrid",
+        "architecture": "BailingMoeV3",
+        "hybrid_attention": {
+          "full_attention_layers": [
+            3,
+            7,
+            11,
+            15,
+            19,
+            23
+          ],
+          "linear_attention": "kda",
+          "kda_conv_kernel": 4,
+          "kda_lower_bound": -5,
+          "note": "KDA (Kimi Delta Attention) — NOT the Ling-2.6 Lightning/GLA linear attention. Per-layer decode state is a recurrent [H,128,128] tensor PLUS three short-conv ring buffers; it does not grow with context."
+        },
+        "bundle_has_mtp": false,
+        "jang_profile": "JANG_6M"
+      }
+    }
+    """#
+
+    private static let modelType = "bailing_hybrid"
+
+    private func parseRaptor() throws -> JangConfig {
+        let data = try XCTUnwrap(Self.raptorJangConfig.data(using: .utf8))
+        let json = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: data) as? [String: Any])
+        return try JangLoader.parseConfig(from: json)
+    }
+
+    /// Drive a parser through the same stream and flatten what it emits so
+    /// two parsers can be compared by behaviour (`insideReasoning` is
+    /// private, so equality of the start state is observed, not read).
+    private func transcript(_ parser: ReasoningParser?, feeding text: String) -> [String] {
+        guard var parser else { return ["<nil parser>"] }
+        var out: [String] = []
+        var segments = parser.feed(text)
+        segments += parser.flush()
+        for segment in segments {
+            switch segment {
+            case .reasoning(let s): out.append("reasoning:\(s)")
+            case .content(let s): out.append("content:\(s)")
+            }
+        }
+        return out
+    }
+
+    // MARK: - Stamps
+
+    func testTopLevelBlocksSynthesizeCapabilities() throws {
+        let config = try parseRaptor()
+        let caps = try XCTUnwrap(config.capabilities,
+            "top-level reasoning/tools must synthesize a capabilities stamp")
+        XCTAssertEqual(caps.reasoningParser, "bailing_v3")
+        XCTAssertEqual(caps.toolParser, "bailing_v3_xml_arg")
+        XCTAssertEqual(caps.thinkInTemplate, true)
+        XCTAssertEqual(caps.supportsThinking, true)
+        XCTAssertEqual(caps.supportsTools, true)
+        XCTAssertEqual(caps.supportsVision, false)
+        XCTAssertEqual(caps.supportsAudio, false)
+        // `think_in_template = true` keeps the stamp honoured (the ignore
+        // path only fires on `think_in_template == false`).
+        XCTAssertFalse(ParserResolution.shouldIgnoreReasoningStamp(
+            capabilities: caps, modelType: Self.modelType))
+    }
+
+    func testStampedReasoningParserMatchesHeuristic() throws {
+        let config = try parseRaptor()
+        let stamped = ParserResolution.reasoning(
+            capabilities: config.capabilities, modelType: Self.modelType)
+        let heuristic = ParserResolution.reasoning(
+            capabilities: nil, modelType: Self.modelType)
+
+        XCTAssertEqual(stamped.source, .jangStamped)
+        XCTAssertEqual(heuristic.source, .modelTypeHeuristic)
+        XCTAssertNotNil(stamped.parser)
+        XCTAssertNotNil(heuristic.parser)
+
+        // Same tag pair, same start state (both start inside `<think>`).
+        XCTAssertEqual(stamped.parser?.startTag, heuristic.parser?.startTag)
+        XCTAssertEqual(stamped.parser?.endTag, heuristic.parser?.endTag)
+        let stream = "let me think</think>The answer is 42. <think>again</think> done"
+        let stampedOut = transcript(stamped.parser, feeding: stream)
+        let heuristicOut = transcript(heuristic.parser, feeding: stream)
+        XCTAssertEqual(stampedOut, heuristicOut)
+        // Sanity: the stream really exercised the start-in-reasoning state
+        // (the first emitted segment is reasoning, not content).
+        XCTAssertEqual(stampedOut.first?.hasPrefix("reasoning:"), true)
+        XCTAssertTrue(stampedOut.contains { $0.hasPrefix("content:") })
+    }
+
+    func testStampedToolParserMatchesHeuristic() throws {
+        let config = try parseRaptor()
+        let stamped = ParserResolution.toolCall(
+            capabilities: config.capabilities, modelType: Self.modelType)
+        let heuristic = ParserResolution.toolCall(
+            capabilities: nil, modelType: Self.modelType)
+        XCTAssertEqual(stamped.source, .jangStamped)
+        XCTAssertEqual(heuristic.source, .modelTypeHeuristic)
+        XCTAssertEqual(stamped.format, .glm4)
+        XCTAssertEqual(stamped.format, heuristic.format)
+        // The factories consult `chat.tool_calling.parser` first; it must
+        // resolve to the same format too.
+        XCTAssertEqual(config.chat?.toolCalling?.parser, "bailing_v3_xml_arg")
+        XCTAssertEqual(
+            ToolCallFormat.fromCapabilityName(config.chat?.toolCalling?.parser), .glm4)
+    }
+
+    // MARK: - Stop tokens
+
+    func testChatStopTokenIdsReachTheResolvedEOSSet() throws {
+        let config = try parseRaptor()
+        XCTAssertEqual(config.chat?.stopTokenIds, [156895])
+
+        let configJSON = #"{"model_type": "bailing_hybrid", "eos_token_id": 156892}"#
+        let configData = try XCTUnwrap(configJSON.data(using: .utf8))
+        let base = try JSONDecoder().decode(BaseConfiguration.self, from: configData)
+
+        let resolved = ModelTokenConfigurationResolver.resolvedEOSTokenIds(
+            baseConfig: base,
+            configurationData: configData,
+            generationConfig: nil,
+            jangStopTokenIds: config.chat?.stopTokenIds)
+        XCTAssertTrue(resolved.contains(156895), "chat.stop_token_ids must be in the stop set")
+        XCTAssertTrue(resolved.contains(156892), "config.json eos must be kept, not replaced")
+
+        // Without the JANG ids the set is exactly the config declaration.
+        let withoutJang = ModelTokenConfigurationResolver.resolvedEOSTokenIds(
+            baseConfig: base,
+            configurationData: configData,
+            generationConfig: nil,
+            jangStopTokenIds: nil)
+        XCTAssertEqual(withoutJang, [156892])
+    }
+
+    // MARK: - Reasoning default
+
+    func testReasoningDefaultOnBecomesEnableThinkingDefault() throws {
+        let config = try parseRaptor()
+        XCTAssertEqual(config.chat?.templateKwargsDefaults?.enableThinking, true)
+        XCTAssertEqual(config.chat?.reasoning?.defaultMode, "thinking")
+        XCTAssertEqual(config.chat?.reasoning?.supported, true)
+
+        let context = llmDefaultAdditionalContext(
+            modelType: Self.modelType,
+            capabilities: config.capabilities,
+            generationConfig: nil,
+            chatConfig: config.chat)
+        XCTAssertEqual(context?["enable_thinking"] as? Bool, true)
+    }
+
+    func testReasoningDefaultOffMapsToChatMode() throws {
+        var json = try XCTUnwrap(
+            JSONSerialization.jsonObject(
+                with: try XCTUnwrap(Self.raptorJangConfig.data(using: .utf8)))
+                as? [String: Any])
+        var reasoning = try XCTUnwrap(json["reasoning"] as? [String: Any])
+        reasoning["default"] = "off"
+        json["reasoning"] = reasoning
+        let config = try JangLoader.parseConfig(from: json)
+        XCTAssertEqual(config.chat?.templateKwargsDefaults?.enableThinking, false)
+        XCTAssertEqual(config.chat?.reasoning?.defaultMode, "chat")
+    }
+
+    // MARK: - Precedence / no-op guarantees
+
+    func testExplicitCapabilitiesBlockWinsOverTopLevelBlocks() throws {
+        var json = try XCTUnwrap(
+            JSONSerialization.jsonObject(
+                with: try XCTUnwrap(Self.raptorJangConfig.data(using: .utf8)))
+                as? [String: Any])
+        json["capabilities"] = [
+            "reasoning_parser": "qwen3",
+            "tool_parser": "xml_function",
+        ] as [String: Any]
+        let config = try JangLoader.parseConfig(from: json)
+        XCTAssertEqual(config.capabilities?.reasoningParser, "qwen3")
+        XCTAssertEqual(config.capabilities?.toolParser, "xml_function")
+        // The chat sub-blocks still derive from the top-level blocks where
+        // `chat` itself says nothing.
+        XCTAssertEqual(config.chat?.stopTokenIds, [156895])
+        XCTAssertEqual(config.chat?.templateKwargsDefaults?.enableThinking, true)
+    }
+
+    func testExplicitChatSubBlocksWinOverTopLevelBlocks() throws {
+        var json = try XCTUnwrap(
+            JSONSerialization.jsonObject(
+                with: try XCTUnwrap(Self.raptorJangConfig.data(using: .utf8)))
+                as? [String: Any])
+        var chat = try XCTUnwrap(json["chat"] as? [String: Any])
+        chat["reasoning"] = ["default_mode": "chat"] as [String: Any]
+        chat["tool_calling"] = ["parser": "json"] as [String: Any]
+        chat["template_kwargs_defaults"] = ["enable_thinking": false] as [String: Any]
+        json["chat"] = chat
+        let config = try JangLoader.parseConfig(from: json)
+        XCTAssertEqual(config.chat?.reasoning?.defaultMode, "chat")
+        XCTAssertEqual(config.chat?.toolCalling?.parser, "json")
+        XCTAssertEqual(config.chat?.templateKwargsDefaults?.enableThinking, false)
+    }
+
+    func testPreStampBundleStaysUnstamped() throws {
+        let json: [String: Any] = [
+            "format": "jang",
+            "format_version": "2.0",
+        ]
+        let config = try JangLoader.parseConfig(from: json)
+        XCTAssertNil(config.capabilities)
+        XCTAssertNil(config.chat)
+        let heuristic = ParserResolution.reasoning(
+            capabilities: config.capabilities, modelType: Self.modelType)
+        XCTAssertEqual(heuristic.source, .modelTypeHeuristic)
+    }
+}


### PR DESCRIPTION
## Why
- Raptor (Ling 3 / KDA) users see replies that are a run of `!` — token id 0 in that vocab — which is exactly what `TopPSampler` returns for a NaN/−inf logits row (top-p masks every entry, categorical picks index 0). To tell corrupted recurrent state / overflow apart from anything else we need to see non-finite rows at the sampling sites.
- Raptor's `jang_config.json` carries its stamps in TOP-LEVEL `reasoning` / `tools` / `chat` blocks (no `capabilities`), so `JangLoader` read nothing and the model-type heuristic happened to pick the same parsers. `chat.stop_token_ids` (156895) was also ignored.

## What
- `NaNLogitsTrace` (new): behind `VMLX_LOGITS_NAN_TRACE=1`, checks the last-position logits row at every AR sampling site — solo (eager + compiled), batch slots, and native MTP verify/repair/verify-seq/AR — logs the first non-finite row per generation (`[vmlx][nan-logits] site=… step=… slot=… model=… nan=… inf=… sampled=…`) and one summary at the end. Zero cost when the flag is off; sampling behaviour unchanged.
- `JangLoader`: when `capabilities` is absent, synthesise it from top-level `reasoning.parser` / `tools.parser`, derive the chat reasoning default from `reasoning.default`, and union `chat.stop_token_ids` into the resolved EOS set (never replacing config/tokenizer ids). Explicit `capabilities` / `chat` sub-blocks always win; pre-stamp bundles are untouched.

## Tests
`RaptorTopLevelStampTests` (fixture = Raptor's real jang_config): stamped parsers behave identically to the heuristic (`bailing_v3` → think_xml; `bailing_v3_xml_arg` → glm4 args), 156895 joins the EOS set, reasoning default on/off, explicit blocks win, pre-stamp bundle stays nil. Neighbouring suites (JangConfig chat schema, ReasoningStampFromModelType, AR-safety, hybrid restore, BailingMoeV3) green: 38 XCTest + 31 swift-testing locally.