### PR TITLE
Glm5Next: build a causal mask when the sparse selection is skipped

### DIFF
--- a/Libraries/MLXVLM/Models/Glm5Next.swift
+++ b/Libraries/MLXVLM/Models/Glm5Next.swift
@@ -657,15 +657,41 @@ public final class Glm5NextSparseAttention: Module {
         // applied causality (a pool is a candidate only if its last token is visible to the query),
         // so anding them again would be redundant, and passing the causal mask instead of the
         // sparse one would silently un-sparsify the layer.
-        var effectiveMask = mask
+        var maskMode: MLXFast.ScaledDotProductAttentionMaskMode =
+            mask.map { .array($0) } ?? .none
         if let selected {
             let visible = indexer.maskFromIndices(selected, kvLength: keys.dim(2))
-            effectiveMask = MLX.where(
-                visible, MLXArray(Float(0)).asType(q.dtype),
-                MLXArray(-Float.greatestFiniteMagnitude).asType(q.dtype))
+            maskMode = .array(
+                MLX.where(
+                    visible, MLXArray(Float(0)).asType(q.dtype),
+                    MLXArray(-Float.greatestFiniteMagnitude).asType(q.dtype)))
+        } else if mask == nil, T > 1 {
+            // CAUSALITY, for the path where the selection is SKIPPED.
+            //
+            // The sparse mask above carries causality with it — a pool is a candidate only if its
+            // last token is visible to the query — so a SELECTING forward needs nothing more. But
+            // below `index_topk` the indexer deliberately returns nothing, and on that path nothing
+            // supplied causality at all: every caller passes `mask: nil`, the language model
+            // forwards that nil to each layer unchanged, and `scaledDotProductAttention` treats nil
+            // as NO MASK rather than as a causal sentinel.
+            //
+            // Prefill below `index_topk` was therefore BIDIRECTIONAL — every token attended to every
+            // later token. Measured on this layer, appending 4 tokens to a 16-token prefill moved
+            // each earlier token's output by ~50% of its own magnitude, and single-shot, chunked and
+            // stepwise prefill produced three different answers. It also silently poisoned the
+            // SELECTING path, because a first chunk below `index_topk` wrote non-causal keys into
+            // the cache that later selecting chunks then read.
+            //
+            // `.causal` and NOT a materialised `[T, S]` array: the mode lets MLX take its fused
+            // kernel, whereas an explicit mask array can force the scores to be materialised — at
+            // 64 heads an 8k prefill is then 8192 x 8192 x 64 x 2 B = 8.6 GB per layer. The mode
+            // also carries the cache offset by convention (the last `T` queries align to the last
+            // `T` keys), which is what `createAttentionMask` relies on when it returns `.causal`
+            // for a non-zero offset. `T == 1` needs no mask: a lone query has no future.
+            maskMode = .causal
         }
         let out = MLXFast.scaledDotProductAttention(
-            queries: q, keys: keys, values: values, scale: scale, mask: effectiveMask)
+            queries: q, keys: keys, values: values, scale: scale, mask: maskMode)
         return oProj(out.transposed(0, 2, 1, 3).reshaped(B, T, numHeads * vHeadDim))
     }
 }


### PR DESCRIPTION
### The defect

`Glm5NextSparseAttention` applies a mask only when the indexer returns a selection:

```swift
var effectiveMask = mask
if let selected {
    let visible = indexer.maskFromIndices(selected, kvLength: keys.dim(2))
    effectiveMask = MLX.where(visible, 0, -greatestFiniteMagnitude)
}
let out = MLXFast.scaledDotProductAttention(… mask: effectiveMask)
```

Below `index_topk` the selection is skipped on purpose — the comment above it explains why that is
an equivalence rather than an approximation, and it is right about that. But on that path
`effectiveMask` stays exactly what arrived, which is always `nil`: no caller passes a mask,
`Glm5NextLanguageModel` forwards `nil` to every layer unchanged, and `createAttentionMask` is never
called anywhere in the file. `scaledDotProductAttention` treats a `nil` mask as *no* mask.

**Prefill below `index_topk` was therefore bidirectional** — every token attended to every later
token. `DeepseekV4`, which this MLA follows closely, does build the mask (`createAttentionMask(h:
hFlat2, cache: firstCache)`) and threads it down; that step is missing here.

### Evidence

Layer-level, random weights, no model — `Glm5NextSparseAttention` alone, GLM-5.3-Flash's own
`text_config` with size fields shrunk and every behaviour field as shipped.

The primary assertion is **causality**, not segmentation: appending tokens must not change outputs
already computed for earlier ones. It names the defect directly and cannot be confused with a cache
hand-off problem.

| | before | after |
|---|---|---|
| causality, selection skipped (`index_topk` 2048, T 16) | max Δ **0.140**, ~50% of \|y\|max | **0.0** |
| causality, selection active (`index_topk` 8, T 16) | 0.0 | 0.0 |
| whole vs chunked at 1 / 6 / 8 / stepwise, selection skipped | 0.88 / 0.27 / 0.27 / 0.88 | ~2e-7 |
| whole vs chunked at 1 / 6 / 8 / stepwise, selection active | 3e-7 / **0.91** / **0.86** / 3e-7 | ~2e-7 |

Two things worth reading off that table. Selection-active causality was already exact, which
confirms the sparse mask carries causality and pinpoints the gap as the skipped path. And the
selection-active chunking failures were the *same* bug: their first chunk (6 and 8 tokens) sat below
`index_topk` and wrote non-causal keys into the cache that the later selecting chunk then read —
`split@1` and stepwise passed only because a one-token chunk has no future to leak.

Downstream, this is why single-shot, chunked and stepwise prefill disagreed on a ~130-token prompt,
each showing a different amount of the future to each query, with stepwise accidentally the only
correct arm.

### The fix

One `else if` in the layer, passing the `.causal` **mode** rather than a materialised `[T, S]`
array — the mode lets MLX use its fused kernel, where an explicit array can force the scores to be
materialised (at 64 heads, an 8k prefill is 8192 x 8192 x 64 x 2 B = 8.6 GB per layer). The mode
also carries the cache offset by convention, which is what `createAttentionMask` relies on when it
returns `.causal` for a non-zero offset. It is built there rather than in the model forward — the way DeepseekV4
does it — because `Glm5NextDecoderLayer` hands the **same** `mask` argument to its KDA layers, where
it means a per-token *padding* mask; an attention mask arriving there would be wrong. `cached` is
read before `cache.update`, so it is the pre-update offset `createCausalMask` expects, and `T == 1`
needs no mask because a lone query has no future.

Verified end to end on GLM-5.3-Flash-JANG (loads, prefills, decodes cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
