### PR TITLE
JangLoader: top-level reasoning default 'on' synthesises nothing (Raptor prompt bytes back to the template default)

### DIFF
--- a/Libraries/MLXLMCommon/JangLoader.swift
+++ b/Libraries/MLXLMCommon/JangLoader.swift
@@ -1949,13 +1949,17 @@ public struct JangLoader: Sendable {
                 templateKwargsDefaults = ChatTemplateKwargsDefaults(
                     enableThinking: defaults["enable_thinking"] as? Bool)
             } else if let rDict = topLevelReasoning,
-                let enableThinking = topLevelReasoningDefaultEnableThinking(rDict)
+                let enableThinking = topLevelReasoningDefaultEnableThinking(rDict),
+                enableThinking == false
             {
-                // `reasoning.default: "on"` is the bundle-authored template
-                // default (`enable_thinking`), the same knob
-                // `chat.template_kwargs_defaults.enable_thinking` carries.
+                // Only an explicit `reasoning.default: "off"` needs the kwarg:
+                // the template's own default is what "on" already produces,
+                // and passing `enable_thinking=true` explicitly moved the
+                // Bailing "detailed thinking on" directive from the end of the
+                // system turn (template default) to its start (injected
+                // context), changing Raptor's prompt bytes between releases.
                 templateKwargsDefaults = ChatTemplateKwargsDefaults(
-                    enableThinking: enableThinking)
+                    enableThinking: false)
             } else {
                 templateKwargsDefaults = nil
             }
@@ -2028,10 +2032,14 @@ public struct JangLoader: Sendable {
     /// `reasoning.default` (`"on"` / `"off"`) → the `chat.reasoning.default_mode`
     /// vocabulary (`"thinking"` / `"chat"`) `llmDefaultAdditionalContext` reads.
     static func topLevelReasoningDefaultMode(_ reasoning: [String: Any]) -> String? {
+        // Only an explicit "off" needs a synthesised mode: "on" is what the
+        // Bailing template already does by default, and stamping it made the
+        // factories inject `enable_thinking=true` (moving the "detailed
+        // thinking on" directive to the start of the system turn and changing
+        // Raptor's prompt bytes between releases).
         switch topLevelReasoningDefaultEnableThinking(reasoning) {
-        case true?: return "thinking"
         case false?: return "chat"
-        case nil: return nil
+        case true?, nil: return nil
         }
     }
 

--- a/Tests/MLXLMCommonFocusedTests/RaptorTopLevelStampTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/RaptorTopLevelStampTests.swift
@@ -221,10 +221,13 @@ final class RaptorTopLevelStampTests: XCTestCase {
 
     // MARK: - Reasoning default
 
-    func testReasoningDefaultOnBecomesEnableThinkingDefault() throws {
+    func testReasoningDefaultOnLeavesTemplateDefaultUntouched() throws {
         let config = try parseRaptor()
-        XCTAssertEqual(config.chat?.templateKwargsDefaults?.enableThinking, true)
-        XCTAssertEqual(config.chat?.reasoning?.defaultMode, "thinking")
+        // `on` is the template's own default: no kwarg is synthesised, so the
+        // Bailing directive stays where the template puts it (prompt bytes
+        // identical to pre-stamp builds).
+        XCTAssertNil(config.chat?.templateKwargsDefaults?.enableThinking)
+        XCTAssertNil(config.chat?.reasoning?.defaultMode)
         XCTAssertEqual(config.chat?.reasoning?.supported, true)
 
         let context = llmDefaultAdditionalContext(
@@ -232,7 +235,7 @@ final class RaptorTopLevelStampTests: XCTestCase {
             capabilities: config.capabilities,
             generationConfig: nil,
             chatConfig: config.chat)
-        XCTAssertEqual(context?["enable_thinking"] as? Bool, true)
+        XCTAssertNil(context?["enable_thinking"])
     }
 
     func testReasoningDefaultOffMapsToChatMode() throws {
@@ -265,7 +268,8 @@ final class RaptorTopLevelStampTests: XCTestCase {
         // The chat sub-blocks still derive from the top-level blocks where
         // `chat` itself says nothing.
         XCTAssertEqual(config.chat?.stopTokenIds, [156895])
-        XCTAssertEqual(config.chat?.templateKwargsDefaults?.enableThinking, true)
+        // "on" is the template default: nothing is synthesised for it.
+        XCTAssertNil(config.chat?.templateKwargsDefaults?.enableThinking)
     }
 
     func testExplicitChatSubBlocksWinOverTopLevelBlocks() throws {


### PR DESCRIPTION
## Why
#427's top-level stamp fallback mapped `reasoning.default: on` to `chat.reasoning.default_mode = thinking` and `template_kwargs_defaults.enable_thinking = true`. For Ling 3 / Raptor that made the factories inject `enable_thinking=true`, so `BailingThinkingTemplateContext` prepends "detailed thinking on" to the system turn instead of the template appending it at the end. Thinking was already on by the template's own default, so this only moved bytes — but Raptor's rendered prompt changed between 0.24.6 and 0.24.7 (prefix-cache keys and any first-token behaviour with it).

## What
`reasoning.default: on` synthesises nothing (the template default applies); only an explicit `off` maps to `default_mode = chat` / `enable_thinking = false`. Parser names and `chat.stop_token_ids` handling unchanged.

## Tests
`RaptorTopLevelStampTests` updated (on → no kwarg, no default mode, no injected context; off → chat/false; explicit capabilities and chat blocks still win); with `JangConfigChatSchemaTests` and `ReasoningStampFromModelTypeTests`: 29 XCTest + 8 swift-testing green locally.