### PR TITLE
DiskCache: publish rows atomically, fail closed on a short file, sweep unpublished/incomplete rows at open

### DIFF
--- a/Libraries/MLXLMCommon/Cache/DiskCache.swift
+++ b/Libraries/MLXLMCommon/Cache/DiskCache.swift
@@ -78,6 +78,11 @@ public enum MLXCacheIOLock {
 /// that mattered, because it implies the caller's arrays are retained past the
 /// call, and callers reasoning about copy lifetimes were misled by it. Reads are
 /// likewise synchronous since they typically feed directly into model inference.
+enum DiskCacheIntegrityError: Error {
+    case incompleteFile(String)
+    case incompleteWrite(String)
+}
+
 public final class DiskCache: @unchecked Sendable {
 
     private struct ValidatedFileFingerprint: Equatable {
@@ -175,6 +180,17 @@ public final class DiskCache: @unchecked Sendable {
 
         // Create cache directory if needed
         try? FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+        // Storage integrity at open: an interrupted store (crash, force-quit,
+        // disk full) used to leave a partial `<hash>.safetensors` under its
+        // FINAL name. `fetch` only checked existence, `loadArraysAndMetadata`
+        // maps lazily, and the MLX reader's short-read exception is dropped
+        // on the stream (`Load::eval_cpu` waits on the future without
+        // `get()`), so the row restored as zero-filled KV / recurrent state
+        // at a valid offset — silently. Stores now publish atomically
+        // (temp → rename), so at open anything still named `*.tmp` is a dead
+        // write, and any final-named file whose size is short of the
+        // payload its own header declares is removed together with its row.
+        Self.sweepUnpublishedAndIncompleteFiles(in: cacheDir)
 
         // Open SQLite database
         let dbPath = cacheDir.appendingPathComponent("cache_index.db").path
@@ -325,8 +341,22 @@ public final class DiskCache: @unchecked Sendable {
         Stream.gpu.synchronize()
         let tEval = Date()
         do {
+            // Atomic publication: the row becomes visible under its content
+            // hash only after every byte is on disk. A reader that races the
+            // write, or a process that dies mid-write, never sees a partial
+            // file under the final name (it sees a miss, or a `.tmp` swept
+            // at the next open).
+            let finalURL = url
+            let url = Self.temporaryURL(for: finalURL)
+            try? FileManager.default.removeItem(at: url)
             try save(arrays: arrays, metadata: ["format": "mlx"], url: url)
             Stream.gpu.synchronize()
+            guard Self.isCompleteSafetensors(url: url) else {
+                try? FileManager.default.removeItem(at: url)
+                throw DiskCacheIntegrityError.incompleteWrite(finalURL.lastPathComponent)
+            }
+            try? FileManager.default.removeItem(at: finalURL)
+            try FileManager.default.moveItem(at: url, to: finalURL)
             if phaseTrace {
                 // A 27B ternary model spent ~25 s storing a single ~357 MB
                 // boundary — about 14 MB/s, which is far too slow to be the
@@ -341,7 +371,7 @@ public final class DiskCache: @unchecked Sendable {
             }
 
             let fileSize: Int
-            if let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
+            if let attrs = try? FileManager.default.attributesOfItem(atPath: finalURL.path),
                 let size = attrs[.size] as? Int
             {
                 fileSize = size
@@ -350,7 +380,7 @@ public final class DiskCache: @unchecked Sendable {
             }
 
             _insertEntryLocked(hash: hash, tokenCount: tokenCount, fileSize: fileSize)
-            if let fingerprint = _fileFingerprint(url: url), fingerprint.size > 0 {
+            if let fingerprint = _fileFingerprint(url: finalURL), fingerprint.size > 0 {
                 validatedFiles[hash] = fingerprint
             } else {
                 validatedFiles.removeValue(forKey: hash)
@@ -429,6 +459,12 @@ public final class DiskCache: @unchecked Sendable {
         }
 
         do {
+            // Fail closed on a short file BEFORE the lazy map: the reader's
+            // short-read error never reaches the caller, so a truncated row
+            // would otherwise restore as zeros at a valid offset.
+            guard Self.isCompleteSafetensors(url: url) else {
+                throw DiskCacheIntegrityError.incompleteFile(url.lastPathComponent)
+            }
             let (arrays, _) = try loadArraysAndMetadata(url: url)
             if let fingerprint = _fileFingerprint(url: url), fingerprint.size > 0 {
                 validatedFiles[hash] = fingerprint
@@ -716,6 +752,74 @@ public final class DiskCache: @unchecked Sendable {
     /// Build the file URL for a given hash.
     private func safetensorsURL(for hash: String) -> URL {
         cacheDir.appendingPathComponent("\(hash).safetensors")
+    }
+
+    /// Sibling temp name used while a row is being written. MLX's `save`
+    /// chooses the container format from the extension, so the temp name
+    /// must still end in `.safetensors`; the `.partial-` infix marks it as
+    /// unpublished (never a content-hash filename, never fetched).
+    static func temporaryURL(for finalURL: URL) -> URL {
+        let stem = finalURL.deletingPathExtension().lastPathComponent
+        return finalURL.deletingLastPathComponent()
+            .appendingPathComponent("\(stem).partial-\(UUID().uuidString.prefix(8)).safetensors")
+    }
+
+    static func isUnpublishedName(_ name: String) -> Bool {
+        name.contains(".partial-") && name.hasSuffix(".safetensors")
+    }
+
+    /// The byte offset one past the last tensor payload the file's own
+    /// safetensors header declares (8-byte little-endian header length, JSON
+    /// header, `data_offsets: [begin, end]` per tensor relative to the end
+    /// of the header), or nil when the header itself cannot be read.
+    static func declaredPayloadEnd(url: URL) -> Int? {
+        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        defer { try? handle.close() }
+        guard let lengthData = try? handle.read(upToCount: 8), lengthData.count == 8 else { return nil }
+        let headerLength = lengthData.withUnsafeBytes { Int($0.load(as: UInt64.self).littleEndian) }
+        guard headerLength > 0, headerLength < 256 * 1024 * 1024 else { return nil }
+        guard let headerData = try? handle.read(upToCount: headerLength), headerData.count == headerLength,
+            let header = try? JSONSerialization.jsonObject(with: headerData) as? [String: Any]
+        else { return nil }
+        var end = 0
+        for (key, value) in header where key != "__metadata__" {
+            guard let tensor = value as? [String: Any],
+                let offsets = tensor["data_offsets"] as? [Any], offsets.count == 2,
+                let last = (offsets[1] as? NSNumber)?.intValue
+            else { return nil }
+            end = max(end, last)
+        }
+        return 8 + headerLength + end
+    }
+
+    /// True when the file on disk holds every byte its header declares.
+    static func isCompleteSafetensors(url: URL) -> Bool {
+        guard let declared = declaredPayloadEnd(url: url),
+            let attributes = try? FileManager.default.attributesOfItem(atPath: url.path),
+            let size = (attributes[.size] as? NSNumber)?.intValue
+        else { return false }
+        return size >= declared
+    }
+
+    /// Remove dead temp files and incomplete final-named rows (with their
+    /// index rows) from `cacheDir`. Header-only reads: cheap even for a
+    /// multi-hundred-GB cache.
+    static func sweepUnpublishedAndIncompleteFiles(in cacheDir: URL) {
+        guard let names = try? FileManager.default.contentsOfDirectory(atPath: cacheDir.path) else { return }
+        var removed = 0
+        for name in names {
+            let url = cacheDir.appendingPathComponent(name)
+            if isUnpublishedName(name) {
+                try? FileManager.default.removeItem(at: url); removed += 1
+            } else if name.hasSuffix(".safetensors"), !isCompleteSafetensors(url: url) {
+                try? FileManager.default.removeItem(at: url); removed += 1
+                FileHandle.standardError.write(Data(
+                    "[vmlx][cache/disk] removed incomplete row \(name) at open (short of its declared payload)\n".utf8))
+            }
+        }
+        if removed > 0 {
+            FileHandle.standardError.write(Data("[vmlx][cache/disk] integrity sweep removed \(removed) file(s)\n".utf8))
+        }
     }
 
     private func _fileFingerprint(url: URL) -> ValidatedFileFingerprint? {

--- a/Tests/MLXLMTests/DiskCacheTests.swift
+++ b/Tests/MLXLMTests/DiskCacheTests.swift
@@ -1075,3 +1075,72 @@ import Testing
         #expect(companion.fetch(tokens: tokens, boundary: tokens.count) == nil)
     }
 }
+
+// MARK: - Storage integrity (2026-09-05 audit: a partial row restored as zeros)
+
+/// A row whose file is shorter than the payload its own header declares must
+/// be a MISS (and be removed with its index row), never a lazily-mapped hit
+/// whose short read is swallowed on the MLX stream.
+@Test func diskCacheTruncatedRowIsAMissAndIsRemoved() async throws {
+    try await MLXMetalTestLock.withLock {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vmlx_test_\(UUID())")
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let cache = DiskCache(cacheDir: tempDir, maxSizeGB: 0.1)
+        let tokens = [7, 8, 9, 10, 11, 12]
+        cache.store(tokens: tokens, arrays: ["keys": MLXArray.ones([2, 4, 64]), "values": MLXArray.ones([2, 4, 64])])
+        try await Task.sleep(nanoseconds: 200_000_000)
+
+        let files = try FileManager.default.contentsOfDirectory(atPath: tempDir.path)
+        let row = try #require(files.first { $0.hasSuffix(".safetensors") && !$0.contains(".partial-") })
+        #expect(!files.contains { $0.contains(".partial-") }, "store must publish atomically, leaving no partial file")
+        let url = tempDir.appendingPathComponent(row)
+        #expect(DiskCache.isCompleteSafetensors(url: url))
+        let declared = try #require(DiskCache.declaredPayloadEnd(url: url))
+        let full = try Data(contentsOf: url)
+        #expect(full.count >= declared)
+
+        // Truncate: keep the header and half the payload — the shape an
+        // interrupted write leaves behind.
+        let cut = 8 + (declared - 8) / 2
+        try full.prefix(cut).write(to: url)
+        #expect(!DiskCache.isCompleteSafetensors(url: url))
+
+        let result = cache.fetch(tokens: tokens)
+        #expect(result == nil, "a short row must fail closed to a miss")
+        #expect(!FileManager.default.fileExists(atPath: url.path), "the short row is removed")
+        // The next store of the same prefix heals the entry.
+        cache.store(tokens: tokens, arrays: ["keys": MLXArray.ones([2, 4, 64]), "values": MLXArray.ones([2, 4, 64])])
+        try await Task.sleep(nanoseconds: 200_000_000)
+        #expect(cache.fetch(tokens: tokens) != nil)
+    }
+}
+
+/// Dead temp files and incomplete final-named rows left by a crash are
+/// removed when the cache opens, so quota accounting and fetches never see
+/// them.
+@Test func diskCacheOpenSweepsUnpublishedAndIncompleteFiles() async throws {
+    try await MLXMetalTestLock.withLock {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vmlx_test_\(UUID())")
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+        // A dead temp file and a header-only "row" (declares 4 floats, has no payload).
+        let deadTemp = tempDir.appendingPathComponent("deadbeef.partial-1a2b3c4d.safetensors")
+        try Data("junk".utf8).write(to: deadTemp)
+        let header = #"{"kv_0_keys":{"dtype":"F32","shape":[4],"data_offsets":[0,16]}}"#
+        var incomplete = Data()
+        var length = UInt64(header.utf8.count).littleEndian
+        incomplete.append(Data(bytes: &length, count: 8))
+        incomplete.append(Data(header.utf8))
+        let shortRow = tempDir.appendingPathComponent("0123456789abcdef.safetensors")
+        try incomplete.write(to: shortRow)
+        #expect(DiskCache.declaredPayloadEnd(url: shortRow) == 8 + header.utf8.count + 16)
+        #expect(!DiskCache.isCompleteSafetensors(url: shortRow))
+
+        _ = DiskCache(cacheDir: tempDir, maxSizeGB: 0.1)
+        #expect(!FileManager.default.fileExists(atPath: deadTemp.path))
+        #expect(!FileManager.default.fileExists(atPath: shortRow.path))
+    }
+}


### PR DESCRIPTION
## What

Storage integrity for the disk cache tier. This is not a change to what a cache row contains and not a fix for any model-behaviour report; it removes one way a bad row could be served silently.

- A row was written under its final content-hash name before every byte was on disk. `fetch` checked only that the file existed, `loadArraysAndMetadata` maps lazily, and the MLX reader's short-read exception is dropped on the stream (`Load::eval_cpu` waits on the future without `get()`), so an interrupted store could later restore as zero-filled KV / recurrent state at a valid offset with no error.
- Rows are now written to a `<hash>.partial-<uuid>.safetensors` sibling and renamed into place after the write completes.
- `fetch` validates the file against the payload length its own header declares (8-byte LE header length + `data_offsets`) before mapping; a short row is removed with its index entry and the fetch misses, so the next store heals it.
- Open sweeps dead partial files and incomplete rows.
- No format change; existing complete rows are read exactly as before.

## Tests

- `diskCacheTruncatedRowIsAMissAndIsRemoved`: a row truncated to a prefix of its declared payload is a miss, the file and index row are removed, and the next store heals it.
- `diskCacheOpenSweepsUnpublishedAndIncompleteFiles`: a dead partial file and a header-only row are removed at open.
- Cache suites (DiskCacheTests, CacheCoordinator/Hybrid seed suites): 63/63 green locally.

# PROOF:
- Reproduced the defect class in a test before the change: a short file under the final name restored without error (zeros). After the change the same file is a miss and is removed.
- Independently verified against the looping-session investigation: with a fresh fetch per restore, store → fetch → restore → re-feed is bit-identical to an in-memory split for re-feed lengths 1…400 on Raptor JANG_6M (max |Δlogit| 0.0, identical recurrent and conv states). The rows from the looping session were intact; this PR is filed as storage integrity only.