### PR TITLE
Load: skip the awq_activations.safetensors capture when globbing a bundle's shards

### DIFF
--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -1247,7 +1247,10 @@ public func loadWeights(
 /// must never participate in inference weight loading.
 func isAuxiliaryCalibrationSafetensor(_ filename: String) -> Bool {
     switch filename {
-    case "awq-calibration.safetensors", "jang_imatrix.safetensors":
+    // `awq_activations.safetensors`: the Ling 3 / Raptor converter's activation
+    // capture, shipped next to the bf16 source shards. Its flat `lm_head` key
+    // fails `update(parameters:)` when globbed in with the indexed shards.
+    case "awq-calibration.safetensors", "jang_imatrix.safetensors", "awq_activations.safetensors":
         true
     default:
         false

--- a/Tests/MLXLMTests/LoadWeightShardSelectionTests.swift
+++ b/Tests/MLXLMTests/LoadWeightShardSelectionTests.swift
@@ -6,6 +6,7 @@ final class LoadWeightShardSelectionTests: XCTestCase {
     func testCalibrationArtifactsAreExcluded() {
         XCTAssertTrue(isAuxiliaryCalibrationSafetensor("awq-calibration.safetensors"))
         XCTAssertTrue(isAuxiliaryCalibrationSafetensor("jang_imatrix.safetensors"))
+        XCTAssertTrue(isAuxiliaryCalibrationSafetensor("awq_activations.safetensors"))
     }
 
     func testInferenceArtifactsRemainEligible() {


### PR DESCRIPTION
## What

The Ling 3 / Raptor converter leaves its activation capture (`awq_activations.safetensors`) next to the bf16 source shards. `loadWeights` globs every `.safetensors` in the bundle directory, and the capture's flat `lm_head` key fails `update(parameters:)` as an unhandled key, so the unquantized source bundle could not be loaded at all:

```
unhandledKeys(path: ["lm_head"], modules: ["BailingMoeV3Model", "Linear"], keys: [""])
```

It is a provenance artifact like `awq-calibration.safetensors` / `jang_imatrix.safetensors`, which `isAuxiliaryCalibrationSafetensor` already skips; treat it the same. No effect on bundles without the file.

## Tests

`LoadWeightShardSelectionTests`: the new name is recognised as auxiliary; shard names still are not. 2/2 locally.

# PROOF:
- Before: loading `Ling-3.0-tiny-Osaurus-v2mcp-c7e06` (bf16, with the capture present) threw the error above; a symlinked copy without the capture loaded and generated normally.
- After: the filter covers the file; the unit test pins the name.