### PR TITLE
KDA Metal kernel: the per-channel decay and beta stay float32 into the recurrence

### DIFF
--- a/Libraries/MLXLLM/Models/KDADelta.swift
+++ b/Libraries/MLXLLM/Models/KDADelta.swift
@@ -160,7 +160,14 @@ private func kdaKernel(
         mask != nil ? KDAKernelManager.shared.kernelMasked : KDAKernelManager.shared.kernel
     guard let kernel = selected else { fatalError("KDA kernel not available") }
 
-    var inputs: [MLXArray] = [q, k, v, g.asType(q.dtype), beta, state, MLXArray(T)]
+    // The decay `g` (exp of the fp32 gate, values in (0, 1]) and `beta` stay
+    // float32 into the kernel: narrowed to bf16, any per-channel decay above
+    // ~0.998 rounds to exactly 1.0 (no decay) and 0.997 to 0.996, an error
+    // the recurrence compounds every token. Upstream FLA computes the gate
+    // in fp32 inside its kernel; the Metal source reads both through
+    // `static_cast<float>`, so the array dtype is the only thing that
+    // decides the precision.
+    var inputs: [MLXArray] = [q, k, v, g.asType(.float32), beta.asType(.float32), state, MLXArray(T)]
     if let mask { inputs.append(mask) }
 
     let outputs = kernel(
@@ -220,7 +227,7 @@ public func kdaUpdate(
     let available = (mask != nil ? manager.kernelMasked : manager.kernel) != nil
     if available && Dk >= 32 && Dk % 32 == 0 {
         return kdaKernel(
-            q: q, k: k, v: v, g: g, beta: beta.asType(q.dtype),
+            q: q, k: k, v: v, g: g, beta: beta,
             state: state, mask: mask)
     }
     return gatedDeltaOps(

--- a/Tests/MLXLMTests/BailingMoeV3Tests.swift
+++ b/Tests/MLXLMTests/BailingMoeV3Tests.swift
@@ -202,6 +202,47 @@ struct BailingMoeV3Tests {
         }
     }
 
+    /// The kernel used to receive the decay narrowed to the activation dtype:
+    /// in bf16 every per-channel decay above ~0.998 is exactly 1.0 (that
+    /// channel never forgets) and 0.997 becomes 0.996. Nine steps of random
+    /// gates never show it; a long horizon of slow-decay channels does. The
+    /// ops fallback keeps everything fp32 and is the reference here.
+    @Test("KDA Metal kernel keeps slow decays over a long horizon (fp32 gate into the kernel)")
+    func kdaKernelSlowDecayLongHorizon() throws {
+        try MLXMetalTestLock.withLock {
+            MLXRandom.seed(11)
+            let (B, T, H, Dk, Dv) = (1, 4096, 1, 32, 32)
+            let q = (MLXRandom.normal([B, T, H, Dk]) * 0.3).asType(.bfloat16)
+            let k = (MLXRandom.normal([B, T, H, Dk]) * 0.3).asType(.bfloat16)
+            let v = (MLXRandom.normal([B, T, H, Dv]) * 0.3).asType(.bfloat16)
+            // Very negative pre-activations → sigmoid ≈ 1.7e-5 → g ≈ -8e-5 →
+            // decay ≈ 0.99992: representable in fp32, exactly 1.0 in bf16
+            // (the largest bf16 below 1 is 0.99609). Over 4096 steps the
+            // fp32 reference forgets ~28% of early content; the narrowed
+            // kernel forgets nothing.
+            let fRaw = (MLXRandom.normal([B, T, H, Dk]) * 0.2 - 11.0).asType(.bfloat16)
+            let beta = sigmoid(MLXRandom.normal([B, T, H])).asType(.bfloat16)
+            let aLog = MLXArray(converting: [0.0])
+            let dtBias = MLXArray.zeros([H * Dk])
+
+            let (yKernel, sKernel) = kdaUpdate(
+                q: q, k: k, v: v, fRaw: fRaw, beta: beta,
+                aLog: aLog, dtBias: dtBias, safeGate: true, lowerBound: -5)
+            let g = computeKDADecay(fRaw: fRaw, aLog: aLog, dtBias: dtBias, safeGate: true, lowerBound: -5)
+            #expect(g.min().item(Float.self) > 0.9997, "fixture must exercise decays bf16 cannot represent")
+            #expect(g.max().item(Float.self) < 1.0, "fixture must actually decay")
+            let state = MLXArray.zeros([B, H, Dv, Dk], dtype: .float32)
+            let (yOps, sOps) = gatedDeltaOps(
+                q: q, k: k, v: v, g: g, beta: beta.asType(.float32), state: state)
+
+            let sScale = abs(sOps).max().item(Float.self)
+            let sDiff = abs(sKernel.asType(.float32) - sOps.asType(.float32)).max().item(Float.self)
+            let yDiff = abs(yKernel.asType(.float32)[0, -1] - yOps.asType(.float32)[0, -1]).max().item(Float.self)
+            #expect(sDiff / max(sScale, 1e-6) < 1e-3, "final state diverges from the fp32 reference: \(sDiff) (scale \(sScale)); the narrowed kernel measured 1.1e-2 here, the fp32 one 4e-7")
+            #expect(yDiff < 1e-3, "last-step output diverges from the fp32 reference: \(yDiff); the narrowed kernel measured 1.6e-2 here")
+        }
+    }
+
     @Test("safe-gate decay is bounded to (exp(lower_bound), 1)")
     func safeGateBounds() throws {
         try MLXMetalTestLock.withLock {


### PR DESCRIPTION
## What

`kdaKernel` narrowed the fp32 decay (exp of the safe gate, values in (0, 1]) and beta to the activation dtype before the Metal recurrence, while the recurrent state is float32. In bf16 the largest value below 1 is 0.99609, so every per-channel decay above ~0.998 became exactly 1.0 (that channel never forgets) and 0.997 became 0.996; the recurrence compounds the error every token. Upstream FLA computes the gate in float32 inside its kernel. The Metal source already reads both inputs through `static_cast<float>`, so the array dtype was the only thing deciding the precision. Both now stay float32.

Scope: KDA only (Ling 3 / Raptor / GLM-5.3). The GatedDelta kernel (Qwen3-Next / Ornith) never narrowed and is untouched. Numerical fidelity change; not claimed as a fix for any behaviour report.

## Tests

`kdaKernelSlowDecayLongHorizon`: 4096 steps of decays bf16 cannot represent (≈0.99992), kernel vs the fp32 ops fallback. Pre-fix: state 1.1e-2 relative, last output 1.6e-2. Fixed: 4e-7 and 0. Existing `kdaKernelOpsParity` (9 random steps) never saw it. BailingMoeV3Tests 11/11 locally.

# PROOF:
- Raw last-position logits, Raptor bf16 source, 4,730-token prompt, against an independent implementation (jang-tools' Python MLX model with the FLA safe gate on identical tokens): max |Δ| 1.56 → 0.88, mean 0.26 → 0.14; top-5 identical before and after. The remaining 0.88 is bf16 matmul/chunk numerics shared by any bf16 stack.
- Regression fails on the previous kernel and passes on this one (measured values above).

### Added: long-context parity (11,451-token prompt, same setup)
| tokens | Swift narrowed vs reference | Swift fp32 vs reference |
|---|---|---|
| 4,730 | max 1.56 / mean 0.26 | 0.88 / 0.14 |
| 11,451 | 2.00 / 0.26 | 0.66 / 0.11 |
The narrowed kernel drifts further from the independent implementation as context grows; the fp32 kernel gets closer. Behavioural note: the tool-call repetition ladder is unchanged by this fix (1/5, 3/5, 5/5, 4/5 vs 1/5, 4/5, 5/5, 4/5), so this PR is a fidelity fix, not the loop cause.