### PR TITLE
BailingMoeV3: l2norm-equivalent eps for the KDA q/k normalisation; routed experts combined in float32

### DIFF
--- a/Libraries/MLXLLM/Models/BailingMoeV3.swift
+++ b/Libraries/MLXLLM/Models/BailingMoeV3.swift
@@ -329,15 +329,17 @@ public final class BailingV3KDAAttention: Module {
         q = q.reshaped(B, T, numHeads, headDim)
         k = k.reshaped(B, T, numHeads, headDim)
 
-        // fla applies true per-head L2 norm and scales q by Dk^-0.5. An
-        // unweighted rmsNorm is l2norm * sqrt(D), so multiplying by
-        // invScale^2 / invScale reproduces l2(q)*Dk^-0.5 and l2(k) exactly —
-        // the same identity Qwen3Next uses.
+        // fla applies true per-head L2 norm (eps 1e-6 on the SUM of squares)
+        // and scales q by Dk^-0.5. An unweighted rmsNorm is l2norm * sqrt(D)
+        // — but its eps sits on the MEAN of squares, so the equivalent
+        // stabiliser is 1e-6 / D (upstream mlx-lm `_normalize_kda_qk` uses
+        // exactly that). A bare 1e-6 here was D× too large.
         let invScale = pow(Float(headDim), -0.5)
+        let l2Eps = Float(1e-6) / Float(headDim)
         q = MLXArray(invScale * invScale, dtype: q.dtype)
-            * MLXFast.rmsNorm(q, weight: MLXArray.mlxNone, eps: 1e-6)
+            * MLXFast.rmsNorm(q, weight: MLXArray.mlxNone, eps: l2Eps)
         k = MLXArray(invScale, dtype: k.dtype)
-            * MLXFast.rmsNorm(k, weight: MLXArray.mlxNone, eps: 1e-6)
+            * MLXFast.rmsNorm(k, weight: MLXArray.mlxNone, eps: l2Eps)
 
         let fRaw: MLXArray
         if let fProj {
@@ -623,12 +625,22 @@ final class BailingV3SparseMoE: Module, UnaryLayer {
 
     func callAsFunction(_ x: MLXArray) -> MLXArray {
         let (inds, scores) = gate(x)
-        var y = switchMLP(x, inds)
-        y = (y * scores[.ellipsis, .newAxis].asType(y.dtype)).sum(axis: -2)
+        var y = Self.combineExpertOutputs(switchMLP(x, inds), scores: scores)
         if let sharedExperts {
             y = y + sharedExperts(x)
         }
         return y
+    }
+
+    /// Routed-expert combination in float32, cast back once — the reference
+    /// (`modeling_bailing_moe_v3.py`, `.type(topk_weight.dtype).mul_(…).sum(…).type(new_x.dtype)`)
+    /// and upstream mlx-lm both weight and sum in the scores' float32. The
+    /// previous form rounded the scores to the expert dtype and summed the
+    /// top-k products in bf16.
+    static func combineExpertOutputs(_ y: MLXArray, scores: MLXArray) -> MLXArray {
+        (y.asType(.float32) * scores[.ellipsis, .newAxis].asType(.float32))
+            .sum(axis: -2)
+            .asType(y.dtype)
     }
 }
 

--- a/Tests/MLXLMTests/BailingMoeV3Tests.swift
+++ b/Tests/MLXLMTests/BailingMoeV3Tests.swift
@@ -243,6 +243,48 @@ struct BailingMoeV3Tests {
         }
     }
 
+    /// fla's l2norm puts eps on the SUM of squares; rmsNorm puts it on the
+    /// MEAN. The equivalent rmsNorm eps is therefore eps / D. With a bare
+    /// 1e-6 the stabiliser is D× too large — invisible on ordinary
+    /// activations, measurable on small ones.
+    @Test("KDA q/k normalisation reproduces fla's l2norm (eps on the sum of squares)")
+    func kdaQKNormMatchesL2Norm() throws {
+        try MLXMetalTestLock.withLock {
+            let D = 128
+            MLXRandom.seed(3)
+            let x = (MLXRandom.normal([1, 4, 2, D]) * 0.002).asType(.float32)  // small activations
+            let invScale = pow(Float(D), -0.5)
+            let l2 = x * rsqrt((x * x).sum(axis: -1, keepDims: true) + 1e-6)  // fla l2norm
+            let viaRms = MLXArray(invScale) * MLXFast.rmsNorm(x, weight: MLXArray.mlxNone, eps: 1e-6 / Float(D))
+            let viaRmsBareEps = MLXArray(invScale) * MLXFast.rmsNorm(x, weight: MLXArray.mlxNone, eps: 1e-6)
+            let good = abs(viaRms - l2).max().item(Float.self)
+            let bad = abs(viaRmsBareEps - l2).max().item(Float.self)
+            #expect(good < 1e-5, "eps/D form must equal l2norm: \(good)")
+            #expect(bad > 1e-3, "the bare-eps form is measurably different on small activations: \(bad)")
+        }
+    }
+
+    /// The reference combines routed expert outputs with float32 routing
+    /// weights and sums in float32; rounding the weights to bf16 and summing
+    /// the top-k products in bf16 is a different result.
+    @Test("routed-expert combination is float32 (weights and sum), cast back once")
+    func moeCombineIsFloat32() throws {
+        try MLXMetalTestLock.withLock {
+            MLXRandom.seed(5)
+            let y = MLXRandom.normal([2, 3, 8, 64]).asType(.bfloat16)          // [B, T, topk, D]
+            let scores = softmax(MLXRandom.normal([2, 3, 8]), axis: -1)          // float32
+            let combined = BailingV3SparseMoE.combineExpertOutputs(y, scores: scores)
+            #expect(combined.dtype == .bfloat16)
+            let reference = (y.asType(.float32) * scores[.ellipsis, .newAxis]).sum(axis: -2)
+            let bf16Path = (y * scores[.ellipsis, .newAxis].asType(.bfloat16)).sum(axis: -2).asType(.float32)
+            let ours = abs(combined.asType(.float32) - reference).max().item(Float.self)
+            let old = abs(bf16Path - reference).max().item(Float.self)
+            // Ours differs from the float32 reference only by the final bf16 rounding of the result.
+            #expect(ours <= abs(reference).max().item(Float.self) * 0.008, "combine deviates from the float32 reference: \(ours)")
+            #expect(old > ours, "the bf16 path must be measurably worse (old \(old) vs ours \(ours))")
+        }
+    }
+
     @Test("safe-gate decay is bounded to (exp(lower_bound), 1)")
     func safeGateBounds() throws {
         try MLXMetalTestLock.withLock {


### PR DESCRIPTION
Stacked on #433.

## What

Two reference deviations in the Ling 3 runtime, found by source comparison against the checkpoint's own `modeling_bailing_moe_v3.py` and upstream mlx-lm:

1. **KDA q/k normalisation eps.** fla's `l2norm` puts eps (1e-6) on the sum of squares; `rmsNorm` puts it on the mean, so the equivalent rmsNorm eps is `1e-6 / head_dim` (upstream mlx-lm `_normalize_kda_qk`). A bare 1e-6 was 128× too large at head_dim 128.
2. **Routed-expert combination.** The float32 routing scores were rounded to the expert dtype and the top-k products summed in bf16. The reference (`.type(topk_weight.dtype).mul_(…).sum(…).type(new_x.dtype)`) and mlx-lm weight and sum in float32, casting back once. Now a `combineExpertOutputs` helper does the same.

Numerical-fidelity changes; neither is claimed as a behaviour fix.

## Tests

- `kdaQKNormMatchesL2Norm`: the eps/D form equals fla's l2norm to 1e-5 on small activations; the bare-eps form differs by more than 1e-3.
- `moeCombineIsFloat32`: matches the float32 reference up to the final bf16 rounding; the previous bf16 path is measurably worse.
- BailingMoeV3Tests 13/13 locally.

# PROOF:

### Parity against the independent implementation (jang-tools' Python MLX model with the FLA gate, same tokens)
| tokens | #433 only (fp32 decay) | #433 + this PR |
|---|---|---|
| 4,730 | max 0.88 / mean 0.14 | max 0.68 / mean 0.13 |
| 11,451 | max 0.66 / mean 0.11 | max 0.56 / mean 0.089 |
Top-5 identical throughout. (Original narrowed kernel: 1.56 / 0.26 and 2.00 / 0.26.)