### PR TITLE
Bailing: templates that read enable_thinking get the kwarg, not a prepended directive

### DIFF
--- a/Libraries/MLXLLM/BailingThinkingTemplateContext.swift
+++ b/Libraries/MLXLLM/BailingThinkingTemplateContext.swift
@@ -19,12 +19,26 @@ enum BailingThinkingTemplateContext {
         modelType?.lowercased().hasPrefix("bailing") == true
     }
 
+    /// Ling 3.0's template reads the standard kwarg (`{%- if enable_thinking is
+    /// defined %}`) and renders "detailed thinking on/off" itself at the END
+    /// of the SYSTEM turn, after the tools block — the trained position. The
+    /// prepend below puts it at the START of the system content (and the
+    /// template then skips its own), which is not what the model saw in
+    /// training. When the template reads the kwarg, leave the messages alone
+    /// and let the kwarg travel.
+    static func templateReadsEnableThinking(_ chatTemplate: String?) -> Bool {
+        guard let chatTemplate else { return false }
+        return chatTemplate.contains("enable_thinking is defined")
+            || chatTemplate.contains("enable_thinking is not defined")
+    }
+
     static func apply(
         to messages: [Message],
         modelType: String?,
-        additionalContext: [String: any Sendable]?
+        additionalContext: [String: any Sendable]?,
+        templateReadsEnableThinking: Bool = false
     ) -> [Message] {
-        guard applies(to: modelType) else {
+        guard applies(to: modelType), !templateReadsEnableThinking else {
             return messages
         }
 

--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -1311,18 +1311,26 @@ private struct LLMUserInputProcessor: UserInputProcessor {
     let modelType: String?
     let messageGenerator: MessageGenerator
     let defaultAdditionalContext: [String: any Sendable]?
+    /// True when the bundle's chat template reads the standard
+    /// `enable_thinking` kwarg itself (Ling 3.0: `{%- if enable_thinking is
+    /// defined %}` and it renders "detailed thinking on/off" at the END of the
+    /// SYSTEM turn). Then the kwarg is passed through untouched; the legacy
+    /// Bailing directive prepend is only for templates that do not read it.
+    let templateReadsEnableThinking: Bool
 
     internal init(
         tokenizer: any Tokenizer, configuration: ModelConfiguration,
         modelType: String?,
         messageGenerator: MessageGenerator,
-        defaultAdditionalContext: [String: any Sendable]? = nil
+        defaultAdditionalContext: [String: any Sendable]? = nil,
+        templateReadsEnableThinking: Bool = false
     ) {
         self.tokenizer = tokenizer
         self.configuration = configuration
         self.modelType = modelType
         self.messageGenerator = messageGenerator
         self.defaultAdditionalContext = defaultAdditionalContext
+        self.templateReadsEnableThinking = templateReadsEnableThinking
     }
 
     func prepare(input: UserInput) throws -> LMInput {
@@ -1340,7 +1348,8 @@ private struct LLMUserInputProcessor: UserInputProcessor {
         let bailingMessages = BailingThinkingTemplateContext.apply(
             to: messageGenerator.generate(from: input),
             modelType: modelType,
-            additionalContext: additionalContext
+            additionalContext: additionalContext,
+            templateReadsEnableThinking: templateReadsEnableThinking
         )
         var messages = NemotronToolChoiceTemplateContext.apply(
             to: bailingMessages,
@@ -2049,7 +2058,8 @@ public final class LLMModelFactory: ModelFactory {
                 modelType: baseConfig.modelType,
                 capabilities: jangConfig?.capabilities,
                 generationConfig: generationConfig,
-                chatConfig: jangConfig?.chat))
+                chatConfig: jangConfig?.chat),
+            templateReadsEnableThinking: BailingThinkingTemplateContext.templateReadsEnableThinking(chatTemplate))
 
         return .init(
             configuration: modelConfig, model: model, processor: processor,

--- a/Tests/MLXLMTests/BailingThinkingTemplateContextTests.swift
+++ b/Tests/MLXLMTests/BailingThinkingTemplateContextTests.swift
@@ -147,4 +147,21 @@ final class BailingThinkingTemplateContextTests: XCTestCase {
             """
         )
     }
+    /// Ling 3.0 templates read `enable_thinking` themselves and place the
+    /// directive at the end of the SYSTEM turn; the prepend must not run there.
+    func testTemplateThatReadsEnableThinkingIsLeftToTheTemplate() {
+        let ling3 = "{%- if enable_thinking is defined %}\n{%- if enable_thinking %}{%- set thinking_option = 'on' %}{%- endif %}{%- endif %}"
+        XCTAssertTrue(BailingThinkingTemplateContext.templateReadsEnableThinking(ling3))
+        XCTAssertFalse(BailingThinkingTemplateContext.templateReadsEnableThinking("{{ messages[0].content }} detailed thinking on"))
+        XCTAssertFalse(BailingThinkingTemplateContext.templateReadsEnableThinking(nil))
+        let messages: [Message] = [["role": "system", "content": "You are Osaurus."], ["role": "user", "content": "hi"]]
+        let untouched = BailingThinkingTemplateContext.apply(
+            to: messages, modelType: "bailing_hybrid",
+            additionalContext: ["enable_thinking": true], templateReadsEnableThinking: true)
+        XCTAssertEqual(untouched[0]["content"] as? String, "You are Osaurus.")
+        let legacy = BailingThinkingTemplateContext.apply(
+            to: messages, modelType: "bailing_hybrid",
+            additionalContext: ["enable_thinking": true], templateReadsEnableThinking: false)
+        XCTAssertEqual(legacy[0]["content"] as? String, "detailed thinking on\n\nYou are Osaurus.")
+    }
 }


### PR DESCRIPTION
## What

`BailingThinkingTemplateContext` translated `enable_thinking` into a `detailed thinking on/off` line prepended to the system content, for Ling templates that did not read the kwarg. Ling 3.0's template does read it (`{%- if enable_thinking is defined %}`) and renders the directive itself at the **end** of the SYSTEM turn, after the tools block, which is the trained position. With the prepend in place the template found the directive in the content and skipped its own, so every Ling 3 / Raptor prompt carried it at the start of the system message.

The input processor now learns from the bundle's chat template whether it reads the kwarg (`templateReadsEnableThinking`); when it does, the messages are left alone and the kwarg travels. Templates that do not read it keep the legacy prepend.

## Tests

`testTemplateThatReadsEnableThinkingIsLeftToTheTemplate` (detection on the Ling 3 guard text; pass-through leaves the system message untouched; legacy templates still get the prepend). BailingThinkingTemplateContextTests 9/9.

# PROOF:
- Rendered prompts from the app currently begin `<role>SYSTEM</role>detailed thinking on\n\nYou are…` (every captured Raptor prompt dump); the template's own path ends the system turn with `…\ndetailed thinking on<|role_end|>`.
- Engine ladder on Raptor (history kept, 5 seeds): trained position 2/5 re-issues after two identical reads vs 4/5 with the prepend; 5/5 at three either way. Fidelity fix, not a loop fix.
- Live render check (prompt dump shows the directive at the end of the system turn) to be attached from an osaurus build pinned to this commit.