### PR TITLE
bailing_hybrid: Ling 2.6 architecture loads the GLA runtime again; stale index falls back to one complete shard family (osaurus#2652)

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -387,15 +387,17 @@ public enum LLMTypeRegistry {
         return ZayaModel(config, moe: context)
     }
 
-    /// `model_type = "bailing_hybrid"` is Ling 3.0 (KDA + MLA + V3 MoE,
-    /// `BailingMoeV3Model`). It used to fall back to the Ling 2.6 GLA runtime
-    /// (`BailingHybridModel`) when the V3 markers were absent — and a Ling 3
-    /// bundle routed there decodes to garbage (token 0 "!" streams, loops).
-    /// Nothing we ship needs the 2.6 path under this model type, so the
-    /// fallback is gone: `bailing_hybrid` is V3-only, and a config that does
-    /// not decode as V3 fails LOUDLY naming the runtime instead of silently
-    /// loading the wrong architecture. The 2.6 runtime remains reachable only
-    /// under its own `bailing_moe_v2_5` model type.
+    /// `model_type = "bailing_hybrid"` covers two architectures that share the
+    /// model type:
+    /// - Ling 3.0 (KDA + MLA + V3 MoE, `BailingMoeV3Model`): any Ling 3 marker
+    ///   (a `MoeV3` architecture name, `linear_attention: kda`,
+    ///   `kda_lower_bound`) — and the default when a config names neither.
+    /// - Ling 2.6 (GLA + MLA + V2 MoE, `BailingHybridModel`): ONLY a config
+    ///   whose `architectures` names `BailingMoeV2…` with no Ling 3 marker
+    ///   (Ling 2.6 flash / JANGTQ, osaurus#2652).
+    /// The marker-less FALLBACK to the 2.6 runtime is gone (#424): a Ling 3
+    /// bundle routed there decodes to garbage (token 0 "!" streams, loops), so
+    /// an ambiguous config is decoded as Ling 3 and fails LOUDLY if it is not.
     private static func dispatchBailingHybrid(data: Data, requesting: Set<ModelRuntimeRequestModality>? = nil)
         throws -> any LanguageModel
     {
@@ -412,17 +414,26 @@ public enum LLMTypeRegistry {
         let probe = try? JSONDecoder().decode(Probe.self, from: data)
         let markers =
             "architectures=\(probe?.architectures ?? []) linear_attention=\(probe?.linearAttention ?? "nil") kda_lower_bound=\(probe?.kdaLowerBound.map { String($0) } ?? "nil")"
-        // A config that NAMES the Ling 2.6 architecture is a genuine 2.6
-        // bundle. The GLA runtime is gone, and decoding it as V3 would only
-        // produce garbage — fail with a named error instead.
-        if let architectures = probe?.architectures,
+        // Ling 3 markers: the V3 architecture name, KDA linear attention, or
+        // the KDA gate lower bound. Any one of them makes the bundle Ling 3.
+        let isV3 =
+            probe?.architectures?.contains(where: { $0.contains("MoeV3") }) == true
+            || probe?.linearAttention == "kda"
+            || probe?.kdaLowerBound != nil
+        // A config that NAMES the Ling 2.6 architecture (BailingMoeV2_5ForCausalLM)
+        // and carries no Ling 3 marker is a genuine 2.6 bundle: GLA linear
+        // attention + MLA + V2 MoE, the `BailingHybridModel` runtime. This is
+        // the ONLY way to reach that runtime — the marker-less fallback that
+        // sent Ling 3 bundles there (#424) stays gone: a config naming neither
+        // architecture is decoded as Ling 3 below.
+        if !isV3, let architectures = probe?.architectures,
             architectures.contains(where: { $0.hasPrefix("BailingMoeV2") })
         {
+            let configuration = try JSONDecoder().decode(
+                BailingHybridConfiguration.self, from: data)
             FileHandle.standardError.write(Data(
-                ("[LLMModelFactory] bailing_hybrid refused: \(markers) names the Ling 2.6 (GLA) architecture. "
-                    + "The Ling 2.6 runtime is not shipped; only Ling 3.0 (BailingMoeV3, KDA) bundles are supported.\n").utf8))
-            throw ModelFactoryError.unsupportedModelType(
-                "bailing_hybrid (Ling 2.6 / \(architectures.joined(separator: ","))) — only Ling 3.0 (BailingMoeV3) bundles are supported")
+                "[LLMModelFactory] bailing_hybrid → Ling 2.6 runtime (BailingHybridModel, GLA) \(markers)\n".utf8))
+            return BailingHybridModel(configuration)
         }
         do {
             let configuration = try JSONDecoder().decode(
@@ -433,8 +444,8 @@ public enum LLMTypeRegistry {
         } catch {
             FileHandle.standardError.write(Data(
                 ("[LLMModelFactory] bailing_hybrid config does not decode as Ling 3.0 (BailingMoeV3Configuration): "
-                    + "\(error). The Ling 2.6 GLA runtime is no longer a fallback for this model_type "
-                    + "(it produces garbage for Ling 3 bundles) and is not shipped. \(markers)\n").utf8))
+                    + "\(error). The Ling 2.6 GLA runtime is reached only by a config naming the "
+                    + "BailingMoeV2 architecture; it is not a fallback (it produces garbage for Ling 3 bundles). \(markers)\n").utf8))
             throw error
         }
     }

--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -128,6 +128,81 @@ private func modelIndexContainsPreservedMTPWeight(at modelDirectory: URL) -> Boo
 /// the bundle (absolute paths, `..`) are dropped — weight_map values are
 /// plain file names by contract, and a hostile index must not become a
 /// file-system probe.
+/// What `model.safetensors.index.json` means for the load, given which of the
+/// files it names exist next to it:
+/// - every named file exists → the index is the load manifest (`manifest`);
+/// - some exist and some do not → a truncated or partially replaced download
+///   (`truncated`): loading the rest would silently leave tensors
+///   uninitialised (`model.update` verifies unused keys, not missing ones),
+///   so the load fails loud;
+/// - NONE exist and the directory holds exactly one COMPLETE numbered
+///   `model-NNNNN-of-MMMMM` family (every 1…M present) → the index is from
+///   another layout of the same bundle (`staleIndex`); that family — and
+///   only that family — is the bundle the index failed to describe;
+/// - NONE exist and there is no complete family (an empty or partial
+///   download, unrelated sidecars only, two families) → `incomplete`: fail
+///   loud, nothing can be positively identified as the model.
+enum IndexManifestDecision: Equatable {
+    case manifest([String])
+    case truncated(missing: [String])
+    case staleIndex(missing: [String], replacement: [String])
+    case incomplete(missing: [String])
+}
+
+/// The one complete `model-NNNNN-of-MMMMM.safetensors` family among `names`
+/// (1…M all present, exactly one M), in shard order; nil otherwise.
+func completeNumberedShardFamily(in names: [String]) -> [String]? {
+    let regex = try! NSRegularExpression(pattern: #"^model-(\d+)-of-(\d+)\.safetensors$"#)
+    var byTotal: [Int: [Int: String]] = [:]
+    for name in names {
+        let whole = NSRange(name.startIndex..., in: name)
+        guard let match = regex.firstMatch(in: name, range: whole),
+            let indexRange = Range(match.range(at: 1), in: name),
+            let totalRange = Range(match.range(at: 2), in: name),
+            let index = Int(name[indexRange]), let total = Int(name[totalRange])
+        else { continue }
+        byTotal[total, default: [:]][index] = name
+    }
+    guard byTotal.count == 1, let (total, files) = byTotal.first, total > 0,
+        Set(files.keys) == Set(1...total)
+    else { return nil }
+    return (1...total).map { files[$0]! }
+}
+
+func indexManifestDecision(indexedNames: [String], presentNames: [String]) -> IndexManifestDecision {
+    let present = Set(presentNames)
+    var found: [String] = []
+    var missing: [String] = []
+    for name in indexedNames {
+        if present.contains(name) { found.append(name) } else { missing.append(name) }
+    }
+    if missing.isEmpty { return .manifest(found) }
+    if !found.isEmpty { return .truncated(missing: missing) }
+    if let family = completeNumberedShardFamily(in: presentNames) {
+        return .staleIndex(missing: missing, replacement: family)
+    }
+    return .incomplete(missing: missing)
+}
+
+/// The tensor names a safetensors file declares (header only, no payload
+/// read); nil when the header cannot be read.
+func safetensorsTensorKeys(_ url: URL) -> [String]? {
+    guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+    defer { try? handle.close() }
+    guard let lengthData = try? handle.read(upToCount: 8), lengthData.count == 8
+    else { return nil }
+    var headerLength: UInt64 = 0
+    for (index, byte) in lengthData.enumerated() {
+        headerLength |= UInt64(byte) << UInt64(index * 8)
+    }
+    guard headerLength > 0, headerLength <= 64 * 1024 * 1024,
+        let headerData = try? handle.read(upToCount: Int(headerLength)),
+        headerData.count == Int(headerLength),
+        let header = try? JSONSerialization.jsonObject(with: headerData) as? [String: Any]
+    else { return nil }
+    return header.keys.filter { $0 != "__metadata__" }
+}
+
 func indexedShardFileNames(at modelDirectory: URL) -> [String]? {
     let indexURL = modelDirectory.appendingPathComponent("model.safetensors.index.json")
     guard let data = try? Data(contentsOf: indexURL),
@@ -281,17 +356,14 @@ public func loadWeights(
         if jangConfig != nil,
             let indexedNames = indexedShardFileNames(at: modelDirectory)
         {
+            let decision = indexManifestDecision(
+                indexedNames: indexedNames,
+                presentNames: allShardURLs.map(\.lastPathComponent))
             var selected: [URL] = []
-            var missing: [String] = []
-            for name in indexedNames {
-                let url = modelDirectory.appendingPathComponent(name)
-                if FileManager.default.fileExists(atPath: url.path) {
-                    selected.append(url)
-                } else {
-                    missing.append(name)
-                }
-            }
-            if !missing.isEmpty {
+            switch decision {
+            case .manifest(let names):
+                selected = names.map { modelDirectory.appendingPathComponent($0) }
+            case .truncated(let missing), .incomplete(let missing):
                 let message =
                     "model.safetensors.index.json references \(missing.count) "
                     + "file(s) that are not in \(modelDirectory.path): "
@@ -300,6 +372,45 @@ public func loadWeights(
                     + "re-download the bundle."
                 FileHandle.standardError.write(Data("[loadWeights] \(message)\n".utf8))
                 throw TruncatedSafetensorsError(description: message)
+            case .staleIndex(let missing, let replacement):
+                // The index describes a layout that is not in this directory
+                // at all (a bundle re-uploaded with new shards but an old
+                // index — JANGQ-AI/Ling-2.6-flash-JANGTQ names 31 files, ships
+                // a complete 29-shard family, osaurus#2652). The one complete
+                // numbered family IS the bundle; load exactly it (plus the
+                // named overlays below), never every safetensors file, and
+                // refuse if two shards declare the same tensor — the
+                // `model.update` verification behind this only checks unused
+                // keys, so a duplicate would silently win by order.
+                var seen: [String: String] = [:]
+                var duplicates: [String] = []
+                for name in replacement {
+                    let url = modelDirectory.appendingPathComponent(name)
+                    guard let keys = safetensorsTensorKeys(url) else {
+                        let message =
+                            "model.safetensors.index.json is stale (names \(missing.count) absent file(s)) "
+                            + "and the replacement shard \(name) has an unreadable header — re-download the bundle."
+                        FileHandle.standardError.write(Data("[loadWeights] \(message)\n".utf8))
+                        throw TruncatedSafetensorsError(description: message)
+                    }
+                    for key in keys {
+                        if let first = seen[key] { duplicates.append("\(key) (\(first), \(name))") } else { seen[key] = name }
+                    }
+                }
+                if !duplicates.isEmpty {
+                    let message =
+                        "model.safetensors.index.json is stale and the \(replacement.count)-shard replacement "
+                        + "declares \(duplicates.count) duplicate tensor(s): "
+                        + duplicates.sorted().prefix(5).joined(separator: ", ") + " — re-download the bundle."
+                    FileHandle.standardError.write(Data("[loadWeights] \(message)\n".utf8))
+                    throw TruncatedSafetensorsError(description: message)
+                }
+                FileHandle.standardError.write(Data(
+                    ("[loadWeights] model.safetensors.index.json is stale: none of the "
+                        + "\(missing.count) file(s) it names exist in \(modelDirectory.path) "
+                        + "(e.g. \(missing.sorted().first ?? "")); loading the complete "
+                        + "\(replacement.count)-shard family present instead (\(seen.count) tensors, no duplicates)\n").utf8))
+                selected = replacement.map { modelDirectory.appendingPathComponent($0) }
             }
             for overlay in ["jangtq_stacked.safetensors", "jangpress-prestacked.safetensors"] {
                 if overlay == "jangtq_stacked.safetensors" && skipDSV4Sidecar { continue }

--- a/Tests/MLXLMTests/BailingMoeV3Tests.swift
+++ b/Tests/MLXLMTests/BailingMoeV3Tests.swift
@@ -61,8 +61,9 @@ struct BailingMoeV3Tests {
         """.data(using: .utf8)!
 
     /// Ling 2.6 (GLA) shaped config — a minimal field set naming the 2.6
-    /// architecture, with NO V3 markers. The GLA runtime is unreachable;
-    /// this fixture proves the refusal path.
+    /// architecture, with NO V3 markers. The architecture name is the ONLY
+    /// route to the GLA runtime (osaurus#2652: a genuine Ling 2.6 bundle
+    /// must load; #424: a marker-less config must never reach GLA).
     static let legacyConfigJSON = """
         {
           "model_type": "bailing_hybrid",
@@ -101,26 +102,37 @@ struct BailingMoeV3Tests {
         #expect(name.contains("BailingMoeV3"))
     }
 
-    @Test("a config naming the Ling 2.6 architecture is refused under bailing_hybrid (never GLA, never garbage-as-V3)")
-    func legacyArchitectureRefused() async throws {
-        // Raptor reports: a bundle that reached the GLA runtime under
-        // `bailing_hybrid` streamed `!` at 100+ tok/s. The GLA runtime is
-        // unreachable now; a genuine 2.6 bundle gets a named error.
-        let outcome: String = try await MLXMetalTestLock.withLock {
-            do {
-                let model = try await LLMTypeRegistry.shared.createModel(
-                    configuration: Self.legacyConfigJSON, modelType: "bailing_hybrid")
-                return "loaded:" + String(describing: type(of: model))
-            } catch let error as ModelFactoryError {
-                return "refused:" + String(describing: error)
-            }
+    @Test("a config naming the Ling 2.6 architecture dispatches to the GLA runtime (osaurus#2652)")
+    func legacyArchitectureDispatchesToGLA() async throws {
+        // Ling 2.6 flash JANGTQ (`architectures: [BailingMoeV2_5ForCausalLM]`,
+        // no KDA marker) is a real bundle users run; it must reach
+        // `BailingHybridModel`, never the V3 decoder and never a refusal.
+        let name = try await MLXMetalTestLock.withLock {
+            let model = try await LLMTypeRegistry.shared.createModel(
+                configuration: Self.legacyConfigJSON, modelType: "bailing_hybrid")
+            return String(describing: type(of: model))
         }
-        #expect(outcome.hasPrefix("refused:"), Comment(rawValue: outcome))
-        #expect(outcome.contains("Ling 3.0"))
-        #expect(!outcome.contains("BailingHybridModel"))
+        #expect(name.contains("BailingHybridModel"), Comment(rawValue: name))
+        #expect(!name.contains("BailingMoeV3"))
     }
 
-    @Test("no model_type reaches the Ling 2.6 GLA runtime (bailing_moe_v2_5 is unregistered)")
+    @Test("a config naming the 2.6 architecture WITH a Ling 3 marker is Ling 3 (markers win)")
+    func v3MarkerBeatsLegacyArchitectureName() async throws {
+        // Belt and braces: a converter that leaves a stale V2 architecture
+        // string on a Ling 3 config still lands on the KDA runtime.
+        var root = try #require(
+            try JSONSerialization.jsonObject(with: Self.v3ConfigJSON) as? [String: Any])
+        root["architectures"] = ["BailingMoeV2_5ForCausalLM"]
+        let data = try JSONSerialization.data(withJSONObject: root)
+        let name = try await MLXMetalTestLock.withLock {
+            let model = try await LLMTypeRegistry.shared.createModel(
+                configuration: data, modelType: "bailing_hybrid")
+            return String(describing: type(of: model))
+        }
+        #expect(name.contains("BailingMoeV3"), Comment(rawValue: name))
+    }
+
+    @Test("no separate model_type reaches the Ling 2.6 GLA runtime (bailing_moe_v2_5 is unregistered)")
     func noRouteToGLA() async throws {
         let outcome: String = try await MLXMetalTestLock.withLock {
             do {

--- a/Tests/MLXLMTests/Ling26GLAProbe.swift
+++ b/Tests/MLXLMTests/Ling26GLAProbe.swift
@@ -1,0 +1,215 @@
+//
+//  Ling26GLAProbe.swift
+//  vmlx-swift — DIAGNOSTIC PROBE, not a regression test (skips unless env is set).
+//
+//  osaurus#2652: Ling 2.6 flash JANGTQ answered "!!!!…" (token 0) from 0.24.5
+//  (vmlx 97676e19) and was refused outright from 0.24.7 (#424). Loads the bundle
+//  through the factory, renders a chat prompt with the bundle's own template
+//  (a long system prompt like the app sends, then a short user turn), reports
+//  whether the last-position logits are finite and what greedy decode produces.
+//
+//  Env: VMLX_LING26_MODEL_DIR=<bundle dir>
+//       VMLX_LING26_SYSTEM_TOKENS=<approx system prompt length, default 400>
+//       VMLX_LING26_MAXTOK=<greedy tokens, default 24>
+//
+
+import Foundation
+import MLX
+import MLXLLM
+import MLXLMCommon
+import MLXHuggingFace
+import VMLXTokenizers
+import VMLXHub
+import Testing
+
+@Suite(.serialized)
+struct Ling26GLAProbe {
+
+    @Test("Ling 2.6 flash JANGTQ: finite logits and a real answer through the GLA runtime")
+    func gla() async throws {
+        let env = ProcessInfo.processInfo.environment
+        guard let modelDir = env["VMLX_LING26_MODEL_DIR"] else {
+            print("PROBE SKIPPED: set VMLX_LING26_MODEL_DIR")
+            return
+        }
+        let systemWords = Int(env["VMLX_LING26_SYSTEM_TOKENS"] ?? "") ?? 400
+        let maxTok = Int(env["VMLX_LING26_MAXTOK"] ?? "") ?? 24
+        let userText = env["VMLX_LING26_USER"] ?? "Hello"
+
+        let context = try await LLMModelFactory.shared.load(
+            from: URL(fileURLWithPath: modelDir), using: #huggingFaceTokenizerLoader())
+        let tokenizer = context.tokenizer
+        let model = context.model
+        print("PROBE model=\(type(of: model)) dir=\(modelDir)")
+
+        // A system prompt in the app's shape (long, prose) so the GLA prefill
+        // runs well past the ~80-token horizon where the fp16 overflow lived.
+        let sentence = "You are Osaurus, a careful assistant running locally on this Mac; answer briefly, cite files when you read them, and never invent tool results. "
+        var system = ""
+        while system.split(separator: " ").count < systemWords { system += sentence }
+        let messages: [[String: String]] = [
+            ["role": "system", "content": system],
+            ["role": "user", "content": userText],
+        ]
+        let prompt = try tokenizer.applyChatTemplate(messages: messages)
+        print("PROBE prompt tokens=\(prompt.count)")
+
+        let cache = model.newCache(parameters: nil)
+        let array = MLXArray(prompt.map { Int32($0) }).expandedDimensions(axis: 0)
+        let prepared = try model.prepare(LMInput(text: .init(tokens: array)), cache: cache, windowSize: 512)
+        var logits: MLXArray
+        switch prepared {
+        case .tokens(let tail):
+            let t = tail.tokens.ndim == 1 ? tail.tokens[.newAxis] : tail.tokens
+            logits = model(t, cache: cache)[0, -1].asType(.float32)
+        case .logits(let r):
+            logits = r.logits[0, -1].asType(.float32)
+        }
+        MLX.eval(logits)
+        let values = logits.asArray(Float.self)
+        let nonFinite = values.filter { !$0.isFinite }.count
+        let top = argSort(logits, axis: -1)[(-5)...].asArray(Int32.self).reversed()
+        print("PROBE prefill logits: nonFinite=\(nonFinite)/\(values.count) top5=\(Array(top)) vals=\(top.map { values[Int($0)] })")
+
+        // Greedy decode from the prefilled cache.
+        var out: [Int] = []
+        var next = Int(argMax(logits).item(Int32.self))
+        for _ in 0..<maxTok {
+            out.append(next)
+            if let eos = tokenizer.eosTokenId, next == eos { break }
+            let step = MLXArray([Int32(next)]).expandedDimensions(axis: 0)
+            let l = model(step, cache: cache)[0, -1].asType(.float32)
+            MLX.eval(l)
+            next = Int(argMax(l).item(Int32.self))
+        }
+        let text = tokenizer.decode(tokenIds: out, skipSpecialTokens: false)
+        let bangs = out.filter { $0 == 0 }.count
+        print("PROBE greedy tokens=\(out) token0Count=\(bangs)/\(out.count) text=\(text.replacingOccurrences(of: "\n", with: "\\n"))")
+        print("PROBE VERDICT greedy nonFiniteLogits=\(nonFinite) token0Fraction=\(Double(bangs) / Double(max(out.count, 1)))")
+
+        // The app's shape: TokenIterator with the bundle sampler defaults
+        // (temperature/top_p/penalty as osaurus sends them), windowed prefill,
+        // fresh cache; optional compiled decode (VMLX_LING26_COMPILED=1).
+        var params = GenerateParameters(
+            maxTokens: maxTok, temperature: 0.7, topP: 0.95, topK: 20, minP: 0,
+            randomSeed: 11, repetitionPenalty: 1.05, repetitionContextSize: 64,
+            prefillStepSize: 512)
+        if env["VMLX_LING26_COMPILED"] == "1" { params.enableCompiledDecode = true }
+        var it = try TokenIterator(
+            input: LMInput(tokens: MLXArray(prompt.map { Int32($0) }).expandedDimensions(axis: 0), tokenIds: prompt),
+            model: model, parameters: params)
+        var sampled: [Int] = []
+        while sampled.count < maxTok, let t = it.next() {
+            sampled.append(t)
+            if let eos = tokenizer.eosTokenId, t == eos { break }
+        }
+        let sampledText = tokenizer.decode(tokenIds: sampled, skipSpecialTokens: false)
+        let sampledBangs = sampled.filter { $0 == 0 }.count
+        print("PROBE sampled tokens=\(sampled.count) token0Count=\(sampledBangs) compiled=\(params.enableCompiledDecode) text=\(sampledText.replacingOccurrences(of: "\n", with: "\\n"))")
+        print("PROBE VERDICT sampled token0Fraction=\(Double(sampledBangs) / Double(max(sampled.count, 1)))")
+
+        // ---------- RESTORE (the app's shape) ----------
+        // osaurus warms the system prompt up, stores that prefix through the
+        // cache coordinator (disk tier), and the request restores it and
+        // re-feeds the user turn. The boundary is a system-prompt render, not
+        // a multiple of the prefill step. Compare the last-position logits with
+        // the fresh one-shot forward above and decode greedily from the
+        // restored cache.
+        if env["VMLX_LING26_RESTORE"] == "1" {
+            let systemOnly = try tokenizer.applyChatTemplate(messages: [messages[0]])
+            var boundary = 0
+            while boundary < min(systemOnly.count, prompt.count), systemOnly[boundary] == prompt[boundary] {
+                boundary += 1
+            }
+            print("PROBE restore boundary=\(boundary) (system-only render \(systemOnly.count) tokens, full prompt \(prompt.count))")
+            let diskDir = FileManager.default.temporaryDirectory
+                .appendingPathComponent("ling26-restore-\(UUID().uuidString)")
+            defer { try? FileManager.default.removeItem(at: diskDir) }
+            let coordinator = CacheCoordinator(config: CacheCoordinatorConfig(
+                usePagedCache: false, enableDiskCache: true, diskCacheDir: diskDir,
+                modelKey: "ling26-restore"))
+            let topology = ModelCacheTopologySnapshot(cache: model.newCache(parameters: nil))
+            coordinator.setHybrid(
+                topology.requiresSSMCompanionState,
+                requiresRecurrentSSMCompanion: topology.requiresRecurrentSSMCompanionState,
+                requiresSeparateRecurrentPayload: topology.requiresSeparateRecurrentPayloadState)
+            func makeInput(_ tokens: [Int], prefix: [Int]) -> LMInput {
+                LMInput(
+                    tokens: MLXArray(tokens.map { Int32($0) }).expandedDimensions(axis: 0),
+                    tokenIds: tokens,
+                    cachePrefixTokenCounts: prefix,
+                    cacheStablePrefixTokenCounts: prefix)
+            }
+            var seedParams = GenerateParameters(maxTokens: 1, temperature: 0)
+            seedParams.prefillStepSize = 512
+            let seedPrompt = Array(prompt.prefix(boundary + 8))
+            var seedIt = try TokenIterator(
+                input: makeInput(seedPrompt, prefix: [boundary]), model: model,
+                parameters: seedParams, cacheCoordinator: coordinator)
+            _ = seedIt.next()
+            seedIt.storeCacheAfterGeneration(generatedTokenIds: [], includeGeneratedBoundary: false)
+            let salt = computeCacheSalt(for: makeInput(prompt, prefix: [boundary]), parameters: seedParams)
+            let fetched = coordinator.fetch(
+                tokens: prompt, mediaSalt: salt, skipExactDiskBoundary: true,
+                preferredDiskBoundaries: [boundary])
+            guard case .hit(let matched, let remaining, let detail, _, _, let arrays) = fetched, let record = arrays else {
+                print("PROBE restore: fetch MISSED (\(fetched)) — restore path not exercised")
+                return
+            }
+            print("PROBE restore hit matched=\(matched) remaining=\(remaining.count) detail=\(detail)")
+            var restoredCache = model.newCache(parameters: nil)
+            let restoredTokens = restoreFromDiskArrays(record, into: &restoredCache)
+            let offsets = restoredCache.map { $0.offset }
+            let perLayer = restoredCache.enumerated().map { "\($0.offset):\(String(describing: type(of: $0.element)).prefix(12)):\($0.element.offset)" }
+            print("PROBE restored tokens=\(restoredTokens) layer offsets distinct=\(Set(offsets).sorted()) perLayer=\(perLayer.prefix(10).joined(separator: " ")) …")
+            let remArray = MLXArray(remaining.map { Int32($0) }).expandedDimensions(axis: 0)
+            let preparedR = try model.prepare(LMInput(text: .init(tokens: remArray)), cache: restoredCache, windowSize: 512)
+            var rl: MLXArray
+            switch preparedR {
+            case .tokens(let tail):
+                let t = tail.tokens.ndim == 1 ? tail.tokens[.newAxis] : tail.tokens
+                rl = model(t, cache: restoredCache)[0, -1].asType(.float32)
+            case .logits(let r):
+                rl = r.logits[0, -1].asType(.float32)
+            }
+            MLX.eval(rl)
+            let rv = rl.asArray(Float.self)
+            let rNonFinite = rv.filter { !$0.isFinite }.count
+            let maxDelta = zip(rv, values).map { abs($0 - $1) }.max() ?? .nan
+            let rTop = argSort(rl, axis: -1)[(-5)...].asArray(Int32.self).reversed()
+            print("PROBE restore logits: nonFinite=\(rNonFinite)/\(rv.count) top5=\(Array(rTop)) maxAbsDeltaVsFresh=\(maxDelta) freshTop1=\(top.first ?? -1)")
+            var rout: [Int] = []
+            var rnext = Int(argMax(rl).item(Int32.self))
+            for _ in 0..<maxTok {
+                rout.append(rnext)
+                if let eos = tokenizer.eosTokenId, rnext == eos { break }
+                let l = model(MLXArray([Int32(rnext)]).expandedDimensions(axis: 0), cache: restoredCache)[0, -1].asType(.float32)
+                MLX.eval(l)
+                rnext = Int(argMax(l).item(Int32.self))
+            }
+            let rtext = tokenizer.decode(tokenIds: rout, skipSpecialTokens: false)
+            let rBangs = rout.filter { $0 == 0 }.count
+            print("PROBE restore greedy token0Count=\(rBangs)/\(rout.count) text=\(rtext.replacingOccurrences(of: "\n", with: "\\n"))")
+            print("PROBE VERDICT restore nonFinite=\(rNonFinite) token0Fraction=\(Double(rBangs) / Double(max(rout.count, 1))) maxAbsDeltaVsFresh=\(maxDelta)")
+
+            // The app path proper: a second request through TokenIterator with
+            // the coordinator (fetch + validated restore + re-feed inside the
+            // iterator), greedy. Any '[vmlx][cache/restore] REFUSED' line in
+            // the log means the engine fell back to a full prefill.
+            var reqParams = GenerateParameters(maxTokens: maxTok, temperature: 0)
+            reqParams.prefillStepSize = 512
+            var reqIt = try TokenIterator(
+                input: makeInput(prompt, prefix: [boundary]), model: model,
+                parameters: reqParams, cacheCoordinator: coordinator)
+            var iout: [Int] = []
+            while iout.count < maxTok, let t = reqIt.next() {
+                iout.append(t)
+                if let eos = tokenizer.eosTokenId, t == eos { break }
+            }
+            let itext = tokenizer.decode(tokenIds: iout, skipSpecialTokens: false)
+            let iBangs = iout.filter { $0 == 0 }.count
+            print("PROBE iterator-restore greedy token0Count=\(iBangs)/\(iout.count) text=\(itext.replacingOccurrences(of: "\n", with: "\\n"))")
+            print("PROBE VERDICT iterator-restore token0Fraction=\(Double(iBangs) / Double(max(iout.count, 1)))")
+        }
+    }
+}

--- a/Tests/MLXLMTests/LoadWeightShardSelectionTests.swift
+++ b/Tests/MLXLMTests/LoadWeightShardSelectionTests.swift
@@ -15,4 +15,44 @@ final class LoadWeightShardSelectionTests: XCTestCase {
         XCTAssertFalse(isAuxiliaryCalibrationSafetensor("jangtq_stacked.safetensors"))
         XCTAssertFalse(isAuxiliaryCalibrationSafetensor("jangpress-prestacked.safetensors"))
     }
+
+    /// osaurus#2652: JANGQ-AI/Ling-2.6-flash-JANGTQ ships a complete 29-shard
+    /// family and an index naming 31 files from an earlier layout. Only a
+    /// COMPLETE replacement family may stand in for a stale index; an empty
+    /// or partial download, unrelated sidecars, two families, or a partially
+    /// present indexed set all stay fail-closed.
+    func testStaleIndexNeedsOneCompleteReplacementFamily() {
+        let indexed = ["model-00001-of-00031.safetensors", "model-00002-of-00031.safetensors"]
+        let family = (1...29).map { String(format: "model-%05d-of-00029.safetensors", $0) }
+
+        XCTAssertEqual(
+            indexManifestDecision(indexedNames: indexed, presentNames: family + ["jangtq_runtime.safetensors"]),
+            .staleIndex(missing: indexed, replacement: family))
+        XCTAssertEqual(
+            indexManifestDecision(indexedNames: indexed, presentNames: indexed),
+            .manifest(indexed))
+        XCTAssertEqual(
+            indexManifestDecision(indexedNames: indexed, presentNames: ["model-00001-of-00031.safetensors"]),
+            .truncated(missing: ["model-00002-of-00031.safetensors"]))
+        // Empty download: nothing present.
+        XCTAssertEqual(
+            indexManifestDecision(indexedNames: indexed, presentNames: []),
+            .incomplete(missing: indexed))
+        // One replacement shard missing.
+        XCTAssertEqual(
+            indexManifestDecision(indexedNames: indexed, presentNames: Array(family.dropLast())),
+            .incomplete(missing: indexed))
+        // Unrelated sidecar only.
+        XCTAssertEqual(
+            indexManifestDecision(indexedNames: indexed, presentNames: ["jangtq_runtime.safetensors"]),
+            .incomplete(missing: indexed))
+        // Two families: ambiguous, not a replacement.
+        XCTAssertEqual(
+            indexManifestDecision(indexedNames: indexed, presentNames: family + ["model-00001-of-00002.safetensors", "model-00002-of-00002.safetensors"]),
+            .incomplete(missing: indexed))
+        XCTAssertEqual(indexManifestDecision(indexedNames: [], presentNames: family), .manifest([]))
+        XCTAssertNil(completeNumberedShardFamily(in: ["model-00002-of-00002.safetensors"]))
+        XCTAssertEqual(completeNumberedShardFamily(in: ["model-00002-of-00002.safetensors", "model-00001-of-00002.safetensors"]),
+            ["model-00001-of-00002.safetensors", "model-00002-of-00002.safetensors"])
+    }
 }


### PR DESCRIPTION
Fixes osaurus-ai/osaurus#2652 (Ling 2.6 flash JANGTQ: "Unsupported model type: bailing_hybrid" since 0.24.7).

## What

1. **Dispatch.** `model_type = bailing_hybrid` with `architectures` naming `BailingMoeV2…` and no Ling 3 marker (no `MoeV3` name, no `linear_attention: kda`, no `kda_lower_bound`) dispatches to the Ling 2.6 GLA runtime (`BailingHybridModel`) again. #424 removed the marker-less **fallback** that sent Ling 3 bundles to GLA (token-0 `!` streams); that protection stays: any Ling 3 marker wins, and a config naming neither architecture is decoded as Ling 3 and fails loud if it is not. The 2.6 runtime is reachable only through the architecture name (`bailing_moe_v2_5` stays unregistered).
2. **Stale index vs truncated download.** The published bundle (Hub revision 68e3bda2) ships a complete 29-shard family and a `model.safetensors.index.json` from an earlier layout (31 file names, per-expert keys; none of them exist). #423's index-as-manifest contract refused it as truncated. The decision is now:
   - every indexed file present → index is the manifest (unchanged);
   - some present, some missing → truncated, refuse (unchanged);
   - none present **and** exactly one complete `model-NNNNN-of-MMMMM` family (1…M all present) whose headers declare no duplicate tensor → load that family only (plus the named overlays), logged as a stale index;
   - none present and no complete family (empty or partial download, sidecars only, two families) → refuse with the existing message.
   The fallback never loads "every safetensors file", so #423's isolation of withdrawn sidecars holds; `model.update` still verifies unused keys as before (it does not verify missing ones, which is why an incomplete family stays fail-closed).

The bundle's own index should still be regenerated on the Hub (a rebuilt `weight_map` for the 29 stacked shards is at `/Volumes/EricMLWork/models/JANGQ-AI/Ling-2.6-flash-JANGTQ-fixedindex/model.safetensors.index.json`, 1149 keys); this PR makes the already-downloaded copies load.

## Tests

`BailingMoeV3Tests`: 2.6 architecture → `BailingHybridModel`; 2.6 name + a Ling 3 marker → V3; marker-less → V3; `bailing_moe_v2_5` unregistered. `LoadWeightShardSelectionTests.testStaleIndexNeedsOneCompleteReplacementFamily`: complete family, manifest, truncated, empty download, one replacement shard missing, sidecar only, two families. `Ling26GLAProbe` is an env-gated diagnostic (skips without `VMLX_LING26_MODEL_DIR`).

# PROOF:
Engine runs on the downloaded bundle (30.59 GB, byte-complete vs the Hub), Xcode toolchain, this branch at 50318fb0 (`ling26_probe_head_final.log`):
- load log: `index.json is stale: none of the 31 file(s) it names exist … loading the complete 29-shard family present instead (1149 tensors, no duplicates)`; dispatch log: `bailing_hybrid → Ling 2.6 runtime (BailingHybridModel, GLA)`.
- 542-token prompt (long system prompt + "Write a 150-word paragraph about black holes."): prefill logits finite (0/157184 non-finite), greedy 64 tokens coherent, token-0 count 0; sampled (0.7/0.95/20, penalty 1.05) 48 tokens coherent, token-0 count 0.
- app-shaped restore: system-prompt prefix (521 tokens, not a prefill-step multiple) stored through `CacheCoordinator` (disk), request restored + re-fed through `TokenIterator`: 48 greedy tokens coherent, token-0 count 0.
- The 0.24.5 engine (97676e19, same probe, `ling26_probe_0245*.log`) gives the same finite/coherent output on fresh and restore paths, so the reporter's 0.24.5 "!!!!" is **not** reproduced at the engine level with this prompt shape; what this PR proves is the 0.24.7 refusal (both the dispatch and the stale-index refusal) is gone and the bundle answers.
- Unit: 11/11 (`BailingMoeV3Tests`, `LoadWeightShardSelectionTests`).
- Not covered: the osaurus app end-to-end (needs a repin), and the `mac_build_and_test` job — no self-hosted runner is registered for osaurus-ai/vmlx-swift (the runner on this Mac is registered to jjang-ai/vmlx), so that job stays queued on every PR.
