### PR TITLE
Load: Ling 2.6 JANGTQ materialises its affine weights to bf16 under mmap — the osaurus#2652 '!!!!' root cause

### DIFF
--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -1447,7 +1447,16 @@ private func isJANGTQParameterKey(_ key: String) -> Bool {
     key.hasSuffix(".tq_packed") || key.hasSuffix(".tq_norms")
 }
 
-private func requiresJANGTQMmapBFloat16(_ modelDirectory: URL) -> Bool {
+/// JANGTQ-native bundles whose NON-TurboQuant affine weights must be
+/// materialised to bf16 even under mmap. Under mmap the loader otherwise keeps
+/// every file-backed tensor as stored, and JANG stamps f16 affine scales: the
+/// 8-bit embedding then seeds an f16 residual stream and every f16-range
+/// overflow in the runtime becomes NaN. Ling 2.6 flash JANGTQ (`bailing_hybrid`,
+/// GLA linear attention, osaurus#2652) is the measured case: with the mmap
+/// path every logit was NaN (157184/157184, token 0 "!" streams) and with the
+/// bf16 materialisation alone the same load answered coherently. The
+/// TurboQuant tensors themselves (`tq_packed`/`tq_norms`) stay raw either way.
+func requiresJANGTQMmapBFloat16(_ modelDirectory: URL) -> Bool {
     let configURL = modelDirectory.appendingPathComponent("config.json")
     guard
         let data = try? Data(contentsOf: configURL),
@@ -1455,10 +1464,14 @@ private func requiresJANGTQMmapBFloat16(_ modelDirectory: URL) -> Bool {
     else {
         return false
     }
+    return requiresJANGTQMmapBFloat16(config: object)
+}
+
+func requiresJANGTQMmapBFloat16(config object: [String: Any]) -> Bool {
     let config = (object["text_config"] as? [String: Any]) ?? object
     let modelType = ((config["model_type"] as? String) ?? (object["model_type"] as? String) ?? "")
         .lowercased()
-    if modelType == "nemotron_h" {
+    if modelType == "nemotron_h" || modelType == "bailing_hybrid" {
         return true
     }
     guard modelType == "qwen3_5_moe" || modelType == "qwen3_5_moe_text" else {

--- a/Tests/MLXLMTests/LoadWeightShardSelectionTests.swift
+++ b/Tests/MLXLMTests/LoadWeightShardSelectionTests.swift
@@ -55,4 +55,18 @@ final class LoadWeightShardSelectionTests: XCTestCase {
         XCTAssertEqual(completeNumberedShardFamily(in: ["model-00002-of-00002.safetensors", "model-00001-of-00002.safetensors"]),
             ["model-00001-of-00002.safetensors", "model-00002-of-00002.safetensors"])
     }
+
+    /// osaurus#2652: under mmap a JANGTQ-native bundle keeps its f16 affine
+    /// scales unless its family is listed here; Ling 2.6 flash (bailing_hybrid)
+    /// produced all-NaN logits without the bf16 materialisation and answered
+    /// coherently with it (single-variable control, 2026-09-06).
+    func testJANGTQMmapBFloat16FamiliesIncludeBailingHybrid() {
+        XCTAssertTrue(requiresJANGTQMmapBFloat16(config: ["model_type": "bailing_hybrid"]))
+        XCTAssertTrue(requiresJANGTQMmapBFloat16(config: ["model_type": "Bailing_Hybrid"]))
+        XCTAssertTrue(requiresJANGTQMmapBFloat16(config: ["model_type": "nemotron_h"]))
+        XCTAssertTrue(requiresJANGTQMmapBFloat16(config: ["model_type": "qwen3_5_moe", "layer_types": ["linear_attention", "full_attention"]]))
+        XCTAssertFalse(requiresJANGTQMmapBFloat16(config: ["model_type": "qwen3_5_moe", "layer_types": ["full_attention"]]))
+        XCTAssertFalse(requiresJANGTQMmapBFloat16(config: ["model_type": "llama"]))
+        XCTAssertFalse(requiresJANGTQMmapBFloat16(config: [:]))
+    }
 }


### PR DESCRIPTION
Root cause of osaurus-ai/osaurus#2652 ("!!!!" answers from Ling 2.6 flash JANGTQ since 0.24.5), reproduced in the app and isolated at the engine level with a single-variable control.

## What

`requiresJANGTQMmapBFloat16` gains `bailing_hybrid`: under the mmap load path (the one the app uses for large bundles) the JANGTQ-native Ling 2.6 flash bundle's non-TurboQuant affine weights (8-bit attention/embedding with JANG's f16 scales) are now materialised to bf16, exactly as nemotron_h and qwen3_5_moe linear-attention bundles already are. TurboQuant tensors (`tq_packed`/`tq_norms`) stay raw.

## Why

Under mmap the loader keeps every file-backed tensor as stored, so the 8-bit embedding with f16 scales seeds an **f16** residual stream. Since #407 (in 0.24.4+) the GLA layer casts its fp32 recurrence output back to the activation dtype; in f16 that output overflows (the exact overflow the 2026-05 fp32 promotion in `recurrentGLAReference` documents) → NaN → every logit NaN → token 0 `!`. Before #407 the fp32 GLA output promoted the whole stream and hid the f16 seed — which is why the reporter's bundle answered on 0.24.3 and streamed `!` from the first #407 pin on. The non-mmap engine path materialises to bf16 and never showed it, which is why the earlier probes were clean.

## Tests

`LoadWeightShardSelectionTests.testJANGTQMmapBFloat16FamiliesIncludeBailingHybrid` (bailing_hybrid true incl. case; nemotron_h; qwen3_5_moe with/without linear_attention; llama/empty false). `Ling26GLAProbe` (env-gated) is the measurement below.

# PROOF:
Same bundle (`/Volumes/EricMLWork/models/JANGQ-AI/Ling-2.6-flash-JANGTQ`, Hub rev 68e3bda2), same 542-token prompt, Xcode toolchain, `Ling26GLAProbe`:

| arm | prefill non-finite logits | token-0 fraction (greedy / sampled) | text |
|---|---|---|---|
| `MLX_SAFETENSORS_MMAP=1` (app path), before | 157184/157184 | 1.0 / 1.0 | `!!!!…` |
| `MLX_SAFETENSORS_MMAP=1 VMLX_JANGTQ_BF16_MMAP=1` (control: only the materialisation differs) | 0/157184 | 0.0 / 0.0 | coherent, top-5 identical to the non-mmap run |
| `MLX_SAFETENSORS_MMAP=1`, this branch (no override) | 0/157184 | 0.0 / 0.0 | coherent; disk-restore + iterator-restore coherent, 0 token-0 |

In-app reproduction (before): combined osaurus dev build (#2647 + repin eeccf887, linker-signed), harness OBSIDIAN leg, Ling 2.6 flash JANGTQ: every assistant row 1073 tokens of `!`, run log `[vmlx][nan-logits] site=solo step=0 model=BailingHybridModel nan=157184` on every generation including 143-token fresh-prefill title generations (not the cache). The in-app after-run is taken with the repin to this fix (next step in the same lane; recorded on the repin PR). CI baseline: lint/Linux identical to merged #424; no mac runner registered.
