### PR TITLE
Load: always-on dtype-materialisation line per load (osaurus#2652 diagnostics)

### DIFF
--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -1255,13 +1255,32 @@ public func loadWeights(
                 modelDirectory: modelDirectory)
             || shouldPreserveDeepseekV4PrestackedAffineMmapDtypes(
                 modelDirectory: modelDirectory))
-    if !preserveJANGAffineMmapDtypes
+    let materialiseBFloat16 =
+        !preserveJANGAffineMmapDtypes
         && (!isJANGTQNative || !mmapSafetensorsActive || allowJANGTQMmapBFloat16
             || autoJANGTQMmapBFloat16)
-    {
+    if materialiseBFloat16 {
         convertToBFloat16(
             model: model,
             shouldSkip: isJANGTQNative ? isJANGTQParameterKey : { _ in false })
+    }
+    // Always-on, one line per load: which dtype policy this load took and what
+    // the parameters actually are afterwards. An f16-seeded activation stream
+    // (JANG f16 affine scales kept file-backed under mmap) is invisible in
+    // every other log line and surfaces only as NaN logits (osaurus#2652);
+    // this line makes the loaded dtype a fact instead of an inference.
+    do {
+        var histogram: [String: Int] = [:]
+        for (_, array) in model.parameters().flattened() {
+            histogram[String(describing: array.dtype), default: 0] += 1
+        }
+        let summary = histogram.sorted { $0.key < $1.key }
+            .map { "\($0.key)=\($0.value)" }.joined(separator: " ")
+        FileHandle.standardError.write(Data(
+            ("[Load] dtype-materialisation bf16=\(materialiseBFloat16) mmap=\(mmapSafetensorsActive) "
+                + "jangtqNative=\(isJANGTQNative) preserveJANGAffine=\(preserveJANGAffineMmapDtypes) "
+                + "autoJANGTQBF16=\(autoJANGTQMmapBFloat16) allowJANGTQBF16=\(allowJANGTQMmapBFloat16) "
+                + "params[\(summary)]\n").utf8))
     }
 
     // The Gemma-4 / DSV4-prestacked preserve branches keep f16 affine

--- a/Tests/MLXLMTests/Ling26GLAProbe.swift
+++ b/Tests/MLXLMTests/Ling26GLAProbe.swift
@@ -41,6 +41,15 @@ struct Ling26GLAProbe {
         let tokenizer = context.tokenizer
         let model = context.model
         print("PROBE model=\(type(of: model)) dir=\(modelDir)")
+        // Effective parameter dtypes after load: the embedding scales and one
+        // attention projection tell whether the loader materialised bf16.
+        let flat = model.parameters().flattened()
+        let samples = ["model.word_embeddings.scales", "model.word_embeddings.weight", "model.layers.0.attention.query_key_value.scales", "model.layers.7.attention.q_a_proj.scales", "model.layers.0.attention.dense.scales", "model.layers.0.input_layernorm.weight", "model.norm.weight", "lm_head.scales"]
+        for name in samples {
+            if let arr = flat.first(where: { $0.0 == name })?.1 { print("PROBE dtype \(name) = \(arr.dtype)") }
+        }
+        let dtypeCounts = Dictionary(grouping: flat.map { String(describing: $0.1.dtype) }, by: { $0 }).mapValues(\.count)
+        print("PROBE dtype histogram: \(dtypeCounts)")
 
         // A system prompt in the app's shape (long, prose) so the GLA prefill
         // runs well past the ~80-token horizon where the fp16 overflow lived.
@@ -51,12 +60,23 @@ struct Ling26GLAProbe {
             ["role": "system", "content": system],
             ["role": "user", "content": userText],
         ]
-        let prompt = try tokenizer.applyChatTemplate(messages: messages)
-        print("PROBE prompt tokens=\(prompt.count)")
+        let prefillStep = Int(env["VMLX_LING26_PREFILL_STEP"] ?? "") ?? 512
+        let prompt: [Int]
+        if let rawPath = env["VMLX_LING26_RAW_PROMPT_FILE"] {
+            // The app's own rendered prompt (a VMLX_REASONING_PROMPT_DUMP_DIR
+            // file: header lines, then the prompt text after the first blank line).
+            let raw = try String(contentsOfFile: rawPath, encoding: .utf8)
+            let body = raw.range(of: "\n\n").map { String(raw[$0.upperBound...]) } ?? raw
+            prompt = tokenizer.encode(text: body, addSpecialTokens: false)
+            print("PROBE raw prompt from \(rawPath): \(prompt.count) tokens")
+        } else {
+            prompt = try tokenizer.applyChatTemplate(messages: messages)
+        }
+        print("PROBE prompt tokens=\(prompt.count) prefillStep=\(prefillStep)")
 
         let cache = model.newCache(parameters: nil)
         let array = MLXArray(prompt.map { Int32($0) }).expandedDimensions(axis: 0)
-        let prepared = try model.prepare(LMInput(text: .init(tokens: array)), cache: cache, windowSize: 512)
+        let prepared = try model.prepare(LMInput(text: .init(tokens: array)), cache: cache, windowSize: prefillStep)
         var logits: MLXArray
         switch prepared {
         case .tokens(let tail):
@@ -93,7 +113,7 @@ struct Ling26GLAProbe {
         var params = GenerateParameters(
             maxTokens: maxTok, temperature: 0.7, topP: 0.95, topK: 20, minP: 0,
             randomSeed: 11, repetitionPenalty: 1.05, repetitionContextSize: 64,
-            prefillStepSize: 512)
+            prefillStepSize: prefillStep)
         if env["VMLX_LING26_COMPILED"] == "1" { params.enableCompiledDecode = true }
         var it = try TokenIterator(
             input: LMInput(tokens: MLXArray(prompt.map { Int32($0) }).expandedDimensions(axis: 0), tokenIds: prompt),
@@ -107,6 +127,32 @@ struct Ling26GLAProbe {
         let sampledBangs = sampled.filter { $0 == 0 }.count
         print("PROBE sampled tokens=\(sampled.count) token0Count=\(sampledBangs) compiled=\(params.enableCompiledDecode) text=\(sampledText.replacingOccurrences(of: "\n", with: "\\n"))")
         print("PROBE VERDICT sampled token0Fraction=\(Double(sampledBangs) / Double(max(sampled.count, 1)))")
+
+        // ---------- BATCH ENGINE (the app's generation path: BatchEngine solo/batch slots) ----------
+        if let bs = Int(env["VMLX_LING26_BATCH"] ?? "") {
+            let engine = BatchEngine(context: context, maxBatchSize: bs)
+            var bparams = GenerateParameters(maxTokens: maxTok, temperature: 0)
+            bparams.prefillStepSize = prefillStep
+            if env["VMLX_LING26_COMPILED"] == "1" { bparams.enableCompiledDecode = true }
+            if let kv = Int(env["VMLX_LING26_KVBITS"] ?? "") { bparams.kvBits = kv }
+            print("PROBE batch params compiled=\(bparams.enableCompiledDecode) kvBits=\(String(describing: bparams.kvBits)) kvGroupSize=\(bparams.kvGroupSize) quantizedKVStart=\(bparams.quantizedKVStart)")
+            let stream = await engine.generate(
+                input: LMInput(tokens: MLXArray(prompt.map { Int32($0) }).expandedDimensions(axis: 0), tokenIds: prompt),
+                parameters: bparams)
+            var btext = ""
+            var stop = "?"
+            for await ev in stream {
+                switch ev {
+                case .chunk(let s): btext += s
+                case .info(let info): stop = String(describing: info.stopReason)
+                default: break
+                }
+            }
+            await engine.shutdown()
+            let bangs = btext.filter { $0 == "!" }.count
+            print("PROBE batch(maxBatchSize=\(bs)) stop=\(stop) chars=\(btext.count) bangChars=\(bangs) text=\(btext.prefix(160).replacingOccurrences(of: "\n", with: "\\n"))")
+            print("PROBE VERDICT batch bangFraction=\(Double(bangs) / Double(max(btext.count, 1)))")
+        }
 
         // ---------- RESTORE (the app's shape) ----------
         // osaurus warms the system prompt up, stores that prefix through the
@@ -141,7 +187,7 @@ struct Ling26GLAProbe {
                     cacheStablePrefixTokenCounts: prefix)
             }
             var seedParams = GenerateParameters(maxTokens: 1, temperature: 0)
-            seedParams.prefillStepSize = 512
+            seedParams.prefillStepSize = prefillStep
             let seedPrompt = Array(prompt.prefix(boundary + 8))
             var seedIt = try TokenIterator(
                 input: makeInput(seedPrompt, prefix: [boundary]), model: model,
@@ -163,7 +209,7 @@ struct Ling26GLAProbe {
             let perLayer = restoredCache.enumerated().map { "\($0.offset):\(String(describing: type(of: $0.element)).prefix(12)):\($0.element.offset)" }
             print("PROBE restored tokens=\(restoredTokens) layer offsets distinct=\(Set(offsets).sorted()) perLayer=\(perLayer.prefix(10).joined(separator: " ")) …")
             let remArray = MLXArray(remaining.map { Int32($0) }).expandedDimensions(axis: 0)
-            let preparedR = try model.prepare(LMInput(text: .init(tokens: remArray)), cache: restoredCache, windowSize: 512)
+            let preparedR = try model.prepare(LMInput(text: .init(tokens: remArray)), cache: restoredCache, windowSize: prefillStep)
             var rl: MLXArray
             switch preparedR {
             case .tokens(let tail):
@@ -197,7 +243,7 @@ struct Ling26GLAProbe {
             // iterator), greedy. Any '[vmlx][cache/restore] REFUSED' line in
             // the log means the engine fell back to a full prefill.
             var reqParams = GenerateParameters(maxTokens: maxTok, temperature: 0)
-            reqParams.prefillStepSize = 512
+            reqParams.prefillStepSize = prefillStep
             var reqIt = try TokenIterator(
                 input: makeInput(prompt, prefix: [boundary]), model: model,
                 parameters: reqParams, cacheCoordinator: coordinator)


### PR DESCRIPTION
Diagnostic only. After the loader's dtype decision, one stderr line per load:

```
[Load] dtype-materialisation bf16=true mmap=true jangtqNative=true preserveJANGAffine=false autoJANGTQBF16=true allowJANGTQBF16=false params[bfloat16=651 float16=93 uint32=295]
```

An f16-seeded activation stream (JANG f16 affine scales kept file-backed under mmap) appears in no other log line and surfaces only as NaN logits (osaurus#2652); with this line an app run states what its loaded model is. `Ling26GLAProbe` (env-gated) gains the app's shapes: raw rendered-prompt replay, prefill step, a BatchEngine stage (batch size / compiled decode / quantized KV) and the effective parameter dtypes.

# PROOF:
Line shown on the Ling 2.6 flash JANGTQ bundle under both load paths (Xcode toolchain, `Ling26GLAProbe`): mmap → `bf16=true mmap=true … params[bfloat16=651 float16=93 uint32=295]`, non-mmap → `bf16=true mmap=false …` same histogram (the 93 float16 tensors are the raw `tq_norms`, 31 MoE layers × 3 projections); prefill logits finite in both. No behaviour change; CI lint/Linux baseline identical to merged #424; no mac runner registered.