### PR TITLE
BailingHybrid: per-layer non-finite trace under VMLX_LOGITS_NAN_TRACE (osaurus#2652 diagnostics)

### DIFF
--- a/Libraries/MLXLLM/Models/BailingHybrid.swift
+++ b/Libraries/MLXLLM/Models/BailingHybrid.swift
@@ -1131,6 +1131,8 @@ class BailingDecoderLayer: Module {
 // MARK: - Top-level model
 
 public class BailingHybridLanguageModel: Module {
+    nonisolated(unsafe) static let nonFiniteTraceEnabled: Bool =
+        ProcessInfo.processInfo.environment["VMLX_LOGITS_NAN_TRACE"] == "1"
     let args: BailingHybridConfiguration
 
     @ModuleInfo(key: "word_embeddings") var wordEmbeddings: Embedding
@@ -1177,10 +1179,35 @@ public class BailingHybridLanguageModel: Module {
         // even on small (20-token) prompts. Per-layer eval bounds peak
         // resident memory to a single layer's worth of intermediates
         // (~5 GB) at the cost of a Metal dispatch sync per layer.
+        // VMLX_LOGITS_NAN_TRACE=1 (observation only, never a guard): the first
+        // layer whose output carries a non-finite value, with the activation
+        // dtype and magnitude at the embedding, so an all-NaN logit row can be
+        // placed inside this runtime (osaurus#2652).
+        let trace = Self.nonFiniteTraceEnabled
+        if trace {
+            let emb = h.asType(.float32)
+            let nonFinite = (1 - MLX.isFinite(emb).asType(.int32)).sum().item(Int32.self)
+            FileHandle.standardError.write(Data(
+                "[vmlx][bailing-hybrid-trace] embedding dtype=\(h.dtype) shape=\(h.shape) maxAbs=\(MLX.abs(emb).max().item(Float.self)) nonFinite=\(nonFinite) offset=\(offset)\n".utf8))
+        }
+        var firstBadLayer: Int? = nil
         for (i, layer) in layers.enumerated() {
             let layerCache = (cache != nil && i < cache!.count) ? cache![i] : nil
             h = layer(h, attnMask: attnMask, cache: layerCache, offset: offset)
             MLX.eval(h)
+            if trace, firstBadLayer == nil {
+                let hf = h.asType(.float32)
+                let nonFinite = (1 - MLX.isFinite(hf).asType(.int32)).sum().item(Int32.self)
+                if nonFinite > 0 {
+                    firstBadLayer = i
+                    FileHandle.standardError.write(Data(
+                        ("[vmlx][bailing-hybrid-trace] FIRST non-finite at layer \(i) (\(layers[i].isGlobal ? "MLA" : "GLA")) "
+                            + "dtype=\(h.dtype) nonFinite=\(nonFinite)/\(h.size) L=\(h.dim(1)) offset=\(offset)\n").utf8))
+                } else if i == 0 || i == firstGlobalIdx {
+                    FileHandle.standardError.write(Data(
+                        "[vmlx][bailing-hybrid-trace] layer \(i) (\(layers[i].isGlobal ? "MLA" : "GLA")) dtype=\(h.dtype) maxAbs=\(MLX.abs(hf).max().item(Float.self)) finite\n".utf8))
+                }
+            }
         }
         return norm(h)
     }

--- a/Tests/MLXLMTests/Ling26GLAProbe.swift
+++ b/Tests/MLXLMTests/Ling26GLAProbe.swift
@@ -130,14 +130,33 @@ struct Ling26GLAProbe {
 
         // ---------- BATCH ENGINE (the app's generation path: BatchEngine solo/batch slots) ----------
         if let bs = Int(env["VMLX_LING26_BATCH"] ?? "") {
-            let engine = BatchEngine(context: context, maxBatchSize: bs)
-            var bparams = GenerateParameters(maxTokens: maxTok, temperature: 0)
+            // App-shaped options: compiled BATCH decode (the native-MTP fallback the app
+            // enables), a disk-backed CacheCoordinator, and the request's prefix boundaries.
+            let cbd = env["VMLX_LING26_CBD"] == "1"
+            var coordinator: CacheCoordinator? = nil
+            if env["VMLX_LING26_COORD"] == "1" {
+                let diskDir = FileManager.default.temporaryDirectory.appendingPathComponent("ling26-batch-\(UUID().uuidString)")
+                let c = CacheCoordinator(config: CacheCoordinatorConfig(
+                    usePagedCache: false, enableDiskCache: true, diskCacheDir: diskDir, modelKey: "ling26-batch"))
+                let topology = ModelCacheTopologySnapshot(cache: model.newCache(parameters: nil))
+                c.setHybrid(topology.requiresSSMCompanionState,
+                    requiresRecurrentSSMCompanion: topology.requiresRecurrentSSMCompanionState,
+                    requiresSeparateRecurrentPayload: topology.requiresSeparateRecurrentPayloadState)
+                coordinator = c
+            }
+            let boundaries = (env["VMLX_LING26_BOUNDARIES"] ?? "").split(separator: ",").compactMap { Int($0) }
+            let stable = (env["VMLX_LING26_STABLE"] ?? "").split(separator: ",").compactMap { Int($0) }
+            let engine = coordinator.map { BatchEngine(context: context, maxBatchSize: bs, cacheCoordinator: $0) }
+                ?? BatchEngine(context: context, maxBatchSize: bs)
+            var bparams = GenerateParameters(maxTokens: maxTok, enableCompiledBatchDecode: cbd, temperature: 0)
             bparams.prefillStepSize = prefillStep
+            print("PROBE batch shape cbd=\(cbd) coordinator=\(coordinator != nil) boundaries=\(boundaries) stable=\(stable)")
             if env["VMLX_LING26_COMPILED"] == "1" { bparams.enableCompiledDecode = true }
             if let kv = Int(env["VMLX_LING26_KVBITS"] ?? "") { bparams.kvBits = kv }
             print("PROBE batch params compiled=\(bparams.enableCompiledDecode) kvBits=\(String(describing: bparams.kvBits)) kvGroupSize=\(bparams.kvGroupSize) quantizedKVStart=\(bparams.quantizedKVStart)")
             let stream = await engine.generate(
-                input: LMInput(tokens: MLXArray(prompt.map { Int32($0) }).expandedDimensions(axis: 0), tokenIds: prompt),
+                input: LMInput(tokens: MLXArray(prompt.map { Int32($0) }).expandedDimensions(axis: 0), tokenIds: prompt,
+                    cachePrefixTokenCounts: boundaries, cacheStablePrefixTokenCounts: stable),
                 parameters: bparams)
             var btext = ""
             var stop = "?"


### PR DESCRIPTION
Diagnostic only, gated on `VMLX_LOGITS_NAN_TRACE=1` (the flag the osaurus harness already sets). The Ling 2.6 forward prints the embedding dtype/maxAbs, the layer-0 (GLA) and first-MLA outputs, and the FIRST layer whose output carries a non-finite value:

```
[vmlx][bailing-hybrid-trace] embedding dtype=bfloat16 shape=[1, 512, 4096] maxAbs=0.4296875 nonFinite=0 offset=0
[vmlx][bailing-hybrid-trace] layer 0 (GLA) dtype=float32 maxAbs=2.0529628 finite
[vmlx][bailing-hybrid-trace] layer 7 (MLA) dtype=float32 maxAbs=1210.8898 finite
```

Why: the in-app osaurus#2652 reproduction still yields all-NaN logits on the integrated build (engine 5332a2a2, loader line confirms bf16 materialisation identical to the engine probe, which is finite on the same prompt through BatchEngine/coordinator/compiled decode). The app run has to name the layer.

`Ling26GLAProbe` (env-gated) gains the app's BatchEngine shapes (compiled batch decode, cache coordinator with prefix boundaries) and the effective parameter dtypes.

# PROOF:
Trace shown on the real bundle under mmap with the Xcode toolchain (lines above; prefill logits finite, no behaviour change without the flag). CI lint/Linux baseline identical to merged #424; no mac runner registered.