### PR TITLE
DiskCache: never store or restore a record with NaN/Inf; remove a poisoned file on first touch (osaurus#2652)

### DIFF
--- a/Libraries/MLXLMCommon/Cache/DiskCache.swift
+++ b/Libraries/MLXLMCommon/Cache/DiskCache.swift
@@ -81,6 +81,12 @@ public enum MLXCacheIOLock {
 enum DiskCacheIntegrityError: Error {
     case incompleteFile(String)
     case incompleteWrite(String)
+    /// A record whose payload carries NaN/Inf. A cache row is only worth
+    /// restoring when it reproduces a finite forward; a poisoned row restores
+    /// a non-finite recurrent state or KV and every generation built on it is
+    /// token 0 forever (osaurus#2652: 14 such rows, written once by a broken
+    /// build, kept serving "!" on every later build until removed).
+    case nonFinitePayload(String)
 }
 
 public final class DiskCache: @unchecked Sendable {
@@ -118,6 +124,27 @@ public final class DiskCache: @unchecked Sendable {
 
     /// Number of store operations that reused an already validated file.
     public private(set) var storeSkips: Int = 0
+    /// Stores refused because the payload carried NaN/Inf (never persisted).
+    public private(set) var refusedNonFiniteStores: Int = 0
+    /// Fetches that found a NaN/Inf record on disk (removed, reported as a miss).
+    public private(set) var refusedNonFiniteFetches: Int = 0
+
+    /// The names of the float tensors in `arrays` that carry a non-finite
+    /// value (at most `limit`), in key order. Integer and boolean tensors are
+    /// skipped. Used on both sides of the disk boundary: a record is neither
+    /// written nor restored when it is not entirely finite.
+    static func nonFiniteTensorNames(in arrays: [String: MLXArray], limit: Int = 4) -> [String] {
+        var names: [String] = []
+        for key in arrays.keys.sorted() {
+            guard let array = arrays[key], array.dtype.isFloatingPoint, array.size > 0 else { continue }
+            let nonFinite = (1 - MLX.isFinite(array).asType(.int32)).sum().item(Int32.self)
+            if nonFinite > 0 {
+                names.append("\(key)(\(nonFinite))")
+                if names.count >= limit { break }
+            }
+        }
+        return names
+    }
 
     /// Number of logical cache boundaries removed by quota enforcement.
     public private(set) var evictions: Int = 0
@@ -289,6 +316,19 @@ public final class DiskCache: @unchecked Sendable {
         // `@Sendable` closures under Swift 6 strict concurrency. The
         // unfair-lock primitive doesn't require Sendable — we just need
         // `defer { unlock() }` to cover every exit path.
+        // A payload with NaN/Inf is not a cache entry, it is the failure the
+        // cache would replay: refuse before touching the disk or the index.
+        let nonFinite = Self.nonFiniteTensorNames(in: arrays)
+        if !nonFinite.isEmpty {
+            lock.lock()
+            refusedNonFiniteStores += 1
+            lock.unlock()
+            FileHandle.standardError.write(Data(
+                ("[vmlx][cache/disk-store] REFUSED non-finite payload count=\(tokenCount) "
+                    + "hash=\(hash.prefix(12)) modelKey=\(modelKey ?? "nil") tensors=\(nonFinite)\n").utf8))
+            return
+        }
+
         MLXDiskCacheIOLock.shared.lock()
         defer { MLXDiskCacheIOLock.shared.unlock() }
         lock.lock()
@@ -466,6 +506,15 @@ public final class DiskCache: @unchecked Sendable {
                 throw DiskCacheIntegrityError.incompleteFile(url.lastPathComponent)
             }
             let (arrays, _) = try loadArraysAndMetadata(url: url)
+            // A record written before the store-side check (or by a build that
+            // computed NaN) must never be restored: it is removed on first touch
+            // so an installed user recovers on the next prefill without clearing
+            // anything by hand.
+            let nonFinite = Self.nonFiniteTensorNames(in: arrays)
+            if !nonFinite.isEmpty {
+                refusedNonFiniteFetches += 1
+                throw DiskCacheIntegrityError.nonFinitePayload(nonFinite.joined(separator: ","))
+            }
             if let fingerprint = _fileFingerprint(url: url), fingerprint.size > 0 {
                 validatedFiles[hash] = fingerprint
             }
@@ -488,7 +537,7 @@ public final class DiskCache: @unchecked Sendable {
             // corrupt file so the next turn doesn't retry and log the
             // same error on every fetch.
             FileHandle.standardError.write(Data(
-                "[vmlx][cache/disk] fetch corrupt entry at \(url.lastPathComponent): \(error) — removing\n"
+                "[vmlx][cache/disk] fetch REFUSED entry at \(url.lastPathComponent) count=\(tokens.count): \(error) — removing\n"
                 .utf8))
             try? FileManager.default.removeItem(at: url)
             // Drop the SQLite row too. Removing only the file orphans the

--- a/Tests/MLXLMTests/DiskCacheTests.swift
+++ b/Tests/MLXLMTests/DiskCacheTests.swift
@@ -1144,3 +1144,45 @@ import Testing
         #expect(!FileManager.default.fileExists(atPath: shortRow.path))
     }
 }
+
+/// osaurus#2652: a record carrying NaN/Inf must be neither persisted nor
+/// restored. Store-side: refused, no file. Fetch-side: an existing poisoned
+/// file (written by an older build) is removed on first touch and reported
+/// as a miss, so the next prefill re-stores a finite record.
+@Test func diskCacheRefusesNonFiniteRecordsOnStoreAndOnFetch() async throws {
+    try await MLXMetalTestLock.withLock {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("vmlx_test_\(UUID())")
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+        let cache = DiskCache(cacheDir: tempDir, maxSizeGB: 0.1)
+
+        // Store-side refusal: one NaN in one tensor.
+        let poisoned: [String: MLXArray] = [
+            "kv_7_keys": MLXArray.ones([1, 2, 8, 4]),
+            "ssm_1": MLXArray([Float.nan, 1, 2, 3]).reshaped(1, 1, 2, 2),
+        ]
+        cache.store(tokens: [1, 2, 3], arrays: poisoned)
+        try await Task.sleep(nanoseconds: 300_000_000)
+        #expect(cache.refusedNonFiniteStores == 1)
+        #expect(cache.stores == 0)
+        #expect(cache.fetch(tokens: [1, 2, 3]) == nil)
+        #expect(try FileManager.default.contentsOfDirectory(atPath: tempDir.path).filter { $0.hasSuffix(".safetensors") }.isEmpty)
+
+        // Fetch-side removal: a finite record whose file is later overwritten
+        // with an Inf payload (the shape an older build left behind).
+        let finite: [String: MLXArray] = ["kv_7_keys": MLXArray.ones([1, 2, 8, 4]), "ssm_1": MLXArray.zeros([1, 1, 2, 2])]
+        cache.store(tokens: [4, 5, 6], arrays: finite)
+        try await Task.sleep(nanoseconds: 500_000_000)
+        #expect(cache.fetch(tokens: [4, 5, 6]) != nil)
+        let files = try FileManager.default.contentsOfDirectory(atPath: tempDir.path).filter { $0.hasSuffix(".safetensors") }
+        #expect(files.count == 1)
+        let url = tempDir.appendingPathComponent(files[0])
+        let inf: [String: MLXArray] = ["kv_7_keys": MLXArray.ones([1, 2, 8, 4]), "ssm_1": MLXArray([Float.infinity, 0, 0, 0]).reshaped(1, 1, 2, 2)]
+        try MLX.save(arrays: inf, url: url)
+        #expect(cache.fetch(tokens: [4, 5, 6]) == nil)
+        #expect(cache.refusedNonFiniteFetches == 1)
+        #expect(!FileManager.default.fileExists(atPath: url.path))
+        // Integer payloads are never inspected for finiteness.
+        #expect(DiskCache.nonFiniteTensorNames(in: ["ids": MLXArray([Int32(1), 2])]).isEmpty)
+    }
+}


### PR DESCRIPTION
The second half of osaurus-ai/osaurus#2652.

## What

- **Store side:** a payload with any non-finite float tensor is refused before the disk or the index is touched; `refusedNonFiniteStores` counts it and one stderr line names the tensors (`[vmlx][cache/disk-store] REFUSED non-finite payload …`).
- **Fetch side:** a record that loads with a non-finite tensor throws `DiskCacheIntegrityError.nonFinitePayload`, is removed like a corrupt file and counted as a miss (`refusedNonFiniteFetches`, `[vmlx][cache/disk] fetch REFUSED entry … — removing`). Integer/bool tensors are not inspected.

## Why (measured in the app)

With the loader fix (#437) in the binary, Ling 2.6 flash JANGTQ still answered `!!!!` in the app. The per-layer trace (#439) placed it: fresh prefills finite through every layer; after the warm-up restore at boundary 2910 the GLA state of layer 1 came back entirely non-finite. Scanning the harness cache found **14 poisoned records** (NaN in `ssm_1…`, and in the MLA KV of layers 7/15/23/31), the first four written at 23:42 by the first in-app run on the pre-#437 build (f16 stream), the rest by later builds that restored those and stored their extensions. A user who ran the broken release once keeps the poison across updates. This makes a poisoned row a miss that deletes itself, and stops new ones from being written.

Not a limit on the user: a NaN row cannot serve any request; refusing it costs one prefill.

## Tests

`DiskCacheTests.diskCacheRefusesNonFiniteRecordsOnStoreAndOnFetch` (NaN store refused, no file; a finite record overwritten with Inf is removed on fetch and reported as a miss; integer payloads ignored). 24/24 DiskCacheTests.

# PROOF:
- Preserved evidence: `~/vmlx-private-evidence/mtp-swift-2026-09-04/preserved/cache-ling26-010917/` (the served cache dir, copied before any change); scan of the 14 poisoned rows with dtypes/shapes/non-finite counts and mtimes in `ISSUES.md`.
- App trace (engine 3e57c5d9, run `OBSIDIAN_Ling-2.6-flash-JANGTQ_010917.run`): embedding bf16 finite, layer 0 finite, `FIRST non-finite at layer 1 (GLA) … offset=2910` after `cache/fetch HIT disk boundary=2910`; the 512-token fresh prefills finite through layer 7.
- Unit 24/24 with the Xcode toolchain. The in-app after-run with the poisoned cache left in place is taken next with the repin build and recorded on osaurus #2655. CI lint/Linux baseline identical to merged #424; no mac runner registered.