### PR TITLE
GLM-5: declare the low/high/max reasoning-effort scale

### DIFF
--- a/Libraries/MLXLMCommon/ReasoningEffortPolicy.swift
+++ b/Libraries/MLXLMCommon/ReasoningEffortPolicy.swift
@@ -302,6 +302,56 @@ public enum Hy3EffortPolicy: ReasoningEffortPolicy {
     }
 }
 
+/// GLM-5.x (`glm5`, `glm5_next`). The control is a SYSTEM LINE, not a boolean, and the template
+/// states the whole contract on its first two lines:
+///
+///     {%- set effective_reasoning_effort = reasoning_effort
+///           if reasoning_effort is defined and reasoning_effort in ['low', 'high']
+///           else 'max' -%}
+///     {%- if effective_reasoning_effort is not none -%}
+///     <|system|>Reasoning Effort: {{ effective_reasoning_effort | capitalize }}{%- endif -%}
+///
+/// So: `low` and `high` are honoured verbatim, ANYTHING else — including an absent key — resolves
+/// to `max`, and there is no off state. The generation prompt then ends `<|assistant|><think>`
+/// unconditionally, which is why the model reasons whatever you ask of it.
+///
+/// WITHOUT THIS POLICY the family fell through to the "no effort scale" branch, because a bundle's
+/// effort vocabulary is only ever read from `jang_config.json` and neither `zai-org/GLM-5.3-Flash`
+/// nor its JANG conversion ships one — the declaration lives in the template, where nothing looked.
+/// `ReasoningCapability.forModel(at:)` therefore reported `levels=[1] efforts=[] templateKey=nil`,
+/// `applying(level:)` returned an EMPTY context for the only level it admitted, no `reasoning_effort`
+/// was ever populated, and every request — including one for the LEAST reasoning — took the
+/// template's `else 'max'` branch. A control the model genuinely has was invisible, and the failure
+/// was silent in both directions: nothing errored, and the rows recorded a level nobody ran at.
+public enum Glm5EffortPolicy: ReasoningEffortPolicy {
+    /// `glm5`, `glm5_next`, `glm_5_*` — but NOT `glm4*`, whose templates carry `enable_thinking`
+    /// instead and are governed by the toggle path.
+    public static func applies(to modelType: String?) -> Bool {
+        guard let t = modelType?.lowercased() else { return false }
+        let compact = t.replacingOccurrences(of: "_", with: "")
+            .replacingOccurrences(of: "-", with: "")
+            .replacingOccurrences(of: ".", with: "")
+        return compact.hasPrefix("glm5")
+    }
+    public static let templateKey = "reasoning_effort"
+    /// Weakest to strongest. `max` is in the list because the template reaches it by FALLING
+    /// THROUGH: passing the literal string `max` is not in `['low', 'high']`, so the else-branch
+    /// fires and the system line reads `Reasoning Effort: Max`. Sending it explicitly is therefore
+    /// both correct and, unlike sending nothing, self-documenting in the recorded context.
+    public static let efforts = ["low", "high", "max"]
+    /// The template's OWN fallback when the key is absent — which is what every run got before this
+    /// policy existed.
+    public static let defaultEffort = "max"
+    /// No off state: the template emits a Reasoning Effort line unconditionally and prefills
+    /// `<think>` at the generation prompt. A caller asking for level 0 gets the nearest thing the
+    /// model can do, and the harness records that it was substituted.
+    public static let supportsDisabling = false
+    public static let offEffort: String? = nil
+    // No `normalize` override: the default is derived from `efforts` and cannot drift from it, and
+    // this family has no aliases worth inventing. `medium` in particular is NOT mapped — low/high/max
+    // has no middle rung, and guessing one would put a run at an effort nobody chose.
+}
+
 // MARK: - Resolution
 
 public enum ReasoningCapabilityRegistry {
@@ -312,6 +362,7 @@ public enum ReasoningCapabilityRegistry {
         BailingReasoningPolicy.self,
         DeepseekV4EffortPolicy.self,
         Hy3EffortPolicy.self,
+        Glm5EffortPolicy.self,
     ]
 
     public static func policy(for modelType: String?) -> (any ReasoningEffortPolicy.Type)? {


### PR DESCRIPTION
## Symptom

Asking GLM-5.3 for its **lowest** reasoning effort ran it at its **highest**, and nothing said so.

`ReasoningCapability.forModel(at:)` reports, for the shipped bundle:

```
levels=[1]  efforts=[]  default=1  max=1  thinkOnly=true  templateKey=nil
  level 1: applying = [:]        ← an EMPTY context
```

With no `reasoning_effort` in the context, the template's own `else 'max'` branch fires.

## Cause

A bundle's effort vocabulary is only read from `jang_config`'s
`reasoning_effort_levels` / `reasoning_values` / `modes`. GLM-5 declares the control in its **chat
template** instead, on its first two lines:

```jinja
{%- set effective_reasoning_effort = reasoning_effort
      if reasoning_effort is defined and reasoning_effort in ['low', 'high'] else 'max' -%}
{%- if effective_reasoning_effort is not none -%}
<|system|>Reasoning Effort: {{ effective_reasoning_effort | capitalize }}{%- endif -%}
```

`ReasoningCapabilityRegistry` already handles exactly this shape — a family policy carrying the
template key and vocabulary, as for gpt-oss, Muse Glimmer, Bailing, DeepSeek-V4 and Hunyuan-3.
There was simply no GLM-5 entry, so the family fell through to the "no effort scale" branch and a
control the model genuinely has was invisible.

## Fix

`Glm5EffortPolicy`, following the five existing policies:

| | |
|---|---|
| `templateKey` | `reasoning_effort` |
| `efforts` | `["low", "high", "max"]` |
| `defaultEffort` | `max` — the template's own fallback |
| `supportsDisabling` | `false` — the template emits the effort line unconditionally and prefills `<think>` |

`max` is in the vocabulary because the template reaches it by falling through: the literal string is
not in `['low','high']`, so the else-branch fires and the system line reads `Reasoning Effort: Max`.
Sending it explicitly is therefore correct and, unlike sending nothing, self-documenting in the
recorded context.

**No `normalize` override.** The protocol default derives from `efforts` and so cannot drift from
it, and this family has no aliases worth inventing — `medium` in particular is deliberately not
mapped, because low/high/max has no middle rung.

## Verification

Rendering the shipped template directly, which is also why `medium` is not aliased:

```
reasoning_effort=None     -> 'Reasoning Effort: Max'      ← what every request got
reasoning_effort=low      -> 'Reasoning Effort: Low'
reasoning_effort=high     -> 'Reasoning Effort: High'
reasoning_effort=max      -> 'Reasoning Effort: Max'
reasoning_effort=medium   -> 'Reasoning Effort: Max'      ← a guess here would be silent
```

Tested against the real bundle rather than a fixture: hand-built low/high/max capabilities pass
their unit tests while the object the runtime actually consults declares nothing, which is how this
went unnoticed. Mutation-checked — removing the registry entry fails all four assertions.

Measured effect, 8 ARC-Challenge items, greedy, interleaved A/B: `max` costs roughly an extra hour
of decode over `low` for the same eight questions, at equal accuracy.

Builds clean against `main` at 45bcb1de.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
