### PR TITLE
A declared reasoning-parser stamp that names nothing disables reasoning entirely

### DIFF
--- a/Libraries/MLXLMCommon/JangLoader.swift
+++ b/Libraries/MLXLMCommon/JangLoader.swift
@@ -365,13 +365,30 @@ public enum ParserResolution {
             )
         }
 
-        if let cap = capabilities, cap.reasoningParser != nil {
+        if let cap = capabilities, let stamp = cap.reasoningParser {
             // Stamped — honour exactly. `nil` is a valid stamp meaning
             // "this model emits no reasoning".
-            return (
-                ReasoningParser.fromCapabilityName(cap.reasoningParser),
-                .jangStamped
-            )
+            //
+            // An UNRECOGNISED stamp is a different thing entirely, and
+            // conflating the two is how a declared reasoning model ended up
+            // with no parser at all. GLM-5.3 ships
+            // `reasoning_parser: "glm_think_block"`; that named nothing in
+            // `fromCapabilityName`, which returned nil, and nil was taken as
+            // the model's own claim not to reason. The bundle that DECLARED
+            // its parser therefore fared WORSE than one declaring nothing,
+            // which falls through to the model_type heuristic below and gets a
+            // working `think_xml`.
+            //
+            // So: a stamp we understand wins; a stamp we do not understand is
+            // missing information, not a negative claim, and degrades to the
+            // heuristic. The next vendor spelling we have not seen then loses
+            // precision instead of losing the reasoning channel.
+            // A stamp we KNOW wins outright — including the spellings that mean "no reasoning",
+            // whose nil is an answer rather than a gap. Only a name we do not recognise falls
+            // through to the heuristic below.
+            if ReasoningParser.namesAKnownFamily(stamp) {
+                return (ReasoningParser.fromCapabilityName(stamp), .jangStamped)
+            }
         }
         if declaresLFM25ThinkingTemplate(modelType: modelType, chatTemplate: chatTemplate) {
             return (

--- a/Libraries/MLXLMCommon/ReasoningParser.swift
+++ b/Libraries/MLXLMCommon/ReasoningParser.swift
@@ -837,6 +837,25 @@ extension ReasoningParser {
     ///
     /// - **`none`** (Mistral, LFM2, plain models) — returns `nil` so the
     ///   pipeline skips reasoning parsing entirely.
+    /// Whether a stamp NAMES something this type understands — including the spellings that mean
+    /// "no reasoning".
+    ///
+    /// `fromCapabilityName` returns nil for two unrelated reasons, and a caller that cannot tell them
+    /// apart will get one of them wrong:
+    ///
+    ///   * `none`, `off`, `disabled`, `mistral`, `gemma` are RECOGNISED, and they declare that the
+    ///     model emits no reasoning. That is an answer.
+    ///   * anything else falls to `default`, meaning the name is unknown to us. That is a gap.
+    ///
+    /// Honouring the first and degrading gracefully on the second needs this distinction, because
+    /// both arrive as a nil parser.
+    public static func namesAKnownFamily(_ name: String?) -> Bool {
+        guard let name, !name.isEmpty else { return false }
+        if fromCapabilityName(name) != nil { return true }
+        let n = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return ["none", "off", "disabled", "mistral", "gemma"].contains(n)
+    }
+
     public static func fromCapabilityName(_ name: String?) -> ReasoningParser? {
         guard let name, !name.isEmpty else { return nil }
         let n = name.lowercased()
@@ -860,7 +879,17 @@ extension ReasoningParser {
                 stripStrayTags: false)
         }
 
-        if normalized.hasPrefix("glm4_moe")
+        // `glm_think_block` is the stamp GLM-5.3 bundles actually ship
+        // (`jang_config.capabilities.reasoning_parser`, inside config.json).
+        // It named nothing here, so resolution fell through to the terminal
+        // `default: return nil` and NO parser was built — every decoded byte
+        // routed to `.chunk` and the generation came back as
+        // `"…reasoning…</think>…answer…"` in the answer channel, with the close
+        // marker intact. The bundle also sets `reasoning_prefill_open_tag:
+        // true`, matching the template's unconditional `<|assistant|><think>`
+        // tail, so this starts INSIDE reasoning like the rest of the family.
+        if normalized == "glm_think_block"
+            || normalized.hasPrefix("glm4_moe")
             || normalized.hasPrefix("glm5")
             || normalized.hasPrefix("glm_5")
             || compact.hasPrefix("glm5")


### PR DESCRIPTION
## Symptom

GLM-5.3 generations arrive with the chain of thought, the literal close marker, and the answer all
in the **answer** channel:

```
"Red, Green, Blue</think>Red, Green, Blue"
"</think>80"
"Four words starting with Q.</think>Quiet, quirky, quick, queen"
```

`.reasoning` is never emitted, so anything downstream that keys on a reasoning trace sees none — a
think-only model becomes indistinguishable from a non-reasoning one.

## Cause

Probed against the shipped bundle, through the real load path:

```
reasoningParserName                      = Optional("glm_think_block")
ReasoningParser.forPrompt(stampName: …)  = nil — no parser built
```

`JANGQ-AI/GLM-5.3-Flash-JANG` declares `capabilities.reasoning_parser = "glm_think_block"`. That
name matches no branch in `fromCapabilityName`, which falls through to its terminal
`default: return nil`. With no parser, every decoded byte routes to `.chunk`.

**The inversion is the part worth fixing.** `ParserResolution.reasoning` honours a declared stamp
"exactly", and documents `nil` as a valid stamp meaning *"this model emits no reasoning"*. An
unrecognised name produces exactly the same `nil` — so the bundle that **declared** its parser fares
**worse** than one declaring nothing at all, which falls through to `reasoningStampFromModelType` →
`think_xml` → a working parser. Declaring more information makes the outcome worse.

Note `shouldIgnoreReasoningStamp` does not rescue this: it requires `thinkInTemplate == false`, and
this bundle sets `think_in_template: true`.

## Fix

Two hunks:

* `fromCapabilityName` recognises `glm_think_block`, in the existing GLM branch, so it starts inside
  reasoning — matching the bundle's own `reasoning_prefill_open_tag: true` and the template's
  unconditional `<|assistant|>{{- '<think>' -}}` tail.
* `ParserResolution.reasoning` distinguishes *"a stamp we understand"* from *"a stamp we do not"*.
  The first wins as before; the second is missing information rather than a negative claim, and
  degrades to the model_type heuristic. The next vendor spelling nobody has seen then loses
  precision instead of losing the reasoning channel.

## Verification

Tested against the real bundle through the real load path, not against `fromCapabilityName` alone —
that weaker assertion would have passed while the shipped path still returned `nil`, which is
exactly the failure described above. Confirmed behaviourally, same prompts and settings before and
after:

```
before   'Red, Green, Blue</think>Red, Green, Blue'
after    'Red, Green, Blue'
before   '</think>80'
after    '80'
```

Builds clean against `main` at 45bcb1de.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
