### PR TITLE
BailingV3RMSNormGated: round once, at the end

### DIFF
--- a/Libraries/MLXLLM/Models/BailingMoeV3.swift
+++ b/Libraries/MLXLLM/Models/BailingMoeV3.swift
@@ -192,7 +192,22 @@ public final class BailingV3RMSNormGated: Module {
     }
 
     public func callAsFunction(_ x: MLXArray, gate: MLXArray) -> MLXArray {
-        MLXFast.rmsNorm(x, weight: weight, eps: eps) * sigmoid(gate.asType(.float32))
+        // ROUND ONCE, AT THE END. Swift binds the trailing `.asType` to the expression it
+        // follows, so the original
+        //
+        //     MLXFast.rmsNorm(x, weight: weight, eps: eps) * sigmoid(gate.asType(.float32))
+        //         .asType(x.dtype)
+        //
+        // cast the SIGMOID back to `x.dtype` and then multiplied — rounding the gate to half
+        // precision before it was applied. The output dtype was already `x.dtype`; what differs is
+        // WHERE the rounding happens.
+        //
+        // The reference weights in float32 and casts the product once:
+        // `(o32 * sigmoid(gate.astype(float32))).astype(seg.dtype)`. Parenthesising the product and
+        // casting that reproduces it, and matches the discipline the surrounding code already keeps
+        // — the float32 sigmoid is deliberate because the gate saturates, and rounding it early
+        // throws away the precision it was computed at.
+        (MLXFast.rmsNorm(x, weight: weight, eps: eps) * sigmoid(gate.asType(.float32)))
             .asType(x.dtype)
     }
 }


### PR DESCRIPTION
## What this changes

`BailingV3RMSNormGated.callAsFunction` currently reads:

```swift
MLXFast.rmsNorm(x, weight: weight, eps: eps) * sigmoid(gate.asType(.float32))
    .asType(x.dtype)
```

Swift binds the trailing `.asType` to the expression it follows, so this is

```swift
rmsNorm(…) * (sigmoid(gate.asType(.float32)).asType(x.dtype))
```

— the **sigmoid** is cast back to `x.dtype`, then multiplied.

## Why it matters

The returned dtype is already `x.dtype`, so this is not a promotion bug. What differs is **where
the rounding happens**: the gate is computed in float32 precisely because it saturates and half
precision costs accuracy there, and then it is rounded to half precision again *before* being
applied — discarding the precision it was just computed at.

The reference weights in float32 and casts the product once:

```python
(o32 * sigmoid(gate.astype(float32))).astype(seg.dtype)
```

## Fix

Parenthesise the product and cast that:

```swift
(MLXFast.rmsNorm(x, weight: weight, eps: eps) * sigmoid(gate.asType(.float32)))
    .asType(x.dtype)
```

One rounding, at the end, matching the reference and the float32 discipline the surrounding code
already keeps.

Complementary to #434, which moved the routed-expert combination in this same file to float32 for
the same reason.

Builds clean against `main` at 45bcb1de.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
