### PR TITLE
fix(mlxllm): enable Qwen3.5 text routed-MoE decode

### DIFF
--- a/Libraries/MLXLLM/Models/Qwen35.swift
+++ b/Libraries/MLXLLM/Models/Qwen35.swift
@@ -853,6 +853,12 @@ final class Qwen35SparseMoeBlock: Module, UnaryLayer {
     let normTopkProb: Bool
     let numExperts: Int
     let topK: Int
+    /// Whether exact-shape single-token decode may reach the trusted compiled
+    /// routed-MoE region in `SwitchGLU` (see `Qwen35CompiledDecodePolicy`).
+    /// Mirrors the VLM construction: the main decoder stack consults the
+    /// shared architecture/environment policy; MTP layers keep the eager
+    /// default, matching the VLM's MTP path.
+    let compileDecodeRegions: Bool
 
     @ModuleInfo(key: "gate") var gate: Linear
     @ModuleInfo(key: "switch_mlp") var switchMLP: SwitchGLU
@@ -860,17 +866,23 @@ final class Qwen35SparseMoeBlock: Module, UnaryLayer {
     @ModuleInfo(key: "shared_expert") var sharedExpert: Qwen3NextMLP
     @ModuleInfo(key: "shared_expert_gate") var sharedExpertGate: Linear
 
-    init(_ args: Qwen35TextConfiguration, layerIdx: Int) {
+    init(
+        _ args: Qwen35TextConfiguration,
+        layerIdx: Int,
+        compileDecodeRegions: Bool = false
+    ) {
         self.layerIdx = layerIdx
         self.normTopkProb = args.normTopkProb
         self.numExperts = args.numExperts
         self.topK = args.numExpertsPerTok
+        self.compileDecodeRegions = compileDecodeRegions
 
         _gate.wrappedValue = Linear(args.hiddenSize, args.numExperts, bias: false)
         _switchMLP.wrappedValue = SwitchGLU(
             inputDims: args.hiddenSize,
             hiddenDims: args.moeIntermediateSize,
-            numExperts: args.numExperts
+            numExperts: args.numExperts,
+            compileSeparatedDecode: compileDecodeRegions
         )
 
         _sharedExpert.wrappedValue = Qwen3NextMLP(
@@ -918,6 +930,21 @@ final class Qwen35DecoderLayer: Module {
 
     init(_ args: Qwen35TextConfiguration, layerIdx: Int) {
         self.isLinear = (layerIdx + 1) % args.fullAttentionInterval != 0
+        // Same architecture/environment policy as the VLM path: only the
+        // validated Qwen 3.5 MoE text topology may reach the trusted
+        // compiled routed-MoE decode region; every other shape stays eager.
+        let compiledDecodeRegions = Qwen35CompiledDecodePolicy.shouldCompileDecodeRegions(
+            modelType: args.modelType,
+            hiddenSize: args.hiddenSize,
+            hiddenLayers: args.hiddenLayers,
+            fullAttentionInterval: args.fullAttentionInterval,
+            numExperts: args.numExperts,
+            numExpertsPerTok: args.numExpertsPerTok,
+            moeIntermediateSize: args.moeIntermediateSize,
+            linearNumKeyHeads: args.linearNumKeyHeads,
+            linearNumValueHeads: args.linearNumValueHeads,
+            linearKeyHeadDim: args.linearKeyHeadDim,
+            linearValueHeadDim: args.linearValueHeadDim)
 
         if isLinear {
             _linearAttn.wrappedValue = Qwen35GatedDeltaNet(args)
@@ -926,7 +953,10 @@ final class Qwen35DecoderLayer: Module {
         }
 
         if args.numExperts > 0 {
-            _mlp.wrappedValue = Qwen35SparseMoeBlock(args, layerIdx: layerIdx)
+            _mlp.wrappedValue = Qwen35SparseMoeBlock(
+                args,
+                layerIdx: layerIdx,
+                compileDecodeRegions: compiledDecodeRegions)
         } else {
             _mlp.wrappedValue = Qwen3NextMLP(
                 dimensions: args.hiddenSize,

--- a/Libraries/MLXLMCommon/Qwen35CompiledDecodePolicy.swift
+++ b/Libraries/MLXLMCommon/Qwen35CompiledDecodePolicy.swift
@@ -1,0 +1,60 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Foundation
+
+/// Architecture/environment policy gating the Qwen 3.5 MoE text backbone's
+/// trusted routed-MoE decode region (`Qwen4ExpCompiledRoutedSwitchGLU` in
+/// `SwitchLayers.swift`).
+///
+/// The region is reached from `SwitchGLU` only when `compileSeparatedDecode` is
+/// set, and both Qwen 3.5 constructions must agree on when: the text-only model
+/// in `MLXLLM/Models/Qwen35.swift` and the VLM in `MLXVLM/Models/Qwen35.swift`.
+/// Keeping the predicate here, next to the region itself, stops the two callers
+/// from drifting apart.
+///
+/// The region keeps its own exact-shape, dtype, quantization, and single-token
+/// guards at call time, so this policy only decides which `SwitchGLU` instances
+/// are allowed to attempt it. Everything else — prefill, unsupported shapes,
+/// disabled configuration — falls back to the eager routed path unchanged.
+public enum Qwen35CompiledDecodePolicy {
+
+    /// Explicit opt-out (or forced enable) for the compiled decode regions:
+    /// `0`/`false` disables, any other value enables. When absent, the
+    /// architecture match below decides. The legacy `VMLINUX_` spelling is
+    /// honored through `RuntimeEnvironment`.
+    public static let environmentVariable = "VMLX_QWEN35_COMPILE_DECODE_REGIONS"
+
+    /// Whether a Qwen 3.5 MoE text backbone with the given shape may use the
+    /// compiled routed-MoE decode region. Only the validated
+    /// `qwen3_5_moe_text` topology is eligible; neighboring shapes stay eager.
+    public static func shouldCompileDecodeRegions(
+        modelType: String,
+        hiddenSize: Int,
+        hiddenLayers: Int,
+        fullAttentionInterval: Int,
+        numExperts: Int,
+        numExpertsPerTok: Int,
+        moeIntermediateSize: Int,
+        linearNumKeyHeads: Int,
+        linearNumValueHeads: Int,
+        linearKeyHeadDim: Int,
+        linearValueHeadDim: Int,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        if let override = RuntimeEnvironment.value(environmentVariable, in: environment) {
+            return override != "0" && override.lowercased() != "false"
+        }
+        return modelType == "qwen3_5_moe_text"
+            && hiddenSize == 2048
+            && hiddenLayers == 40
+            && fullAttentionInterval == 4
+            && numExperts == 256
+            && numExpertsPerTok == 8
+            && moeIntermediateSize == 512
+            && linearNumKeyHeads == 16
+            && linearNumValueHeads == 32
+            && linearKeyHeadDim == 128
+            && linearValueHeadDim == 128
+    }
+}

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -1120,22 +1120,22 @@ enum Qwen35Language {
         _ args: Qwen35Configuration.TextConfiguration,
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> Bool {
-        if let override = RuntimeEnvironment.value(
-            "VMLX_QWEN35_COMPILE_DECODE_REGIONS", in: environment)
-        {
-            return override != "0" && override.lowercased() != "false"
-        }
-        return args.modelType == "qwen3_5_moe_text"
-            && args.hiddenSize == 2048
-            && args.hiddenLayers == 40
-            && args.fullAttentionInterval == 4
-            && args.numExperts == 256
-            && args.numExpertsPerTok == 8
-            && args.moeIntermediateSize == 512
-            && args.linearNumKeyHeads == 16
-            && args.linearNumValueHeads == 32
-            && args.linearKeyHeadDim == 128
-            && args.linearValueHeadDim == 128
+        // Shared with the text-only path (Qwen35CompiledDecodePolicy lives in
+        // MLXLMCommon next to the compiled region it gates), so the two Qwen 3.5
+        // constructions cannot drift apart.
+        Qwen35CompiledDecodePolicy.shouldCompileDecodeRegions(
+            modelType: args.modelType,
+            hiddenSize: args.hiddenSize,
+            hiddenLayers: args.hiddenLayers,
+            fullAttentionInterval: args.fullAttentionInterval,
+            numExperts: args.numExperts,
+            numExpertsPerTok: args.numExpertsPerTok,
+            moeIntermediateSize: args.moeIntermediateSize,
+            linearNumKeyHeads: args.linearNumKeyHeads,
+            linearNumValueHeads: args.linearNumValueHeads,
+            linearKeyHeadDim: args.linearKeyHeadDim,
+            linearValueHeadDim: args.linearValueHeadDim,
+            environment: environment)
     }
 
     final class RotaryEmbedding {

--- a/Tests/MLXLMTests/Qwen35CompiledDecodePolicyTests.swift
+++ b/Tests/MLXLMTests/Qwen35CompiledDecodePolicyTests.swift
@@ -1,0 +1,135 @@
+// Copyright © 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+// Focused coverage for the Qwen 3.5 text-only compile-decode policy (issue #453):
+//
+// 1. The shared `Qwen35CompiledDecodePolicy` predicate is architecture-scoped:
+//    only the validated `qwen3_5_moe_text` shape enables, neighbors do not, and
+//    the explicit `VMLX_QWEN35_COMPILE_DECODE_REGIONS` override (current and
+//    legacy spelling) opts out or forces on.
+// 2. The text-only construction actually threads that policy into the
+//    `SwitchGLU(compileSeparatedDecode:)` decision: eligible topologies reach
+//    the trusted routed-MoE decode region, neighbors fall back to eager, and
+//    the MTP layers keep the eager default (mirroring the VLM path). The
+//    region's own shape/dtype/quantization guards and the eager fallback are
+//    unchanged; they live in `SwitchLayers.swift`.
+
+import Foundation
+import MLXLMCommon
+import Testing
+
+@testable import MLXLLM
+
+@Suite("Qwen3.5 text-only compile-decode policy")
+struct Qwen35CompiledDecodePolicyTests {
+
+    private static let variable = Qwen35CompiledDecodePolicy.environmentVariable
+
+    private static func shouldCompile(
+        modelType: String = "qwen3_5_moe_text",
+        hiddenSize: Int = 2048,
+        hiddenLayers: Int = 40,
+        fullAttentionInterval: Int = 4,
+        numExperts: Int = 256,
+        numExpertsPerTok: Int = 8,
+        moeIntermediateSize: Int = 512,
+        linearNumKeyHeads: Int = 16,
+        linearNumValueHeads: Int = 32,
+        linearKeyHeadDim: Int = 128,
+        linearValueHeadDim: Int = 128,
+        environment: [String: String] = [:]
+    ) -> Bool {
+        Qwen35CompiledDecodePolicy.shouldCompileDecodeRegions(
+            modelType: modelType,
+            hiddenSize: hiddenSize,
+            hiddenLayers: hiddenLayers,
+            fullAttentionInterval: fullAttentionInterval,
+            numExperts: numExperts,
+            numExpertsPerTok: numExpertsPerTok,
+            moeIntermediateSize: moeIntermediateSize,
+            linearNumKeyHeads: linearNumKeyHeads,
+            linearNumValueHeads: linearNumValueHeads,
+            linearKeyHeadDim: linearKeyHeadDim,
+            linearValueHeadDim: linearValueHeadDim,
+            environment: environment)
+    }
+
+    /// The validated `qwen3_5_moe_text` topology enables the compiled region.
+    @Test("eligible Qwen3.5 MoE text topology enables the compiled region")
+    func eligibleTopologyEnables() {
+        #expect(Self.shouldCompile())
+    }
+
+    /// Neighboring shapes must not enable compilation: the region was not
+    /// validated for them, so they keep the eager routed path.
+    @Test("neighboring shapes stay eager")
+    func neighboringShapesStayEager() {
+        #expect(!Self.shouldCompile(modelType: "qwen3_5_moe"))
+        #expect(!Self.shouldCompile(hiddenSize: 2560))
+        #expect(!Self.shouldCompile(hiddenLayers: 48))
+        #expect(!Self.shouldCompile(fullAttentionInterval: 8))
+        #expect(!Self.shouldCompile(numExperts: 128))
+        #expect(!Self.shouldCompile(numExpertsPerTok: 4))
+        #expect(!Self.shouldCompile(moeIntermediateSize: 640))
+        #expect(!Self.shouldCompile(linearNumKeyHeads: 8))
+        #expect(!Self.shouldCompile(linearNumValueHeads: 16))
+        #expect(!Self.shouldCompile(linearKeyHeadDim: 192))
+        #expect(!Self.shouldCompile(linearValueHeadDim: 64))
+    }
+
+    /// The explicit override wins over the architecture match in both
+    /// directions, and the legacy `VMLINUX_` spelling still works.
+    @Test("explicit override opts out or forces on, legacy spelling honored")
+    func explicitOverrideOptsOutOrForcesOn() {
+        #expect(!Self.shouldCompile(environment: [Self.variable: "0"]))
+        #expect(!Self.shouldCompile(environment: [Self.variable: "false"]))
+        #expect(
+            Self.shouldCompile(
+                hiddenSize: 2560, environment: [Self.variable: "1"]))
+        #expect(
+            !Self.shouldCompile(
+                environment: ["VMLINUX_QWEN35_COMPILE_DECODE_REGIONS": "0"]))
+        #expect(
+            Self.shouldCompile(
+                hiddenSize: 2560,
+                environment: ["VMLINUX_QWEN35_COMPILE_DECODE_REGIONS": "true"]))
+    }
+
+    /// The text-only decoder layer feeds the shared policy into the MoE block.
+    /// Only the eligible topology may attempt the compiled region; a neighbor
+    /// falls back to the eager `SwitchGLU` path.
+    @Test("text decoder threads the policy into the routed-MoE block")
+    func textDecoderThreadsPolicy() throws {
+        var eligible = try JSONDecoder().decode(
+            Qwen35TextConfiguration.self, from: Data("{}".utf8))
+        eligible.modelType = "qwen3_5_moe_text"
+        eligible.hiddenSize = 2048
+        eligible.hiddenLayers = 40
+        eligible.fullAttentionInterval = 4
+        eligible.numExperts = 256
+        eligible.numExpertsPerTok = 8
+        eligible.moeIntermediateSize = 512
+        eligible.linearNumKeyHeads = 16
+        eligible.linearNumValueHeads = 32
+        eligible.linearKeyHeadDim = 128
+        eligible.linearValueHeadDim = 128
+        eligible.sharedExpertIntermediateSize = 64
+
+        let eligibleBlock = try #require(
+            Qwen35DecoderLayer(eligible, layerIdx: 0).mlp
+                as? Qwen35SparseMoeBlock)
+        #expect(eligibleBlock.compileDecodeRegions)
+
+        var neighbor = eligible
+        neighbor.hiddenSize = 2560
+        let neighborBlock = try #require(
+            Qwen35DecoderLayer(neighbor, layerIdx: 0).mlp
+                as? Qwen35SparseMoeBlock)
+        #expect(!neighborBlock.compileDecodeRegions)
+
+        // MTP layers keep the eager default, exactly like the VLM's MTP path.
+        let mtpBlock = try #require(
+            Qwen35MTPDecoderLayer(eligible).mlp as? Qwen35SparseMoeBlock)
+        #expect(!mtpBlock.compileDecodeRegions)
+    }
+}


### PR DESCRIPTION
## Proposed changes

Fixes #453

- Factor the Qwen3.5 compiled routed-MoE decode predicate into `MLXLMCommon`.
- Wire the text-only Qwen3.5 decoder to the same architecture- and environment-scoped policy already used by the VLM path.
- Preserve `SwitchGLU`'s existing eager fallback and exact-shape, dtype, quantization, and single-token guards.
- Keep MTP layers on their existing eager default.

## Verification

- `swift test --filter Qwen35CompiledDecodePolicyTests --jobs 4` — 4/4 passed.
- `swift test --filter Qwen35VLMGatedDeltaTests/compiledDecodePolicyIsArchitectureScoped --jobs 4` — 1/1 passed.
- `swift test --filter Qwen4ExpConfigurationTests --jobs 4` — 4/4 passed.
- `swift-format lint` passes for the new policy and focused test files.
- The CMake pre-commit hook passes; the repository-wide in-place Swift formatter was not run because it rewrites unrelated existing files.

No checkpoint fixture was available for a runtime eager-versus-compiled parity run or decode measurement, so this PR adds focused policy and construction coverage rather than claiming runtime parity or a speedup.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
