### PR TITLE
fix(cache): reuse stripped boundary for standalone rotating caches

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -3328,7 +3328,8 @@ public actor BatchEngine {
             let sharedPromptStripBoundary = TokenIterator.hybridStripBoundaryIndex(
                 coordinator: coordinator,
                 promptTokenIds: promptTokens,
-                input: slot.originalInput)
+                input: slot.originalInput,
+                cache: slot.cache)
             var sharedPromptRederivedStates: [Int: [MLXArray]]?
             let sharedPromptAdditionalBoundaries = Array(Set(
                 slot.originalInput.cachePrefixTokenCounts
@@ -3347,6 +3348,8 @@ public actor BatchEngine {
             // existing prompt/post-answer policy.
             // Still `isHybrid` on purpose — see the note in Evaluate.swift. This
             // suppresses every other boundary; only an SSM hybrid can afford that.
+            // Standalone rotating/SWA caches keep this policy untouched and only
+            // gain the stripped-boundary store itself (below).
             let usesCanonicalHybridBoundary =
                 coordinator.isHybrid && sharedPromptStripBoundary != nil
             let isReusablePrefixWarmup =
@@ -3664,29 +3667,22 @@ public actor BatchEngine {
                     }
                 }
 
-                // Gen-suffix-stripped cross-turn boundary (hybrid SSM).
+                // Gen-suffix-stripped cross-turn boundary — hybrid SSM and
+                // standalone rotating/SWA.
                 //
                 // The prompt boundary stored above ends in the chat template's
                 // generation-prompt suffix (`<|im_start|>assistant\n`, …). The
                 // NEXT chat turn replaces that suffix with the assistant reply +
                 // the following user turn, so the full-prompt key can never match
-                // as a prefix — which is why growing hybrid turns never reused
-                // prefill and recomputed the whole context every turn. The
-                // boundary the next turn DOES contain as an exact prefix is this
-                // prompt stripped back to the end of the last real (user) message,
-                // i.e. everything before the final turn-start token. Store it so
-                // hybrid multi-turn chat reuses prior prefill.
+                // as a prefix. The stripped boundary does match the next prompt
+                // as an exact prefix, so store it for growing-chat reuse.
                 //
                 // Correctness: KV comes from the prompt-boundary trim/re-derive;
                 // clean SSM/GatedDeltaNet state at the stripped position comes from
                 // `storeCacheEntry`'s re-derive (enableSSMReDerive), NOT from the
                 // live post-generation state (which is ahead by the gen suffix).
-                // The store only fires when the prompt's tail actually is the
-                // template's gen-prompt suffix, so non-chat / tool-scaffold prompts
-                // that don't match simply skip it (no reuse, still correct). Proven
-                // cache-ON == cache-OFF (byte-identical, temp=0, fresh disk cache)
-                // on qwen-agentworld-35b-a3b MXFP8 (GatedDeltaNet MoE) and
-                // nemotron-omni-nano (Mamba-2); inert on dense gemma-4-e2b.
+                // The store only fires when the prompt tail matches the template's
+                // generation prompt; non-chat/tool-scaffold prompts simply skip it.
                 // NOTE: intentionally NOT gated on
                 // `!cachePrefixTokenCounts.contains(stripAt)`. For hybrid caches
                 // the history-boundary path can't store this boundary without a
@@ -3694,7 +3690,8 @@ public actor BatchEngine {
                 // `cachePrefixTokenCounts` entry — gating on it silently disables
                 // the store entirely (the re-derive here is the only writer).
                 if ProcessInfo.processInfo.environment["VMLX_HYBRID_STRIPPED_STORE"] != "0",
-                   coordinator.isHybrid,
+                   (coordinator.isHybrid
+                       || cacheHasStandaloneRotatingWindowState(slot.cache)),
                    let stripAt = sharedPromptStripBoundary
                 {
                     let strippedTokens = Array(promptTokens.prefix(stripAt))

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1630,11 +1630,12 @@ public struct TokenIterator: TokenIteratorProtocol {
     /// generated token is fed back into the model.
     var promptCacheSnapshot: [KVCache]?
 
-    /// Absolute index into ``promptTokenIds`` of the hybrid cross-turn reuse
-    /// boundary — the last turn-start token, i.e. the end of the prompt with
-    /// its trailing generation prompt stripped. `nil` when the boundary does
-    /// not apply (dense model, media input, no turn-start token, cache tiers
-    /// all disabled).
+    /// Absolute index into ``promptTokenIds`` of the generation-suffix-stripped
+    /// cross-turn reuse boundary — the last turn-start token, i.e. the end of
+    /// the prompt with its trailing generation prompt stripped. `nil` when the
+    /// boundary does not apply (dense model, media input, no turn-start token,
+    /// cache tiers all disabled, or a topology that is neither hybrid nor a
+    /// standalone rotating/sliding-window cache).
     var hybridStripBoundary: Int?
 
     /// Cache state at ``hybridStripBoundary``, captured *during* prefill.
@@ -2171,7 +2172,8 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.hybridStripBoundary = Self.hybridStripBoundaryIndex(
             coordinator: self.cacheCoordinator,
             promptTokenIds: self.promptTokenIds,
-            input: input)
+            input: input,
+            cache: self.cache)
         self.diskSeedBoundary = Self.diskSeedBoundaryIndex(
             coordinator: self.cacheCoordinator,
             promptTokenIds: self.promptTokenIds,
@@ -2260,13 +2262,15 @@ public struct TokenIterator: TokenIteratorProtocol {
         self.promptCacheSnapshot = makePromptBoundaryCacheSnapshot(from: self.cache)
     }
 
-    /// The hybrid cross-turn reuse boundary. Prefer the canonical history
-    /// boundary derived from the exact active chat template (including the
+    /// The cross-turn reuse boundary for path-dependent hybrid and standalone
+    /// rotating/sliding-window caches. Prefer the canonical history boundary
+    /// derived from the exact active chat template (including the
     /// assistant-continuation LCP proof); fall back to the model-load suffix
     /// heuristic only for raw/benchmark inputs that carry no canonical chat
     /// boundaries. The next chat turn replaces the generation prompt with the
     /// assistant's reply, so the full-prompt key never matches again, but this
-    /// boundary does — it is what gives hybrid models cross-turn prefix reuse.
+    /// boundary does — it is what gives hybrid and standalone rotating/SWA
+    /// models cross-turn prefix reuse.
     ///
     /// Returns `nil` when the boundary cannot pay for itself: dense models reuse
     /// via the post-answer boundary, media inputs are excluded, and with every
@@ -2275,7 +2279,8 @@ public struct TokenIterator: TokenIteratorProtocol {
     static func hybridStripBoundaryIndex(
         coordinator: CacheCoordinator?,
         promptTokenIds: [Int],
-        input: LMInput
+        input: LMInput,
+        cache: [KVCache]
     ) -> Int? {
         let heuristicBoundary = coordinator?.genPromptSuffixTokens.first
             .flatMap { promptTokenIds.lastIndex(of: $0) }
@@ -2297,7 +2302,7 @@ public struct TokenIterator: TokenIteratorProtocol {
         }
         guard ProcessInfo.processInfo.environment["VMLX_HYBRID_STRIPPED_STORE"] != "0",
             let coordinator,
-            coordinator.isHybrid,
+            (coordinator.isHybrid || cacheHasStandaloneRotatingWindowState(cache)),
             coordinator.canPersistBoundaries,
             let stripAt = canonicalBoundary ?? heuristicBoundary,
             stripAt > 0, stripAt < promptTokenIds.count,
@@ -2894,6 +2899,9 @@ public struct TokenIterator: TokenIteratorProtocol {
         // post-answer snapshots are both larger and not the boundary the next
         // templated turn is guaranteed to contain.  Prompts without this
         // processor-proven boundary keep the existing storage policy.
+        // Standalone rotating/SWA caches deliberately keep the exact/N-1
+        // disk-seed and post-answer policy (see `diskSeedBoundaryIndex`); they
+        // only gain the stripped-boundary store itself.
         let usesCanonicalHybridBoundary =
             coordinator.isHybrid && hybridStripBoundary != nil
         let isReusablePrefixWarmup =
@@ -3065,23 +3073,17 @@ public struct TokenIterator: TokenIteratorProtocol {
                     }
                 }
                 // Cross-turn reuse boundary for hybrid-SSM models (qwen3.5 /
-                // ornith GatedDeltaNet, Nemotron-H Mamba-2, LFM2, ZAYA CCA, …):
-                // store the generation-prompt-STRIPPED prompt, ending just before
-                // the LAST turn-start token (`<|im_start|>` / `<start_of_turn>` —
-                // the first token of the gen-prompt diff computed at load).
-                // `add_generation_prompt` appends `<turn-start>assistant\n` + a
-                // request-dependent scaffold, so we anchor on the structural
-                // turn-start token, not the exact suffix. The NEXT chat turn
-                // replaces that trailing gen prompt with the actual assistant
-                // reply, so the full-prompt key never matches next turn — but
-                // this stripped boundary (ending at the user turn) DOES, which is
-                // what restores hybrid cross-turn prefix reuse (proven live on
-                // qwen-agentworld-35B / qwen3.6-35B-A3B GDN MoE + Qwen3.6-27B MTP:
-                // growing turns HIT the stripped boundary and stay coherent —
-                // byte-identical to cache-off ground truth). Default ON for hybrid
-                // models; disable with `VMLX_HYBRID_STRIPPED_STORE=0`. Dense /
-                // sliding-window models are excluded — they already reuse via the
-                // post-answer boundary and don't need this.
+                // ornith GatedDeltaNet, Nemotron-H Mamba-2, LFM2, ZAYA CCA, …)
+                // and standalone rotating/sliding-window caches: store the
+                // generation-prompt-STRIPPED prompt, ending just before the LAST
+                // turn-start token (`<|im_start|>` / `<start_of_turn>` — the first
+                // token of the gen-prompt diff computed at load). The NEXT chat
+                // turn replaces that trailing gen prompt with the actual assistant
+                // reply, so the full-prompt key never matches next turn — but the
+                // stripped boundary does, restoring cross-turn prefix reuse.
+                // Default ON for hybrid and standalone rotating/SWA topologies;
+                // disable with `VMLX_HYBRID_STRIPPED_STORE=0`. Dense models are
+                // excluded because they already reuse via the post-answer boundary.
                 //
                 // `hybridStripSnapshot` was captured as prefill crossed the
                 // boundary, so this store is just a copy. There is deliberately no

--- a/Libraries/MLXLMCommon/SpecDec/DFlash2TokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/DFlash2TokenIterator.swift
@@ -116,15 +116,14 @@ struct DFlash2TokenIterator: TokenIteratorProtocol {
     /// Index of the generation-suffix-stripped boundary in
     /// ``promptTokenIds`` — the last turn-start token, i.e. the end of the
     /// prompt with its trailing generation prompt removed. `nil` when it
-    /// does not apply (dense target, no turn-start token, tiers disabled).
+    /// does not apply (dense target, no turn-start token, tiers disabled, or
+    /// a topology that is neither hybrid nor a standalone rotating/SWA
+    /// cache).
     ///
-    /// For a hybrid target this is the ONLY reusable cross-turn
-    /// checkpoint: the next turn's prompt replaces the generation suffix,
-    /// so it never contains this turn's full prompt, and hybrid state is
-    /// path-dependent, so the full-prompt cache cannot be trimmed back.
-    /// Storing only the full prompt therefore stores a boundary no later
-    /// turn can match — measured as turn 2 re-prefilling all 14 of 14
-    /// tokens in `DFlash2PrefixCacheReuseTests` before this existed.
+    /// For hybrid and standalone rotating/SWA targets this is the reusable
+    /// cross-turn checkpoint: the next turn replaces the generation suffix,
+    /// so it never contains this turn's full prompt. The full-prompt cache
+    /// therefore cannot provide this growing-turn boundary.
     private var hybridStripBoundary: Int?
 
     /// Cache state at ``hybridStripBoundary``, captured DURING prefill as
@@ -499,11 +498,13 @@ struct DFlash2TokenIterator: TokenIteratorProtocol {
             ? (config.slidingWindow.map { $0 - 1 })
             : nil
         // Same boundary rule as TokenIterator, so both iterators agree on
-        // what the canonical cross-turn checkpoint is.
+        // what the canonical cross-turn checkpoint is (hybrid SSM and
+        // standalone rotating/SWA topologies).
         self.hybridStripBoundary = TokenIterator.hybridStripBoundaryIndex(
             coordinator: cacheCoordinator,
             promptTokenIds: self.promptTokenIds,
-            input: input)
+            input: input,
+            cache: self.cache)
         // The boundary index is absolute; prefill only sees the suffix a
         // cache hit left over. A boundary inside the restored prefix needs
         // no capture — a stored boundary at least that long already exists

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -974,7 +974,8 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             let sharedPromptStripBoundary = TokenIterator.hybridStripBoundaryIndex(
                 coordinator: coordinator,
                 promptTokenIds: promptTokenIds,
-                input: originalInput)
+                input: originalInput,
+                cache: cache)
             let isReusablePrefixWarmup =
                 originalInput.cachePromptIntent == .reusablePrefixWarmup
             // Same canonical-boundary policy as the solo TokenIterator,
@@ -988,6 +989,8 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             // path; the first three were gated and this one was missed —
             // measured live as an extra ~100ms + ~350-500MB record on
             // EVERY tool-call cycle (exact 3446 beside canonical 3445).
+            // Standalone rotating/SWA caches keep the post-answer policy
+            // untouched and only gain the stripped-boundary store below.
             let usesCanonicalHybridBoundary =
                 coordinator.isHybrid && sharedPromptStripBoundary != nil
             let shouldPersistExactWarmupPrompt = shouldPersistExactPromptBoundary(
@@ -1128,16 +1131,15 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                     }
                 }
 
-                // Gen-suffix-stripped cross-turn boundary (hybrid SSM) — same as
-                // the solo TokenIterator path. The prompt boundary ends in the
-                // chat template's generation-prompt suffix, which the NEXT chat
-                // turn replaces with the assistant reply + following user turn, so
-                // the full-prompt key never matches as a prefix. The stripped
-                // boundary (everything before the final turn-start token) DOES,
-                // so store it to enable growing-turn reuse under MTP. Clean SSM
-                // comes from `store`'s re-derive (enableSSMReDerive).
+                // Gen-suffix-stripped cross-turn boundary — same as the solo
+                // TokenIterator path for hybrid SSM and standalone rotating/SWA.
+                // The prompt boundary ends in the generation-prompt suffix,
+                // which the next chat turn replaces with the assistant reply and
+                // following user turn. The stripped boundary remains an exact
+                // prefix of that next prompt, so store it for growing-turn reuse.
                 if ProcessInfo.processInfo.environment["VMLX_HYBRID_STRIPPED_STORE"] != "0",
-                   coordinator.isHybrid,
+                   (coordinator.isHybrid
+                       || cacheHasStandaloneRotatingWindowState(cache)),
                    !originalInput.hasMediaContent,
                    let stripAt = sharedPromptStripBoundary
                 {

--- a/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/BatchEngineGrowingChatCacheSourceTests.swift
@@ -510,6 +510,86 @@ struct BatchEngineGrowingChatCacheSourceTests {
         #expect(nativeMTP.contains("boundary: matchedTokens"))
     }
 
+    @Test("standalone rotating/SWA caches share the generation-suffix-stripped boundary policy")
+    func standaloneRotatingSharesStrippedBoundaryPolicy() throws {
+        let evaluate = try String(
+            contentsOfFile: "Libraries/MLXLMCommon/Evaluate.swift",
+            encoding: .utf8)
+        let batch = try String(
+            contentsOfFile: "Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift",
+            encoding: .utf8)
+        let mtp = try String(
+            contentsOfFile: "Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift",
+            encoding: .utf8)
+        let dflash2 = try String(
+            contentsOfFile: "Libraries/MLXLMCommon/SpecDec/DFlash2TokenIterator.swift",
+            encoding: .utf8)
+
+        // The shared helper admits the proven standalone rotating/SWA
+        // predicate in addition to the coordinator hybrid flag, so rotating
+        // chat prompts get the same generation-suffix-stripped cross-turn
+        // boundary instead of only the never-matching full-prompt key.
+        #expect(evaluate.contains(
+            "coordinator.isHybrid || cacheHasStandaloneRotatingWindowState(cache))"))
+        // Every call site hands the helper the live cache topology so the
+        // standalone-rotating admission cannot silently miss an engine.
+        #expect(evaluate.contains(
+            "input: input,\n            cache: self.cache)"))
+        #expect(batch.contains(
+            "input: slot.originalInput,\n                cache: slot.cache)"))
+        #expect(mtp.contains(
+            "input: originalInput,\n                cache: cache)"))
+        #expect(dflash2.contains(
+            "input: input,\n            cache: self.cache)"))
+        // The gen-suffix-stripped store itself admits the same topology
+        // predicate on the batched and MTP paths; the solo store is driven by
+        // `hybridStripBoundary` alone and follows via the helper.
+        #expect(batch.contains(
+            "cacheHasStandaloneRotatingWindowState(slot.cache)),\n"
+                + "                   let stripAt = sharedPromptStripBoundary"))
+        #expect(mtp.contains(
+            "cacheHasStandaloneRotatingWindowState(cache)),\n"
+                + "                   !originalInput.hasMediaContent"))
+        // DFlash2's store is boundary-driven with no local gate of its own; the
+        // widened helper is what admits standalone rotating there.
+        #expect(dflash2.contains("TokenIterator.hybridStripBoundaryIndex("))
+        #expect(!dflash2.contains(
+            "coordinator.isHybrid,\n                   let stripAt"))
+        // The exact/N-1 disk-seed and post-answer policy for standalone
+        // rotating/SWA caches is deliberately preserved: the canonical-boundary
+        // flag stays hybrid-only on every path (`diskSeedBoundaryIndex` owns
+        // the rotating N-1 seed contract).
+        #expect(evaluate.contains(
+            "let usesCanonicalHybridBoundary =\n"
+                + "            coordinator.isHybrid && hybridStripBoundary != nil"))
+        #expect(batch.contains(
+            "let usesCanonicalHybridBoundary =\n"
+                + "                coordinator.isHybrid && sharedPromptStripBoundary != nil"))
+        #expect(mtp.contains(
+            "let usesCanonicalHybridBoundary =\n"
+                + "                coordinator.isHybrid && sharedPromptStripBoundary != nil"))
+        #expect(!batch.contains(
+            "usesCanonicalHybridBoundary =\n"
+                + "                (coordinator.isHybrid"))
+        #expect(!mtp.contains(
+            "usesCanonicalHybridBoundary =\n"
+                + "                (coordinator.isHybrid"))
+        #expect(!evaluate.contains(
+            "usesCanonicalHybridBoundary =\n"
+                + "            (coordinator.isHybrid"))
+        // Dense/paged, media-unsafe, path-dependent-hybrid, and unsupported
+        // topologies keep their existing gates: rotating admission must not
+        // widen the recurrent/SSM companion paths or the media-unsafe store.
+        #expect(evaluate.contains(
+            "guard coordinator.isHybrid else { return nil }"))
+        #expect(batch.contains(
+            "guard cacheCoordinator?.isHybrid == true,"))
+        #expect(batch.contains(
+            "guard coordinator.isHybrid else { return nil }"))
+        #expect(evaluate.contains("input.canCaptureHybridStripBoundary("))
+        #expect(mtp.contains("!originalInput.hasMediaContent"))
+    }
+
     @Test("token iterator does not blanket-eval disk-backed cache snapshots before store")
     func tokenIteratorDoesNotBlanketEvalDiskBackedSnapshotsBeforeStore() throws {
         let source = try String(


### PR DESCRIPTION
## Proposed changes

Fixes #454

- Pass the cache topology into the shared generation-suffix-stripped boundary helper.
- Admit standalone rotating/sliding-window caches through the existing proven predicate.
- Apply the same stripped-boundary store condition in `BatchEngine` and the native MTP path; DFlash2 uses the shared helper as well.
- Keep the existing hybrid-only `usesCanonicalHybridBoundary` and exact/N-1 disk-seed policy unchanged.
- Preserve dense, paged, media, path-dependent hybrid, and unsupported-cache safety gates.

## Verification

- `swift test --filter standaloneRotatingSharesStrippedBoundaryPolicy --jobs 4` — 1/1 passed.
- `swift test --filter BatchEngineGrowingChatCacheSourceTests --jobs 4` — the filtered source assertions completed, but the process exited during teardown because this machine cannot load the default Metal library (`Failed to load the default metallib`).
- `swift-format lint` exits 0 on the changed files; the repository also reports existing baseline formatting diagnostics.
- The CMake pre-commit hook passes; the repository-wide in-place Swift formatter was not run because it rewrites unrelated existing files.

No rotating/sliding-window checkpoint fixture was available for a runtime multi-turn restore or cold-prefill parity run, so the regression coverage is source-level and the runtime limitation is left explicit.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/ml-explore/mlx/blob/main/CONTRIBUTING.md) document
- [ ] I have run `pre-commit run --all-files` to format my code / installed pre-commit prior to committing changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the necessary documentation (if needed)
