### PR TITLE
Support native MiniCPM5 XML tools and stable tokenizer history

### DIFF
--- a/Libraries/MLXHuggingFaceMacros/HuggingFaceIntegrationMacros.swift
+++ b/Libraries/MLXHuggingFaceMacros/HuggingFaceIntegrationMacros.swift
@@ -138,6 +138,16 @@ public struct TokenizerAdaptorMacro: ExpressionMacro {
                                 throw MLXLMCommon.TokenizerError.missingChatTemplate
                             }
                         }
+                        // MiniCPM shares <s>/ChatML tokens with Nemotron, but NOT
+                        // its tool grammar or thinking tail. Keep the configured
+                        // native template, including errors; never substitute a
+                        // foreign dialect merely because tools are present.
+                        if MLXLMCommon.MiniCPM5ToolCallParser.matchesTemplate(
+                            upstream.configuredChatTemplate(forTools: !(tools?.isEmpty ?? true))) {
+                            return try upstream.applyChatTemplate(
+                                messages: messages, tools: chatTemplateTools,
+                                additionalContext: additionalContext)
+                        }
                         let lagunaEos =
                             String(UnicodeScalar(0x3008)!)
                             + "|EOS|"
@@ -570,6 +580,14 @@ public struct TokenizerAdaptorMacro: ExpressionMacro {
                             } catch VMLXTokenizers.TokenizerError.missingChatTemplate {
                                 throw MLXLMCommon.TokenizerError.missingChatTemplate
                             }
+                        }
+                        if MLXLMCommon.MiniCPM5ToolCallParser.matchesTemplate(
+                            upstream.configuredChatTemplate(forTools: !(tools?.isEmpty ?? true))) {
+                            return try upstream.applyChatTemplate(
+                                messages: messages, chatTemplate: nil,
+                                addGenerationPrompt: addGenerationPrompt,
+                                truncation: false, maxLength: nil,
+                                tools: chatTemplateTools, additionalContext: additionalContext)
                         }
                         let lagunaEos =
                             String(UnicodeScalar(0x3008)!)

--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -1978,7 +1978,7 @@ public final class LLMModelFactory: ModelFactory {
                     resolvedReasoning.parser == nil
                     ? "none"
                     : (resolvedReasoning.source == .chatTemplate
-                        ? "qwen3"
+                        ? (resolvedReasoning.parser?.preservesXMLFunctionPayloads == true ? "minicpm5" : "qwen3")
                         : reasoningStampFromModelType(baseConfig.modelType))
             } else if let stamp = jangConfig?.capabilities?.reasoningParser {
                 mutableConfiguration.reasoningParserName = stamp
@@ -1991,7 +1991,7 @@ public final class LLMModelFactory: ModelFactory {
                     resolvedReasoning.parser == nil
                     ? "none"
                     : (resolvedReasoning.source == .chatTemplate
-                        ? "qwen3"
+                        ? (resolvedReasoning.parser?.preservesXMLFunctionPayloads == true ? "minicpm5" : "qwen3")
                         : reasoningStampFromModelType(baseConfig.modelType))
             }
         }

--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -1251,14 +1251,15 @@ internal func llmDefaultAdditionalContext(
     modelType: String?,
     capabilities: JangCapabilities?,
     generationConfig: GenerationConfigFile?,
-    chatConfig: JangChatConfig?
+    chatConfig: JangChatConfig?,
+    chatTemplate: String? = nil
 ) -> [String: any Sendable]? {
     var context: [String: any Sendable] = [:]
 
-    // Trust the bundle's capability stamp. A bundle that explicitly declares
-    // no thinking wins over stale template metadata. Otherwise use the
-    // model-authored default from generation_config.json, falling back to the
-    // mirrored JANG chat stamp. Request/UI context is merged later and wins.
+    // Preserve a native explicit-only generation tail: a capability flag is
+    // not an enable_thinking default. Otherwise retain legacy non-thinking
+    // capability behavior. Explicit defaults come from generation_config or
+    // the mirrored JANG chat stamp; request/UI context is merged later and wins.
     let declaredEnableThinking: Bool?
     if let explicitTemplateDefault =
         generationConfig?.defaultChatTemplateKwargs?.enableThinking
@@ -1277,8 +1278,11 @@ internal func llmDefaultAdditionalContext(
     }
 
     if capabilities?.supportsThinking == false {
-        context["enable_thinking"] = false
-    } else if let enableThinking = declaredEnableThinking {
+        if !ThinkingTemplateContract.preservesOmittedThinking(chatTemplate) {
+            return ["enable_thinking": false]
+        }
+    }
+    if let enableThinking = declaredEnableThinking {
         context["enable_thinking"] = enableThinking
         if enableThinking,
            let effort = chatConfig?.reasoning?.defaultEffort?
@@ -1466,13 +1470,15 @@ private struct LLMUserInputProcessor: UserInputProcessor {
         modelType: String?,
         capabilities: JangCapabilities?,
         generationConfig: GenerationConfigFile?,
-        chatConfig: JangChatConfig?
+        chatConfig: JangChatConfig?,
+        chatTemplate: String?
     ) -> [String: any Sendable]? {
         llmDefaultAdditionalContext(
             modelType: modelType,
             capabilities: capabilities,
             generationConfig: generationConfig,
-            chatConfig: chatConfig)
+            chatConfig: chatConfig,
+            chatTemplate: chatTemplate)
     }
 }
 
@@ -2069,7 +2075,8 @@ public final class LLMModelFactory: ModelFactory {
                 modelType: baseConfig.modelType,
                 capabilities: jangConfig?.capabilities,
                 generationConfig: generationConfig,
-                chatConfig: jangConfig?.chat),
+                chatConfig: jangConfig?.chat,
+                chatTemplate: chatTemplate),
             templateReadsEnableThinking: BailingThinkingTemplateContext.templateReadsEnableThinking(chatTemplate))
 
         return .init(

--- a/Libraries/MLXLMCommon/Chat.swift
+++ b/Libraries/MLXLMCommon/Chat.swift
@@ -287,6 +287,7 @@ public struct NoSystemMessageGenerator: MessageGenerator {
 /// beside (not inside) `tool_calls`, so templates serializing a tool call do
 /// not expose an implementation field to the model.
 let rawToolArgumentsJSONMessageKey = "_vmlx_raw_tool_arguments_json"
+let toolArgumentOrdersMessageKey = "_vmlx_tool_argument_orders"
 
 /// Produce the canonical Jinja-renderer dict for a ``Chat.Message``.
 ///
@@ -316,6 +317,10 @@ public func defaultMessageDict(for message: Chat.Message) -> Message {
         let rawArguments = toolCalls.map { $0.function.rawArgumentsJSON ?? "" }
         if rawArguments.contains(where: { !$0.isEmpty }) {
             dict[rawToolArgumentsJSONMessageKey] = rawArguments
+        }
+        let argumentOrders = toolCalls.map { $0.function.argumentOrder ?? [] }
+        if argumentOrders.contains(where: { !$0.isEmpty }) {
+            dict[toolArgumentOrdersMessageKey] = argumentOrders
         }
     }
 

--- a/Libraries/MLXLMCommon/ChatTemplates/ThinkingTemplateContract.swift
+++ b/Libraries/MLXLMCommon/ChatTemplates/ThinkingTemplateContract.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Detect the native three-way generation-tail contract without a model-name table.
+public enum ThinkingTemplateContract {
+    /// Omitted `enable_thinking` is distinct from both explicit bool values.
+    /// A normalization/default assignment or an absent-kwarg else branch is
+    /// not this contract. This inspection never modifies the rendered prompt.
+    public static func preservesOmittedThinking(_ template: String?) -> Bool {
+        guard let lower = template?.lowercased(),
+            !lower.contains("set enable_thinking"),
+            let generation = lower.range(of: "if add_generation_prompt"),
+            let regex = try? NSRegularExpression(
+                pattern: #"\{%-?\s*(.*?)\s*-?%\}"#,
+                options: [.dotMatchesLineSeparators])
+        else { return false }
+        let tail = String(lower[generation.lowerBound...]) as NSString
+        let tags = regex.matches(in: tail as String, range: NSRange(location: 0, length: tail.length))
+        func body(_ match: NSTextCheckingResult) -> String {
+            tail.substring(with: match.range(at: 1)).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        guard let start = tags.firstIndex(where: {
+            ["if enable_thinking is defined", "if (enable_thinking is defined)"].contains(body($0))
+        }) else { return false }
+        var depth = 0
+        let contentStart = NSMaxRange(tags[start].range)
+        for tag in tags.dropFirst(start + 1) {
+            let keyword = body(tag).split(whereSeparator: \.isWhitespace).first
+            if keyword == "if" {
+                depth += 1
+            } else if keyword == "else" || keyword == "elif" {
+                if depth == 0 { return false }
+            } else if keyword == "endif" {
+                if depth == 0 {
+                    let branch = tail.substring(with: NSRange(
+                        location: contentStart, length: tag.range.location - contentStart))
+                    return branch.contains("enable_thinking is true")
+                        && branch.contains("enable_thinking is false")
+                        && branch.contains("<think>") && branch.contains("</think>")
+                }
+                depth -= 1
+            }
+        }
+        return false
+    }
+}

--- a/Libraries/MLXLMCommon/JangLoader.swift
+++ b/Libraries/MLXLMCommon/JangLoader.swift
@@ -390,6 +390,11 @@ public enum ParserResolution {
                 return (ReasoningParser.fromCapabilityName(stamp), .jangStamped)
             }
         }
+        if MiniCPM5ToolCallParser.matchesTemplate(chatTemplate),
+            templateDeclaresThinkEnvelope(chatTemplate)
+        {
+            return (ReasoningParser.fromCapabilityName("minicpm5"), .chatTemplate)
+        }
         if declaresLFM25ThinkingTemplate(modelType: modelType, chatTemplate: chatTemplate) {
             return (
                 ReasoningParser.fromCapabilityName("qwen3"),
@@ -519,6 +524,14 @@ public enum ParserResolution {
         modelType: String?,
         chatTemplate: String? = nil
     ) -> (format: ToolCallFormat?, source: JangCapabilities.ResolutionSource) {
+        // This complete native grammar distinguishes MiniCPM5 from Llama
+        // JSON tools despite their shared architecture. Generic converter
+        // metadata (or a vocab-size heuristic) cannot describe its wire form.
+        if MiniCPM5ToolCallParser.matchesTemplate(chatTemplate),
+            capabilities?.toolParser == nil || capabilities?.toolParser == "llama"
+        {
+            return (.minicpm5, .chatTemplate)
+        }
         if let cap = capabilities,
             let stamped = ToolCallFormat.fromCapabilityName(cap.toolParser)
         {
@@ -552,6 +565,7 @@ public enum ParserResolution {
 
     private static func templateDeclaredToolCallFormat(_ chatTemplate: String?) -> ToolCallFormat? {
         guard let chatTemplate else { return nil }
+        if MiniCPM5ToolCallParser.matchesTemplate(chatTemplate) { return .minicpm5 }
         let lower = chatTemplate.lowercased()
         // XML-function envelope: `<tool_call><function=name><parameter=key>…`
         // (Qwen3-Coder, Qwen3.5/3.6, Nemotron-style). Checked BEFORE the bare-JSON

--- a/Libraries/MLXLMCommon/ReasoningParser.swift
+++ b/Libraries/MLXLMCommon/ReasoningParser.swift
@@ -117,6 +117,10 @@ public struct ReasoningParser: Sendable {
     /// reasoning/content mode.
     public let consumesRecipientHeaders: Bool
 
+    /// MiniCPM5's native XML envelope owns its payload, including literal
+    /// reasoning tags inside CDATA. Opt-in; other dialects are unchanged.
+    public let preservesXMLFunctionPayloads: Bool
+
     // MARK: State
 
     /// Text not yet emitted because it might be a partial tag prefix.
@@ -171,13 +175,15 @@ public struct ReasoningParser: Sendable {
         stripStrayTags: Bool = true,
         startTagAliases: [String] = [],
         endTagAliases: [String] = [],
-        consumesRecipientHeaders: Bool = false
+        consumesRecipientHeaders: Bool = false,
+        preservesXMLFunctionPayloads: Bool = false
     ) {
         self.startTag = startTag
         self.endTag = endTag
         self.insideReasoning = startInReasoning
         self.stripStrayTags = stripStrayTags
         self.consumesRecipientHeaders = consumesRecipientHeaders
+        self.preservesXMLFunctionPayloads = preservesXMLFunctionPayloads
         self.startTagAliases = startTagAliases.filter { !$0.isEmpty && $0 != startTag }
         self.endTagAliases = endTagAliases.filter { !$0.isEmpty && $0 != endTag }
     }
@@ -712,6 +718,29 @@ public struct ReasoningParser: Sendable {
                         $0, among: firstTagIsOpener ? openerSpellings : closerSpellings)
                 } == true
 
+            // Once content commits to a native XML function, reasoning tags
+            // inside its values are data. A reasoning example is deliberately
+            // NOT protected while insideReasoning. Hold incomplete envelopes
+            // until their CDATA-aware closer; never invent or close a tag.
+            if preservesXMLFunctionPayloads, !insideReasoning,
+                let function = buffer.range(of: "<function name=\""),
+                firstTagRange.map({ function.lowerBound < $0.lowerBound }) ?? true
+            {
+                let before = String(buffer[..<function.lowerBound])
+                if !before.isEmpty { out.append(.content(before)) }
+                buffer = String(buffer[function.lowerBound...])
+                if let end = MiniCPM5ToolCallParser().completeToolCallEnd(in: buffer) {
+                    out.append(.content(String(buffer[..<end])))
+                    buffer.removeSubrange(buffer.startIndex..<end)
+                    continue
+                }
+                if !allowPartialTagAtEnd {
+                    out.append(.content(buffer))
+                    buffer.removeAll(keepingCapacity: false)
+                }
+                break
+            }
+
             // A tool-recipient channel header is protocol that no tag spelling
             // covers, so it is resolved against the tag search by position:
             // whichever starts first wins. Running it unconditionally first
@@ -780,7 +809,9 @@ public struct ReasoningParser: Sendable {
                 // guards the edge case of an empty tag (a mis-configured
                 // model-specific override), where a negative `safeTail` would
                 // make `offsetBy: -safeTail` walk past `endIndex` and trap.
-                let longestTag = (openerSpellings + closerSpellings)
+                let literalOpeners = preservesXMLFunctionPayloads && !insideReasoning
+                    ? ["<function name=\""] : []
+                let longestTag = (openerSpellings + closerSpellings + literalOpeners)
                     .map(\.count).max() ?? 0
                 let safeTail = max(0, longestTag - 1)
                 if buffer.count > safeTail {
@@ -861,6 +892,10 @@ extension ReasoningParser {
         let n = name.lowercased()
         let normalized = normalizedReasoningAlias(n)
         let compact = compactReasoningAlias(n)
+
+        if normalized == "minicpm5" || normalized == "minicpm5_xml_function" {
+            return ReasoningParser(preservesXMLFunctionPayloads: true)
+        }
 
         if compact.hasPrefix("gemma4") {
             return ReasoningParser(
@@ -1191,7 +1226,8 @@ extension ReasoningParser {
             // exactly this way: the flag was set by `fromCapabilityName`,
             // dropped here, and the generation loop only ever uses this path,
             // so three correct parser fixes changed nothing on the app.
-            consumesRecipientHeaders: base.consumesRecipientHeaders)
+            consumesRecipientHeaders: base.consumesRecipientHeaders,
+            preservesXMLFunctionPayloads: base.preservesXMLFunctionPayloads)
         if startInReasoning && parser.isHarmonyChannelParser {
             parser.insideHarmonyChannel = true
             parser.harmonyChannelIsReasoning = true

--- a/Libraries/MLXLMCommon/Tool/Parsers/MiniCPM5ToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/MiniCPM5ToolCallParser.swift
@@ -92,14 +92,17 @@ public struct MiniCPM5ToolCallParser: ToolCallParser, Sendable {
         case "number":
             if let value = Double(trimmed), value.isFinite { return value }
         case "boolean":
-            if trimmed == "true" { return true }
-            if trimmed == "false" { return false }
+            if trimmed.lowercased() == "true" { return true }
+            if trimmed.lowercased() == "false" { return false }
         case "null":
             if trimmed == "null" { return NSNull() }
         case "array", "object":
             if let value = try? JSONSerialization.jsonObject(with: Data(trimmed.utf8)),
                 (type == "array" && value is [Any]) || (type == "object" && value is [String: Any])
             { return asSendable(value) }
+            if let value = PythonicToolCallParser().parsePythonContainerLiteral(trimmed),
+                (type == "array" && value is [Any]) || (type == "object" && value is [String: Any])
+            { return value }
         default: break
         }
         // Malformed schema-typed values stay visible to downstream validation.

--- a/Libraries/MLXLMCommon/Tool/Parsers/MiniCPM5ToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/MiniCPM5ToolCallParser.swift
@@ -1,0 +1,164 @@
+import Foundation
+#if canImport(FoundationXML)
+import FoundationXML
+#endif
+
+/// Native MiniCPM5 XML transport. No guessed argument types, truncated calls,
+/// or execution of examples from the reasoning rail. CDATA is value data,
+/// including literal </function>, </param>, and <think> strings within it.
+public struct MiniCPM5ToolCallParser: ToolCallParser, Sendable {
+    public let startTag: String? = "<function name=\""
+    public let endTag: String? = "</function>"
+    public var usesCustomEndBoundary: Bool { true }
+    public var preservesWhitespaceBeforeToolCalls: Bool { true }
+
+    public init() {}
+
+    public static func matchesTemplate(_ template: String?) -> Bool {
+        guard let template else { return false }
+        return template.contains("<function name=\"")
+            && template.contains("<param name=\"")
+            && template.contains("</function>")
+            && template.contains("<![CDATA[")
+    }
+
+    /// The first real function closer, not one quoted inside a CDATA value.
+    public func completeToolCallEnd(in content: String) -> String.Index? {
+        var cursor = content.startIndex
+        while cursor < content.endIndex {
+            let close = content.range(of: "</function>", range: cursor..<content.endIndex)
+            let cdata = content.range(of: "<![CDATA[", range: cursor..<content.endIndex)
+            if let cdata, close == nil || cdata.lowerBound < close!.lowerBound {
+                guard let end = content.range(of: "]]>", range: cdata.upperBound..<content.endIndex)
+                else { return nil }
+                cursor = end.upperBound
+            } else {
+                return close?.upperBound
+            }
+        }
+        return nil
+    }
+
+    public func parse(content: String, tools: [[String: any Sendable]]?) -> ToolCall? {
+        parseEOS(content, tools: tools).first
+    }
+
+    public func parseEOS(_ content: String, tools: [[String: any Sendable]]?) -> [ToolCall] {
+        var calls: [ToolCall] = []
+        var cursor = content.startIndex
+        while cursor < content.endIndex {
+            let open = content.range(of: "<function name=\"", range: cursor..<content.endIndex)
+            let think = content.range(of: "<think>", range: cursor..<content.endIndex)
+            if let think, open == nil || think.lowerBound < open!.lowerBound {
+                guard let end = content.range(of: "</think>", range: think.upperBound..<content.endIndex)
+                else { break }
+                cursor = end.upperBound
+                continue
+            }
+            guard let open else { break }
+            let remaining = String(content[open.lowerBound...])
+            guard let end = completeToolCallEnd(in: remaining) else { break }
+            let xml = String(remaining[..<end])
+            let delegate = FunctionXMLDelegate()
+            let parser = XMLParser(data: Data(xml.utf8))
+            parser.shouldResolveExternalEntities = false
+            parser.delegate = delegate
+            if parser.parse(), !delegate.invalid, let name = delegate.functionName,
+                delegate.depth == 0
+            {
+                var arguments: [String: any Sendable] = [:]
+                for key in delegate.order {
+                    let value = delegate.values[key] ?? ""
+                    arguments[key] = Self.coerce(value, function: name, parameter: key, tools: tools)
+                }
+                calls.append(ToolCall(function: .init(
+                    name: name, arguments: arguments, argumentOrder: delegate.order)))
+            }
+            cursor = content.index(open.lowerBound, offsetBy: xml.count)
+        }
+        return calls
+    }
+
+    private static func coerce(
+        _ raw: String, function: String, parameter: String, tools: [[String: any Sendable]]?
+    ) -> any Sendable {
+        // An absent schema means string, not JSON guessing: 007 and 3.10
+        // must survive parse -> persisted history -> native template exactly.
+        let type = getParameterType(funcName: function, paramName: parameter, tools: tools)
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        switch type {
+        case "integer":
+            if let value = Int(trimmed) { return value }
+        case "number":
+            if let value = Double(trimmed), value.isFinite { return value }
+        case "boolean":
+            if trimmed == "true" { return true }
+            if trimmed == "false" { return false }
+        case "null":
+            if trimmed == "null" { return NSNull() }
+        case "array", "object":
+            if let value = try? JSONSerialization.jsonObject(with: Data(trimmed.utf8)),
+                (type == "array" && value is [Any]) || (type == "object" && value is [String: Any])
+            { return asSendable(value) }
+        default: break
+        }
+        // Malformed schema-typed values stay visible to downstream validation.
+        return raw
+    }
+}
+
+private final class FunctionXMLDelegate: NSObject, XMLParserDelegate {
+    var functionName: String?
+    var values: [String: String] = [:]
+    var order: [String] = []
+    var depth = 0
+    var invalid = false
+    private var parameter: String?
+    private var value = ""
+
+    func parser(
+        _ parser: XMLParser, didStartElement elementName: String, namespaceURI: String?,
+        qualifiedName qName: String?, attributes: [String: String]
+    ) {
+        if depth == 0, elementName == "function", functionName == nil,
+            attributes.count == 1, let name = attributes["name"], !name.isEmpty
+        {
+            functionName = name
+        } else if depth == 1, elementName == "param", attributes.count == 1,
+            let name = attributes["name"], !name.isEmpty, values[name] == nil
+        {
+            parameter = name
+            value = ""
+        } else {
+            invalid = true
+            parser.abortParsing()
+        }
+        depth += 1
+    }
+
+    func parser(_ parser: XMLParser, foundCharacters string: String) {
+        if parameter != nil { value += string }
+        else if !string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { invalid = true }
+    }
+
+    func parser(_ parser: XMLParser, foundCDATA CDATABlock: Data) {
+        guard parameter != nil, let text = String(data: CDATABlock, encoding: .utf8) else {
+            invalid = true
+            parser.abortParsing()
+            return
+        }
+        value += text
+    }
+
+    func parser(
+        _ parser: XMLParser, didEndElement elementName: String, namespaceURI: String?,
+        qualifiedName qName: String?
+    ) {
+        if depth == 2, elementName == "param", let parameter {
+            values[parameter] = value
+            order.append(parameter)
+            self.parameter = nil
+        }
+        depth -= 1
+    }
+}

--- a/Libraries/MLXLMCommon/Tool/Parsers/PythonicToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/PythonicToolCallParser.swift
@@ -602,7 +602,9 @@ public struct PythonicToolCallParser: ToolCallParser, Sendable {
             value, paramName: paramName, funcName: funcName, tools: tools)
     }
 
-    private func parsePythonContainerLiteral(_ value: String) -> (any Sendable)? {
+    // Shared with XML transports whose native templates print Python-style
+    // collection literals. This parses data only, never evaluates source.
+    func parsePythonContainerLiteral(_ value: String) -> (any Sendable)? {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         guard
             (trimmed.first == "[" && trimmed.last == "]")

--- a/Libraries/MLXLMCommon/Tool/ToolCall.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCall.swift
@@ -74,7 +74,16 @@ public struct ToolCall: Hashable, Codable, Sendable {
                 if inString {
                     if ch == "\"" {
                         inString = false
-                        if capturing { keys.append(current); current = ""; capturing = false }
+                        if capturing {
+                            // Decode JSON escapes in the key too: persisted
+                            // JSON may spell the same XML name with \u escapes.
+                            guard let key = try? JSONDecoder().decode(
+                                String.self, from: Data(("\"" + current + "\"").utf8))
+                            else { return nil }
+                            keys.append(key)
+                            current = ""
+                            capturing = false
+                        }
                     } else if capturing {
                         current.append(ch)
                     }

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -36,6 +36,15 @@ public protocol ToolCallParser: Sendable {
     /// Prefixes for dynamic end tags matching ``startTagPrefixes``.
     var endTagPrefixes: [String] { get }
 
+    /// Opt-in boundary scanning for formats whose values can contain literal
+    /// closing tags (for example XML CDATA). Other formats keep tag matching.
+    var usesCustomEndBoundary: Bool { get }
+    func completeToolCallEnd(in content: String) -> String.Index?
+
+    /// Inline text/tool dialects retain even a whitespace-only chunk before
+    /// a call; otherwise detokenizer chunk boundaries change the answer text.
+    var preservesWhitespaceBeforeToolCalls: Bool { get }
+
     /// Exact protocol CLOSER tags that must be stripped from the visible
     /// stream even when they appear WITHOUT a matching opener ("orphan
     /// closers"). Live rows of some families (ZAYA / Gemma-4 AppleScript
@@ -101,6 +110,10 @@ extension ToolCallParser {
     public var startTagPrefixes: [String] { [] }
 
     public var endTagPrefixes: [String] { [] }
+
+    public var usesCustomEndBoundary: Bool { false }
+    public func completeToolCallEnd(in content: String) -> String.Index? { nil }
+    public var preservesWhitespaceBeforeToolCalls: Bool { false }
 
     public var orphanStripTags: [String] { [] }
 
@@ -182,6 +195,9 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
     /// Example: `<invoke name="f"><parameter name="k">v</parameter></invoke>`
     case minimaxM2 = "minimax_m2"
 
+    /// MiniCPM5: `<function name="f"><param name="x">v</param></function>`.
+    case minicpm5 = "minicpm5_xml_function"
+
     /// Mistral V11+ format with [TOOL_CALLS] and [ARGS] delimiters.
     /// Example: `[TOOL_CALLS]get_weather [ARGS]{"location": "Tokyo"}`
     case mistral
@@ -247,6 +263,8 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
             return KimiK2ToolCallParser()
         case .minimaxM2:
             return MiniMaxM2ToolCallParser()
+        case .minicpm5:
+            return MiniCPM5ToolCallParser()
         case .mistral:
             return MistralToolCallParser()
         case .llama3:
@@ -272,8 +290,8 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
     /// formats because the parser only accepts explicit protocol envelopes.
     public var parsesToolCallsFromReasoningChannel: Bool {
         switch self {
-        case .dsml:
-            // The official DSV4 contract places complete reasoning inside
+        case .dsml, .minicpm5:
+            // These contracts place complete reasoning inside
             // <think>...</think> before any tool call. Tool-shaped examples or
             // malformed protocol text inside reasoning_content are therefore
             // reasoning, never executable transport.
@@ -639,6 +657,8 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
         // `minimax_m2_5` per the converter.
         case "minimax", "minimax_m2_5":
             return .minimaxM2
+        case "minicpm5":
+            return .minicpm5
         // GLM 4.x / 5 / DeepSeek tool format (arg_key / arg_value tags).
         // `glm4` is also the canonical rawValue and already matches via
         // the direct lookup above, but is listed here for parity with

--- a/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallProcessor.swift
@@ -1917,14 +1917,16 @@ public class ToolCallProcessor {
                 return visible.isEmpty ? nil : visible
             }
 
-            if let matchedEndTag = firstTag(
-                in: toolCallBuffer,
-                tags: endTags,
-                prefixes: endTagPrefixes
-            ) {
-                // Separate the trailing token
-                let trailingToken = separateToken(
-                    from: &toolCallBuffer, separator: matchedEndTag, returnLeading: false)
+            let completeEnd: String.Index?
+            if parser.usesCustomEndBoundary {
+                completeEnd = parser.completeToolCallEnd(in: toolCallBuffer)
+            } else {
+                completeEnd = firstTag(in: toolCallBuffer, tags: endTags, prefixes: endTagPrefixes)
+                    .flatMap { toolCallBuffer.range(of: $0)?.upperBound }
+            }
+            if let completeEnd {
+                let trailingToken: String? = String(toolCallBuffer[completeEnd...])
+                toolCallBuffer = String(toolCallBuffer[..<completeEnd])
 
                 // Parse the completed wrapper. Some formats, including Hy3 /
                 // Hunyuan, can carry multiple calls inside one outer block.
@@ -1995,7 +1997,7 @@ public class ToolCallProcessor {
     }
 
     private func visibleLeadingTextBeforeToolCall(parsedToolCalls: [ToolCall]) -> String {
-        if !parsedToolCalls.isEmpty,
+        if !parser.preservesWhitespaceBeforeToolCalls, !parsedToolCalls.isEmpty,
             leadingTextBeforeToolCall
                 .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         {

--- a/Libraries/MLXVLM/VLMModelFactory.swift
+++ b/Libraries/MLXVLM/VLMModelFactory.swift
@@ -690,7 +690,7 @@ public final class VLMModelFactory: ModelFactory {
                     resolvedReasoning.parser == nil
                     ? "none"
                     : (resolvedReasoning.source == .chatTemplate
-                        ? "qwen3"
+                        ? (resolvedReasoning.parser?.preservesXMLFunctionPayloads == true ? "minicpm5" : "qwen3")
                         : reasoningStampFromModelType(baseConfig.modelType))
             } else if let stamp = jangConfig?.capabilities?.reasoningParser {
                 mutableConfiguration.reasoningParserName = stamp
@@ -703,7 +703,7 @@ public final class VLMModelFactory: ModelFactory {
                     resolvedReasoning.parser == nil
                     ? "none"
                     : (resolvedReasoning.source == .chatTemplate
-                        ? "qwen3"
+                        ? (resolvedReasoning.parser?.preservesXMLFunctionPayloads == true ? "minicpm5" : "qwen3")
                         : reasoningStampFromModelType(baseConfig.modelType))
             }
         }

--- a/Tests/MLXLMTests/ActualMiniCPMTokenizerTests.swift
+++ b/Tests/MLXLMTests/ActualMiniCPMTokenizerTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+import MLXLMCommon
+import MLXHuggingFace
+@preconcurrency import VMLXTokenizers
+
+@Suite("Actual MiniCPM5 tokenizer bridge — no model weights", .serialized,
+       .enabled(if: FileManager.default.fileExists(atPath: FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("models/OsaurusAI/MiniCPM5-2B-JANG_8M/tokenizer.json").path)))
+struct ActualMiniCPMTokenizerTests {
+    @Test func nativeToolsDoNotTriggerNemotronFallback() async throws {
+        let directory = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("models/OsaurusAI/MiniCPM5-2B-JANG_8M")
+        let tokenizer = try await #huggingFaceTokenizerLoader().load(
+            from: JangLoader.resolveChatTemplateSidecarSubstitution(for: directory))
+        let parameters: [String: any Sendable] = ["type": "object", "properties": ["path": ["type": "string"]], "required": ["path"]]
+        let function: [String: any Sendable] = ["name": "read_file", "description": "Read a file", "parameters": parameters]
+        let tools: [[String: any Sendable]] = [["type": "function", "function": function]]
+        for thinking: Bool? in [nil, true, false] {
+            let context: [String: any Sendable]? = thinking.map { ["enable_thinking": $0] }
+            let ids = try tokenizer.applyChatTemplate(messages: [["role": "user", "content": "Read note.md"]], tools: tools, additionalContext: context)
+            let rendered = tokenizer.decode(tokenIds: ids, skipSpecialTokens: false)
+            #expect(rendered.contains("<function name="), "native XML grammar must survive the production bridge")
+            #expect(!rendered.contains("<function="), "Nemotron fallback must not replace MiniCPM")
+            let tail = "<|im_start|>assistant\n" + (thinking == true ? "<think>\n" : thinking == false ? "<think>\n\n</think>\n\n" : "")
+            #expect(rendered.hasSuffix(tail), "native mode \(String(describing: thinking)) tail: \(rendered.suffix(100))")
+            let controllable = try #require(tokenizer as? any GenerationPromptControllableTokenizer)
+            let withoutTail = try controllable.applyChatTemplate(
+                messages: [["role": "user", "content": "Read note.md"]], tools: tools,
+                additionalContext: context, addGenerationPrompt: false)
+            let historyOnly = tokenizer.decode(tokenIds: withoutTail, skipSpecialTokens: false)
+            #expect(historyOnly.contains("<function name="))
+            #expect(!historyOnly.contains("<function="))
+            #expect(!historyOnly.hasSuffix(tail))
+        }
+    }
+    @Test func persistedNativeToolArgumentsRenderInEmittedOrder() async throws {
+        let directory = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("models/OsaurusAI/MiniCPM5-2B-JANG_8M")
+        let tokenizer = try await #huggingFaceTokenizerLoader().load(
+            from: JangLoader.resolveChatTemplateSidecarSubstitution(for: directory))
+        let call = ToolCall(function: .init(name: "write", arguments: [
+            "path": .string("note.md"), "content": .string("007")
+        ], argumentOrder: ["path", "content"]))
+        let restored = try JSONDecoder().decode(ToolCall.self, from: JSONEncoder().encode(call))
+        let messages = [
+            defaultMessageDict(for: .user("Write the note.")),
+            defaultMessageDict(for: .assistant("", toolCalls: [restored]))
+        ]
+        let ids = try tokenizer.applyChatTemplate(messages: messages, tools: nil, additionalContext: nil)
+        let rendered = tokenizer.decode(tokenIds: ids, skipSpecialTokens: false)
+        #expect(rendered.contains(#"<function name="write"><param name="path">note.md</param><param name="content">007</param></function>"#))
+        #expect(!rendered.contains("_vmlx_tool_argument_orders"))
+        print("MINICPM_ORDER native tokenizer history tokens=\(ids.count) persisted order path,content")
+    }
+
+    @Test func nativePromptTailsAndEndToken() async throws {
+        let directory = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent("models/OsaurusAI/MiniCPM5-2B-JANG_8M")
+        let template = try String(contentsOf: directory.appendingPathComponent("chat_template.jinja"), encoding: .utf8)
+        #expect(!ChatTemplateRepair.needsRepair(template))
+        #expect(ChatTemplateRepair.repaired(template) == template)
+        let resolved = JangLoader.resolveChatTemplateSidecarSubstitution(for: directory)
+        let tokenizer = try await #huggingFaceTokenizerLoader().load(from: resolved)
+        #expect(tokenizer.convertTokenToId("<|im_end|>") == 130073)
+        #expect(tokenizer.eosTokenId == 1)
+        let messages: [[String: any Sendable]] = [["role": "user", "content": "What is 2 plus 3?"]]
+        var tails: [String] = []
+        for thinking: Bool? in [nil, true, false] {
+            let context: [String: any Sendable]? = thinking.map { ["enable_thinking": $0] }
+            let ids = try tokenizer.applyChatTemplate(messages: messages, tools: nil, additionalContext: context)
+            let rendered = tokenizer.decode(tokenIds: ids, skipSpecialTokens: false)
+            print("MINICPM_TOKENIZER thinking=\(String(describing: thinking)) count=\(ids.count) ids=\(ids) text=\(rendered.debugDescription)")
+            tails.append(rendered)
+        }
+        #expect(tails[0].hasSuffix("<|im_start|>assistant\n"))
+        #expect(tails[1] == tails[0] + "<think>\n")
+        #expect(tails[2] == tails[0] + "<think>\n\n</think>\n\n")
+        let defaults = try JSONDecoder().decode(GenerationConfigFile.self, from: Data(contentsOf: directory.appendingPathComponent("generation_config.json")))
+        let sampling = GenerateParameters(generationConfig: defaults)
+        #expect(sampling.temperature == 1)
+        #expect(sampling.topP == 0.95)
+        #expect(sampling.repetitionPenalty == nil)
+        #expect(sampling.topK == 0)
+    }
+}

--- a/Tests/MLXLMTests/MiniCPM5ParserResolutionTests.swift
+++ b/Tests/MLXLMTests/MiniCPM5ParserResolutionTests.swift
@@ -1,0 +1,20 @@
+import Testing
+@testable import MLXLMCommon
+
+@Suite("MiniCPM5 template-derived parser resolution")
+struct MiniCPM5ParserResolutionTests {
+    @Test func dialectNotArchitectureSelectsParser() {
+        let template = #"<function name="f"><param name="s"><![CDATA[x]]></param></function>"#
+        let capabilities = JangCapabilities(toolParser: "llama")
+        #expect(ParserResolution.toolCall(capabilities: capabilities, modelType: "llama", chatTemplate: template).format == .minicpm5)
+        #expect(ParserResolution.toolCall(capabilities: nil, modelType: "llama", chatTemplate: template).format == .minicpm5)
+        #expect(ParserResolution.toolCall(capabilities: nil, modelType: "llama", chatTemplate: "plain prose").format == nil)
+        // Explicit non-generic publisher declarations retain priority.
+        #expect(ParserResolution.toolCall(capabilities: .init(toolParser: "dsml"), modelType: "llama", chatTemplate: template).format == .dsml)
+        let reasoningTemplate = template + "<think></think> enable_thinking"
+        let reasoning = ParserResolution.reasoning(capabilities: capabilities, modelType: "llama", chatTemplate: reasoningTemplate)
+        #expect(reasoning.parser?.preservesXMLFunctionPayloads == true)
+        #expect(reasoning.source == .chatTemplate)
+        #expect(ParserResolution.reasoning(capabilities: .init(reasoningParser: "none"), modelType: "llama", chatTemplate: reasoningTemplate).parser == nil)
+    }
+}

--- a/Tests/MLXLMTests/MiniCPM5ToolCallParserTests.swift
+++ b/Tests/MLXLMTests/MiniCPM5ToolCallParserTests.swift
@@ -1,0 +1,148 @@
+import Foundation
+import Testing
+@testable import MLXLMCommon
+
+@Suite("MiniCPM5 native XML tool contract — no model allocation")
+struct MiniCPM5ToolCallParserTests {
+    private let parser = MiniCPM5ToolCallParser()
+    private static let tools: [[String: any Sendable]] = {
+        let data = Data("""
+            [{
+              "type": "function",
+              "function": {
+                "name": "f",
+                "parameters": {
+                  "type": "object",
+                  "properties": {
+                    "s": {"type": "string"},
+                    "n": {"type": "integer"},
+                    "b": {"type": "boolean"},
+                    "a": {"type": "array", "items": {"type": "string"}}
+                  }
+                }
+              }
+            }]
+            """.utf8)
+        let decoded = try! JSONSerialization.jsonObject(with: data) as! [[String: Any]]
+        return decoded.map { $0.mapValues { asSendable($0) } }
+    }()
+
+    private func call(_ body: String, name: String = "f") -> String {
+        "<function name=\"\(name)\">\(body)</function>"
+    }
+
+    @Test func schemaTypesAndUnknownStrings() {
+        let xml = call("<param name=\"n\">3</param><param name=\"s\">007</param><param name=\"b\">false</param><param name=\"a\">[\"x\"]</param><param name=\"version\">3.10</param>")
+        let parsed = parser.parse(content: xml, tools: Self.tools)
+        #expect(parsed?.function.arguments["n"] == .int(3))
+        #expect(parsed?.function.arguments["s"] == .string("007"))
+        #expect(parsed?.function.arguments["b"] == .bool(false))
+        #expect(parsed?.function.arguments["a"] == .array([.string("x")]))
+        #expect(parsed?.function.arguments["version"] == .string("3.10"))
+        #expect(parser.parse(content: xml, tools: nil)?.function.arguments["n"] == .string("3"))
+        #expect(parser.parse(content: call("<param name=\"b\">banana</param>"), tools: Self.tools)?
+            .function.arguments["b"] == .string("banana"))
+    }
+
+    @Test func cdataIsLiteralAndDoesNotEndTheEnvelope() {
+        let value = "if a < b:\n  &x </function></param><think>literal</think>\n"
+        let xml = call("<param name=\"s\"><![CDATA[\(value)]]></param>")
+        #expect(parser.parse(content: xml, tools: Self.tools)?.function.arguments["s"] == .string(value))
+        #expect(parser.completeToolCallEnd(in: xml) == xml.endIndex)
+        #expect(parser.completeToolCallEnd(in: "<function name=\"f\"><param name=\"s\"><![CDATA[</function>") == nil)
+    }
+
+    @Test func reasoningExamplesAreNotCalls() {
+        let ghost = call("", name: "ghost")
+        let real = call("", name: "real")
+        #expect(parser.parseEOS("<think>Consider \(ghost)</think>\(real)", tools: nil).map(\.function.name) == ["real"])
+        #expect(parser.parseEOS("<think>Never closed \(ghost)", tools: nil).isEmpty)
+        #expect(!ToolCallFormat.minicpm5.parsesToolCallsFromReasoningChannel)
+    }
+
+    @Test func malformedOrTruncatedCallsAreNotExecutable() {
+        #expect(parser.parse(content: "<function name=\"f\"><param name=\"n\">3", tools: Self.tools) == nil)
+        #expect(parser.parse(content: call("<param name=\"n\">1</param><param name=\"n\">2</param>"), tools: Self.tools) == nil)
+        #expect(parser.parse(content: call("<param name=\"s\"><nested>bad</nested></param>"), tools: Self.tools) == nil)
+        #expect(parser.parse(content: call("<param name=\"s\">&external;</param>"), tools: Self.tools) == nil)
+    }
+
+    @Test func persistedArgumentOrderAndValuesSurvive() throws {
+        let parsed = try #require(parser.parse(
+            content: call("<param name=\"s\">007</param><param name=\"n\">3</param>"), tools: Self.tools))
+        let restored = try JSONDecoder().decode(ToolCall.self, from: JSONEncoder().encode(parsed))
+        #expect(restored.function.argumentOrder == ["s", "n"])
+        #expect(restored.function.arguments == parsed.function.arguments)
+    }
+
+    @Test func everyChunkSplitAndMultipleCalls() {
+        let value = "</function> & <think>literal</think>"
+        let xml = call("<param name=\"s\"><![CDATA[\(value)]]></param>") + call("", name: "g")
+        let text = "Before " + xml + " After"
+        // Every character boundary, including CDATA/open/close delimiters.
+        for offset in 0...text.count {
+            let split = text.index(text.startIndex, offsetBy: offset)
+            let processor = ToolCallProcessor(format: .minicpm5, tools: Self.tools)
+            var visible = processor.processChunk(String(text[..<split])) ?? ""
+            visible += processor.processChunk(String(text[split...])) ?? ""
+            visible += processor.processEOS() ?? ""
+            #expect(processor.toolCalls.map(\.function.name) == ["f", "g"], "split \(offset)")
+            #expect(processor.toolCalls.first?.function.arguments["s"] == .string(value), "split \(offset)")
+            #expect(visible == "Before  After", "split \(offset): \(visible)")
+            #expect(processor.toolCallProtocolFailure == nil)
+        }
+    }
+
+    @Test func templateSignatureAndOtherDialectsStaySeparate() {
+        let template = #"<function name="f"><param name="s"><![CDATA[x]]></param></function>"#
+        #expect(MiniCPM5ToolCallParser.matchesTemplate(template))
+        #expect(!MiniCPM5ToolCallParser.matchesTemplate("a <function name=\" mentioned in prose"))
+        #expect(ToolCallFormat.fromCapabilityName("minicpm5") == .minicpm5)
+        #expect(ToolCallFormat.fromCapabilityName("minicpm5_xml_function") == .minicpm5)
+        #expect(ToolCallFormat.json.createParser().usesCustomEndBoundary == false)
+        #expect(ToolCallFormat.xmlFunction.createParser().usesCustomEndBoundary == false)
+    }
+
+    @Test func reasoningThenToolPipelinePreservesLiteralPayload() {
+        // Production uses the prompt-resolved parser, not the factory alone.
+        var reasoning = ReasoningParser.forPrompt(stampName: "minicpm5", promptTail: "<|im_start|>assistant\n")!
+        let processor = ToolCallProcessor(format: .minicpm5, tools: Self.tools)
+        let literal = "save <think>literal</think> and </function> & data"
+        let xml = call("<param name=\"s\"><![CDATA[\(literal)]]></param>")
+        let stream = "<think>Need the file.</think>" + xml + "Saved."
+        var thought = ""
+        var visible = ""
+        func consume(_ segments: [ReasoningSegment]) {
+            for segment in segments {
+                switch segment {
+                case .reasoning(let text): thought += text
+                case .content(let text): visible += processor.processChunk(text) ?? ""
+                }
+            }
+        }
+        for character in stream { consume(reasoning.feed(String(character))) }
+        consume(reasoning.flush())
+        visible += processor.processEOS() ?? ""
+        #expect(thought == "Need the file.")
+        #expect(visible == "Saved.")
+        #expect(processor.toolCalls.first?.function.arguments["s"] == .string(literal))
+    }
+
+    @Test func nativeReasoningPromptStateAndUnfinishedEnvelopes() throws {
+        for (tail, inside) in [("<|im_start|>assistant\n", false), ("<think>\n", true), ("<think>\n\n</think>\n\n", false)] {
+            let parser = try #require(ReasoningParser.forPrompt(stampName: "minicpm5", promptTail: tail))
+            #expect(parser.preservesXMLFunctionPayloads)
+            #expect(parser.isInsideReasoning == inside)
+        }
+        #expect(ReasoningParser().preservesXMLFunctionPayloads == false)
+        #expect(ReasoningParser.fromCapabilityName("qwen3")?.preservesXMLFunctionPayloads == false)
+        var parser = try #require(ReasoningParser.forPrompt(stampName: "minicpm5", promptTail: "<|im_start|>assistant\n"))
+        let text = "<function name=\"f\"><param name=\"s\"><![CDATA[<think>unfinished"
+        let segments = parser.feed(text) + parser.flush()
+        #expect(segments == [.content(text)])
+        let processor = ToolCallProcessor(format: .minicpm5, tools: Self.tools)
+        for case .content(let content) in segments { _ = processor.processChunk(content) }
+        _ = processor.processEOS()
+        #expect(processor.toolCalls.isEmpty)
+    }
+}

--- a/Tests/MLXLMTests/MiniCPM5ToolCallParserTests.swift
+++ b/Tests/MLXLMTests/MiniCPM5ToolCallParserTests.swift
@@ -42,6 +42,15 @@ struct MiniCPM5ToolCallParserTests {
         #expect(parser.parse(content: xml, tools: nil)?.function.arguments["n"] == .string("3"))
         #expect(parser.parse(content: call("<param name=\"b\">banana</param>"), tools: Self.tools)?
             .function.arguments["b"] == .string("banana"))
+        #expect(parser.parse(content: call("<param name=\"b\">True</param>"), tools: Self.tools)?
+            .function.arguments["b"] == .bool(true))
+        #expect(parser.parse(content: call("<param name=\"a\">['x', True, None]</param>"), tools: Self.tools)?
+            .function.arguments["a"] == .array([.string("x"), .bool(true), .null]))
+        let expression = "[__import__('os').system('not executed')]"
+        #expect(parser.parse(content: call("<param name=\"a\">\(expression)</param>"), tools: Self.tools)?
+            .function.arguments["a"] == .string(expression))
+        #expect(parser.parse(content: call("<param name=\"a\">['x']</param>"), tools: nil)?
+            .function.arguments["a"] == .string("['x']"))
     }
 
     @Test func cdataIsLiteralAndDoesNotEndTheEnvelope() {

--- a/Tests/MLXLMTests/ThinkingTemplateDefaultTests.swift
+++ b/Tests/MLXLMTests/ThinkingTemplateDefaultTests.swift
@@ -1,0 +1,53 @@
+import Testing
+@testable import MLXLLM
+import MLXLMCommon
+
+@Suite("Native omitted thinking reaches processor defaults")
+struct ThinkingTemplateDefaultTests {
+    private let native = """
+        {% if add_generation_prompt %}<|im_start|>assistant
+        {% if enable_thinking is defined %}
+        {% if enable_thinking is false %}<think>\n\n</think>\n\n
+        {% elif enable_thinking is true %}<think>\n{% endif %}
+        {% endif %}{% endif %}
+        """
+
+    @Test func nativeOmissionWinsOverStaleCapability() {
+        let context = llmDefaultAdditionalContext(
+            modelType: "llama", capabilities: .init(supportsThinking: false),
+            generationConfig: nil, chatConfig: nil, chatTemplate: native)
+        #expect(context == nil)
+    }
+
+    @Test(arguments: [true, false]) func declaredDefaultsRemainEffective(_ value: Bool) throws {
+        let context = try #require(llmDefaultAdditionalContext(
+            modelType: "llama", capabilities: .init(supportsThinking: false),
+            generationConfig: .init(defaultChatTemplateKwargs: .init(enableThinking: value)),
+            chatConfig: nil, chatTemplate: native))
+        #expect(context["enable_thinking"] as? Bool == value)
+    }
+
+    @Test(arguments: [true, false]) func explicitRequestsWin(_ value: Bool) throws {
+        let defaults = llmDefaultAdditionalContext(
+            modelType: "llama", capabilities: .init(supportsThinking: false),
+            generationConfig: nil, chatConfig: nil, chatTemplate: native)
+        let resolved = try llmMergedAdditionalContext(
+            defaultAdditionalContext: defaults,
+            requestAdditionalContext: ["enable_thinking": value], modelType: "llama")
+        let merged = try #require(resolved)
+        #expect(merged["enable_thinking"] as? Bool == value)
+    }
+
+    @Test func legacyCapabilityAndExplicitOnlyDetection() throws {
+        #expect(ThinkingTemplateContract.preservesOmittedThinking(native))
+        for template in ["plain", native.replacingOccurrences(of: "{% endif %}{% endif %}", with: "{% else %}<think>{% endif %}{% endif %}"),
+                         "{% set enable_thinking = false %}" + native] {
+            #expect(!ThinkingTemplateContract.preservesOmittedThinking(template))
+            let context = try #require(llmDefaultAdditionalContext(
+                modelType: "example", capabilities: .init(supportsThinking: false),
+                generationConfig: .init(defaultChatTemplateKwargs: .init(enableThinking: true)),
+                chatConfig: nil, chatTemplate: template))
+            #expect(context["enable_thinking"] as? Bool == false)
+        }
+    }
+}

--- a/Tests/MLXLMTests/ToolArgumentOrderRenderingTests.swift
+++ b/Tests/MLXLMTests/ToolArgumentOrderRenderingTests.swift
@@ -6,6 +6,15 @@ import VMLXJinja
 
 @Suite("Tool argument order reaches native template rendering")
 struct ToolArgumentOrderRenderingTests {
+    @Test func jsonEscapedNamesRetainTheirNativeOrder() throws {
+        let call = ToolCall(function: .init(
+            name: "write", arguments: ["zé": .string("007"), "a\"b": .int(2)],
+            rawArgumentsJSON: #"{"z\u00e9":"007","a\"b":2}"#))
+        #expect(call.function.argumentOrder == ["zé", "a\"b"])
+        let input = defaultMessageDict(for: .assistant("", toolCalls: [call]))
+        #expect(try keys(input, nested: true) == "zé=007;a\"b=2;")
+    }
+
     private func message(order: [String]?) throws -> [String: any Sendable] {
         let call = ToolCall(function: .init(
             name: "write", arguments: ["path": .string("note.md"), "content": .string("007")],

--- a/Tests/MLXLMTests/ToolArgumentOrderRenderingTests.swift
+++ b/Tests/MLXLMTests/ToolArgumentOrderRenderingTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+import MLXLMCommon
+import VMLXJinja
+@testable import VMLXTokenizers
+
+@Suite("Tool argument order reaches native template rendering")
+struct ToolArgumentOrderRenderingTests {
+    private func message(order: [String]?) throws -> [String: any Sendable] {
+        let call = ToolCall(function: .init(
+            name: "write", arguments: ["path": .string("note.md"), "content": .string("007")],
+            argumentOrder: order))
+        let restored = try JSONDecoder().decode(ToolCall.self, from: JSONEncoder().encode(call))
+        return defaultMessageDict(for: .assistant("", toolCalls: [restored]))
+    }
+
+    private func keys(_ message: [String: any Sendable], nested: Bool) throws -> String {
+        let access = nested ? "m.tool_calls[0].function.arguments" : "m.tool_calls[0].arguments"
+        return try Template("{% for key, value in " + access + ".items() %}{{ key }}={{ value }};{% endfor %}")
+            .render(["m": try chatTemplateMessageValue(message)])
+    }
+
+    @Test func persistedOrderReachesBothNativeViews() throws {
+        let input = try message(order: ["path", "content"])
+        #expect(try keys(input, nested: true) == "path=note.md;content=007;")
+        #expect(try keys(input, nested: false) == "path=note.md;content=007;")
+        guard case .object(let rendered) = try chatTemplateMessageValue(input) else {
+            Issue.record("Expected message object"); return
+        }
+        #expect(rendered["_vmlx_tool_argument_orders"] == nil)
+    }
+
+    @Test(arguments: [["path", "path"], ["missing", "content"], ["path"], []])
+    func invalidOrderDoesNotDropOrInventArguments(_ order: [String]) throws {
+        #expect(try keys(message(order: order), nested: true) == "content=007;path=note.md;")
+    }
+
+    @Test func absentMetadataPreservesExistingRendering() throws {
+        let input = try message(order: nil)
+        #expect(try chatTemplateMessageValue(input) == Value(any: input))
+        #expect(try keys(input, nested: true) == "content=007;path=note.md;")
+    }
+}

--- a/Tests/MLXLMTests/ZeroArgumentToolCallTests.swift
+++ b/Tests/MLXLMTests/ZeroArgumentToolCallTests.swift
@@ -43,6 +43,7 @@ struct ZeroArgumentToolCallTests {
         (.glm4, "<tool_call>list_mailboxes</tool_call>"),
         (.hunyuan, "<tool_calls><tool_call>list_mailboxes<tool_sep></tool_call></tool_calls>"),
         (.minimaxM2, #"<invoke name="list_mailboxes"></invoke>"#),
+        (.minicpm5, #"<function name="list_mailboxes"></function>"#),
         (.atem, """
             <atem:function_calls>
             <atem:invoke name="list_mailboxes">

--- a/Vendors/swift-transformers/Sources/Tokenizers/Tokenizer.swift
+++ b/Vendors/swift-transformers/Sources/Tokenizers/Tokenizer.swift
@@ -15,6 +15,46 @@ public typealias Message = [String: any Sendable]
 /// A type alias for tool specifications used in chat templating.
 public typealias ToolSpec = [String: any Sendable]
 
+/// Preserve an explicitly recorded tool argument order at the Jinja boundary.
+/// The sidecar is internal history metadata, never a field in a rendered call.
+/// Missing, duplicate or stale key lists leave the existing canonical order alone.
+func chatTemplateMessageValue(_ message: Message) throws -> Value {
+    let key = "_vmlx_tool_argument_orders"
+    let orders = message[key] as? [[String]]
+    var visibleMessage = message
+    visibleMessage.removeValue(forKey: key)
+    let value = try Value(any: visibleMessage)
+    guard let orders, case .object(var object) = value,
+        case .array(var calls) = object["tool_calls"], orders.count == calls.count
+    else { return value }
+
+    func reordered(_ value: Value?, using order: [String]) -> Value? {
+        guard case .object(let arguments) = value,
+            order.count == arguments.count, Set(order).count == order.count,
+            Set(order) == Set(arguments.keys)
+        else { return value }
+        var result = OrderedDictionary<String, Value>()
+        for key in order { result[key] = arguments[key] }
+        return .object(result)
+    }
+
+    for index in calls.indices {
+        guard case .object(var call) = calls[index] else { continue }
+        if let arguments = call["arguments"] {
+            call["arguments"] = reordered(arguments, using: orders[index])
+        }
+        if case .object(var function) = call["function"] {
+            if let arguments = function["arguments"] {
+                function["arguments"] = reordered(arguments, using: orders[index])
+            }
+            call["function"] = .object(function)
+        }
+        calls[index] = .object(call)
+    }
+    object["tool_calls"] = .array(calls)
+    return .object(object)
+}
+
 /// Errors that can occur during tokenizer operations.
 public enum TokenizerError: LocalizedError {
     case missingConfig
@@ -898,7 +938,7 @@ public class PreTrainedTokenizer: @unchecked Sendable, Tokenizer {
         // survive the loader re-fetching it from the Hub.
         let template = try compiledTemplate(for: ChatTemplateRepair.repaired(selectedChatTemplate))
         var context: [String: VMLXJinja.Value] = try [
-            "messages": .array(messages.map { try Value(any: $0) }),
+            "messages": .array(messages.map { try chatTemplateMessageValue($0) }),
             "add_generation_prompt": .boolean(addGenerationPrompt),
         ]
         if let tools {

--- a/Vendors/swift-transformers/Sources/Tokenizers/Tokenizer.swift
+++ b/Vendors/swift-transformers/Sources/Tokenizers/Tokenizer.swift
@@ -366,6 +366,10 @@ public protocol Tokenizer: Sendable {
     /// Whether this tokenizer has a chat template configured.
     var hasChatTemplate: Bool { get }
 
+    /// Configured source selected by the ordinary default/tool-use contract.
+    /// Allows adapters to recognize native grammars without guessing from BOS tokens.
+    func configuredChatTemplate(forTools: Bool) -> String?
+
     /// Applies the configured chat template to format messages for model input.
     ///
     /// - Parameter messages: Array of message dictionaries representing the conversation
@@ -455,6 +459,7 @@ public protocol Tokenizer: Sendable {
 
 extension Tokenizer {
     public var hasChatTemplate: Bool { false }
+    public func configuredChatTemplate(forTools: Bool) -> String? { nil }
 
     /// Default: defer to `encode`.
     ///
@@ -835,6 +840,16 @@ public class PreTrainedTokenizer: @unchecked Sendable, Tokenizer {
     /// Whether this tokenizer has a chat template configured.
     public var hasChatTemplate: Bool {
         !tokenizerConfig.chatTemplate.isNull()
+    }
+
+    public func configuredChatTemplate(forTools: Bool) -> String? {
+        let value: Config = tokenizerConfig.chatTemplate
+        if let source = value.string() { return source }
+        guard let entries = value.array() else { return nil }
+        if forTools, let entry = entries.first(where: { $0["name"].string() == "tool_use" }) {
+            return entry["template"].string()
+        }
+        return entries.first(where: { $0["name"].string() == "default" })?["template"].string()
     }
 
     public func applyChatTemplate(messages: [Message]) throws -> [Int] {


### PR DESCRIPTION
## Scope

Native MiniCPM5 XML tools, CDATA boundaries, schema-derived argument types/order, and the bundle's distinct omitted/on/off thinking contract. Both tokenizer bridges avoid the unrelated Nemotron fallback when a native template exists. No template rewrite, sampler masking, or forced reasoning markers.

## Source and verification

- Exact head `f7971dfb32e23faed98d6db595b07c76f0d0a2dd`; 252 production-module tests across18 suites. Native-default regression fails before the factory correction (2 issues), passes after. Existing parser/tokenizer/DSML/ATEM/LFM2/reasoning controls included. CI waiver for this repository is user-authorized; no CI result is claimed.
- Actual Osaurus integration PR#2676 at `c64de8bfc`, six matching pins and resolved engine checkout; Release binary `b86af744f68458784234473342d93352aafe5ef615af358b2a21f947ab52b919`. Its eight CI checks passed in run34236742199.
- Real UI four-turn run: native Default, explicitOn/Off, two executed get_current_time calls, grounded prior code/timestamps, closed reasoning, natural stops. Engine143.57–148.90tok/s. Native raw prompt tails and UI images preserved.
- Real API ordinary file-tool calls in all three modes, exact payload readback, streamed result-grounded continuation, and a second streamed tool call using the earlier receipt. Engine84.35–163.61tok/s across traced rows. API-client executions are separate from UI registry executions.

## Explicit limitations, not covered up

- Adversarial XML-copy task: Default hit its1024token cap; On/Off omitted two requested literal-tag lines. Traced generated envelope already omits them; this was not parser truncation. No claim of general model reliability.
- Existing app tool-response API reports zero completion tokens and can omit speed; engine measurements above come from generation logs, not fabricated API usage. Immediate tool dispatch drains statistics after the public stream closes. Follow-up must preserve dispatch/cache behavior.
- Four-turn UI physical-footprint peak3174MB exceeds the2.49GiB bundle-size qualification gate, despite normal memory pressure and unchanged swap. Low-RAM family qualification remains PARTIAL.
- A subsequent server-settings navigation hung in SwiftUI layout; attribution unproven. Unload and full settings parity remain open in the app lane. This merge is the bounded runtime correction, not a release or a declaration that all Osaurus/model gates are complete.

Private evidence: `mtp-swift-2026-09-04/proofs/minicpm5-live.oTrB5u/FINAL-NATIVE-RESULT.md`; `SWIFTTEST_MiniCPMDefaultBeforeRetry__070946`, `MiniCPMDefaultAfter__071040`, `MiniCPMFinalNativeVisual__074146`, `MiniCPMNativeAPITrace__075407`. No research documents or model data published.
