### PR TITLE
Spark2.5 text runtime and native serving contract

### DIFF
--- a/Libraries/MLXLLM/LLMModelFactory.swift
+++ b/Libraries/MLXLLM/LLMModelFactory.swift
@@ -47,6 +47,7 @@ public enum LLMTypeRegistry {
             "diffusion_gemma": create(DiffusionGemmaConfiguration.self, DiffusionGemmaModel.init),
             "qwen2": create(Qwen2Configuration.self, Qwen2Model.init),
             "qwen3": create(Qwen3Configuration.self, Qwen3Model.init),
+            "spark2_5": create(Spark25Configuration.self, Spark25Model.init),
             "qwen3_moe": create(Qwen3MoEConfiguration.self, Qwen3MoEModel.init),
             "qwen3_next": create(Qwen3NextConfiguration.self, Qwen3NextModel.init),
             "qwen3_5": create(Qwen35Configuration.self, Qwen35Model.init),

--- a/Libraries/MLXLLM/Models/Spark25.swift
+++ b/Libraries/MLXLLM/Models/Spark25.swift
@@ -1,0 +1,266 @@
+// Copyright 2026 The XHToken team and the HuggingFace Inc. team.
+// SPDX-License-Identifier: Apache-2.0
+// Swift port of XHToken/Spark-X2.5-4B modeling_spark.py.
+
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+
+public struct Spark25Configuration: Codable, Sendable {
+    enum LayerType: String, Codable, Sendable {
+        case full = "full_attention"
+        case sliding = "sliding_attention"
+    }
+
+    struct Rotary: Codable, Sendable {
+        let theta: Float
+        let partialFactor: Float
+        enum CodingKeys: String, CodingKey {
+            case theta = "rope_theta"
+            case partialFactor = "partial_rotary_factor"
+        }
+    }
+
+    let hiddenSize: Int
+    let hiddenLayers: Int
+    let intermediateSize: Int
+    let attentionHeads: Int
+    let kvHeads: Int
+    let headDim: Int
+    let vocabularySize: Int
+    let rmsNormEps: Float
+    let hiddenAct: String
+    let gateAct: String
+    let headwiseGate: Bool
+    let attentionBias: Bool
+    let mlpBias: Bool
+    let tieWordEmbeddings: Bool
+    let slidingWindow: Int?
+    let layerTypes: [LayerType]
+    let ropeParameters: [String: Rotary]
+
+    enum CodingKeys: String, CodingKey {
+        case hiddenSize = "hidden_size"
+        case hiddenLayers = "num_hidden_layers"
+        case intermediateSize = "intermediate_size"
+        case attentionHeads = "num_attention_heads"
+        case kvHeads = "num_key_value_heads"
+        case headDim = "head_dim"
+        case vocabularySize = "vocab_size"
+        case rmsNormEps = "rms_norm_eps"
+        case hiddenAct = "hidden_act"
+        case gateAct = "gate_attn_act_mode"
+        case headwiseGate = "headwise_attn_output_gate"
+        case attentionBias = "attention_bias"
+        case mlpBias = "mlp_bias"
+        case tieWordEmbeddings = "tie_word_embeddings"
+        case slidingWindow = "sliding_window"
+        case layerTypes = "layer_types"
+        case ropeParameters = "rope_parameters"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        hiddenSize = try c.decode(Int.self, forKey: .hiddenSize)
+        hiddenLayers = try c.decode(Int.self, forKey: .hiddenLayers)
+        intermediateSize = try c.decode(Int.self, forKey: .intermediateSize)
+        attentionHeads = try c.decode(Int.self, forKey: .attentionHeads)
+        kvHeads = try c.decodeIfPresent(Int.self, forKey: .kvHeads) ?? attentionHeads
+        headDim = try c.decode(Int.self, forKey: .headDim)
+        vocabularySize = try c.decode(Int.self, forKey: .vocabularySize)
+        rmsNormEps = try c.decodeIfPresent(Float.self, forKey: .rmsNormEps) ?? 1e-6
+        hiddenAct = try c.decodeIfPresent(String.self, forKey: .hiddenAct) ?? "gelu"
+        gateAct = try c.decodeIfPresent(String.self, forKey: .gateAct) ?? "sigmoid"
+        headwiseGate = try c.decodeIfPresent(Bool.self, forKey: .headwiseGate) ?? false
+        attentionBias = try c.decodeIfPresent(Bool.self, forKey: .attentionBias) ?? false
+        mlpBias = try c.decodeIfPresent(Bool.self, forKey: .mlpBias) ?? false
+        tieWordEmbeddings = try c.decodeIfPresent(Bool.self, forKey: .tieWordEmbeddings) ?? false
+        slidingWindow = try c.decodeIfPresent(Int.self, forKey: .slidingWindow)
+        layerTypes =
+            try c.decodeIfPresent([LayerType].self, forKey: .layerTypes)
+            ?? Array(repeating: .full, count: Swift.max(0, hiddenLayers))
+        ropeParameters =
+            try c.decodeIfPresent([String: Rotary].self, forKey: .ropeParameters) ?? [:]
+
+        guard hiddenSize > 0, hiddenLayers > 0, intermediateSize > 0,
+            vocabularySize > 0, attentionHeads > 0, kvHeads > 0, headDim > 0,
+            attentionHeads % kvHeads == 0, layerTypes.count == hiddenLayers,
+            rmsNormEps.isFinite, rmsNormEps > 0, hiddenAct == "gelu",
+            ["sigmoid", "silu"].contains(gateAct),
+            !layerTypes.contains(.sliding) || (slidingWindow ?? 0) > 0
+        else {
+            throw DecodingError.dataCorrupted(
+                .init(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Invalid Spark2.5 geometry or activation contract"))
+        }
+        for type in layerTypes {
+            let r = rotary(for: type)
+            let dims = Float(headDim) * r.partialFactor
+            guard r.theta.isFinite, r.theta > 0, dims.isFinite,
+                dims >= 2, dims <= Float(headDim), dims.rounded() == dims, Int(dims) % 2 == 0
+            else {
+                throw DecodingError.dataCorrupted(
+                    .init(
+                        codingPath: decoder.codingPath,
+                        debugDescription: "Invalid Spark2.5 rotary dimensions or base"))
+            }
+        }
+    }
+
+    func rotary(for type: LayerType) -> Rotary {
+        ropeParameters[type.rawValue] ?? Rotary(theta: 10_000, partialFactor: 1)
+    }
+}
+
+final class Spark25Attention: Module {
+    @ModuleInfo(key: "q_k_v_proj") var qkv: Linear
+    @ModuleInfo(key: "out_proj") var output: Linear
+    @ModuleInfo(key: "g_proj") var gate: Linear?
+    let config: Spark25Configuration
+    let rope: RoPE
+    let scale: Float
+
+    init(_ config: Spark25Configuration, type: Spark25Configuration.LayerType) {
+        self.config = config
+        let q = config.attentionHeads * config.headDim
+        let kv = config.kvHeads * config.headDim
+        _qkv.wrappedValue = Linear(config.hiddenSize, q + 2 * kv, bias: config.attentionBias)
+        _output.wrappedValue = Linear(q, config.hiddenSize, bias: config.attentionBias)
+        if config.headwiseGate {
+            _gate.wrappedValue = Linear(
+                config.hiddenSize, config.attentionHeads, bias: config.attentionBias)
+        }
+        let rotary = config.rotary(for: type)
+        rope = RoPE(
+            dimensions: Int(Float(config.headDim) * rotary.partialFactor), traditional: false,
+            base: rotary.theta)
+        scale = pow(Float(config.headDim), -0.5)
+    }
+
+    func callAsFunction(
+        _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
+    ) -> MLXArray {
+        let (b, n) = (x.dim(0), x.dim(1))
+        let qDim = config.attentionHeads * config.headDim
+        let kvDim = config.kvHeads * config.headDim
+        let fused = qkv(x)
+        var q = fused[.ellipsis, ..<qDim].reshaped(b, n, config.attentionHeads, config.headDim)
+            .transposed(0, 2, 1, 3)
+        var k = fused[.ellipsis, qDim ..< (qDim + kvDim)].reshaped(
+            b, n, config.kvHeads, config.headDim
+        ).transposed(0, 2, 1, 3)
+        let v = fused[.ellipsis, (qDim + kvDim)...].reshaped(b, n, config.kvHeads, config.headDim)
+            .transposed(0, 2, 1, 3)
+        q = applyRotaryPosition(rope, to: q, cache: cache)
+        k = applyRotaryPosition(rope, to: k, cache: cache)
+        var attended = attentionWithCacheUpdate(
+            queries: q, keys: k, values: v, cache: cache, scale: scale, mask: mask)
+        if let gate {
+            let score = gate(x).reshaped(b, n, config.attentionHeads, 1).transposed(0, 2, 1, 3)
+                .asType(.float32)
+            let weight = config.gateAct == "sigmoid" ? sigmoid(score) : silu(score)
+            attended = attended * weight.asType(attended.dtype)
+        }
+        return output(attended.transposed(0, 2, 1, 3).reshaped(b, n, qDim))
+    }
+}
+
+final class Spark25MLP: Module, UnaryLayer {
+    @ModuleInfo(key: "gate_proj") var gate: Linear
+    @ModuleInfo(key: "up_proj") var up: Linear
+    @ModuleInfo(key: "down_proj") var down: Linear
+    init(_ c: Spark25Configuration) {
+        _gate.wrappedValue = Linear(c.hiddenSize, c.intermediateSize, bias: c.mlpBias)
+        _up.wrappedValue = Linear(c.hiddenSize, c.intermediateSize, bias: c.mlpBias)
+        _down.wrappedValue = Linear(c.intermediateSize, c.hiddenSize, bias: c.mlpBias)
+    }
+    func callAsFunction(_ x: MLXArray) -> MLXArray { down(gelu(gate(x)) * up(x)) }
+}
+
+final class Spark25DecoderLayer: Module {
+    @ModuleInfo(key: "self_attn") var attention: Spark25Attention
+    @ModuleInfo(key: "input_layernorm") var inputNorm: RMSNorm
+    @ModuleInfo(key: "post_attention_layernorm") var postNorm: RMSNorm
+    let mlp: Spark25MLP
+    init(_ c: Spark25Configuration, type: Spark25Configuration.LayerType) {
+        _attention.wrappedValue = Spark25Attention(c, type: type)
+        _inputNorm.wrappedValue = RMSNorm(dimensions: c.hiddenSize, eps: c.rmsNormEps)
+        _postNorm.wrappedValue = RMSNorm(dimensions: c.hiddenSize, eps: c.rmsNormEps)
+        mlp = Spark25MLP(c)
+    }
+    func callAsFunction(
+        _ x: MLXArray, mask: MLXFast.ScaledDotProductAttentionMaskMode, cache: KVCache?
+    ) -> MLXArray {
+        // Residuals accumulate in fp32; projection input dtype comes from a
+        // floating norm, never the packed uint32 weight of a quantized Linear.
+        let h = x + attention(inputNorm(x).asType(inputNorm.weight.dtype), mask: mask, cache: cache)
+        return h + mlp(postNorm(h).asType(postNorm.weight.dtype))
+    }
+}
+
+final class Spark25ModelInner: Module {
+    @ModuleInfo(key: "embedding") var embedding: Embedding
+    let layers: [Spark25DecoderLayer]
+    let norm: RMSNorm
+    let config: Spark25Configuration
+    init(_ c: Spark25Configuration) {
+        config = c
+        _embedding.wrappedValue = Embedding(
+            embeddingCount: c.vocabularySize, dimensions: c.hiddenSize)
+        layers = c.layerTypes.map { Spark25DecoderLayer(c, type: $0) }
+        norm = RMSNorm(dimensions: c.hiddenSize, eps: c.rmsNormEps)
+    }
+    func callAsFunction(_ tokens: MLXArray, cache: [KVCache]?) -> MLXArray {
+        let embedded = embedding(tokens)
+        var h = embedded.asType(.float32)
+        // Compute masks before updating any layer's cache. Each type owns a
+        // different cache extent; a full-layer offset cannot size an SWA mask.
+        let fullIndex = config.layerTypes.firstIndex(of: .full)
+        let slidingIndex = config.layerTypes.firstIndex(of: .sliding)
+        let full = createAttentionMask(h: h, cache: fullIndex.flatMap { cache?[$0] })
+        let sliding = createAttentionMask(
+            h: h, cache: slidingIndex.flatMap { cache?[$0] }, windowSize: config.slidingWindow)
+        for (i, layer) in layers.enumerated() {
+            h = layer(h, mask: config.layerTypes[i] == .full ? full : sliding, cache: cache?[i])
+        }
+        return norm(h).asType(embedded.dtype)
+    }
+}
+
+public final class Spark25Model: Module, LLMModel, KVCacheDimensionProvider {
+    public let vocabularySize: Int
+    public let kvHeads: [Int]
+    let model: Spark25ModelInner
+    let config: Spark25Configuration
+    @ModuleInfo(key: "lm_head") var lmHead: Linear?
+
+    public init(_ config: Spark25Configuration) {
+        self.config = config
+        vocabularySize = config.vocabularySize
+        kvHeads = Array(repeating: config.kvHeads, count: config.hiddenLayers)
+        model = Spark25ModelInner(config)
+        if !config.tieWordEmbeddings {
+            _lmHead.wrappedValue = Linear(config.hiddenSize, config.vocabularySize, bias: false)
+        }
+    }
+    public var loraLayers: [Module] { model.layers }
+    public func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        let h = model(inputs, cache: cache)
+        return lmHead?(h) ?? model.embedding.asLinear(h)
+    }
+    public func newCache(parameters: GenerateParameters? = nil) -> [KVCache] {
+        config.layerTypes.map { type in
+            if type == .sliding, let window = config.slidingWindow {
+                return RotatingKVCache(maxSize: window, keep: 0)
+            }
+            return KVCacheSimple()
+        }
+    }
+    public func sanitize(weights: [String: MLXArray]) -> [String: MLXArray] {
+        var result = weights
+        if config.tieWordEmbeddings { result["lm_head.weight"] = nil }
+        return result
+    }
+}

--- a/Libraries/MLXLMCommon/Tool/Parsers/GLM4ToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/GLM4ToolCallParser.swift
@@ -7,17 +7,53 @@ import Foundation
 public struct GLM4ToolCallParser: ToolCallParser, Sendable {
     public let startTag: String? = "<tool_call>"
     public let endTag: String? = "</tool_call>"
+    public var usesCustomEndBoundary: Bool { true }
 
     public init() {}
 
-    public func parse(content: String, tools: [[String: any Sendable]]?) -> ToolCall? {
-        // Strip tags if present
-        var text = content
-        if let start = startTag {
-            text = text.replacingOccurrences(of: start, with: "")
+    /// Argument values are raw text, not nested tool envelopes. Only a closer
+    /// outside an arg_value can finish the call (including across stream chunks).
+    public func completeToolCallEnd(in content: String) -> String.Index? {
+        var cursor = content.startIndex
+        while cursor < content.endIndex {
+            let close = content.range(of: "</tool_call>", range: cursor..<content.endIndex)
+            let value = content.range(of: "<arg_value>", range: cursor..<content.endIndex)
+            if let value, close == nil || value.lowerBound < close!.lowerBound {
+                guard let end = content.range(of: "</arg_value>", range: value.upperBound..<content.endIndex)
+                else { return nil }
+                cursor = end.upperBound
+            } else {
+                return close?.upperBound
+            }
         }
-        if let end = endTag {
-            text = text.replacingOccurrences(of: end, with: "")
+        return nil
+    }
+
+    public func parseEOS(_ content: String, tools: [[String: any Sendable]]?) -> [ToolCall] {
+        var remaining = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !remaining.hasPrefix("<tool_call>") {
+            return parse(content: remaining, tools: tools).map { [$0] } ?? []
+        }
+        var calls: [ToolCall] = []
+        while !remaining.isEmpty {
+            guard remaining.hasPrefix("<tool_call>"),
+                let end = completeToolCallEnd(in: remaining),
+                let call = parse(content: String(remaining[..<end]), tools: tools)
+            else { return [] }
+            calls.append(call)
+            remaining = String(remaining[end...]).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        return calls
+    }
+
+    public func parse(content: String, tools: [[String: any Sendable]]?) -> ToolCall? {
+        // Remove only the outer envelope. Global replacement corrupts strings
+        // that document the protocol or contain another call as literal data.
+        var text = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        if text.hasPrefix("<tool_call>") {
+            guard let end = completeToolCallEnd(in: text), end == text.endIndex else { return nil }
+            text.removeFirst("<tool_call>".count)
+            text.removeLast("</tool_call>".count)
         }
         text = text.trimmingCharacters(in: .whitespacesAndNewlines)
 
@@ -44,15 +80,17 @@ public struct GLM4ToolCallParser: ToolCallParser, Sendable {
         if nameEnd == nil {
             guard Self.isFunctionNameShaped(funcName) else { return nil }
         } else {
-            guard !funcName.isEmpty else { return nil }
+            guard !funcName.isEmpty, !funcName.contains("<"), !funcName.contains(">") else { return nil }
         }
 
         var arguments: [String: any Sendable] = [:]
 
         // An unfinished pair invalidates the entire call. Returning the pairs
         // parsed so far can execute a different operation from the emitted one.
-        var searchRange = text.startIndex ..< text.endIndex
+        var searchRange = (nameEnd ?? text.endIndex) ..< text.endIndex
         while let keyStart = text.range(of: "<arg_key>", range: searchRange) {
+            guard text[searchRange.lowerBound..<keyStart.lowerBound]
+                .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
             // Find </arg_key>
             guard
                 let keyEnd = text.range(
@@ -61,12 +99,16 @@ public struct GLM4ToolCallParser: ToolCallParser, Sendable {
 
             let key = String(text[keyStart.upperBound ..< keyEnd.lowerBound])
                 .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !key.isEmpty, !key.contains("<"), !key.contains(">"), arguments[key] == nil else { return nil }
 
             // Find <arg_value> after </arg_key>
             guard
                 let valueStart = text.range(
                     of: "<arg_value>", range: keyEnd.upperBound ..< text.endIndex)
             else { return nil }
+
+            guard text[keyEnd.upperBound..<valueStart.lowerBound]
+                .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
 
             // Find </arg_value>
             guard
@@ -86,6 +128,8 @@ public struct GLM4ToolCallParser: ToolCallParser, Sendable {
 
             searchRange = valueEnd.upperBound ..< text.endIndex
         }
+
+        guard text[searchRange].trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
 
         return ToolCall(function: .init(name: funcName, arguments: arguments))
     }

--- a/Libraries/MLXLMCommon/Tool/Parsers/GLM4ToolCallParser.swift
+++ b/Libraries/MLXLMCommon/Tool/Parsers/GLM4ToolCallParser.swift
@@ -49,14 +49,15 @@ public struct GLM4ToolCallParser: ToolCallParser, Sendable {
 
         var arguments: [String: any Sendable] = [:]
 
-        // Find all arg_key/arg_value pairs
+        // An unfinished pair invalidates the entire call. Returning the pairs
+        // parsed so far can execute a different operation from the emitted one.
         var searchRange = text.startIndex ..< text.endIndex
         while let keyStart = text.range(of: "<arg_key>", range: searchRange) {
             // Find </arg_key>
             guard
                 let keyEnd = text.range(
                     of: "</arg_key>", range: keyStart.upperBound ..< text.endIndex)
-            else { break }
+            else { return nil }
 
             let key = String(text[keyStart.upperBound ..< keyEnd.lowerBound])
                 .trimmingCharacters(in: .whitespacesAndNewlines)
@@ -65,13 +66,13 @@ public struct GLM4ToolCallParser: ToolCallParser, Sendable {
             guard
                 let valueStart = text.range(
                     of: "<arg_value>", range: keyEnd.upperBound ..< text.endIndex)
-            else { break }
+            else { return nil }
 
             // Find </arg_value>
             guard
                 let valueEnd = text.range(
                     of: "</arg_value>", range: valueStart.upperBound ..< text.endIndex)
-            else { break }
+            else { return nil }
 
             let value = String(text[valueStart.upperBound ..< valueEnd.lowerBound])
                 .trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
+++ b/Libraries/MLXLMCommon/Tool/ToolCallFormat.swift
@@ -372,6 +372,9 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
         }
 
         // GLM/GLM-style families (glm4, glm4_moe, glm5, glm47, GPT-OSS).
+        if compact == "spark25" {
+            return .glm4
+        }
         if compact.hasPrefix("glm4")
             || compact.hasPrefix("glm5")
             || compact.hasPrefix("glm47")
@@ -549,6 +552,9 @@ public enum ToolCallFormat: String, Sendable, Codable, CaseIterable {
         let n = name.lowercased()
         let normalized = normalizedAlias(n)
         let compact = compactAlias(n)
+
+        // Spark2.5 declares the GLM arg_key/arg_value wire grammar by this name.
+        if compact == "spark25" { return .glm4 }
 
         // Direct rawValue match first (e.g. "xml_function", "minimax_m2").
         if let direct = ToolCallFormat(rawValue: n)

--- a/Tests/MLXLMTests/JinjaSparkTemplateTests.swift
+++ b/Tests/MLXLMTests/JinjaSparkTemplateTests.swift
@@ -1,0 +1,44 @@
+import Testing
+import VMLXJinja
+
+@Suite("Native Spark template primitives")
+struct JinjaSparkTemplateTests {
+    @Test func commentWhitespaceControls() throws {
+        #expect(try Template("a \n{#- comment -#}\n b").render([:]) == "ab")
+        #expect(try Template("a \n{# comment #}\n b").render([:]) == "a \n\n b")
+        #expect(try Template("a \n{#- comment #}\n b").render([:]) == "a\n b")
+        #expect(try Template("a \n{# comment -#}\n b").render([:]) == "a \nb")
+    }
+
+    @Test func quotedCommentLookingTextIsData() throws {
+        #expect(try Template("{{ 'a {#- literal -#} b' }}").render([:]) == "a {#- literal -#} b")
+    }
+
+    @Test func neighborsAreValuesWithUndefinedEdges() throws {
+        let source = "{% for x in xs %}{{ loop.previtem|default('L') }}:{{ x }}:{{ loop.nextitem|default('R') }};{% endfor %}"
+        #expect(try Template(source).render(["xs": .array([.int(1), .int(2), .int(3)])]) == "L:1:2;1:2:3;2:3:R;")
+        #expect(try Template(source).render(["xs": .array([.int(7)])]) == "L:7:R;")
+        #expect(try Template(source).render(["xs": .array([])]) == "")
+    }
+
+    @Test func nativeToolGroupingUsesNeighborRoles() throws {
+        let source = "{% for m in messages %}{% if m.role == 'tool' %}{% if loop.previtem is undefined or loop.previtem.role != 'tool' %}<T>{% endif %}{{ m.content }}{% if loop.nextitem is undefined or loop.nextitem.role != 'tool' %}</T>{% endif %}{% endif %}{% endfor %}"
+        let messages: [Value] = [.object(["role": .string("user")]),
+            .object(["role": .string("tool"), "content": .string("a")]),
+            .object(["role": .string("tool"), "content": .string("b")]),
+            .object(["role": .string("user")]),
+            .object(["role": .string("tool"), "content": .string("c")])]
+        #expect(try Template(source).render(["messages": .array(messages)]) == "<T>ab</T><T>c</T>")
+    }
+
+    @Test func filteredArrayNeighborsAndElseUseIncludedItems() throws {
+        let source = "{% for x in xs if x > 1 %}{{ loop.index }}/{{ loop.length }}:{{ loop.previtem|default('L') }}:{{ x }}:{{ loop.nextitem|default('R') }};{% else %}empty{% endfor %}"
+        #expect(try Template(source).render(["xs": .array([.int(1), .int(2), .int(0), .int(3)])]) == "1/2:L:2:3;2/2:2:3:R;")
+        #expect(try Template(source).render(["xs": .array([.int(0), .int(1)])]) == "empty")
+    }
+
+    @Test func nestedLoopsRestoreTheOuterNeighborScope() throws {
+        let source = "{% for x in xs %}{% for y in ys %}{{ loop.previtem|default('L') }}{% endfor %}:{{ loop.nextitem|default('R') }};{% endfor %}"
+        #expect(try Template(source).render(["xs": .array([.int(1), .int(2)]), "ys": .array([.int(3)])]) == "L:2;L:R;")
+    }
+}

--- a/Tests/MLXLMTests/Spark25CacheParityTests.swift
+++ b/Tests/MLXLMTests/Spark25CacheParityTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import MLX
+import Testing
+import MLXLMCommon
+@testable import MLXLLM
+
+/// Strict numerical diagnostic runs in a fresh process with TF32 disabled;
+/// production defaults are never changed by this test.
+@Suite("Spark mixed-window cache parity", .serialized,
+       .enabled(if: ProcessInfo.processInfo.environment["MLX_ENABLE_TF32"] == "0"))
+struct Spark25CacheParityTests {
+    @Test func longChunkedPrefillAndDiskContinuationMatchFreshAttention() throws {
+        try MLXMetalTestLock.withLock {
+            let model = Spark25Model(try Spark25Tests.config(["sliding_window": 512]))
+            #expect(model.parameters().flattened().reduce(0) { $0 + $1.1.size } < 250_000)
+            let tokens = MLXArray((0..<525).map { Int32(($0 * 7 + 3) % 127) }).reshaped(1, 525)
+            let baseline = model(tokens, cache: nil)
+            eval(baseline)
+            #expect(all(isFinite(baseline)).item(Bool.self))
+            let cache = model.newCache()
+            var offset = 0
+            for count in [509, 3, 1] {
+                let out = model(tokens[0..., offset..<(offset + count)], cache: cache)
+                eval(out, cache)
+                let expected = baseline[0..., (offset + count - 1)..<(offset + count), 0...]
+                let actual = out[0..., (count - 1)..<count, 0...]
+                let error = max(abs(actual - expected)).item(Float.self)
+                print("SPARK_CACHE chunk=\(count) boundary=\(offset + count) maxAbs=\(error)")
+                #expect(error < 1e-4)
+                offset += count
+            }
+            #expect(cache.allSatisfy { $0.offset == 513 })
+            let copied = cache.map { $0.copy() }
+            let file = FileManager.default.temporaryDirectory
+                .appendingPathComponent("spark-cache-\(UUID().uuidString).safetensors")
+            defer { try? FileManager.default.removeItem(at: file) }
+            try savePromptCache(url: file, cache: cache, metadata: ["case": "spark-513"])
+            let (restored, metadata) = try loadPromptCache(url: file)
+            #expect(metadata["case"] == "spark-513")
+            #expect(restored.prefix(3).allSatisfy { $0 is RotatingKVCache })
+            #expect(restored[3] is KVCacheSimple)
+            #expect(restored.map(\.metaState) == cache.map(\.metaState))
+            for count in [7, 5] {
+                let input = tokens[0..., offset..<(offset + count)]
+                let continuous = model(input, cache: cache)
+                let fromCopy = model(input, cache: copied)
+                let fromDisk = model(input, cache: restored)
+                eval(continuous, fromCopy, fromDisk)
+                let expected = baseline[0..., (offset + count - 1)..<(offset + count), 0...]
+                let actual = continuous[0..., (count - 1)..<count, 0...]
+                let error = max(abs(actual - expected)).item(Float.self)
+                print("SPARK_CACHE continuation=\(count) boundary=\(offset + count) maxAbs=\(error)")
+                #expect(error < 1e-4)
+                #expect(all(continuous .== fromCopy).item(Bool.self))
+                #expect(all(continuous .== fromDisk).item(Bool.self))
+                offset += count
+            }
+            #expect(restored.allSatisfy { $0.offset == 525 })
+        }
+    }
+}

--- a/Tests/MLXLMTests/Spark25ServingTests.swift
+++ b/Tests/MLXLMTests/Spark25ServingTests.swift
@@ -6,6 +6,79 @@ import MLXHuggingFace
 
 @Suite("Spark2.5 declared tool dialect", .serialized)
 struct Spark25DialectTests {
+    @Test func eosCannotPublishAnUnfinishedValueOrEnvelope() {
+        for raw in [
+            "<tool_call>write_note<arg_key>text</arg_key><arg_value>literal </tool_call>",
+            "<tool_call>write_note<arg_key>text</arg_key><arg_value>note</arg_value>",
+        ] {
+            let processor = ToolCallProcessor(format: .glm4)
+            for char in raw { _ = processor.processChunk(String(char)) }
+            #expect(processor.toolCalls.isEmpty)
+            _ = processor.processEOS()
+            #expect(processor.toolCalls.isEmpty)
+            #expect(processor.toolCallProtocolFailure == .malformedEnvelope)
+        }
+    }
+
+    @Test func literalClosersAndAdjacentCallsKeepTheirBoundaries() throws {
+        let value = "Literal <tool_call>example</tool_call> and <arg_key>key</arg_key>."
+        let first = "<tool_call>write_note<arg_key>text</arg_key><arg_value>\(value)</arg_value></tool_call>"
+        let raw = first + "<tool_call>lookup_marker</tool_call>"
+        let parser = GLM4ToolCallParser()
+        #expect(parser.parseEOS(raw, tools: nil).count == 2)
+        for split in 0...raw.count {
+            let index = raw.index(raw.startIndex, offsetBy: split)
+            let processor = ToolCallProcessor(format: .glm4)
+            _ = processor.processChunk(String(raw[..<index]))
+            _ = processor.processChunk(String(raw[index...]))
+            #expect(processor.toolCalls.map(\.function.name) == ["write_note", "lookup_marker"], "split \(split)")
+            #expect(processor.toolCalls.first?.function.arguments["text"] == .string(value))
+            #expect(processor.toolCallProtocolFailure == nil)
+        }
+    }
+
+    @Test func malformedStructureOutsideValuesIsNotReinterpreted() {
+        let pair = "<arg_key>text</arg_key><arg_value>note</arg_value>"
+        for body in [
+            "write_note<tool_call>other\(pair)",
+            "write_note\(pair)<tool_call>other",
+            "write_note<arg_key>text</arg_key><tool_call>other<arg_value>note</arg_value>",
+            "write_note\(pair)unparsed suffix",
+            "write_note\(pair)\(pair)",
+        ] {
+            let raw = "<tool_call>\(body)</tool_call>"
+            #expect(GLM4ToolCallParser().parse(content: raw, tools: nil) == nil)
+            #expect(GLM4ToolCallParser().parseEOS(raw, tools: nil).isEmpty)
+            let processor = ToolCallProcessor(format: .glm4)
+            for char in raw { _ = processor.processChunk(String(char)) }
+            #expect(processor.toolCalls.isEmpty)
+            #expect(processor.toolCallProtocolFailure == .malformedEnvelope)
+        }
+    }
+
+    @Test func literalToolStartMarkerInsideStringArgumentIsNotDeleted() throws {
+        let value = "Document <tool_call> as the opening marker."
+        let body = "write_note<arg_key>text</arg_key><arg_value>\(value)</arg_value>"
+        let function: [String: any Sendable] = [
+            "name": "write_note", "parameters": ["type": "object",
+                "properties": ["text": ["type": "string"]], "required": ["text"]] as [String: any Sendable]]
+        let tools: [[String: any Sendable]] = [["type": "function", "function": function]]
+        for input in [body, "<tool_call>\(body)</tool_call>"] {
+            let call = try #require(GLM4ToolCallParser().parse(content: input, tools: tools))
+            #expect(call.function.arguments["text"] == .string(value))
+        }
+        let raw = "<tool_call>\(body)</tool_call>"
+        for split in 0...raw.count {
+            let index = raw.index(raw.startIndex, offsetBy: split)
+            let processor = ToolCallProcessor(format: .glm4, tools: tools)
+            _ = processor.processChunk(String(raw[..<index]))
+            _ = processor.processChunk(String(raw[index...]))
+            #expect(processor.toolCalls.count == 1)
+            #expect(processor.toolCalls.first?.function.arguments["text"] == .string(value), "split \(split)")
+            #expect(processor.toolCallProtocolFailure == nil)
+        }
+    }
+
     @Test func incompleteArgumentCannotPublishAPartialCall() {
         let processor = ToolCallProcessor(format: .glm4)
         _ = processor.processChunk("<tool_call>read_file<arg_key>path</arg_key><arg_value>note.md</arg_value><arg_key>limit</arg_key></tool_call>")

--- a/Tests/MLXLMTests/Spark25ServingTests.swift
+++ b/Tests/MLXLMTests/Spark25ServingTests.swift
@@ -1,0 +1,143 @@
+import Foundation
+import Testing
+import MLXLMCommon
+import MLXHuggingFace
+@preconcurrency import VMLXTokenizers
+
+@Suite("Spark2.5 declared tool dialect", .serialized)
+struct Spark25DialectTests {
+    @Test func incompleteArgumentCannotPublishAPartialCall() {
+        let processor = ToolCallProcessor(format: .glm4)
+        _ = processor.processChunk("<tool_call>read_file<arg_key>path</arg_key><arg_value>note.md</arg_value><arg_key>limit</arg_key></tool_call>")
+        #expect(processor.toolCalls.isEmpty)
+        #expect(processor.toolCallProtocolFailure == .malformedEnvelope)
+    }
+
+    @Test func nativeCallSurvivesEveryTwoChunkBoundary() throws {
+        let text = "<tool_call>read_file<arg_key>path</arg_key><arg_value>note.md</arg_value></tool_call>"
+        for offset in 0...text.count {
+            let index = text.index(text.startIndex, offsetBy: offset)
+            let processor = ToolCallProcessor(format: .glm4)
+            _ = processor.processChunk(String(text[..<index]))
+            _ = processor.processChunk(String(text[index...]))
+            #expect(processor.toolCalls.count == 1, "split \(offset)")
+            #expect(processor.toolCalls.first?.function.arguments["path"] == .string("note.md"))
+            #expect(processor.toolCallProtocolFailure == nil)
+        }
+    }
+
+    @Test func promptOwnedReasoningOpenerNeedsNoSyntheticOutputTag() throws {
+        for mode in [true, false] {
+            var parser = try #require(ReasoningParser.forPrompt(
+                stampName: "qwen3", promptTail: "<|Bot|>" + (mode ? "<think>" : "</think>")))
+            let output = mode ? "Check the result.</think>Done." : "Done."
+            var reasoning = ""
+            var content = ""
+            var segments: [ReasoningSegment] = []
+            for char in output { segments += parser.feed(String(char)) }
+            segments += parser.flush()
+            for segment in segments {
+                switch segment {
+                case .reasoning(let text): reasoning += text
+                case .content(let text): content += text
+                }
+            }
+            #expect(content == "Done.")
+            #expect(reasoning == (mode ? "Check the result." : ""))
+        }
+    }
+
+    @Test func bundleAndArchitectureResolveTheNativeArgumentDialect() throws {
+        #expect(ToolCallFormat.infer(from: "spark2_5") == .glm4)
+        let format = try #require(ToolCallFormat.fromCapabilityName("spark25"))
+        #expect(format == .glm4)
+        let properties: [String: any Sendable] = [
+            "path": ["type": "string"], "options": ["type": "object"]]
+        let parameters: [String: any Sendable] = [
+            "type": "object", "properties": properties, "required": ["path"]]
+        let function: [String: any Sendable] = ["name": "read_file", "parameters": parameters]
+        let tools: [[String: any Sendable]] = [["type": "function", "function": function]]
+        let call = try #require(format.createParser().parse(
+            content: #"<tool_call>read_file<arg_key>path</arg_key><arg_value>007</arg_value><arg_key>options</arg_key><arg_value>{"enabled":true,"items":[1,2]}</arg_value></tool_call>"#,
+            tools: tools))
+        #expect(call.function.name == "read_file")
+        #expect(call.function.arguments["path"] == .string("007"))
+        #expect(call.function.arguments["options"] == .object([
+            "enabled": .bool(true), "items": .array([.int(1), .int(2)])
+        ]))
+    }
+}
+
+/// Optional local bundle proof: tokenizer/config only, never model weights.
+@Suite("Actual Spark2.5 native tokenizer bridge", .serialized,
+       .enabled(if: FileManager.default.fileExists(atPath: FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent("models/JANGQ-AI/Spark-X2.5-4B-JANG_8M/tokenizer.json").path)))
+struct Spark25NativeTokenizerTests {
+    private var directory: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("models/JANGQ-AI/Spark-X2.5-4B-JANG_8M")
+    }
+
+    @Test func nativeModeTailsAndSpecialTokens() async throws {
+        let tokenizer = try await #huggingFaceTokenizerLoader().load(
+            from: JangLoader.resolveChatTemplateSidecarSubstitution(for: directory))
+        #expect(tokenizer.eosTokenId == 1)
+        for (token, id) in [("<think>", 3), ("</think>", 4), ("<tool_call>", 130977),
+                            ("</tool_call>", 130984), ("<arg_key>", 130980)] {
+            #expect(tokenizer.convertTokenToId(token) == id)
+        }
+        let expected = "<｜start▁of▁sentence｜><|System|>\nyou are a helpful assistant."
+            + "<｜end▁of▁sentence｜><｜start▁of▁sentence｜><|User|>What is 2 plus 3?"
+            + "<｜end▁of▁sentence｜><｜start▁of▁sentence｜><|Bot|>"
+        for thinking: Bool? in [nil, true, false] {
+            let ids = try tokenizer.applyChatTemplate(
+                messages: [["role": "user", "content": "What is 2 plus 3?"]], tools: nil,
+                additionalContext: thinking.map { ["enable_thinking": $0] })
+            let rendered = tokenizer.decode(tokenIds: ids, skipSpecialTokens: false)
+            #expect(rendered == expected + (thinking == false ? "</think>" : "<think>"))
+            print("SPARK_NATIVE mode=\(String(describing: thinking)) ids=\(ids) text=\(rendered.debugDescription)")
+        }
+    }
+
+    @Test func nativeToolsKeepTheCompleteParameterContract() async throws {
+        let tokenizer = try await #huggingFaceTokenizerLoader().load(
+            from: JangLoader.resolveChatTemplateSidecarSubstitution(for: directory))
+        let options: [String: any Sendable] = [
+            "type": "object", "properties": ["enabled": ["type": "boolean"]]]
+        let properties: [String: any Sendable] = ["path": ["type": "string"], "options": options]
+        let parameters: [String: any Sendable] = [
+            "type": "object", "properties": properties, "required": ["path"]]
+        let function: [String: any Sendable] = [
+            "name": "read_file", "description": "Read a file", "parameters": parameters]
+        let tools: [[String: any Sendable]] = [["type": "function", "function": function]]
+        for thinking: Bool? in [nil, true, false] {
+            let ids = try tokenizer.applyChatTemplate(messages: [["role": "user", "content": "Read note.md"]],
+                tools: tools, additionalContext: thinking.map { ["enable_thinking": $0] })
+            let text = tokenizer.decode(tokenIds: ids, skipSpecialTokens: false)
+            let start = try #require(text.range(of: "<tools>\n"))
+            let end = try #require(text.range(of: "\n</tools>"))
+            let actual = try JSONSerialization.jsonObject(with: Data(text[start.upperBound..<end.lowerBound].utf8)) as? NSDictionary
+            let expected = try JSONSerialization.jsonObject(with: JSONSerialization.data(withJSONObject: function)) as? NSDictionary
+            #expect(actual == expected)
+            #expect(text.hasPrefix("<｜start▁of▁sentence｜><|System|>\nyou are a helpful assistant.## Tools\n"))
+            #expect(text.hasSuffix("<|Bot|>" + (thinking == false ? "</think>" : "<think>")))
+            #expect(!text.contains("<function="))
+            print("SPARK_CATALOG mode=\(String(describing: thinking)) tokens=\(ids.count) text=\(text.debugDescription)")
+        }
+    }
+
+    @Test func nativeToolHistoryPreservesCallAndConsecutiveResults() async throws {
+        let tokenizer = try await #huggingFaceTokenizerLoader().load(
+            from: JangLoader.resolveChatTemplateSidecarSubstitution(for: directory))
+        let call = ToolCall(function: .init(name: "read_file", arguments: ["path": .string("note.md")]))
+        let messages = [defaultMessageDict(for: .user("Read the note.")),
+            defaultMessageDict(for: .assistant("", toolCalls: [call])),
+            ["role": "tool", "content": "first"], ["role": "tool", "content": "second"]]
+        let ids = try tokenizer.applyChatTemplate(messages: messages, tools: nil, additionalContext: nil)
+        let text = tokenizer.decode(tokenIds: ids, skipSpecialTokens: false)
+        #expect(text.contains("<|Bot|></think><tool_call>read_file<arg_key>path</arg_key><arg_value>note.md</arg_value></tool_call><｜end▁of▁sentence｜>"))
+        #expect(text.contains("<|Tool|><tool_response>first</tool_response><tool_response>second</tool_response><｜end▁of▁sentence｜>"))
+        #expect(text.hasSuffix("<|Bot|><think>"))
+        print("SPARK_HISTORY tokens=\(ids.count) text=\(text.debugDescription)")
+    }
+}

--- a/Tests/MLXLMTests/Spark25Tests.swift
+++ b/Tests/MLXLMTests/Spark25Tests.swift
@@ -1,0 +1,108 @@
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import Testing
+
+@testable import MLXLLM
+
+@Suite(.serialized)
+struct Spark25Tests {
+    static func config(_ overrides: [String: Any] = [:]) throws -> Spark25Configuration {
+        var fields: [String: Any] = [
+            "hidden_size": 64, "num_hidden_layers": 4, "intermediate_size": 96,
+            "num_attention_heads": 4, "num_key_value_heads": 2, "head_dim": 32,
+            "vocab_size": 128, "rms_norm_eps": 0.000001, "hidden_act": "gelu",
+            "gate_attn_act_mode": "sigmoid", "headwise_attn_output_gate": true,
+            "attention_bias": false, "mlp_bias": false, "tie_word_embeddings": true,
+            "sliding_window": 4,
+            "layer_types": [
+                "sliding_attention", "sliding_attention", "sliding_attention", "full_attention",
+            ],
+            "rope_parameters": [
+                "full_attention": ["rope_theta": 5_000_000.0, "partial_rotary_factor": 0.25],
+                "sliding_attention": ["rope_theta": 10_000.0, "partial_rotary_factor": 1.0],
+            ],
+        ]
+        fields.merge(overrides) { _, new in new }
+        return try JSONDecoder().decode(
+            Spark25Configuration.self, from: JSONSerialization.data(withJSONObject: fields))
+    }
+
+    @Test func configRejectsIncompatibleGeometryBeforeConstruction() throws {
+        for bad: [String: Any] in [
+            ["num_key_value_heads": 3], ["head_dim": 0], ["hidden_act": "silu"],
+            ["layer_types": ["full_attention"]], ["layer_types": ["unknown"]],
+            ["sliding_window": 0], ["gate_attn_act_mode": "unknown"],
+            [
+                "rope_parameters": [
+                    "full_attention": ["rope_theta": 10000, "partial_rotary_factor": 0.1]
+                ]
+            ],
+        ] {
+            #expect(throws: DecodingError.self) { try Self.config(bad) }
+        }
+    }
+
+    @Test func tensorNamesAndGeometryMatchFusedCheckpoint() throws {
+        try MLXMetalTestLock.withLock {
+            let model = Spark25Model(try Self.config())
+            let parameters = Dictionary(uniqueKeysWithValues: model.parameters().flattened())
+            #expect(parameters.values.reduce(0) { $0 + $1.size } < 250_000)
+            #expect(parameters["model.embedding.weight"]?.shape == [128, 64])
+            #expect(parameters["model.layers.0.self_attn.q_k_v_proj.weight"]?.shape == [256, 64])
+            #expect(parameters["model.layers.0.self_attn.out_proj.weight"]?.shape == [64, 128])
+            #expect(parameters["model.layers.0.self_attn.g_proj.weight"]?.shape == [4, 64])
+            #expect(parameters["lm_head.weight"] == nil)
+            #expect(parameters["model.embed_tokens.weight"] == nil)
+            #expect(model.config.rotary(for: .full).partialFactor == 0.25)
+            #expect(model.config.rotary(for: .sliding).partialFactor == 1)
+        }
+    }
+
+    @Test func tiedProjectionAndResidualStayFloatingAfterQuantization() throws {
+        try MLXMetalTestLock.withLock {
+            let model = Spark25Model(try Self.config())
+            quantize(
+                model: model, groupSize: 32, bits: 8,
+                filter: { path, _ in
+                    !path.hasSuffix("g_proj")
+                })
+            #expect(model.model.embedding is QuantizedEmbedding)
+            #expect(model.model.layers[0].attention.qkv is QuantizedLinear)
+            #expect(!(model.model.layers[0].attention.gate is QuantizedLinear))
+            let tokens = MLXArray([Int32(1), 5, 7]).reshaped(1, 3)
+            let cache = model.newCache()
+            let logits = model(tokens, cache: cache)
+            eval(logits)
+            #expect(logits.shape == [1, 3, 128])
+            #expect(logits.dtype == .float32)
+            #expect(all(isFinite(logits)).item(Bool.self))
+            #expect((max(logits) - min(logits)).item(Float.self) > 0)
+            let hidden = model.model(tokens, cache: nil)
+            #expect(
+                all(model.model.embedding.asLinear(hidden) .== model(tokens, cache: nil)).item(
+                    Bool.self))
+        }
+    }
+
+    @Test func mixedCacheUsesOwnOffsetsAndBounds() throws {
+        try MLXMetalTestLock.withLock {
+            let model = Spark25Model(try Self.config())
+            let cache = model.newCache()
+            #expect(cache.prefix(3).allSatisfy { $0 is RotatingKVCache })
+            #expect(cache[3] is KVCacheSimple)
+            for token in 0 ..< 11 {
+                let logits = model(MLXArray([Int32(token)]).reshaped(1, 1), cache: cache)
+                eval(logits)
+                eval(cache)
+                #expect(all(isFinite(logits)).item(Bool.self))
+                #expect(cache.allSatisfy { $0.offset == token + 1 })
+            }
+            for layer in cache.prefix(3) {
+                #expect(layer.state.allSatisfy { $0.dim(2) <= 4 })
+            }
+            #expect(cache[3].state.allSatisfy { $0.dim(2) == 11 })
+        }
+    }
+}

--- a/Vendors/Jinja/Sources/Jinja/Interpreter.swift
+++ b/Vendors/Jinja/Sources/Jinja/Interpreter.swift
@@ -310,6 +310,24 @@ public enum Interpreter {
 
             switch iterableValue {
             case let .array(items):
+                // Loop metadata and neighbors describe the items that actually
+                // participate, not entries excluded by a Jinja for-if filter.
+                let items: [Value] = try {
+                    guard let test else { return items }
+                    let filterEnv = Environment(parent: env)
+                    return try items.filter { item in
+                        switch loopVar {
+                        case let .single(name): filterEnv[name] = item
+                        case let .tuple(names):
+                            if case let .array(values) = item {
+                                for (i, name) in names.enumerated() {
+                                    filterEnv[name] = i < values.count ? values[i] : .undefined
+                                }
+                            }
+                        }
+                        return try evaluateExpression(test, env: filterEnv).isTruthy
+                    }
+                }()
                 if items.isEmpty {
                     // Execute else block
                     for node in elseBody {
@@ -331,12 +349,10 @@ public enum Interpreter {
                             }
                         }
 
-                        childEnv["loop"] = makeLoopObject(index: index, totalCount: items.count)
-                        if let test = test {
-                            let testValue = try evaluateExpression(test, env: childEnv)
-                            if !testValue.isTruthy { continue }
-                        }
-
+                        childEnv["loop"] = makeLoopObject(
+                            index: index, totalCount: items.count,
+                            previous: index > 0 ? items[index - 1] : .undefined,
+                            next: index + 1 < items.count ? items[index + 1] : .undefined)
                         var shouldBreak = false
                         for node in body {
                             do {
@@ -785,7 +801,9 @@ public enum Interpreter {
         throw JinjaError.runtime("Unknown filter: \(filterName)")
     }
 
-    private static func makeLoopObject(index: Int, totalCount: Int) -> Value {
+    private static func makeLoopObject(
+        index: Int, totalCount: Int, previous: Value = .undefined, next: Value = .undefined
+    ) -> Value {
         var loopContext: OrderedDictionary<String, Value> = [
             "index": .int(index + 1),
             "index0": .int(index),
@@ -794,6 +812,8 @@ public enum Interpreter {
             "length": .int(totalCount),
             "revindex": .int(totalCount - index),
             "revindex0": .int(totalCount - index - 1),
+            "previtem": previous,
+            "nextitem": next,
         ]
 
         loopContext["cycle"] = .function { args, _, _ in

--- a/Vendors/Jinja/Sources/Jinja/Lexer.swift
+++ b/Vendors/Jinja/Sources/Jinja/Lexer.swift
@@ -48,12 +48,29 @@ public enum Lexer: Sendable {
                 }
             }
 
-            let (token, newPosition) = try extractToken(
+            let (token, extractedPosition) = try extractToken(
                 from: preprocessed,
                 at: position,
                 inTag: inTag,
                 curlyBracketDepth: curlyBracketDepth
             )
+            var newPosition = extractedPosition
+
+            // Comments have the same explicit whitespace controls as statements.
+            // Handle them only after lexing a real comment, never with a global
+            // replacement that could alter a quoted template string.
+            if token.kind == .comment {
+                if token.value.hasPrefix("-"), let previous = tokens.last,
+                    previous.kind == .text {
+                    var value = previous.value
+                    while value.last?.isWhitespace == true { value.removeLast() }
+                    tokens[tokens.count - 1] = Token(
+                        kind: .text, value: value, position: previous.position)
+                }
+                if token.value.hasSuffix("-") {
+                    newPosition = skipWhitespace(in: preprocessed, at: newPosition)
+                }
+            }
 
             switch token.kind {
             case .openExpression, .openStatement:


### PR DESCRIPTION
## PROOF — runtime scope at 42269ff06a78854ccb14854846a514c55244e596

Source review covers Spark25Model/attention/mixed caches, the factory entry, native dialect resolution, GLM4ToolCallParser boundaries, and Jinja comment/array-neighbor behavior. Exact-head focused tests: 114/114 across 10 suites, including shared parser and MiniCPM tokenizer controls. The earlier isolated marker-framing regression failed before the correction. The separate tiny >512-token mixed-cache diagnostic retains its explicit TF32-off qualification; no production setting was changed.

Actual Osaurus Release app source415d10c856b906bf6a33fc6b4ac84dfd42feb7bc, engine42269ff06a78854ccb14854846a514c55244e596, binary SHA256a5d7b4782753a5f0f3ddc9e84f4a0358e251de5620547f99c81afb2753813e2d:

- JANG_8M: five visible turns, history recall and three actual time-tool calls with changed arguments/results; four agent-policy thinking-off turns and one explicit thinking-on turn. Correct final answers, closed reasoning, natural stops, no protocol leakage. Settled displayed rates67.0/63.3/81.9/72.3/96.7tok/s (the fifth initially displayed91.3 before the finalized metrics).
- JANG_6M: selected without loading; Send then loaded it and rebuilt history. Correct recall106.1tok/s and UTC-tool/result+recall112.8tok/s (initial displayed rate). No sampler coercion; bundle temp1/top_p.95/top_k-1/rep1 applied.
- App-owned disk-prefix hits observed during growing tool history. Effective topology27rotating/9full,fp16 KV,pagedRAMoff,diskL2on,TurboQuant KV layers0. NativeMTP absent/tensors0, no forced greedy sampling. After idle eviction, loaded list empty and footprint~1.00GB; next6M request reloaded and restored boundary24 from disk, correct response112.7334tok/s.
- Named supervised app run peak sampled tracked physical footprint2.85GB, settled~1.98–2.02GB loaded; normal pressure, swap1.53GB→1.52GB through this update. No source/BF16 or large GLM run.

Limits retained: the earlier synthetic thinking-OFF tool-introduction task failed in Swift and Python; these successful different tasks do not close that model-quality case. Cross-family grammar tests are not live qualification of every GLM-family model. No long-context capacity or speculative speed claim.

Osaurus integration remains separate: exact-head eight CI checks succeeded after one unchanged-head core rerun (first failure preserved). Live API tool call/result semantics succeeded, but pre-existing ChatEngine tool-response accounting reports zero completion tokens and loses terminal stats through early dispatch; this is an open app-side finding, not a runtime fix claimed here. Remaining UI/cache-policy/permission/lifecycle matrix stays explicit. Runtime CI is waived by maintainer direction; no release.
