### PR TITLE
Gate original-shard alignment repair on direct Send and report progress

### DIFF
--- a/Libraries/MLXLMCommon/Cache/AlignmentRepairProgress.swift
+++ b/Libraries/MLXLMCommon/Cache/AlignmentRepairProgress.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Original-file repair requires both explicit opt-in and a direct user Send.
+/// Background consumers must keep `.disabled`, including parent-model restore.
+public enum AlignmentRepairAuthorization: Sendable, Equatable {
+    case disabled
+    case directUserSend
+}
+
+/// Per-shard preparation, not a transaction across the entire model bundle.
+public struct AlignmentRepairProgress: Sendable, Equatable {
+    public enum Stage: Sendable, Equatable { case copying, verifying, installed, fallback }
+    public let bundle: URL
+    public let shard: URL
+    public let stage: Stage
+    public let copiedBytes: UInt64
+    public let totalBytes: UInt64
+
+    public init(bundle: URL, shard: URL, stage: Stage, copiedBytes: UInt64, totalBytes: UInt64) {
+        self.bundle = bundle
+        self.shard = shard
+        self.stage = stage
+        self.copiedBytes = copiedBytes
+        self.totalBytes = totalBytes
+    }
+
+    /// Scoped to the load task. Hosts must additionally match their load identity
+    /// before displaying an event; an observer never authorizes a rewrite.
+    @TaskLocal public static var observer: (@Sendable (AlignmentRepairProgress) -> Void)?
+}

--- a/Libraries/MLXLMCommon/Cache/JangPressPrestacker.swift
+++ b/Libraries/MLXLMCommon/Cache/JangPressPrestacker.swift
@@ -45,7 +45,8 @@ public enum JangPressPrestacker {
 
     public static func prepareBundleIfNeeded(
         originalURL: URL,
-        enabled: Bool
+        enabled: Bool,
+        alignmentRepairAuthorization: AlignmentRepairAuthorization = .disabled
     ) throws -> URL {
         guard enabled else { return originalURL }
 
@@ -54,7 +55,8 @@ public enum JangPressPrestacker {
         // writable model directories. Hash-addressed/symlinked stores and all
         // failures retain the original shard and use MLX's aligned-copy
         // fallback, so storage optimization can never refuse a model load.
-        SafetensorsStorageHealer.healBundleIfEligible(at: originalURL)
+        SafetensorsStorageHealer.healBundleIfEligible(
+            at: originalURL, authorization: alignmentRepairAuthorization)
 
         let env = ProcessInfo.processInfo.environment
         let prestackRaw = env["MLXPRESS_PRESTACK"] ?? env["JANGPRESS_PRESTACK"]

--- a/Libraries/MLXLMCommon/Cache/LoadConfiguration.swift
+++ b/Libraries/MLXLMCommon/Cache/LoadConfiguration.swift
@@ -106,6 +106,8 @@ public enum ResidentCap: Sendable, Equatable {
 /// `loadModel(from:using:loadConfiguration:)` overload (added in
 /// step 2) consumes this struct.
 public struct LoadConfiguration: Sendable, Equatable {
+    /// Default-denied original-file repair. Does not replace the existing opt-in.
+    public var alignmentRepairAuthorization: AlignmentRepairAuthorization = .disabled
     /// Cold-weight (MLXPress) policy.
     public var jangPress: JangPressPolicy
 

--- a/Libraries/MLXLMCommon/Cache/SafetensorsStorageHealer.swift
+++ b/Libraries/MLXLMCommon/Cache/SafetensorsStorageHealer.swift
@@ -20,6 +20,8 @@ enum SafetensorsStorageHealer {
         var environment: [String: String] = ProcessInfo.processInfo.environment
         var availableBytes: ((URL) throws -> UInt64)?
         var failAfterCopiedBytes: UInt64?
+        var checkCancellation: () throws -> Void = { try Task.checkCancellation() }
+        var progress: (AlignmentRepairProgress) -> Void = { AlignmentRepairProgress.observer?($0) }
         var logger: (String) -> Void = { message in
             fputs("[SafetensorsStorageHealer] \(message)\n", stderr)
         }
@@ -53,7 +55,11 @@ enum SafetensorsStorageHealer {
     private static let freeSpaceReserve = UInt64(512 * 1024 * 1024)
     private static let maximumHeaderBytes = UInt64(100_000_000)
 
-    static func healBundleIfEligible(at originalURL: URL) {
+    static func healBundleIfEligible(
+        at originalURL: URL,
+        authorization: AlignmentRepairAuthorization = .disabled
+    ) {
+        guard authorization == .directUserSend else { return }
         _ = healBundle(at: originalURL, configuration: Configuration())
     }
 
@@ -135,6 +141,7 @@ enum SafetensorsStorageHealer {
         }
 
         for shard in entries {
+            if (try? configuration.checkCancellation()) == nil { break }
             result.scannedShards += 1
             do {
                 let values = try shard.resourceValues(forKeys: [.isSymbolicLinkKey])
@@ -178,12 +185,15 @@ enum SafetensorsStorageHealer {
                     sourceHeader: header,
                     sourceAttributes: attributes,
                     directoryFD: directoryFD,
-                    failAfterCopiedBytes: configuration.failAfterCopiedBytes)
+                    configuration: configuration)
                 result.healedShards += 1
                 configuration.logger(
                     "event=healed shard=\(quoted(shard.path)) tensors=\(header.tensors.count) bytes=\(sourceSize)"
                 )
             } catch {
+                configuration.progress(.init(
+                    bundle: directory, shard: shard, stage: .fallback,
+                    copiedBytes: 0, totalBytes: 0))
                 result.fallbackShards += 1
                 configuration.logger(
                     "event=fallback reason=heal_failed shard=\(quoted(shard.path)) detail=\(quoted(String(describing: error)))"
@@ -199,7 +209,7 @@ enum SafetensorsStorageHealer {
         sourceHeader: Header,
         sourceAttributes: [FileAttributeKey: Any],
         directoryFD: Int32,
-        failAfterCopiedBytes: UInt64?
+        configuration: Configuration
     ) throws {
         let temporary = shard.deletingLastPathComponent().appendingPathComponent(
             ".\(shard.lastPathComponent).vmlx-heal-\(UUID().uuidString).tmp")
@@ -223,6 +233,14 @@ enum SafetensorsStorageHealer {
             cursor = addition.partialValue
         }
         let headerData = try makeHeader(metadata: sourceHeader.metadata, tensors: rewritten)
+        let totalBytes = cursor
+        func report(_ stage: AlignmentRepairProgress.Stage, _ copied: UInt64) {
+            configuration.progress(.init(
+                bundle: shard.deletingLastPathComponent(), shard: shard,
+                stage: stage, copiedBytes: copied, totalBytes: totalBytes))
+        }
+        try configuration.checkCancellation()
+        report(.copying, 0)
 
         let outputFD = systemOpen(
             temporary.path,
@@ -257,7 +275,9 @@ enum SafetensorsStorageHealer {
                 byteLength: tensor.byteLength,
                 outputFD: outputFD,
                 copied: &copied,
-                failAfterCopiedBytes: failAfterCopiedBytes)
+                failAfterCopiedBytes: configuration.failAfterCopiedBytes,
+                checkCancellation: configuration.checkCancellation,
+                progress: { report(.copying, $0) })
         }
         guard systemFsync(outputFD) == 0 else {
             throw posixError("fsync", temporary.path)
@@ -275,6 +295,8 @@ enum SafetensorsStorageHealer {
         }
 
         let outputHeader = try readHeader(temporary)
+        try configuration.checkCancellation()
+        report(.verifying, copied)
         try verifyDescriptorsAndPayloads(
             sourceURL: shard,
             sourceHeader: sourceHeader,
@@ -282,6 +304,7 @@ enum SafetensorsStorageHealer {
             outputHeader: outputHeader)
 
         let currentAttributes = try FileManager.default.attributesOfItem(atPath: shard.path)
+        try configuration.checkCancellation()
         guard sameSourceIdentity(sourceAttributes, currentAttributes) else {
             throw healerError("source changed during heal")
         }
@@ -293,6 +316,7 @@ enum SafetensorsStorageHealer {
         // The shard itself is already durable. Directory fsync is best effort
         // because some filesystems reject fsync on directory descriptors.
         _ = systemFsync(directoryFD)
+        report(.installed, copied)
     }
 
     private static func readHeader(_ url: URL) throws -> Header {
@@ -430,13 +454,16 @@ enum SafetensorsStorageHealer {
         byteLength: UInt64,
         outputFD: Int32,
         copied: inout UInt64,
-        failAfterCopiedBytes: UInt64?
+        failAfterCopiedBytes: UInt64?,
+        checkCancellation: () throws -> Void,
+        progress: (UInt64) -> Void
     ) throws {
         let buffer = UnsafeMutableRawPointer.allocate(byteCount: bufferBytes, alignment: 4096)
         defer { buffer.deallocate() }
         var remaining = byteLength
         var offset = sourceOffset
         while remaining > 0 {
+            try checkCancellation()
             if let limit = failAfterCopiedBytes, copied >= limit {
                 throw healerError("injected interrupted write")
             }
@@ -451,6 +478,7 @@ enum SafetensorsStorageHealer {
             remaining -= UInt64(read)
             offset += UInt64(read)
             copied += UInt64(read)
+            progress(copied)
         }
     }
 

--- a/Libraries/MLXLMCommon/ModelFactory.swift
+++ b/Libraries/MLXLMCommon/ModelFactory.swift
@@ -713,12 +713,13 @@ public func loadModel(
     //    compression/reclaim instead of a large stacked cache overlay.
     //    Active-expert pread streaming is an explicit fallback/diagnostic
     //    path only. Before mmap, ordinary writable model directories are
-    //    automatically healed when a safetensors shard has dtype-misaligned
-    //    offsets. The older side-copy alignment overlay remains separately
+    //    healed only with direct-Send authorization AND explicit repair opt-in.
+    //    The older side-copy alignment overlay remains separately
     //    gated by MLXPRESS_ALIGN_* / JANGPRESS_ALIGN_*.
     let loadDirectory = try JangPressPrestacker.prepareBundleIfNeeded(
         originalURL: directory,
-        enabled: useMmapSafetensors)
+        enabled: useMmapSafetensors,
+        alignmentRepairAuthorization: loadConfiguration.alignmentRepairAuthorization)
 
     // 5. Load the model normally. Patched osaurus mlx-swift pins honor
     //    MLX_SAFETENSORS_MMAP=1 inside loadArraysAndMetadata(url:),

--- a/Tests/AlignmentRepairStandaloneProof.swift
+++ b/Tests/AlignmentRepairStandaloneProof.swift
@@ -1,0 +1,144 @@
+// Foundation-only proof of the production storage implementation. No MLX or model load.
+import Foundation
+
+@main
+struct AlignmentRepairStandaloneProof {
+    static func require(_ value: Bool, _ label: String) throws {
+        if !value { throw NSError(domain: label, code: 1) }
+    }
+
+    static func fixture(_ shard: URL) throws {
+        let header: [String: Any] = [
+            "__metadata__": ["format": "pt", "mxtq_bits": "8"],
+            "norm.weight": ["dtype": "BF16", "shape": [1], "data_offsets": [0, 2]],
+            "experts.0.weight": ["dtype": "U32", "shape": [1], "data_offsets": [2, 6]],
+            "dense.weight": ["dtype": "F32", "shape": [1], "data_offsets": [6, 10]],
+        ]
+        var json = try JSONSerialization.data(withJSONObject: header, options: [.sortedKeys])
+        while (8 + json.count) % 8 != 0 { json.append(32) }
+        var length = UInt64(json.count).littleEndian
+        var data = withUnsafeBytes(of: &length) { Data($0) }
+        data.append(json)
+        data.append(contentsOf: Array(0..<10))
+        try data.write(to: shard)
+    }
+
+    static func payloads(_ shard: URL) throws -> [String: Data] {
+        let data = try Data(contentsOf: shard)
+        let length = data.prefix(8).withUnsafeBytes { Int($0.loadUnaligned(as: UInt64.self)) }
+        let base = 8 + length
+        let header = try JSONSerialization.jsonObject(with: data[8..<base]) as! [String: Any]
+        var result: [String: Data] = [:]
+        for (name, value) in header where name != "__metadata__" {
+            let tensor = value as! [String: Any]
+            let offsets = tensor["data_offsets"] as! [Int]
+            result[name] = data[(base + offsets[0])..<(base + offsets[1])]
+        }
+        result["__metadata__"] = try JSONSerialization.data(
+            withJSONObject: header["__metadata__"]!, options: [.sortedKeys])
+        return result
+    }
+
+    static func main() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("alignment-proof-\(UUID())")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let shard = root.appendingPathComponent("model.safetensors")
+        var config = SafetensorsStorageHealer.Configuration(
+            environment: ["MLXPRESS_HEAL_SAFETENSORS": "1"],
+            availableBytes: { _ in UInt64.max }, logger: { print($0) })
+        try fixture(shard)
+        let original = try Data(contentsOf: shard)
+        let expected = try payloads(shard)
+        let saved = ProcessInfo.processInfo.environment["MLXPRESS_HEAL_SAFETENSORS"]
+        setenv("MLXPRESS_HEAL_SAFETENSORS", "1", 1)
+        defer {
+            if let saved { setenv("MLXPRESS_HEAL_SAFETENSORS", saved, 1) }
+            else { unsetenv("MLXPRESS_HEAL_SAFETENSORS") }
+        }
+        SafetensorsStorageHealer.healBundleIfEligible(at: root)
+        try require(try Data(contentsOf: shard) == original, "default denied with env opt-in")
+        print("PASS default-denied production entry")
+        SafetensorsStorageHealer.healBundleIfEligible(at: root, authorization: .directUserSend)
+        try require(try payloads(shard) == expected && Data(contentsOf: shard) != original,
+                    "direct-send production entry")
+        print("PASS explicitly authorized production entry")
+        try fixture(shard)
+
+        var events: [AlignmentRepairProgress] = []
+        config.progress = { events.append($0) }
+        let result = SafetensorsStorageHealer.healBundle(at: root, configuration: config)
+        try require(result.healedShards == 1, "repair")
+        try require(try payloads(shard) == expected, "named payload and metadata preservation")
+        try require(events.map(\.stage).contains(.verifying) && events.last?.stage == .installed, "progress stages")
+        try require(events.last?.copiedBytes == 10 && events.last?.totalBytes == 10, "measured bytes")
+        print("PASS repair + exact payload/metadata + real progress")
+        let repaired = try Data(contentsOf: shard)
+        events.removeAll()
+        let repeatResult = SafetensorsStorageHealer.healBundle(at: root, configuration: config)
+        try require(repeatResult.healedShards == 0 && events.isEmpty, "repeat silent no-op")
+        try require(try Data(contentsOf: shard) == repaired, "repeat unchanged")
+        print("PASS repeat/aligned no-op")
+
+        for mode in ["disk", "interrupt", "cancel", "optout"] {
+            try fixture(shard)
+            var failure = config
+            if mode == "disk" { failure.availableBytes = { _ in 0 } }
+            if mode == "interrupt" { failure.failAfterCopiedBytes = 3 }
+            if mode == "optout" { failure.environment = [:] }
+            var cancelled = false
+            if mode == "cancel" {
+                failure.progress = { if $0.stage == .verifying { cancelled = true } }
+                failure.checkCancellation = { if cancelled { throw CancellationError() } }
+            }
+            let outcome = SafetensorsStorageHealer.healBundle(at: root, configuration: failure)
+            try require(outcome.healedShards == 0, mode)
+            try require(try Data(contentsOf: shard) == original, "original preserved: \(mode)")
+            let files = try FileManager.default.contentsOfDirectory(atPath: root.path)
+            try require(!files.contains(where: { $0.contains(".vmlx-heal-") }), "temp cleanup")
+            print("PASS \(mode) original preserved + temp cleanup")
+        }
+        try Data([0, 1, 2]).write(to: shard)
+        let malformed = SafetensorsStorageHealer.healBundle(at: root, configuration: config)
+        try require(malformed.fallbackShards == 1, "malformed refusal")
+        try require(try Data(contentsOf: shard) == Data([0, 1, 2]), "malformed unchanged")
+        print("PASS malformed refusal; storage-only proof complete")
+        try fixture(shard)
+        var changed = original
+        changed.append(99)
+        var sourceChange = config
+        sourceChange.progress = {
+            if $0.stage == .verifying { try! changed.write(to: shard) }
+        }
+        let changedResult = SafetensorsStorageHealer.healBundle(at: root, configuration: sourceChange)
+        try require(changedResult.healedShards == 0, "source-change refused")
+        try require(try Data(contentsOf: shard) == changed, "external writer not overwritten")
+        print("PASS changed source is not replaced")
+        let dtypes: [(String, Int)] = [
+            ("C128", 16), ("F64", 8), ("I64", 8), ("U64", 8), ("C64", 8),
+            ("F32", 4), ("I32", 4), ("U32", 4), ("F16", 2), ("BF16", 2),
+            ("I16", 2), ("U16", 2), ("BOOL", 1), ("U8", 1), ("I8", 1),
+            ("F8_E5M2", 1), ("F8_E4M3", 1), ("F8_E4M3FN", 1),
+            ("F8_E4M3FNUZ", 1), ("F8_E5M2FNUZ", 1), ("F8_E8M0", 1),
+        ]
+        for (dtype, bytes) in dtypes {
+            let header: [String: Any] = [
+                "__metadata__": ["format": "pt"],
+                "prefix": ["dtype": "U8", "shape": [1], "data_offsets": [0, 1]],
+                "weight": ["dtype": dtype, "shape": [1], "data_offsets": [1, 1 + bytes]],
+            ]
+            var json = try JSONSerialization.data(withJSONObject: header, options: [.sortedKeys])
+            while (8 + json.count) % 16 != 0 { json.append(32) }
+            var length = UInt64(json.count).littleEndian
+            var data = withUnsafeBytes(of: &length) { Data($0) }
+            data.append(json)
+            data.append(contentsOf: Array(repeating: UInt8(37), count: 1 + bytes))
+            try data.write(to: shard)
+            let before = try payloads(shard)
+            let outcome = SafetensorsStorageHealer.healBundle(at: root, configuration: config)
+            try require(outcome.healedShards == (bytes > 1 ? 1 : 0), "dtype \(dtype)")
+            try require(try payloads(shard) == before, "dtype payload \(dtype)")
+        }
+        print("PASS 21 supported storage dtypes, including byte-aligned no-ops")
+    }
+}

--- a/Tests/MLXLMTests/JangPressSafetensorsAlignmentTests.swift
+++ b/Tests/MLXLMTests/JangPressSafetensorsAlignmentTests.swift
@@ -166,7 +166,8 @@ struct JangPressSafetensorsAlignmentTests {
         setenv("MLXPRESS_HEAL_SAFETENSORS", "1", 1)
 
         let prepared = try JangPressPrestacker.prepareBundleIfNeeded(
-            originalURL: bundle, enabled: true)
+            originalURL: bundle, enabled: true,
+            alignmentRepairAuthorization: .directUserSend)
 
         #expect(prepared.standardizedFileURL == bundle.standardizedFileURL)
         #expect(try Self.readFixture(shard).unalignedCount == 0)


### PR DESCRIPTION
Adds default-denied original-shard repair authorization alongside the existing explicit opt-in, actual per-shard copy/verification progress, and cancellation checks before replacement.

Native proof uses Osaurus610c0e1d0 with this exact runtime9460dcc1 and signed binary8adcc013: visible copy/verification banner on direct Send, coherent follow-up, no repeated repair after reload, cold API/spawn/parent-restore exclusions on genuinely misaligned copies, and Stop during verification preserving the original followed by a successful retry. Production storage-only tests cover exact payload/metadata preservation, failure paths, and21 dtype tags. Full raw evidence and failed-row accounting: https://github.com/osaurus-ai/vmlx-swift/pull/459#issuecomment-5606273767.

Original-file repair remains opt-in. Atomicity is per shard, not a bundle-wide or cross-process transaction. This is not general corrupt-tensor recovery, universal model-family qualification, or low-RAM qualification. No release cut.
