### PR TITLE
Respect fixed native MTP depth ceilings and use monotonic timing

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/BatchEngine.swift
@@ -2108,6 +2108,12 @@ public actor BatchEngine {
                             }
                             return count
                         }
+                        if diskRestored == 0 {
+                            coordinator.rejectDiskCandidate(
+                                tokens: Array(tokenIds.prefix(matchedTokens)),
+                                arrays: diskArrays,
+                                mediaSalt: slot.mediaSalt)
+                        }
                         if diskRestored > 0 {
                             restoredTokenCount = diskRestored
                             // 2026-04-27 fix: materialize restored cache state

--- a/Libraries/MLXLMCommon/BatchEngine/CompilableMambaCache.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/CompilableMambaCache.swift
@@ -121,6 +121,7 @@ public final class CompilableMambaCache: MambaCache, @unchecked Sendable {
     ///   prefill of Mamba / GDN layers.
     public convenience init(from mamba: MambaCache) {
         self.init(slots: mamba.slotCount, leftPadding: nil)
+        self.persistentStateSlotCount = mamba.persistentStateSlotCount
 
         // Copy offset + leftPadding from source.
         self.offset = mamba.offset
@@ -257,6 +258,7 @@ public final class CompilableMambaCache: MambaCache, @unchecked Sendable {
 
     public override func copy() -> any KVCache {
         let new = CompilableMambaCache(slots: stableSlotCount)
+        new.persistentStateSlotCount = persistentStateSlotCount
         new.offset = self.offset
         new.leftPadding = self.leftPadding
         for index in 0 ..< stableSlotCount {

--- a/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
@@ -713,7 +713,11 @@ public final class CacheCoordinator: @unchecked Sendable {
         else {
             return false
         }
-        if isHybrid, requiresRecurrentSSMCompanion {
+        // Match storeAfterGeneration's payload contract, not the broader
+        // path-dependence flag. Mamba state is persisted inside the v2 row;
+        // requiring an intentionally unwritten sidecar rebuilds every boundary.
+        // ArraysCache/GDN still requires its separate recurrent payload.
+        if isHybrid, requiresSeparateRecurrentPayload {
             return ssmStateCache.hasValidatedCompleteDiskEntry(
                 tokens: tokens,
                 boundary: tokens.count,
@@ -732,7 +736,7 @@ public final class CacheCoordinator: @unchecked Sendable {
     ) -> Bool {
         guard diskCache?.hasDurableEntry(tokens: tokens, mediaSalt: mediaSalt) == true
         else { return false }
-        if isHybrid, requiresRecurrentSSMCompanion {
+        if isHybrid, requiresSeparateRecurrentPayload {
             return ssmStateCache.hasValidatedCompleteDiskEntry(
                 tokens: tokens,
                 boundary: tokens.count,

--- a/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheCoordinator.swift
@@ -702,6 +702,16 @@ public final class CacheCoordinator: @unchecked Sendable {
         return .miss
     }
 
+    /// A structurally readable disk payload can still be incompatible with
+    /// the model's cache layout. Do not retain its validated/durable status
+    /// after that rejection, or stable-prefix stores will elide the repair.
+    /// Invoke after leaving any serialized MLX restore closure.
+    public func rejectDiskCandidate(
+        tokens: [Int], arrays: [String: MLXArray], mediaSalt: String? = nil
+    ) {
+        diskCache?.rejectCandidate(tokens: tokens, arrays: arrays, mediaSalt: mediaSalt)
+    }
+
     /// True only after the current process has deserialized or written the
     /// exact L2 entry and its on-disk fingerprint still matches the index.
     public func hasValidatedDiskEntry(

--- a/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
@@ -833,6 +833,18 @@ private func restoreFromV2Arrays(
             continue
         }
         switch entry.data {
+        case .mamba(let comp):
+            guard canRestoreMambaLayer(comp, into: cache[entry.index]) else {
+                FileHandle.standardError.write(Data(
+                    "[disk cache] restore REFUSED: incomplete or incompatible Mamba persistent slots at layer \(entry.index), stored capacity \(comp.persistentSlotCount)\n".utf8))
+                return 0
+            }
+        case .cacheList(let subs):
+            for sub in subs {
+                if case .requiredMiss = sub { return 0 }
+                if case .mamba(let comp) = sub,
+                   !canRestoreMambaLayer(comp, into: cache[entry.index]) { return 0 }
+            }
         case .qkv(let comp):
             // Quantized-KV layers share the atomic contract: a record whose
             // group size / bit width no longer matches the runtime cache (or
@@ -1610,13 +1622,30 @@ private func restoreZayaCCATQLayer(
 /// `CacheList` containing one). Silently no-ops for other cache classes,
 /// which can happen if the serialized model layout has drifted from the
 /// current runtime.
+private func canRestoreMambaLayer(
+    _ comp: TQDiskSerializer.MambaLayerComponents, into layer: any KVCache
+) -> Bool {
+    if let mamba = layer as? MambaCache {
+        return comp.offset >= 0
+            && comp.persistentSlotCount == mamba.persistentStateSlotCount
+            && comp.persistentSlotCount <= mamba.slotCount
+            && (comp.persistentSlotCount <= 2
+                || (comp.state1 != nil
+                    && comp.additionalStates.count == comp.persistentSlotCount - 2))
+    }
+    if let list = layer as? CacheList {
+        return (0..<list.count).contains { canRestoreMambaLayer(comp, into: list[$0]) }
+    }
+    return false
+}
+
 private func restoreMambaLayer(
     _ comp: TQDiskSerializer.MambaLayerComponents,
     into layer: any KVCache
 ) {
     func apply(_ mamba: MambaCache) {
         if let state1 = comp.state1 {
-            mamba.state = [comp.state0, state1]
+            mamba.state = [comp.state0, state1] + comp.additionalStates
         } else {
             // Single-slot layout (LFM2/LFM2.5 short-conv): restore into
             // slot 0 via the subscript so the 2-slot container geometry is

--- a/Libraries/MLXLMCommon/Cache/DiskCache.swift
+++ b/Libraries/MLXLMCommon/Cache/DiskCache.swift
@@ -96,6 +96,21 @@ public final class DiskCache: @unchecked Sendable {
         let modificationDate: Date
     }
 
+    private struct TensorLayout: Equatable {
+        let shape: [Int]
+        let dtype: DType
+    }
+
+    private struct ValidatedEntry {
+        let fingerprint: ValidatedFileFingerprint
+        let layout: [String: TensorLayout]
+        let candidateIdentity: [String: ObjectIdentifier]?
+    }
+
+    private static func layout(of arrays: [String: MLXArray]) -> [String: TensorLayout] {
+        arrays.mapValues { TensorLayout(shape: $0.shape, dtype: $0.dtype) }
+    }
+
     // MARK: - Properties
 
     /// Root directory for cache files and the SQLite index.
@@ -153,7 +168,7 @@ public final class DiskCache: @unchecked Sendable {
     /// fingerprint lets `store` avoid realizing and rewriting the same large
     /// prompt boundary after a cache hit, while a fresh process still validates
     /// an inherited file before it can take the fast path.
-    private var validatedFiles: [String: ValidatedFileFingerprint] = [:]
+    private var validatedFiles: [String: ValidatedEntry] = [:]
 
     /// Trace-only identity of the most recent boundary written by this cache
     /// instance. Growing agent loops can store N tokens and immediately probe N
@@ -350,7 +365,8 @@ public final class DiskCache: @unchecked Sendable {
         // entry instead of preserving an assumption.
         if let validated = validatedFiles[hash],
            let current = _fileFingerprint(url: url),
-           current == validated,
+           current == validated.fingerprint,
+           validated.layout == Self.layout(of: arrays),
            let indexed = _entryMetadataLocked(hash: hash),
            indexed.tokenCount == tokenCount,
            indexed.fileSize == current.size,
@@ -421,7 +437,9 @@ public final class DiskCache: @unchecked Sendable {
 
             _insertEntryLocked(hash: hash, tokenCount: tokenCount, fileSize: fileSize)
             if let fingerprint = _fileFingerprint(url: finalURL), fingerprint.size > 0 {
-                validatedFiles[hash] = fingerprint
+                validatedFiles[hash] = ValidatedEntry(
+                    fingerprint: fingerprint, layout: Self.layout(of: arrays),
+                    candidateIdentity: nil)
             } else {
                 validatedFiles.removeValue(forKey: hash)
             }
@@ -516,7 +534,9 @@ public final class DiskCache: @unchecked Sendable {
                 throw DiskCacheIntegrityError.nonFinitePayload(nonFinite.joined(separator: ","))
             }
             if let fingerprint = _fileFingerprint(url: url), fingerprint.size > 0 {
-                validatedFiles[hash] = fingerprint
+                validatedFiles[hash] = ValidatedEntry(
+                    fingerprint: fingerprint, layout: Self.layout(of: arrays),
+                    candidateIdentity: arrays.mapValues { ObjectIdentifier($0) })
             }
             if touchRecency {
                 _touchEntryLocked(hash: hash)
@@ -574,7 +594,7 @@ public final class DiskCache: @unchecked Sendable {
 
         guard let validated = validatedFiles[hash],
               let current = _fileFingerprint(url: url),
-              current == validated,
+              current == validated.fingerprint,
               current.size > 0,
               let indexed = _entryMetadataLocked(hash: hash),
               indexed.tokenCount == tokens.count,
@@ -611,6 +631,37 @@ public final class DiskCache: @unchecked Sendable {
             return false
         }
         return true
+    }
+
+    /// Invalidate the candidate identified by this instance's last fetch.
+    /// Preserve a file whose observed fingerprint changed in the meantime.
+    /// Call outside withSerializedMLXCacheIO (the IO lock is non-recursive).
+    @discardableResult
+    func rejectCandidate(
+        tokens: [Int], arrays: [String: MLXArray], mediaSalt: String? = nil
+    ) -> Bool {
+        let hash = Self.hashTokens(tokens, modelKey: modelKey, mediaSalt: mediaSalt)
+        let url = safetensorsURL(for: hash)
+        MLXDiskCacheIOLock.shared.lock()
+        defer { MLXDiskCacheIOLock.shared.unlock() }
+        lock.lock()
+        defer { lock.unlock() }
+        guard let validated = validatedFiles[hash],
+              validated.candidateIdentity == arrays.mapValues({ ObjectIdentifier($0) }),
+              _fileFingerprint(url: url) == validated.fingerprint
+        else { return false }
+        validatedFiles.removeValue(forKey: hash)
+        do {
+            try FileManager.default.removeItem(at: url)
+            _deleteEntryLocked(hash: hash)
+            FileHandle.standardError.write(Data(
+                "[vmlx][cache/disk] removed model-rejected candidate hash=\(hash) tokens=\(tokens.count)\n".utf8))
+            return true
+        } catch {
+            FileHandle.standardError.write(Data(
+                "[vmlx][cache/disk] failed to remove model-rejected candidate hash=\(hash): \(error)\n".utf8))
+            return false
+        }
     }
 
     /// Candidate prompt-boundary lengths currently present in the disk index.

--- a/Libraries/MLXLMCommon/Cache/TQDiskSerializer.swift
+++ b/Libraries/MLXLMCommon/Cache/TQDiskSerializer.swift
@@ -456,7 +456,8 @@ public enum TQDiskSerializer {
     }
 
     /// Serialize a single MambaCache layer's state. Full Mamba layers carry
-    /// two slots (conv state + hidden state); LFM2/LFM2.5 short-conv layers
+    /// two slots (conv state + hidden state); extended hosts declare additional
+    /// persistent slots separately from temporary verifier scratch. LFM2/LFM2.5 short-conv layers
     /// occupy only slot 0, and dropping that single slot here (the old
     /// `count >= 2` guard) meant every disk restore handed the model 22
     /// zeroed conv windows while still reporting a KV hit.
@@ -465,18 +466,27 @@ public enum TQDiskSerializer {
         index i: Int,
         into result: inout [String: MLXArray]
     ) {
-        let state = mamba.state
-        guard state.count >= 1 else {
+        serializeMambaState(mamba, prefix: "mamba_\(i)", into: &result)
+    }
+
+    private static func serializeMambaState(
+        _ mamba: MambaCache, prefix: String, into result: inout [String: MLXArray]
+    ) {
+        guard mamba[0] != nil,
+              mamba.persistentStateSlotCount > 0,
+              mamba.persistentStateSlotCount <= mamba.slotCount else {
             // Pre-prefill layer with no state at all — nothing to persist.
             // Deserialization treats a tagged mamba layer without state as
             // an atomic required miss.
             return
         }
-        result["mamba_\(i)_state0"] = state[0]
-        if state.count >= 2 {
-            result["mamba_\(i)_state1"] = state[1]
+        for slot in 0..<mamba.persistentStateSlotCount {
+            if let state = mamba[slot] {
+                result["\(prefix)_state\(slot)"] = state
+            }
         }
-        result["__mamba_\(i)_offset__"] = metaInt32(Int32(mamba.offset))
+        result["__\(prefix)_persistent_slots__"] = metaInt32(Int32(mamba.persistentStateSlotCount))
+        result["__\(prefix)_offset__"] = metaInt32(Int32(mamba.offset))
     }
 
     /// Serialize a single RotatingKVCache layer (sliding-window attention).
@@ -561,12 +571,7 @@ public enum TQDiskSerializer {
             if let mamba = sub as? MambaCache {
                 let state = mamba.state
                 if state.count >= 1 {
-                    result["mamba_\(i)_sub_\(j)_state0"] = state[0]
-                    if state.count >= 2 {
-                        result["mamba_\(i)_sub_\(j)_state1"] = state[1]
-                    }
-                    result["__mamba_\(i)_sub_\(j)_offset__"] =
-                        metaInt32(Int32(mamba.offset))
+                    serializeMambaState(mamba, prefix: "mamba_\(i)_sub_\(j)", into: &result)
                     result[subKindKey(layer: i, sub: j)] = kindArray(.mamba)
                     anyPersisted = true
                 } else {
@@ -888,11 +893,41 @@ public enum TQDiskSerializer {
     /// single-slot layouts: LFM2/LFM2.5 short-conv layers only ever occupy
     /// slot 0 of their 2-slot `MambaCache` container
     /// (`jang_runtime.cache.conv: "arrays_state_size_1"`), while full Mamba
-    /// layers (Nemotron-H, Jamba) persist both conv and hidden state.
+    /// layers (Nemotron-H, Jamba) persist both conv and hidden state. Extended
+    /// hosts also carry every declared additional persistent slot.
     public struct MambaLayerComponents {
         public let state0: MLXArray
         public let state1: MLXArray?
         public let offset: Int
+        public var additionalStates: [MLXArray] = []
+        public var persistentSlotCount: Int = 2
+    }
+
+    /// Legacy one/two-slot entries remain readable for matching caches. An
+    /// extended declaration requires every persistent slot; missing metadata
+    /// cannot turn an old two-slot row into a complete PLE snapshot.
+    private static func deserializeMambaState(
+        prefix: String, arrays: [String: MLXArray], offset: Int
+    ) -> MambaLayerComponents? {
+        guard let state0 = arrays["\(prefix)_state0"] else { return nil }
+        let slots: Int
+        if let metadata = arrays["__\(prefix)_persistent_slots__"] {
+            guard let count = readMetaInt32(metadata), count > 0, count <= 64 else { return nil }
+            slots = Int(count)
+        } else {
+            slots = 2
+        }
+        var extra: [MLXArray] = []
+        if slots > 2 {
+            guard arrays["\(prefix)_state1"] != nil else { return nil }
+            for slot in 2..<slots {
+                guard let state = arrays["\(prefix)_state\(slot)"] else { return nil }
+                extra.append(state)
+            }
+        }
+        return MambaLayerComponents(
+            state0: state0, state1: arrays["\(prefix)_state1"], offset: offset,
+            additionalStates: extra, persistentSlotCount: slots)
     }
 
     /// RotatingKVCache state for a single sliding-window attention layer.
@@ -1145,7 +1180,7 @@ public enum TQDiskSerializer {
                     out.append(IndexedLayerData(index: i, data: .requiredMiss))
                 }
             case .mamba:
-                if let s0 = arrays["mamba_\(i)_state0"] {
+                if arrays["mamba_\(i)_state0"] != nil {
                     // `state1` is optional: short-conv (LFM2/LFM2.5) layers
                     // persist a single slot, full Mamba layers persist two.
                     let offset: Int
@@ -1172,16 +1207,16 @@ public enum TQDiskSerializer {
                         out.append(IndexedLayerData(index: i, data: .requiredMiss))
                         continue
                     }
+                    guard let component = deserializeMambaState(
+                        prefix: "mamba_\(i)", arrays: arrays, offset: offset)
+                    else {
+                        out.append(IndexedLayerData(index: i, data: .requiredMiss))
+                        continue
+                    }
                     out.append(
                         IndexedLayerData(
                             index: i,
-                            data: .mamba(
-                                MambaLayerComponents(
-                                    state0: s0,
-                                    state1: arrays["mamba_\(i)_state1"],
-                                    offset: offset
-                                )
-                            )
+                            data: .mamba(component)
                         )
                     )
                 } else {
@@ -1512,7 +1547,7 @@ public enum TQDiskSerializer {
                     subs.append(.skip)
                 }
             case .mamba:
-                if let s0 = arrays["mamba_\(i)_sub_\(j)_state0"] {
+                if arrays["mamba_\(i)_sub_\(j)_state0"] != nil {
                     let off: Int
                     if let oa = arrays["__mamba_\(i)_sub_\(j)_offset__"] {
                         guard let offValue = readMetaInt32(oa) else {
@@ -1523,12 +1558,10 @@ public enum TQDiskSerializer {
                     } else {
                         off = 0
                     }
-                    subs.append(
-                        .mamba(
-                            MambaLayerComponents(
-                                state0: s0,
-                                state1: arrays["mamba_\(i)_sub_\(j)_state1"],
-                                offset: off)))
+                    guard let component = deserializeMambaState(
+                        prefix: "mamba_\(i)_sub_\(j)", arrays: arrays, offset: off)
+                    else { return [.requiredMiss] }
+                    subs.append(.mamba(component))
                 } else {
                     subs.append(.skip)
                 }

--- a/Libraries/MLXLMCommon/Diffusion/BlockDiffusionTokenIterator.swift
+++ b/Libraries/MLXLMCommon/Diffusion/BlockDiffusionTokenIterator.swift
@@ -173,6 +173,12 @@ public struct BlockDiffusionTokenIterator: TokenIteratorProtocol {
                 }
                 if !restored, let diskArrays {
                     restored = restoreFromDiskArrays(diskArrays, into: &self.cache) > 0
+                    if !restored {
+                        coordinator.rejectDiskCandidate(
+                            tokens: Array(promptTokenIds.prefix(matchedTokens)),
+                            arrays: diskArrays,
+                            mediaSalt: mediaSalt)
+                    }
                     if restored {
                         MLX.eval(self.cache)
                     }

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -273,6 +273,10 @@ public struct GenerateParameters: Sendable {
     /// `DDTREE-DESIGN.md` for the full spec.
     public var draftStrategy: DraftStrategy? = nil
 
+    /// Fixed native-MTP depth is a ceiling; adaptive exploration must be
+    /// requested explicitly. Either policy may descend to shallower work or AR.
+    public var nativeMTPDepthPolicy: NativeMTPDepthPolicy = .fixed
+
     /// Additional text-level stop sequences. When any of these strings
     /// appears in the user-visible assistant output, the library halts
     /// generation, truncates the match and everything after it, and

--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -1980,6 +1980,12 @@ public struct TokenIterator: TokenIteratorProtocol {
                         }
                         return count
                     }
+                    if diskRestored == 0 {
+                        coordinator.rejectDiskCandidate(
+                            tokens: Array(cacheLookupTokenIds.prefix(matchedTokens)),
+                            arrays: diskArrays,
+                            mediaSalt: mediaSalt)
+                    }
                     if diskRestored > 0 {
                         restoredTokenCount = diskRestored
                         restored = true

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -617,15 +617,26 @@ public class QSAKVCache: KVCacheSimple {
     /// context every step).
     ///
     /// This lane is pure derivation from `indexerKeys`: it is never
-    /// serialized (`state` drops it), never copied, and any trim/rollback
-    /// clears it — the next forward rebuilds it from the raw lane in one
-    /// pass, bit-identical, and resumes incrementally after that.
+    /// serialized (`state` drops it) or copied. Rollback retains only complete
+    /// blocks covered by the accepted raw prefix. Unknown geometry fails
+    /// closed to a full rebuild rather than guessing a compression ratio.
     public var derivedPooledBlocks: MLXArray?
     public var derivedPooledBlockCount: Int = 0
+    private var derivedPoolCompressionRatio: Int?
+
+    /// The indexer supplies the active model's geometry, independently of
+    /// quantization. Changing it invalidates the previous derived lane.
+    public func prepareDerivedPooledBlocks(compressionRatio: Int) {
+        if compressionRatio <= 0 || derivedPoolCompressionRatio != compressionRatio {
+            dropDerivedPooledBlocks()
+        }
+        derivedPoolCompressionRatio = compressionRatio > 0 ? compressionRatio : nil
+    }
 
     public func dropDerivedPooledBlocks() {
         derivedPooledBlocks = nil
         derivedPooledBlockCount = 0
+        derivedPoolCompressionRatio = nil
     }
 
     public func updateIndexerKeys(_ rawKeys: MLXArray) -> MLXArray {
@@ -676,8 +687,24 @@ public class QSAKVCache: KVCacheSimple {
             if let existing = indexerKeys, existing.dim(1) > offset {
                 indexerKeys = existing[0..., ..<offset, 0...]
             }
-            // Rollback invalidates trailing blocks; rebuild from raw keys.
-            dropDerivedPooledBlocks()
+            // Complete blocks within the accepted prefix contain no rejected
+            // rows. Retain that prefix, but never retain a partial block.
+            if let ratio = derivedPoolCompressionRatio,
+                let pooled = derivedPooledBlocks, pooled.ndim == 3,
+                derivedPooledBlockCount >= 0,
+                derivedPooledBlockCount <= pooled.dim(1),
+                let raw = indexerKeys, raw.dim(1) >= offset
+            {
+                let keep = min(derivedPooledBlockCount, offset / ratio)
+                if keep > 0 {
+                    derivedPooledBlocks = pooled[0..., ..<keep, 0...]
+                    derivedPooledBlockCount = keep
+                } else {
+                    dropDerivedPooledBlocks()
+                }
+            } else {
+                dropDerivedPooledBlocks()
+            }
         }
         return trimmed
     }

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -1513,6 +1513,9 @@ public class ArraysCache: BaseKVCache {
 
 /// Simple cache for Mamba-style state space models
 public class MambaCache: ArraysCache {
+    /// Leading slots owned by the model across requests. Slots beyond this
+    /// boundary are temporary verification scratch, not reusable prefix state.
+    public var persistentStateSlotCount: Int
     private struct PrefixCommitState {
         var arrays: [MLXArray]
         var offset: Int
@@ -1521,6 +1524,7 @@ public class MambaCache: ArraysCache {
     private var prefixCommitStates: [Int: PrefixCommitState] = [:]
 
     public init(leftPadding: [Int]? = nil) {
+        persistentStateSlotCount = 2
         super.init(size: 2, leftPadding: leftPadding)
     }
 
@@ -1529,6 +1533,7 @@ public class MambaCache: ArraysCache {
     /// layer's cache and stores previous-context token ids in slot 2 and the
     /// dilated-conv state in slot 3.
     public init(slots: Int, leftPadding: [Int]? = nil) {
+        persistentStateSlotCount = slots
         super.init(size: slots, leftPadding: leftPadding)
     }
 
@@ -1646,6 +1651,7 @@ public class MambaCache: ArraysCache {
 
     public override func copy() -> any KVCache {
         let new = MambaCache(slots: slotCount)
+        new.persistentStateSlotCount = persistentStateSlotCount
         copySlots(into: new)
         new.offset = self.offset
         new.leftPadding = self.leftPadding

--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -537,6 +537,12 @@ public func loadWeights(
             JANGTQStreamingExperts.configureModelDirectory(modelDirectory)
         }
         let modelKeyExcluder = model as? any SafetensorsLoadKeyExcluding
+        let uncachedResidentRead = modelKeyExcluder?.requiresResidentSafetensorsWeights == true
+            && ProcessInfo.processInfo.environment["VMLX_FLASH_RESIDENT_READER"] == "uncached"
+        if uncachedResidentRead {
+            FileHandle.standardError.write(Data(
+                "[loadWeights] resident_reader=uncached_owned opt_in=true source_files_unchanged=true\n".utf8))
+        }
         for url in allShardURLs {
             let isPrestackedShard = url.lastPathComponent == "jangpress-prestacked.safetensors"
             let headerNames = (try? loadSafetensorsHeaderNamesForBaseLoad(url)) ?? []
@@ -577,10 +583,12 @@ public func loadWeights(
                     continue
                 }
             }
-            let (w, m) = try loadArraysAndMetadata(
-                url: url,
-                excludingKeys: excludedKeys,
-                exactTensorBuffers: modelKeyExcluder?.requiresExactTensorMmapBuffers == true)
+            let (w, m) = try uncachedResidentRead
+                ? ResidentSafetensorsReader.load(url: url, excludingKeys: excludedKeys)
+                : loadArraysAndMetadata(
+                    url: url,
+                    excludingKeys: excludedKeys,
+                    exactTensorBuffers: modelKeyExcluder?.requiresExactTensorMmapBuffers == true)
             var shardWeights: [String: MLXArray] = [:]
             for (key, value) in w {
                 if shouldFilterPreservedMTP, isPreservedMTPWeightKey(key) {
@@ -612,7 +620,7 @@ public func loadWeights(
                 // excluded above, so this materializes compute tensors only.
                 // `* 1` creates owned MLX storage even for already-contiguous
                 // mmap inputs (unlike `contiguous()`, which may return them as-is).
-                let resident = shardWeights.mapValues { $0 * 1 }
+                let resident = uncachedResidentRead ? shardWeights : shardWeights.mapValues { $0 * 1 }
                 MLX.eval(Array(resident.values))
                 residentSafetensorsBytes += resident.values.reduce(0) { $0 + $1.nbytes }
                 for (key, value) in resident { weights[key] = value }

--- a/Libraries/MLXLMCommon/ModelContainer.swift
+++ b/Libraries/MLXLMCommon/ModelContainer.swift
@@ -92,7 +92,9 @@ public struct ModelCacheTopologySnapshot: Codable, Sendable, Equatable {
     /// position: v2 has no `LayerKind` for it, so `restoreFromDiskArrays`
     /// leaves those layers at their initial value and the companion is the
     /// sole carrier. MambaCache state round-trips in-file as
-    /// `mamba_{i}_state0/1` and is restored by `deserializeV2` directly —
+    /// `mamba_{i}_stateN` with the model-declared persistent-slot capacity
+    /// (including extended PLE history/convolution, excluding verify scratch)
+    /// and is restored by `deserializeV2` directly —
     /// measured live on Qwen3.8-27B (48 mamba layers), the companion copies
     /// added ~300MB per stored boundary that the restore path never applied.
     ///

--- a/Libraries/MLXLMCommon/ResidentSafetensorsReader.swift
+++ b/Libraries/MLXLMCommon/ResidentSafetensorsReader.swift
@@ -60,13 +60,13 @@ enum ResidentSafetensorsReader {
         guard fstat(file.fileDescriptor, &status) == 0, status.st_size >= 8 else {
             throw InvalidFile(detail: "missing or short file")
         }
-        let prefix = try readExactly(file, count: 8)
+        let prefix = try readExactly(file, count: 8, fileSize: Int(status.st_size))
         let length = prefix.enumerated().reduce(UInt64(0)) { $0 | UInt64($1.element) << (8 * $1.offset) }
         guard length > 0, length <= 64 * 1024 * 1024,
             length <= UInt64(status.st_size - 8) else {
             throw InvalidFile(detail: "header length out of bounds")
         }
-        let header = try JSONDecoder().decode(Header.self, from: readExactly(file, count: Int(length)))
+        let header = try JSONDecoder().decode(Header.self, from: readExactly(file, count: Int(length), fileSize: Int(status.st_size)))
         let dataStart = 8 + Int(length)
         let dataLength = Int(status.st_size) - dataStart
         // Validate every entry before allocating any tensors, including excluded
@@ -109,7 +109,7 @@ enum ResidentSafetensorsReader {
         for (name, entry) in ordered where !excludingKeys.contains(name) {
             try autoreleasepool {
                 try file.seek(toOffset: UInt64(dataStart + entry.data_offsets[0]))
-                let data = try readExactly(file, count: entry.data_offsets[1] - entry.data_offsets[0])
+                let data = try readExactly(file, count: entry.data_offsets[1] - entry.data_offsets[0], fileSize: Int(status.st_size))
                 let array = MLXArray(data, entry.shape, dtype: dtypes[entry.dtype]!)
                 MLX.eval(array)
                 arrays[name] = array
@@ -121,14 +121,41 @@ enum ResidentSafetensorsReader {
         #endif
     }
 
-    private static func readExactly(_ file: FileHandle, count: Int) throws -> Data {
+    private static func readExactly(_ file: FileHandle, count: Int, fileSize: Int) throws -> Data {
+        #if canImport(Darwin)
+        let offset = try file.offset()
+        guard offset <= UInt64(fileSize), count >= 0, count <= fileSize - Int(offset) else {
+            throw InvalidFile(detail: "read range out of bounds")
+        }
+        if count == 0 { return Data() }
+        let start = Int(offset)
+        let end = start + count
+        let page = Int(getpagesize())
+        // Unaligned large reads can populate the filesystem cache even with
+        // F_NOCACHE. Read page-aligned ranges and retain only the requested bytes.
+        // This is I/O alignment, not a rewrite of the safetensors bundle.
+        var position = start - start % page
+        let padding = end % page == 0 ? 0 : min(page - end % page, fileSize - end)
+        let physicalEnd = end + padding
+        try file.seek(toOffset: UInt64(position))
         var result = Data()
         result.reserveCapacity(count)
-        while result.count < count {
-            guard let chunk = try file.read(upToCount: min(count - result.count, 4 * 1024 * 1024)),
-                !chunk.isEmpty else { throw InvalidFile(detail: "unexpected end of file") }
-            result.append(chunk)
+        while position < physicalEnd {
+            let remaining = physicalEnd - position
+            // Keep a partial EOF page separate from the aligned bulk read.
+            let amount = remaining < page ? remaining : min(remaining / page * page, 4 * 1024 * 1024)
+            guard let chunk = try file.read(upToCount: amount), chunk.count == amount else {
+                throw InvalidFile(detail: "short aligned read")
+            }
+            let lower = max(start - position, 0)
+            let upper = min(end - position, amount)
+            if lower < upper { result.append(chunk[lower..<upper]) }
+            position += amount
         }
+        try file.seek(toOffset: UInt64(end))
         return result
+        #else
+        throw InvalidFile(detail: "uncached owned reader requires Darwin")
+        #endif
     }
 }

--- a/Libraries/MLXLMCommon/ResidentSafetensorsReader.swift
+++ b/Libraries/MLXLMCommon/ResidentSafetensorsReader.swift
@@ -32,7 +32,9 @@ enum ResidentSafetensorsReader {
             let values = try decoder.container(keyedBy: Key.self)
             for key in values.allKeys {
                 if key.stringValue == "__metadata__" {
-                    metadata = try values.decode([String: String].self, forKey: key)
+                    // Existing safetensors readers treat null metadata as absent.
+                    // Some Flash Next shards use null while others omit the key.
+                    metadata = try values.decodeIfPresent([String: String].self, forKey: key) ?? [:]
                 } else {
                     entries[key.stringValue] = try values.decode(Entry.self, forKey: key)
                 }

--- a/Libraries/MLXLMCommon/ResidentSafetensorsReader.swift
+++ b/Libraries/MLXLMCommon/ResidentSafetensorsReader.swift
@@ -1,0 +1,132 @@
+import Foundation
+import MLX
+#if canImport(Darwin)
+import Darwin
+#endif
+
+/// Diagnostic opt-in for models that already require owned compute weights.
+/// Does not modify the source file or manufacture model/dtype defaults.
+enum ResidentSafetensorsReader {
+    struct InvalidFile: LocalizedError {
+        let detail: String
+        var errorDescription: String? { "Resident safetensors reader: \(detail)" }
+    }
+
+    private struct Entry: Decodable {
+        let dtype: String
+        let shape: [Int]
+        let data_offsets: [Int]
+    }
+
+    private struct Key: CodingKey {
+        var stringValue: String
+        var intValue: Int? { nil }
+        init?(stringValue: String) { self.stringValue = stringValue }
+        init?(intValue: Int) { return nil }
+    }
+
+    private struct Header: Decodable {
+        var entries: [String: Entry] = [:]
+        var metadata: [String: String] = [:]
+        init(from decoder: Decoder) throws {
+            let values = try decoder.container(keyedBy: Key.self)
+            for key in values.allKeys {
+                if key.stringValue == "__metadata__" {
+                    metadata = try values.decode([String: String].self, forKey: key)
+                } else {
+                    entries[key.stringValue] = try values.decode(Entry.self, forKey: key)
+                }
+            }
+        }
+    }
+
+    private static let dtypes: [String: DType] = [
+        "BOOL": .bool, "U8": .uint8, "U16": .uint16, "U32": .uint32, "U64": .uint64,
+        "I8": .int8, "I16": .int16, "I32": .int32, "I64": .int64,
+        "F16": .float16, "BF16": .bfloat16, "F32": .float32, "F64": .float64,
+    ]
+
+    static func load(url: URL, excludingKeys: Set<String>) throws -> ([String: MLXArray], [String: String]) {
+        #if canImport(Darwin)
+        guard url.isFileURL else { throw InvalidFile(detail: "not a file URL") }
+        let file = try FileHandle(forReadingFrom: url)
+        defer { try? file.close() }
+        guard fcntl(file.fileDescriptor, F_NOCACHE, 1) == 0 else {
+            throw InvalidFile(detail: "uncached I/O unavailable (errno \(errno))")
+        }
+        var status = stat()
+        guard fstat(file.fileDescriptor, &status) == 0, status.st_size >= 8 else {
+            throw InvalidFile(detail: "missing or short file")
+        }
+        let prefix = try readExactly(file, count: 8)
+        let length = prefix.enumerated().reduce(UInt64(0)) { $0 | UInt64($1.element) << (8 * $1.offset) }
+        guard length > 0, length <= 64 * 1024 * 1024,
+            length <= UInt64(status.st_size - 8) else {
+            throw InvalidFile(detail: "header length out of bounds")
+        }
+        let header = try JSONDecoder().decode(Header.self, from: readExactly(file, count: Int(length)))
+        let dataStart = 8 + Int(length)
+        let dataLength = Int(status.st_size) - dataStart
+        // Validate every entry before allocating any tensors, including excluded
+        // entries, so malformed shapes never reach MLX's nonthrowing constructors.
+        for (name, entry) in header.entries {
+            guard let dtype = dtypes[entry.dtype], entry.data_offsets.count == 2 else {
+                throw InvalidFile(detail: "unsupported dtype or offsets for \(name)")
+            }
+            let start = entry.data_offsets[0], end = entry.data_offsets[1]
+            guard start >= 0, end >= start, end <= dataLength else {
+                throw InvalidFile(detail: "out-of-bounds tensor \(name)")
+            }
+            var elements = 1
+            for dimension in entry.shape {
+                guard dimension >= 0 else { throw InvalidFile(detail: "negative shape for \(name)") }
+                let product = elements.multipliedReportingOverflow(by: dimension)
+                guard !product.overflow else { throw InvalidFile(detail: "shape overflow for \(name)") }
+                elements = product.partialValue
+            }
+            let size = elements.multipliedReportingOverflow(by: dtype.size)
+            guard !size.overflow, size.partialValue == end - start else {
+                throw InvalidFile(detail: "shape/byte mismatch for \(name)")
+            }
+        }
+        let ordered = header.entries.sorted {
+            if $0.value.data_offsets[0] == $1.value.data_offsets[0] {
+                return $0.value.data_offsets[1] < $1.value.data_offsets[1]
+            }
+            return $0.value.data_offsets[0] < $1.value.data_offsets[0]
+        }
+        var previousEnd = 0
+        for (_, entry) in ordered {
+            guard entry.data_offsets[0] == previousEnd else {
+                throw InvalidFile(detail: "overlapping or noncontiguous payload")
+            }
+            previousEnd = entry.data_offsets[1]
+        }
+        guard previousEnd == dataLength else { throw InvalidFile(detail: "unindexed payload bytes") }
+        var arrays: [String: MLXArray] = [:]
+        for (name, entry) in ordered where !excludingKeys.contains(name) {
+            try autoreleasepool {
+                try file.seek(toOffset: UInt64(dataStart + entry.data_offsets[0]))
+                let data = try readExactly(file, count: entry.data_offsets[1] - entry.data_offsets[0])
+                let array = MLXArray(data, entry.shape, dtype: dtypes[entry.dtype]!)
+                MLX.eval(array)
+                arrays[name] = array
+            }
+        }
+        return (arrays, header.metadata)
+        #else
+        throw InvalidFile(detail: "uncached owned reader requires Darwin")
+        #endif
+    }
+
+    private static func readExactly(_ file: FileHandle, count: Int) throws -> Data {
+        var result = Data()
+        result.reserveCapacity(count)
+        while result.count < count {
+            guard let chunk = try file.read(upToCount: min(count - result.count, 4 * 1024 * 1024)),
+                !chunk.isEmpty else { throw InvalidFile(detail: "unexpected end of file") }
+            result.append(chunk)
+        }
+        return result
+    }
+}

--- a/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
+++ b/Libraries/MLXLMCommon/ServerRuntimeSettings.swift
@@ -366,7 +366,7 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
                     // measured tuning artifact. An explicit bundle safety
                     // block still wins; a user request is not permission to
                     // bypass a known-bad production result.
-                    if status.nativeMTPTuning?.manualBlocked == true {
+                    if status.isExplicitlyBlocked {
                         issues.append(.error(
                             field: "mtp.mode",
                             message: "MTP is explicitly blocked by this bundle's tuning metadata: \(status.nativeMTPTuning?.reason ?? "no reason recorded")"))
@@ -439,7 +439,7 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
                 // Manual depth can bypass missing measurement, never an
                 // explicit bundle safety block.
                 return (status?.hasCompleteMTPArtifact == true
-                    && status?.nativeMTPTuning?.manualBlocked != true) ? .speculative : .blocked
+                    && status?.isExplicitlyBlocked != true) ? .speculative : .blocked
             }
             return (status?.canAutoLaunchMTP == true) ? .speculative : .blocked
         }
@@ -469,7 +469,7 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
         // Manual depth: an explicit user activation. Family/profile/tensor
         // evidence is still required (requireVerifiedRuntime: false skips only
         // the measured-tuning gate), the requested depth replaces the tuned
-        // recommendation, and greedy sampling is enforced for the session.
+        // recommendation. Sampling remains the resolved generation contract.
         if mtp.mode == .forceOn, let depth = mtp.explicitDepth {
             guard (1...3).contains(depth) else {
                 return .init(
@@ -477,7 +477,7 @@ public struct VMLXServerRuntimeSettings: Codable, Sendable, Equatable {
                     recommendation: nil,
                     reason: "MTP explicit depth must be 1, 2, or 3 (got \(depth)).")
             }
-            if status?.nativeMTPTuning?.manualBlocked == true {
+            if status?.isExplicitlyBlocked == true {
                 return .init(
                     launchMode: .blocked,
                     recommendation: nil,
@@ -1585,13 +1585,11 @@ public struct VMLXServerMTPSettings: Codable, Sendable, Equatable {
 
     /// Explicit user-enforced draft depth (1–3) for `mode == .forceOn`.
     ///
-    /// Manual depth is a different contract from Auto: Auto launches only
-    /// from a measured, usable `vmlx_mtp_tuning.json`, while an explicit
-    /// depth is a deliberate user activation that requires tensor-complete
-    /// MTP evidence for a supported runtime but NOT a tuning artifact —
-    /// the user is the measurement. Any active MTP launch (auto or manual)
-    /// forces greedy sampling for that model+session; see
-    /// ``mtpEnforcedGreedySampling``.
+    /// Auto requires usable tuning or a supported measured-family default.
+    /// Explicit depth can activate a supported MTP artifact without tuning,
+    /// but cannot bypass an explicit safety block. Choosing a depth is not
+    /// evidence of quality or speed. Sampling remains the request/runtime/
+    /// bundle contract, independent of the depth control.
     public var explicitDepth: Int?
 
     /// Folder holding a downloaded DFlash 2 drafter, or `nil` for none.
@@ -1625,11 +1623,10 @@ public struct VMLXServerMTPSettings: Codable, Sendable, Equatable {
         self.explicitDepth = explicitDepth
     }
 
-    /// The sampler override every active MTP launch enforces, scoped to the
-    /// requests of the model+session that runs speculative decode: greedy
-    /// (temperature 0, top-p 1, top-k 0, min-p 0). Measured on JANG_2L:
-    /// greedy MTP 41.4 tok/s with byte-exact AR parity; sampled MTP loses
-    /// ~10% and forfeits the parity guarantee.
+    /// Compatibility-only constants for an explicitly requested greedy run.
+    /// Despite the historical name, native MTP does not apply this override.
+    /// Hosts must preserve resolved generation parameters rather than using
+    /// these values merely because speculation is enabled.
     public static var mtpEnforcedGreedySampling:
         (temperature: Float, topP: Float, topK: Int, minP: Float)
     { (0, 1, 0, 0) }

--- a/Libraries/MLXLMCommon/SpecDec/DFlash2TokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/DFlash2TokenIterator.swift
@@ -444,7 +444,14 @@ struct DFlash2TokenIterator: TokenIteratorProtocol {
                     }
                 }
                 if let diskArrays, !restored {
-                    if restoreFromDiskArrays(diskArrays, into: &self.cache) > 0 {
+                    let diskRestored = restoreFromDiskArrays(diskArrays, into: &self.cache)
+                    if diskRestored == 0 {
+                        coordinator.rejectDiskCandidate(
+                            tokens: Array(tokensToPrefill.prefix(matchedTokens)),
+                            arrays: diskArrays,
+                            mediaSalt: mediaSalt)
+                    }
+                    if diskRestored > 0 {
                         if let ssm = ssmStates {
                             restoreSSMStates(ssm, into: self.cache, boundary: matchedTokens)
                         }

--- a/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
+++ b/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
@@ -974,8 +974,9 @@ public enum NativeMTPAutoDecodePolicy {
     /// measured tuning artifact. A tuning file, when present, contributes its
     /// explicit verifier mode. An explicitly blocked artifact vetoes manual
     /// activation too: `blocked` is the bundle owner's safety decision, not a
-    /// missing-measurement condition. Callers must pair every accepted manual
-    /// activation with greedy sampling for the model+session.
+    /// missing-measurement condition. Sampling remains the caller's resolved
+    /// generation contract; native MTP supports greedy and exact-p/q sampling
+    /// on eligible requests. Manual activation is not a performance proof.
     public static func manualRecommendation(
         depth: Int,
         configData: Data?,
@@ -999,7 +1000,7 @@ public enum NativeMTPAutoDecodePolicy {
             depth: depth,
             verifierMode: status.nativeMTPTuning?.explicitVerifierMode,
             reason:
-                "User-enforced manual depth \(depth): tensor-evidence activation without measured tuning; greedy sampling enforced for this model+session.",
+                "User-enforced manual depth \(depth): tensor-evidence activation without measured tuning; configured sampling is preserved.",
             evidence: evidence)
     }
 

--- a/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
+++ b/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
@@ -744,6 +744,12 @@ public extension NativeMTPModel {
     }
 }
 
+/// Explicit eligibility for the default-off sampled-staging experiment.
+/// Conformance is not production qualification. Other native-MTP formats must
+/// retain their existing verifier until separately checked with real cache state.
+public protocol NativeMTPSampledStagedDiagnosticModel:
+    NativeMTPModel, DFlash2StagedVerifyRollbackModel {}
+
 public enum NativeMTPActivationError: Error, LocalizedError, CustomStringConvertible {
     case requestedButMissingArtifact(MTPBundleStatus?)
     case requestedWithoutUsableTuning(MTPBundleStatus?)

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPClock.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPClock.swift
@@ -1,0 +1,19 @@
+// Copyright 2026 Osaurus AI. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+import Dispatch
+import Foundation
+
+/// Process-local elapsed-time clock, never a calendar timestamp. All iterator
+/// phase durations and governor windows must use the same time domain so a
+/// wall-clock correction cannot suppress a loss or fabricate a slow cycle.
+enum NativeMTPClock {
+    @inline(__always)
+    static func now() -> TimeInterval {
+        seconds(uptimeNanoseconds: DispatchTime.now().uptimeNanoseconds)
+    }
+
+    static func seconds(uptimeNanoseconds: UInt64) -> TimeInterval {
+        Double(uptimeNanoseconds) / 1_000_000_000
+    }
+}

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPDepthPolicy.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPDepthPolicy.swift
@@ -1,0 +1,32 @@
+
+/// A selected fixed depth is a ceiling, not permission to explore deeper.
+/// Safety may use a shallower depth or AR under either policy.
+public enum NativeMTPDepthPolicy: Sendable, Equatable {
+    case fixed
+    case adaptive(maximumDepth: Int)
+
+    struct Resolution: Equatable {
+        let initialDepth: Int
+        let maximumDepth: Int
+    }
+
+    enum ValidationError: Error, Equatable {
+        case invalidRequestedDepth
+        case invalidMaximumDepth
+        case invalidRuntimeCap
+    }
+
+    func resolve(requestedDepth: Int, runtimeCap: Int) throws -> Resolution {
+        guard requestedDepth > 0 else { throw ValidationError.invalidRequestedDepth }
+        guard runtimeCap > 0 else { throw ValidationError.invalidRuntimeCap }
+        let maximum: Int
+        switch self {
+        case .fixed:
+            maximum = min(requestedDepth, runtimeCap)
+        case .adaptive(let ceiling):
+            guard ceiling > 0 else { throw ValidationError.invalidMaximumDepth }
+            maximum = min(ceiling, runtimeCap)
+        }
+        return Resolution(initialDepth: min(requestedDepth, maximum), maximumDepth: maximum)
+    }
+}

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -713,6 +713,12 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
 
                 if let diskArrays, !restored {
                     let diskRestored = restoreFromDiskArrays(diskArrays, into: &self.cache)
+                    if diskRestored == 0 {
+                        coordinator.rejectDiskCandidate(
+                            tokens: Array(cacheLookupTokenIds.prefix(matchedTokens)),
+                            arrays: diskArrays,
+                            mediaSalt: mediaSalt)
+                    }
                     if diskRestored > 0 {
                         restoredTokenCount = diskRestored
                         let cacheHasArraysState = self.cache.contains {

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -2374,7 +2374,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         mtpDraftTime += NativeMTPClock.now() - draftStart
     }
 
-    private mutating func recordAdaptiveCycle(accepted: Int) {
+    private mutating func recordAdaptiveCycle(accepted: Int, committedSequentially: Bool = false) {
         // While the AR-safety governor holds the request in AR (or is
         // probing a resume) the depth controller must not also act: one
         // decision per window, one owner.
@@ -2592,14 +2592,18 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
 
         if currentDepth == 1, acceptanceRatio < depthOneFloor, !inRestoredGraceWindow {
-            // Under the staged verifier with the governor on, "d1 doesn't
+            // Under a committed verifier with the governor on, "d1 doesn't
             // pay" is a REVERSIBLE verdict: pause to AR and let the governor's
             // probes bring MTP back when the regime changes. Live (4M prose,
             // build #4): this irreversible fallback fired on 6/8 prose gens
             // BEFORE the governor could act, locking 55–366 AR tokens per
             // turn — the "never recovers" behaviour the governor exists to
-            // end. The lazy-repair verifier keeps the irreversible fallback.
-            if staged, !Self.arSafetyDisabled {
+            // end. Sampled sequential verification also commits only accepted
+            // inputs before reaching this callback, and its ordinary governor
+            // pauses already support re-entry. Do not confuse it with a chunk
+            // lazy-repair path, which retains the irreversible safety fallback.
+            let resumableSampled = committedSequentially && !speculativeSampler.isGreedy
+            if (staged || resumableSampled), !Self.arSafetyDisabled {
                 arSafetyPause(
                     reason: String(
                         format: "adaptive_accept_ratio=%.2f_depth=1_paused",
@@ -2851,7 +2855,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
 
         nextMain = nextToken
         arSafetyAfterVerifyCycle(accepted: accepted)
-        recordAdaptiveCycle(accepted: accepted)
+        recordAdaptiveCycle(accepted: accepted, committedSequentially: true)
         if forceAutoregressiveFallback || arSafetyPaused {
             drafts.removeAll(keepingCapacity: true)
             draftProbabilities.removeAll(keepingCapacity: true)

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -880,22 +880,27 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
 
         nextMain = secondToken
         pendingTokens.append(recordMaterializeSync { secondToken.item(Int.self) })
-        let draftStart = NativeMTPClock.now()
         try Task.checkCancellation()
-        let draftBatch = Self.makeDrafts(
-            model: model,
-            hidden: Self.lastHidden(bridge.hiddenStates),
-            nextToken: secondToken,
-            mtpCache: mtpCache,
-            depth: self.currentDepth,
-            sampler: sampler,
-            speculativeSampler: speculativeSampler,
-            processor: processor)
-        drafts = draftBatch.tokens
-        draftProbabilities = draftBatch.probabilities
-        mtpForwardCount += draftBatch.forwardCount
-        materializeSyncTime += draftBatch.materializeSyncTime
-        self.mtpDraftTime += NativeMTPClock.now() - draftStart
+        // With the governor enabled, next() first measures two AR steps.
+        // Those steps discard initial drafts and re-prime from fresh hidden
+        // states, so generating proposals here would be entirely wasted work.
+        if Self.arSafetyDisabled && !forceAutoregressiveFallback {
+            let draftStart = NativeMTPClock.now()
+            let draftBatch = Self.makeDrafts(
+                model: model,
+                hidden: Self.lastHidden(bridge.hiddenStates),
+                nextToken: secondToken,
+                mtpCache: mtpCache,
+                depth: self.currentDepth,
+                sampler: sampler,
+                speculativeSampler: speculativeSampler,
+                processor: processor)
+            drafts = draftBatch.tokens
+            draftProbabilities = draftBatch.probabilities
+            mtpForwardCount += draftBatch.forwardCount
+            materializeSyncTime += draftBatch.materializeSyncTime
+            self.mtpDraftTime += NativeMTPClock.now() - draftStart
+        }
 
         // MARK: compiled verify promotion — after prefill and the boundary
         // snapshot, so stored prefix-cache entries stay plain.

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -396,9 +396,8 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     /// level demoted twice is closed for the rest of the generation.
     private var adaptiveDemotedFromCount: [Int: Int] = [:]
     private static let adaptiveMaxDemotesPerLevel = 2
-    /// Hard ceiling for adaptive promotion — the resolved depth cap, which
-    /// may exceed the REQUESTED depth (the request is a starting point, not
-    /// a lid, since 2026-09-04). See the depth-policy comment in `init`.
+    /// Resolved promotion ceiling: fixed requests never exceed their chosen
+    /// depth; explicitly adaptive requests may explore to their bounded cap.
     private let adaptiveDepthCeiling: Int
     private(set) var seedMainForwardTime: TimeInterval = 0
     private(set) var verifyMainForwardTime: TimeInterval = 0
@@ -591,23 +590,16 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         self.sampler = effectiveParameters.sampler()
         self.speculativeSampler = SpeculativeSamplingController(parameters: effectiveParameters)
         self.maxTokens = effectiveParameters.maxTokens
-        // Depth policy (2026-09-04): the REQUESTED depth is the STARTING
-        // depth; the hard cap is 5 and the adaptive controller may promote
-        // past the request up to that cap when a full acceptance window
-        // clears the top floor with margin — near-perfect-acceptance shapes
-        // (counting, enumeration, tables) earn d4/d5 at runtime instead of
-        // being pinned to their start. History: the D2 cap era was
-        // calibrated on the lazy-repair verifier (Nemotron D3 0.48x); the
-        // staged verifier re-measured D3 as a win (27B_4D: 28.4 vs 16.5
-        // plain, byte-identical), and the same acceptance-priced controller
-        // that downshifts unprofitable depth governs every step above the
-        // start. Benchmarks can still override via VMLX_MTP_DEPTH_CAP.
+        // One resolved policy governs initialization, recovery and promotion.
+        // The environment bounds exploration but cannot raise a fixed request.
         let depthCap =
             ProcessInfo.processInfo.environment["VMLX_MTP_DEPTH_CAP"]
             .flatMap(Int.init).map { Swift.max($0, 1) } ?? 5
-        self.adaptiveDepthCeiling = depthCap
-        self.depth = Swift.min(requestedDepth, depthCap)
-        self.currentDepth = Swift.min(requestedDepth, depthCap)
+        let resolvedDepth = try effectiveParameters.nativeMTPDepthPolicy.resolve(
+            requestedDepth: requestedDepth, runtimeCap: depthCap)
+        self.adaptiveDepthCeiling = resolvedDepth.maximumDepth
+        self.depth = resolvedDepth.initialDepth
+        self.currentDepth = resolvedDepth.initialDepth
         self.verifierModeSetting = effectiveParameters.draftStrategy?.nativeMTPVerifierMode
         let promptTokenStart = NativeMTPClock.now()
         let promptTokenIds = input.text.tokens.reshaped(-1).asArray(Int.self)
@@ -2512,15 +2504,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             return
         }
 
-        // Promote. Historically bounded by the REQUESTED depth (recovery
-        // only); since 2026-09-04 the request is a STARTING depth and a full
-        // window that clears the floor of the level above with margin climbs
-        // toward `adaptiveDepthCeiling` — near-perfect-acceptance shapes
-        // (counting, enumeration) ride to d4/d5 while ordinary prose, whose
-        // acceptance sits under the floors, never leaves its start. Only the
-        // staged verifier earns the extended ceiling: the lazy-repair
-        // verifier keeps the old recover-to-request bound (its rejection
-        // cost model was never re-measured above d3).
+        // Recovery/promotion respects the request's resolved policy. Only an
+        // explicitly adaptive staged verifier may explore above its initial
+        // depth; the lazy-repair verifier remains bounded by its initial depth.
         let promotionCeiling = staged ? adaptiveDepthCeiling : depth
         if currentDepth < promotionCeiling {
             let nextFloor: Double

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -439,7 +439,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     //
     // Runs every cycle regardless of depth policy (fixed or adaptive): if a
     // WINDOWED MTP ms/token exceeds a context-scaled AR baseline, the request
-    // pauses speculation and decodes AR "instantaneously"; while paused it
+    // pauses speculation and returns to AR; while paused it
     // measures the live AR step cost and periodically PROBES a resume at the
     // starting depth, keeping MTP only if the probe window beats live AR.
     // Design + audit trail: docs/internal/MTP-AR-SAFETY-GOVERNOR-SWIFT-2026-09-04.md
@@ -479,6 +479,15 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private static let arSafetyWarmupCycles = 8
     private static let arSafetyMargin = 1.25
     private static let arSafetyProbeWindow = 6
+
+    /// Advance once per completed verify cycle, including while the timing
+    /// ring is filling. Waiting for a full ring before counting doubles the
+    /// probe's exposure to a losing depth.
+    static func advanceARSafetyProbe(remaining: inout Int) -> Bool {
+        guard remaining > 0 else { return false }
+        remaining -= 1
+        return remaining == 0
+    }
     /// Re-probe after 16, 32, 64… AR tokens (×2 per lost probe, ×4 on a
     /// clear loss); a kept re-entry that trips again backs off further.
     private static let arSafetyResumeIntervalStart = 16
@@ -1730,8 +1739,6 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
 
         verifyCalls += 1
         acceptedByDepth[accepted, default: 0] += 1
-        arSafetyAfterVerifyCycle(accepted: accepted)
-        recordAdaptiveCycle(accepted: accepted)
         if Self.traceEnabled {
             let requestedIDs = recordMaterializeSync { requested.map { $0.item(Int.self) } }
             let currentDrafts = drafts
@@ -1923,7 +1930,11 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
 
         nextMain = nextToken
-        if forceAutoregressiveFallback {
+        // Controllers may clear drafts. Only invoke them after the accepted
+        // proposals have been queued and their cache state committed.
+        arSafetyAfterVerifyCycle(accepted: accepted)
+        recordAdaptiveCycle(accepted: accepted)
+        if forceAutoregressiveFallback || arSafetyPaused {
             drafts.removeAll(keepingCapacity: true)
             draftProbabilities.removeAll(keepingCapacity: true)
             return
@@ -2115,7 +2126,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         arSafetyRing.append(
             ARSafetySample(
                 emitted: arSafetyEmittedTotal, wall: now, verifyTotal: targetVerifyTime))
-        let window = arSafetyProbeCyclesRemaining > 0
+        let wasProbe = arSafetyProbeCyclesRemaining > 0
+        let probeComplete = Self.advanceARSafetyProbe(remaining: &arSafetyProbeCyclesRemaining)
+        let window = wasProbe
             ? Self.arSafetyProbeWindow : arSafetyWindowForRequest
         if arSafetyRing.count > window + 1 {
             arSafetyRing.removeFirst(arSafetyRing.count - (window + 1))
@@ -2131,9 +2144,8 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         let deltaWallMs = (newest.wall - oldest.wall) * 1000
         let deltaVerifyMs = (newest.verifyTotal - oldest.verifyTotal) * 1000
 
-        if arSafetyProbeCyclesRemaining > 0 {
-            arSafetyProbeCyclesRemaining -= 1
-            guard arSafetyProbeCyclesRemaining == 0 else { return }
+        if wasProbe {
+            guard probeComplete else { return }
             // Probe verdict against the LIVE AR cost measured while paused
             // (already at the current context — no scaling needed). MTP must
             // WIN outright to stay; otherwise pause again with backoff.
@@ -2245,6 +2257,13 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         currentDepth = depth
         arSafetyRing.removeAll(keepingCapacity: true)
         arSafetyProbeCyclesRemaining = probe ? Self.arSafetyProbeWindow : 0
+        if probe {
+            // Anchor before drafting so the first cycle and re-prime cost
+            // are priced, not dropped from the resume decision.
+            arSafetyRing.append(ARSafetySample(
+                emitted: arSafetyEmittedTotal, wall: NativeMTPClock.now(),
+                verifyTotal: targetVerifyTime))
+        }
         let draftStart = NativeMTPClock.now()
         let draftBatch = Self.makeDrafts(
             model: model,
@@ -2723,8 +2742,6 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
 
         acceptedByDepth[accepted, default: 0] += 1
-        arSafetyAfterVerifyCycle(accepted: accepted)
-        recordAdaptiveCycle(accepted: accepted)
         prefixCommitCount += 1
 
         guard let nextToken, let hiddenForNextMTP else {
@@ -2742,7 +2759,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
 
         nextMain = nextToken
-        if forceAutoregressiveFallback {
+        arSafetyAfterVerifyCycle(accepted: accepted)
+        recordAdaptiveCycle(accepted: accepted)
+        if forceAutoregressiveFallback || arSafetyPaused {
             drafts.removeAll(keepingCapacity: true)
             draftProbabilities.removeAll(keepingCapacity: true)
             return

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -232,6 +232,8 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private var restoredPrefixStart: Bool = false
     private var adaptiveDepthPromotionCount = 0
     let verifierModeSetting: String?
+    // Default-off diagnostic, additionally restricted by model capability.
+    private let experimentalSampledStaging: Bool
     var promptTokenIds: [Int]
     let cachePrefixTokenCounts: [Int]
     let originalInput: LMInput
@@ -533,6 +535,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private static let wallClockDemoteFactor = 1.05
     private(set) var nativeMTPStats: NativeMTPGenerationStats?
     private var generationStatsFinalized = false
+    private(set) var terminalErrorDescription: String?
     private let iteratorStartTime = NativeMTPClock.now()
 
     private var usesHybridMambaCache: Bool {
@@ -558,7 +561,8 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         cache: [KVCache]? = nil,
         parameters: GenerateParameters,
         depth requestedDepth: Int,
-        cacheCoordinator: CacheCoordinator? = nil
+        cacheCoordinator: CacheCoordinator? = nil,
+        experimentalSampledStaging: Bool = false
     ) throws {
         guard model.nativeMTPAvailable else {
             throw NativeMTPRuntimeError.modelDoesNotExposeNativeMTP
@@ -617,6 +621,10 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         self.depth = resolvedDepth.initialDepth
         self.currentDepth = resolvedDepth.initialDepth
         self.verifierModeSetting = effectiveParameters.draftStrategy?.nativeMTPVerifierMode
+        let sampledStagingRequested = experimentalSampledStaging
+            || RuntimeEnvironment.value("VMLX_FLASH_EXPERIMENTAL_SAMPLED_STAGED") == "1"
+        self.experimentalSampledStaging = sampledStagingRequested
+            && model is NativeMTPSampledStagedDiagnosticModel
         let promptTokenStart = NativeMTPClock.now()
         let promptTokenIds = input.text.tokens.reshaped(-1).asArray(Int.self)
         let promptTokenElapsed = NativeMTPClock.now() - promptTokenStart
@@ -986,6 +994,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                     try verifyCycle()
                 }
             } catch {
+                terminalErrorDescription = String(describing: error)
                 return nil
             }
         }
@@ -1552,7 +1561,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         // ONLY; it must never leak into prefill/seed/sequential forwards.
         let explicitHybridMode = Self.nativeMTPHybridVerifySetting(verifierModeSetting)
         let stagedCapable = usesHybridMambaCache
-            && speculativeSampler.isGreedy
+            && (speculativeSampler.isGreedy || experimentalSampledStaging)
             && processor == nil
             && model is DFlash2StagedVerifyRollbackModel
         let stagedVerify = stagedCapable
@@ -1634,7 +1643,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 cache,
                 verifierMode: verifierModeSetting)
         let canCommitVerifierCache = Self.canCommitVerifierCache(cache)
-        let requiresSequentialRepair = Self.requiresSequentialVerifierRepair(
+        // Staged commit owns rollback. A sequential replay here would erase
+        // its staging slots before commit whenever at least one draft wins.
+        let requiresSequentialRepair = !stagedVerify && Self.requiresSequentialVerifierRepair(
             cache,
             speculativeSampler: speculativeSampler,
             verifierMode: verifierModeSetting)
@@ -3008,11 +3019,12 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             }
             let syncStart = NativeMTPClock.now()
             MLX.eval(correction)
+            let correctionID = correction.item(Int.self)
             materializeSyncTime += NativeMTPClock.now() - syncStart
             return VerifyDecision(
                 accepted: accepted,
                 nextToken: correction,
-                targetTokenIds: [],
+                targetTokenIds: Array(draftTokenIds.prefix(accepted)) + [correctionID],
                 acceptanceProbabilitySum: probabilitySum,
                 acceptanceProbabilityCount: probabilityCount,
                 materializeSyncTime: materializeSyncTime)
@@ -3021,11 +3033,12 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         let bonus = speculativeSampler.sampleFromTarget(probabilities: targetProbabilities[drafts.count])
         let syncStart = NativeMTPClock.now()
         MLX.eval(bonus)
+        let bonusID = bonus.item(Int.self)
         materializeSyncTime += NativeMTPClock.now() - syncStart
         return VerifyDecision(
             accepted: accepted,
             nextToken: bonus,
-            targetTokenIds: [],
+            targetTokenIds: draftTokenIds + [bonusID],
             acceptanceProbabilitySum: probabilitySum,
             acceptanceProbabilityCount: probabilityCount,
             materializeSyncTime: materializeSyncTime)

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -1722,7 +1722,8 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             draftProbabilities: draftProbabilities,
             sampler: sampler,
             speculativeSampler: speculativeSampler,
-            processor: processor)
+            processor: processor,
+            batchTargetProbabilityEvaluation: experimentalSampledStaging && stagedVerify)
         else {
             if let checkpoint {
                 let restoreStart = NativeMTPClock.now()
@@ -2915,7 +2916,8 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         draftProbabilities: [MLXArray],
         sampler: LogitSampler,
         speculativeSampler: SpeculativeSamplingController,
-        processor: LogitProcessor?
+        processor: LogitProcessor?,
+        batchTargetProbabilityEvaluation: Bool
     ) -> VerifyDecision? {
         if speculativeSampler.isGreedy {
             var materializeSyncTime: TimeInterval = 0
@@ -2984,18 +2986,30 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         var targetProbabilities: [MLXArray] = []
         targetProbabilities.reserveCapacity(drafts.count + 1)
         var verifyProcessor = processor
+        let batchEvaluation = batchTargetProbabilityEvaluation && processor == nil
         for index in 0 ... drafts.count {
             let probabilities = processedProbabilities(
                 logits: logits[0..., index, 0...],
                 speculativeSampler: speculativeSampler,
                 processor: &verifyProcessor)
-            let syncStart = NativeMTPClock.now()
-            MLX.eval(probabilities)
-            materializeSyncTime += NativeMTPClock.now() - syncStart
+            if !batchEvaluation {
+                let syncStart = NativeMTPClock.now()
+                MLX.eval(probabilities)
+                materializeSyncTime += NativeMTPClock.now() - syncStart
+            }
             targetProbabilities.append(probabilities)
             if index < drafts.count {
                 verifyProcessor?.didSample(token: drafts[index])
             }
+        }
+        if batchEvaluation {
+            // No processor history or RNG is advanced by probabilities(). Preserve
+            // each row's graph and filter order, but submit their materialization
+            // together instead of draining the GPU once per target row. This stays
+            // inside the opt-in Flash staged diagnostic until live qualification.
+            let syncStart = NativeMTPClock.now()
+            MLX.eval(targetProbabilities)
+            materializeSyncTime += NativeMTPClock.now() - syncStart
         }
 
         var accepted = 0

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -518,7 +518,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private static let wallClockDemoteFactor = 1.05
     private(set) var nativeMTPStats: NativeMTPGenerationStats?
     private var generationStatsFinalized = false
-    private let iteratorStartTime = Date.timeIntervalSinceReferenceDate
+    private let iteratorStartTime = NativeMTPClock.now()
 
     private var usesHybridMambaCache: Bool {
         cache.contains { $0 is MambaCache }
@@ -609,9 +609,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         self.depth = Swift.min(requestedDepth, depthCap)
         self.currentDepth = Swift.min(requestedDepth, depthCap)
         self.verifierModeSetting = effectiveParameters.draftStrategy?.nativeMTPVerifierMode
-        let promptTokenStart = Date.timeIntervalSinceReferenceDate
+        let promptTokenStart = NativeMTPClock.now()
         let promptTokenIds = input.text.tokens.reshaped(-1).asArray(Int.self)
-        let promptTokenElapsed = Date.timeIntervalSinceReferenceDate - promptTokenStart
+        let promptTokenElapsed = NativeMTPClock.now() - promptTokenStart
         self.promptTokenIds = promptTokenIds
         self.cachePrefixTokenCounts = input.cachePrefixTokenCounts
         self.restoredPrefixStart = input.cachePrefixTokenCounts.contains { $0 > 0 }
@@ -798,20 +798,20 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             }
         }
 
-        let start = Date.timeIntervalSinceReferenceDate
+        let start = NativeMTPClock.now()
         try Task.checkCancellation()
         let prepared = try model.prepare(
             inputForPrepare,
             cache: self.cache,
             windowSize: effectiveParameters.prefillStepSize)
-        self.promptPrefillTime = Date.timeIntervalSinceReferenceDate - start
+        self.promptPrefillTime = NativeMTPClock.now() - start
         self.promptCacheSnapshot = makePromptBoundaryCacheSnapshot(from: self.cache)
 
         let firstToken: MLXArray
         switch prepared {
         case .tokens(let tokens):
             processor?.prompt(input.text.tokens)
-            let seedStart = Date.timeIntervalSinceReferenceDate
+            let seedStart = NativeMTPClock.now()
             let backbone = model.nativeBackboneForward(
                 Self.sequenceInput(tokens.tokens),
                 cache: self.cache)
@@ -821,11 +821,11 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 speculativeSampler: speculativeSampler,
                 processor: &processor)
                 .token
-            let syncStart = Date.timeIntervalSinceReferenceDate
+            let syncStart = NativeMTPClock.now()
             try Task.checkCancellation()
             MLX.eval(firstToken)
-            self.materializeSyncTime += Date.timeIntervalSinceReferenceDate - syncStart
-            self.seedMainForwardTime += Date.timeIntervalSinceReferenceDate - seedStart
+            self.materializeSyncTime += NativeMTPClock.now() - syncStart
+            self.seedMainForwardTime += NativeMTPClock.now() - seedStart
             self.seedMainForwardCount += 1
         case .logits(let output):
             if let effectivePromptTokens = output.effectivePromptTokens,
@@ -850,10 +850,10 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 speculativeSampler: speculativeSampler,
                 processor: &processor)
                 .token
-            let syncStart = Date.timeIntervalSinceReferenceDate
+            let syncStart = NativeMTPClock.now()
             try Task.checkCancellation()
             MLX.eval(firstToken)
-            self.materializeSyncTime += Date.timeIntervalSinceReferenceDate - syncStart
+            self.materializeSyncTime += NativeMTPClock.now() - syncStart
         }
 
         let firstID = recordMaterializeSync {
@@ -861,7 +861,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
         pendingTokens.append(firstID)
 
-        let bridgeStart = Date.timeIntervalSinceReferenceDate
+        let bridgeStart = NativeMTPClock.now()
         try Task.checkCancellation()
         let bridge = model.nativeBackboneForward(Self.tokenInput(firstToken), cache: self.cache)
         let secondToken = Self.sampleLast(
@@ -870,16 +870,16 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             speculativeSampler: speculativeSampler,
             processor: &processor)
             .token
-        let secondSyncStart = Date.timeIntervalSinceReferenceDate
+        let secondSyncStart = NativeMTPClock.now()
         try Task.checkCancellation()
         MLX.eval(secondToken)
-        self.materializeSyncTime += Date.timeIntervalSinceReferenceDate - secondSyncStart
-        self.seedMainForwardTime += Date.timeIntervalSinceReferenceDate - bridgeStart
+        self.materializeSyncTime += NativeMTPClock.now() - secondSyncStart
+        self.seedMainForwardTime += NativeMTPClock.now() - bridgeStart
         self.seedMainForwardCount += 1
 
         nextMain = secondToken
         pendingTokens.append(recordMaterializeSync { secondToken.item(Int.self) })
-        let draftStart = Date.timeIntervalSinceReferenceDate
+        let draftStart = NativeMTPClock.now()
         try Task.checkCancellation()
         let draftBatch = Self.makeDrafts(
             model: model,
@@ -894,7 +894,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         draftProbabilities = draftBatch.probabilities
         mtpForwardCount += draftBatch.forwardCount
         materializeSyncTime += draftBatch.materializeSyncTime
-        self.mtpDraftTime += Date.timeIntervalSinceReferenceDate - draftStart
+        self.mtpDraftTime += NativeMTPClock.now() - draftStart
 
         // MARK: compiled verify promotion — after prefill and the boundary
         // snapshot, so stored prefix-cache entries stay plain.
@@ -1235,7 +1235,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             : 0
         let gdnReplay = NativeMTPGDNReplayDiagnostics.snapshot()
         let phaseSummary = NativeMTPPhaseDiagnostics.summary()
-        let iteratorWallTime = Date.timeIntervalSinceReferenceDate - iteratorStartTime
+        let iteratorWallTime = NativeMTPClock.now() - iteratorStartTime
         let adaptiveFallback = adaptiveFallbackReason ?? "none"
         let verifierMode: String
         if chunkVerifierCount > 0 && sequentialVerifierCount > 0 {
@@ -1375,17 +1375,17 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
 
     @inline(__always)
     private mutating func recordMaterializeSync<T>(_ body: () -> T) -> T {
-        let start = Date.timeIntervalSinceReferenceDate
+        let start = NativeMTPClock.now()
         let result = body()
-        materializeSyncTime += Date.timeIntervalSinceReferenceDate - start
+        materializeSyncTime += NativeMTPClock.now() - start
         return result
     }
 
     @inline(__always)
     private mutating func recordCacheSnapshotRestore<T>(_ body: () -> T) -> T {
-        let start = Date.timeIntervalSinceReferenceDate
+        let start = NativeMTPClock.now()
         let result = body()
-        cacheSnapshotRestoreTime += Date.timeIntervalSinceReferenceDate - start
+        cacheSnapshotRestoreTime += NativeMTPClock.now() - start
         return result
     }
 
@@ -1564,13 +1564,13 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             // captured immediately before the prefetched forward.
             checkpoint = consumedPrefetch.checkpoint
         } else {
-            let checkpointStart = Date.timeIntervalSinceReferenceDate
+            let checkpointStart = NativeMTPClock.now()
             checkpoint =
                 (canCommitVerifierCache && !requiresSequentialRepair && !replayChunkCommit
                     && !lazyChunkRepair && !needsBatchedVerifierRecovery)
                 ? nil
                 : NativeMTPCacheCheckpoint(cache)
-            cacheSnapshotRestoreTime += Date.timeIntervalSinceReferenceDate - checkpointStart
+            cacheSnapshotRestoreTime += NativeMTPClock.now() - checkpointStart
         }
         let forwardVerifierMode = stagedVerify
             ? NativeMTPVerifierStatePolicy.Mode.inputCaptureStaged.rawValue
@@ -1579,7 +1579,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         if let consumedPrefetch {
             verifier = consumedPrefetch.verifier
         } else {
-        let verifyStart = Date.timeIntervalSinceReferenceDate
+        let verifyStart = NativeMTPClock.now()
         if stagedVerify, compiledVerifyEnabled,
             compiledVerifyWarmedSizes.contains(requested.count)
         {
@@ -1607,21 +1607,21 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 compiledVerifyWarmedSizes.insert(requested.count)
             }
         }
-        let verifyElapsed = Date.timeIntervalSinceReferenceDate - verifyStart
+        let verifyElapsed = NativeMTPClock.now() - verifyStart
         targetVerifyTime += verifyElapsed
         verifyMainForwardTime += verifyElapsed
         }
         if Self.phaseTimersEnabled {
-            let gpuStart = Date.timeIntervalSinceReferenceDate
+            let gpuStart = NativeMTPClock.now()
             MLX.eval(verifier.logits)
-            verifyGpuWaitTime += Date.timeIntervalSinceReferenceDate - gpuStart
+            verifyGpuWaitTime += NativeMTPClock.now() - gpuStart
         }
         targetForwardCount += 1
         verifyMainForwardCount += 1
         verifyInputTokenCount += requested.count
         chunkVerifierCount += 1
 
-        let sampleStart = Date.timeIntervalSinceReferenceDate
+        let sampleStart = NativeMTPClock.now()
         guard let verifyDecision = Self.verifyDrafts(
             logits: verifier.logits,
             drafts: drafts,
@@ -1632,9 +1632,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             processor: processor)
         else {
             if let checkpoint {
-                let restoreStart = Date.timeIntervalSinceReferenceDate
+                let restoreStart = NativeMTPClock.now()
                 checkpoint.restore(into: &cache)
-                cacheSnapshotRestoreTime += Date.timeIntervalSinceReferenceDate - restoreStart
+                cacheSnapshotRestoreTime += NativeMTPClock.now() - restoreStart
             }
             if stagedVerify {
                 for layer in cache { (layer as? MambaCache)?.clearVerifyStaging() }
@@ -1643,7 +1643,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             return
         }
         materializeSyncTime += verifyDecision.materializeSyncTime
-        samplingTime += Date.timeIntervalSinceReferenceDate - sampleStart
+        samplingTime += NativeMTPClock.now() - sampleStart
         if let nanTrace {
             // Whole verify slab `[1, K+1, V]`: every row is a decode position.
             let next = verifyDecision.nextToken
@@ -1663,19 +1663,19 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             }
 
             func restoreCheckpoint() {
-                let restoreStart = Date.timeIntervalSinceReferenceDate
+                let restoreStart = NativeMTPClock.now()
                 checkpoint.restore(into: &cache)
-                cacheSnapshotRestoreTime += Date.timeIntervalSinceReferenceDate - restoreStart
+                cacheSnapshotRestoreTime += NativeMTPClock.now() - restoreStart
             }
 
             func replayPrefix(count: Int) -> NativeMTPForwardResult {
                 // Host ids already materialized once at cycle start.
                 let acceptedInputIds = Array(requestedInputIds.prefix(count))
                 let acceptedInput = MLXArray(acceptedInputIds).reshaped(1, count)
-                let replayStart = Date.timeIntervalSinceReferenceDate
+                let replayStart = NativeMTPClock.now()
                 let repaired = model.nativeBackboneForward(acceptedInput, cache: cache)
                 MLX.eval(repaired.logits, repaired.hiddenStates)
-                replayMainForwardTime += Date.timeIntervalSinceReferenceDate - replayStart
+                replayMainForwardTime += NativeMTPClock.now() - replayStart
                 repairForwardCount += 1
                 replayMainForwardCount += 1
                 return repaired
@@ -1759,16 +1759,16 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             guard let checkpoint else {
                 throw NativeMTPRuntimeError.verifierCacheCommitFailed
             }
-            let restoreStart = Date.timeIntervalSinceReferenceDate
+            let restoreStart = NativeMTPClock.now()
             checkpoint.restore(into: &cache)
-            cacheSnapshotRestoreTime += Date.timeIntervalSinceReferenceDate - restoreStart
+            cacheSnapshotRestoreTime += NativeMTPClock.now() - restoreStart
 
             let acceptedInputIds = Array(requestedInputIds.prefix(accepted + 1))
             let acceptedInput = MLXArray(acceptedInputIds).reshaped(1, accepted + 1)
-            let replayStart = Date.timeIntervalSinceReferenceDate
+            let replayStart = NativeMTPClock.now()
             let repaired = model.nativeBackboneForward(acceptedInput, cache: cache)
             MLX.eval(repaired.logits, repaired.hiddenStates)
-            replayMainForwardTime += Date.timeIntervalSinceReferenceDate - replayStart
+            replayMainForwardTime += NativeMTPClock.now() - replayStart
             repairForwardCount += 1
             replayMainForwardCount += 1
 
@@ -1794,7 +1794,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
 
         let committedInputCount = accepted + 1
-        let commitStart = Date.timeIntervalSinceReferenceDate
+        let commitStart = NativeMTPClock.now()
         let committedCache: Bool
         if stagedVerify {
             // Staged verify left recurrent state and offsets untouched;
@@ -1827,7 +1827,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                     totalInputCount: requested.count)
                 : false
         }
-        cacheCommitTime += Date.timeIntervalSinceReferenceDate - commitStart
+        cacheCommitTime += NativeMTPClock.now() - commitStart
         if committedCache {
             prefixCommitCount += 1
         }
@@ -1888,18 +1888,18 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 guard let checkpoint else {
                     throw NativeMTPRuntimeError.verifierCacheCommitFailed
                 }
-                let restoreStart = Date.timeIntervalSinceReferenceDate
+                let restoreStart = NativeMTPClock.now()
                 checkpoint.restore(into: &cache)
-                cacheSnapshotRestoreTime += Date.timeIntervalSinceReferenceDate - restoreStart
+                cacheSnapshotRestoreTime += NativeMTPClock.now() - restoreStart
 
                 let acceptedInputIds = recordMaterializeSync {
                     requested.prefix(accepted + 1).map { Int32($0.item(Int.self)) }
                 }
                 let acceptedInput = MLXArray(acceptedInputIds).reshaped(1, accepted + 1)
-                let replayStart = Date.timeIntervalSinceReferenceDate
+                let replayStart = NativeMTPClock.now()
                 let repaired = model.nativeBackboneForward(acceptedInput, cache: cache)
                 MLX.eval(repaired.logits, repaired.hiddenStates)
-                replayMainForwardTime += Date.timeIntervalSinceReferenceDate - replayStart
+                replayMainForwardTime += NativeMTPClock.now() - replayStart
                 repairForwardCount += 1
                 replayMainForwardCount += 1
                 hiddenForNextMTP =
@@ -1936,7 +1936,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             draftProbabilities.removeAll(keepingCapacity: true)
             return
         }
-        let draftStart = Date.timeIntervalSinceReferenceDate
+        let draftStart = NativeMTPClock.now()
         let draftBatch = Self.makeDrafts(
             model: model,
             hidden: alignedCommitHidden ?? hiddenForNextMTP,
@@ -1955,7 +1955,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             ? Swift.max(0, draftBatch.tokens.count - 1) : 0
         mtpForwardCount += draftBatch.forwardCount
         materializeSyncTime += draftBatch.materializeSyncTime
-        mtpDraftTime += Date.timeIntervalSinceReferenceDate - draftStart
+        mtpDraftTime += NativeMTPClock.now() - draftStart
 
         maybePrefetchNextVerify(stagedVerify: stagedVerify)
     }
@@ -1994,10 +1994,10 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             stacked(requested.map { $0.reshaped(-1) }).asArray(Int32.self)
         }
         let input = MLXArray(requestedInputIds).reshaped(1, requested.count)
-        let checkpointStart = Date.timeIntervalSinceReferenceDate
+        let checkpointStart = NativeMTPClock.now()
         let checkpoint = NativeMTPCacheCheckpoint(cache)
-        cacheSnapshotRestoreTime += Date.timeIntervalSinceReferenceDate - checkpointStart
-        let verifyStart = Date.timeIntervalSinceReferenceDate
+        cacheSnapshotRestoreTime += NativeMTPClock.now() - checkpointStart
+        let verifyStart = NativeMTPClock.now()
         let verifier = NativeMTPVerifierStatePolicy.withVerifierMode(
             NativeMTPVerifierStatePolicy.Mode.inputCaptureStaged.rawValue
         ) {
@@ -2016,7 +2016,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             asyncEval(logits, hidden)
             scheduled.signal()
         }
-        let verifyElapsed = Date.timeIntervalSinceReferenceDate - verifyStart
+        let verifyElapsed = NativeMTPClock.now() - verifyStart
         targetVerifyTime += verifyElapsed
         verifyMainForwardTime += verifyElapsed
         verifyPrefetchSubmitCount += 1
@@ -2037,13 +2037,13 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         guard let prefetch = pendingVerify else { return }
         pendingVerify = nil
         verifyPrefetchAbandonedCount += 1
-        let restoreStart = Date.timeIntervalSinceReferenceDate
+        let restoreStart = NativeMTPClock.now()
         // The background thread may still be scheduling the graph; it must
         // finish before the checkpoint restore rewrites the cache arrays.
         prefetch.scheduled.wait()
         prefetch.checkpoint.restore(into: &cache)
         for layer in cache { (layer as? MambaCache)?.clearVerifyStaging() }
-        cacheSnapshotRestoreTime += Date.timeIntervalSinceReferenceDate - restoreStart
+        cacheSnapshotRestoreTime += NativeMTPClock.now() - restoreStart
     }
 
     /// Measurement-only escape hatch: `VMLX_NATIVE_MTP_DISABLE_ADAPTIVE=1`
@@ -2119,7 +2119,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private mutating func arSafetyAfterVerifyCycle(accepted: Int) {
         guard !Self.arSafetyDisabled, !forceAutoregressiveFallback else { return }
         arSafetyEmittedTotal += accepted + 1
-        let now = Date.timeIntervalSinceReferenceDate
+        let now = NativeMTPClock.now()
         arSafetyRing.append(
             ARSafetySample(
                 emitted: arSafetyEmittedTotal, wall: now, verifyTotal: targetVerifyTime))
@@ -2253,7 +2253,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         currentDepth = depth
         arSafetyRing.removeAll(keepingCapacity: true)
         arSafetyProbeCyclesRemaining = probe ? Self.arSafetyProbeWindow : 0
-        let draftStart = Date.timeIntervalSinceReferenceDate
+        let draftStart = NativeMTPClock.now()
         let draftBatch = Self.makeDrafts(
             model: model,
             hidden: hidden,
@@ -2269,7 +2269,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             ? Swift.max(0, draftBatch.tokens.count - 1) : 0
         mtpForwardCount += draftBatch.forwardCount
         materializeSyncTime += draftBatch.materializeSyncTime
-        mtpDraftTime += Date.timeIntervalSinceReferenceDate - draftStart
+        mtpDraftTime += NativeMTPClock.now() - draftStart
     }
 
     private mutating func recordAdaptiveCycle(accepted: Int) {
@@ -2288,7 +2288,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             }
             return
         }
-        let now = Date.timeIntervalSinceReferenceDate
+        let now = NativeMTPClock.now()
         let cycleWall = lastAdaptiveCycleTimestamp.map { now - $0 } ?? 0
         lastAdaptiveCycleTimestamp = now
         adaptiveWindow.append(
@@ -2565,17 +2565,17 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             throw NativeMTPRuntimeError.verifierProducedNoTokens
         }
 
-        let verifyStart = Date.timeIntervalSinceReferenceDate
+        let verifyStart = NativeMTPClock.now()
         let output = model.nativeBackboneForward(Self.tokenInput(primary), cache: cache)
         MLX.eval(output.logits, output.hiddenStates)
-        let elapsed = Date.timeIntervalSinceReferenceDate - verifyStart
+        let elapsed = NativeMTPClock.now() - verifyStart
         targetVerifyTime += elapsed
         verifyMainForwardTime += elapsed
         targetForwardCount += 1
         verifyMainForwardCount += 1
         verifyInputTokenCount += 1
 
-        let sampleStart = Date.timeIntervalSinceReferenceDate
+        let sampleStart = NativeMTPClock.now()
         let sample = Self.sampleLast(
             logits: output.logits,
             sampler: sampler,
@@ -2584,7 +2584,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         recordMaterializeSync {
             MLX.eval(sample.token)
         }
-        samplingTime += Date.timeIntervalSinceReferenceDate - sampleStart
+        samplingTime += NativeMTPClock.now() - sampleStart
 
         let tokenID = recordMaterializeSync { sample.token.item(Int.self) }
         nanTrace?.observe(
@@ -2617,10 +2617,10 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         sequentialVerifierCount += 1
 
         for index in 0 ... drafts.count {
-            let verifyStart = Date.timeIntervalSinceReferenceDate
+            let verifyStart = NativeMTPClock.now()
             let verifier = model.nativeBackboneForward(Self.tokenInput(currentInput), cache: cache)
             MLX.eval(verifier.logits, verifier.hiddenStates)
-            let verifyElapsed = Date.timeIntervalSinceReferenceDate - verifyStart
+            let verifyElapsed = NativeMTPClock.now() - verifyStart
             targetVerifyTime += verifyElapsed
             verifyMainForwardTime += verifyElapsed
             targetForwardCount += 1
@@ -2646,7 +2646,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             hiddenForNextMTP = Self.lastHidden(verifier.hiddenStates)
 
             if speculativeSampler.isGreedy {
-                let sampleStart = Date.timeIntervalSinceReferenceDate
+                let sampleStart = NativeMTPClock.now()
                 let sample = Self.sampleLast(
                     logits: verifier.logits,
                     sampler: sampler,
@@ -2655,7 +2655,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 recordMaterializeSync {
                     MLX.eval(sample.token)
                 }
-                samplingTime += Date.timeIntervalSinceReferenceDate - sampleStart
+                samplingTime += NativeMTPClock.now() - sampleStart
 
                 let targetID = recordMaterializeSync { sample.token.item(Int.self) }
                 targetTokenIds.append(targetID)
@@ -2682,7 +2682,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 break
             }
 
-            let sampleStart = Date.timeIntervalSinceReferenceDate
+            let sampleStart = NativeMTPClock.now()
             let probabilities = Self.processedProbabilities(
                 logits: verifier.logits[0..., -1, 0...],
                 speculativeSampler: speculativeSampler,
@@ -2690,7 +2690,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             recordMaterializeSync {
                 MLX.eval(probabilities)
             }
-            samplingTime += Date.timeIntervalSinceReferenceDate - sampleStart
+            samplingTime += NativeMTPClock.now() - sampleStart
 
             if index < drafts.count {
                 let decision = speculativeSampler.acceptOrCorrect(
@@ -2761,7 +2761,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             draftProbabilities.removeAll(keepingCapacity: true)
             return
         }
-        let draftStart = Date.timeIntervalSinceReferenceDate
+        let draftStart = NativeMTPClock.now()
         let draftBatch = Self.makeDrafts(
             model: model,
             hidden: hiddenForNextMTP,
@@ -2775,7 +2775,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         draftProbabilities = draftBatch.probabilities
         mtpForwardCount += draftBatch.forwardCount
         materializeSyncTime += draftBatch.materializeSyncTime
-        mtpDraftTime += Date.timeIntervalSinceReferenceDate - draftStart
+        mtpDraftTime += NativeMTPClock.now() - draftStart
     }
 
     private struct VerifyDecision {
@@ -2829,11 +2829,11 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                         sampler: sampler,
                         speculativeSampler: speculativeSampler,
                         processor: &verifyProcessor)
-                    let syncStart = Date.timeIntervalSinceReferenceDate
+                    let syncStart = NativeMTPClock.now()
                     MLX.eval(sample.token)
                     tokenRows.append(sample.token)
                     tokenIDs.append(sample.token.item(Int.self))
-                    materializeSyncTime += Date.timeIntervalSinceReferenceDate - syncStart
+                    materializeSyncTime += NativeMTPClock.now() - syncStart
                 }
                 sampled = tokenRows
                 sampledIDs = tokenIDs
@@ -2875,9 +2875,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 logits: logits[0..., index, 0...],
                 speculativeSampler: speculativeSampler,
                 processor: &verifyProcessor)
-            let syncStart = Date.timeIntervalSinceReferenceDate
+            let syncStart = NativeMTPClock.now()
             MLX.eval(probabilities)
-            materializeSyncTime += Date.timeIntervalSinceReferenceDate - syncStart
+            materializeSyncTime += NativeMTPClock.now() - syncStart
             targetProbabilities.append(probabilities)
             if index < drafts.count {
                 verifyProcessor?.didSample(token: drafts[index])
@@ -2903,9 +2903,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             guard let correction = decision.correction else {
                 preconditionFailure("rejected speculative token must return a residual correction")
             }
-            let syncStart = Date.timeIntervalSinceReferenceDate
+            let syncStart = NativeMTPClock.now()
             MLX.eval(correction)
-            materializeSyncTime += Date.timeIntervalSinceReferenceDate - syncStart
+            materializeSyncTime += NativeMTPClock.now() - syncStart
             return VerifyDecision(
                 accepted: accepted,
                 nextToken: correction,
@@ -2916,9 +2916,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
 
         let bonus = speculativeSampler.sampleFromTarget(probabilities: targetProbabilities[drafts.count])
-        let syncStart = Date.timeIntervalSinceReferenceDate
+        let syncStart = NativeMTPClock.now()
         MLX.eval(bonus)
-        materializeSyncTime += Date.timeIntervalSinceReferenceDate - syncStart
+        materializeSyncTime += NativeMTPClock.now() - syncStart
         return VerifyDecision(
             accepted: accepted,
             nextToken: bonus,
@@ -3026,9 +3026,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             // on-graph and the NEXT cycle reads every draft id in one
             // batched readback. A per-level MLX.eval here stalled the whole
             // pipeline once per draft for a value nobody reads yet.
-            let syncStart = Date.timeIntervalSinceReferenceDate
+            let syncStart = NativeMTPClock.now()
             asyncEval(draft.token, out.hiddenStates)
-            materializeSyncTime += Date.timeIntervalSinceReferenceDate - syncStart
+            materializeSyncTime += NativeMTPClock.now() - syncStart
             tokens.append(draft.token)
             if !speculativeSampler.isGreedy {
                 probabilities.append(draft.probabilities)
@@ -3205,7 +3205,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
 
         let candidateLogits = logits[0..., 0 ..< count, 0...]
         let tokenBatch = argMax(candidateLogits, axis: -1).asType(.int32)
-        let syncStart = Date.timeIntervalSinceReferenceDate
+        let syncStart = NativeMTPClock.now()
         MLX.eval(tokenBatch)
         guard tokenBatch.size == count else {
             return nil
@@ -3214,7 +3214,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         guard tokenIds.count == count else {
             return nil
         }
-        let materializeSyncTime = Date.timeIntervalSinceReferenceDate - syncStart
+        let materializeSyncTime = NativeMTPClock.now() - syncStart
         let tokens = tokenIds.map { MLXArray([Int32($0)]) }
         return (
             tokens: tokens,

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -237,6 +237,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     let originalInput: LMInput
     let cacheInitParameters: GenerateParameters
     var promptCacheSnapshot: [KVCache]?
+    /// Owned state at the reusable text boundary, captured before consuming
+    /// the generation suffix. Recurrent state cannot be trimmed back later.
+    var strippedPromptSnapshot: (boundary: Int, cache: [KVCache])?
     let mediaSalt: String?
 
     var tokenCount = 0
@@ -801,12 +804,35 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
 
         let start = NativeMTPClock.now()
         try Task.checkCancellation()
+        if originalInput.cachePromptIntent != .auxiliary,
+           let boundary = TokenIterator.hybridStripBoundaryIndex(
+            coordinator: cacheCoordinator, promptTokenIds: promptTokenIds,
+            input: originalInput, cache: self.cache),
+           let split = Self.splitTextPrefill(
+            inputForPrepare, promptCount: promptTokenIds.count,
+            boundary: boundary, cache: self.cache)
+        {
+            if let head = split.head {
+                switch try model.prepare(
+                    head, cache: self.cache, windowSize: effectiveParameters.prefillStepSize)
+                {
+                case .tokens(let remainder):
+                    _ = model.nativeBackboneForward(
+                        Self.sequenceInput(remainder.tokens), cache: self.cache)
+                case .logits:
+                    break
+                }
+            }
+            try Task.checkCancellation()
+            self.strippedPromptSnapshot = (
+                boundary, makePromptBoundaryCacheSnapshot(from: self.cache))
+            inputForPrepare = split.tail
+        }
         let prepared = try model.prepare(
             inputForPrepare,
             cache: self.cache,
             windowSize: effectiveParameters.prefillStepSize)
         self.promptPrefillTime = NativeMTPClock.now() - start
-        self.promptCacheSnapshot = makePromptBoundaryCacheSnapshot(from: self.cache)
 
         let firstToken: MLXArray
         switch prepared {
@@ -857,6 +883,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             self.materializeSyncTime += NativeMTPClock.now() - syncStart
         }
 
+        // A .tokens prepare result has not consumed its final remainder yet.
+        // Seal only after that forward, before the bridge adds generated tokens.
+        self.promptCacheSnapshot = makePromptBoundaryCacheSnapshot(from: self.cache)
         let firstID = recordMaterializeSync {
             firstToken.item(Int.self)
         }
@@ -962,6 +991,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         generatedTokenIds: [Int],
         includeGeneratedBoundary: Bool
     ) {
+        defer { strippedPromptSnapshot = nil }
         // A prefetched verify that was never consumed left speculative rows
         // in the attention lanes; roll it back before any boundary snapshot
         // can capture them.
@@ -1156,7 +1186,10 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                     // and `stripAt` routinely coincides with a prefix-count entry.
                     let strippedTokens = Array(promptTokenIds.prefix(stripAt))
                     let tStrip = Date()
-                    let strippedSnapshotOpt = cacheSnapshotForBoundary(
+                    let captured = strippedPromptSnapshot.flatMap {
+                        $0.boundary == stripAt ? $0.cache : nil
+                    }
+                    let strippedSnapshotOpt = captured ?? cacheSnapshotForBoundary(
                         tokens: strippedTokens,
                         promptSnapshot: promptCacheSnapshot,
                         allowDiskBackedRederive: true)
@@ -1393,6 +1426,39 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         let result = body()
         cacheSnapshotRestoreTime += NativeMTPClock.now() - start
         return result
+    }
+
+    /// Same text-only structural split as solo prefill. A restored prefix is
+    /// subtracted from the absolute boundary; masks must be token-aligned.
+    /// Unknown media/typed-pool contracts retain the existing replay path.
+    private static func splitTextPrefill(
+        _ input: LMInput, promptCount: Int, boundary: Int, cache: [KVCache]
+    ) -> (head: LMInput?, tail: LMInput)? {
+        guard !input.hasMediaContent, !input.requiresPostPrepareCacheKey,
+              !cache.contains(where: { $0 is HybridPoolCache }) else { return nil }
+        let size = input.text.tokens.size
+        let split = boundary - (promptCount - size)
+        guard split >= 0, split < size else { return nil }
+        if let mask = input.text.mask, mask.size != size { return nil }
+        if let ids = input.text.tokenIds, ids.count != size { return nil }
+        let flat = input.text.tokens.reshaped([-1])
+        func part(_ range: Range<Int>) -> LMInput {
+            let mask = input.text.mask.map { original -> MLXArray in
+                let sliced = original.reshaped([-1])[range]
+                return original.ndim >= 2 ? sliced[.newAxis, 0...] : sliced
+            }
+            return LMInput(
+                text: LMInput.Text(
+                    tokens: flat[range][.newAxis, 0...], mask: mask,
+                    tokenIds: input.text.tokenIds.map { Array($0[range]) }),
+                cacheScopeSalt: input.cacheScopeSalt,
+                cachePrefixTokenCounts: input.cachePrefixTokenCounts,
+                cacheStablePrefixTokenCounts: input.cacheStablePrefixTokenCounts,
+                cachePromptIntent: input.cachePromptIntent,
+                cacheRestorePolicy: input.cacheRestorePolicy,
+                toolSchemas: input.toolSchemas)
+        }
+        return (split > 0 ? part(0..<split) : nil, part(split..<size))
     }
 
     private func cacheSnapshotForBoundary(

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -481,7 +481,10 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     /// d3), a later drop is caught within ~8 cycles (~0.3 s).
     private static let arSafetyWindow = 8
     private static let arSafetyWarmupCycles = 8
-    private static let arSafetyMargin = 1.25
+    // Do not deliberately retain sustained MTP losses. The median guard
+    // rejects isolated stalls; re-entry has its own stricter hysteresis.
+    // This windowed estimate is not an instantaneous AR speed guarantee.
+    static let arSafetyMargin = 1.0
     private static let arSafetyProbeWindow = 6
 
     /// Advance once per completed verify cycle, including while the timing

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -458,7 +458,8 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     /// Wall of one TRUE single-token AR step measured after eval — the first
     /// decode cycle runs AR precisely to capture this (the seed forward is
     /// prompt-sized here, not an AR step; the lazy-eval trap is avoided by
-    /// timing after `MLX.eval`).
+    /// timing after `MLX.eval`). After a successful resume this anchor is
+    /// refreshed from the AR steps measured during the preceding pause.
     private var arSafetySeedStepSec: TimeInterval?
     private var arSafetySeedFirstSampleSec: TimeInterval?
     /// First MTP cycle's verify-forward wall; verify growth over it tracks
@@ -2239,13 +2240,26 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             } else {
                 arSafetyResumes += 1
                 arSafetyReentered = true
+                // The probe won against current-context AR, not startup AR.
+                // Keep that same measurement for ordinary windows after the
+                // resume. Re-anchor verify timing at the probe as well: mixing
+                // a new AR measurement with the startup verify duration would
+                // apply the old context-growth estimate a second time.
+                if let liveStep = arSafetyLiveStepSec, liveStep.isFinite, liveStep > 0 {
+                    arSafetySeedStepSec = liveStep
+                    let probeVerifySec = deltaVerifyMs / Double(window) / 1000
+                    arSafetyFirstVerifySec = probeVerifySec.isFinite && probeVerifySec > 0
+                        ? probeVerifySec : nil
+                }
                 // The interval is NOT reset here: a re-entry that trips again
                 // backs off from where it was (no ping-pong); it resets only
                 // when the generation ends.
                 adaptiveFallbackReason = nil
                 FileHandle.standardError.write(Data(String(
-                    format: "[NativeMTP] ar_safety resumed: mtp=%.1fms/tok live_ar=%.1fms depth=%d\n",
-                    mtpMsPerToken, liveArMs, currentDepth).utf8))
+                    format: "[NativeMTP] ar_safety resumed: mtp=%.1fms/tok live_ar=%.1fms depth=%d ordinary_ar=%.1fms verify_anchor=%.1fms\n",
+                    mtpMsPerToken, liveArMs, currentDepth,
+                    (arSafetySeedStepSec ?? 0) * 1000,
+                    (arSafetyFirstVerifySec ?? 0) * 1000).utf8))
             }
             return
         }

--- a/Libraries/MLXVLM/Models/Qwen35.swift
+++ b/Libraries/MLXVLM/Models/Qwen35.swift
@@ -93,6 +93,9 @@ private let _vlmCompiledPreciseSwiGLU: @Sendable (MLXArray, MLXArray, MLXArray) 
 enum Qwen4ExpCompiledGDNInputs {
     typealias Region = @Sendable ([MLXArray]) -> [MLXArray]
 
+    static let preprocessEnabled =
+        RuntimeEnvironment.value("VMLX_QWEN4_EXP_COMPILE_GDN_PREPROCESS") == "1"
+
     private static let enabled: Bool = {
         let value =
             RuntimeEnvironment.value("VMLX_QWEN4_EXP_COMPILE_GDN")
@@ -266,6 +269,54 @@ enum Qwen4ExpCompiledGDNInputs {
             input, convState, weight, scales, biases, convWeight,
         ])
         return outputs.count == 7 ? outputs : nil
+    }
+
+    /// Decode-only experiment after projection dispatch. All layer weights are
+    /// explicit inputs; neither quantized projection selection nor cache writes
+    /// are part of this graph. Geometry comes from the active layer.
+    static func callPreprocess(
+        convInput: MLXArray, convWeight: MLXArray,
+        numKHeads: Int, headKDim: Int, numVHeads: Int, headVDim: Int
+    ) -> [MLXArray]? {
+        guard enabled, !CompiledDecodeTrace.isActive,
+            convInput.ndim == 3, convWeight.ndim == 3,
+            numKHeads > 0, headKDim > 0, numVHeads > 0, headVDim > 0,
+            convInput.dtype == .bfloat16, convWeight.dtype == convInput.dtype
+        else { return nil }
+        let keyDim = numKHeads * headKDim
+        let convDim = 2 * keyDim + numVHeads * headVDim
+        guard convInput.dim(2) == convDim,
+            convWeight.dim(0) == convDim, convWeight.dim(2) == 1,
+            convInput.dim(1) == convWeight.dim(1), convWeight.dim(1) > 0
+        else { return nil }
+        let key = ["preprocess", String(numKHeads), String(headKDim),
+            String(numVHeads), String(headVDim), String(convWeight.dim(1))]
+            .joined(separator: "|")
+        lock.lock()
+        var region = regions[key]
+        if region == nil {
+            region = vmlxTrustedCompile { (args: [MLXArray]) -> [MLXArray] in
+                let B = args[0].dim(0)
+                let output = silu(conv1d(args[0], args[1], stride: 1,
+                    padding: 0, dilation: 1, groups: convDim))
+                let split = MLX.split(output, indices: [keyDim, 2 * keyDim], axis: -1)
+                let q = split[0].reshaped(B, 1, numKHeads, headKDim)
+                let k = split[1].reshaped(B, 1, numKHeads, headKDim)
+                let v = split[2].reshaped(B, 1, numVHeads, headVDim)
+                let invScale = pow(Float(headKDim), -0.5)
+                return [
+                    MLXArray(pow(invScale, 2), dtype: q.dtype)
+                        * MLXFast.rmsNorm(q, weight: MLXArray.mlxNone, eps: 1e-6),
+                    MLXArray(invScale, dtype: k.dtype)
+                        * MLXFast.rmsNorm(k, weight: MLXArray.mlxNone, eps: 1e-6), v,
+                ]
+            }
+            regions[key] = region
+            FileHandle.standardError.write(Data(
+                "[Qwen4Exp] compiled_gdn_preprocess=selected geometry=\(key) weights=explicit_inputs dtype=bfloat16\n".utf8))
+        }
+        lock.unlock()
+        return region!([convInput, convWeight])
     }
 
     static func callTail(
@@ -1879,18 +1930,31 @@ enum Qwen35Language {
                     }
                 }
 
-                let convOut = silu(conv1d(convInput))
-                let split = MLX.split(convOut, indices: [keyDim, 2 * keyDim], axis: -1)
-                let q = split[0].reshaped(B, S, numKHeads, headKDim)
-                let k = split[1].reshaped(B, S, numKHeads, headKDim)
-                v = split[2].reshaped(B, S, numVHeads, headVDim)
-                let invScale = pow(Float(headKDim), -0.5)
-                qNormed =
-                    MLXArray(pow(invScale, 2), dtype: q.dtype)
-                    * MLXFast.rmsNorm(q, weight: MLXArray.mlxNone, eps: 1e-6)
-                kNormed =
-                    MLXArray(invScale, dtype: k.dtype)
-                    * MLXFast.rmsNorm(k, weight: MLXArray.mlxNone, eps: 1e-6)
+                let preprocessing = S == 1 && mask == nil
+                    && Qwen4ExpCompiledGDNInputs.preprocessEnabled
+                    ? Qwen4ExpCompiledGDNInputs.callPreprocess(
+                        convInput: convInput, convWeight: conv1d.weight,
+                        numKHeads: numKHeads, headKDim: headKDim,
+                        numVHeads: numVHeads, headVDim: headVDim)
+                    : nil
+                if let preprocessing {
+                    qNormed = preprocessing[0]
+                    kNormed = preprocessing[1]
+                    v = preprocessing[2]
+                } else {
+                    let convOut = silu(conv1d(convInput))
+                    let split = MLX.split(convOut, indices: [keyDim, 2 * keyDim], axis: -1)
+                    let q = split[0].reshaped(B, S, numKHeads, headKDim)
+                    let k = split[1].reshaped(B, S, numKHeads, headKDim)
+                    v = split[2].reshaped(B, S, numVHeads, headVDim)
+                    let invScale = pow(Float(headKDim), -0.5)
+                    qNormed =
+                        MLXArray(pow(invScale, 2), dtype: q.dtype)
+                        * MLXFast.rmsNorm(q, weight: MLXArray.mlxNone, eps: 1e-6)
+                    kNormed =
+                        MLXArray(invScale, dtype: k.dtype)
+                        * MLXFast.rmsNorm(k, weight: MLXArray.mlxNone, eps: 1e-6)
+                }
             }
 
             // Same defense as the conv slot: a mis-restored recurrent state

--- a/Libraries/MLXVLM/Models/Qwen4Exp.swift
+++ b/Libraries/MLXVLM/Models/Qwen4Exp.swift
@@ -945,13 +945,14 @@ private final class Qwen4ExpQSAIndexer: Module {
         // processed form is append-only. Re-pooling + re-norming + re-rotating
         // the ENTIRE history every decode token made the indexer's overhead
         // linear in context per step; keep the processed blocks on the cache
-        // and extend by only the newly completed ones. Any trim/rollback or
-        // state restore drops the derived lane and the next forward rebuilds
-        // it here in one pass. `VMLX_QSA_POOL_CACHE=0` restores full
+        // and extend by only the newly completed ones. Trim/rollback retains
+        // only complete accepted blocks; state restore drops the derived lane.
+        // `VMLX_QSA_POOL_CACHE=0` restores full
         // recompute for A/B.
         var pooled: MLXArray
         if Qwen4ExpQSARuntime.poolCache, let cache {
             if cache.derivedPooledBlockCount > blocks { cache.dropDerivedPooledBlocks() }
+            cache.prepareDerivedPooledBlocks(compressionRatio: extras.indexerCompressRatio)
             let have = cache.derivedPooledBlockCount
             if blocks > have {
                 let fresh = processBlocks(have ..< blocks)

--- a/Libraries/MLXVLM/Models/Qwen4Exp.swift
+++ b/Libraries/MLXVLM/Models/Qwen4Exp.swift
@@ -1431,6 +1431,7 @@ protocol Qwen4ExpModelDirectoryConfigurable: AnyObject {
 
 public final class Qwen4Exp: Module, VLMModel, Qwen4ExpModelDirectoryConfigurable,
     SafetensorsLoadKeyExcluding, NativeMTPModel, DFlash2StagedVerifyRollbackModel,
+    NativeMTPSampledStagedDiagnosticModel,
     CompiledDecodeExternalInputModel, ModalityBearing, ModelComponentMapping
 {
     /// QSA index selection and its path-dependent cache currently require a

--- a/Libraries/MLXVLM/Models/Qwen4Exp.swift
+++ b/Libraries/MLXVLM/Models/Qwen4Exp.swift
@@ -1562,7 +1562,9 @@ public final class Qwen4Exp: Module, VLMModel, Qwen4ExpModelDirectoryConfigurabl
     public func newCache(parameters: GenerateParameters?) -> [KVCache] {
         textModel.layers.map { layer in
             if layer.isLinear {
-                return MambaCache(slots: layer.ple == nil ? 2 : 6) as KVCache
+                let cache = MambaCache(slots: layer.ple == nil ? 2 : 6)
+                cache.persistentStateSlotCount = layer.ple == nil ? 2 : 4
+                return cache as KVCache
             }
             return QSAKVCache() as KVCache
         }

--- a/Libraries/MLXVLM/Models/Qwen4Exp.swift
+++ b/Libraries/MLXVLM/Models/Qwen4Exp.swift
@@ -1573,6 +1573,29 @@ public final class Qwen4Exp: Module, VLMModel, Qwen4ExpModelDirectoryConfigurabl
 
         guard input.image != nil || input.video != nil else {
             setRopeDelta(0, for: cache)
+            // The caller's window also bounds cache-boundary reconstruction.
+            // A whole-prompt forward here retained prefill intermediates at the
+            // post-generation high-water mark. Keep QSA/PLE/recurrent state in
+            // the supplied cache and materialize it between text chunks.
+            // Media retains its full-grid M-RoPE/scatter path below.
+            let step = windowSize ?? GenerateParameters().prefillStepSize
+            if inputIds.ndim == 2, !cache.isEmpty, step > 0, inputIds.dim(1) > step {
+                let count = inputIds.dim(1)
+                var offset = 0
+                while count - offset > step {
+                    try Task.checkCancellation()
+                    let end = offset + step
+                    _ = textModel(inputIds[0..., offset ..< end], cache: cache)
+                    MLX.eval(cache)
+                    PrefillProgressReporter.reportCompletedUnits(end)
+                    offset = end
+                    MLX.Memory.clearCache()
+                }
+                try Task.checkCancellation()
+                return .logits(LMOutput(
+                    logits: callAsFunction(inputIds[0..., offset...], cache: cache)))
+            }
+            try Task.checkCancellation()
             return .logits(LMOutput(logits: callAsFunction(inputIds, cache: cache)))
         }
 

--- a/Libraries/MLXVLM/Models/Qwen4ExpNGramTable.swift
+++ b/Libraries/MLXVLM/Models/Qwen4ExpNGramTable.swift
@@ -372,8 +372,52 @@ final class Qwen4ExpNGramTable: @unchecked Sendable {
     }
 
     /// Returns row-major Float32 values. Only bytes belonging to selected rows
-    /// are touched; duplicate row ids are intentionally preserved.
+    /// are touched. Duplicate output rows are preserved, but each distinct row
+    /// is read and dequantized once per gather. No data is retained across calls.
     func gather(_ rows: [Int64], parallelRows: Bool? = nil) throws -> [Float] {
+        // Avoid dictionary/scatter allocation for single rows or an already
+        // strictly increasing set. A decode token has multiple n-gram heads;
+        // disjoint ordered head ranges need no duplicate detection dictionary.
+        if rows.count <= 1 || zip(rows, rows.dropFirst()).allSatisfy({ $0.0 < $0.1 }) {
+            let (values, bytesRead) = try gatherDistinct(rows, parallelRows: parallelRows)
+            recordGather(rows: rows.count, bytesRead: bytesRead)
+            return values
+        }
+        var uniqueRows: [Int64] = []
+        var positions: [Int64: Int] = [:]
+        var outputPositions: [Int] = []
+        uniqueRows.reserveCapacity(rows.count)
+        outputPositions.reserveCapacity(rows.count)
+        for row in rows {
+            guard row >= 0, row < rowCount else {
+                throw Qwen4ExpNGramTableError.rowOutOfRange(row)
+            }
+            if let position = positions[row] {
+                outputPositions.append(position)
+            } else {
+                positions[row] = uniqueRows.count
+                outputPositions.append(uniqueRows.count)
+                uniqueRows.append(row)
+            }
+        }
+        let (values, bytesRead) = try gatherDistinct(
+            uniqueRows, parallelRows: parallelRows)
+        // rowsRead remains the logical requested-row count; payloadBytesRead
+        // measures actual selected-row I/O, excluding duplicate reads avoided.
+        recordGather(rows: rows.count, bytesRead: bytesRead)
+        guard uniqueRows.count != rows.count else { return values }
+        var output = [Float](repeating: 0, count: rows.count * dimensions)
+        for (outputRow, position) in outputPositions.enumerated() {
+            output.replaceSubrange(
+                outputRow * dimensions ..< (outputRow + 1) * dimensions,
+                with: values[position * dimensions ..< (position + 1) * dimensions])
+        }
+        return output
+    }
+
+    private func gatherDistinct(
+        _ rows: [Int64], parallelRows: Bool?
+    ) throws -> ([Float], UInt64) {
         if parallelRows ?? Self.parallelRows, rows.count > 1 {
             return try gatherParallel(rows)
         }
@@ -392,11 +436,10 @@ final class Qwen4ExpNGramTable: @unchecked Sendable {
                 outputRow * dimensions ..< (outputRow + 1) * dimensions,
                 with: values)
         }
-        recordGather(rows: rows.count, bytesRead: bytesRead)
-        return output
+        return (output, bytesRead)
     }
 
-    private func gatherParallel(_ rows: [Int64]) throws -> [Float] {
+    private func gatherParallel(_ rows: [Int64]) throws -> ([Float], UInt64) {
         let buffers = ParallelGatherBuffers(
             valueCount: rows.count * dimensions, rowCount: rows.count)
         DispatchQueue.concurrentPerform(iterations: rows.count) { outputRow in
@@ -424,8 +467,7 @@ final class Qwen4ExpNGramTable: @unchecked Sendable {
         let bytesRead = (0 ..< rows.count).reduce(UInt64(0)) {
             $0 + buffers.bytes[$1]
         }
-        recordGather(rows: rows.count, bytesRead: bytesRead)
-        return output
+        return (output, bytesRead)
     }
 
     func ioStats() -> IOStats {

--- a/Libraries/MLXVLM/Models/Qwen4ExpQSA.swift
+++ b/Libraries/MLXVLM/Models/Qwen4ExpQSA.swift
@@ -81,19 +81,27 @@ enum Qwen4ExpQSA {
         return expandedDimensions(mask, axis: 1)  // [B, 1, T, keyLen]
     }
 
-    /// Membership is constant within a compressed block. Compare each selected
-    /// block once, then expand the boolean result, instead of constructing a
-    /// [B,T,K,keyLen] equality temporary. The partial final block is included
-    /// in this grid; the caller retains ownership of causal and tail masking.
+    /// Scatter selected block membership, then expand to tokens. Integer max
+    /// makes duplicate IDs order-independent without a [B,T,K,blocks] equality
+    /// grid. Invalid IDs contribute zero to a safe index, preserving the old
+    /// equality implementation's behavior. Causal/tail policy remains above.
     static func tokenMembership(
         selectedBlocks: MLXArray, keyLen: Int, compressRatio: Int
     ) -> MLXArray {
         let blocks = (keyLen + compressRatio - 1) / compressRatio
-        let ids = MLXArray((0..<blocks).map(Int32.init))
-        let membership = MLX.any(
-            MLX.equal(ids.reshaped(1, 1, 1, blocks),
-                expandedDimensions(selectedBlocks, axis: -1)), axis: 2)
         let batch = selectedBlocks.dim(0), queries = selectedBlocks.dim(1)
+        guard blocks > 0, selectedBlocks.dim(2) > 0 else {
+            return MLXArray.zeros([batch, queries, keyLen], dtype: .bool)
+        }
+        let valid = logicalAnd(
+            greaterEqual(selectedBlocks, MLXArray(Int32(0))),
+            less(selectedBlocks, MLXArray(Int32(blocks))))
+        let safeIDs = MLX.where(valid, selectedBlocks, MLXArray(Int32(0)))
+        let batchIDs = MLXArray((0..<batch).map(Int32.init)).reshaped(batch, 1, 1)
+        let queryIDs = MLXArray((0..<queries).map(Int32.init)).reshaped(1, queries, 1)
+        let membership = MLXArray.zeros([batch, queries, blocks], dtype: .int32)
+            .at[batchIDs, queryIDs, safeIDs].maximum(valid.asType(.int32))
+            .asType(.bool)
         return broadcast(
             expandedDimensions(membership, axis: -1),
             to: [batch, queries, blocks, compressRatio])

--- a/Package.swift
+++ b/Package.swift
@@ -852,6 +852,7 @@ let package = Package(
                 "NativeMTPClockTests.swift",
                 "NativeMTPDepthPolicyTests.swift",
                 "NativeMTPDepthExecutionTests.swift",
+                "NativeMTPBoundaryCaptureTests.swift",
                 "NativeMTPManualSafetyParityTests.swift",
                 "RaptorTopLevelStampTests.swift",
                 "HybridRestoreBoundaryInvariantTests.swift",

--- a/Package.swift
+++ b/Package.swift
@@ -852,6 +852,7 @@ let package = Package(
                 "NativeMTPClockTests.swift",
                 "NativeMTPDepthPolicyTests.swift",
                 "NativeMTPDepthExecutionTests.swift",
+                "NativeMTPManualSafetyParityTests.swift",
                 "RaptorTopLevelStampTests.swift",
                 "HybridRestoreBoundaryInvariantTests.swift",
                 "DualPathFamiliesTests.swift",

--- a/Package.swift
+++ b/Package.swift
@@ -849,6 +849,7 @@ let package = Package(
             sources: [
                 "ProposalHeadStampTests.swift",
                 "NativeMTPARSafetyTests.swift",
+                "NativeMTPClockTests.swift",
                 "RaptorTopLevelStampTests.swift",
                 "HybridRestoreBoundaryInvariantTests.swift",
                 "DualPathFamiliesTests.swift",

--- a/Package.swift
+++ b/Package.swift
@@ -850,6 +850,8 @@ let package = Package(
                 "ProposalHeadStampTests.swift",
                 "NativeMTPARSafetyTests.swift",
                 "NativeMTPClockTests.swift",
+                "NativeMTPDepthPolicyTests.swift",
+                "NativeMTPDepthExecutionTests.swift",
                 "RaptorTopLevelStampTests.swift",
                 "HybridRestoreBoundaryInvariantTests.swift",
                 "DualPathFamiliesTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/LFM2ShortConvCacheRestoreFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/LFM2ShortConvCacheRestoreFocusedTests.swift
@@ -71,6 +71,87 @@ struct LFM2ShortConvCacheRestoreFocusedTests {
         }
     }
 
+    @Test("extended Mamba disk payload preserves PLE history and convolution state")
+    func diskRoundTripExtendedPLEState() throws {
+        try FocusedMLXTestSupport.withLock {
+            let extended = MambaCache(slots: 6)
+            extended.persistentStateSlotCount = 4
+            extended[0] = MLXArray.full([1, 2, 8], values: MLXArray(Float(1.5)))
+            extended[1] = MLXArray.full([1, 4, 4], values: MLXArray(Float(2.5)))
+            extended[2] = MLXArray([Int32(17), 23, 31]).reshaped(1, 3)
+            extended[3] = MLXArray.full([1, 2, 8], values: MLXArray(Float(3.5)))
+            extended[4] = MLXArray([Int32(999)])
+            extended[5] = MLXArray([Float(999)])
+            extended.offset = 9
+            let arrays = TQDiskSerializer.serialize(cache: [prefilledKV(tokens: 9), extended])
+            #expect(arrays["mamba_1_state4"] == nil && arrays["mamba_1_state5"] == nil)
+            let directory = FileManager.default.temporaryDirectory
+                .appendingPathComponent("ple-disk-roundtrip-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: directory) }
+            let file = directory.appendingPathComponent("boundary.safetensors")
+            try MLX.save(arrays: arrays, url: file)
+            let persisted = try MLX.loadArrays(url: file)
+            var target: [any KVCache] = [KVCacheSimple(), MambaCache(slots: 6)]
+            (target[1] as! MambaCache).persistentStateSlotCount = 4
+            #expect(restoreFromDiskArrays(persisted, into: &target) == 9)
+            let restored = target[1] as! MambaCache
+            #expect(restored.slotCount == 6)
+            #expect(restored.state.count == 4)
+            for slot in 0..<4 {
+                guard let actual = restored[slot], let expected = extended[slot] else {
+                    Issue.record("disk restore lost persistent PLE slot \(slot)")
+                    continue
+                }
+                #expect(actual.dtype == expected.dtype)
+                #expect(actual.shape == expected.shape)
+                #expect(MLX.all(actual .== expected).item(Bool.self))
+            }
+            #expect(restored[4] == nil && restored[5] == nil)
+
+            for missing in ["mamba_1_state2", "mamba_1_state3", "__mamba_1_persistent_slots__"] {
+                var damaged = persisted
+                damaged.removeValue(forKey: missing)
+                var fresh: [any KVCache] = [KVCacheSimple(), MambaCache(slots: 6)]
+                (fresh[1] as! MambaCache).persistentStateSlotCount = 4
+                #expect(restoreFromDiskArrays(damaged, into: &fresh) == 0)
+                #expect(fresh.allSatisfy { $0.offset == 0 && $0.state.isEmpty })
+            }
+            let copied = extended.copy() as! MambaCache
+            #expect(copied.persistentStateSlotCount == 4)
+            let compiled = CompilableMambaCache(from: extended)
+            #expect(compiled.persistentStateSlotCount == 4)
+            #expect((compiled.copy() as! MambaCache).persistentStateSlotCount == 4)
+
+            let nested = TQDiskSerializer.serialize(cache: [
+                CacheList([prefilledKV(tokens: 9), extended])
+            ])
+            let nestedMamba = MambaCache(slots: 6)
+            nestedMamba.persistentStateSlotCount = 4
+            var nestedTarget: [any KVCache] = [CacheList([KVCacheSimple(), nestedMamba])]
+            #expect(restoreFromDiskArrays(nested, into: &nestedTarget) == 9)
+            #expect(nestedMamba.state.count == 4)
+            if let ids = nestedMamba[2] {
+                #expect(ids.asArray(Int32.self) == [17, 23, 31])
+            }
+        }
+    }
+
+    @Test("old two-slot disk payload cannot seed an extended PLE cache")
+    func truncatedPLEPayloadIsRequiredMiss() {
+        FocusedMLXTestSupport.withLock {
+            let old = MambaCache()
+            old[0] = MLXArray.zeros([1, 2, 8])
+            old[1] = MLXArray.zeros([1, 4, 4])
+            old.offset = 9
+            let arrays = TQDiskSerializer.serialize(cache: [prefilledKV(tokens: 9), old])
+            var target: [any KVCache] = [KVCacheSimple(), MambaCache(slots: 6)]
+            (target[1] as! MambaCache).persistentStateSlotCount = 4
+            #expect(restoreFromDiskArrays(arrays, into: &target) == 0)
+            #expect(target.allSatisfy { $0.offset == 0 && $0.state.isEmpty })
+        }
+    }
+
     @Test("v2 disk payload still round-trips the full two-slot Mamba layout")
     func diskRoundTripTwoSlotMamba() {
         FocusedMLXTestSupport.withLock {

--- a/Tests/MLXLMCommonFocusedTests/LFM2ShortConvCacheRestoreFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/LFM2ShortConvCacheRestoreFocusedTests.swift
@@ -71,6 +71,100 @@ struct LFM2ShortConvCacheRestoreFocusedTests {
         }
     }
 
+    @Test("same-key disk publication replaces a fetched legacy PLE layout")
+    func diskPublicationReplacesLegacyPLELayout() throws {
+        try FocusedMLXTestSupport.withLock {
+            let directory = FileManager.default.temporaryDirectory
+                .appendingPathComponent("ple-disk-upgrade-\(UUID().uuidString)")
+            defer { try? FileManager.default.removeItem(at: directory) }
+            let tokens = Array(1...9)
+            let modelKey = "tiny-ple-layout-upgrade"
+            let disk = DiskCache(cacheDir: directory, maxSizeGB: 0.01, modelKey: modelKey)
+            let legacy = MambaCache()
+            legacy[0] = MLXArray.ones([1, 2, 8])
+            legacy[1] = MLXArray.ones([1, 4, 4])
+            legacy.offset = tokens.count
+            let oldArrays = TQDiskSerializer.serialize(
+                cache: [prefilledKV(tokens: tokens.count), legacy])
+            disk.store(tokens: tokens, arrays: oldArrays)
+            disk.store(tokens: tokens, arrays: oldArrays, mediaSalt: "unrelated-media")
+            let fetched = try #require(disk.fetch(tokens: tokens))
+            var target: [any KVCache] = [KVCacheSimple(), MambaCache(slots: 6)]
+            (target[1] as! MambaCache).persistentStateSlotCount = 4
+            #expect(restoreFromDiskArrays(fetched, into: &target) == 0)
+
+            let repaired = MambaCache(slots: 6)
+            repaired.persistentStateSlotCount = 4
+            repaired[0] = MLXArray.ones([1, 2, 8])
+            repaired[1] = MLXArray.ones([1, 4, 4])
+            repaired[2] = MLXArray([Int32(17), 23, 31]).reshaped(1, 3)
+            repaired[3] = MLXArray.full([1, 2, 8], values: MLXArray(Float(3.5)))
+            repaired.offset = tokens.count
+            disk.store(tokens: tokens, arrays: TQDiskSerializer.serialize(
+                cache: [prefilledKV(tokens: tokens.count), repaired]))
+
+            // Open a new disk-cache instance so the assertion cannot be
+            // satisfied by only updating a process-local validation record.
+            let reopened = DiskCache(
+                cacheDir: directory, maxSizeGB: 0.01, modelKey: modelKey)
+            let persisted = try #require(reopened.fetch(tokens: tokens))
+            #expect(persisted["mamba_1_state2"] != nil)
+            #expect(persisted["mamba_1_state3"] != nil)
+            #expect(restoreFromDiskArrays(persisted, into: &target) == tokens.count)
+            let unrelated = try #require(reopened.fetch(
+                tokens: tokens, mediaSalt: "unrelated-media"))
+            #expect(unrelated["mamba_1_state2"] == nil)
+            #expect(unrelated["mamba_1_state3"] == nil)
+        }
+    }
+
+    @Test("rejected disk candidates lose validation without removing newer readers or other keys")
+    func rejectedDiskCandidateIdentityAndIsolation() throws {
+        try FocusedMLXTestSupport.withLock {
+            let directory = FileManager.default.temporaryDirectory
+                .appendingPathComponent("ple-reject-identity-\(UUID().uuidString)")
+            defer { try? FileManager.default.removeItem(at: directory) }
+            let config = CacheCoordinatorConfig(
+                usePagedCache: false, enableDiskCache: true,
+                diskCacheMaxGB: 0.01, diskCacheDir: directory, modelKey: "reject-ple")
+            let coordinator = CacheCoordinator(config: config)
+            let disk = try #require(coordinator.diskCache)
+            let tokens = Array(1...9)
+            let arrays = TQDiskSerializer.serialize(cache: [
+                prefilledKV(tokens: 9), shortConvCache(fill: 1, offset: 9),
+            ])
+            disk.store(tokens: tokens, arrays: arrays)
+            let storesBefore = disk.snapshotStats().storeSkips
+            disk.store(tokens: tokens, arrays: arrays)
+            #expect(disk.snapshotStats().storeSkips == storesBefore + 1)
+            disk.store(tokens: tokens, arrays: arrays, mediaSalt: "other")
+            let otherModel = DiskCache(
+                cacheDir: directory, maxSizeGB: 0.01, modelKey: "other-model")
+            otherModel.store(tokens: tokens, arrays: arrays)
+            let earlier = try #require(disk.fetch(tokens: tokens))
+            let current = try #require(disk.fetch(tokens: tokens))
+            coordinator.rejectDiskCandidate(tokens: tokens, arrays: earlier)
+            #expect(coordinator.hasValidatedDiskEntry(tokens: tokens))
+            coordinator.rejectDiskCandidate(tokens: tokens, arrays: current)
+            #expect(!coordinator.hasValidatedDiskEntry(tokens: tokens))
+            #expect(!coordinator.hasDurableDiskEntry(tokens: tokens))
+            #expect(disk.fetch(tokens: tokens) == nil)
+            #expect(disk.fetch(tokens: tokens, mediaSalt: "other") != nil)
+            #expect(otherModel.fetch(tokens: tokens) != nil)
+
+            disk.store(tokens: tokens, arrays: arrays)
+            let stale = try #require(disk.fetch(tokens: tokens))
+            let externalWriter = DiskCache(
+                cacheDir: directory, maxSizeGB: 0.01, modelKey: "reject-ple")
+            var replacement = arrays
+            replacement["new-layout-state"] = MLXArray.ones([32])
+            externalWriter.store(tokens: tokens, arrays: replacement)
+            coordinator.rejectDiskCandidate(tokens: tokens, arrays: stale)
+            let retained = try #require(disk.fetch(tokens: tokens))
+            #expect(retained["new-layout-state"] != nil)
+        }
+    }
+
     @Test("extended Mamba disk payload preserves PLE history and convolution state")
     func diskRoundTripExtendedPLEState() throws {
         try FocusedMLXTestSupport.withLock {

--- a/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/MTPRuntimeFocusedTests.swift
@@ -583,6 +583,12 @@ struct MTPRuntimeFocusedTests {
         #expect(status.snapshot.tuning?.legacyBlockSuperseded == true)
         #expect(status.statusLine.contains("legacy_block=superseded_by_row_parity_fix"))
         #expect(recommendation?.depth == 3)
+        var manualSettings = VMLXServerRuntimeSettings()
+        manualSettings.mtp.mode = .forceOn
+        manualSettings.mtp.explicitDepth = 3
+        #expect(manualSettings.effectiveMTPLaunchMode(for: status) == .speculative)
+        #expect(manualSettings.resolvedMTPLaunch(
+            configData: config, jangConfig: nil, status: status).launchMode == .speculative)
         #expect(recommendation?.evidence.contains(
             "legacy_block=superseded_by_qwen4_exp_q4_row_parity_fix") == true)
 
@@ -610,6 +616,9 @@ struct MTPRuntimeFocusedTests {
         #expect(!changedStatus.isLegacyBlockSuperseded)
         #expect(changedStatus.isExplicitlyBlocked)
         #expect(!changedStatus.canAutoLaunchMTP)
+        #expect(manualSettings.effectiveMTPLaunchMode(for: changedStatus) == .blocked)
+        #expect(manualSettings.resolvedMTPLaunch(
+            configData: config, jangConfig: nil, status: changedStatus).launchMode == .blocked)
     }
 
     @Test("measured Flash-Next cold start is not inherited by other Qwen families")

--- a/Tests/MLXLMCommonFocusedTests/NativeMTPARSafetyTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NativeMTPARSafetyTests.swift
@@ -16,6 +16,24 @@ final class NativeMTPARSafetyTests: XCTestCase {
 
     private typealias V = NativeMTPTokenIterator
 
+    func testProductionMarginDoesNotDeliberatelyPermitSustainedSlowdown() {
+        // Same context, sustained 5% loss: both the window and median must
+        // reject it. This pins the production threshold, not a test override.
+        let samples = ring(Array(repeating: 42, count: 8))
+        let verdict = V.windowedARVerdict(
+            arStepMs: 10, firstVerifyMs: 12, windowCycles: 8,
+            deltaEmitted: 32, deltaWallMs: 336, deltaVerifyMs: 96,
+            margin: V.arSafetyMargin)
+        XCTAssertNotNil(verdict)
+        XCTAssertGreaterThan(V.medianCycleMsPerToken(samples)!, 10 * V.arSafetyMargin)
+        for cost in [9.0, 10.0] {
+            XCTAssertNil(V.windowedARVerdict(
+                arStepMs: 10, firstVerifyMs: 12, windowCycles: 8,
+                deltaEmitted: 32, deltaWallMs: cost * 32, deltaVerifyMs: 96,
+                margin: V.arSafetyMargin))
+        }
+    }
+
     func testResumeProbeCompletesAtSixCyclesNotTwelve() {
         var remaining = 6
         var samples = [V.ARSafetySample(emitted: 40, wall: 1, verifyTotal: 0)]

--- a/Tests/MLXLMCommonFocusedTests/NativeMTPARSafetyTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NativeMTPARSafetyTests.swift
@@ -16,6 +16,26 @@ final class NativeMTPARSafetyTests: XCTestCase {
 
     private typealias V = NativeMTPTokenIterator
 
+    func testResumeProbeCompletesAtSixCyclesNotTwelve() {
+        var remaining = 6
+        var samples = [V.ARSafetySample(emitted: 40, wall: 1, verifyTotal: 0)]
+        for cycle in 1...6 {
+            samples.append(V.ARSafetySample(
+                emitted: 40 + cycle * 2, wall: 1.030 + Double(cycle) * 0.020,
+                verifyTotal: Double(cycle) * 0.010))
+            let complete = V.advanceARSafetyProbe(remaining: &remaining)
+            XCTAssertEqual(complete, cycle == 6)
+            XCTAssertEqual(remaining, 6 - cycle)
+        }
+        XCTAssertEqual(samples.count, 7)
+        let wall = samples.last!.wall - samples.first!.wall
+        let emitted = samples.last!.emitted - samples.first!.emitted
+        // 30ms initial drafting plus six 20ms cycles; initial cost counts.
+        XCTAssertEqual(wall * 1000 / Double(emitted), 12.5, accuracy: 1e-9)
+        XCTAssertFalse(V.advanceARSafetyProbe(remaining: &remaining))
+        XCTAssertEqual(remaining, 0)
+    }
+
     func testFastMTPHolds() {
         // MTP at 5ms/tok, AR seed 10ms, no context growth -> MTP is 2x faster.
         XCTAssertNil(

--- a/Tests/MLXLMCommonFocusedTests/NativeMTPBoundaryCaptureTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NativeMTPBoundaryCaptureTests.swift
@@ -1,0 +1,200 @@
+import Foundation
+import MLX
+import MLXNN
+import XCTest
+@testable import MLXLMCommon
+
+final class NativeMTPBoundaryCaptureTests: XCTestCase {
+    func testMaskSplitAndAuxiliaryExclusion() throws {
+        try FocusedMLXTestSupport.withLock {
+            for mode in 0..<3 {
+                let directory = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("native-mask-\(UUID().uuidString)")
+                defer { try? FileManager.default.removeItem(at: directory) }
+                let coordinator = CacheCoordinator(config: CacheCoordinatorConfig(
+                    usePagedCache: false, enableDiskCache: true,
+                    diskCacheDir: directory, modelKey: "native-mask-fixture"))
+                coordinator.setHybrid(true)
+                coordinator.setGenPromptSuffixTokens([21])
+                let ids = [11, 12, 21, 22]
+                let mask = mode == 1
+                    ? MLXArray.ones([1, 1, 4, 4])
+                    : MLXArray([Int32(1), 2, 3, 4]).reshaped([1, 4])
+                let model = BoundaryRecordingTarget(returnsLogits: true)
+                let input = LMInput(
+                    text: .init(tokens: MLXArray(ids.map(Int32.init))[.newAxis],
+                                mask: mask, tokenIds: ids),
+                    cacheScopeSalt: "reasoning=off",
+                    cachePromptIntent: mode == 2 ? .auxiliary : .generation)
+                let iterator = try NativeMTPTokenIterator(
+                    input: input, model: model,
+                    parameters: GenerateParameters(maxTokens: 16, temperature: 0),
+                    depth: 3, cacheCoordinator: coordinator)
+                XCTAssertEqual(model.forwarded, ids + [1])
+                XCTAssertEqual(model.preparedInputs.count, mode == 0 ? 2 : 1)
+                if mode == 0 {
+                    XCTAssertEqual(model.preparedInputs.map { $0.text.tokenIds! }, [[11, 12], [21, 22]])
+                    XCTAssertEqual(model.preparedInputs.map { $0.text.mask!.asArray(Int32.self) },
+                                   [[1, 2], [3, 4]])
+                    XCTAssertTrue(model.preparedInputs.allSatisfy { $0.cacheScopeSalt == "reasoning=off" })
+                    XCTAssertNotNil(iterator.strippedPromptSnapshot)
+                } else {
+                    XCTAssertNil(iterator.strippedPromptSnapshot)
+                }
+            }
+        }
+    }
+
+    func testCancellationAfterHeadPublishesNothing() async throws {
+        try await FocusedMLXTestSupport.withLock {
+            let directory = FileManager.default.temporaryDirectory
+                .appendingPathComponent("native-cancel-\(UUID().uuidString)")
+            defer { try? FileManager.default.removeItem(at: directory) }
+            let coordinator = CacheCoordinator(config: CacheCoordinatorConfig(
+                usePagedCache: false, enableDiskCache: true,
+                diskCacheDir: directory, modelKey: "native-cancel-fixture"))
+            coordinator.setHybrid(true)
+            coordinator.setGenPromptSuffixTokens([21])
+            let model = BoundaryRecordingTarget(returnsLogits: true)
+            model.afterPrepare = { withUnsafeCurrentTask { $0?.cancel() } }
+            do {
+                _ = try NativeMTPTokenIterator(
+                    input: LMInput(tokens: MLXArray([Int32(11), 12, 21, 22])[.newAxis]),
+                    model: model, parameters: GenerateParameters(maxTokens: 16, temperature: 0),
+                    depth: 3, cacheCoordinator: coordinator)
+                XCTFail("Expected cancellation before suffix/bridge")
+            } catch is CancellationError {
+                XCTAssertEqual(model.forwarded, [11, 12])
+                XCTAssertEqual(coordinator.snapshotStats().diskStats?.stores ?? 0, 0)
+            }
+        }
+    }
+
+    func testStrippedBoundaryDoesNotReplayPromptAtStore() throws {
+        try FocusedMLXTestSupport.withLock {
+            for returnsLogits in [false, true] {
+                for depth in 1...3 {
+                    let directory = FileManager.default.temporaryDirectory
+                        .appendingPathComponent("native-boundary-\(UUID().uuidString)")
+                    defer { try? FileManager.default.removeItem(at: directory) }
+                    let coordinator = CacheCoordinator(config: CacheCoordinatorConfig(
+                        usePagedCache: false, enableDiskCache: true,
+                        diskCacheDir: directory, modelKey: "native-boundary-fixture"))
+                    coordinator.setHybrid(true)
+                    coordinator.setGenPromptSuffixTokens([21, 22, 23])
+                    let model = BoundaryRecordingTarget(returnsLogits: returnsLogits)
+                    var parameters = GenerateParameters(
+                        maxTokens: 16, temperature: 0, prefillStepSize: 3)
+                    parameters.draftStrategy = .nativeMTP(depth: depth)
+                    parameters.nativeMTPDepthPolicy = .fixed
+                    let prompt = [11, 12, 13, 14, 15, 16, 17, 21, 22, 23]
+                    let input = LMInput(tokens: MLXArray(prompt.map(Int32.init))[.newAxis])
+                    var iterator = try NativeMTPTokenIterator(
+                        input: input, model: model, parameters: parameters,
+                        depth: depth, cacheCoordinator: coordinator)
+                    // Construction also forwards the first sampled token to prime the bridge.
+                    XCTAssertEqual(model.forwarded, prompt + [1])
+                    XCTAssertEqual(iterator.promptCacheSnapshot?.first?.offset, prompt.count,
+                                   "The exact snapshot must include the final prepare remainder")
+                    let captured = try XCTUnwrap(iterator.strippedPromptSnapshot)
+                    XCTAssertEqual(captured.boundary, 7)
+                    XCTAssertEqual(captured.cache.first?.offset, 7)
+                    XCTAssertEqual(captured.cache.first?.state.first?.asArray(Float.self), [98],
+                                   "Later suffix/bridge forwards must not mutate the owned boundary")
+                    let beforeStore = model.forwarded
+                    iterator.storeCacheAfterGeneration(
+                        generatedTokenIds: [], includeGeneratedBoundary: false)
+                    XCTAssertEqual(model.forwarded, beforeStore,
+                                   "The reusable boundary must come from live prefill, not replay")
+                    let hit = coordinator.fetch(
+                        tokens: prompt + [9],
+                        mediaSalt: computeCacheSalt(for: input, parameters: parameters),
+                        skipExactDiskBoundary: true)
+                    guard case .hit(let count, _, let tier, _, _, _) = hit else {
+                        XCTFail("No disk-restorable boundary"); continue
+                    }
+                    XCTAssertEqual(count, 7)
+                    XCTAssertEqual(tier, .disk)
+                    // Restore the published recurrent state, not merely its key.
+                    model.forwarded = []
+                    var warm = try NativeMTPTokenIterator(
+                        input: input, model: model, parameters: parameters,
+                        depth: depth, cacheCoordinator: coordinator)
+                    XCTAssertEqual(model.forwarded, [21, 22, 23, 1])
+                    XCTAssertEqual(warm.strippedPromptSnapshot?.cache.first?.state.first?
+                        .asArray(Float.self), [98])
+                    XCTAssertEqual(warm.promptCacheSnapshot?.first?.state.first?
+                        .asArray(Float.self), [164])
+                    let warmForwards = model.forwarded
+                    warm.storeCacheAfterGeneration(
+                        generatedTokenIds: [], includeGeneratedBoundary: false)
+                    XCTAssertEqual(model.forwarded, warmForwards)
+                    model.forwarded = []
+                    let grownPrompt = Array(prompt.prefix(7)) + [24, 25, 21, 22, 23]
+                    var grown = try NativeMTPTokenIterator(
+                        input: LMInput(tokens: MLXArray(grownPrompt.map(Int32.init))[.newAxis]),
+                        model: model, parameters: parameters,
+                        depth: depth, cacheCoordinator: coordinator)
+                    XCTAssertEqual(model.forwarded, [24, 25, 21, 22, 23, 1])
+                    XCTAssertEqual(grown.strippedPromptSnapshot?.boundary, 9)
+                    XCTAssertEqual(grown.strippedPromptSnapshot?.cache.first?.state.first?
+                        .asArray(Float.self), [147])
+                    let grownForwards = model.forwarded
+                    grown.storeCacheAfterGeneration(
+                        generatedTokenIds: [], includeGeneratedBoundary: false)
+                    XCTAssertEqual(model.forwarded, grownForwards)
+                }
+            }
+        }
+    }
+}
+
+private final class BoundaryRecordingTarget: Module, NativeMTPModel, @unchecked Sendable {
+    let returnsLogits: Bool
+    var forwarded: [Int] = []
+    var preparedInputs: [LMInput] = []
+    var afterPrepare: (() -> Void)?
+    var vocabularySize: Int { 32 }
+    var nativeMTPAvailable: Bool { true }
+    init(returnsLogits: Bool) { self.returnsLogits = returnsLogits; super.init() }
+    // Hybrid restore derives the matched token count from the attention lane.
+    func newCache(parameters: GenerateParameters?) -> [KVCache] {
+        [MambaCache(), KVCacheSimple()]
+    }
+    func makeNativeMTPCache() -> [KVCache] { [] }
+    func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult {
+        preparedInputs.append(input)
+        defer { afterPrepare?() }
+        if returnsLogits {
+            return .logits(LMOutput(logits: callAsFunction(input.text.tokens, cache: cache)))
+        }
+        return .tokens(input.text)
+    }
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        nativeBackboneForward(inputs, cache: cache).logits
+    }
+    func nativeBackboneForward(_ inputs: MLXArray, cache: [KVCache]?) -> NativeMTPForwardResult {
+        let ids = inputs.reshaped([-1]).asArray(Int32.self).map(Int.init)
+        forwarded += ids
+        if let cache = cache?.first as? MambaCache {
+            let previous = cache.state.first?.asArray(Float.self).first ?? 0
+            cache[0] = MLXArray([previous + Float(ids.reduce(0, +))]).reshaped([1, 1, 1])
+            cache.offset += ids.count
+        }
+        if let attention = cache?.last as? KVCacheSimple {
+            let rows = MLXArray(ids.map(Float.init)).reshaped([1, 1, ids.count, 1])
+            _ = attention.update(keys: rows, values: rows)
+        }
+        return result(count: inputs.size)
+    }
+    func nativeMTPForward(
+        hiddenStates: MLXArray, nextTokenIds: MLXArray, cache: [KVCache]?
+    ) -> NativeMTPForwardResult { result(count: nextTokenIds.size) }
+    private func result(count: Int) -> NativeMTPForwardResult {
+        var values = Array(repeating: Float(-100), count: 32)
+        values[1] = 100
+        return NativeMTPForwardResult(
+            logits: broadcast(MLXArray(values), to: [1, count, 32]),
+            hiddenStates: MLXArray.zeros([1, count, 1]))
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/NativeMTPClockTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NativeMTPClockTests.swift
@@ -1,0 +1,31 @@
+import Foundation
+import XCTest
+
+@testable import MLXLMCommon
+
+final class NativeMTPClockTests: XCTestCase {
+    func testUptimeUnitsAndElapsedInterval() {
+        XCTAssertEqual(NativeMTPClock.seconds(uptimeNanoseconds: 1_250_000_000), 1.25)
+        let first = NativeMTPClock.seconds(uptimeNanoseconds: 10_000_000_000)
+        let last = NativeMTPClock.seconds(uptimeNanoseconds: 10_023_300_000)
+        XCTAssertEqual(last - first, 0.0233, accuracy: 1e-12)
+    }
+
+    func testClockDoesNotMoveBackward() {
+        var previous = NativeMTPClock.now()
+        for _ in 0..<1000 {
+            let current = NativeMTPClock.now()
+            XCTAssertGreaterThanOrEqual(current, previous)
+            previous = current
+        }
+    }
+
+    func testIteratorNeverMixesCalendarAndUptimeClocks() throws {
+        let root = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+        let source = try String(contentsOf: root.appendingPathComponent(
+            "Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift"), encoding: .utf8)
+        XCTAssertFalse(source.contains("Date.timeIntervalSinceReferenceDate"))
+        XCTAssertTrue(source.contains("NativeMTPClock.now()"))
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/NativeMTPDepthExecutionTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NativeMTPDepthExecutionTests.swift
@@ -29,6 +29,59 @@ final class NativeMTPDepthExecutionTests: XCTestCase {
         }
     }
 
+    func testSampledIteratorDoesNotSilentlyBecomeGreedy() throws {
+        try requireIsolatedDepthRun()
+        try FocusedMLXTestSupport.withLock {
+            let tokens = try runSampled(disjointDraft: false)
+            XCTAssertEqual(Set(tokens), Set([0, 1]))
+        }
+    }
+
+    func testSampledIteratorRejectsDraftsOutsideTargetSupport() throws {
+        try requireIsolatedDepthRun()
+        try FocusedMLXTestSupport.withLock {
+            let tokens = try runSampled(disjointDraft: true)
+            XCTAssertEqual(Set(tokens), Set([0, 1]))
+        }
+    }
+
+    /// The target assigns equal probability to tokens 0 and 1; top-k removes
+    /// the other two. A disjoint proposal must be rejected, then corrected
+    /// from the target residual. This exercises iterator sampling, NOT real
+    /// model rollback: this fixture's cache commit methods are deliberate no-ops.
+    private func runSampled(disjointDraft: Bool) throws -> [Int] {
+        let target: [Float] = [1, 1, -100, -100]
+        let model = DepthDispatchTarget(
+            targetLogits: target,
+            draftLogits: disjointDraft ? [-100, -100, 1, 1] : target)
+        var parameters = GenerateParameters(maxTokens: 160, temperature: 1, topK: 2)
+        parameters.randomSeed = 829
+        parameters.draftStrategy = .nativeMTP(depth: 3)
+        parameters.nativeMTPDepthPolicy = .fixed
+        var iterator = try NativeMTPTokenIterator(
+            input: LMInput(tokens: MLXArray([0, 1, 0])), model: model,
+            parameters: parameters, depth: 3)
+        var tokens: [Int] = []
+        let started = ProcessInfo.processInfo.systemUptime
+        while tokens.count < 160, let token = iterator.next() { tokens.append(token) }
+        let elapsed = ProcessInfo.processInfo.systemUptime - started
+        XCTAssertEqual(tokens.count, 160)
+        // Sampled hybrid verification is sequential; the staged verify hook
+        // observed by verifyWidths is intentionally not used on that path.
+        XCTAssertGreaterThan(iterator.verifyMainForwardCount, 0)
+        XCTAssertGreaterThan(iterator.mtpForwardCount, 0)
+        XCTAssertGreaterThan(iterator.acceptanceProbabilityCount, 0)
+        XCTAssertTrue(model.verifyWidths.allSatisfy { $0 <= 4 })
+        if disjointDraft {
+            XCTAssertGreaterThan(iterator.rejectedCount, 0)
+            XCTAssertGreaterThan(iterator.residualCorrectionCount, 0)
+        } else {
+            XCTAssertEqual(iterator.rejectedCount, 0)
+        }
+        print("SAMPLED-DISPATCH disjointDraft=\(disjointDraft) support=\(Set(tokens).sorted()) rejections=\(iterator.rejectedCount) residuals=\(iterator.residualCorrectionCount) sequentialVerifies=\(iterator.sequentialVerifierCount) fixtureTokens=\(tokens.count) fixtureTokS=\(Double(tokens.count) / max(elapsed, 1e-9))")
+        return tokens
+    }
+
     private func requireIsolatedDepthRun() throws {
         guard ProcessInfo.processInfo.environment["VMLX_NATIVE_MTP_AR_SAFETY"] == "0" else {
             throw XCTSkip("Run this dispatch-only fixture with VMLX_NATIVE_MTP_AR_SAFETY=0; real governor speed qualification is separate")
@@ -44,14 +97,16 @@ final class NativeMTPDepthExecutionTests: XCTestCase {
             input: LMInput(tokens: MLXArray([1, 1, 1])), model: model,
             parameters: parameters, depth: depth)
         var count = 0
+        let started = ProcessInfo.processInfo.systemUptime
         while let token = iterator.next() {
             XCTAssertEqual(token, 1)
             count += 1
             if count >= 160 { break }
         }
+        let elapsed = ProcessInfo.processInfo.systemUptime - started
         XCTAssertEqual(count, 160)
         XCTAssertGreaterThan(iterator.stagedVerifierCommitCount, 0)
-        print("DEPTH-DISPATCH requested=\(depth) policy=\(policy) widths=\(Set(model.verifyWidths).sorted()) stagedCommits=\(iterator.stagedVerifierCommitCount) fixtureTokens=\(count)")
+        print("DEPTH-DISPATCH requested=\(depth) policy=\(policy) widths=\(Set(model.verifyWidths).sorted()) stagedCommits=\(iterator.stagedVerifierCommitCount) fixtureTokens=\(count) fixtureTokS=\(Double(count) / max(elapsed, 1e-9))")
         return model.verifyWidths
     }
 }
@@ -62,6 +117,16 @@ private final class DepthDispatchTarget: Module, LanguageModel, NativeMTPModel,
     var kvHeads: [Int] { [1] }
     var nativeMTPAvailable: Bool { true }
     var verifyWidths: [Int] = []
+    private let targetLogits: MLXArray
+    private let draftLogits: MLXArray
+    init(
+        targetLogits: [Float] = [-100, 100, -100, -100],
+        draftLogits: [Float] = [-100, 100, -100, -100]
+    ) {
+        self.targetLogits = MLXArray(targetLogits)
+        self.draftLogits = MLXArray(draftLogits)
+        super.init()
+    }
     func newCache(parameters: GenerateParameters?) -> [KVCache] { [MambaCache()] }
     func makeNativeMTPCache() -> [KVCache] { [] }
     func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult {
@@ -76,13 +141,13 @@ private final class DepthDispatchTarget: Module, LanguageModel, NativeMTPModel,
         return result(inputs)
     }
     func nativeMTPForward(hiddenStates: MLXArray, nextTokenIds: MLXArray, cache: [KVCache]?) -> NativeMTPForwardResult {
-        result(nextTokenIds)
+        result(nextTokenIds, logits: draftLogits)
     }
     func commitVerifiedBlock(cache: [KVCache], acceptedInputs: Int) -> Bool { true }
     func commitStagedVerifiedBlock(cache: [KVCache], acceptedInputs: Int, blockLength: Int) -> Bool { true }
-    private func result(_ inputs: MLXArray) -> NativeMTPForwardResult {
+    private func result(_ inputs: MLXArray, logits: MLXArray? = nil) -> NativeMTPForwardResult {
         let length = inputs.ndim >= 2 ? inputs.dim(1) : inputs.size
-        return .init(logits: broadcast(MLXArray([Float(-100), 100, -100, -100]), to: [1, length, 4]),
+        return .init(logits: broadcast(logits ?? targetLogits, to: [1, length, 4]),
                      hiddenStates: MLXArray.zeros([1, length, 4]))
     }
 }

--- a/Tests/MLXLMCommonFocusedTests/NativeMTPDepthExecutionTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NativeMTPDepthExecutionTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import MLX
+import MLXNN
+import XCTest
+@testable import MLXLMCommon
+
+/// Exercises actual iterator verify dispatch. The zero-weight constant target
+/// makes every proposal correct; it is not a model-quality or speed benchmark.
+final class NativeMTPDepthExecutionTests: XCTestCase {
+    func testFixedDepthsBoundExecutedVerifyWidths() throws {
+        try requireIsolatedDepthRun()
+        try FocusedMLXTestSupport.withLock {
+            for depth in 1...3 {
+                let widths = try run(depth: depth, policy: .fixed)
+                XCTAssertFalse(widths.isEmpty)
+                XCTAssertTrue(widths.allSatisfy { $0 <= depth + 1 }, "D\(depth): \(widths)")
+                XCTAssertTrue(widths.contains(depth + 1))
+            }
+        }
+    }
+
+    func testAdaptiveActuallyPromotesButRespectsCeiling() throws {
+        try requireIsolatedDepthRun()
+        try FocusedMLXTestSupport.withLock {
+            let widths = try run(depth: 1, policy: .adaptive(maximumDepth: 3))
+            XCTAssertTrue(widths.contains(2))
+            XCTAssertTrue(widths.contains { $0 > 2 }, "No actual promotion: \(widths)")
+            XCTAssertTrue(widths.allSatisfy { $0 <= 4 })
+        }
+    }
+
+    private func requireIsolatedDepthRun() throws {
+        guard ProcessInfo.processInfo.environment["VMLX_NATIVE_MTP_AR_SAFETY"] == "0" else {
+            throw XCTSkip("Run this dispatch-only fixture with VMLX_NATIVE_MTP_AR_SAFETY=0; real governor speed qualification is separate")
+        }
+    }
+
+    private func run(depth: Int, policy: NativeMTPDepthPolicy) throws -> [Int] {
+        let model = DepthDispatchTarget()
+        var parameters = GenerateParameters(maxTokens: 160, temperature: 0)
+        parameters.draftStrategy = .nativeMTP(depth: depth)
+        parameters.nativeMTPDepthPolicy = policy
+        var iterator = try NativeMTPTokenIterator(
+            input: LMInput(tokens: MLXArray([1, 1, 1])), model: model,
+            parameters: parameters, depth: depth)
+        var count = 0
+        while let token = iterator.next() {
+            XCTAssertEqual(token, 1)
+            count += 1
+            if count >= 160 { break }
+        }
+        XCTAssertEqual(count, 160)
+        XCTAssertGreaterThan(iterator.stagedVerifierCommitCount, 0)
+        print("DEPTH-DISPATCH requested=\(depth) policy=\(policy) widths=\(Set(model.verifyWidths).sorted()) stagedCommits=\(iterator.stagedVerifierCommitCount) fixtureTokens=\(count)")
+        return model.verifyWidths
+    }
+}
+
+private final class DepthDispatchTarget: Module, LanguageModel, NativeMTPModel,
+    KVCacheDimensionProvider, DFlash2StagedVerifyRollbackModel, @unchecked Sendable
+{
+    var kvHeads: [Int] { [1] }
+    var nativeMTPAvailable: Bool { true }
+    var verifyWidths: [Int] = []
+    func newCache(parameters: GenerateParameters?) -> [KVCache] { [MambaCache()] }
+    func makeNativeMTPCache() -> [KVCache] { [] }
+    func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult {
+        .tokens(input.text)
+    }
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray { result(inputs).logits }
+    func nativeBackboneForward(_ inputs: MLXArray, cache: [KVCache]?) -> NativeMTPForwardResult {
+        result(inputs)
+    }
+    func nativeBackboneMTPVerifyForward(_ inputs: MLXArray, cache: [KVCache]?) -> NativeMTPForwardResult {
+        verifyWidths.append(inputs.ndim >= 2 ? inputs.dim(1) : inputs.size)
+        return result(inputs)
+    }
+    func nativeMTPForward(hiddenStates: MLXArray, nextTokenIds: MLXArray, cache: [KVCache]?) -> NativeMTPForwardResult {
+        result(nextTokenIds)
+    }
+    func commitVerifiedBlock(cache: [KVCache], acceptedInputs: Int) -> Bool { true }
+    func commitStagedVerifiedBlock(cache: [KVCache], acceptedInputs: Int, blockLength: Int) -> Bool { true }
+    private func result(_ inputs: MLXArray) -> NativeMTPForwardResult {
+        let length = inputs.ndim >= 2 ? inputs.dim(1) : inputs.size
+        return .init(logits: broadcast(MLXArray([Float(-100), 100, -100, -100]), to: [1, length, 4]),
+                     hiddenStates: MLXArray.zeros([1, length, 4]))
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/NativeMTPDepthExecutionTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NativeMTPDepthExecutionTests.swift
@@ -7,6 +7,25 @@ import XCTest
 /// Exercises actual iterator verify dispatch. The zero-weight constant target
 /// makes every proposal correct; it is not a model-quality or speed benchmark.
 final class NativeMTPDepthExecutionTests: XCTestCase {
+    func testSampledStagingOptInDoesNotEnableUnqualifiedModel() throws {
+        try FocusedMLXTestSupport.withLock {
+            let model = DepthDispatchTarget()
+            var parameters = GenerateParameters(maxTokens: 32, temperature: 1)
+            parameters.randomSeed = 829
+            parameters.draftStrategy = .nativeMTP(depth: 3)
+            var iterator = try NativeMTPTokenIterator(
+                input: LMInput(tokens: MLXArray([1, 1, 1])), model: model,
+                parameters: parameters, depth: 3, experimentalSampledStaging: true)
+            var count = 0
+            let start = ProcessInfo.processInfo.systemUptime
+            while iterator.next() != nil { count += 1 }
+            XCTAssertEqual(count, 32)
+            XCTAssertNil(iterator.terminalErrorDescription)
+            XCTAssertEqual(iterator.stagedVerifierCommitCount, 0)
+            XCTAssertGreaterThan(iterator.sequentialVerifierCount, 0)
+            print("SAMPLED-STAGING-EXCLUDED fixtureTokS=\(Double(count) / max(ProcessInfo.processInfo.systemUptime - start, 1e-9)) realModelSpeedProof=false")
+        }
+    }
     func testSampledAcceptancePauseCanProbeAgain() throws {
         guard ProcessInfo.processInfo.environment["VMLX_NATIVE_MTP_AR_SAFETY"] != "0" else {
             throw XCTSkip("Requires the production AR-safety governor")

--- a/Tests/MLXLMCommonFocusedTests/NativeMTPDepthExecutionTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NativeMTPDepthExecutionTests.swift
@@ -7,6 +7,33 @@ import XCTest
 /// Exercises actual iterator verify dispatch. The zero-weight constant target
 /// makes every proposal correct; it is not a model-quality or speed benchmark.
 final class NativeMTPDepthExecutionTests: XCTestCase {
+    func testGovernorCalibrationDoesNotBuildDiscardedInitialDrafts() throws {
+        guard ProcessInfo.processInfo.environment["VMLX_NATIVE_MTP_AR_SAFETY"] != "0" else {
+            throw XCTSkip("Requires governor calibration")
+        }
+        try FocusedMLXTestSupport.withLock {
+            for depth in 1...3 {
+                for temperature: Float in [0, 1] {
+                    let model = DepthDispatchTarget()
+                    var parameters = GenerateParameters(maxTokens: 16, temperature: temperature)
+                    parameters.randomSeed = 829
+                    parameters.draftStrategy = .nativeMTP(depth: depth)
+                    parameters.nativeMTPDepthPolicy = .fixed
+                    let started = ProcessInfo.processInfo.systemUptime
+                    var iterator = try NativeMTPTokenIterator(
+                        input: LMInput(tokens: MLXArray([1, 1, 1])), model: model,
+                        parameters: parameters, depth: depth)
+                    XCTAssertEqual(model.draftCalls, 0, "D\(depth) initial proposals would be discarded")
+                    for _ in 0..<3 { XCTAssertEqual(iterator.next(), 1) }
+                    XCTAssertEqual(model.draftCalls, 0, "First calibration step must not draft")
+                    XCTAssertEqual(iterator.next(), 1)
+                    XCTAssertEqual(iterator.autoregressiveFallbackTokenCount, 2)
+                    XCTAssertEqual(model.draftCalls, depth, "Prime only after the second calibration step")
+                    print("CALIBRATION depth=\(depth) temperature=\(temperature) drafts=\(model.draftCalls) fixtureTokS=\(4 / (ProcessInfo.processInfo.systemUptime - started))")
+                }
+            }
+        }
+    }
     func testEarlyStopAbandonsPrefetchedKVRows() throws {
         guard ProcessInfo.processInfo.environment["VMLX_MTP_VERIFY_PREFETCH"] != "0" else {
             throw XCTSkip("Requires prefetch enabled")

--- a/Tests/MLXLMCommonFocusedTests/NativeMTPDepthExecutionTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NativeMTPDepthExecutionTests.swift
@@ -7,6 +7,102 @@ import XCTest
 /// Exercises actual iterator verify dispatch. The zero-weight constant target
 /// makes every proposal correct; it is not a model-quality or speed benchmark.
 final class NativeMTPDepthExecutionTests: XCTestCase {
+    func testGroupedProbabilityEvaluationTiming() throws {
+        guard ProcessInfo.processInfo.environment["VMLX_BENCH_GROUPED_PROBABILITIES"] == "1" else {
+            throw XCTSkip("Opt-in generated-logit component timing")
+        }
+        try FocusedMLXTestSupport.withLock {
+            // Matches the inspected Flash bundle vocabulary, not an allocation
+            // of model weights. Production still derives shapes from logits.
+            let vocab = 248_320
+            var parameters = GenerateParameters(temperature: 1, topP: 0.95, topK: 20)
+            parameters.randomSeed = 829
+            let sampler = SpeculativeSamplingController(parameters: parameters)
+            for count in [2, 3, 4, 6] {
+                let values = (0..<(count * vocab)).map { Float(sin(Double($0) * 0.037)) }
+                let logits = MLXArray(values).reshaped(count, vocab).asType(.bfloat16)
+                MLX.eval(logits)
+                func measure(grouped: Bool) -> Double {
+                    let start = ProcessInfo.processInfo.systemUptime
+                    var rows: [MLXArray] = []
+                    for row in 0..<count {
+                        let p = sampler.probabilities(logits: logits[row])
+                        if !grouped { MLX.eval(p) }
+                        rows.append(p)
+                    }
+                    if grouped { MLX.eval(rows) }
+                    return (ProcessInfo.processInfo.systemUptime - start) * 1000
+                }
+                for _ in 0..<3 { _ = measure(grouped: false); _ = measure(grouped: true) }
+                var sequential: [Double] = []
+                var grouped: [Double] = []
+                for trial in 0..<9 {
+                    if trial.isMultiple(of: 2) {
+                        sequential.append(measure(grouped: false)); grouped.append(measure(grouped: true))
+                    } else {
+                        grouped.append(measure(grouped: true)); sequential.append(measure(grouped: false))
+                    }
+                }
+                print("GROUPED-PROBABILITY-BENCH rows=\(count) vocab=\(vocab) sequential_ms=\(sequential) grouped_ms=\(grouped) median_ratio=\(sequential.sorted()[4] / grouped.sorted()[4]) generated_logits=1 synchronized=1 realModelSpeedProof=false")
+            }
+        }
+    }
+
+    func testGroupedProbabilityEvaluationPreservesDistributionsAndRandomDraws() throws {
+        try FocusedMLXTestSupport.withLock {
+            var parameters = GenerateParameters(temperature: 1, topP: 0.95, topK: 20)
+            parameters.randomSeed = 829
+            var compared = 0
+            var accepted = 0
+            var corrected = 0
+            for dtype: DType in [.float16, .bfloat16, .float32] {
+                for depth in [1, 2, 3, 5] {
+                    let count = depth + 1
+                    let vocab = 257
+                    let values = (0..<(count * vocab)).map {
+                        Float(sin(Double($0) * 0.37) * 3 + cos(Double($0) * 0.11))
+                    }
+                    let logits = MLXArray(values).reshaped(count, vocab).asType(dtype)
+                    MLX.eval(logits)
+                    let sequential = SpeculativeSamplingController(parameters: parameters)
+                    let grouped = SpeculativeSamplingController(parameters: parameters)
+                    var reference: [MLXArray] = []
+                    var candidate: [MLXArray] = []
+                    for row in 0..<count {
+                        let p = sequential.probabilities(logits: logits[row])
+                        MLX.eval(p)
+                        reference.append(p)
+                        candidate.append(grouped.probabilities(logits: logits[row]))
+                    }
+                    MLX.eval(candidate)
+                    for row in 0..<count {
+                        XCTAssertEqual(reference[row].asArray(Float.self),
+                                       candidate[row].asArray(Float.self))
+                        let token = MLXArray(0)
+                        // Alternating exact proposals and disjoint-support proposals
+                        // cover acceptance and residual correction without new draws.
+                        let q = row.isMultiple(of: 2) ? reference[row]
+                            : MLXArray([Float(1)] + Array(repeating: Float(0), count: vocab - 1))
+                        let a = sequential.acceptOrCorrect(draftToken: token,
+                            targetProbabilities: reference[row], draftProbabilities: q)
+                        let b = grouped.acceptOrCorrect(draftToken: token,
+                            targetProbabilities: candidate[row], draftProbabilities: q)
+                        XCTAssertEqual(a.accepted, b.accepted)
+                        if a.accepted { accepted += 1 } else { corrected += 1 }
+                        XCTAssertEqual(a.acceptanceProbability, b.acceptanceProbability)
+                        XCTAssertEqual(a.correction?.item(Int.self), b.correction?.item(Int.self))
+                        XCTAssertEqual(sequential.sampleFromTarget(probabilities: reference[row]).item(Int.self),
+                                       grouped.sampleFromTarget(probabilities: candidate[row]).item(Int.self))
+                        compared += 1
+                    }
+                }
+            }
+            XCTAssertGreaterThan(accepted, 0)
+            XCTAssertGreaterThan(corrected, 0)
+            print("GROUPED-PROBABILITY rows=\(compared) exact_distribution_and_rng_control=true realModelSpeedProof=false")
+        }
+    }
+
     func testSampledStagingOptInDoesNotEnableUnqualifiedModel() throws {
         try FocusedMLXTestSupport.withLock {
             let model = DepthDispatchTarget()

--- a/Tests/MLXLMCommonFocusedTests/NativeMTPDepthExecutionTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NativeMTPDepthExecutionTests.swift
@@ -7,6 +7,87 @@ import XCTest
 /// Exercises actual iterator verify dispatch. The zero-weight constant target
 /// makes every proposal correct; it is not a model-quality or speed benchmark.
 final class NativeMTPDepthExecutionTests: XCTestCase {
+    func testEarlyStopAbandonsPrefetchedKVRows() throws {
+        guard ProcessInfo.processInfo.environment["VMLX_MTP_VERIFY_PREFETCH"] != "0" else {
+            throw XCTSkip("Requires prefetch enabled")
+        }
+        try FocusedMLXTestSupport.withLock {
+            let model = DepthDispatchTarget(trackKV: true)
+            var parameters = GenerateParameters(maxTokens: 80, temperature: 0)
+            parameters.draftStrategy = .nativeMTP(depth: 3)
+            parameters.nativeMTPDepthPolicy = .fixed
+            var iterator = try NativeMTPTokenIterator(
+                input: LMInput(tokens: MLXArray([1, 1, 1])), model: model,
+                parameters: parameters, depth: 3)
+            let started = ProcessInfo.processInfo.systemUptime
+            var tokens: [Int] = []
+            while iterator.verifyPrefetchSubmitCount == 0, tokens.count < 40,
+                  let token = iterator.next() { tokens.append(token) }
+            XCTAssertGreaterThan(iterator.verifyPrefetchSubmitCount, 0)
+            let committed = iterator.acceptedByDepth.reduce(0) { $0 + ($1.key + 1) * $1.value }
+            let expectedOffset = 3 + 1 + iterator.autoregressiveFallbackTokenCount + committed
+            XCTAssertGreaterThan(iterator.cache.last!.offset, expectedOffset,
+                                 "The control must have speculative KV rows outstanding")
+            iterator.storeCacheAfterGeneration(generatedTokenIds: tokens, includeGeneratedBoundary: false)
+            XCTAssertEqual(iterator.verifyPrefetchAbandonedCount, 1)
+            let kv = try XCTUnwrap(iterator.cache.last as? KVCacheSimple)
+            XCTAssertEqual(kv.offset, expectedOffset)
+            let state = try XCTUnwrap(kv.readKV())
+            XCTAssertEqual(state.keys.asArray(Int32.self), (0..<expectedOffset).map(Int32.init))
+            XCTAssertEqual(state.values.asArray(Int32.self), Array(repeating: 1, count: expectedOffset))
+            print("PREFETCH-STOP fixtureTokS=\(Double(tokens.count) / (ProcessInfo.processInfo.systemUptime - started)) restoredOffset=\(kv.offset) diskProof=false")
+        }
+    }
+    func testGovernorPausePreservesCommittedTokensAndBoundsResumeProbe() throws {
+        guard ProcessInfo.processInfo.environment["VMLX_NATIVE_MTP_AR_SAFETY"] != "0" else {
+            throw XCTSkip("Governor-on fixture requires AR safety enabled")
+        }
+        try FocusedMLXTestSupport.withLock {
+            let model = DepthDispatchTarget(draftDelay: 0.010, backboneDelay: 0.001, trackKV: true)
+            var parameters = GenerateParameters(maxTokens: 240, temperature: 0)
+            parameters.draftStrategy = .nativeMTP(depth: 3)
+            parameters.nativeMTPDepthPolicy = .fixed
+            var iterator = try NativeMTPTokenIterator(
+                input: LMInput(tokens: MLXArray([1, 1, 1])), model: model,
+                parameters: parameters, depth: 3)
+            var count = 0
+            var previousAR = 0
+            var pauses: [Int] = []
+            let started = ProcessInfo.processInfo.systemUptime
+            while count < 240 {
+                let oldTrips = iterator.arSafetyTrips
+                let oldDrafts = model.draftCalls
+                guard let token = iterator.next() else { break }
+                count += 1
+                XCTAssertEqual(token, 1)
+                if iterator.arSafetyTrips > oldTrips {
+                    pauses.append(iterator.verifyCalls)
+                    XCTAssertEqual(model.draftCalls, oldDrafts,
+                                   "A paused cycle must not build another draft batch")
+                }
+                if iterator.autoregressiveFallbackTokenCount > previousAR {
+                    previousAR = iterator.autoregressiveFallbackTokenCount
+                    let committed = iterator.acceptedByDepth.reduce(0) { $0 + ($1.key + 1) * $1.value }
+                    XCTAssertEqual(count, 2 + previousAR + committed,
+                                   "AR resumed before all verified tokens reached the consumer")
+                    let kv = try XCTUnwrap(iterator.cache.last as? KVCacheSimple)
+                    XCTAssertEqual(kv.offset, 3 + count - 1)
+                    let state = try XCTUnwrap(kv.readKV())
+                    XCTAssertEqual(state.keys.asArray(Int32.self), (0..<kv.offset).map(Int32.init))
+                    XCTAssertEqual(state.values.asArray(Int32.self), Array(repeating: 1, count: kv.offset))
+                    if pauses.count >= 2 { break }
+                }
+            }
+            XCTAssertGreaterThanOrEqual(pauses.count, 2)
+            if pauses.count >= 2 { XCTAssertEqual(pauses[1] - pauses[0], 6) }
+            XCTAssertGreaterThan(iterator.stagedVerifierCommitCount, 0)
+            if ProcessInfo.processInfo.environment["VMLX_MTP_VERIFY_PREFETCH"] != "0" {
+                XCTAssertGreaterThan(iterator.verifyPrefetchConsumedCount, 0)
+            }
+            let elapsed = ProcessInfo.processInfo.systemUptime - started
+            print("GOVERNOR-FIXTURE pauses=\(pauses) tokens=\(count) fixtureTokS=\(Double(count) / elapsed) prefetchConsumed=\(iterator.verifyPrefetchConsumedCount) kvPositionProof=true recurrentStateProof=false")
+        }
+    }
     func testFixedDepthsBoundExecutedVerifyWidths() throws {
         try requireIsolatedDepthRun()
         try FocusedMLXTestSupport.withLock {
@@ -114,36 +195,62 @@ final class NativeMTPDepthExecutionTests: XCTestCase {
 private final class DepthDispatchTarget: Module, LanguageModel, NativeMTPModel,
     KVCacheDimensionProvider, DFlash2StagedVerifyRollbackModel, @unchecked Sendable
 {
-    var kvHeads: [Int] { [1] }
+    var kvHeads: [Int] { trackKV ? [1, 1] : [1] }
     var nativeMTPAvailable: Bool { true }
     var verifyWidths: [Int] = []
     private let targetLogits: MLXArray
     private let draftLogits: MLXArray
+    private let draftDelay: TimeInterval
+    private let backboneDelay: TimeInterval
+    private let trackKV: Bool
+    var draftCalls = 0
     init(
         targetLogits: [Float] = [-100, 100, -100, -100],
-        draftLogits: [Float] = [-100, 100, -100, -100]
+        draftLogits: [Float] = [-100, 100, -100, -100],
+        draftDelay: TimeInterval = 0, backboneDelay: TimeInterval = 0, trackKV: Bool = false
     ) {
         self.targetLogits = MLXArray(targetLogits)
         self.draftLogits = MLXArray(draftLogits)
+        self.draftDelay = draftDelay
+        self.backboneDelay = backboneDelay
+        self.trackKV = trackKV
         super.init()
     }
-    func newCache(parameters: GenerateParameters?) -> [KVCache] { [MambaCache()] }
+    func newCache(parameters: GenerateParameters?) -> [KVCache] {
+        trackKV ? [MambaCache(), KVCacheSimple()] : [MambaCache()]
+    }
     func makeNativeMTPCache() -> [KVCache] { [] }
     func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult {
         .tokens(input.text)
     }
-    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray { result(inputs).logits }
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        appendKV(inputs, cache: cache)
+        return result(inputs).logits
+    }
     func nativeBackboneForward(_ inputs: MLXArray, cache: [KVCache]?) -> NativeMTPForwardResult {
-        result(inputs)
+        if backboneDelay > 0 { Thread.sleep(forTimeInterval: backboneDelay) }
+        appendKV(inputs, cache: cache)
+        return result(inputs)
     }
     func nativeBackboneMTPVerifyForward(_ inputs: MLXArray, cache: [KVCache]?) -> NativeMTPForwardResult {
         verifyWidths.append(inputs.ndim >= 2 ? inputs.dim(1) : inputs.size)
+        appendKV(inputs, cache: cache)
         return result(inputs)
     }
     func nativeMTPForward(hiddenStates: MLXArray, nextTokenIds: MLXArray, cache: [KVCache]?) -> NativeMTPForwardResult {
-        result(nextTokenIds, logits: draftLogits)
+        draftCalls += 1
+        if draftDelay > 0 { Thread.sleep(forTimeInterval: draftDelay) }
+        return result(nextTokenIds, logits: draftLogits)
     }
     func commitVerifiedBlock(cache: [KVCache], acceptedInputs: Int) -> Bool { true }
+    private func appendKV(_ inputs: MLXArray, cache: [KVCache]?) {
+        guard trackKV, let kv = cache?.last as? KVCacheSimple else { return }
+        let count = inputs.size
+        let positions = MLXArray((kv.offset..<(kv.offset + count)).map(Int32.init))
+        let arrays = kv.update(keys: positions.reshaped(1, 1, count, 1),
+                               values: inputs.reshaped(1, 1, count, 1))
+        MLX.eval(arrays.0, arrays.1)
+    }
     func commitStagedVerifiedBlock(cache: [KVCache], acceptedInputs: Int, blockLength: Int) -> Bool { true }
     private func result(_ inputs: MLXArray, logits: MLXArray? = nil) -> NativeMTPForwardResult {
         let length = inputs.ndim >= 2 ? inputs.dim(1) : inputs.size

--- a/Tests/MLXLMCommonFocusedTests/NativeMTPDepthExecutionTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NativeMTPDepthExecutionTests.swift
@@ -7,6 +7,53 @@ import XCTest
 /// Exercises actual iterator verify dispatch. The zero-weight constant target
 /// makes every proposal correct; it is not a model-quality or speed benchmark.
 final class NativeMTPDepthExecutionTests: XCTestCase {
+    func testSuccessfulResumeUsesRecentlyMeasuredARCostForLaterLoss() throws {
+        guard ProcessInfo.processInfo.environment["VMLX_NATIVE_MTP_AR_SAFETY"] != "0" else {
+            throw XCTSkip("Requires the production AR-safety governor")
+        }
+        try FocusedMLXTestSupport.withLock {
+            // Controlled host delays, not model performance: expensive startup
+            // AR, then cheaper live AR, a winning resume and a subsequent loss.
+            let model = DepthDispatchTarget(
+                draftDelay: 0.100, backboneDelay: 0.020, verifyDelay: 0.004)
+            var parameters = GenerateParameters(maxTokens: 320, temperature: 0)
+            parameters.draftStrategy = .nativeMTP(depth: 3)
+            parameters.nativeMTPDepthPolicy = .fixed
+            var iterator = try NativeMTPTokenIterator(
+                input: LMInput(tokens: MLXArray([1, 1, 1])), model: model,
+                parameters: parameters, depth: 3)
+            var enteredPause = false
+            var resumedAt: Int?
+            var count = 0
+            let start = ProcessInfo.processInfo.systemUptime
+            while count < 320, let token = iterator.next() {
+                count += 1
+                XCTAssertEqual(token, 1)
+                if !enteredPause, iterator.arSafetyTrips > 0 {
+                    enteredPause = true
+                    model.setDelays(draft: 0, backbone: 0.004)
+                }
+                if resumedAt == nil, iterator.arSafetyResumes > 0 {
+                    resumedAt = iterator.verifyCalls
+                    // ~16ms/token now loses to live AR ~4ms, but looks cheap
+                    // against the stale startup AR ~20ms. Verify width is fixed.
+                    model.setDelays(draft: 0.020, backbone: 0.004)
+                }
+                if let resumedAt,
+                    iterator.arSafetyTrips >= 2 || iterator.verifyCalls >= resumedAt + 12
+                { break }
+            }
+            XCTAssertTrue(enteredPause, "Control must enter the initial AR pause")
+            XCTAssertNotNil(resumedAt, "Control must complete a winning resume probe")
+            XCTAssertGreaterThanOrEqual(iterator.arSafetyTrips, 2,
+                "A later loss must use the recent AR measurement, not the startup seed")
+            if let resumedAt {
+                XCTAssertLessThanOrEqual(iterator.verifyCalls - resumedAt, 12)
+            }
+            print("GOVERNOR-REENTRY tokens=\(count) fixtureTokS=\(Double(count) / (ProcessInfo.processInfo.systemUptime - start)) trips=\(iterator.arSafetyTrips) resumes=\(iterator.arSafetyResumes) resumedAt=\(String(describing: resumedAt)) finalVerify=\(iterator.verifyCalls) realModelSpeedProof=false")
+        }
+    }
+
     func testGovernorCalibrationDoesNotBuildDiscardedInitialDrafts() throws {
         guard ProcessInfo.processInfo.environment["VMLX_NATIVE_MTP_AR_SAFETY"] != "0" else {
             throw XCTSkip("Requires governor calibration")
@@ -227,19 +274,23 @@ private final class DepthDispatchTarget: Module, LanguageModel, NativeMTPModel,
     var verifyWidths: [Int] = []
     private let targetLogits: MLXArray
     private let draftLogits: MLXArray
-    private let draftDelay: TimeInterval
-    private let backboneDelay: TimeInterval
+    private let timingLock = NSLock()
+    private var draftDelay: TimeInterval
+    private var backboneDelay: TimeInterval
+    private let verifyDelay: TimeInterval
     private let trackKV: Bool
     var draftCalls = 0
     init(
         targetLogits: [Float] = [-100, 100, -100, -100],
         draftLogits: [Float] = [-100, 100, -100, -100],
-        draftDelay: TimeInterval = 0, backboneDelay: TimeInterval = 0, trackKV: Bool = false
+        draftDelay: TimeInterval = 0, backboneDelay: TimeInterval = 0,
+        verifyDelay: TimeInterval = 0, trackKV: Bool = false
     ) {
         self.targetLogits = MLXArray(targetLogits)
         self.draftLogits = MLXArray(draftLogits)
         self.draftDelay = draftDelay
         self.backboneDelay = backboneDelay
+        self.verifyDelay = verifyDelay
         self.trackKV = trackKV
         super.init()
     }
@@ -247,6 +298,12 @@ private final class DepthDispatchTarget: Module, LanguageModel, NativeMTPModel,
         trackKV ? [MambaCache(), KVCacheSimple()] : [MambaCache()]
     }
     func makeNativeMTPCache() -> [KVCache] { [] }
+    func setDelays(draft: TimeInterval, backbone: TimeInterval) {
+        timingLock.withLock {
+            draftDelay = draft
+            backboneDelay = backbone
+        }
+    }
     func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult {
         .tokens(input.text)
     }
@@ -255,18 +312,21 @@ private final class DepthDispatchTarget: Module, LanguageModel, NativeMTPModel,
         return result(inputs).logits
     }
     func nativeBackboneForward(_ inputs: MLXArray, cache: [KVCache]?) -> NativeMTPForwardResult {
-        if backboneDelay > 0 { Thread.sleep(forTimeInterval: backboneDelay) }
+        let delay = timingLock.withLock { backboneDelay }
+        if delay > 0 { Thread.sleep(forTimeInterval: delay) }
         appendKV(inputs, cache: cache)
         return result(inputs)
     }
     func nativeBackboneMTPVerifyForward(_ inputs: MLXArray, cache: [KVCache]?) -> NativeMTPForwardResult {
+        if verifyDelay > 0 { Thread.sleep(forTimeInterval: verifyDelay) }
         verifyWidths.append(inputs.ndim >= 2 ? inputs.dim(1) : inputs.size)
         appendKV(inputs, cache: cache)
         return result(inputs)
     }
     func nativeMTPForward(hiddenStates: MLXArray, nextTokenIds: MLXArray, cache: [KVCache]?) -> NativeMTPForwardResult {
         draftCalls += 1
-        if draftDelay > 0 { Thread.sleep(forTimeInterval: draftDelay) }
+        let delay = timingLock.withLock { draftDelay }
+        if delay > 0 { Thread.sleep(forTimeInterval: delay) }
         return result(nextTokenIds, logits: draftLogits)
     }
     func commitVerifiedBlock(cache: [KVCache], acceptedInputs: Int) -> Bool { true }

--- a/Tests/MLXLMCommonFocusedTests/NativeMTPDepthExecutionTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NativeMTPDepthExecutionTests.swift
@@ -7,6 +7,51 @@ import XCTest
 /// Exercises actual iterator verify dispatch. The zero-weight constant target
 /// makes every proposal correct; it is not a model-quality or speed benchmark.
 final class NativeMTPDepthExecutionTests: XCTestCase {
+    func testSampledAcceptancePauseCanProbeAgain() throws {
+        guard ProcessInfo.processInfo.environment["VMLX_NATIVE_MTP_AR_SAFETY"] != "0" else {
+            throw XCTSkip("Requires the production AR-safety governor")
+        }
+        try FocusedMLXTestSupport.withLock {
+            let model = DepthDispatchTarget(
+                draftLogits: [100, -100, -100, -100], backboneDelay: 0.005,
+                trackKV: true)
+            var parameters = GenerateParameters(maxTokens: 160, temperature: 1)
+            parameters.randomSeed = 829
+            parameters.draftStrategy = .nativeMTP(depth: 1)
+            parameters.nativeMTPDepthPolicy = .fixed
+            var iterator = try NativeMTPTokenIterator(
+                input: LMInput(tokens: MLXArray([1, 1, 1])), model: model,
+                parameters: parameters, depth: 1)
+            let start = ProcessInfo.processInfo.systemUptime
+            var count = 0
+            var verifiesAtChange = 0
+            var previousAR = 0
+            while count < 160, let token = iterator.next() {
+                count += 1
+                XCTAssertEqual(token, 1, "Rejected proposals must never enter target output")
+                if iterator.autoregressiveFallbackTokenCount > previousAR {
+                    previousAR = iterator.autoregressiveFallbackTokenCount
+                    let kv = try XCTUnwrap(iterator.cache.last as? KVCacheSimple)
+                    XCTAssertEqual(kv.offset, 3 + count - 1)
+                    let state = try XCTUnwrap(kv.readKV())
+                    XCTAssertEqual(state.keys.asArray(Int32.self), (0..<kv.offset).map(Int32.init))
+                    XCTAssertEqual(state.values.asArray(Int32.self), Array(repeating: 1, count: kv.offset))
+                }
+                if count == 64 {
+                    verifiesAtChange = iterator.verifyCalls
+                    model.useTargetAsDraft = true
+                }
+            }
+            XCTAssertEqual(count, 160)
+            XCTAssertGreaterThan(iterator.sequentialVerifierCount, 0)
+            XCTAssertEqual(iterator.stagedVerifierCommitCount, 0)
+            XCTAssertGreaterThan(iterator.rejectedCount, 0)
+            XCTAssertGreaterThan(iterator.autoregressiveFallbackTokenCount, 2)
+            XCTAssertGreaterThan(iterator.verifyCalls, verifiesAtChange,
+                "An acceptance-based AR pause must probe again after proposal quality changes")
+            print("SAMPLED-RECOVERY verifiesAtChange=\(verifiesAtChange) finalVerifies=\(iterator.verifyCalls) trips=\(iterator.arSafetyTrips) fixtureTokS=\(Double(count) / (ProcessInfo.processInfo.systemUptime - start)) fullCacheProof=false realModelSpeedProof=false")
+        }
+    }
     func testSuccessfulResumeUsesRecentlyMeasuredARCostForLaterLoss() throws {
         guard ProcessInfo.processInfo.environment["VMLX_NATIVE_MTP_AR_SAFETY"] != "0" else {
             throw XCTSkip("Requires the production AR-safety governor")
@@ -280,6 +325,7 @@ private final class DepthDispatchTarget: Module, LanguageModel, NativeMTPModel,
     private let verifyDelay: TimeInterval
     private let trackKV: Bool
     var draftCalls = 0
+    var useTargetAsDraft = false
     init(
         targetLogits: [Float] = [-100, 100, -100, -100],
         draftLogits: [Float] = [-100, 100, -100, -100],
@@ -327,7 +373,7 @@ private final class DepthDispatchTarget: Module, LanguageModel, NativeMTPModel,
         draftCalls += 1
         let delay = timingLock.withLock { draftDelay }
         if delay > 0 { Thread.sleep(forTimeInterval: delay) }
-        return result(nextTokenIds, logits: draftLogits)
+        return result(nextTokenIds, logits: useTargetAsDraft ? targetLogits : draftLogits)
     }
     func commitVerifiedBlock(cache: [KVCache], acceptedInputs: Int) -> Bool { true }
     private func appendKV(_ inputs: MLXArray, cache: [KVCache]?) {

--- a/Tests/MLXLMCommonFocusedTests/NativeMTPDepthPolicyTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NativeMTPDepthPolicyTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import MLXLMCommon
+
+final class NativeMTPDepthPolicyTests: XCTestCase {
+    func testFixedRequestsCannotPromoteAboveSelectedDepth() throws {
+        for depth in 1...3 {
+            let result = try NativeMTPDepthPolicy.fixed.resolve(requestedDepth: depth, runtimeCap: 5)
+            XCTAssertEqual(result.initialDepth, depth)
+            XCTAssertEqual(result.maximumDepth, depth)
+        }
+    }
+
+    func testAdaptiveExplorationIsExplicitAndBounded() throws {
+        let result = try NativeMTPDepthPolicy.adaptive(maximumDepth: 3)
+            .resolve(requestedDepth: 1, runtimeCap: 5)
+        XCTAssertEqual(result.initialDepth, 1)
+        XCTAssertEqual(result.maximumDepth, 3)
+        let capped = try NativeMTPDepthPolicy.adaptive(maximumDepth: 5)
+            .resolve(requestedDepth: 3, runtimeCap: 2)
+        XCTAssertEqual(capped.initialDepth, 2)
+        XCTAssertEqual(capped.maximumDepth, 2)
+    }
+
+    func testRuntimeCapCanOnlyLowerFixedDepth() throws {
+        let result = try NativeMTPDepthPolicy.fixed.resolve(requestedDepth: 3, runtimeCap: 2)
+        XCTAssertEqual(result.initialDepth, 2)
+        XCTAssertEqual(result.maximumDepth, 2)
+    }
+
+    func testInvalidPolicyInputsThrow() {
+        XCTAssertThrowsError(try NativeMTPDepthPolicy.fixed.resolve(requestedDepth: 0, runtimeCap: 5))
+        XCTAssertThrowsError(try NativeMTPDepthPolicy.fixed.resolve(requestedDepth: 3, runtimeCap: 0))
+        XCTAssertThrowsError(try NativeMTPDepthPolicy.adaptive(maximumDepth: -1)
+            .resolve(requestedDepth: 3, runtimeCap: 5))
+    }
+
+    func testParametersDefaultToFixedAndCopiesPreserveExplicitPolicy() {
+        var parameters = GenerateParameters()
+        XCTAssertEqual(parameters.nativeMTPDepthPolicy, .fixed)
+        parameters.nativeMTPDepthPolicy = .adaptive(maximumDepth: 3)
+        let copy = parameters
+        XCTAssertEqual(copy.nativeMTPDepthPolicy, .adaptive(maximumDepth: 3))
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/NativeMTPManualSafetyParityTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NativeMTPManualSafetyParityTests.swift
@@ -1,0 +1,52 @@
+import Foundation
+import Testing
+
+@testable import MLXLMCommon
+
+/// Metadata-policy consistency only, not a complete-head or real-load proof.
+@Suite struct NativeMTPManualSafetyParityTests {
+    private func settings() -> VMLXServerRuntimeSettings {
+        var settings = VMLXServerRuntimeSettings()
+        settings.mtp.mode = .forceOn
+        settings.mtp.explicitDepth = 3
+        return settings
+    }
+
+    @Test func explicitSafetyBlockHasTheSameMeaningAtEveryGate() {
+        for family in ["qwen3_5", "qwen4_exp"] {
+            for manual in [false, true] {
+                let status = MTPBundleStatus(
+                    bundleHasMTP: true, configuredLayers: 1, tensorCount: 31,
+                    mode: .preservedEnabled,
+                    nativeMTPTuning: NativeMTPTuning(
+                        bestDepth: 2, blocked: true, manualBlocked: manual,
+                        reason: "fixture safety block"))
+                let settings = settings()
+                let resolved = settings.resolvedMTPLaunch(
+                    configData: Data("{\"model_type\":\"\(family)\"}".utf8),
+                    jangConfig: nil, status: status)
+                #expect(resolved.launchMode == .blocked)
+                #expect(settings.effectiveMTPLaunchMode(for: status) == resolved.launchMode)
+                #expect(resolved.reason.contains("fixture safety block"))
+                #expect(settings.validationIssues(mtpStatus: status).contains {
+                    $0.field == "mtp.mode" && $0.message.contains("fixture safety block")
+                })
+            }
+        }
+    }
+
+    @Test func missingMeasurementIsNotAnExplicitSafetyBlock() {
+        for family in ["qwen3_5", "qwen4_exp"] {
+            let status = MTPBundleStatus(
+                bundleHasMTP: true, configuredLayers: 1, tensorCount: 31,
+                mode: .preservedEnabled)
+            let settings = settings()
+            let resolved = settings.resolvedMTPLaunch(
+                configData: Data("{\"model_type\":\"\(family)\"}".utf8),
+                jangConfig: nil, status: status)
+            #expect(resolved.launchMode == .speculative)
+            #expect(resolved.recommendation?.depth == 3)
+            #expect(settings.effectiveMTPLaunchMode(for: status) == resolved.launchMode)
+        }
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/NativeMTPTuningShapeTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NativeMTPTuningShapeTests.swift
@@ -54,6 +54,31 @@ struct NativeMTPTuningShapeTests {
         #expect(tuning.usableBestDepth == 2)
     }
 
+    @Test func missingEquivalenceIsDecodedButDoesNotBecomeAutoEvidence() throws {
+        let row = "\"best_depth\": 2, \"validated\": true, \"blocked\": false, \"speedup_vs_baseline\": 1.1"
+        for json in ["{\(row)}", "{\"native_mtp\": {\(row)}}"] {
+            let dir = try write(json)
+            defer { try? FileManager.default.removeItem(at: dir) }
+            let tuning = try #require(MTPBundleInspector.tuningForTesting(at: dir))
+            #expect(tuning.bestDepth == 2)
+            #expect(!tuning.outputEquivalent)
+            #expect(tuning.usableBestDepth == nil)
+        }
+    }
+
+    @Test func decodingBothShapesDoesNotEraseExplicitBlocks() throws {
+        for block in ["blocked", "manual_blocked"] {
+            let row = "\(Self.row), \"\(block)\": true"
+            for json in ["{\(row)}", "{\"native_mtp\": {\(row)}}"] {
+                let dir = try write(json)
+                defer { try? FileManager.default.removeItem(at: dir) }
+                let tuning = try #require(MTPBundleInspector.tuningForTesting(at: dir))
+                #expect(tuning.usableBestDepth == nil)
+                #expect(block == "blocked" ? tuning.blocked : tuning.manualBlocked)
+            }
+        }
+    }
+
     /// No file at all is still no tuning — leniency must not invent one.
     @Test func absentFileYieldsNothing() throws {
         let dir = URL(fileURLWithPath: NSTemporaryDirectory())

--- a/Tests/MLXLMTests/CacheCoordinatorTests.swift
+++ b/Tests/MLXLMTests/CacheCoordinatorTests.swift
@@ -6,6 +6,59 @@ import Testing
 
 // MARK: - CacheCoordinator Tests
 
+@Test func coordinatorDurableMambaBoundaryDoesNotRequireUnwrittenSidecar() throws {
+    try MLXMetalTestLock.withLock {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("durable-mamba-boundary-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let config = CacheCoordinatorConfig(
+            usePagedCache: false, enableDiskCache: true,
+            diskCacheMaxGB: 0.1, diskCacheDir: tmp,
+            modelKey: "durable-mamba-boundary")
+        let tokens = [31, 32, 33]
+        let cache = MambaCache()
+        cache.offset = tokens.count
+        cache[0] = MLXArray.ones([1, 2, 4])
+        cache[1] = MLXArray.ones([1, 2, 4, 4]) * 2
+        let topology = ModelCacheTopologySnapshot(cache: [cache])
+        #expect(topology.requiresRecurrentSSMCompanionState)
+        #expect(!topology.requiresSeparateRecurrentPayloadState)
+        let writer = CacheCoordinator(config: config)
+        writer.setHybrid(true,
+            requiresRecurrentSSMCompanion: topology.requiresRecurrentSSMCompanionState,
+            requiresSeparateRecurrentPayload: topology.requiresSeparateRecurrentPayloadState)
+        writer.storeAfterGeneration(promptTokens: tokens, perLayerData: [],
+            ssmStates: nil, cache: [cache])
+        #expect(writer.diskCache?.hasDurableEntry(tokens: tokens) == true)
+        #expect(writer.hasDurableDiskEntry(tokens: tokens),
+            "the in-file Mamba payload must not be rebuilt for an intentionally absent sidecar")
+        #expect(writer.hasValidatedDiskEntry(tokens: tokens))
+        let restarted = CacheCoordinator(config: config)
+        restarted.setHybrid(true, requiresRecurrentSSMCompanion: true,
+            requiresSeparateRecurrentPayload: false)
+        #expect(restarted.hasDurableDiskEntry(tokens: tokens))
+        #expect(!restarted.hasValidatedDiskEntry(tokens: tokens))
+        #expect(!restarted.hasDurableDiskEntry(tokens: [31, 32, 99]))
+        #expect(!restarted.hasDurableDiskEntry(tokens: tokens, mediaSalt: "different-media"))
+        guard case .hit(let matched, _, _, _, _, let arrays) =
+            restarted.fetch(tokens: tokens + [34])
+        else {
+            Issue.record("the persisted Mamba prefix must remain consumable after restart")
+            return
+        }
+        #expect(matched == tokens.count)
+        let payload = try #require(arrays)
+        var restored: [any KVCache] = [MambaCache()]
+        _ = restoreFromDiskArrays(payload, into: &restored)
+        #expect(restored[0].offset == tokens.count)
+        #expect(restored[0].state.count == cache.state.count)
+        for (actual, expected) in zip(restored[0].state, cache.state) {
+            #expect(actual.asArray(Float.self) == expected.asArray(Float.self))
+        }
+        #expect(restarted.hasValidatedDiskEntry(tokens: tokens))
+    }
+}
+
 @Test func coordinatorValidatedDiskEntryRequiresCurrentProcessProof() throws {
     try MLXMetalTestLock.withLock {
         let tmp = FileManager.default.temporaryDirectory
@@ -73,6 +126,7 @@ import Testing
             cache: nil)
         #expect(!coordinator.hasValidatedDiskEntry(tokens: tokens),
             "validated KV alone must not hide a missing recurrent companion")
+        #expect(!coordinator.hasDurableDiskEntry(tokens: tokens))
 
         coordinator.storeAfterGeneration(
             promptTokens: tokens,
@@ -80,6 +134,7 @@ import Testing
             ssmStates: [MLXArray.ones([1, 4])],
             cache: nil)
         #expect(coordinator.hasValidatedDiskEntry(tokens: tokens))
+        #expect(coordinator.hasDurableDiskEntry(tokens: tokens))
     }
 }
 

--- a/Tests/MLXLMTests/NativeMTPManualDepthTests.swift
+++ b/Tests/MLXLMTests/NativeMTPManualDepthTests.swift
@@ -5,8 +5,8 @@ import Testing
 
 /// Manual-depth activation contract (the Speculative Depth 1/2/3 buttons):
 /// an explicit user depth activates a tensor-complete MTP head WITHOUT a
-/// measured `vmlx_mtp_tuning.json`, Auto stays tuning-gated, and any active
-/// launch pairs with enforced greedy sampling for that model+session.
+/// measured `vmlx_mtp_tuning.json`. Auto uses usable tuning or its supported
+/// measured-family default; neither mode prescribes a sampler override.
 @Suite("Native MTP manual depth contract")
 struct NativeMTPManualDepthTests {
 
@@ -50,10 +50,11 @@ struct NativeMTPManualDepthTests {
                 reason: "live workload regressed versus autoregressive decode"))
     }
 
-    /// Auto has no winning depth, but manual diagnostics remain permitted.
-    /// This is the existing Flash-Next 4M shape and must not be changed by the
-    /// Ornith-specific `manual_blocked` contract.
-    private static var autoOnlyBlockedStatus: MTPBundleStatus {
+    /// `blocked` alone is still an explicit veto. A missing winning measurement
+    /// is represented by unusable/absent tuning, not by ignoring a safety block.
+    /// The separately fingerprinted superseded Flash-Next exception is not this
+    /// generic fixture.
+    private static var blockedWithoutManualFlagStatus: MTPBundleStatus {
         MTPBundleStatus(
             bundleHasMTP: true,
             configuredLayers: 1,
@@ -91,13 +92,13 @@ struct NativeMTPManualDepthTests {
         }
     }
 
-    @Test("auto stays tuning-gated for the same complete untuned head")
+    @Test("dense Qwen Auto stays tuning-gated for a complete untuned head")
     func autoStaysTuningGated() throws {
         let settings = Self.settings(mode: .auto)
         #expect(
             settings.effectiveMTPLaunchMode(for: Self.completeUntunedStatus) == .off)
         let launch = settings.resolvedMTPLaunch(
-            configData: Self.config(),
+            configData: Self.config(modelType: "qwen3_5"),
             jangConfig: nil,
             status: Self.completeUntunedStatus)
         #expect(launch.launchMode == .off)
@@ -140,11 +141,13 @@ struct NativeMTPManualDepthTests {
 
     @Test("the load gate accepts a manual-depth run without usable tuning")
     func loadGateAcceptsManualDepth() throws {
+        // Dense Qwen has no measured-family cold start. Flash-Next does, so
+        // using it as the negative control would now permit Auto legitimately.
         try NativeMTPActivation.$explicitRequestOverride.withValue(true) {
             try NativeMTPActivation.$manualDepthOverride.withValue(2) {
                 let allowed = try NativeMTPActivation.shouldLoadNativeMTPWeights(
-                    configData: Self.config(),
-                    baseModelType: "qwen4_exp",
+                    configData: Self.config(modelType: "qwen3_5"),
+                    baseModelType: "qwen3_5",
                     status: Self.completeUntunedStatus)
                 #expect(allowed)
             }
@@ -153,8 +156,8 @@ struct NativeMTPManualDepthTests {
         try NativeMTPActivation.$explicitRequestOverride.withValue(true) {
             #expect(throws: (any Error).self) {
                 _ = try NativeMTPActivation.shouldLoadNativeMTPWeights(
-                    configData: Self.config(),
-                    baseModelType: "qwen4_exp",
+                    configData: Self.config(modelType: "qwen3_5"),
+                    baseModelType: "qwen3_5",
                     status: Self.completeUntunedStatus)
             }
         }
@@ -197,31 +200,33 @@ struct NativeMTPManualDepthTests {
         }
     }
 
-    @Test("an Auto-only block does not disable explicit diagnostics")
-    func autoOnlyBlockStillAllowsManualDepth() throws {
+    @Test("a non-superseded block vetoes manual activation without a second flag")
+    func blockedWithoutManualFlagStillVetoesDepth() throws {
         let settings = Self.settings(mode: .forceOn, explicitDepth: 2)
         #expect(
-            settings.effectiveMTPLaunchMode(for: Self.autoOnlyBlockedStatus)
-                == .speculative)
+            settings.effectiveMTPLaunchMode(for: Self.blockedWithoutManualFlagStatus)
+                == .blocked)
         let launch = settings.resolvedMTPLaunch(
             configData: Self.config(),
             jangConfig: nil,
-            status: Self.autoOnlyBlockedStatus)
-        #expect(launch.launchMode == .speculative)
-        #expect(launch.recommendation?.depth == 2)
+            status: Self.blockedWithoutManualFlagStatus)
+        #expect(launch.launchMode == .blocked)
+        #expect(launch.recommendation == nil)
+        #expect(launch.reason.contains("explicitly blocked"))
 
         try NativeMTPActivation.$explicitRequestOverride.withValue(true) {
             try NativeMTPActivation.$manualDepthOverride.withValue(2) {
-                let allowed = try NativeMTPActivation.shouldLoadNativeMTPWeights(
-                    configData: Self.config(),
-                    baseModelType: "qwen4_exp",
-                    status: Self.autoOnlyBlockedStatus)
-                #expect(allowed)
+                #expect(throws: NativeMTPActivationError.self) {
+                    _ = try NativeMTPActivation.shouldLoadNativeMTPWeights(
+                        configData: Self.config(),
+                        baseModelType: "qwen4_exp",
+                        status: Self.blockedWithoutManualFlagStatus)
+                }
             }
         }
     }
 
-    @Test("enforced greedy sampling constants are exact")
+    @Test("legacy explicit-greedy compatibility constants retain their values")
     func enforcedGreedySamplingConstants() {
         let greedy = VMLXServerMTPSettings.mtpEnforcedGreedySampling
         #expect(greedy.temperature == 0)

--- a/Tests/MLXLMTests/QSAKVCachePersistenceTests.swift
+++ b/Tests/MLXLMTests/QSAKVCachePersistenceTests.swift
@@ -27,6 +27,57 @@ private func makeQSACache(
     return cache
 }
 
+@Test(arguments: [2, 4, 8])
+func qsaRollbackRetainsOnlyCompleteAcceptedBlocks(ratio: Int) throws {
+    try MLXMetalTestLock.withLock {
+        for removed in [1, ratio, ratio + 1, 32] {
+            let cache = makeQSACache(tokens: 32)
+            cache.prepareDerivedPooledBlocks(compressionRatio: ratio)
+            let blocks = MLXArray((0..<(32 / ratio * 4)).map(Float.init))
+                .reshaped(1, 32 / ratio, 4)
+            cache.derivedPooledBlocks = blocks
+            cache.derivedPooledBlockCount = 32 / ratio
+            #expect(cache.trim(removed) == removed)
+            let kept = (32 - removed) / ratio
+            #expect(cache.derivedPooledBlockCount == kept)
+            #expect(cache.indexerKeys?.dim(1) == 32 - removed)
+            if kept == 0 {
+                #expect(cache.derivedPooledBlocks == nil)
+            } else {
+                let actual = try #require(cache.derivedPooledBlocks)
+                #expect(arrayEqual(actual, blocks[0..., ..<kept, 0...]).item(Bool.self))
+            }
+            // Neither disk state nor copies carry derived blocks or geometry.
+            let copied = try #require(cache.copy() as? QSAKVCache)
+            #expect(copied.derivedPooledBlockCount == 0)
+            #expect(copied.derivedPooledBlocks == nil)
+            let rawState = cache.state
+            cache.state = rawState
+            #expect(cache.derivedPooledBlockCount == 0)
+        }
+    }
+}
+
+@Test func qsaPoolGeometryChangeAndUnknownGeometryInvalidate() {
+    MLXMetalTestLock.withLock {
+        for ratio in [0, 2, 8] {
+            let cache = makeQSACache(tokens: 32)
+            cache.prepareDerivedPooledBlocks(compressionRatio: 4)
+            cache.derivedPooledBlocks = MLXArray.ones([1, 8, 4])
+            cache.derivedPooledBlockCount = 8
+            cache.prepareDerivedPooledBlocks(compressionRatio: ratio)
+            #expect(cache.derivedPooledBlocks == nil)
+            #expect(cache.derivedPooledBlockCount == 0)
+        }
+        let unknown = makeQSACache(tokens: 32)
+        unknown.derivedPooledBlocks = MLXArray.ones([1, 8, 4])
+        unknown.derivedPooledBlockCount = 8
+        _ = unknown.trim(1)
+        #expect(unknown.derivedPooledBlocks == nil)
+        #expect(unknown.derivedPooledBlockCount == 0)
+    }
+}
+
 /// The full round-trip: serialize → deserialize (kind `.qsaKV`) → restore
 /// into a fresh QSAKVCache → the lane covers exactly `offset`, and a
 /// follow-up segment keeps `total == offset + S` — the invariant whose

--- a/Tests/MLXLMTests/Qwen4ExpFusedAffineMoETests.swift
+++ b/Tests/MLXLMTests/Qwen4ExpFusedAffineMoETests.swift
@@ -44,7 +44,8 @@ struct Qwen4ExpFusedAffineMoETests {
     ]
 
     private static func makeProjection(
-        inputDims: Int, outputDims: Int, bits: Int, groupSize: Int, seed: UInt64
+        inputDims: Int, outputDims: Int, bits: Int, groupSize: Int, seed: UInt64,
+        metadataDType: DType = .float16
     ) -> (module: QuantizedSwitchLinear, dequantized: MLXArray) {
         let source = MLXRandom.uniform(
             low: -0.5, high: 0.5, [experts, outputDims, inputDims],
@@ -57,13 +58,13 @@ struct Qwen4ExpFusedAffineMoETests {
             outputDims: outputDims,
             numExperts: experts,
             weight: weight,
-            scales: scales,
-            biases: biases,
+            scales: scales.asType(metadataDType),
+            biases: biases?.asType(metadataDType),
             groupSize: groupSize,
             bits: bits,
             mode: .affine)
         let exact = dequantized(
-            weight, scales: scales, biases: biases,
+            weight, scales: scales.asType(metadataDType), biases: biases?.asType(metadataDType),
             groupSize: groupSize, bits: bits, mode: .affine, dtype: .float32)
         return (module, exact)
     }
@@ -74,6 +75,85 @@ struct Qwen4ExpFusedAffineMoETests {
         let num = MLX.sqrt(((c - r) * (c - r)).sum())
         let den = MLX.sqrt((r * r).sum())
         return (num / den).item(Float.self)
+    }
+
+    // Explicit diagnostic only: generated, cache-warm weights and synchronized
+    // calls do not establish whole-model bandwidth or app token throughput.
+    @Test("opt-in mixed-layout fused versus generic reducer timing", .enabled(
+        if: ProcessInfo.processInfo.environment["VMLX_RUN_FLASH_MOE_BENCH"] == "1"))
+    func fusedReducerTiming() throws {
+        try MLXMetalTestLock.withLock {
+            let combos = Self.shippedCombos + [
+                Combo(label: "2L_uniform_q2g64", gate: (2, 64), up: (2, 64), down: (2, 64)),
+            ]
+            for (combo, metadata) in combos.flatMap({ combo in
+                [DType.float16, .bfloat16].map { (combo, $0) }
+            }) {
+                let (gate, _) = Self.makeProjection(
+                    inputDims: Self.inputDims, outputDims: Self.expertDims,
+                    bits: combo.gate.bits, groupSize: combo.gate.group, seed: 901,
+                    metadataDType: metadata)
+                let (up, _) = Self.makeProjection(
+                    inputDims: Self.inputDims, outputDims: Self.expertDims,
+                    bits: combo.up.bits, groupSize: combo.up.group, seed: 902,
+                    metadataDType: metadata)
+                let (down, _) = Self.makeProjection(
+                    inputDims: Self.expertDims, outputDims: Self.inputDims,
+                    bits: combo.down.bits, groupSize: combo.down.group, seed: 903,
+                    metadataDType: metadata)
+                let reducer = try #require(Qwen4ExpFusedAffineMoE.makeReducer(
+                    gate: gate, up: up, down: down))
+                MLX.eval(gate, up, down)
+                for rows in 1 ... 4 {
+                    let x = MLXRandom.uniform(
+                        low: -1, high: 1, [1, rows, Self.inputDims],
+                        key: MLXRandom.key(904)).asType(.bfloat16)
+                    let indices = MLXArray((0 ..< rows * Self.topK).map {
+                        UInt32(($0 * 3) % Self.experts)
+                    }).reshaped(1, rows, Self.topK)
+                    let scores = MLX.softmax(MLXRandom.uniform(
+                        low: 0, high: 1, [1, rows, Self.topK],
+                        key: MLXRandom.key(905)), axis: -1)
+                    MLX.eval(x, indices, scores)
+                    let fused: () -> MLXArray = { reducer(x, indices, scores)! }
+                    let generic: () -> MLXArray = {
+                        let expanded = MLX.expandedDimensions(x, axes: [-2, -3])
+                        let g = gate(expanded, indices)
+                        let u = up(expanded, indices)
+                        let activation = (g * MLX.sigmoid(g)) * u
+                        let routed = MLX.squeezed(down(activation, indices), axis: -2)
+                        return (routed.asType(.float32) * scores[.ellipsis, .newAxis])
+                            .sum(axis: -2).asType(.bfloat16)
+                    }
+                    let error = Self.relativeError(fused(), generic())
+                    #expect(error.isFinite && error < 0.02, "reducer relative error \(error)")
+                    for _ in 0 ..< 5 { MLX.eval(fused()); MLX.eval(generic()) }
+                    func measure(_ operation: () -> MLXArray) -> Double {
+                        let start = DispatchTime.now().uptimeNanoseconds
+                        for _ in 0 ..< 20 { MLX.eval(operation()) }
+                        return Double(DispatchTime.now().uptimeNanoseconds - start) / 20_000_000
+                    }
+                    var fusedSamples: [Double] = []
+                    var genericSamples: [Double] = []
+                    for round in 0 ..< 7 {
+                        if round.isMultiple(of: 2) {
+                            fusedSamples.append(measure(fused))
+                            genericSamples.append(measure(generic))
+                        } else {
+                            genericSamples.append(measure(generic))
+                            fusedSamples.append(measure(fused))
+                        }
+                    }
+                    print("[FlashMoEBench] combo=\(combo.label) metadata=\(metadata) rows=\(rows)"
+                        + " gate=\(gate.bits)/\(gate.groupSize) up=\(up.bits)/\(up.groupSize)"
+                        + " down=\(down.bits)/\(down.groupSize)"
+                        + " relative_error=\(error) fused_ms=\(fusedSamples)"
+                        + " generic_ms=\(genericSamples)"
+                        + " median_ratio=\(genericSamples.sorted()[3] / fusedSamples.sorted()[3])"
+                        + " generated_weights=1 cache_warm=1 synchronized_calls=1")
+                }
+            }
+        }
     }
 
     @Test("fused kernel matches exact math for every shipped bit/group layout")

--- a/Tests/MLXLMTests/Qwen4ExpFusedAffineMoETests.swift
+++ b/Tests/MLXLMTests/Qwen4ExpFusedAffineMoETests.swift
@@ -40,6 +40,7 @@ struct Qwen4ExpFusedAffineMoETests {
         Combo(label: "6S_up_down_q6", gate: (4, 64), up: (6, 64), down: (6, 64)),
         Combo(label: "Ornith_late_gate_up_q5", gate: (5, 64), up: (5, 64), down: (4, 64)),
         Combo(label: "q5_all_projections", gate: (5, 64), up: (5, 64), down: (5, 64)),
+        Combo(label: "mixed_gate_g128_up_down_g64", gate: (4, 128), up: (4, 64), down: (4, 64)),
     ]
 
     private static func makeProjection(
@@ -349,7 +350,7 @@ struct Qwen4ExpFusedAffineMoETests {
         #expect(error < 0.01, "Ornith fused/eager relative error \(error)")
     }
 
-    @Test("construction rejects unsupported metadata and group sizes")
+    @Test("construction accepts qualified groups and rejects unsupported metadata and bits")
     func constructionRejection() throws {
         // f32 affine metadata must be rejected: the kernels only accept
         // bf16/f16 scales with matching bias dtype.
@@ -374,7 +375,8 @@ struct Qwen4ExpFusedAffineMoETests {
             Qwen4ExpFusedAffineMoE.makeReducer(
                 gate: f32Projection, up: good, down: goodDown) == nil)
 
-        // Group size 128 is outside the supported set.
+        // Group 128 was added to the supported set; mixed-group arithmetic is
+        // covered above and in the multirow verifier parity test.
         let g128Source = MLXRandom.uniform(
             low: -0.5, high: 0.5, [Self.experts, Self.expertDims, Self.inputDims],
             key: MLXRandom.key(8)
@@ -387,6 +389,12 @@ struct Qwen4ExpFusedAffineMoETests {
 
         #expect(
             Qwen4ExpFusedAffineMoE.makeReducer(
-                gate: g128Projection, up: good, down: goodDown) == nil)
+                gate: g128Projection, up: good, down: goodDown) != nil)
+
+        // Valid generic affine storage, but outside this fused kernel's bits.
+        let (q8, _) = Self.makeProjection(
+            inputDims: Self.inputDims, outputDims: Self.expertDims,
+            bits: 8, groupSize: 64, seed: 13)
+        #expect(Qwen4ExpFusedAffineMoE.makeReducer(gate: q8, up: good, down: goodDown) == nil)
     }
 }

--- a/Tests/MLXLMTests/Qwen4ExpGDNPreprocessTests.swift
+++ b/Tests/MLXLMTests/Qwen4ExpGDNPreprocessTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import MLXRandom
+import Testing
+
+@testable import MLXVLM
+
+@Suite("Flash GDN post-projection compile candidate", .serialized)
+struct Qwen4ExpGDNPreprocessTests {
+    @Test("unsupported dtype, width and nested trace retain native fallback")
+    func rejectionBoundaries() throws {
+        try MLXMetalTestLock.withLock {
+            let input = MLXArray.zeros([1, 2, 128], dtype: .bfloat16)
+            let weight = MLXArray.ones([128, 2, 1], dtype: .bfloat16)
+            func call(_ x: MLXArray, _ w: MLXArray) -> [MLXArray]? {
+                Qwen4ExpCompiledGDNInputs.callPreprocess(
+                    convInput: x, convWeight: w,
+                    numKHeads: 2, headKDim: 16, numVHeads: 4, headVDim: 16)
+            }
+            #expect(call(input.asType(.float32), weight) == nil)
+            #expect(call(input.asType(.float16), weight.asType(.float16)) == nil)
+            #expect(call(input, weight.asType(.float32)) == nil)
+            #expect(call(MLXArray.zeros([1, 3, 128], dtype: .bfloat16), weight) == nil)
+            #expect(call(MLXArray.zeros([1, 2, 127], dtype: .bfloat16), weight) == nil)
+            #expect(call(input, MLXArray.ones([128, 2, 2], dtype: .bfloat16)) == nil)
+            #expect(CompiledDecodeTrace.withActive { call(input, weight) } == nil)
+        }
+    }
+
+    @Test("explicit layer geometry, weights and batch preserve native preprocessing")
+    func parityAndTiming() throws {
+        try MLXMetalTestLock.withLock {
+            // Tiny geometry plus actual Flash head geometry; no projection
+            // matrices, model files or model-sized allocations are involved.
+            for (hk, dk, hv, dv, taps) in [(2, 16, 4, 16, 2), (16, 128, 48, 128, 4)] {
+                let width = 2 * hk * dk + hv * dv
+                for batch in [1, 2] {
+                    for seed: UInt64 in [71, 83] {
+                        let input = MLXRandom.uniform(low: -1, high: 1,
+                            [batch, taps, width], key: MLXRandom.key(seed)).asType(.bfloat16)
+                        let weight = MLXRandom.uniform(low: -0.25, high: 0.25,
+                            [width, taps, 1], key: MLXRandom.key(seed + 1)).asType(.bfloat16)
+                        MLX.eval(input, weight)
+                        func plain() -> [MLXArray] {
+                            let output = silu(conv1d(input, weight, stride: 1,
+                                padding: 0, dilation: 1, groups: width))
+                            let split = MLX.split(output, indices: [hk * dk, 2 * hk * dk], axis: -1)
+                            let q = split[0].reshaped(batch, 1, hk, dk)
+                            let k = split[1].reshaped(batch, 1, hk, dk)
+                            let scale = pow(Float(dk), -0.5)
+                            return [MLXArray(pow(scale, 2), dtype: q.dtype)
+                                * MLXFast.rmsNorm(q, weight: MLXArray.mlxNone, eps: 1e-6),
+                                MLXArray(scale, dtype: k.dtype)
+                                * MLXFast.rmsNorm(k, weight: MLXArray.mlxNone, eps: 1e-6),
+                                split[2].reshaped(batch, 1, hv, dv)]
+                        }
+                        func candidate() -> [MLXArray] {
+                            Qwen4ExpCompiledGDNInputs.callPreprocess(
+                                convInput: input, convWeight: weight,
+                                numKHeads: hk, headKDim: dk, numVHeads: hv, headVDim: dv)!
+                        }
+                        let reference = plain()
+                        let actual = candidate()
+                        MLX.eval(reference); MLX.eval(actual)
+                        for (slot, arrays) in zip(actual, reference).enumerated() {
+                            #expect(arrays.0.shape == arrays.1.shape)
+                            #expect(arrays.0.dtype == arrays.1.dtype)
+                            let error = MLX.max(abs(arrays.0.asType(.float32)
+                                - arrays.1.asType(.float32))).item(Float.self)
+                            #expect(error == 0, "slot=\(slot) seed=\(seed) batch=\(batch) maxAbs=\(error)")
+                        }
+                        for _ in 0 ..< 5 { MLX.eval(plain()); MLX.eval(candidate()) }
+                        func measure(_ operation: () -> [MLXArray]) -> Double {
+                            let start = DispatchTime.now().uptimeNanoseconds
+                            for _ in 0 ..< 50 { MLX.eval(operation()) }
+                            return Double(DispatchTime.now().uptimeNanoseconds - start) / 50_000_000
+                        }
+                        var p: [Double] = [], c: [Double] = []
+                        for round in 0 ..< 7 {
+                            if round.isMultiple(of: 2) {
+                                p.append(measure(plain)); c.append(measure(candidate))
+                            } else {
+                                c.append(measure(candidate)); p.append(measure(plain))
+                            }
+                        }
+                        print("[GDNPreprocessBench] hk=\(hk) dk=\(dk) hv=\(hv) dv=\(dv)"
+                            + " taps=\(taps) batch=\(batch) seed=\(seed)"
+                            + " plain_ms=\(p) compiled_ms=\(c)"
+                            + " median_ratio=\(p.sorted()[3] / c.sorted()[3])")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Tests/MLXLMTests/Qwen4ExpMixedQuantDispatchTests.swift
+++ b/Tests/MLXLMTests/Qwen4ExpMixedQuantDispatchTests.swift
@@ -1,0 +1,49 @@
+import MLX
+import MLXLMCommon
+import MLXNN
+import Testing
+
+@Suite(.serialized)
+struct Qwen4ExpMixedQuantDispatchTests {
+    @Test("each projection selects its own quantization contract, including fallback")
+    func mixedProjectionContracts() throws {
+        try MLXMetalTestLock.withLock {
+            for bits in [2, 3, 4, 5, 6, 8] {
+                for groupSize in [32, 64, 128] {
+                    let input = ((MLXArray(0..<1024, [2, 512]).asType(.float32) % 23) / 23 - 0.5)
+                        .asType(.bfloat16)
+                    let source = ((MLXArray(0..<3584, [7, 512]).asType(.float32) % 31) / 31 - 0.5)
+                        .asType(.float16)
+                    let (weight, scales, biases) = quantized(
+                        source, groupSize: groupSize, bits: bits, mode: .affine)
+                    let native = Qwen4ExpBF16Affine.supports(
+                        input: input, weight: weight, scales: scales, biases: biases,
+                        groupSize: groupSize, bits: bits, mode: .affine)
+                    #expect(native == (groupSize == 64 && (bits == 4 || bits == 8)))
+                    let actual = Qwen4ExpBF16Affine.dense(
+                        input, weight, scales: scales, biases: biases,
+                        groupSize: groupSize, bits: bits, mode: .affine)
+                    let reference = quantizedMM(
+                        input, weight, scales: scales, biases: biases, transpose: true,
+                        groupSize: groupSize, bits: bits, mode: .affine).asType(input.dtype)
+                    MLX.eval(actual, reference)
+                    #expect(actual.shape == [2, 7])
+                    #expect(actual.dtype == input.dtype)
+                    #expect(MLX.isFinite(actual).all().item(Bool.self))
+                    let error = abs(actual.asType(.float32) - reference.asType(.float32)).max().item(Float.self)
+                    // Existing native-kernel BF16 tolerance; fallback must be exact.
+                    #expect(error <= (native ? 0.015625 : 0), "bits=\(bits) group=\(groupSize) error=\(error)")
+                    let gathered = Qwen4ExpBF16Affine.gathered(
+                        input, weight.expandedDimensions(axis: 0), scales: scales.expandedDimensions(axis: 0),
+                        biases: biases?.expandedDimensions(axis: 0), indices: MLXArray([UInt32(0), 0], [2, 1]),
+                        groupSize: groupSize, bits: bits, mode: .affine)
+                    #expect((gathered != nil) == native)
+                    if let gathered {
+                        MLX.eval(gathered)
+                        #expect(abs(gathered.reshaped([2, 7]) - actual).max().item(Float.self) == 0)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Tests/MLXLMTests/Qwen4ExpNGramTableTests.swift
+++ b/Tests/MLXLMTests/Qwen4ExpNGramTableTests.swift
@@ -132,10 +132,94 @@ struct Qwen4ExpNGramTableTests {
         #expect(table.ioStats() == .init(
             gatherCalls: 3,
             rowsRead: 7,
-            payloadBytesRead: 84,
+            payloadBytesRead: 60,
             backingFileCount: 1,
             backingFileBytes: UInt64(bytes.count),
             noCacheFileCount: 1))
+
+        for parallel in [false, true] {
+            let before = table.ioStats()
+            #expect(try table.gather([], parallelRows: parallel).isEmpty)
+            let repeated = try table.gather([1, 1, 1, 1], parallelRows: parallel)
+            #expect(repeated == Array(repeating: values, count: 4).flatMap { $0 })
+            #expect(table.ioStats().payloadBytesRead - before.payloadBytesRead == 12)
+            let uniqueBefore = table.ioStats()
+            let unique = try table.gather([0, 1], parallelRows: parallel)
+            #expect(Array(unique[8..<16]) == values)
+            #expect(table.ioStats().payloadBytesRead - uniqueBefore.payloadBytesRead == 24)
+            let invalidBefore = table.ioStats()
+            #expect(throws: Qwen4ExpNGramTableError.self) {
+                _ = try table.gather([1, -1, 1], parallelRows: parallel)
+            }
+            #expect(table.ioStats() == invalidBefore)
+        }
+
+        // Opt-in host-I/O diagnostic, not a model throughput benchmark. Keep
+        // identical fixture, row order and schedules across before/after runs.
+        if ProcessInfo.processInfo.environment["VMLX_PLE_IO_BENCH"] == "1" {
+            for parallel in [false, true] {
+                for (label, rows) in [
+                    ("single", [Int64(1)]),
+                    ("unique", [Int64(0), 1]),
+                    ("duplicate512", (0..<512).map { Int64($0 % 2) }),
+                ] {
+                    let before = table.ioStats()
+                    let start = DispatchTime.now().uptimeNanoseconds
+                    var checksum: Float = 0
+                    for _ in 0..<32 {
+                        let result = try table.gather(rows, parallelRows: parallel)
+                        checksum += result.last ?? 0
+                    }
+                    let elapsed = DispatchTime.now().uptimeNanoseconds - start
+                    let readBytes = table.ioStats().payloadBytesRead - before.payloadBytesRead
+                    print("PLE_IO_BENCH schedule=\(parallel ? "parallel" : "sequential") "
+                        + "case=\(label) iterations=32 ns=\(elapsed) bytes=\(readBytes) checksum=\(checksum)")
+                }
+            }
+        }
+    }
+
+    @Test("opt-in real PLE table row parity and bounded host I/O timing")
+    func realTableRowTiming() throws {
+        guard let path = ProcessInfo.processInfo.environment["VMLX_PLE_TABLE_BENCH_MODEL"] else {
+            return
+        }
+        let directory = URL(fileURLWithPath: path, isDirectory: true)
+        let config = try JSONDecoder().decode(
+            Qwen4ExpConfiguration.self,
+            from: Data(contentsOf: directory.appendingPathComponent("config.json")))
+        let layer = try #require(config.extras.pleLayerIds.first)
+        let table = try Qwen4ExpNGramTable(
+            modelDirectory: directory, layerIndex: layer - 1,
+            shardCount: config.extras.splitNgramParts)
+        #expect(table.rowCount >= 512)
+        guard table.rowCount >= 512 else { return }
+        let uniqueRows = (0..<512).map { Int64($0) * (table.rowCount / 512) }
+        // An independently gathered row at a time checks the scatter ordering,
+        // including shard boundaries, without loading any model weights.
+        let reference = try uniqueRows.flatMap { try table.gather([$0], parallelRows: false) }
+        let duplicateRows = (0..<512).map { uniqueRows[$0 % 8] }
+        let duplicateReference = (0..<512).flatMap { row in
+            Array(reference[(row % 8) * table.dimensions..<(row % 8 + 1) * table.dimensions])
+        }
+        for parallel in [false, true] {
+            #expect(try table.gather(uniqueRows, parallelRows: parallel) == reference)
+            #expect(try table.gather(duplicateRows, parallelRows: parallel) == duplicateReference)
+            for round in 0..<3 {
+                for (label, rows) in [("unique512", uniqueRows), ("duplicate512", duplicateRows)] {
+                    let before = table.ioStats()
+                    let start = DispatchTime.now().uptimeNanoseconds
+                    var checksum: Float = 0
+                    for _ in 0..<8 {
+                        checksum += try table.gather(rows, parallelRows: parallel).last ?? 0
+                    }
+                    let ns = DispatchTime.now().uptimeNanoseconds - start
+                    print("PLE_REAL_BENCH round=\(round) parallel=\(parallel) case=\(label) "
+                        + "iterations=8 ns=\(ns) bytes=\(table.ioStats().payloadBytesRead - before.payloadBytesRead) "
+                        + "checksum=\(checksum) dimensions=\(table.dimensions)")
+                }
+            }
+        }
     }
 
     @Test("local Qwen4Exp variants validate every PLE shard and use exact SSD reads")

--- a/Tests/MLXLMTests/Qwen4ExpPrefillTests.swift
+++ b/Tests/MLXLMTests/Qwen4ExpPrefillTests.swift
@@ -1,0 +1,275 @@
+import Foundation
+import MLX
+import MLXLMCommon
+import MLXNN
+import MLXRandom
+import Testing
+
+@testable import MLXVLM
+
+@Suite("Flash text prefill window", .serialized)
+struct Qwen4ExpPrefillTests {
+    private final class Progress: @unchecked Sendable {
+        private let lock = NSLock()
+        private var values: [Int] = []
+        func append(_ value: Int) { lock.withLock { values.append(value) } }
+        func read() -> [Int] { lock.withLock { values } }
+    }
+
+    private func withFixture(_ body: (Qwen4Exp) throws -> Void) throws {
+        // Entire geometry is bounded before construction; no installed model is read.
+        let data = Data(
+            """
+            {
+              "model_type":"qwen4_exp","eos_token_id":1,
+              "text_config":{
+                "model_type":"qwen4_exp_text","dtype":"float32",
+                "hidden_size":64,"num_hidden_layers":2,"intermediate_size":64,
+                "num_attention_heads":4,"num_key_value_heads":1,"head_dim":16,
+                "linear_num_value_heads":4,"linear_num_key_heads":1,
+                "linear_key_head_dim":16,"linear_value_head_dim":16,
+                "linear_conv_kernel_dim":4,"vocab_size":128,
+                "num_experts":8,"num_experts_per_tok":2,
+                "moe_intermediate_size":16,"shared_expert_intermediate_size":16,
+                "layer_types":["linear_attention","full_attention"],
+                "hc_count":4,"hc_lowrank":8,"ple_layer_ids":[1],
+                "ple_embed_dim":64,"ple_conv_kernel_size":4,
+                "ngram_size":3,"heads_per_ngram":2,"ngram_vocab_size_base":101,
+                "make_ngram_vocab_size_divisible_by":128,"seed":1234,
+                "split_ngram_parts":4,"indexer_n_heads":2,"indexer_kv_heads":1,
+                "indexer_head_dim":8,"indexer_budget":32,"indexer_compress_ratio":4,
+                "mrope_section":[1,1,1],"mtp_num_hidden_layers":0
+              }
+            }
+            """.utf8)
+        let config = try JSONDecoder().decode(Qwen4ExpConfiguration.self, from: data)
+        let text = config.base.textConfiguration
+        try #require(text.hiddenSize == 64 && text.hiddenLayers == 2)
+        try #require(text.vocabularySize == 128 && text.numExperts == 8)
+        MLXRandom.seed(0)
+        let model = Qwen4Exp(config)
+        let count = model.parameters().flattened().reduce(0) { $0 + $1.1.size }
+        try #require(count < 2_000_000, "refuse fixture drift before MLX evaluation")
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("flash-prefill-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        var arrays: [String: MLXArray] = [:]
+        var map: [String: String] = [:]
+        var specs: [String: [String: Int]] = [:]
+        for shard in 0 ..< 4 {
+            let base = "language_model.layers.0.ple.ngram_embedding.shards.\(shard)"
+            arrays[base + ".weight"] = MLXArray(
+                (0 ..< (128 * 2)).map { UInt32(truncatingIfNeeded: ($0 + shard) * 0x12345) }
+            ).reshaped(128, 2)
+            arrays[base + ".scales"] = MLXArray.full([128, 4], values: MLXArray(Float(0.01)))
+                .asType(.float16)
+            arrays[base + ".biases"] = MLXArray.full([128, 4], values: MLXArray(Float(-0.05)))
+                .asType(.float16)
+            specs[base + ".weight"] = ["bits": 4, "group_size": 4]
+            for suffix in [".weight", ".scales", ".biases"] {
+                map[base + suffix] = "model.safetensors"
+            }
+        }
+        try MLX.save(arrays: arrays, url: directory.appendingPathComponent("model.safetensors"))
+        try JSONSerialization.data(withJSONObject: ["weight_map": map])
+            .write(to: directory.appendingPathComponent("model.safetensors.index.json"))
+        try JSONSerialization.data(withJSONObject: ["jang_config": ["bit_map": specs]])
+            .write(to: directory.appendingPathComponent("config.json"))
+        try model.configure(modelDirectory: directory)
+        try body(model)
+    }
+
+    @Test("caller window bounds Flash prefill and reports completed chunks")
+    func flashPrepareHonorsWindowAndReportsProgress() throws {
+        try MLXMetalTestLock.withLock {
+            try withFixture { model in
+                let cache = model.newCache(parameters: nil)
+                let tokens = MLXArray([Int32(2), 3, 4, 5, 6, 7, 8]).reshaped(1, 7)
+                let progress = Progress()
+                let result = try PrefillProgressReporter.withHandler({ progress.append($0) }) {
+                    try model.prepare(
+                        LMInput(text: .init(tokens: tokens)),
+                        cache: cache, windowSize: 3)
+                }
+                guard case .logits(let output) = result else {
+                    Issue.record("Flash prepare must return last-chunk logits")
+                    return
+                }
+                MLX.eval(output.logits)
+                MLX.eval(cache)
+                #expect(progress.read() == [3, 6])
+                #expect(output.logits.shape == [1, 1, 128])
+                #expect(cache.allSatisfy { $0.offset == 7 })
+                #expect(cache.first is MambaCache)
+                #expect(cache.last is QSAKVCache)
+            }
+        }
+    }
+
+    private func expectEqual(_ actual: MLXArray, _ expected: MLXArray, _ label: String) {
+        #expect(actual.shape == expected.shape, "\(label) shape")
+        guard actual.shape == expected.shape else { return }
+        let a = actual.asType(.float32)
+        let b = expected.asType(.float32)
+        let error = MLX.max(abs(a - b)).item(Float.self)
+        #expect(
+            allClose(a, b, rtol: 1e-5, atol: 1e-5).item(Bool.self),
+            "\(label) maxAbs=\(error)")
+    }
+
+    @Test("chunked suffix matches explicit forwards including restored PLE and QSA")
+    func chunkedSuffixMatchesExplicitForwards() throws {
+        try MLXMetalTestLock.withLock {
+            try withFixture { model in
+                for prefixLength in [0, 35] {
+                    let prefix = model.newCache(parameters: nil)
+                    if prefixLength > 0 {
+                        let ids = MLXArray((0 ..< prefixLength).map { Int32(2 + $0 % 100) })
+                            .reshaped(1, prefixLength)
+                        MLX.eval(model(ids, cache: prefix))
+                        MLX.eval(prefix)
+                    }
+                    // copy() discards derived QSA pools, as a restore does;
+                    // raw index keys and PLE token/conv history must suffice.
+                    let actualCache = prefix.map { $0.copy() }
+                    let referenceCache = prefix.map { $0.copy() }
+                    let tokens = MLXArray((0 ..< 17).map { Int32(3 + $0 % 100) }).reshaped(1, 17)
+                    let result = try model.prepare(
+                        LMInput(text: .init(tokens: tokens)),
+                        cache: actualCache, windowSize: 8)
+                    guard case .logits(let output) = result else {
+                        Issue.record("missing logits")
+                        return
+                    }
+                    for range in [0 ..< 8, 8 ..< 16] {
+                        MLX.eval(model(tokens[0..., range], cache: referenceCache))
+                        MLX.eval(referenceCache)
+                    }
+                    let expected = model(tokens[0..., 16...], cache: referenceCache)
+                    expectEqual(output.logits, expected, "prefix\(prefixLength) last logits")
+                    for (layer, pair) in zip(actualCache, referenceCache).enumerated() {
+                        #expect(pair.0.offset == prefixLength + 17)
+                        #expect(pair.0.offset == pair.1.offset)
+                        #expect(pair.0.state.count == pair.1.state.count)
+                        for (slot, arrays) in zip(pair.0.state, pair.1.state).enumerated() {
+                            expectEqual(arrays.0, arrays.1, "layer\(layer) slot\(slot)")
+                        }
+                    }
+                    let next = MLXArray([Int32(31)]).reshaped(1, 1)
+                    expectEqual(
+                        model(next, cache: actualCache),
+                        model(next, cache: referenceCache), "next decode")
+                }
+            }
+        }
+    }
+
+    // MLX's default TF32 path uses reduced precision for float32 matrix ops.
+    // Keep the 1e-5 FP32 oracle strict and explicitly run this row with
+    // MLX_ENABLE_TF32=0; a default run must report it skipped, not proven.
+    @Test(
+        "one-shot and chunked prefill agree across QSA budget",
+        .enabled(
+            if: ProcessInfo.processInfo.environment["MLX_ENABLE_TF32"] == "0",
+            "Strict FP32 oracle requires MLX_ENABLE_TF32=0; default TF32 drift is recorded separately"
+        ))
+    func chunkedMatchesOneShot() throws {
+        try MLXMetalTestLock.withLock {
+            try withFixture { model in
+                let tokens = MLXArray((0 ..< 44).map { Int32(2 + $0 % 100) }).reshaped(1, 44)
+                let whole = model.newCache(parameters: nil)
+                let chunked = model.newCache(parameters: nil)
+                let expected = model(tokens, cache: whole)
+                MLX.eval(expected)
+                let result = try model.prepare(
+                    LMInput(text: .init(tokens: tokens)),
+                    cache: chunked, windowSize: 8)
+                guard case .logits(let output) = result else {
+                    Issue.record("missing logits")
+                    return
+                }
+                expectEqual(output.logits, expected[0..., 40..., 0...], "one-shot last chunk")
+                let next = MLXArray([Int32(47)]).reshaped(1, 1)
+                expectEqual(
+                    model(next, cache: chunked), model(next, cache: whole),
+                    "one-shot next decode")
+            }
+        }
+    }
+
+    @Test("cancelled text prefill does no cache work")
+    func cancelledPrefillDoesNotAdvanceCache() async throws {
+        try await MLXMetalTestLock.withLock {
+            try withFixture { model in
+                let cache = model.newCache(parameters: nil)
+                let progress = Progress()
+                let tokens = MLXArray([Int32(2), 3, 4, 5]).reshaped(1, 4)
+                withUnsafeCurrentTask { $0?.cancel() }
+                do {
+                    _ = try PrefillProgressReporter.withHandler({ progress.append($0) }) {
+                        try model.prepare(
+                            LMInput(text: .init(tokens: tokens)),
+                            cache: cache, windowSize: 2)
+                    }
+                    Issue.record("expected cancellation")
+                } catch is CancellationError {
+                    #expect(progress.read().isEmpty)
+                    #expect(cache.allSatisfy { $0.offset == 0 })
+                }
+            }
+        }
+    }
+
+    @Test("cancellation after one completed chunk prevents subsequent chunks")
+    func cancellationAtChunkBoundary() async throws {
+        try await MLXMetalTestLock.withLock {
+            try withFixture { model in
+                let cache = model.newCache(parameters: nil)
+                let progress = Progress()
+                let tokens = MLXArray([Int32(2), 3, 4, 5, 6]).reshaped(1, 5)
+                do {
+                    _ = try PrefillProgressReporter.withHandler({ value in
+                        progress.append(value)
+                        withUnsafeCurrentTask { $0?.cancel() }
+                    }) {
+                        try model.prepare(
+                            LMInput(text: .init(tokens: tokens)),
+                            cache: cache, windowSize: 2)
+                    }
+                    Issue.record("expected cancellation at second chunk")
+                } catch is CancellationError {
+                    #expect(progress.read() == [2])
+                    #expect(cache.allSatisfy { $0.offset == 2 })
+                }
+            }
+        }
+    }
+
+    @Test("short prompts and disabled windows retain single-shot behavior")
+    func shortAndDisabledWindows() throws {
+        try MLXMetalTestLock.withLock {
+            try withFixture { model in
+                for window: Int? in [nil, 0, -1, 4, 8] {
+                    let cache = model.newCache(parameters: nil)
+                    let progress = Progress()
+                    let tokens = MLXArray([Int32(2), 3, 4, 5]).reshaped(1, 4)
+                    let result = try PrefillProgressReporter.withHandler({ progress.append($0) }) {
+                        try model.prepare(
+                            LMInput(text: .init(tokens: tokens)),
+                            cache: cache, windowSize: window)
+                    }
+                    guard case .logits(let output) = result else {
+                        Issue.record("missing logits")
+                        return
+                    }
+                    MLX.eval(output.logits)
+                    #expect(progress.read().isEmpty)
+                    #expect(output.logits.shape == [1, 4, 128])
+                    #expect(cache.allSatisfy { $0.offset == 4 })
+                }
+            }
+        }
+    }
+}

--- a/Tests/MLXLMTests/Qwen4ExpPrefillTests.swift
+++ b/Tests/MLXLMTests/Qwen4ExpPrefillTests.swift
@@ -1,7 +1,7 @@
 import Foundation
 import CryptoKit
 import MLX
-import MLXLMCommon
+@testable import MLXLMCommon
 import MLXNN
 import MLXRandom
 import Testing
@@ -17,7 +17,7 @@ struct Qwen4ExpPrefillTests {
         func read() -> [Int] { lock.withLock { values } }
     }
 
-    private func withFixture(routedBits: [Int] = [], _ body: (Qwen4Exp) throws -> Void) throws {
+    private func withFixture(routedBits: [Int] = [], mtpEnabled: Bool = false, _ body: (Qwen4Exp) throws -> Void) throws {
         // Entire geometry is bounded before construction; no installed model is read.
         let data = Data(
             """
@@ -44,10 +44,17 @@ struct Qwen4ExpPrefillTests {
             }
             """.utf8)
         var fixtureData = data
+        if mtpEnabled {
+            var root = try #require(JSONSerialization.jsonObject(with: fixtureData) as? [String: Any])
+            var text = try #require(root["text_config"] as? [String: Any])
+            text["mtp_num_hidden_layers"] = 1
+            root["text_config"] = text
+            fixtureData = try JSONSerialization.data(withJSONObject: root)
+        }
         var routedSpecs: [String: Int] = [:]
         if !routedBits.isEmpty {
             try #require(routedBits.count == 3 && (routedBits == [0, 0, 0] || routedBits.allSatisfy { [2, 3, 4, 6].contains($0) }))
-            var root = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            var root = try #require(JSONSerialization.jsonObject(with: fixtureData) as? [String: Any])
             var text = try #require(root["text_config"] as? [String: Any])
             text["dtype"] = "bfloat16"
             text["moe_intermediate_size"] = 64
@@ -127,6 +134,218 @@ struct Qwen4ExpPrefillTests {
             .write(to: directory.appendingPathComponent("config.json"))
         try model.configure(modelDirectory: directory)
         try body(model)
+    }
+
+    @Test("sampled Flash iterator target cache matches emitted-prefix replay",
+          .enabled(if: ProcessInfo.processInfo.environment["MLX_ENABLE_TF32"] == "0"
+                   && ProcessInfo.processInfo.environment["VMLX_MTP_VERIFY_PREFETCH"] == "0",
+                   "Requires TF32 off and prefetch off before inspecting live cache; abandonment is tested separately"),
+          arguments: [false, true])
+    func sampledIteratorCommittedPrefixParity(staged: Bool) throws {
+        try MLXMetalTestLock.withLock {
+            try withFixture(routedBits: [2, 3, 4], mtpEnabled: true) { model in
+                try #require(model.nativeMTPAvailable)
+                for depth in 1...3 {
+                    let prompt = MLXArray([Int32(2), 3, 4]).reshaped(1, 3)
+                    var parameters = GenerateParameters(maxTokens: 32, temperature: 1, topP: 0.95, topK: 20)
+                    parameters.randomSeed = 829
+                    parameters.draftStrategy = .nativeMTP(depth: depth)
+                    parameters.nativeMTPDepthPolicy = .fixed
+                    var iterator = try NativeMTPTokenIterator(
+                        input: LMInput(tokens: prompt), model: model, parameters: parameters, depth: depth,
+                        experimentalSampledStaging: staged)
+                    var emitted: [Int32] = []
+                    var checked = 0
+                    let start = Date()
+                    while let token = iterator.next() {
+                        emitted.append(Int32(token))
+                        let offset = try #require(iterator.cache.first).offset
+                        // Pending accepted tokens can be ahead of the consumer.
+                        // Compare only boundaries fully represented in emitted ids.
+                        let generatedInputs = offset - 3
+                        guard generatedInputs >= 0, generatedInputs <= emitted.count else { continue }
+                        let reference = model.newCache(parameters: parameters)
+                        MLX.eval(model.nativeBackboneForward(prompt, cache: reference).logits)
+                        for id in emitted.prefix(generatedInputs) {
+                            MLX.eval(model.nativeBackboneForward(MLXArray([id]).reshaped(1, 1), cache: reference).logits)
+                        }
+                        for (layer, pair) in zip(iterator.cache, reference).enumerated() {
+                            #expect(pair.0.offset == pair.1.offset)
+                            #expect(pair.0.state.count == pair.1.state.count)
+                            for (slot, arrays) in zip(pair.0.state, pair.1.state).enumerated() {
+                                expectEqual(arrays.0, arrays.1, "sampled D\(depth) emitted\(emitted.count) layer\(layer) slot\(slot)")
+                            }
+                        }
+                        checked += 1
+                    }
+                    #expect(emitted.count == 32)
+                    #expect(iterator.terminalErrorDescription == nil)
+                    #expect(checked > 0)
+                    #expect(iterator.acceptanceProbabilityCount > 0)
+                    if staged {
+                        #expect(iterator.stagedVerifierCommitCount > 0)
+                    } else {
+                        #expect(iterator.stagedVerifierCommitCount == 0)
+                    }
+                    print("FLASH-SAMPLED-CACHE depth=\(depth) checked=\(checked) rejections=\(iterator.rejectedCount) staged=\(iterator.stagedVerifierCommitCount) fixtureTokS=\(Double(emitted.count) / max(Date().timeIntervalSince(start), 1e-9)) realModelSpeedProof=false draftCacheProof=false")
+                }
+            }
+        }
+    }
+
+    @Test("sampled Flash early stop abandons real prefetched state",
+          .enabled(if: ProcessInfo.processInfo.environment["MLX_ENABLE_TF32"] == "0"
+                   && ProcessInfo.processInfo.environment["VMLX_MTP_VERIFY_PREFETCH"] != "0",
+                   "Requires strict fixture oracle and prefetch enabled"))
+    func sampledPrefetchAbandonmentParity() throws {
+        try MLXMetalTestLock.withLock {
+            try withFixture(routedBits: [2, 3, 4], mtpEnabled: true) { model in
+                for prefixLength in [3, 35] {
+                    for depth in 1...3 {
+                        let prompt = MLXArray((0..<prefixLength).map { Int32(2 + $0) })
+                            .reshaped(1, prefixLength)
+                        var parameters = GenerateParameters(maxTokens: 64, temperature: 1, topP: 0.95, topK: 20)
+                        parameters.randomSeed = 829
+                        parameters.draftStrategy = .nativeMTP(depth: depth)
+                        parameters.nativeMTPDepthPolicy = .fixed
+                        var iterator = try NativeMTPTokenIterator(
+                            input: LMInput(tokens: prompt), model: model, parameters: parameters, depth: depth,
+                            experimentalSampledStaging: true)
+                        var emitted: [Int] = []
+                        let start = Date()
+                        while let token = iterator.next() {
+                            emitted.append(token)
+                            let committedOffset = try #require(iterator.cache.first).offset
+                            if iterator.verifyPrefetchSubmitCount > iterator.verifyPrefetchConsumedCount
+                                + iterator.verifyPrefetchAbandonedCount,
+                               committedOffset - prefixLength <= emitted.count { break }
+                        }
+                        try #require(iterator.verifyPrefetchSubmitCount > iterator.verifyPrefetchConsumedCount
+                                     + iterator.verifyPrefetchAbandonedCount)
+                        let abandonedBefore = iterator.verifyPrefetchAbandonedCount
+                        // Joins outstanding work and restores its checkpoint before
+                        // any comparison touches mutable attention/staging arrays.
+                        iterator.storeCacheAfterGeneration(generatedTokenIds: emitted, includeGeneratedBoundary: false)
+                        #expect(iterator.verifyPrefetchAbandonedCount == abandonedBefore + 1)
+                        #expect(iterator.terminalErrorDescription == nil)
+                        let offset = try #require(iterator.cache.first).offset
+                        let generatedInputs = offset - prefixLength
+                        try #require(generatedInputs >= 0 && generatedInputs <= emitted.count)
+                        let reference = model.newCache(parameters: parameters)
+                        MLX.eval(model.nativeBackboneForward(prompt, cache: reference).logits)
+                        for id in emitted.prefix(generatedInputs) {
+                            MLX.eval(model.nativeBackboneForward(MLXArray([Int32(id)]).reshaped(1, 1), cache: reference).logits)
+                        }
+                        for (layer, pair) in zip(iterator.cache, reference).enumerated() {
+                            #expect(pair.0.offset == pair.1.offset)
+                            #expect(pair.0.state.count == pair.1.state.count)
+                            for (slot, arrays) in zip(pair.0.state, pair.1.state).enumerated() {
+                                expectEqual(arrays.0, arrays.1, "abandon prefix\(prefixLength) D\(depth) layer\(layer) slot\(slot)")
+                            }
+                        }
+                        let next = MLXArray([Int32(73)]).reshaped(1, 1)
+                        expectEqual(model(next, cache: iterator.cache), model(next, cache: reference),
+                                    "abandon prefix\(prefixLength) D\(depth) next logits")
+                        print("FLASH-SAMPLED-PREFETCH-STOP prefix=\(prefixLength) depth=\(depth) offset=\(offset) abandoned=\(iterator.verifyPrefetchAbandonedCount) fixtureTokS=\(Double(emitted.count) / max(Date().timeIntervalSince(start), 1e-9)) realModelSpeedProof=false")
+                    }
+                }
+            }
+        }
+    }
+
+    @Test("sampled staged Flash draft cache matches fresh replay after trimming",
+          .enabled(if: ProcessInfo.processInfo.environment["MLX_ENABLE_TF32"] == "0"
+                   && ProcessInfo.processInfo.environment["VMLX_MTP_VERIFY_PREFETCH"] == "0",
+                   "Requires isolated strict fixture with prefetch off"))
+    func sampledDraftCacheContinuationParity() throws {
+        try MLXMetalTestLock.withLock {
+            try withFixture(routedBits: [2, 3, 4], mtpEnabled: true) { base in
+                for depth in 1...3 {
+                    let model = DraftReplayAuditor(base: base, compare: expectEqual)
+                    var parameters = GenerateParameters(maxTokens: 40, temperature: 1, topP: 0.95, topK: 20)
+                    parameters.randomSeed = 829
+                    parameters.draftStrategy = .nativeMTP(depth: depth)
+                    parameters.nativeMTPDepthPolicy = .fixed
+                    var iterator = try NativeMTPTokenIterator(
+                        input: LMInput(tokens: MLXArray([Int32(2), 3, 4]).reshaped(1, 3)), model: model,
+                        parameters: parameters, depth: depth, experimentalSampledStaging: true)
+                    let start = Date()
+                    var emitted = 0
+                    while iterator.next() != nil { emitted += 1 }
+                    #expect(emitted == 40)
+                    #expect(iterator.terminalErrorDescription == nil)
+                    #expect(iterator.stagedVerifierCommitCount > 0)
+                    #expect(iterator.rejectedCount > 0)
+                    #expect(model.checked > 0)
+                    if depth > 1 { #expect(model.trims > 0) }
+                    print("FLASH-DRAFT-REPLAY depth=\(depth) checked=\(model.checked) trims=\(model.trims) staged=\(iterator.stagedVerifierCommitCount) fixtureTokS=\(Double(emitted) / max(Date().timeIntervalSince(start), 1e-9)) realModelSpeedProof=false")
+                }
+            }
+        }
+    }
+
+    private final class DraftReplayAuditor: Module, NativeMTPModel,
+        NativeMTPSampledStagedDiagnosticModel, @unchecked Sendable {
+        let base: Qwen4Exp
+        let compare: (MLXArray, MLXArray, String) -> Void
+        var pairs: [(MLXArray, MLXArray)] = []
+        var checked = 0
+        var trims = 0
+        init(base: Qwen4Exp, compare: @escaping (MLXArray, MLXArray, String) -> Void) {
+            self.base = base
+            self.compare = compare
+            super.init()
+        }
+        var nativeMTPAvailable: Bool { base.nativeMTPAvailable }
+        func newCache(parameters: GenerateParameters?) -> [KVCache] { base.newCache(parameters: parameters) }
+        func makeNativeMTPCache() -> [KVCache] { base.makeNativeMTPCache() }
+        func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult {
+            try base.prepare(input, cache: cache, windowSize: windowSize)
+        }
+        func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray { base(inputs, cache: cache) }
+        func nativeBackboneForward(_ inputs: MLXArray, cache: [KVCache]?) -> NativeMTPForwardResult {
+            base.nativeBackboneForward(inputs, cache: cache)
+        }
+        func nativeBackboneMTPVerifyForward(_ inputs: MLXArray, cache: [KVCache]?) -> NativeMTPForwardResult {
+            base.nativeBackboneMTPVerifyForward(inputs, cache: cache)
+        }
+        func commitVerifiedBlock(cache: [KVCache], acceptedInputs: Int) -> Bool {
+            base.commitVerifiedBlock(cache: cache, acceptedInputs: acceptedInputs)
+        }
+        func commitStagedVerifiedBlock(cache: [KVCache], acceptedInputs: Int, blockLength: Int) -> Bool {
+            base.commitStagedVerifiedBlock(cache: cache, acceptedInputs: acceptedInputs, blockLength: blockLength)
+        }
+        func nativeMTPForward(hiddenStates: MLXArray, nextTokenIds: MLXArray, cache: [KVCache]?) -> NativeMTPForwardResult {
+            let offset = cache?.first?.offset ?? 0
+            #expect(offset <= pairs.count)
+            if offset < pairs.count { trims += 1; pairs = Array(pairs.prefix(offset)) }
+            let ownedHidden = hiddenStates * 1
+            let ownedIds = nextTokenIds * 1
+            MLX.eval(ownedHidden, ownedIds)
+            let actual = base.nativeMTPForward(hiddenStates: hiddenStates, nextTokenIds: nextTokenIds, cache: cache)
+            MLX.eval(actual.logits, actual.hiddenStates)
+            for row in 0..<nextTokenIds.size {
+                pairs.append((ownedHidden[0..., row..<(row + 1), 0...], ownedIds.reshaped(1, -1)[0..., row..<(row + 1)]))
+            }
+            let reference = base.makeNativeMTPCache()
+            var last: NativeMTPForwardResult?
+            for pair in pairs {
+                last = base.nativeMTPForward(hiddenStates: pair.0, nextTokenIds: pair.1, cache: reference)
+                MLX.eval(last!.logits, last!.hiddenStates)
+            }
+            if let last {
+                compare(actual.logits[0..., -1, 0...], last.logits[0..., -1, 0...], "draft continuation logits")
+                for (layer, pair) in zip(cache ?? [], reference).enumerated() {
+                    #expect(pair.0.offset == pair.1.offset)
+                    #expect(pair.0.state.count == pair.1.state.count)
+                    for (slot, arrays) in zip(pair.0.state, pair.1.state).enumerated() {
+                        compare(arrays.0, arrays.1, "draft layer\(layer) slot\(slot)")
+                    }
+                }
+            }
+            checked += 1
+            return actual
+        }
     }
 
     @Test("caller window bounds Flash prefill and reports completed chunks")
@@ -440,8 +659,22 @@ struct Qwen4ExpPrefillTests {
                             let referenceFreshPools = reference.map { $0.copy() }
                             MLX.eval(stagedFreshPools)
                             MLX.eval(referenceFreshPools)
-                            expectEqual(model(next, cache: staged), model(next, cache: reference),
+                            let stagedNext = model(next, cache: staged)
+                            let referenceNext = model(next, cache: reference)
+                            expectEqual(stagedNext, referenceNext,
                                 "prefix\(prefixLength) width\(width) accepted\(accepted) next logits")
+                            // Sampled verification needs the target distribution,
+                            // not just an unchanged argmax. Exercise the actual
+                            // probability transform after every committed prefix.
+                            // This is a fixture setting, not a production override;
+                            // it does not qualify draft-cache or iterator rollback.
+                            var sampling = GenerateParameters(temperature: 1, topP: 0.95, topK: 20)
+                            sampling.randomSeed = 829
+                            let sampler = SpeculativeSamplingController(parameters: sampling)
+                            expectEqual(
+                                sampler.probabilities(logits: stagedNext[0..., -1, 0...]),
+                                sampler.probabilities(logits: referenceNext[0..., -1, 0...]),
+                                "sampled distribution prefix\(prefixLength) width\(width) accepted\(accepted)")
                             expectEqual(
                                 model(next, cache: stagedFreshPools),
                                 model(next, cache: referenceFreshPools),

--- a/Tests/MLXLMTests/Qwen4ExpPrefillTests.swift
+++ b/Tests/MLXLMTests/Qwen4ExpPrefillTests.swift
@@ -217,6 +217,18 @@ struct Qwen4ExpPrefillTests {
                 _ = try model.prepare(head, cache: captured, windowSize: 8)
                 let owned = captured.map { $0.copy() }
                 MLX.eval(owned)
+                let file = FileManager.default.temporaryDirectory
+                    .appendingPathComponent("flash-ple-boundary-\(UUID().uuidString).safetensors")
+                defer { try? FileManager.default.removeItem(at: file) }
+                let serialized = TQDiskSerializer.serialize(cache: owned)
+                try MLX.save(arrays: serialized, url: file)
+                let persisted = try MLX.loadArrays(url: file)
+                var diskRestored = model.newCache(parameters: nil)
+                #expect(restoreFromDiskArrays(persisted, into: &diskRestored) == 37)
+                let ple = try #require(diskRestored.first as? MambaCache)
+                #expect(ple.persistentStateSlotCount == 4 && ple.state.count == 4)
+                _ = try model.prepare(
+                    LMInput(text: .init(tokens: ids[0..., 37...])), cache: diskRestored, windowSize: 8)
                 _ = try model.prepare(
                     LMInput(text: .init(tokens: ids[0..., 37...])), cache: captured, windowSize: 8)
                 _ = try model.prepare(head, cache: headReference, windowSize: 8)
@@ -228,8 +240,11 @@ struct Qwen4ExpPrefillTests {
                     }
                 }
                 let next = MLXArray([Int32(47)]).reshaped(1, 1)
-                expectEqual(model(next, cache: captured), model(next, cache: baseline),
+                let expectedNext = model(next, cache: baseline)
+                expectEqual(model(next, cache: captured), expectedNext,
                             "structural split next-token logits")
+                expectEqual(model(next, cache: diskRestored), expectedNext,
+                            "disk-restored PLE QSA next-token logits")
             }
         }
     }

--- a/Tests/MLXLMTests/Qwen4ExpPrefillTests.swift
+++ b/Tests/MLXLMTests/Qwen4ExpPrefillTests.swift
@@ -16,7 +16,7 @@ struct Qwen4ExpPrefillTests {
         func read() -> [Int] { lock.withLock { values } }
     }
 
-    private func withFixture(_ body: (Qwen4Exp) throws -> Void) throws {
+    private func withFixture(routedBits: [Int] = [], _ body: (Qwen4Exp) throws -> Void) throws {
         // Entire geometry is bounded before construction; no installed model is read.
         let data = Data(
             """
@@ -42,7 +42,29 @@ struct Qwen4ExpPrefillTests {
               }
             }
             """.utf8)
-        let config = try JSONDecoder().decode(Qwen4ExpConfiguration.self, from: data)
+        var fixtureData = data
+        var routedSpecs: [String: Int] = [:]
+        if !routedBits.isEmpty {
+            try #require(routedBits.count == 3 && (routedBits == [0, 0, 0] || routedBits.allSatisfy { [2, 3, 4, 6].contains($0) }))
+            var root = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            var text = try #require(root["text_config"] as? [String: Any])
+            text["dtype"] = "bfloat16"
+            text["moe_intermediate_size"] = 64
+            text["shared_expert_intermediate_size"] = 64
+            root["text_config"] = text
+            var quantization: [String: Any] = ["bits": 8, "group_size": 64]
+            for layer in 0..<2 {
+                for (projection, bits) in zip(["gate_proj", "up_proj", "down_proj"], routedBits) {
+                    if bits == 0 { continue } // BF16 dense control, same geometry.
+                    let path = "language_model.layers.\(layer).mlp.switch_mlp.\(projection)"
+                    routedSpecs[path] = bits
+                    quantization[path] = ["bits": bits, "group_size": 64]
+                }
+            }
+            if !routedSpecs.isEmpty { root["quantization"] = quantization }
+            fixtureData = try JSONSerialization.data(withJSONObject: root)
+        }
+        let config = try JSONDecoder().decode(Qwen4ExpConfiguration.self, from: fixtureData)
         let text = config.base.textConfiguration
         try #require(text.hiddenSize == 64 && text.hiddenLayers == 2)
         try #require(text.vocabularySize == 128 && text.numExperts == 8)
@@ -50,6 +72,31 @@ struct Qwen4ExpPrefillTests {
         let model = Qwen4Exp(config)
         let count = model.parameters().flattened().reduce(0) { $0 + $1.1.size }
         try #require(count < 2_000_000, "refuse fixture drift before MLX evaluation")
+        if !routedBits.isEmpty {
+            // Match the retained live parameter-domain contract: ordinary
+            // parameters BF16, router weights FP32. This is still a tiny
+            // generated fixture, not a shipped-weight numerical reference.
+            model.update(parameters: ModuleParameters.unflattened(
+                model.parameters().flattened().map { path, value in
+                    (path, path.hasSuffix(".mlp.gate.weight") ? value : value.asType(.bfloat16))
+                }))
+        }
+        if !routedSpecs.isEmpty {
+            quantize(model: model, filter: { path, _ in
+                guard let bits = routedSpecs[path] else { return nil }
+                return (groupSize: 64, bits: bits, mode: QuantizationMode.affine)
+            })
+            let leaves = Dictionary(uniqueKeysWithValues: model.leafModules().flattened())
+            for (path, bits) in routedSpecs {
+                let projection = try #require(leaves[path] as? any Quantized)
+                try #require(projection.bits == bits && projection.groupSize == 64)
+            }
+            model.update(parameters: ModuleParameters.unflattened(
+                model.parameters().flattened().compactMap { path, value in
+                    guard path.hasSuffix(".scales") || path.hasSuffix(".biases") else { return nil }
+                    return (path, value.asType(.float16))
+                }))
+        }
 
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("flash-prefill-\(UUID().uuidString)", isDirectory: true)
@@ -245,6 +292,142 @@ struct Qwen4ExpPrefillTests {
                             "structural split next-token logits")
                 expectEqual(model(next, cache: diskRestored), expectedNext,
                             "disk-restored PLE QSA next-token logits")
+            }
+        }
+    }
+
+    @Test(
+        "staged Flash acceptance preserves PLE GDN QSA state and next logits",
+        .enabled(
+            if: ProcessInfo.processInfo.environment["MLX_ENABLE_TF32"] == "0",
+            "Strict comparison requires TF32 off; no tolerance relaxation for mixed quantization"
+        ),
+        arguments: [[], [0, 0, 0], [2, 2, 2], [2, 3, 3], [4, 4, 4], [4, 4, 6]])
+    func stagedAcceptedPrefixMatchesSequential(routedBits: [Int]) throws {
+        try MLXMetalTestLock.withLock {
+            try withFixture(routedBits: routedBits) { model in
+                let start = Date()
+                var checkedRows = 0
+                for prefixLength in [0, 35, 71, 127] {
+                    let prefix = model.newCache(parameters: nil)
+                    if prefixLength > 0 {
+                        let ids = MLXArray((0..<prefixLength).map { Int32(2 + $0 % 100) })
+                            .reshaped(1, prefixLength)
+                        _ = try model.prepare(
+                            LMInput(text: .init(tokens: ids)), cache: prefix, windowSize: 8)
+                        MLX.eval(prefix)
+                    }
+                    for width in [2, 3, 4] {
+                        let ids = MLXArray((0..<width).map { Int32(47 + $0) }).reshaped(1, width)
+                        for accepted in 1...width {
+                            let staged = prefix.map { $0.copy() }
+                            let reference = prefix.map { $0.copy() }
+                            let before = staged.map { $0.copy() }
+                            MLX.eval(before)
+                            let verified = NativeMTPVerifierStatePolicy.withVerifierMode("input_capture_staged") {
+                                model.nativeBackboneMTPVerifyForward(ids, cache: staged)
+                            }
+                            MLX.eval(verified.logits, verified.hiddenStates)
+                            MLX.eval(staged)
+                            let qsa = try #require(staged.last as? QSAKVCache)
+                            let pooledBeforeTrim = qsa.derivedPooledBlockCount
+                            let mamba = try #require(staged.first as? MambaCache)
+                            #expect(mamba.offset == prefixLength)
+                            #expect(mamba.verifyStagingReady)
+                            #expect(mamba[4] != nil && mamba[5] != nil)
+                            let prior = try #require(before.first as? MambaCache)
+                            for slot in 0..<4 {
+                                if let expected = prior[slot] {
+                                    let actual = try #require(mamba[slot])
+                                    expectEqual(actual, expected, "uncommitted slot\(slot)")
+                                } else {
+                                    #expect(mamba[slot] == nil)
+                                }
+                            }
+                            if accepted < width {
+                                for layer in staged where layer.isTrimmable {
+                                    #expect(layer.trim(width - accepted) == width - accepted)
+                                }
+                            }
+                            try #require(model.commitStagedVerifiedBlock(
+                                cache: staged, acceptedInputs: accepted, blockLength: width))
+                            // Fixture compression ratio is 4. Completed blocks
+                            // preceding the accepted boundary must not be rebuilt
+                            // merely because the speculative suffix was rejected.
+                            #expect(qsa.derivedPooledBlockCount == min(
+                                pooledBeforeTrim, (prefixLength + accepted) / 4))
+                            #expect(mamba[4] == nil && mamba[5] == nil)
+                            for row in 0..<accepted {
+                                MLX.eval(model(ids[0..., row..<(row + 1)], cache: reference))
+                                MLX.eval(reference)
+                            }
+                            for (layer, pair) in zip(staged, reference).enumerated() {
+                                #expect(pair.0.offset == prefixLength + accepted)
+                                #expect(pair.0.offset == pair.1.offset)
+                                #expect(pair.0.state.count == pair.1.state.count)
+                                for (slot, arrays) in zip(pair.0.state, pair.1.state).enumerated() {
+                                    if prefixLength == 35 && width == 2 && accepted == 1 {
+                                        let delta = MLX.max(abs(arrays.0.asType(.float32) - arrays.1.asType(.float32))).item(Float.self)
+                                        print("STAGED-STATE-DELTA bits=\(routedBits) layer=\(layer) slot=\(slot) maxAbs=\(delta)")
+                                    }
+                                    expectEqual(arrays.0, arrays.1,
+                                        "prefix\(prefixLength) width\(width) accepted\(accepted) layer\(layer) slot\(slot)")
+                                }
+                            }
+                            let next = MLXArray([Int32(73)]).reshaped(1, 1)
+                            if prefixLength == 35 && width == 2 && accepted == 1 {
+                                let patched = staged.map { $0.copy() }
+                                let control = reference.map { $0.copy() }
+                                let patchedMamba = try #require(patched.first as? MambaCache)
+                                let controlMamba = try #require(control.first as? MambaCache)
+                                let recurrent = try #require(controlMamba[1]) * 1
+                                MLX.eval(recurrent)
+                                patchedMamba[1] = recurrent
+                                let a = model(next, cache: patched).asType(.float32)
+                                let b = model(next, cache: control).asType(.float32)
+                                let delta = MLX.max(abs(a - b)).item(Float.self)
+                                print("STAGED-RECURRENT-TRANSPLANT bits=\(routedBits) nextMaxAbs=\(delta); diagnostic only")
+                            }
+                            // Both copies drop derived QSA pools. Keep the original
+                            // comparison below: this is localization, not a bypass.
+                            let stagedFreshPools = staged.map { $0.copy() }
+                            let referenceFreshPools = reference.map { $0.copy() }
+                            MLX.eval(stagedFreshPools)
+                            MLX.eval(referenceFreshPools)
+                            expectEqual(model(next, cache: staged), model(next, cache: reference),
+                                "prefix\(prefixLength) width\(width) accepted\(accepted) next logits")
+                            expectEqual(
+                                model(next, cache: stagedFreshPools),
+                                model(next, cache: referenceFreshPools),
+                                "freshPools prefix\(prefixLength) width\(width) accepted\(accepted) next logits")
+                            if prefixLength >= 35 {
+                                let rebuilt = try #require(stagedFreshPools.last as? QSAKVCache)
+                                let retainedPool = try #require(qsa.derivedPooledBlocks)
+                                let rebuiltPool = try #require(rebuilt.derivedPooledBlocks)
+                                expectEqual(retainedPool, rebuiltPool, "retained vs rebuilt pooled keys")
+                                // Exercise sparse selection on those real indexer
+                                // pools with fixed, varied query directions. This
+                                // supplements the actual model next-logit checks.
+                                for direction in [-1, 1] {
+                                    let query = MLXArray((0..<16).map {
+                                        Float(direction * ($0 - 7)) / 8
+                                    }).reshaped(1, 2, 1, 8).asType(retainedPool.dtype)
+                                    let mask = try #require(Qwen4ExpQSA.selectedTokenMask(
+                                        query: query, pooledKeys: expandedDimensions(retainedPool, axis: 1),
+                                        pastLen: qsa.offset - 1, compressRatio: 4,
+                                        blockTopK: 8, keyLen: qsa.offset))
+                                    let full = try #require(Qwen4ExpQSA.selectedTokenMask(
+                                        query: query, pooledKeys: expandedDimensions(rebuiltPool, axis: 1),
+                                        pastLen: rebuilt.offset - 1, compressRatio: 4,
+                                        blockTopK: 8, keyLen: rebuilt.offset))
+                                    #expect(arrayEqual(mask, full).item(Bool.self))
+                                }
+                            }
+                            checkedRows += accepted
+                        }
+                    }
+                }
+                print("FLASH-STAGED-FIXTURE routedBits=\(routedBits) checkedAcceptedRows=\(checkedRows) fixtureRowsPerSecond=\(Double(checkedRows) / max(Date().timeIntervalSince(start), 1e-9)); not model decode throughput")
             }
         }
     }

--- a/Tests/MLXLMTests/Qwen4ExpPrefillTests.swift
+++ b/Tests/MLXLMTests/Qwen4ExpPrefillTests.swift
@@ -199,6 +199,41 @@ struct Qwen4ExpPrefillTests {
         }
     }
 
+    @Test(
+        "live structural boundary capture preserves Flash PLE QSA continuation",
+        .enabled(
+            if: ProcessInfo.processInfo.environment["MLX_ENABLE_TF32"] == "0",
+            "Strict FP32 segmentation oracle requires TF32 off; production policy is unchanged"
+        ))
+    func structuralBoundaryCaptureParity() throws {
+        try MLXMetalTestLock.withLock {
+            try withFixture { model in
+                let ids = MLXArray((0..<44).map { Int32(2 + $0 % 100) }).reshaped(1, 44)
+                let baseline = model.newCache(parameters: nil)
+                let captured = model.newCache(parameters: nil)
+                let headReference = model.newCache(parameters: nil)
+                _ = try model.prepare(LMInput(text: .init(tokens: ids)), cache: baseline, windowSize: 8)
+                let head = LMInput(text: .init(tokens: ids[0..., 0..<37]))
+                _ = try model.prepare(head, cache: captured, windowSize: 8)
+                let owned = captured.map { $0.copy() }
+                MLX.eval(owned)
+                _ = try model.prepare(
+                    LMInput(text: .init(tokens: ids[0..., 37...])), cache: captured, windowSize: 8)
+                _ = try model.prepare(head, cache: headReference, windowSize: 8)
+                for (index, pair) in zip(owned, headReference).enumerated() {
+                    #expect(pair.0.offset == 37 && pair.1.offset == 37)
+                    #expect(pair.0.state.count == pair.1.state.count)
+                    for (slot, state) in zip(pair.0.state, pair.1.state).enumerated() {
+                        expectEqual(state.0, state.1, "owned layer\(index) slot\(slot)")
+                    }
+                }
+                let next = MLXArray([Int32(47)]).reshaped(1, 1)
+                expectEqual(model(next, cache: captured), model(next, cache: baseline),
+                            "structural split next-token logits")
+            }
+        }
+    }
+
     @Test("cancelled text prefill does no cache work")
     func cancelledPrefillDoesNotAdvanceCache() async throws {
         try await MLXMetalTestLock.withLock {

--- a/Tests/MLXLMTests/Qwen4ExpPrefillTests.swift
+++ b/Tests/MLXLMTests/Qwen4ExpPrefillTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CryptoKit
 import MLX
 import MLXLMCommon
 import MLXNN
@@ -208,6 +209,51 @@ struct Qwen4ExpPrefillTests {
                     expectEqual(
                         model(next, cache: actualCache),
                         model(next, cache: referenceCache), "next decode")
+                }
+            }
+        }
+    }
+
+    @Test("opt-in preprocessing decode matches native multi-token continuation", .enabled(
+        if: ProcessInfo.processInfo.environment["VMLX_QWEN4_EXP_COMPILE_GDN_PREPROCESS"] == "1"
+            || ProcessInfo.processInfo.environment["VMLX_RUN_GDN_PREPROCESS_CONTROL"] == "1"))
+    func compiledPreprocessingContinuationParity() throws {
+        try MLXMetalTestLock.withLock {
+            try withFixture(routedBits: [2, 3, 4]) { model in
+                let prefix = model.newCache(parameters: nil)
+                let ids = MLXArray((0 ..< 35).map { Int32(2 + $0 % 100) }).reshaped(1, 35)
+                MLX.eval(model(ids, cache: prefix)); MLX.eval(prefix)
+                let decoded = prefix.map { $0.copy() }
+                let native = prefix.map { $0.copy() }
+                let tokens = MLXArray([Int32(41), 42, 43, 44]).reshaped(1, 4)
+                let expected = model(tokens, cache: native)
+                MLX.eval(expected); MLX.eval(native)
+                var pieces: [MLXArray] = []
+                for index in 0 ..< 4 {
+                    let output = model(tokens[0..., index ..< index + 1], cache: decoded)
+                    MLX.eval(output); MLX.eval(decoded)
+                    pieces.append(output)
+                }
+                let actual = concatenated(pieces, axis: 1)
+                func digest(_ arrays: [MLXArray]) -> String {
+                    var hash = SHA256()
+                    for array in arrays {
+                        let values = array.asType(.float32).asArray(Float.self)
+                        values.withUnsafeBytes { hash.update(bufferPointer: $0) }
+                    }
+                    return hash.finalize().map { String(format: "%02x", $0) }.joined()
+                }
+                print("[GDNPreprocessIntegration] enabled=\(Qwen4ExpCompiledGDNInputs.preprocessEnabled)"
+                    + " decode_sha=\(digest([actual])) native_sha=\(digest([expected]))"
+                    + " decode_cache_sha=\(digest(decoded.flatMap { $0.state }))"
+                    + " native_cache_sha=\(digest(native.flatMap { $0.state }))")
+                expectEqual(actual, expected, "compiled decode logits")
+                for (layer, pair) in zip(decoded, native).enumerated() {
+                    #expect(pair.0.offset == 39 && pair.1.offset == 39)
+                    #expect(pair.0.state.count == pair.1.state.count)
+                    for (slot, values) in zip(pair.0.state, pair.1.state).enumerated() {
+                        expectEqual(values.0, values.1, "compiled layer\(layer) slot\(slot)")
+                    }
                 }
             }
         }

--- a/Tests/MLXLMTests/Qwen4ExpQSAOriginalReference.swift
+++ b/Tests/MLXLMTests/Qwen4ExpQSAOriginalReference.swift
@@ -1,3 +1,5 @@
+// Frozen pre-optimization mask reference from runtime 1f41c51e.
+// Test-only: retain token-level membership as an independent regression oracle.
 // Copyright © 2026 Apple Inc.
 
 // Qwen 3.8 Next Flash (qwen4_exp) — QSA (Qwen Sparse Attention) block
@@ -13,7 +15,7 @@
 import Foundation
 import MLX
 
-enum Qwen4ExpQSA {
+enum Qwen4ExpQSAOriginalReference {
     /// Boolean attention mask [B, 1, T, keyLen] from indexer scores.
     ///
     /// - Parameters:
@@ -59,8 +61,12 @@ enum Qwen4ExpQSA {
         // selectedBlocks: [B, T, blockTopK]
 
         let tokenIdx = MLXArray((0 ..< keyLen).map(Int32.init))  // [keyLen]
-        let selectedTokens = tokenMembership(
-            selectedBlocks: selectedBlocks, keyLen: keyLen, compressRatio: compressRatio)
+        let tokenBlocks = floorDivide(tokenIdx, MLXArray(Int32(compressRatio)))
+        let selectedTokens = MLX.any(
+            MLX.equal(
+                tokenBlocks.reshaped(1, 1, 1, keyLen),
+                expandedDimensions(selectedBlocks, axis: -1)),
+            axis: 2)
         // selectedTokens: [B, T, keyLen]
 
         // The incomplete tail block up to each query position always attends.
@@ -80,23 +86,5 @@ enum Qwen4ExpQSA {
             causal)
         return expandedDimensions(mask, axis: 1)  // [B, 1, T, keyLen]
     }
-
-    /// Membership is constant within a compressed block. Compare each selected
-    /// block once, then expand the boolean result, instead of constructing a
-    /// [B,T,K,keyLen] equality temporary. The partial final block is included
-    /// in this grid; the caller retains ownership of causal and tail masking.
-    static func tokenMembership(
-        selectedBlocks: MLXArray, keyLen: Int, compressRatio: Int
-    ) -> MLXArray {
-        let blocks = (keyLen + compressRatio - 1) / compressRatio
-        let ids = MLXArray((0..<blocks).map(Int32.init))
-        let membership = MLX.any(
-            MLX.equal(ids.reshaped(1, 1, 1, blocks),
-                expandedDimensions(selectedBlocks, axis: -1)), axis: 2)
-        let batch = selectedBlocks.dim(0), queries = selectedBlocks.dim(1)
-        return broadcast(
-            expandedDimensions(membership, axis: -1),
-            to: [batch, queries, blocks, compressRatio])
-            .reshaped(batch, queries, blocks * compressRatio)[.ellipsis, ..<keyLen]
-    }
 }
+

--- a/Tests/MLXLMTests/Qwen4ExpQSATests.swift
+++ b/Tests/MLXLMTests/Qwen4ExpQSATests.swift
@@ -11,6 +11,93 @@ import Testing
 @Suite("qwen4_exp QSA block selection", .serialized)
 struct Qwen4ExpQSATests {
 
+    @Test("complete QSA masks match the frozen original across prefill, budget crossings and ties")
+    func completeMaskParity() throws {
+        try MLXMetalTestLock.withLock {
+            for (past, length) in [(0, 128), (2040, 16), (2047, 4),
+                                   (2048, 1), (2048, 128), (8192, 4)] {
+                for tied in [false, true] {
+                    MLXRandom.seed(19)
+                    let keyLen = past + length
+                    let q = tied ? MLXArray.zeros([1, 4, length, 8])
+                        : MLXRandom.normal([1, 4, length, 8])
+                    let pooled = MLXRandom.normal([1, 1, keyLen / 4, 8])
+                    let original = Qwen4ExpQSAOriginalReference.selectedTokenMask(
+                        query: q, pooledKeys: pooled, pastLen: past,
+                        compressRatio: 4, blockTopK: 512, keyLen: keyLen)
+                    let candidate = Qwen4ExpQSA.selectedTokenMask(
+                        query: q, pooledKeys: pooled, pastLen: past,
+                        compressRatio: 4, blockTopK: 512, keyLen: keyLen)
+                    #expect((original == nil) == (candidate == nil))
+                    if let original, let candidate {
+                        #expect(candidate.asArray(Bool.self) == original.asArray(Bool.self),
+                            "past=\(past) length=\(length) tied=\(tied)")
+                    }
+                }
+            }
+        }
+    }
+
+    private func originalMembership(_ selected: MLXArray, keyLen: Int, ratio: Int) -> MLXArray {
+        let tokenBlocks = floorDivide(
+            MLXArray((0..<keyLen).map(Int32.init)), MLXArray(Int32(ratio)))
+        return MLX.any(MLX.equal(
+            tokenBlocks.reshaped(1, 1, 1, keyLen),
+            expandedDimensions(selected, axis: -1)), axis: 2)
+    }
+
+    @Test("block expansion exactly matches original token membership at partial tails and verify widths")
+    func blockMembershipParity() throws {
+        try MLXMetalTestLock.withLock {
+            for ratio in [1, 4, 8] {
+                for keyLen in [1, 7, 8, 9, 31, 32, 33, 257] {
+                    for queries in [1, 2, 3, 4, 6] {
+                        let blocks = (keyLen + ratio - 1) / ratio
+                        let selected = MLXArray((0..<(2 * queries * 5)).map {
+                            Int32(($0 * 7) % (blocks + 2) - 1)
+                        }).reshaped(2, queries, 5)
+                        let expected = originalMembership(selected, keyLen: keyLen, ratio: ratio)
+                        let actual = Qwen4ExpQSA.tokenMembership(
+                            selectedBlocks: selected, keyLen: keyLen, compressRatio: ratio)
+                        #expect(actual.shape == expected.shape)
+                        #expect(actual.asArray(Bool.self) == expected.asArray(Bool.self))
+                    }
+                }
+            }
+        }
+    }
+
+    @Test("QSA membership production-budget diagnostic with synchronized timings")
+    func membershipTiming() throws {
+        guard ProcessInfo.processInfo.environment["VMLX_QSA_MEMBERSHIP_BENCH"] == "1" else { return }
+        try MLXMetalTestLock.withLock {
+            for keyLen in [8193, 32769] {
+                for queries in [1, 4] {
+                    let selected = MLXArray((0..<(queries * 512)).map {
+                        Int32(($0 * 7) % (keyLen / 4))
+                    }).reshaped(1, queries, 512)
+                    let reference = originalMembership(selected, keyLen: keyLen, ratio: 4).asArray(Bool.self)
+                    for round in 0..<3 {
+                        for candidate in [false, true] {
+                            let start = DispatchTime.now().uptimeNanoseconds
+                            for _ in 0..<8 {
+                                let result = candidate
+                                    ? Qwen4ExpQSA.tokenMembership(selectedBlocks: selected, keyLen: keyLen, compressRatio: 4)
+                                    : originalMembership(selected, keyLen: keyLen, ratio: 4)
+                                MLX.eval(result)
+                            }
+                            let elapsed = DispatchTime.now().uptimeNanoseconds - start
+                            let actual = Qwen4ExpQSA.tokenMembership(
+                                selectedBlocks: selected, keyLen: keyLen, compressRatio: 4)
+                            #expect(actual.asArray(Bool.self) == reference)
+                            print("QSA_MEMBERSHIP_BENCH round=\(round) candidate=\(candidate) keys=\(keyLen) queries=\(queries) iterations=8 ns=\(elapsed)")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     private func makeMask(
         pastLen: Int, seqLen: Int, keyLen: Int,
         compressRatio: Int = 4, blockTopK: Int = 2, heads: Int = 2, dim: Int = 8

--- a/Tests/MLXLMTests/Qwen4ExpQSATests.swift
+++ b/Tests/MLXLMTests/Qwen4ExpQSATests.swift
@@ -11,6 +11,85 @@ import Testing
 @Suite("qwen4_exp QSA block selection", .serialized)
 struct Qwen4ExpQSATests {
 
+    private func blockGridMembership(_ selected: MLXArray, keyLen: Int, ratio: Int) -> MLXArray {
+        let blocks = (keyLen + ratio - 1) / ratio
+        let ids = MLXArray((0..<blocks).map(Int32.init))
+        let member = MLX.any(MLX.equal(ids.reshaped(1, 1, 1, blocks),
+            expandedDimensions(selected, axis: -1)), axis: 2)
+        return broadcast(expandedDimensions(member, axis: -1),
+            to: [selected.dim(0), selected.dim(1), blocks, ratio])
+            .reshaped(selected.dim(0), selected.dim(1), blocks * ratio)[.ellipsis, ..<keyLen]
+    }
+
+    @Test("membership scatter preserves duplicates, invalid IDs and independent prefill rows")
+    func scatterMembershipRows() throws {
+        try MLXMetalTestLock.withLock {
+            for queries in [1, 4, 32, 128] {
+                for keyLen in [1, 33, 8193, 32769] {
+                    let batch = 2, count = 512, ratio = 4
+                    let blocks = (keyLen + ratio - 1) / ratio
+                    let values: [Int32] = (0..<(batch * queries * count)).map {
+                        if $0 % 7 == 0 { return -1 }
+                        if $0 % 11 == 0 { return Int32(blocks + 1) }
+                        return Int32(($0 * 13) % blocks)
+                    }
+                    let selected = MLXArray(values).reshaped(batch, queries, count)
+                    var expected = [Bool](repeating: false, count: batch * queries * keyLen)
+                    for row in 0..<(batch * queries) {
+                        for slot in 0..<count {
+                            let block = Int(values[row * count + slot])
+                            guard block >= 0 && block < blocks else { continue }
+                            for token in (block * ratio)..<min((block + 1) * ratio, keyLen) {
+                                expected[row * keyLen + token] = true
+                            }
+                        }
+                    }
+                    let result = Qwen4ExpQSA.tokenMembership(
+                        selectedBlocks: selected, keyLen: keyLen, compressRatio: ratio)
+                    #expect(result.shape == [batch, queries, keyLen])
+                    let actual = result.asArray(Bool.self)
+                    #expect(zip(actual, expected).allSatisfy { $0 == $1 },
+                        "queries=\(queries) keys=\(keyLen)")
+                }
+            }
+            let empty = Qwen4ExpQSA.tokenMembership(
+                selectedBlocks: MLXArray.zeros([2, 4, 0], dtype: .int32),
+                keyLen: 33, compressRatio: 4)
+            #expect(empty.asArray(Bool.self).allSatisfy { !$0 })
+        }
+    }
+
+    @Test("membership scatter versus block-grid synchronized diagnostic")
+    func scatterMembershipTiming() throws {
+        guard ProcessInfo.processInfo.environment["VMLX_QSA_SCATTER_BENCH"] == "1" else { return }
+        try MLXMetalTestLock.withLock {
+            for queries in [1, 4, 32, 128] {
+                let keyLen = 32769, ratio = 4
+                let selected = MLXArray((0..<(queries * 512)).map {
+                    Int32(($0 * 7) % (keyLen / ratio))
+                }).reshaped(1, queries, 512)
+                let expected = blockGridMembership(selected, keyLen: keyLen, ratio: ratio).asArray(Bool.self)
+                for round in 0..<3 {
+                    for candidate in (round % 2 == 0 ? [false, true] : [true, false]) {
+                        let start = DispatchTime.now().uptimeNanoseconds
+                        for _ in 0..<4 {
+                            let result = candidate
+                                ? Qwen4ExpQSA.tokenMembership(selectedBlocks: selected,
+                                    keyLen: keyLen, compressRatio: ratio)
+                                : blockGridMembership(selected, keyLen: keyLen, ratio: ratio)
+                            MLX.eval(result)
+                        }
+                        let elapsed = DispatchTime.now().uptimeNanoseconds - start
+                        let actual = Qwen4ExpQSA.tokenMembership(selectedBlocks: selected,
+                            keyLen: keyLen, compressRatio: ratio).asArray(Bool.self)
+                        #expect(zip(actual, expected).allSatisfy { $0 == $1 })
+                        print("QSA_SCATTER_BENCH round=\(round) candidate=\(candidate) keys=\(keyLen) queries=\(queries) iterations=4 ns=\(elapsed)")
+                    }
+                }
+            }
+        }
+    }
+
     @Test("complete QSA masks match the frozen original across prefill, budget crossings and ties")
     func completeMaskParity() throws {
         try MLXMetalTestLock.withLock {

--- a/Tests/MLXLMTests/ResidentSafetensorsReaderTests.swift
+++ b/Tests/MLXLMTests/ResidentSafetensorsReaderTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import MLX
+import Testing
+@testable import MLXLMCommon
+
+@Suite(.serialized)
+struct ResidentSafetensorsReaderTests {
+    @Test func mixedTypesAndExclusions() throws {
+        try MLXMetalTestLock.withLock {
+            let url = FileManager.default.temporaryDirectory.appendingPathComponent("resident-reader-\(UUID()).safetensors")
+            defer { try? FileManager.default.removeItem(at: url) }
+            let arrays: [String: MLXArray] = [
+                "packed": MLXArray([UInt32(0), UInt32.max, 123]),
+                "scale": MLXArray([Float(0.125), -2, 3]).asType(.float16),
+                "bf": MLXArray([Float(0.5), -7, 9]).asType(.bfloat16),
+                "scalar": MLXArray(Int64(42)),
+                "excluded": MLXArray([Float(123)]),
+            ]
+            try MLX.save(arrays: arrays, metadata: ["format": "pt"], url: url)
+            let (result, metadata) = try ResidentSafetensorsReader.load(url: url, excludingKeys: ["excluded"])
+            #expect(Set(result.keys) == Set(arrays.keys).subtracting(["excluded"]))
+            #expect(metadata == ["format": "pt"])
+            for (key, value) in result {
+                let reference = arrays[key]!
+                #expect(value.shape == reference.shape && value.dtype == reference.dtype)
+                #expect(MLX.all(value.reshaped([-1]).view(dtype: .uint8) .== reference.reshaped([-1]).view(dtype: .uint8)).item(Bool.self))
+            }
+        }
+    }
+
+    @Test func malformedHeadersThrowBeforeAllocation() throws {
+        let entries: [[String: Any]] = [
+            ["dtype": "U32", "shape": [-1], "data_offsets": [0, 4]],
+            ["dtype": "U32", "shape": [Int.max, 4], "data_offsets": [0, 4]],
+            ["dtype": "U32", "shape": [2], "data_offsets": [0, 4]],
+            ["dtype": "U32", "shape": [1], "data_offsets": [0, 8]],
+            ["dtype": "UNKNOWN", "shape": [1], "data_offsets": [0, 4]],
+            ["dtype": "U32", "shape": [1], "data_offsets": [4, 0]],
+        ]
+        for entry in entries {
+            let url = FileManager.default.temporaryDirectory.appendingPathComponent("resident-invalid-\(UUID()).safetensors")
+            defer { try? FileManager.default.removeItem(at: url) }
+            let header = try JSONSerialization.data(withJSONObject: ["w": entry])
+            var length = UInt64(header.count).littleEndian
+            var data = withUnsafeBytes(of: &length) { Data($0) }
+            data.append(header)
+            data.append(Data(repeating: 0, count: 4))
+            try data.write(to: url)
+            #expect(throws: (any Error).self) {
+                _ = try ResidentSafetensorsReader.load(url: url, excludingKeys: [])
+            }
+        }
+    }
+}

--- a/Tests/MLXLMTests/ResidentSafetensorsReaderTests.swift
+++ b/Tests/MLXLMTests/ResidentSafetensorsReaderTests.swift
@@ -5,6 +5,20 @@ import Testing
 
 @Suite(.serialized)
 struct ResidentSafetensorsReaderTests {
+    @Test func unalignedPayloadCrossesReadChunkAndPartialEOF() throws {
+        try MLXMetalTestLock.withLock {
+            let url = FileManager.default.temporaryDirectory.appendingPathComponent("resident-chunks-\(UUID()).safetensors")
+            defer { try? FileManager.default.removeItem(at: url) }
+            // A little over the 4-MiB physical read chunk, with a partial EOF page.
+            let expected = MLXArray((0..<(1024 * 1024 + 3)).map { UInt32($0) })
+            try MLX.save(arrays: ["w": expected], url: url)
+            let (loaded, _) = try ResidentSafetensorsReader.load(url: url, excludingKeys: [])
+            let actual = try #require(loaded["w"])
+            #expect(actual.shape == expected.shape && actual.dtype == expected.dtype)
+            #expect(MLX.all(actual .== expected).item(Bool.self))
+        }
+    }
+
     @Test func nullMetadataMatchesAbsentMetadata() throws {
         // Real Flash Next shards 6, 7 and 13 carry __metadata__: null.
         // Exclude the payload: this regression exercises header parsing only.

--- a/Tests/MLXLMTests/ResidentSafetensorsReaderTests.swift
+++ b/Tests/MLXLMTests/ResidentSafetensorsReaderTests.swift
@@ -5,6 +5,26 @@ import Testing
 
 @Suite(.serialized)
 struct ResidentSafetensorsReaderTests {
+    @Test func nullMetadataMatchesAbsentMetadata() throws {
+        // Real Flash Next shards 6, 7 and 13 carry __metadata__: null.
+        // Exclude the payload: this regression exercises header parsing only.
+        for metadata in [NSNull(), [:] as NSDictionary] as [Any] {
+            let url = FileManager.default.temporaryDirectory.appendingPathComponent("resident-metadata-\(UUID()).safetensors")
+            defer { try? FileManager.default.removeItem(at: url) }
+            let header = try JSONSerialization.data(withJSONObject: [
+                "__metadata__": metadata,
+                "w": ["dtype": "U32", "shape": [1], "data_offsets": [0, 4]],
+            ])
+            var length = UInt64(header.count).littleEndian
+            var data = withUnsafeBytes(of: &length) { Data($0) }
+            data.append(header)
+            data.append(Data(repeating: 0, count: 4))
+            try data.write(to: url)
+            let (arrays, result) = try ResidentSafetensorsReader.load(url: url, excludingKeys: ["w"])
+            #expect(arrays.isEmpty && result.isEmpty)
+        }
+    }
+
     @Test func mixedTypesAndExclusions() throws {
         try MLXMetalTestLock.withLock {
             let url = FileManager.default.temporaryDirectory.appendingPathComponent("resident-reader-\(UUID()).safetensors")

--- a/Tests/MLXLMTests/ResidentShardMemoryDiagnosticTests.swift
+++ b/Tests/MLXLMTests/ResidentShardMemoryDiagnosticTests.swift
@@ -1,0 +1,219 @@
+import Foundation
+import Darwin
+import MLX
+import Testing
+@testable import MLXLMCommon
+
+/// Opt-in component diagnostic, not a cold full-model load or speed benchmark.
+@Suite(.serialized)
+struct ResidentShardMemoryDiagnosticTests {
+    @Test(.enabled(if: ProcessInfo.processInfo.environment["VMLX_RESIDENT_REAL_SHARD"] != nil))
+    func realShardSubsetLifecycle() throws {
+        try MLXMetalTestLock.withLock {
+            let path = try #require(ProcessInfo.processInfo.environment["VMLX_RESIDENT_REAL_SHARD"])
+            let url = URL(fileURLWithPath: path)
+            let input = try FileHandle(forReadingFrom: url)
+            defer { try? input.close() }
+            let prefix = try #require(try input.read(upToCount: 8))
+            try #require(prefix.count == 8)
+            let length = prefix.enumerated().reduce(UInt64(0)) { $0 | UInt64($1.element) << (8 * $1.offset) }
+            try #require(length < 16 * 1024 * 1024)
+            let data = try #require(try input.read(upToCount: Int(length)))
+            let header = try #require(try JSONSerialization.jsonObject(with: data) as? [String: Any])
+            var selected = Set<String>()
+            var bytes = 0
+            var bytesByType: [String: Int] = [:]
+            let types: [String: DType] = ["U32": .uint32, "F16": .float16, "BF16": .bfloat16]
+            let orderedKeys = header.keys.sorted {
+                let a = (header[$0] as? [String: Any])?["dtype"] as? String ?? ""
+                let b = (header[$1] as? [String: Any])?["dtype"] as? String ?? ""
+                return a == b ? $0 < $1 : a < b
+            }
+            for key in orderedKeys {
+                guard !key.contains("ngram"), !key.contains("layer_multipliers"), !key.contains("mtp"),
+                    let entry = header[key] as? [String: Any],
+                    let dtype = entry["dtype"] as? String, types[dtype] != nil,
+                    let offsets = entry["data_offsets"] as? [Int], offsets.count == 2 else { continue }
+                let size = offsets[1] - offsets[0]
+                guard size > 0, size <= 256 * 1024 * 1024 - bytes,
+                    size <= 80 * 1024 * 1024 - bytesByType[dtype, default: 0] else { continue }
+                selected.insert(key)
+                bytes += size
+                bytesByType[dtype, default: 0] += size
+            }
+            try #require(!selected.isEmpty && bytes <= 256 * 1024 * 1024)
+            let selectedTypes = Set(selected.compactMap { (header[$0] as? [String: Any])?["dtype"] as? String })
+            try #require(selectedTypes == Set(types.keys))
+            print("RESIDENT_REAL dtypes=\(selectedTypes.sorted())")
+            print("RESIDENT_REAL file=\(path) bytes=\(bytes) keys=\(selected.sorted()) cache_temperature=unknown")
+            if let arm = ProcessInfo.processInfo.environment["VMLX_RESIDENT_READ_ARM"] {
+                try #require(arm == "mapped" || arm == "direct")
+                MLX.Memory.clearCache()
+                try sample("\(arm)-start")
+                var values: [String: MLXArray] = [:]
+                if arm == "mapped" {
+                    try autoreleasepool {
+                        let excluded = Set(header.keys).subtracting(selected).subtracting(["__metadata__"])
+                        let (mapped, _) = try loadArraysAndMetadata(url: url, excludingKeys: excluded, exactTensorBuffers: true)
+                        values = mapped.mapValues { $0 * 1 }
+                        MLX.eval(Array(values.values))
+                        try sample("mapped-input-and-owned-live")
+                    }
+                } else {
+                    let file = try FileHandle(forReadingFrom: url)
+                    defer { try? file.close() }
+                    try #require(fcntl(file.fileDescriptor, F_NOCACHE, 1) == 0)
+                    for key in selected.sorted() {
+                        try autoreleasepool {
+                            let entry = try #require(header[key] as? [String: Any])
+                            let offsets = try #require(entry["data_offsets"] as? [Int])
+                            let shape = try #require(entry["shape"] as? [Int])
+                            let name = try #require(entry["dtype"] as? String)
+                            let dtype = try #require(types[name])
+                            try file.seek(toOffset: 8 + length + UInt64(offsets[0]))
+                            let data = try #require(try file.read(upToCount: offsets[1] - offsets[0]))
+                            try #require(data.count == offsets[1] - offsets[0])
+                            values[key] = MLXArray(data, shape, dtype: dtype)
+                            MLX.eval(values[key]!)
+                        }
+                    }
+                }
+                #expect(Set(values.keys) == selected)
+                #expect(values.values.reduce(0) { $0 + $1.nbytes } == bytes)
+                try sample("\(arm)-owned-live")
+                MLX.Memory.clearCache()
+                try sample("\(arm)-owned-live-cache-cleared")
+                values.removeAll()
+                MLX.Memory.clearCache()
+                try sample("\(arm)-released")
+                return
+            }
+            let excluded = Set(header.keys).subtracting(selected).subtracting(["__metadata__"])
+            MLX.Memory.clearCache()
+            try sample("real-before-map")
+            var owned: [String: MLXArray] = [:]
+            try autoreleasepool {
+                let (mapped, _) = try loadArraysAndMetadata(url: url, excludingKeys: excluded, exactTensorBuffers: true)
+                #expect(Set(mapped.keys) == selected)
+                try sample("real-mapped-before-eval")
+                owned = mapped.mapValues { $0 * 1 }
+                MLX.eval(Array(owned.values))
+                try sample("real-owned-inputs-live")
+                for key in selected {
+                    #expect(MLX.all(owned[key]! .== mapped[key]!).item(Bool.self))
+                }
+            }
+            try sample("real-mapped-released")
+            MLX.Memory.clearCache()
+            try sample("real-cache-cleared-owned-live")
+            // Diagnostic alternative: independently open the same file for
+            // uncached reads. This does not purge pre-existing cached pages.
+            let start = ProcessInfo.processInfo.systemUptime
+            try autoreleasepool {
+                let (direct, _) = try ResidentSafetensorsReader.load(url: url, excludingKeys: excluded)
+                #expect(Set(direct.keys) == selected)
+                for key in selected.sorted() {
+                    let array = try #require(direct[key])
+                    #expect(MLX.all(array.reshaped([-1]).view(dtype: .uint8) .== owned[key]!.reshaped([-1]).view(dtype: .uint8)).item(Bool.self))
+                }
+            }
+            print("RESIDENT_REAL uncached_read_and_parity_seconds=\(ProcessInfo.processInfo.systemUptime - start)")
+            MLX.Memory.clearCache()
+            try sample("real-uncached-read-parity-complete")
+            owned.removeAll()
+            MLX.Memory.clearCache()
+            try sample("real-all-released")
+        }
+    }
+
+    @Test(.enabled(if: ProcessInfo.processInfo.environment["VMLX_RESIDENT_SHARD_DIAGNOSTIC"] == "1"))
+    func mappedToOwnedLifecycle() throws {
+        try MLXMetalTestLock.withLock {
+            let directory = FileManager.default.temporaryDirectory
+                .appendingPathComponent("resident-shard-\(UUID().uuidString)")
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+            defer { try? FileManager.default.removeItem(at: directory) }
+            let url = directory.appendingPathComponent("fixture.safetensors")
+            // Four 64 MiB tensors, hard bounded before construction. The file is
+            // newly written, so its filesystem cache starts warm, not cold.
+            let count = 16 * 1024 * 1024
+            try autoreleasepool {
+                let arrays = Dictionary(uniqueKeysWithValues: (0..<4).map {
+                    ("w\($0)", MLXArray.full([count], values: MLXArray(UInt32($0 + 1)), dtype: .uint32))
+                })
+                let rawURL = directory.appendingPathComponent("raw.safetensors")
+                try MLX.save(arrays: arrays, url: rawURL)
+                try alignFixture(from: rawURL, to: url)
+                try FileManager.default.removeItem(at: rawURL)
+            }
+            MLX.Memory.clearCache()
+            try sample("fixture-written-warm")
+            var owned: [String: MLXArray] = [:]
+            try autoreleasepool {
+                let (mapped, _) = try loadArraysAndMetadata(url: url, excludingKeys: [], exactTensorBuffers: true)
+                #expect(mapped.count == 4)
+                try sample("mapped-before-eval")
+                owned = mapped.mapValues { $0 * 1 }
+                MLX.eval(Array(owned.values))
+                try sample("owned-evaluated-inputs-in-scope")
+            }
+            try sample("mapped-scope-released")
+            MLX.Memory.clearCache()
+            try sample("allocator-cache-cleared-owned-live")
+            for index in 0..<4 {
+                let array = try #require(owned["w\(index)"])
+                #expect(array.dtype == .uint32)
+                #expect(array.size == count)
+                #expect(MLX.all(array .== UInt32(index + 1)).item(Bool.self))
+            }
+            owned.removeAll()
+            MLX.Memory.clearCache()
+            try sample("all-arrays-released")
+        }
+    }
+
+    private func alignFixture(from source: URL, to target: URL) throws {
+        let input = try FileHandle(forReadingFrom: source)
+        defer { try? input.close() }
+        let prefix = try #require(try input.read(upToCount: 8))
+        #expect(prefix.count == 8)
+        let length = prefix.enumerated().reduce(UInt64(0)) { $0 | UInt64($1.element) << (8 * $1.offset) }
+        #expect(length < 1024 * 1024)
+        let header = try #require(try input.read(upToCount: Int(length)))
+        let padding = (8 - header.count % 8) % 8
+        var paddedLength = UInt64(header.count + padding).littleEndian
+        #expect(FileManager.default.createFile(atPath: target.path, contents: nil))
+        let output = try FileHandle(forWritingTo: target)
+        defer { try? output.close() }
+        try withUnsafeBytes(of: &paddedLength) { try output.write(contentsOf: Data($0)) }
+        try output.write(contentsOf: header)
+        try output.write(contentsOf: Data(repeating: 0x20, count: padding))
+        while let chunk = try input.read(upToCount: 1024 * 1024), !chunk.isEmpty {
+            try output.write(contentsOf: chunk)
+        }
+    }
+
+    private func sample(_ phase: String) throws {
+        let memory = MLX.Memory.snapshot()
+        print("RESIDENT_SHARD phase=\(phase) active=\(memory.activeMemory) cache=\(memory.cacheMemory)")
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/vm_stat")
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        try process.run()
+        let output = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        #expect(process.terminationStatus == 0)
+        print(String(decoding: output, as: UTF8.self))
+        let footprint = Process()
+        footprint.executableURL = URL(fileURLWithPath: "/usr/bin/footprint")
+        footprint.arguments = ["-p", String(ProcessInfo.processInfo.processIdentifier)]
+        let footprintPipe = Pipe()
+        footprint.standardOutput = footprintPipe
+        try footprint.run()
+        let footprintData = footprintPipe.fileHandleForReading.readDataToEndOfFile()
+        footprint.waitUntilExit()
+        try #require(footprint.terminationStatus == 0)
+        print(String(decoding: footprintData, as: UTF8.self))
+    }
+}

--- a/Tests/MLXLMTests/ResidentShardMemoryDiagnosticTests.swift
+++ b/Tests/MLXLMTests/ResidentShardMemoryDiagnosticTests.swift
@@ -47,11 +47,27 @@ struct ResidentShardMemoryDiagnosticTests {
             print("RESIDENT_REAL dtypes=\(selectedTypes.sorted())")
             print("RESIDENT_REAL file=\(path) bytes=\(bytes) keys=\(selected.sorted()) cache_temperature=unknown")
             if let arm = ProcessInfo.processInfo.environment["VMLX_RESIDENT_READ_ARM"] {
-                try #require(arm == "mapped" || arm == "direct")
+                try #require(arm == "mapped" || arm == "direct" || arm == "resident")
+                func fileResidency(_ stage: String) throws {
+                    var status = stat()
+                    try #require(fstat(input.fileDescriptor, &status) == 0)
+                    let size = Int(status.st_size)
+                    let mapping = mmap(nil, size, PROT_NONE, MAP_SHARED, input.fileDescriptor, 0)
+                    try #require(mapping != MAP_FAILED)
+                    defer { munmap(mapping, size) }
+                    let pageSize = Int(getpagesize())
+                    var states = [CChar](repeating: 0, count: (size + pageSize - 1) / pageSize)
+                    try #require(mincore(mapping, size, &states) == 0)
+                    print("FILE_RESIDENCY stage=\(stage) pages=\(states.filter { ($0 & 1) != 0 }.count) pageSize=\(pageSize) mlxActive=\(MLX.Memory.activeMemory) mlxCache=\(MLX.Memory.cacheMemory)")
+                }
                 MLX.Memory.clearCache()
                 try sample("\(arm)-start")
+                try fileResidency("before")
                 var values: [String: MLXArray] = [:]
-                if arm == "mapped" {
+                if arm == "resident" {
+                    let excluded = Set(header.keys).subtracting(selected).subtracting(["__metadata__"])
+                    (values, _) = try ResidentSafetensorsReader.load(url: url, excludingKeys: excluded)
+                } else if arm == "mapped" {
                     try autoreleasepool {
                         let excluded = Set(header.keys).subtracting(selected).subtracting(["__metadata__"])
                         let (mapped, _) = try loadArraysAndMetadata(url: url, excludingKeys: excluded, exactTensorBuffers: true)
@@ -81,11 +97,13 @@ struct ResidentShardMemoryDiagnosticTests {
                 #expect(Set(values.keys) == selected)
                 #expect(values.values.reduce(0) { $0 + $1.nbytes } == bytes)
                 try sample("\(arm)-owned-live")
+                try fileResidency("owned-live")
                 MLX.Memory.clearCache()
                 try sample("\(arm)-owned-live-cache-cleared")
                 values.removeAll()
                 MLX.Memory.clearCache()
                 try sample("\(arm)-released")
+                try fileResidency("released")
                 return
             }
             let excluded = Set(header.keys).subtracting(selected).subtracting(["__metadata__"])


### PR DESCRIPTION
## Latest live update — September 10, 19:12 local

[Current-binary live proof](https://github.com/osaurus-ai/vmlx-swift/pull/460#issuecomment-5628420907): AR and D3 API rows plus two visible D3 turns recorded on the current repin. Structured task totals still fail; prose remains below this AR sample. PARTIAL, remaining gates and raw receipts in the linked comment. This supersedes earlier no-current-binary-result statements below.

## Current proof checkpoint — September 10, 2026

Runtime head: `efd45805a00841a21b5731241d23566714825882`.
Companion: [Osaurus #2699](https://github.com/osaurus-ai/osaurus/pull/2699),
app `ee854831bb3b785a044a3c10bc1ee6d4f0070940`, with all six engine pin references updated.

**PARTIAL — open draft, not yet for merge.** This branch includes depth-ceiling
and monotonic-clock corrections, reusable-boundary capture, and opt-in Flash
sampled staged verification. The latest increment batches independent target
probability materialization inside that opt-in path only. It does not enable
ANE execution or establish an instantaneous AR speed floor.

### Current source and executable

`NativeMTPTokenIterator.swift:1726,2986–3012` gates grouped materialization on
experimental sampled staging, staged verification and no logits processor.
Other paths retain per-row evaluation. `NativeMTPDepthExecutionTests.swift`
contains exact distribution/RNG controls and the generated-logit benchmark.

Source-matched Release `-O` development app completed with exit 0 on September
10 at 18:59 local. Clean app and resolved-engine checkouts were checked again
after building; deep/strict ad-hoc signature verification exited 0. Binary:
`db32fbb3ae4dbc843567a40e39d00d019d86080f51e2012999c4505dfe787d97`.
Build peak tracked physical footprint 8.03 GiB, swap unchanged at 0.52 GiB,
cleanup group/tracked/watchdog 0/0/0. Incremental, batch-disabled compilation
is not a shipping whole-module-optimization comparison.

### Executed focused evidence

Tests exercised the tree subsequently committed as this head:

- `FlashGroupedProbability__183231`: 1 XCTest, 0 failures; 12 Swift Testing
  cases reported with 3 explicit skips, 0 failures. Distribution/RNG control
  covers 45 rows across F16/BF16/F32 and depths 1/2/3/5. Includes tiny Flash
  staged/prefetch controls. An incorrect prefetch environment name left
  prefetch ON; this run is not prefetch-OFF proof.
- `FlashGroupedProbabilityCache__183330`: the two omitted target-prefix and
  draft-cache continuation tests rerun with the correct prefetch-OFF switch;
  2 executed, 0 failures. Tiny fixtures, not shipped bundle qualification.
- `FlashGroupedProbabilityTiming__183441`: 1 XCTest executed, 0 failures.
  Generated BF16 logits, vocabulary 248320, nine paired alternating samples:
  sequential/grouped median milliseconds for 2/3/4/6 rows were
  1.5455/1.1890, 2.3982/1.4888, 3.2298/1.8269, 4.9760/2.5483.
  **Component timings only, not full-model decode speedups.**

All three supervised runs exited 0, with unchanged swap and cleanup 0/0/0.
Strict tiny Flash numerical oracles used TF32 disabled; no production precision
policy was changed. No full-model eval score is claimed for the new binary.

### Retained real-model evidence and failures — predecessor only

Parent app `b7ea36c0` / runtime `2518f0da`, bundle
`JANGQ-AI/Qwen3.8-Flash-Next-JANG_2L`, main effective temperature 1,
top-p 0.95, top-k 20, min-p 0; seed 829, reasoning off explicitly:
prose AR/D3/AR rates 36.8238/34.2776/33.4213 tok/s; structured rates
36.6491/53.7337/33.2755 tok/s. All structured arms produced the wrong total.
Thus no demonstrated prose speedup or universal floor; structured throughput
does not turn incorrect answers into task-completion proof. Two visible D1
turns persisted; the follow-up omitted its requested explanation. Cache hits
were logged, but do not alone prove complete companion-state parity.

### Remaining merge gates

Current-binary full-model AR/MTP comparison, visual complete-turn/tool/cache
controls, selected-depth ceilings and fallback/re-entry behavior remain open.
Initial model admission attempts were refused because another worktree was
building; no new-binary model result exists yet. Default-loader memory behavior,
other quant layouts and universal speed-floor claims remain unqualified.
Runtime CI is not required by this lane; that does not waive live proof.

Evidence base: `/Users/eric/vmlx-private-evidence/mtp-swift-2026-09-04/logs/`,
`SWIFTTEST_` logs with the run names above and
`SWIFTTEST_FlashGroupedProbabilityApp__183657.log` plus memory/process sidecars.
Full retained outputs and limitations:
`/Users/eric/vmlx-private-evidence/post-1653-qwen38-audit/FLASH-GROUPED-PROBABILITY-EVAL-2026-09-10.md`
and `FLASH-SAMPLED-STAGED-APP-ABA-2026-09-10.md`.

## Historical checkpoint notes


The notes below refer to their named earlier commits, not the current head or pin.

## Scope

Separate fixed native-MTP depth ceilings from explicit adaptive exploration, and use monotonic elapsed-time measurements throughout the iterator.

- Fixed requested depths no longer implicitly promote toward the previous default D5 cap.
- `GenerateParameters.nativeMTPDepthPolicy` defaults to fixed; adaptive callers must supply their bounded exploration policy explicitly.
- Runtime caps can lower, but cannot raise, a fixed request's ceiling.
- Calendar clock corrections no longer affect elapsed-cost samples.
- Status, validation and full resolution now agree on explicit bundle safety
  blocks; they no longer advertise speculation and then report an unsupported
  family for the same blocked artifact. Existing full-load refusal is retained.
- Sampling documentation no longer prescribes a greedy override. The companion
  app removes its actual coercion; native exact-p/q behavior is covered below.

## Evidence / PARTIAL

Source: 1f41c51e2ade65bb88477179eb99b2ee3a10e30c, on aa39a70a main; clock commit19e74a85.
Before-control removes only the ceiling assignment: fixed D1 produces verifier widths2–5, D2 widths3–6, D3 widths4–6; fixed and adaptive ceiling assertions fail. Candidate run produces fixed widths2/3/4 and adaptive initialD1/cap3 widths2,3,4.

Exact-head run MTPDepthExactHead__123158:19 XCTest passed (9 governor arithmetic,3 clock,5 policy,2 iterator dispatch), exit0, peak tracked footprint1.63GB, cleanup0/0/0. The dispatch fixture has no trained weights and no-op state commits; AR safety is disabled only for that isolated depth test. It does not prove model quality, cache correctness, or speed.

Current exact-head run MTPSamplingSafetyExactHead__135644:21 XCTest plus18 Swift
Testing cases without failures, exit0, peak1.73GB, swap0.79GB unchanged,
cleanup0/0/0. Includes flat/nested tuning, missing equivalence, explicit blocks,
untuned manual activation, and the narrow legacyFlash4M fingerprint exception.
Safety before-control134328 recorded6 assertion issues where status said
speculative but full resolution refused the block and misidentified the cause.

The sampled iterator fixture emits both supported target tokens with equal p/q;
disjoint drafts produce residual corrections and no out-of-support output.
These sampled hybrid requests use sequential verification, not the greedy
staged hook. Two initial observer assertions incorrectly watched that staged
hook; the retained failing run and corrected counters are recorded. Two old
manual-depth negative controls also used Flash-Next despite its measured-family
Auto default; denseQwen now supplies the intended tuning-required control.
No runtime Auto policy was weakened to satisfy those tests.

Local evidence: `/Users/eric/vmlx-private-evidence/mtp-swift-2026-09-04/logs/` runs MTPClockIntegration__121530, MTPDepthPolicy__122137, MTPDepthExecutionReady__122859, MTPDepthBeforeControl__123113. Swap stayed0.80GB during these supervised runs. Earlier dispatch attempt lacked the Metal library; preserved as infrastructure failure.

## Hold

Draft: no merge until caller integration and source-matched Osaurus UI/runtime verification. Companion osaurus PR2699 pins this SHA; its integrated tests/CI and live proof remain separate gates. No real Qwen bundle/generation-default or visual proof has been collected for this candidate. No assertion of an instantaneous never-below-AR speed floor. Baseline freshness, sampled-path performance, partial-head validation and cache qualification remain open.