### PR TITLE
Optimize Flash QSA membership construction for AR and prefill

### DIFF
--- a/Libraries/MLXVLM/Models/Qwen4ExpQSA.swift
+++ b/Libraries/MLXVLM/Models/Qwen4ExpQSA.swift
@@ -81,19 +81,27 @@ enum Qwen4ExpQSA {
         return expandedDimensions(mask, axis: 1)  // [B, 1, T, keyLen]
     }
 
-    /// Membership is constant within a compressed block. Compare each selected
-    /// block once, then expand the boolean result, instead of constructing a
-    /// [B,T,K,keyLen] equality temporary. The partial final block is included
-    /// in this grid; the caller retains ownership of causal and tail masking.
+    /// Scatter selected block membership, then expand to tokens. Integer max
+    /// makes duplicate IDs order-independent without a [B,T,K,blocks] equality
+    /// grid. Invalid IDs contribute zero to a safe index, preserving the old
+    /// equality implementation's behavior. Causal/tail policy remains above.
     static func tokenMembership(
         selectedBlocks: MLXArray, keyLen: Int, compressRatio: Int
     ) -> MLXArray {
         let blocks = (keyLen + compressRatio - 1) / compressRatio
-        let ids = MLXArray((0..<blocks).map(Int32.init))
-        let membership = MLX.any(
-            MLX.equal(ids.reshaped(1, 1, 1, blocks),
-                expandedDimensions(selectedBlocks, axis: -1)), axis: 2)
         let batch = selectedBlocks.dim(0), queries = selectedBlocks.dim(1)
+        guard blocks > 0, selectedBlocks.dim(2) > 0 else {
+            return MLXArray.zeros([batch, queries, keyLen], dtype: .bool)
+        }
+        let valid = logicalAnd(
+            greaterEqual(selectedBlocks, MLXArray(Int32(0))),
+            less(selectedBlocks, MLXArray(Int32(blocks))))
+        let safeIDs = MLX.where(valid, selectedBlocks, MLXArray(Int32(0)))
+        let batchIDs = MLXArray((0..<batch).map(Int32.init)).reshaped(batch, 1, 1)
+        let queryIDs = MLXArray((0..<queries).map(Int32.init)).reshaped(1, queries, 1)
+        let membership = MLXArray.zeros([batch, queries, blocks], dtype: .int32)
+            .at[batchIDs, queryIDs, safeIDs].maximum(valid.asType(.int32))
+            .asType(.bool)
         return broadcast(
             expandedDimensions(membership, axis: -1),
             to: [batch, queries, blocks, compressRatio])

--- a/Tests/MLXLMTests/Qwen4ExpQSAOriginalReference.swift
+++ b/Tests/MLXLMTests/Qwen4ExpQSAOriginalReference.swift
@@ -1,3 +1,5 @@
+// Frozen pre-optimization mask reference from runtime 1f41c51e.
+// Test-only: retain token-level membership as an independent regression oracle.
 // Copyright © 2026 Apple Inc.
 
 // Qwen 3.8 Next Flash (qwen4_exp) — QSA (Qwen Sparse Attention) block
@@ -13,7 +15,7 @@
 import Foundation
 import MLX
 
-enum Qwen4ExpQSA {
+enum Qwen4ExpQSAOriginalReference {
     /// Boolean attention mask [B, 1, T, keyLen] from indexer scores.
     ///
     /// - Parameters:
@@ -59,8 +61,12 @@ enum Qwen4ExpQSA {
         // selectedBlocks: [B, T, blockTopK]
 
         let tokenIdx = MLXArray((0 ..< keyLen).map(Int32.init))  // [keyLen]
-        let selectedTokens = tokenMembership(
-            selectedBlocks: selectedBlocks, keyLen: keyLen, compressRatio: compressRatio)
+        let tokenBlocks = floorDivide(tokenIdx, MLXArray(Int32(compressRatio)))
+        let selectedTokens = MLX.any(
+            MLX.equal(
+                tokenBlocks.reshaped(1, 1, 1, keyLen),
+                expandedDimensions(selectedBlocks, axis: -1)),
+            axis: 2)
         // selectedTokens: [B, T, keyLen]
 
         // The incomplete tail block up to each query position always attends.
@@ -80,23 +86,5 @@ enum Qwen4ExpQSA {
             causal)
         return expandedDimensions(mask, axis: 1)  // [B, 1, T, keyLen]
     }
-
-    /// Membership is constant within a compressed block. Compare each selected
-    /// block once, then expand the boolean result, instead of constructing a
-    /// [B,T,K,keyLen] equality temporary. The partial final block is included
-    /// in this grid; the caller retains ownership of causal and tail masking.
-    static func tokenMembership(
-        selectedBlocks: MLXArray, keyLen: Int, compressRatio: Int
-    ) -> MLXArray {
-        let blocks = (keyLen + compressRatio - 1) / compressRatio
-        let ids = MLXArray((0..<blocks).map(Int32.init))
-        let membership = MLX.any(
-            MLX.equal(ids.reshaped(1, 1, 1, blocks),
-                expandedDimensions(selectedBlocks, axis: -1)), axis: 2)
-        let batch = selectedBlocks.dim(0), queries = selectedBlocks.dim(1)
-        return broadcast(
-            expandedDimensions(membership, axis: -1),
-            to: [batch, queries, blocks, compressRatio])
-            .reshaped(batch, queries, blocks * compressRatio)[.ellipsis, ..<keyLen]
-    }
 }
+

--- a/Tests/MLXLMTests/Qwen4ExpQSATests.swift
+++ b/Tests/MLXLMTests/Qwen4ExpQSATests.swift
@@ -11,6 +11,93 @@ import Testing
 @Suite("qwen4_exp QSA block selection", .serialized)
 struct Qwen4ExpQSATests {
 
+    @Test("complete QSA masks match the frozen original across prefill, budget crossings and ties")
+    func completeMaskParity() throws {
+        try MLXMetalTestLock.withLock {
+            for (past, length) in [(0, 128), (2040, 16), (2047, 4),
+                                   (2048, 1), (2048, 128), (8192, 4)] {
+                for tied in [false, true] {
+                    MLXRandom.seed(19)
+                    let keyLen = past + length
+                    let q = tied ? MLXArray.zeros([1, 4, length, 8])
+                        : MLXRandom.normal([1, 4, length, 8])
+                    let pooled = MLXRandom.normal([1, 1, keyLen / 4, 8])
+                    let original = Qwen4ExpQSAOriginalReference.selectedTokenMask(
+                        query: q, pooledKeys: pooled, pastLen: past,
+                        compressRatio: 4, blockTopK: 512, keyLen: keyLen)
+                    let candidate = Qwen4ExpQSA.selectedTokenMask(
+                        query: q, pooledKeys: pooled, pastLen: past,
+                        compressRatio: 4, blockTopK: 512, keyLen: keyLen)
+                    #expect((original == nil) == (candidate == nil))
+                    if let original, let candidate {
+                        #expect(candidate.asArray(Bool.self) == original.asArray(Bool.self),
+                            "past=\(past) length=\(length) tied=\(tied)")
+                    }
+                }
+            }
+        }
+    }
+
+    private func originalMembership(_ selected: MLXArray, keyLen: Int, ratio: Int) -> MLXArray {
+        let tokenBlocks = floorDivide(
+            MLXArray((0..<keyLen).map(Int32.init)), MLXArray(Int32(ratio)))
+        return MLX.any(MLX.equal(
+            tokenBlocks.reshaped(1, 1, 1, keyLen),
+            expandedDimensions(selected, axis: -1)), axis: 2)
+    }
+
+    @Test("block expansion exactly matches original token membership at partial tails and verify widths")
+    func blockMembershipParity() throws {
+        try MLXMetalTestLock.withLock {
+            for ratio in [1, 4, 8] {
+                for keyLen in [1, 7, 8, 9, 31, 32, 33, 257] {
+                    for queries in [1, 2, 3, 4, 6] {
+                        let blocks = (keyLen + ratio - 1) / ratio
+                        let selected = MLXArray((0..<(2 * queries * 5)).map {
+                            Int32(($0 * 7) % (blocks + 2) - 1)
+                        }).reshaped(2, queries, 5)
+                        let expected = originalMembership(selected, keyLen: keyLen, ratio: ratio)
+                        let actual = Qwen4ExpQSA.tokenMembership(
+                            selectedBlocks: selected, keyLen: keyLen, compressRatio: ratio)
+                        #expect(actual.shape == expected.shape)
+                        #expect(actual.asArray(Bool.self) == expected.asArray(Bool.self))
+                    }
+                }
+            }
+        }
+    }
+
+    @Test("QSA membership production-budget diagnostic with synchronized timings")
+    func membershipTiming() throws {
+        guard ProcessInfo.processInfo.environment["VMLX_QSA_MEMBERSHIP_BENCH"] == "1" else { return }
+        try MLXMetalTestLock.withLock {
+            for keyLen in [8193, 32769] {
+                for queries in [1, 4] {
+                    let selected = MLXArray((0..<(queries * 512)).map {
+                        Int32(($0 * 7) % (keyLen / 4))
+                    }).reshaped(1, queries, 512)
+                    let reference = originalMembership(selected, keyLen: keyLen, ratio: 4).asArray(Bool.self)
+                    for round in 0..<3 {
+                        for candidate in [false, true] {
+                            let start = DispatchTime.now().uptimeNanoseconds
+                            for _ in 0..<8 {
+                                let result = candidate
+                                    ? Qwen4ExpQSA.tokenMembership(selectedBlocks: selected, keyLen: keyLen, compressRatio: 4)
+                                    : originalMembership(selected, keyLen: keyLen, ratio: 4)
+                                MLX.eval(result)
+                            }
+                            let elapsed = DispatchTime.now().uptimeNanoseconds - start
+                            let actual = Qwen4ExpQSA.tokenMembership(
+                                selectedBlocks: selected, keyLen: keyLen, compressRatio: 4)
+                            #expect(actual.asArray(Bool.self) == reference)
+                            print("QSA_MEMBERSHIP_BENCH round=\(round) candidate=\(candidate) keys=\(keyLen) queries=\(queries) iterations=8 ns=\(elapsed)")
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     private func makeMask(
         pastLen: Int, seqLen: Int, keyLen: Int,
         compressRatio: Int = 4, blockTopK: Int = 2, heads: Int = 2, dim: Int = 8

--- a/Tests/MLXLMTests/Qwen4ExpQSATests.swift
+++ b/Tests/MLXLMTests/Qwen4ExpQSATests.swift
@@ -11,6 +11,85 @@ import Testing
 @Suite("qwen4_exp QSA block selection", .serialized)
 struct Qwen4ExpQSATests {
 
+    private func blockGridMembership(_ selected: MLXArray, keyLen: Int, ratio: Int) -> MLXArray {
+        let blocks = (keyLen + ratio - 1) / ratio
+        let ids = MLXArray((0..<blocks).map(Int32.init))
+        let member = MLX.any(MLX.equal(ids.reshaped(1, 1, 1, blocks),
+            expandedDimensions(selected, axis: -1)), axis: 2)
+        return broadcast(expandedDimensions(member, axis: -1),
+            to: [selected.dim(0), selected.dim(1), blocks, ratio])
+            .reshaped(selected.dim(0), selected.dim(1), blocks * ratio)[.ellipsis, ..<keyLen]
+    }
+
+    @Test("membership scatter preserves duplicates, invalid IDs and independent prefill rows")
+    func scatterMembershipRows() throws {
+        try MLXMetalTestLock.withLock {
+            for queries in [1, 4, 32, 128] {
+                for keyLen in [1, 33, 8193, 32769] {
+                    let batch = 2, count = 512, ratio = 4
+                    let blocks = (keyLen + ratio - 1) / ratio
+                    let values: [Int32] = (0..<(batch * queries * count)).map {
+                        if $0 % 7 == 0 { return -1 }
+                        if $0 % 11 == 0 { return Int32(blocks + 1) }
+                        return Int32(($0 * 13) % blocks)
+                    }
+                    let selected = MLXArray(values).reshaped(batch, queries, count)
+                    var expected = [Bool](repeating: false, count: batch * queries * keyLen)
+                    for row in 0..<(batch * queries) {
+                        for slot in 0..<count {
+                            let block = Int(values[row * count + slot])
+                            guard block >= 0 && block < blocks else { continue }
+                            for token in (block * ratio)..<min((block + 1) * ratio, keyLen) {
+                                expected[row * keyLen + token] = true
+                            }
+                        }
+                    }
+                    let result = Qwen4ExpQSA.tokenMembership(
+                        selectedBlocks: selected, keyLen: keyLen, compressRatio: ratio)
+                    #expect(result.shape == [batch, queries, keyLen])
+                    let actual = result.asArray(Bool.self)
+                    #expect(zip(actual, expected).allSatisfy { $0 == $1 },
+                        "queries=\(queries) keys=\(keyLen)")
+                }
+            }
+            let empty = Qwen4ExpQSA.tokenMembership(
+                selectedBlocks: MLXArray.zeros([2, 4, 0], dtype: .int32),
+                keyLen: 33, compressRatio: 4)
+            #expect(empty.asArray(Bool.self).allSatisfy { !$0 })
+        }
+    }
+
+    @Test("membership scatter versus block-grid synchronized diagnostic")
+    func scatterMembershipTiming() throws {
+        guard ProcessInfo.processInfo.environment["VMLX_QSA_SCATTER_BENCH"] == "1" else { return }
+        try MLXMetalTestLock.withLock {
+            for queries in [1, 4, 32, 128] {
+                let keyLen = 32769, ratio = 4
+                let selected = MLXArray((0..<(queries * 512)).map {
+                    Int32(($0 * 7) % (keyLen / ratio))
+                }).reshaped(1, queries, 512)
+                let expected = blockGridMembership(selected, keyLen: keyLen, ratio: ratio).asArray(Bool.self)
+                for round in 0..<3 {
+                    for candidate in (round % 2 == 0 ? [false, true] : [true, false]) {
+                        let start = DispatchTime.now().uptimeNanoseconds
+                        for _ in 0..<4 {
+                            let result = candidate
+                                ? Qwen4ExpQSA.tokenMembership(selectedBlocks: selected,
+                                    keyLen: keyLen, compressRatio: ratio)
+                                : blockGridMembership(selected, keyLen: keyLen, ratio: ratio)
+                            MLX.eval(result)
+                        }
+                        let elapsed = DispatchTime.now().uptimeNanoseconds - start
+                        let actual = Qwen4ExpQSA.tokenMembership(selectedBlocks: selected,
+                            keyLen: keyLen, compressRatio: ratio).asArray(Bool.self)
+                        #expect(zip(actual, expected).allSatisfy { $0 == $1 })
+                        print("QSA_SCATTER_BENCH round=\(round) candidate=\(candidate) keys=\(keyLen) queries=\(queries) iterations=4 ns=\(elapsed)")
+                    }
+                }
+            }
+        }
+    }
+
     @Test("complete QSA masks match the frozen original across prefill, budget crossings and ties")
     func completeMaskParity() throws {
         try MLXMetalTestLock.withLock {


### PR DESCRIPTION
## Scope

Isolate Qwen Flash QSA membership optimization from the deferred MTP campaign.
Base main: `aa39a70a292fa49f3bf879a1b191d3132512995a`.
Candidate: `c3a5db2106af7b8729254b86378ef372bcdc2353`.

Only three files change: `Qwen4ExpQSA.swift`, its tests, and a frozen reference.
Replace token-by-selected-block equality expansion with duplicate-safe integer
block scatter followed by token expansion. Keep score selection, causal/tail
rules, quantization, sampler, loader and MTP policy unchanged.

## Proof status: component verified; app integration PARTIAL

Exact-head c3a5db21 now has 9/9 exercised QSA tests and both synchronized
component benchmarks; see the exact-head proof comment for timings and limits.
Runtime PR461 merged as c86f29057f405efc50d97f3db5975944c0b6d13f.
Osaurus PR2710 pins the tested child; Release build and app proof remain pending.

Historical component run `FlashQSAScatter184221` on the same QSA implementation
at `81f8ea8a`: exact boolean host-union and geometry/tie controls, 9 tests
reported with one inactive benchmark, 8 workloads exercised, exit 0. Queries
1/4/32/128, duplicate and invalid IDs, partial tails and empty selections.
At 32769 keys, synchronized query-1 component timings were 3.781–5.973 ms
for the old grid versus 1.698–3.179 ms for scatter; query-128 was
20.103–31.422 ms versus 3.410–3.473 ms. Debug component measurements only.

These are NOT current isolated-head full-model AR or prefill speed claims.
Matched AR before/after app qualification remains pending.
No whole-model eval score claimed. MTP speed-floor or depth-controller
changes are explicitly deferred, not merge gates for this AR optimization;
shared QSA mask/cache correctness remains a gate.

The previous mixed branch's integrated live receipts used
`JANGQ-AI/Qwen3.8-Flash-Next-JANG_2L` and bundle sampler temp1/top-p0.95/top-k20;
they cannot establish the speed delta of this isolated composition. The app
pin is PR2710; its proof is not replaced by historical receipts. No release claim.

Internal evidence:
`/Users/eric/vmlx-private-evidence/post-1653-qwen38-audit/AR-ONLY-SPLIT-2026-09-10.md`
and the retained `FlashQSAScatter184221` log under the sibling
`mtp-swift-2026-09-04/logs` directory.
