### PR TITLE
Avoid duplicate source residency for owned compute loads

### DIFF
--- a/Libraries/MLXLMCommon/Load.swift
+++ b/Libraries/MLXLMCommon/Load.swift
@@ -537,6 +537,16 @@ public func loadWeights(
             JANGTQStreamingExperts.configureModelDirectory(modelDirectory)
         }
         let modelKeyExcluder = model as? any SafetensorsLoadKeyExcluding
+        // A model requesting owned compute weights must not also retain a
+        // complete filesystem-backed copy while loading them. Model-owned
+        // auxiliary tensors remain excluded by the existing key contract.
+        let uncachedResidentRead = ResidentSafetensorsReader.shouldUse(
+            requiresOwnedCompute: modelKeyExcluder?.requiresResidentSafetensorsWeights == true,
+            readerOverride: RuntimeEnvironment.value("VMLX_FLASH_RESIDENT_READER"))
+        if uncachedResidentRead {
+            FileHandle.standardError.write(Data(
+                "[loadWeights] resident_reader=uncached_owned source_files_unchanged=true\n".utf8))
+        }
         for url in allShardURLs {
             let isPrestackedShard = url.lastPathComponent == "jangpress-prestacked.safetensors"
             let headerNames = (try? loadSafetensorsHeaderNamesForBaseLoad(url)) ?? []
@@ -577,10 +587,12 @@ public func loadWeights(
                     continue
                 }
             }
-            let (w, m) = try loadArraysAndMetadata(
-                url: url,
-                excludingKeys: excludedKeys,
-                exactTensorBuffers: modelKeyExcluder?.requiresExactTensorMmapBuffers == true)
+            let (w, m) = try uncachedResidentRead
+                ? ResidentSafetensorsReader.load(url: url, excludingKeys: excludedKeys)
+                : loadArraysAndMetadata(
+                    url: url,
+                    excludingKeys: excludedKeys,
+                    exactTensorBuffers: modelKeyExcluder?.requiresExactTensorMmapBuffers == true)
             var shardWeights: [String: MLXArray] = [:]
             for (key, value) in w {
                 if shouldFilterPreservedMTP, isPreservedMTPWeightKey(key) {
@@ -612,7 +624,7 @@ public func loadWeights(
                 // excluded above, so this materializes compute tensors only.
                 // `* 1` creates owned MLX storage even for already-contiguous
                 // mmap inputs (unlike `contiguous()`, which may return them as-is).
-                let resident = shardWeights.mapValues { $0 * 1 }
+                let resident = uncachedResidentRead ? shardWeights : shardWeights.mapValues { $0 * 1 }
                 MLX.eval(Array(resident.values))
                 residentSafetensorsBytes += resident.values.reduce(0) { $0 + $1.nbytes }
                 for (key, value) in resident { weights[key] = value }

--- a/Libraries/MLXLMCommon/ResidentSafetensorsReader.swift
+++ b/Libraries/MLXLMCommon/ResidentSafetensorsReader.swift
@@ -1,0 +1,177 @@
+import Foundation
+import MLX
+#if canImport(Darwin)
+import Darwin
+#endif
+
+/// Uncached reads for models that already require owned compute weights.
+/// Does not modify the source file or manufacture model/dtype defaults.
+enum ResidentSafetensorsReader {
+    static func shouldUse(requiresOwnedCompute: Bool, readerOverride: String?) -> Bool {
+        #if canImport(Darwin)
+        return requiresOwnedCompute && readerOverride != "mmap"
+        #else
+        return false
+        #endif
+    }
+    struct InvalidFile: LocalizedError {
+        let detail: String
+        var errorDescription: String? { "Resident safetensors reader: \(detail)" }
+    }
+
+    private struct Entry: Decodable {
+        let dtype: String
+        let shape: [Int]
+        let data_offsets: [Int]
+    }
+
+    private struct Key: CodingKey {
+        var stringValue: String
+        var intValue: Int? { nil }
+        init?(stringValue: String) { self.stringValue = stringValue }
+        init?(intValue: Int) { return nil }
+    }
+
+    private struct Header: Decodable {
+        var entries: [String: Entry] = [:]
+        var metadata: [String: String] = [:]
+        init(from decoder: Decoder) throws {
+            let values = try decoder.container(keyedBy: Key.self)
+            for key in values.allKeys {
+                if key.stringValue == "__metadata__" {
+                    // Existing safetensors readers treat null metadata as absent.
+                    // Some Flash Next shards use null while others omit the key.
+                    metadata = try values.decodeIfPresent([String: String].self, forKey: key) ?? [:]
+                } else {
+                    entries[key.stringValue] = try values.decode(Entry.self, forKey: key)
+                }
+            }
+        }
+    }
+
+    private static let dtypes: [String: DType] = [
+        "BOOL": .bool, "U8": .uint8, "U16": .uint16, "U32": .uint32, "U64": .uint64,
+        "I8": .int8, "I16": .int16, "I32": .int32, "I64": .int64,
+        "F16": .float16, "BF16": .bfloat16, "F32": .float32, "F64": .float64,
+    ]
+
+    static func load(url: URL, excludingKeys: Set<String>) throws -> ([String: MLXArray], [String: String]) {
+        #if canImport(Darwin)
+        try Task.checkCancellation()
+        guard url.isFileURL else { throw InvalidFile(detail: "not a file URL") }
+        let file = try FileHandle(forReadingFrom: url)
+        defer { try? file.close() }
+        guard fcntl(file.fileDescriptor, F_NOCACHE, 1) == 0 else {
+            throw InvalidFile(detail: "uncached I/O unavailable (errno \(errno))")
+        }
+        var status = stat()
+        guard fstat(file.fileDescriptor, &status) == 0, status.st_size >= 8 else {
+            throw InvalidFile(detail: "missing or short file")
+        }
+        let prefix = try readExactly(file, count: 8, fileSize: Int(status.st_size))
+        let length = prefix.enumerated().reduce(UInt64(0)) { $0 | UInt64($1.element) << (8 * $1.offset) }
+        guard length > 0, length <= 64 * 1024 * 1024,
+            length <= UInt64(status.st_size - 8) else {
+            throw InvalidFile(detail: "header length out of bounds")
+        }
+        let header = try JSONDecoder().decode(Header.self, from: readExactly(file, count: Int(length), fileSize: Int(status.st_size)))
+        let dataStart = 8 + Int(length)
+        let dataLength = Int(status.st_size) - dataStart
+        // Validate every entry before allocating any tensors, including excluded
+        // entries, so malformed shapes never reach MLX's nonthrowing constructors.
+        for (name, entry) in header.entries {
+            guard let dtype = dtypes[entry.dtype], entry.data_offsets.count == 2 else {
+                throw InvalidFile(detail: "unsupported dtype or offsets for \(name)")
+            }
+            let start = entry.data_offsets[0], end = entry.data_offsets[1]
+            guard start >= 0, end >= start, end <= dataLength else {
+                throw InvalidFile(detail: "out-of-bounds tensor \(name)")
+            }
+            var elements = 1
+            for dimension in entry.shape {
+                guard dimension >= 0, dimension <= Int(Int32.max) else {
+                    throw InvalidFile(detail: "shape outside MLX dimension range for \(name)")
+                }
+                let product = elements.multipliedReportingOverflow(by: dimension)
+                guard !product.overflow else { throw InvalidFile(detail: "shape overflow for \(name)") }
+                elements = product.partialValue
+            }
+            let size = elements.multipliedReportingOverflow(by: dtype.size)
+            guard !size.overflow, size.partialValue == end - start else {
+                throw InvalidFile(detail: "shape/byte mismatch for \(name)")
+            }
+        }
+        let ordered = header.entries.sorted {
+            if $0.value.data_offsets[0] == $1.value.data_offsets[0] {
+                return $0.value.data_offsets[1] < $1.value.data_offsets[1]
+            }
+            return $0.value.data_offsets[0] < $1.value.data_offsets[0]
+        }
+        var previousEnd = 0
+        for (_, entry) in ordered {
+            guard entry.data_offsets[0] == previousEnd else {
+                throw InvalidFile(detail: "overlapping or noncontiguous payload")
+            }
+            previousEnd = entry.data_offsets[1]
+        }
+        guard previousEnd == dataLength else { throw InvalidFile(detail: "unindexed payload bytes") }
+        var arrays: [String: MLXArray] = [:]
+        for (name, entry) in ordered where !excludingKeys.contains(name) {
+            try Task.checkCancellation()
+            try autoreleasepool {
+                try file.seek(toOffset: UInt64(dataStart + entry.data_offsets[0]))
+                let data = try readExactly(file, count: entry.data_offsets[1] - entry.data_offsets[0], fileSize: Int(status.st_size))
+                // Empty tensors are legal safetensors entries. Avoid the Data
+                // initializer's forced baseAddress unwrap for a zero-byte buffer.
+                let array = data.isEmpty
+                    ? MLXArray.zeros(entry.shape, dtype: dtypes[entry.dtype]!)
+                    : MLXArray(data, entry.shape, dtype: dtypes[entry.dtype]!)
+                MLX.eval(array)
+                arrays[name] = array
+            }
+        }
+        return (arrays, header.metadata)
+        #else
+        throw InvalidFile(detail: "uncached owned reader requires Darwin")
+        #endif
+    }
+
+    private static func readExactly(_ file: FileHandle, count: Int, fileSize: Int) throws -> Data {
+        #if canImport(Darwin)
+        let offset = try file.offset()
+        guard offset <= UInt64(fileSize), count >= 0, count <= fileSize - Int(offset) else {
+            throw InvalidFile(detail: "read range out of bounds")
+        }
+        if count == 0 { return Data() }
+        let start = Int(offset)
+        let end = start + count
+        let page = Int(getpagesize())
+        // Unaligned large reads can populate the filesystem cache even with
+        // F_NOCACHE. Read page-aligned ranges and retain only the requested bytes.
+        // This is I/O alignment, not a rewrite of the safetensors bundle.
+        var position = start - start % page
+        let padding = end % page == 0 ? 0 : min(page - end % page, fileSize - end)
+        let physicalEnd = end + padding
+        try file.seek(toOffset: UInt64(position))
+        var result = Data()
+        result.reserveCapacity(count)
+        while position < physicalEnd {
+            try Task.checkCancellation()
+            let remaining = physicalEnd - position
+            // Keep a partial EOF page separate from the aligned bulk read.
+            let amount = remaining < page ? remaining : min(remaining / page * page, 4 * 1024 * 1024)
+            guard let chunk = try file.read(upToCount: amount), chunk.count == amount else {
+                throw InvalidFile(detail: "short aligned read")
+            }
+            let lower = max(start - position, 0)
+            let upper = min(end - position, amount)
+            if lower < upper { result.append(chunk[lower..<upper]) }
+            position += amount
+        }
+        try file.seek(toOffset: UInt64(end))
+        return result
+        #else
+        throw InvalidFile(detail: "uncached owned reader requires Darwin")
+        #endif
+    }
+}

--- a/Tests/MLXLMTests/ResidentSafetensorsReaderTests.swift
+++ b/Tests/MLXLMTests/ResidentSafetensorsReaderTests.swift
@@ -1,0 +1,134 @@
+import Foundation
+import MLX
+import Testing
+@testable import MLXLMCommon
+
+@Suite(.serialized)
+struct ResidentSafetensorsReaderTests {
+    @Test func ownedComputeSelectsUncachedWithoutChangingOtherModels() {
+        #if canImport(Darwin)
+        #expect(ResidentSafetensorsReader.shouldUse(requiresOwnedCompute: true, readerOverride: nil))
+        #expect(ResidentSafetensorsReader.shouldUse(requiresOwnedCompute: true, readerOverride: "uncached"))
+        #expect(!ResidentSafetensorsReader.shouldUse(requiresOwnedCompute: true, readerOverride: "mmap"))
+        for override in [nil, "uncached", "mmap"] as [String?] {
+            #expect(!ResidentSafetensorsReader.shouldUse(requiresOwnedCompute: false, readerOverride: override))
+        }
+        #endif
+    }
+
+    @Test func cancellationPreventsAnyReadOrAllocation() async {
+        let task = Task {
+            while !Task.isCancelled { await Task.yield() }
+            _ = try ResidentSafetensorsReader.load(
+                url: URL(fileURLWithPath: "/nonexistent-cancelled-resident-proof"), excludingKeys: [])
+        }
+        task.cancel()
+        do {
+            _ = try await task.value
+            Issue.record("cancelled reader unexpectedly returned")
+        } catch {
+            #expect(error is CancellationError)
+        }
+    }
+    @Test func unalignedPayloadCrossesReadChunkAndPartialEOF() throws {
+        try MLXMetalTestLock.withLock {
+            let url = FileManager.default.temporaryDirectory.appendingPathComponent("resident-chunks-\(UUID()).safetensors")
+            defer { try? FileManager.default.removeItem(at: url) }
+            // A little over the 4-MiB physical read chunk, with a partial EOF page.
+            let expected = MLXArray((0..<(1024 * 1024 + 3)).map { UInt32($0) })
+            try MLX.save(arrays: ["w": expected], url: url)
+            let (loaded, _) = try ResidentSafetensorsReader.load(url: url, excludingKeys: [])
+            let actual = try #require(loaded["w"])
+            #expect(actual.shape == expected.shape && actual.dtype == expected.dtype)
+            #expect(MLX.all(actual .== expected).item(Bool.self))
+        }
+    }
+
+    @Test func nullMetadataMatchesAbsentMetadata() throws {
+        // Real Flash Next shards 6, 7 and 13 carry __metadata__: null.
+        // Exclude the payload: this regression exercises header parsing only.
+        for metadata in [nil, NSNull(), [:] as NSDictionary] as [Any?] {
+            let url = FileManager.default.temporaryDirectory.appendingPathComponent("resident-metadata-\(UUID()).safetensors")
+            defer { try? FileManager.default.removeItem(at: url) }
+            var fields: [String: Any] = [
+                "w": ["dtype": "U32", "shape": [1], "data_offsets": [0, 4]],
+            ]
+            if let metadata { fields["__metadata__"] = metadata }
+            let header = try JSONSerialization.data(withJSONObject: fields)
+            var length = UInt64(header.count).littleEndian
+            var data = withUnsafeBytes(of: &length) { Data($0) }
+            data.append(header)
+            data.append(Data(repeating: 0, count: 4))
+            try data.write(to: url)
+            let (arrays, result) = try ResidentSafetensorsReader.load(url: url, excludingKeys: ["w"])
+            #expect(arrays.isEmpty && result.isEmpty)
+        }
+    }
+
+    @Test func mixedTypesAndExclusions() throws {
+        try MLXMetalTestLock.withLock {
+            let url = FileManager.default.temporaryDirectory.appendingPathComponent("resident-reader-\(UUID()).safetensors")
+            defer { try? FileManager.default.removeItem(at: url) }
+            let arrays: [String: MLXArray] = [
+                "packed": MLXArray([UInt32(0), UInt32.max, 123]),
+                "scale": MLXArray([Float(0.125), -2, 3]).asType(.float16),
+                "bf": MLXArray([Float(0.5), -7, 9]).asType(.bfloat16),
+                "scalar": MLXArray(Int64(42)),
+                "excluded": MLXArray([Float(123)]),
+            ]
+            try MLX.save(arrays: arrays, metadata: ["format": "pt"], url: url)
+            let before = try Data(contentsOf: url)
+            let (result, metadata) = try ResidentSafetensorsReader.load(url: url, excludingKeys: ["excluded"])
+            #expect(Set(result.keys) == Set(arrays.keys).subtracting(["excluded"]))
+            #expect(metadata == ["format": "pt"])
+            #expect(try Data(contentsOf: url) == before)
+            for (key, value) in result {
+                let reference = arrays[key]!
+                #expect(value.shape == reference.shape && value.dtype == reference.dtype)
+                #expect(MLX.all(value.reshaped([-1]).view(dtype: .uint8) .== reference.reshaped([-1]).view(dtype: .uint8)).item(Bool.self))
+            }
+        }
+    }
+
+    @Test func emptyTensorPreservesShapeAndDtype() throws {
+        try MLXMetalTestLock.withLock {
+            let url = FileManager.default.temporaryDirectory.appendingPathComponent("resident-empty-\(UUID()).safetensors")
+            defer { try? FileManager.default.removeItem(at: url) }
+            let header = try JSONSerialization.data(withJSONObject: [
+                "empty": ["dtype": "BF16", "shape": [2, 0, 3], "data_offsets": [0, 0]],
+            ])
+            var length = UInt64(header.count).littleEndian
+            var data = withUnsafeBytes(of: &length) { Data($0) }
+            data.append(header)
+            try data.write(to: url)
+            let (arrays, _) = try ResidentSafetensorsReader.load(url: url, excludingKeys: [])
+            let empty = try #require(arrays["empty"])
+            #expect(empty.shape == [2, 0, 3] && empty.dtype == .bfloat16 && empty.size == 0)
+        }
+    }
+
+    @Test func malformedHeadersThrowBeforeAllocation() throws {
+        let entries: [[String: Any]] = [
+            ["dtype": "U32", "shape": [-1], "data_offsets": [0, 4]],
+            ["dtype": "U32", "shape": [Int.max, 4], "data_offsets": [0, 4]],
+            ["dtype": "U32", "shape": [0, Int(Int32.max) + 1], "data_offsets": [0, 0]],
+            ["dtype": "U32", "shape": [2], "data_offsets": [0, 4]],
+            ["dtype": "U32", "shape": [1], "data_offsets": [0, 8]],
+            ["dtype": "UNKNOWN", "shape": [1], "data_offsets": [0, 4]],
+            ["dtype": "U32", "shape": [1], "data_offsets": [4, 0]],
+        ]
+        for entry in entries {
+            let url = FileManager.default.temporaryDirectory.appendingPathComponent("resident-invalid-\(UUID()).safetensors")
+            defer { try? FileManager.default.removeItem(at: url) }
+            let header = try JSONSerialization.data(withJSONObject: ["w": entry])
+            var length = UInt64(header.count).littleEndian
+            var data = withUnsafeBytes(of: &length) { Data($0) }
+            data.append(header)
+            data.append(Data(repeating: 0, count: 4))
+            try data.write(to: url)
+            #expect(throws: (any Error).self) {
+                _ = try ResidentSafetensorsReader.load(url: url, excludingKeys: [])
+            }
+        }
+    }
+}


### PR DESCRIPTION
## PROOF — narrow Flash reader/QSA integration

Runtime tested head: 0aa728af5deab52141506828ba36a91d5fe2fd51 (includes merged QSA #461).
Osaurus tested head: 4478943ea05965d7f063e27c124e1ab3afa2f366.
Release -O binary SHA256: 5424bd1bbfee5b594d44b215b045a9ebe5b80e02fdd37ff47d2d7b156e9f8183.

Source: ResidentSafetensorsReader / Load.swift select aligned uncached owned reads
only for the model capability already requiring resident compute; currently Qwen4Exp
alone opts in. Mixed dtypes/packed weights preserved; no model files rewritten,
no quant-bit hardcoding or sampler/MTP-controller change. Qwen27B is not opted in.

Tests on exact runtime source: 16 reader/QSA tests exercised (including both QSA
benchmark flags), plus five existing QSA disk persistence regressions. All passed.
Receipts: FlashResidentReaderFinal__213330 and FlashQSAPersistenceFinal__222032.
The latter covers indexer-lane budget crossing and malformed/legacy fail-closed restore.
Exact Osaurus head: eight CI checks passed (run 34562838092 plus 34562838091).

Live Release UI, real Flash Next JANG_2L, MTP Off and runtime draftStrategy none:
- Cold-load Stop released the partial load, returned the composer and empty resident
  list; retry loaded. Cold load on the next run: 17.7 s.
- Two actual get_current_time calls, with correct tool-result timestamps carried into
  the second turn and a correct 64-second difference; natural final responses of 53
  and 122 tokens. Both tool continuations restored request-matched disk prefixes.
- Disk L2 hits 2; separate SSM cache hits 0. Serialized disk restore is the exercised
  path; effective fp16 KV, 36 Mamba / 12 KV layers, no TurboQuant layers, paged off.
- Final live run FlashResidentUITools__221111: peak tracked footprint 57 GiB, minimum
  raw-free 35.9 GiB, swap .52 GiB unchanged, pressure normal. Explicit envelope was
  64 GiB footprint / 32 GiB raw-free. Intentionally stopped after completed proof;
  cleanup group/tracked/watchdog 0/0/0.

Limits retained: earlier 40-GiB-free and 56-GiB-footprint envelopes aborted and are
not passes. One earlier SQL response had a content error (attribution unproven).
Unavailable code-execution request is not a positive tool row. Idle Unload button
was not exercised in this final row; Stop-during-load release was. UI initial versus
detailed rate labels differ (e.g. 36.7 vs 43.3 tok/s); no matched full-model throughput
improvement or universal quality/low-RAM claim. QSA component speedup remains the
separate #461 evidence. MTP controller and universal AR-floor claims remain deferred.

No runtime CI gate is configured/required for this lane; local proof is the runtime
gate. Osaurus CI is required and passed at the exact pinned head. No release cut.
