### PR TITLE
Flash PLE: deduplicate selected rows within each gather

### DIFF
--- a/Libraries/MLXVLM/Models/Qwen4ExpNGramTable.swift
+++ b/Libraries/MLXVLM/Models/Qwen4ExpNGramTable.swift
@@ -372,8 +372,52 @@ final class Qwen4ExpNGramTable: @unchecked Sendable {
     }
 
     /// Returns row-major Float32 values. Only bytes belonging to selected rows
-    /// are touched; duplicate row ids are intentionally preserved.
+    /// are touched. Duplicate output rows are preserved, but each distinct row
+    /// is read and dequantized once per gather. No data is retained across calls.
     func gather(_ rows: [Int64], parallelRows: Bool? = nil) throws -> [Float] {
+        // Avoid dictionary/scatter allocation for single rows or an already
+        // strictly increasing set. A decode token has multiple n-gram heads;
+        // disjoint ordered head ranges need no duplicate detection dictionary.
+        if rows.count <= 1 || zip(rows, rows.dropFirst()).allSatisfy({ $0.0 < $0.1 }) {
+            let (values, bytesRead) = try gatherDistinct(rows, parallelRows: parallelRows)
+            recordGather(rows: rows.count, bytesRead: bytesRead)
+            return values
+        }
+        var uniqueRows: [Int64] = []
+        var positions: [Int64: Int] = [:]
+        var outputPositions: [Int] = []
+        uniqueRows.reserveCapacity(rows.count)
+        outputPositions.reserveCapacity(rows.count)
+        for row in rows {
+            guard row >= 0, row < rowCount else {
+                throw Qwen4ExpNGramTableError.rowOutOfRange(row)
+            }
+            if let position = positions[row] {
+                outputPositions.append(position)
+            } else {
+                positions[row] = uniqueRows.count
+                outputPositions.append(uniqueRows.count)
+                uniqueRows.append(row)
+            }
+        }
+        let (values, bytesRead) = try gatherDistinct(
+            uniqueRows, parallelRows: parallelRows)
+        // rowsRead remains the logical requested-row count; payloadBytesRead
+        // measures actual selected-row I/O, excluding duplicate reads avoided.
+        recordGather(rows: rows.count, bytesRead: bytesRead)
+        guard uniqueRows.count != rows.count else { return values }
+        var output = [Float](repeating: 0, count: rows.count * dimensions)
+        for (outputRow, position) in outputPositions.enumerated() {
+            output.replaceSubrange(
+                outputRow * dimensions ..< (outputRow + 1) * dimensions,
+                with: values[position * dimensions ..< (position + 1) * dimensions])
+        }
+        return output
+    }
+
+    private func gatherDistinct(
+        _ rows: [Int64], parallelRows: Bool?
+    ) throws -> ([Float], UInt64) {
         if parallelRows ?? Self.parallelRows, rows.count > 1 {
             return try gatherParallel(rows)
         }
@@ -392,11 +436,10 @@ final class Qwen4ExpNGramTable: @unchecked Sendable {
                 outputRow * dimensions ..< (outputRow + 1) * dimensions,
                 with: values)
         }
-        recordGather(rows: rows.count, bytesRead: bytesRead)
-        return output
+        return (output, bytesRead)
     }
 
-    private func gatherParallel(_ rows: [Int64]) throws -> [Float] {
+    private func gatherParallel(_ rows: [Int64]) throws -> ([Float], UInt64) {
         let buffers = ParallelGatherBuffers(
             valueCount: rows.count * dimensions, rowCount: rows.count)
         DispatchQueue.concurrentPerform(iterations: rows.count) { outputRow in
@@ -424,8 +467,7 @@ final class Qwen4ExpNGramTable: @unchecked Sendable {
         let bytesRead = (0 ..< rows.count).reduce(UInt64(0)) {
             $0 + buffers.bytes[$1]
         }
-        recordGather(rows: rows.count, bytesRead: bytesRead)
-        return output
+        return (output, bytesRead)
     }
 
     func ioStats() -> IOStats {

--- a/Tests/MLXLMTests/Qwen4ExpNGramTableTests.swift
+++ b/Tests/MLXLMTests/Qwen4ExpNGramTableTests.swift
@@ -132,10 +132,94 @@ struct Qwen4ExpNGramTableTests {
         #expect(table.ioStats() == .init(
             gatherCalls: 3,
             rowsRead: 7,
-            payloadBytesRead: 84,
+            payloadBytesRead: 60,
             backingFileCount: 1,
             backingFileBytes: UInt64(bytes.count),
             noCacheFileCount: 1))
+
+        for parallel in [false, true] {
+            let before = table.ioStats()
+            #expect(try table.gather([], parallelRows: parallel).isEmpty)
+            let repeated = try table.gather([1, 1, 1, 1], parallelRows: parallel)
+            #expect(repeated == Array(repeating: values, count: 4).flatMap { $0 })
+            #expect(table.ioStats().payloadBytesRead - before.payloadBytesRead == 12)
+            let uniqueBefore = table.ioStats()
+            let unique = try table.gather([0, 1], parallelRows: parallel)
+            #expect(Array(unique[8..<16]) == values)
+            #expect(table.ioStats().payloadBytesRead - uniqueBefore.payloadBytesRead == 24)
+            let invalidBefore = table.ioStats()
+            #expect(throws: Qwen4ExpNGramTableError.self) {
+                _ = try table.gather([1, -1, 1], parallelRows: parallel)
+            }
+            #expect(table.ioStats() == invalidBefore)
+        }
+
+        // Opt-in host-I/O diagnostic, not a model throughput benchmark. Keep
+        // identical fixture, row order and schedules across before/after runs.
+        if ProcessInfo.processInfo.environment["VMLX_PLE_IO_BENCH"] == "1" {
+            for parallel in [false, true] {
+                for (label, rows) in [
+                    ("single", [Int64(1)]),
+                    ("unique", [Int64(0), 1]),
+                    ("duplicate512", (0..<512).map { Int64($0 % 2) }),
+                ] {
+                    let before = table.ioStats()
+                    let start = DispatchTime.now().uptimeNanoseconds
+                    var checksum: Float = 0
+                    for _ in 0..<32 {
+                        let result = try table.gather(rows, parallelRows: parallel)
+                        checksum += result.last ?? 0
+                    }
+                    let elapsed = DispatchTime.now().uptimeNanoseconds - start
+                    let readBytes = table.ioStats().payloadBytesRead - before.payloadBytesRead
+                    print("PLE_IO_BENCH schedule=\(parallel ? "parallel" : "sequential") "
+                        + "case=\(label) iterations=32 ns=\(elapsed) bytes=\(readBytes) checksum=\(checksum)")
+                }
+            }
+        }
+    }
+
+    @Test("opt-in real PLE table row parity and bounded host I/O timing")
+    func realTableRowTiming() throws {
+        guard let path = ProcessInfo.processInfo.environment["VMLX_PLE_TABLE_BENCH_MODEL"] else {
+            return
+        }
+        let directory = URL(fileURLWithPath: path, isDirectory: true)
+        let config = try JSONDecoder().decode(
+            Qwen4ExpConfiguration.self,
+            from: Data(contentsOf: directory.appendingPathComponent("config.json")))
+        let layer = try #require(config.extras.pleLayerIds.first)
+        let table = try Qwen4ExpNGramTable(
+            modelDirectory: directory, layerIndex: layer - 1,
+            shardCount: config.extras.splitNgramParts)
+        #expect(table.rowCount >= 512)
+        guard table.rowCount >= 512 else { return }
+        let uniqueRows = (0..<512).map { Int64($0) * (table.rowCount / 512) }
+        // An independently gathered row at a time checks the scatter ordering,
+        // including shard boundaries, without loading any model weights.
+        let reference = try uniqueRows.flatMap { try table.gather([$0], parallelRows: false) }
+        let duplicateRows = (0..<512).map { uniqueRows[$0 % 8] }
+        let duplicateReference = (0..<512).flatMap { row in
+            Array(reference[(row % 8) * table.dimensions..<(row % 8 + 1) * table.dimensions])
+        }
+        for parallel in [false, true] {
+            #expect(try table.gather(uniqueRows, parallelRows: parallel) == reference)
+            #expect(try table.gather(duplicateRows, parallelRows: parallel) == duplicateReference)
+            for round in 0..<3 {
+                for (label, rows) in [("unique512", uniqueRows), ("duplicate512", duplicateRows)] {
+                    let before = table.ioStats()
+                    let start = DispatchTime.now().uptimeNanoseconds
+                    var checksum: Float = 0
+                    for _ in 0..<8 {
+                        checksum += try table.gather(rows, parallelRows: parallel).last ?? 0
+                    }
+                    let ns = DispatchTime.now().uptimeNanoseconds - start
+                    print("PLE_REAL_BENCH round=\(round) parallel=\(parallel) case=\(label) "
+                        + "iterations=8 ns=\(ns) bytes=\(table.ioStats().payloadBytesRead - before.payloadBytesRead) "
+                        + "checksum=\(checksum) dimensions=\(table.dimensions)")
+                }
+            }
+        }
     }
 
     @Test("local Qwen4Exp variants validate every PLE shard and use exact SSD reads")


### PR DESCRIPTION
## Scope

Read/dequantize each distinct PLE row once within a gather, then scatter to the
original requested order. No rows retained across calls; no model file changes.
Single-row and strictly increasing row lists use the direct reader without a
dictionary. Quantization, hashing, EOS/history, threading mode and output dtype
remain unchanged. This is a PLE prefill/duplicate-I/O optimization, not a new
fused expert kernel or an MTP policy change.

Isolated from the pending mixed branch onto runtime main ffe859bc; only
Qwen4ExpNGramTable.swift and Qwen4ExpNGramTableTests.swift change.
Candidate d8b210fe2067b6ca527145a15919b235d0faeb26.

## Evidence and limits

Retained before/after real JANG_2L table rows: 512 selected rows, eight gathers,
three rounds, exact outputs against independent one-row reference. Duplicate case
repeats eight distinct rows. Actual payload bytes 245760 before vs 3840 after.
Parallel duplicate timing before 101.532/101.555/114.319 ms; after
4.638/4.456/4.511 ms. Unique timings overlap/slightly regress in this ordered pair;
do not claim universal throughput benefit. These are Debug host-I/O tests, not
full-model Release decoding or prefill token/s.

Retained logs: FlashPLERealBefore__165650 (three expected duplicate-byte assertions
fail; real-table equality holds), FlashPLERealAfter__165539 (exit 0), and
FlashPLEOrderedRows__173211 (later strictly-increasing fast-path regression).
Current parent implementation blob 06e8f7eab49f85809b3894440fcf74a74ef6202c equals
the original control; candidate blob 7aba38ce2efc8ce24ee71e236a65d80419d195d6 and
test source equal isolated commit f12da3c8. Current-head tests are being rerun.

Current-head run FlashPLEIsolated__222445 completed: five exercised tests (including
the real-table parity/timing row), six reported because the optional variant matrix
returns without its environment gate. Exit 0, peak 2.24 GiB, swap .52 GiB unchanged,
normal pressure, cleanup 0/0/0. Real duplicate case bytes 3840 in all six rounds;
parallel timings 4.636/4.660/4.510 ms. Unique parallel 140.049/139.762/146.644 ms.

## Exact-head Release app integration

Osaurus #2712 head b99df175eef5b321601fe3c78dc3c49519b00dbc pins this
runtime d8b210fe in all six pin/tripwire files. Release -O build (incremental,
jobs=1, not Debug) SHA256
12c49f1393ac828d7aea8aa0b9466ab0db8058f9fca5a051d6312c7bc18643aa.
Build FlashPLEApp__223157 completed; cleanup 0/0/0.

Live supervised native UI run FlashPLEUI__225414, fresh isolated root
QWEN-UI-uI0NsB: selected Flash Next JANG_2L before loading, explicitly saved
Speculative Decoding Off, then sent two real get_current_time requests. Source
trace and /admin/cache-stats agree native_mtp=false, draft_strategy=none,
no sampler change. Both tool calls used {}, actual timestamps
2026-09-10T22:59:19-07:00 and 23:00:05-07:00, naturally terminated answers
(84 and 158 tokens, stop), correct previous timestamp and 46-second difference.
The second answer additionally invented a spelling-correction aside; both raw
tool results spell the timezone identically. Preserve this output-quality
limitation; no universal coherence or sampling-equality claim.

First real PLE gather: 49,344 logical rows, 2,457,940 actual payload bytes.
Retained baseline had 3,203,700 bytes for the same row count; prompt-byte equality
was not established, so this is not a matched full-model speedup claim.
Disk hits at boundaries 3084 and 3418, each with 118 suffix tokens; API reports
two disk L2 hits, eight stores, zero paged/SSM-rederive/TurboQuant hits. Topology
48 layers, 12 KV + 36 Mamba, disk-backed restore, effective KV fp16.
Visible final rolling rates 33.3 and 34.7 tok/s; first prior-turn detailed footer
later showed 40.0 tok/s and TTFT 5.00 s. These different UI measurements are not
interchangeable or proof of a new decode gain. Second stored TTFT 4.959 s.

Physical footprint peak 57 GiB, minimum raw free 36.2 GiB, swap .52 GiB flat,
normal pressure. Intentional supervisor stop after completion exit 130, cleanup
0/0/0. Raw app logs, screenshots first-tool-final.png/second-tool-final.png,
chat-proof.sqlite, cache-stats.json and supervisor memory/process sidecars retained.
No temporary model bundle was created. This row did not test idle Unload or MTP.

App merge remains gated on its exact-head CI; runtime requires no CI by policy.
The optional local-variant matrix is not enabled and must not be counted exercised.
No all-quant/full-model speedup or universal AR-floor claim. No release.
