### PR TITLE
MTP: bounded depth recovery and committed-token-safe handoffs

### DIFF
--- a/Libraries/MLXLMCommon/Evaluate.swift
+++ b/Libraries/MLXLMCommon/Evaluate.swift
@@ -273,6 +273,10 @@ public struct GenerateParameters: Sendable {
     /// `DDTREE-DESIGN.md` for the full spec.
     public var draftStrategy: DraftStrategy? = nil
 
+    /// Fixed native-MTP depth is a ceiling; adaptive exploration must be
+    /// requested explicitly. Either policy may descend to shallower work or AR.
+    public var nativeMTPDepthPolicy: NativeMTPDepthPolicy = .fixed
+
     /// Additional text-level stop sequences. When any of these strings
     /// appears in the user-visible assistant output, the library halts
     /// generation, truncates the match and everything after it, and

--- a/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
+++ b/Libraries/MLXLMCommon/SpecDec/MTPRuntime.swift
@@ -974,8 +974,8 @@ public enum NativeMTPAutoDecodePolicy {
     /// measured tuning artifact. A tuning file, when present, contributes its
     /// explicit verifier mode. An explicitly blocked artifact vetoes manual
     /// activation too: `blocked` is the bundle owner's safety decision, not a
-    /// missing-measurement condition. Callers must pair every accepted manual
-    /// activation with greedy sampling for the model+session.
+    /// missing-measurement condition. Depth selection does not select a sampler;
+    /// callers retain the request's configured sampling parameters.
     public static func manualRecommendation(
         depth: Int,
         configData: Data?,
@@ -999,7 +999,7 @@ public enum NativeMTPAutoDecodePolicy {
             depth: depth,
             verifierMode: status.nativeMTPTuning?.explicitVerifierMode,
             reason:
-                "User-enforced manual depth \(depth): tensor-evidence activation without measured tuning; greedy sampling enforced for this model+session.",
+                "User-selected maximum depth \(depth): tensor-evidence activation without measured tuning; request sampling remains in effect.",
             evidence: evidence)
     }
 

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPClock.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPClock.swift
@@ -1,0 +1,10 @@
+import Dispatch
+import Foundation
+
+/// One monotonic time domain for iterator phases and governor decisions.
+enum NativeMTPClock {
+    @inline(__always)
+    static func now() -> TimeInterval {
+        Double(DispatchTime.now().uptimeNanoseconds) / 1_000_000_000
+    }
+}

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPDepthPolicy.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPDepthPolicy.swift
@@ -1,0 +1,32 @@
+
+/// A selected fixed depth is a ceiling, not permission to explore deeper.
+/// Safety may use a shallower depth or AR under either policy.
+public enum NativeMTPDepthPolicy: Sendable, Equatable {
+    case fixed
+    case adaptive(maximumDepth: Int)
+
+    struct Resolution: Equatable {
+        let initialDepth: Int
+        let maximumDepth: Int
+    }
+
+    enum ValidationError: Error, Equatable {
+        case invalidRequestedDepth
+        case invalidMaximumDepth
+        case invalidRuntimeCap
+    }
+
+    func resolve(requestedDepth: Int, runtimeCap: Int) throws -> Resolution {
+        guard requestedDepth > 0 else { throw ValidationError.invalidRequestedDepth }
+        guard runtimeCap > 0 else { throw ValidationError.invalidRuntimeCap }
+        let maximum: Int
+        switch self {
+        case .fixed:
+            maximum = min(requestedDepth, runtimeCap)
+        case .adaptive(let ceiling):
+            guard ceiling > 0 else { throw ValidationError.invalidMaximumDepth }
+            maximum = min(ceiling, runtimeCap)
+        }
+        return Resolution(initialDepth: min(requestedDepth, maximum), maximumDepth: maximum)
+    }
+}

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -389,16 +389,12 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     /// stats line): which rule moved the depth, how often.
     private var adaptiveWallClockDemotes = 0
     private var adaptiveAcceptanceDemotes = 0
-    /// Oscillation brake: how many times each depth has been demoted FROM
-    /// in this generation. Live on 4M prose (2026-09-04): d3 start →
-    /// 12 downshifts over 414 cycles — acceptance demoted, the margin gate
-    /// promoted straight back, each hop cold-starting the head cache. A
-    /// level demoted twice is closed for the rest of the generation.
+    /// Losses space future exploration geometrically, never close a depth
+    /// permanently. A changed regime can recover within the selected ceiling.
     private var adaptiveDemotedFromCount: [Int: Int] = [:]
-    private static let adaptiveMaxDemotesPerLevel = 2
-    /// Hard ceiling for adaptive promotion — the resolved depth cap, which
-    /// may exceed the REQUESTED depth (the request is a starting point, not
-    /// a lid, since 2026-09-04). See the depth-policy comment in `init`.
+    private var upperProbeNotBeforeCycle: [Int: Int] = [:]
+    /// Resolved promotion ceiling: fixed requests never exceed their chosen
+    /// depth; explicitly adaptive requests may explore to their bounded cap.
     private let adaptiveDepthCeiling: Int
     private(set) var seedMainForwardTime: TimeInterval = 0
     private(set) var verifyMainForwardTime: TimeInterval = 0
@@ -440,9 +436,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     //
     // Runs every cycle regardless of depth policy (fixed or adaptive): if a
     // WINDOWED MTP ms/token exceeds a context-scaled AR baseline, the request
-    // pauses speculation and decodes AR "instantaneously"; while paused it
-    // measures the live AR step cost and periodically PROBES a resume at the
-    // starting depth, keeping MTP only if the probe window beats live AR.
+    // descends one rung, reaching AR only after D1 loses. While paused it
+    // measures live AR cost and periodically probes D1. Observing a loss and
+    // draining committed output have measurable cost, not an instantaneous floor.
     // Design + audit trail: docs/internal/MTP-AR-SAFETY-GOVERNOR-SWIFT-2026-09-04.md
     // (Swift port of vmlx-private-evidence MTP-ONFLY-AR-FALLBACK-PLAN, plus
     // the reversible Phase 2 the Python plan deferred).
@@ -468,6 +464,10 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private var arSafetyTokensSincePause = 0
     private var arSafetyResumeInterval = NativeMTPTokenIterator.arSafetyResumeIntervalStart
     private var arSafetyProbeCyclesRemaining = 0
+    private var arSafetyProbeStartedAt: TimeInterval?
+    private var arSafetyProbeStartedEmitted = 0
+    private var arSafetyLastMeasuredToken = 0
+    private var arSafetyCalibrationRemaining = 0
     /// True while a kept re-entry is speculating: a trip in that state backs
     /// the resume interval off further instead of resetting it.
     private var arSafetyReentered = false
@@ -518,7 +518,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private static let wallClockDemoteFactor = 1.05
     private(set) var nativeMTPStats: NativeMTPGenerationStats?
     private var generationStatsFinalized = false
-    private let iteratorStartTime = Date.timeIntervalSinceReferenceDate
+    private let iteratorStartTime = NativeMTPClock.now()
 
     private var usesHybridMambaCache: Bool {
         cache.contains { $0 is MambaCache }
@@ -591,27 +591,20 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         self.sampler = effectiveParameters.sampler()
         self.speculativeSampler = SpeculativeSamplingController(parameters: effectiveParameters)
         self.maxTokens = effectiveParameters.maxTokens
-        // Depth policy (2026-09-04): the REQUESTED depth is the STARTING
-        // depth; the hard cap is 5 and the adaptive controller may promote
-        // past the request up to that cap when a full acceptance window
-        // clears the top floor with margin — near-perfect-acceptance shapes
-        // (counting, enumeration, tables) earn d4/d5 at runtime instead of
-        // being pinned to their start. History: the D2 cap era was
-        // calibrated on the lazy-repair verifier (Nemotron D3 0.48x); the
-        // staged verifier re-measured D3 as a win (27B_4D: 28.4 vs 16.5
-        // plain, byte-identical), and the same acceptance-priced controller
-        // that downshifts unprofitable depth governs every step above the
-        // start. Benchmarks can still override via VMLX_MTP_DEPTH_CAP.
+        // One resolved policy governs initialization, recovery and promotion.
+        // The environment bounds exploration but cannot raise a fixed request.
         let depthCap =
             ProcessInfo.processInfo.environment["VMLX_MTP_DEPTH_CAP"]
             .flatMap(Int.init).map { Swift.max($0, 1) } ?? 5
-        self.adaptiveDepthCeiling = depthCap
-        self.depth = Swift.min(requestedDepth, depthCap)
-        self.currentDepth = Swift.min(requestedDepth, depthCap)
+        let resolvedDepth = try effectiveParameters.nativeMTPDepthPolicy.resolve(
+            requestedDepth: requestedDepth, runtimeCap: depthCap)
+        self.adaptiveDepthCeiling = resolvedDepth.maximumDepth
+        self.depth = resolvedDepth.initialDepth
+        self.currentDepth = resolvedDepth.initialDepth
         self.verifierModeSetting = effectiveParameters.draftStrategy?.nativeMTPVerifierMode
-        let promptTokenStart = Date.timeIntervalSinceReferenceDate
+        let promptTokenStart = NativeMTPClock.now()
         let promptTokenIds = input.text.tokens.reshaped(-1).asArray(Int.self)
-        let promptTokenElapsed = Date.timeIntervalSinceReferenceDate - promptTokenStart
+        let promptTokenElapsed = NativeMTPClock.now() - promptTokenStart
         self.promptTokenIds = promptTokenIds
         self.cachePrefixTokenCounts = input.cachePrefixTokenCounts
         self.restoredPrefixStart = input.cachePrefixTokenCounts.contains { $0 > 0 }
@@ -798,20 +791,20 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             }
         }
 
-        let start = Date.timeIntervalSinceReferenceDate
+        let start = NativeMTPClock.now()
         try Task.checkCancellation()
         let prepared = try model.prepare(
             inputForPrepare,
             cache: self.cache,
             windowSize: effectiveParameters.prefillStepSize)
-        self.promptPrefillTime = Date.timeIntervalSinceReferenceDate - start
+        self.promptPrefillTime = NativeMTPClock.now() - start
         self.promptCacheSnapshot = makePromptBoundaryCacheSnapshot(from: self.cache)
 
         let firstToken: MLXArray
         switch prepared {
         case .tokens(let tokens):
             processor?.prompt(input.text.tokens)
-            let seedStart = Date.timeIntervalSinceReferenceDate
+            let seedStart = NativeMTPClock.now()
             let backbone = model.nativeBackboneForward(
                 Self.sequenceInput(tokens.tokens),
                 cache: self.cache)
@@ -821,11 +814,11 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 speculativeSampler: speculativeSampler,
                 processor: &processor)
                 .token
-            let syncStart = Date.timeIntervalSinceReferenceDate
+            let syncStart = NativeMTPClock.now()
             try Task.checkCancellation()
             MLX.eval(firstToken)
-            self.materializeSyncTime += Date.timeIntervalSinceReferenceDate - syncStart
-            self.seedMainForwardTime += Date.timeIntervalSinceReferenceDate - seedStart
+            self.materializeSyncTime += NativeMTPClock.now() - syncStart
+            self.seedMainForwardTime += NativeMTPClock.now() - seedStart
             self.seedMainForwardCount += 1
         case .logits(let output):
             if let effectivePromptTokens = output.effectivePromptTokens,
@@ -850,10 +843,10 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 speculativeSampler: speculativeSampler,
                 processor: &processor)
                 .token
-            let syncStart = Date.timeIntervalSinceReferenceDate
+            let syncStart = NativeMTPClock.now()
             try Task.checkCancellation()
             MLX.eval(firstToken)
-            self.materializeSyncTime += Date.timeIntervalSinceReferenceDate - syncStart
+            self.materializeSyncTime += NativeMTPClock.now() - syncStart
         }
 
         let firstID = recordMaterializeSync {
@@ -861,7 +854,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
         pendingTokens.append(firstID)
 
-        let bridgeStart = Date.timeIntervalSinceReferenceDate
+        let bridgeStart = NativeMTPClock.now()
         try Task.checkCancellation()
         let bridge = model.nativeBackboneForward(Self.tokenInput(firstToken), cache: self.cache)
         let secondToken = Self.sampleLast(
@@ -870,16 +863,16 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             speculativeSampler: speculativeSampler,
             processor: &processor)
             .token
-        let secondSyncStart = Date.timeIntervalSinceReferenceDate
+        let secondSyncStart = NativeMTPClock.now()
         try Task.checkCancellation()
         MLX.eval(secondToken)
-        self.materializeSyncTime += Date.timeIntervalSinceReferenceDate - secondSyncStart
-        self.seedMainForwardTime += Date.timeIntervalSinceReferenceDate - bridgeStart
+        self.materializeSyncTime += NativeMTPClock.now() - secondSyncStart
+        self.seedMainForwardTime += NativeMTPClock.now() - bridgeStart
         self.seedMainForwardCount += 1
 
         nextMain = secondToken
         pendingTokens.append(recordMaterializeSync { secondToken.item(Int.self) })
-        let draftStart = Date.timeIntervalSinceReferenceDate
+        let draftStart = NativeMTPClock.now()
         try Task.checkCancellation()
         let draftBatch = Self.makeDrafts(
             model: model,
@@ -894,7 +887,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         draftProbabilities = draftBatch.probabilities
         mtpForwardCount += draftBatch.forwardCount
         materializeSyncTime += draftBatch.materializeSyncTime
-        self.mtpDraftTime += Date.timeIntervalSinceReferenceDate - draftStart
+        self.mtpDraftTime += NativeMTPClock.now() - draftStart
 
         // MARK: compiled verify promotion — after prefill and the boundary
         // snapshot, so stored prefix-cache entries stay plain.
@@ -1235,7 +1228,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             : 0
         let gdnReplay = NativeMTPGDNReplayDiagnostics.snapshot()
         let phaseSummary = NativeMTPPhaseDiagnostics.summary()
-        let iteratorWallTime = Date.timeIntervalSinceReferenceDate - iteratorStartTime
+        let iteratorWallTime = NativeMTPClock.now() - iteratorStartTime
         let adaptiveFallback = adaptiveFallbackReason ?? "none"
         let verifierMode: String
         if chunkVerifierCount > 0 && sequentialVerifierCount > 0 {
@@ -1375,17 +1368,17 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
 
     @inline(__always)
     private mutating func recordMaterializeSync<T>(_ body: () -> T) -> T {
-        let start = Date.timeIntervalSinceReferenceDate
+        let start = NativeMTPClock.now()
         let result = body()
-        materializeSyncTime += Date.timeIntervalSinceReferenceDate - start
+        materializeSyncTime += NativeMTPClock.now() - start
         return result
     }
 
     @inline(__always)
     private mutating func recordCacheSnapshotRestore<T>(_ body: () -> T) -> T {
-        let start = Date.timeIntervalSinceReferenceDate
+        let start = NativeMTPClock.now()
         let result = body()
-        cacheSnapshotRestoreTime += Date.timeIntervalSinceReferenceDate - start
+        cacheSnapshotRestoreTime += NativeMTPClock.now() - start
         return result
     }
 
@@ -1564,13 +1557,13 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             // captured immediately before the prefetched forward.
             checkpoint = consumedPrefetch.checkpoint
         } else {
-            let checkpointStart = Date.timeIntervalSinceReferenceDate
+            let checkpointStart = NativeMTPClock.now()
             checkpoint =
                 (canCommitVerifierCache && !requiresSequentialRepair && !replayChunkCommit
                     && !lazyChunkRepair && !needsBatchedVerifierRecovery)
                 ? nil
                 : NativeMTPCacheCheckpoint(cache)
-            cacheSnapshotRestoreTime += Date.timeIntervalSinceReferenceDate - checkpointStart
+            cacheSnapshotRestoreTime += NativeMTPClock.now() - checkpointStart
         }
         let forwardVerifierMode = stagedVerify
             ? NativeMTPVerifierStatePolicy.Mode.inputCaptureStaged.rawValue
@@ -1579,7 +1572,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         if let consumedPrefetch {
             verifier = consumedPrefetch.verifier
         } else {
-        let verifyStart = Date.timeIntervalSinceReferenceDate
+        let verifyStart = NativeMTPClock.now()
         if stagedVerify, compiledVerifyEnabled,
             compiledVerifyWarmedSizes.contains(requested.count)
         {
@@ -1607,21 +1600,21 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 compiledVerifyWarmedSizes.insert(requested.count)
             }
         }
-        let verifyElapsed = Date.timeIntervalSinceReferenceDate - verifyStart
+        let verifyElapsed = NativeMTPClock.now() - verifyStart
         targetVerifyTime += verifyElapsed
         verifyMainForwardTime += verifyElapsed
         }
         if Self.phaseTimersEnabled {
-            let gpuStart = Date.timeIntervalSinceReferenceDate
+            let gpuStart = NativeMTPClock.now()
             MLX.eval(verifier.logits)
-            verifyGpuWaitTime += Date.timeIntervalSinceReferenceDate - gpuStart
+            verifyGpuWaitTime += NativeMTPClock.now() - gpuStart
         }
         targetForwardCount += 1
         verifyMainForwardCount += 1
         verifyInputTokenCount += requested.count
         chunkVerifierCount += 1
 
-        let sampleStart = Date.timeIntervalSinceReferenceDate
+        let sampleStart = NativeMTPClock.now()
         guard let verifyDecision = Self.verifyDrafts(
             logits: verifier.logits,
             drafts: drafts,
@@ -1632,9 +1625,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             processor: processor)
         else {
             if let checkpoint {
-                let restoreStart = Date.timeIntervalSinceReferenceDate
+                let restoreStart = NativeMTPClock.now()
                 checkpoint.restore(into: &cache)
-                cacheSnapshotRestoreTime += Date.timeIntervalSinceReferenceDate - restoreStart
+                cacheSnapshotRestoreTime += NativeMTPClock.now() - restoreStart
             }
             if stagedVerify {
                 for layer in cache { (layer as? MambaCache)?.clearVerifyStaging() }
@@ -1643,7 +1636,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             return
         }
         materializeSyncTime += verifyDecision.materializeSyncTime
-        samplingTime += Date.timeIntervalSinceReferenceDate - sampleStart
+        samplingTime += NativeMTPClock.now() - sampleStart
         if let nanTrace {
             // Whole verify slab `[1, K+1, V]`: every row is a decode position.
             let next = verifyDecision.nextToken
@@ -1663,19 +1656,19 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             }
 
             func restoreCheckpoint() {
-                let restoreStart = Date.timeIntervalSinceReferenceDate
+                let restoreStart = NativeMTPClock.now()
                 checkpoint.restore(into: &cache)
-                cacheSnapshotRestoreTime += Date.timeIntervalSinceReferenceDate - restoreStart
+                cacheSnapshotRestoreTime += NativeMTPClock.now() - restoreStart
             }
 
             func replayPrefix(count: Int) -> NativeMTPForwardResult {
                 // Host ids already materialized once at cycle start.
                 let acceptedInputIds = Array(requestedInputIds.prefix(count))
                 let acceptedInput = MLXArray(acceptedInputIds).reshaped(1, count)
-                let replayStart = Date.timeIntervalSinceReferenceDate
+                let replayStart = NativeMTPClock.now()
                 let repaired = model.nativeBackboneForward(acceptedInput, cache: cache)
                 MLX.eval(repaired.logits, repaired.hiddenStates)
-                replayMainForwardTime += Date.timeIntervalSinceReferenceDate - replayStart
+                replayMainForwardTime += NativeMTPClock.now() - replayStart
                 repairForwardCount += 1
                 replayMainForwardCount += 1
                 return repaired
@@ -1738,8 +1731,6 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
 
         verifyCalls += 1
         acceptedByDepth[accepted, default: 0] += 1
-        arSafetyAfterVerifyCycle(accepted: accepted)
-        recordAdaptiveCycle(accepted: accepted)
         if Self.traceEnabled {
             let requestedIDs = recordMaterializeSync { requested.map { $0.item(Int.self) } }
             let currentDrafts = drafts
@@ -1759,16 +1750,16 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             guard let checkpoint else {
                 throw NativeMTPRuntimeError.verifierCacheCommitFailed
             }
-            let restoreStart = Date.timeIntervalSinceReferenceDate
+            let restoreStart = NativeMTPClock.now()
             checkpoint.restore(into: &cache)
-            cacheSnapshotRestoreTime += Date.timeIntervalSinceReferenceDate - restoreStart
+            cacheSnapshotRestoreTime += NativeMTPClock.now() - restoreStart
 
             let acceptedInputIds = Array(requestedInputIds.prefix(accepted + 1))
             let acceptedInput = MLXArray(acceptedInputIds).reshaped(1, accepted + 1)
-            let replayStart = Date.timeIntervalSinceReferenceDate
+            let replayStart = NativeMTPClock.now()
             let repaired = model.nativeBackboneForward(acceptedInput, cache: cache)
             MLX.eval(repaired.logits, repaired.hiddenStates)
-            replayMainForwardTime += Date.timeIntervalSinceReferenceDate - replayStart
+            replayMainForwardTime += NativeMTPClock.now() - replayStart
             repairForwardCount += 1
             replayMainForwardCount += 1
 
@@ -1794,7 +1785,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
 
         let committedInputCount = accepted + 1
-        let commitStart = Date.timeIntervalSinceReferenceDate
+        let commitStart = NativeMTPClock.now()
         let committedCache: Bool
         if stagedVerify {
             // Staged verify left recurrent state and offsets untouched;
@@ -1827,7 +1818,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                     totalInputCount: requested.count)
                 : false
         }
-        cacheCommitTime += Date.timeIntervalSinceReferenceDate - commitStart
+        cacheCommitTime += NativeMTPClock.now() - commitStart
         if committedCache {
             prefixCommitCount += 1
         }
@@ -1888,18 +1879,18 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 guard let checkpoint else {
                     throw NativeMTPRuntimeError.verifierCacheCommitFailed
                 }
-                let restoreStart = Date.timeIntervalSinceReferenceDate
+                let restoreStart = NativeMTPClock.now()
                 checkpoint.restore(into: &cache)
-                cacheSnapshotRestoreTime += Date.timeIntervalSinceReferenceDate - restoreStart
+                cacheSnapshotRestoreTime += NativeMTPClock.now() - restoreStart
 
                 let acceptedInputIds = recordMaterializeSync {
                     requested.prefix(accepted + 1).map { Int32($0.item(Int.self)) }
                 }
                 let acceptedInput = MLXArray(acceptedInputIds).reshaped(1, accepted + 1)
-                let replayStart = Date.timeIntervalSinceReferenceDate
+                let replayStart = NativeMTPClock.now()
                 let repaired = model.nativeBackboneForward(acceptedInput, cache: cache)
                 MLX.eval(repaired.logits, repaired.hiddenStates)
-                replayMainForwardTime += Date.timeIntervalSinceReferenceDate - replayStart
+                replayMainForwardTime += NativeMTPClock.now() - replayStart
                 repairForwardCount += 1
                 replayMainForwardCount += 1
                 hiddenForNextMTP =
@@ -1931,12 +1922,15 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
 
         nextMain = nextToken
-        if forceAutoregressiveFallback {
+        // Policy may clear proposals or replace their cache. Consume this
+        // cycle's accepted drafts and commit target state BEFORE that mutation.
+        updateDepthAfterCommittedCycle(accepted: accepted)
+        if forceAutoregressiveFallback || arSafetyPaused {
             drafts.removeAll(keepingCapacity: true)
             draftProbabilities.removeAll(keepingCapacity: true)
             return
         }
-        let draftStart = Date.timeIntervalSinceReferenceDate
+        let draftStart = NativeMTPClock.now()
         let draftBatch = Self.makeDrafts(
             model: model,
             hidden: alignedCommitHidden ?? hiddenForNextMTP,
@@ -1955,7 +1949,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             ? Swift.max(0, draftBatch.tokens.count - 1) : 0
         mtpForwardCount += draftBatch.forwardCount
         materializeSyncTime += draftBatch.materializeSyncTime
-        mtpDraftTime += Date.timeIntervalSinceReferenceDate - draftStart
+        mtpDraftTime += NativeMTPClock.now() - draftStart
 
         maybePrefetchNextVerify(stagedVerify: stagedVerify)
     }
@@ -1994,10 +1988,10 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             stacked(requested.map { $0.reshaped(-1) }).asArray(Int32.self)
         }
         let input = MLXArray(requestedInputIds).reshaped(1, requested.count)
-        let checkpointStart = Date.timeIntervalSinceReferenceDate
+        let checkpointStart = NativeMTPClock.now()
         let checkpoint = NativeMTPCacheCheckpoint(cache)
-        cacheSnapshotRestoreTime += Date.timeIntervalSinceReferenceDate - checkpointStart
-        let verifyStart = Date.timeIntervalSinceReferenceDate
+        cacheSnapshotRestoreTime += NativeMTPClock.now() - checkpointStart
+        let verifyStart = NativeMTPClock.now()
         let verifier = NativeMTPVerifierStatePolicy.withVerifierMode(
             NativeMTPVerifierStatePolicy.Mode.inputCaptureStaged.rawValue
         ) {
@@ -2016,7 +2010,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             asyncEval(logits, hidden)
             scheduled.signal()
         }
-        let verifyElapsed = Date.timeIntervalSinceReferenceDate - verifyStart
+        let verifyElapsed = NativeMTPClock.now() - verifyStart
         targetVerifyTime += verifyElapsed
         verifyMainForwardTime += verifyElapsed
         verifyPrefetchSubmitCount += 1
@@ -2037,13 +2031,13 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         guard let prefetch = pendingVerify else { return }
         pendingVerify = nil
         verifyPrefetchAbandonedCount += 1
-        let restoreStart = Date.timeIntervalSinceReferenceDate
+        let restoreStart = NativeMTPClock.now()
         // The background thread may still be scheduling the graph; it must
         // finish before the checkpoint restore rewrites the cache arrays.
         prefetch.scheduled.wait()
         prefetch.checkpoint.restore(into: &cache)
         for layer in cache { (layer as? MambaCache)?.clearVerifyStaging() }
-        cacheSnapshotRestoreTime += Date.timeIntervalSinceReferenceDate - restoreStart
+        cacheSnapshotRestoreTime += NativeMTPClock.now() - restoreStart
     }
 
     /// Measurement-only escape hatch: `VMLX_NATIVE_MTP_DISABLE_ADAPTIVE=1`
@@ -2119,90 +2113,132 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private mutating func arSafetyAfterVerifyCycle(accepted: Int) {
         guard !Self.arSafetyDisabled, !forceAutoregressiveFallback else { return }
         arSafetyEmittedTotal += accepted + 1
-        let now = Date.timeIntervalSinceReferenceDate
-        arSafetyRing.append(
-            ARSafetySample(
-                emitted: arSafetyEmittedTotal, wall: now, verifyTotal: targetVerifyTime))
-        let window = arSafetyProbeCyclesRemaining > 0
-            ? Self.arSafetyProbeWindow : arSafetyWindowForRequest
+        let now = NativeMTPClock.now()
+        arSafetyRing.append(ARSafetySample(
+            emitted: arSafetyEmittedTotal, wall: now, verifyTotal: targetVerifyTime))
+        let window = arSafetyWindowForRequest
         if arSafetyRing.count > window + 1 {
             arSafetyRing.removeFirst(arSafetyRing.count - (window + 1))
         }
         if arSafetyFirstVerifySec == nil, arSafetyRing.count >= 2 {
-            let d = arSafetyRing[1].verifyTotal - arSafetyRing[0].verifyTotal
-            if d > 0 { arSafetyFirstVerifySec = d }
+            let delta = arSafetyRing[1].verifyTotal - arSafetyRing[0].verifyTotal
+            if delta > 0 { arSafetyFirstVerifySec = delta }
         }
-        guard arSafetyRing.count == window + 1,
-            let oldest = arSafetyRing.first, let newest = arSafetyRing.last
-        else { return }
-        let deltaEmitted = newest.emitted - oldest.emitted
-        let deltaWallMs = (newest.wall - oldest.wall) * 1000
-        let deltaVerifyMs = (newest.verifyTotal - oldest.verifyTotal) * 1000
 
         if arSafetyProbeCyclesRemaining > 0 {
             arSafetyProbeCyclesRemaining -= 1
             guard arSafetyProbeCyclesRemaining == 0 else { return }
-            // Probe verdict against the LIVE AR cost measured while paused
-            // (already at the current context — no scaling needed). MTP must
-            // WIN outright to stay; otherwise pause again with backoff.
-            let liveArMs = (arSafetyLiveStepSec ?? arSafetySeedStepSec ?? 0) * 1000
-            let mtpMsPerToken = deltaEmitted > 0 ? deltaWallMs / Double(deltaEmitted) : .infinity
-            if liveArMs > 0, mtpMsPerToken * Self.arSafetyReentryHysteresis >= liveArMs {
-                arSafetyPause(
-                    reason: String(
-                        format: "ar_safety_probe_lost(mtp=%.1fms/tok live_ar=%.1fms)",
-                        mtpMsPerToken, liveArMs))
-                let clearLoss = liveArMs > 0 && mtpMsPerToken >= liveArMs * Self.arSafetyClearLossFactor
-                arSafetyResumeInterval = Swift.min(
-                    arSafetyResumeInterval * (clearLoss ? 4 : 2), Self.arSafetyResumeIntervalMax)
+            // Include the initial draft/cache re-prime and EVERY probe cycle,
+            // rather than warming six cycles and judging only the following six.
+            let emitted = arSafetyEmittedTotal - arSafetyProbeStartedEmitted
+            let elapsed = now - (arSafetyProbeStartedAt ?? now)
+            let mtpMs = emitted > 0 && elapsed > 0
+                ? elapsed * 1000 / Double(emitted) : .infinity
+            let arMs = (arSafetyLiveStepSec ?? arSafetySeedStepSec ?? 0) * 1000
+            arSafetyProbeStartedAt = nil
+            if arMs <= 0 || mtpMs * Self.arSafetyReentryHysteresis >= arMs {
+                arSafetyDemoteOrPause(reason: String(
+                    format: "ar_safety_probe_lost(mtp=%.1fms/tok live_ar=%.1fms)",
+                    mtpMs, arMs))
+                if arSafetyPaused {
+                    let clearLoss = arMs > 0 && mtpMs >= arMs * Self.arSafetyClearLossFactor
+                    arSafetyResumeInterval = Swift.min(
+                        arSafetyResumeInterval * (clearLoss ? 4 : 2),
+                        Self.arSafetyResumeIntervalMax)
+                }
             } else {
                 arSafetyResumes += 1
                 arSafetyReentered = true
-                // The interval is NOT reset here: a re-entry that trips again
-                // backs off from where it was (no ping-pong); it resets only
-                // when the generation ends.
+                arSafetySeedStepSec = arSafetyLiveStepSec ?? arSafetySeedStepSec
+                arSafetyFirstVerifySec = nil
                 adaptiveFallbackReason = nil
                 FileHandle.standardError.write(Data(String(
                     format: "[NativeMTP] ar_safety resumed: mtp=%.1fms/tok live_ar=%.1fms depth=%d\n",
-                    mtpMsPerToken, liveArMs, currentDepth).utf8))
+                    mtpMs, arMs, currentDepth).utf8))
             }
             return
         }
 
-        // Warmup: judge only once `arSafetyWarmupCycles` have run AND the
-        // window is full of post-warmup cycles (earliest trip = cycle 16).
+        // Refresh real AR periodically; calibration does not reset failed-probe
+        // spacing. This is bounded measurement overhead, not a free speed floor.
+        if arSafetySeedStepSec != nil, tokenCount - arSafetyLastMeasuredToken >= 256 {
+            arSafetyPause(reason: "ar_safety_calibration", loss: false)
+            return
+        }
         guard verifyCalls >= Self.arSafetyWarmupCycles + window,
-            let seed = arSafetySeedStepSec
+            arSafetyRing.count == window + 1,
+            let oldest = arSafetyRing.first, let newest = arSafetyRing.last,
+            let seed = arSafetySeedStepSec,
+            let median = Self.medianCycleMsPerToken(arSafetyRing)
         else { return }
-        if let verdict = Self.windowedARVerdict(
+        let emitted = newest.emitted - oldest.emitted
+        guard emitted > 0 else { return }
+        let wallMs = (newest.wall - oldest.wall) * 1000
+        let mtpMs = wallMs / Double(emitted)
+        if let live = arSafetyLiveStepSec,
+            tokenCount - arSafetyLastMeasuredToken < 512 {
+            let arMs = live * 1000
+            if mtpMs > arMs, median > arMs {
+                arSafetyDemoteOrPause(reason: String(
+                    format: "ar_safety_fresh_loss(mtp=%.1fms/tok median=%.1fms live_ar=%.1fms depth=%d)",
+                    mtpMs, median, arMs, currentDepth))
+            }
+        } else if let verdict = Self.windowedARVerdict(
             arStepMs: seed * 1000,
             firstVerifyMs: (arSafetyFirstVerifySec ?? 0) * 1000,
-            windowCycles: window,
-            deltaEmitted: deltaEmitted,
-            deltaWallMs: deltaWallMs,
-            deltaVerifyMs: deltaVerifyMs,
+            windowCycles: window, deltaEmitted: emitted, deltaWallMs: wallMs,
+            deltaVerifyMs: (newest.verifyTotal - oldest.verifyTotal) * 1000,
             margin: Self.arSafetyMargin),
-            let median = Self.medianCycleMsPerToken(arSafetyRing),
-            median > verdict.arBaselineMs * Self.arSafetyMargin
-        {
-            arSafetyPause(
-                reason: String(
-                    format: "ar_safety_windowed(mtp=%.1fms/tok ar=%.1fms depth=%d)",
-                    verdict.mtpMsPerToken, verdict.arBaselineMs, currentDepth))
+            median > verdict.arBaselineMs * Self.arSafetyMargin {
+            arSafetyDemoteOrPause(reason: String(
+                format: "ar_safety_windowed(mtp=%.1fms/tok ar=%.1fms depth=%d)",
+                verdict.mtpMsPerToken, verdict.arBaselineMs, currentDepth))
         }
     }
 
-    private mutating func arSafetyPause(reason: String) {
+    private mutating func recordDepthLoss() {
+        adaptiveDemotedFromCount[currentDepth, default: 0] += 1
+        let losses = adaptiveDemotedFromCount[currentDepth, default: 0]
+        let delay = 16 << Swift.min(5, Swift.max(0, losses - 1))
+        upperProbeNotBeforeCycle[currentDepth] = verifyCalls + delay
+    }
+
+    private mutating func arSafetyDemoteOrPause(reason: String) {
+        guard currentDepth > 1 else {
+            arSafetyPause(reason: reason)
+            return
+        }
+        let previous = currentDepth
+        recordDepthLoss()
+        currentDepth -= 1
+        adaptiveDepthDownshiftCount += 1
+        adaptiveWallClockDemotes += 1
+        arSafetyRing.removeAll(keepingCapacity: true)
+        adaptiveWindow.removeAll(keepingCapacity: true)
+        lastAdaptiveCycleTimestamp = nil
+        arSafetyFirstVerifySec = nil
+        arSafetyProbeCyclesRemaining = 0
+        arSafetyProbeStartedAt = nil
+        windowsSinceUpperProbe = 0
+        mtpCache = model.makeNativeMTPCache()
+        mtpCacheRefreshCount += 1
+        headChainPairs = 0
+        FileHandle.standardError.write(Data(
+            "[NativeMTP] ar_safety depth=\(previous)->\(currentDepth) reason=\(reason)\n".utf8))
+    }
+    private mutating func arSafetyPause(reason: String, loss: Bool = true) {
         arSafetyPaused = true
         arSafetyTrips += 1
-        if arSafetyReentered {
+        if loss && arSafetyReentered {
             // A kept re-entry lost again: back off further (spec: no ping-pong).
             arSafetyReentered = false
             arSafetyResumeInterval = Swift.min(
                 arSafetyResumeInterval * 2, Self.arSafetyResumeIntervalMax)
         }
         arSafetyTokensSincePause = 0
+        arSafetyCalibrationRemaining = loss ? 0 : 2
         arSafetyProbeCyclesRemaining = 0
+        arSafetyProbeStartedAt = nil
         arSafetyRing.removeAll(keepingCapacity: true)
         adaptiveWindow.removeAll(keepingCapacity: true)
         lastAdaptiveCycleTimestamp = nil
@@ -2227,6 +2263,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             // the MIN of two consecutive true AR steps as the seed.
             if let first = arSafetySeedFirstSampleSec {
                 arSafetySeedStepSec = Swift.min(first, stepSec)
+                arSafetyLastMeasuredToken = tokenCount
                 arSafetyStartSpeculating(hidden: hidden, nextToken: nextToken, probe: false)
             } else {
                 arSafetySeedFirstSampleSec = stepSec
@@ -2235,8 +2272,14 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
         guard arSafetyPaused else { return }
         arSafetyLiveStepSec = arSafetyLiveStepSec.map { 0.7 * $0 + 0.3 * stepSec } ?? stepSec
+        arSafetyLastMeasuredToken = tokenCount
         arSafetyTokensSincePause += 1
-        guard arSafetyTokensSincePause >= arSafetyResumeInterval else { return }
+        if arSafetyCalibrationRemaining > 0 {
+            arSafetyCalibrationRemaining -= 1
+            guard arSafetyCalibrationRemaining == 0 else { return }
+        } else {
+            guard arSafetyTokensSincePause >= arSafetyResumeInterval else { return }
+        }
         arSafetyPaused = false
         arSafetyStartSpeculating(hidden: hidden, nextToken: nextToken, probe: true)
     }
@@ -2250,10 +2293,14 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         // cache can only cost acceptance, never correctness.
         mtpCache = model.makeNativeMTPCache()
         mtpCacheRefreshCount += 1
-        currentDepth = depth
+        currentDepth = probe ? 1 : depth
         arSafetyRing.removeAll(keepingCapacity: true)
         arSafetyProbeCyclesRemaining = probe ? Self.arSafetyProbeWindow : 0
-        let draftStart = Date.timeIntervalSinceReferenceDate
+        arSafetyProbeStartedAt = probe ? NativeMTPClock.now() : nil
+        arSafetyProbeStartedEmitted = arSafetyEmittedTotal
+        arSafetyFirstVerifySec = nil
+        headChainPairs = 0
+        let draftStart = NativeMTPClock.now()
         let draftBatch = Self.makeDrafts(
             model: model,
             hidden: hidden,
@@ -2269,7 +2316,17 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             ? Swift.max(0, draftBatch.tokens.count - 1) : 0
         mtpForwardCount += draftBatch.forwardCount
         materializeSyncTime += draftBatch.materializeSyncTime
-        mtpDraftTime += Date.timeIntervalSinceReferenceDate - draftStart
+        mtpDraftTime += NativeMTPClock.now() - draftStart
+    }
+
+    private mutating func updateDepthAfterCommittedCycle(accepted: Int) {
+        let previousDepth = currentDepth
+        let previousTrips = arSafetyTrips
+        arSafetyAfterVerifyCycle(accepted: accepted)
+        // A loss/recovery decision owns the cycle. Do not immediately undo it
+        // through the acceptance controller on the same committed tokens.
+        guard currentDepth == previousDepth, arSafetyTrips == previousTrips else { return }
+        recordAdaptiveCycle(accepted: accepted)
     }
 
     private mutating func recordAdaptiveCycle(accepted: Int) {
@@ -2288,7 +2345,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             }
             return
         }
-        let now = Date.timeIntervalSinceReferenceDate
+        let now = NativeMTPClock.now()
         let cycleWall = lastAdaptiveCycleTimestamp.map { now - $0 } ?? 0
         lastAdaptiveCycleTimestamp = now
         adaptiveWindow.append(
@@ -2430,7 +2487,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 let lower = measuredThroughputByDepth[currentDepth - 1],
                 lower > throughput * Self.wallClockDemoteFactor
             {
-                adaptiveDemotedFromCount[currentDepth, default: 0] += 1
+                recordDepthLoss()
                 currentDepth -= 1
                 adaptiveDepthDownshiftCount += 1
                 adaptiveWallClockDemotes += 1
@@ -2448,7 +2505,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         // levels exist only because acceptance earned them, and one soft
         // window shouldn't forfeit the whole climb.
         if currentDepth >= 4, acceptanceRatio < depthThreeFloor, !inRestoredGraceWindow {
-            adaptiveDemotedFromCount[currentDepth, default: 0] += 1
+            recordDepthLoss()
             currentDepth -= 1
             adaptiveDepthDownshiftCount += 1
             adaptiveAcceptanceDemotes += 1
@@ -2461,7 +2518,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
 
         if currentDepth == 3, acceptanceRatio < depthThreeFloor, !inRestoredGraceWindow {
-            adaptiveDemotedFromCount[3, default: 0] += 1
+            recordDepthLoss()
             currentDepth = 2
             adaptiveDepthDownshiftCount += 1
             adaptiveAcceptanceDemotes += 1
@@ -2477,7 +2534,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             // A failing D2 downshifts to D1 first — D1's breakeven is far
             // lower, so "D2 doesn't pay" is not evidence that speculation
             // itself doesn't.
-            adaptiveDemotedFromCount[2, default: 0] += 1
+            recordDepthLoss()
             currentDepth = 1
             adaptiveDepthDownshiftCount += 1
             adaptiveAcceptanceDemotes += 1
@@ -2490,14 +2547,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
 
         if currentDepth == 1, acceptanceRatio < depthOneFloor, !inRestoredGraceWindow {
-            // Under the staged verifier with the governor on, "d1 doesn't
-            // pay" is a REVERSIBLE verdict: pause to AR and let the governor's
-            // probes bring MTP back when the regime changes. Live (4M prose,
-            // build #4): this irreversible fallback fired on 6/8 prose gens
-            // BEFORE the governor could act, locking 55–366 AR tokens per
-            // turn — the "never recovers" behaviour the governor exists to
-            // end. The lazy-repair verifier keeps the irreversible fallback.
-            if staged, !Self.arSafetyDisabled {
+            // Economics is reversible for both sampled/sequential and staged
+            // verification. A poor proposal span is not permanent incapability.
+            if !Self.arSafetyDisabled {
                 arSafetyPause(
                     reason: String(
                         format: "adaptive_accept_ratio=%.2f_depth=1_paused",
@@ -2512,15 +2564,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             return
         }
 
-        // Promote. Historically bounded by the REQUESTED depth (recovery
-        // only); since 2026-09-04 the request is a STARTING depth and a full
-        // window that clears the floor of the level above with margin climbs
-        // toward `adaptiveDepthCeiling` — near-perfect-acceptance shapes
-        // (counting, enumeration) ride to d4/d5 while ordinary prose, whose
-        // acceptance sits under the floors, never leaves its start. Only the
-        // staged verifier earns the extended ceiling: the lazy-repair
-        // verifier keeps the old recover-to-request bound (its rejection
-        // cost model was never re-measured above d3).
+        // Recovery/promotion respects the request's resolved policy. Only an
+        // explicitly adaptive staged verifier may explore above its initial
+        // depth; the lazy-repair verifier remains bounded by its initial depth.
         let promotionCeiling = staged ? adaptiveDepthCeiling : depth
         if currentDepth < promotionCeiling {
             let nextFloor: Double
@@ -2535,11 +2581,14 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 measuredThroughputByDepth[currentDepth + 1].map { upper in
                     measuredThroughputByDepth[currentDepth].map { upper < $0 } ?? false
                 } ?? false
-            let upperClosed =
-                adaptiveDemotedFromCount[currentDepth + 1, default: 0]
-                >= Self.adaptiveMaxDemotesPerLevel
+            let upperDue = verifyCalls >= upperProbeNotBeforeCycle[currentDepth + 1, default: 0]
+            let liveAR = arSafetyLiveStepSec ?? arSafetySeedStepSec
+            let measuredCurrent = measuredThroughputByDepth[currentDepth]
+            let beatsAR = Self.arSafetyDisabled || (liveAR.map { ar in
+                measuredCurrent.map { rate in rate > 0 && ar > 0 && 1 / rate < ar } ?? false
+            } ?? false)
             if acceptanceRatio >= nextFloor + Self.adaptivePromotionMargin,
-                !upperKnownWorse, !upperClosed
+                !upperKnownWorse, upperDue, beatsAR
             {
                 currentDepth += 1
                 adaptiveDepthPromotionCount += 1
@@ -2565,17 +2614,17 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             throw NativeMTPRuntimeError.verifierProducedNoTokens
         }
 
-        let verifyStart = Date.timeIntervalSinceReferenceDate
+        let verifyStart = NativeMTPClock.now()
         let output = model.nativeBackboneForward(Self.tokenInput(primary), cache: cache)
         MLX.eval(output.logits, output.hiddenStates)
-        let elapsed = Date.timeIntervalSinceReferenceDate - verifyStart
+        let elapsed = NativeMTPClock.now() - verifyStart
         targetVerifyTime += elapsed
         verifyMainForwardTime += elapsed
         targetForwardCount += 1
         verifyMainForwardCount += 1
         verifyInputTokenCount += 1
 
-        let sampleStart = Date.timeIntervalSinceReferenceDate
+        let sampleStart = NativeMTPClock.now()
         let sample = Self.sampleLast(
             logits: output.logits,
             sampler: sampler,
@@ -2584,7 +2633,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         recordMaterializeSync {
             MLX.eval(sample.token)
         }
-        samplingTime += Date.timeIntervalSinceReferenceDate - sampleStart
+        samplingTime += NativeMTPClock.now() - sampleStart
 
         let tokenID = recordMaterializeSync { sample.token.item(Int.self) }
         nanTrace?.observe(
@@ -2598,7 +2647,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         drafts.removeAll(keepingCapacity: true)
         draftProbabilities.removeAll(keepingCapacity: true)
         arSafetyAfterARStep(
-            stepSec: elapsed,
+            stepSec: NativeMTPClock.now() - verifyStart,
             hidden: Self.lastHidden(output.hiddenStates),
             nextToken: sample.token)
     }
@@ -2617,10 +2666,10 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         sequentialVerifierCount += 1
 
         for index in 0 ... drafts.count {
-            let verifyStart = Date.timeIntervalSinceReferenceDate
+            let verifyStart = NativeMTPClock.now()
             let verifier = model.nativeBackboneForward(Self.tokenInput(currentInput), cache: cache)
             MLX.eval(verifier.logits, verifier.hiddenStates)
-            let verifyElapsed = Date.timeIntervalSinceReferenceDate - verifyStart
+            let verifyElapsed = NativeMTPClock.now() - verifyStart
             targetVerifyTime += verifyElapsed
             verifyMainForwardTime += verifyElapsed
             targetForwardCount += 1
@@ -2646,7 +2695,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             hiddenForNextMTP = Self.lastHidden(verifier.hiddenStates)
 
             if speculativeSampler.isGreedy {
-                let sampleStart = Date.timeIntervalSinceReferenceDate
+                let sampleStart = NativeMTPClock.now()
                 let sample = Self.sampleLast(
                     logits: verifier.logits,
                     sampler: sampler,
@@ -2655,7 +2704,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 recordMaterializeSync {
                     MLX.eval(sample.token)
                 }
-                samplingTime += Date.timeIntervalSinceReferenceDate - sampleStart
+                samplingTime += NativeMTPClock.now() - sampleStart
 
                 let targetID = recordMaterializeSync { sample.token.item(Int.self) }
                 targetTokenIds.append(targetID)
@@ -2682,7 +2731,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 break
             }
 
-            let sampleStart = Date.timeIntervalSinceReferenceDate
+            let sampleStart = NativeMTPClock.now()
             let probabilities = Self.processedProbabilities(
                 logits: verifier.logits[0..., -1, 0...],
                 speculativeSampler: speculativeSampler,
@@ -2690,7 +2739,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             recordMaterializeSync {
                 MLX.eval(probabilities)
             }
-            samplingTime += Date.timeIntervalSinceReferenceDate - sampleStart
+            samplingTime += NativeMTPClock.now() - sampleStart
 
             if index < drafts.count {
                 let decision = speculativeSampler.acceptOrCorrect(
@@ -2737,8 +2786,6 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
 
         acceptedByDepth[accepted, default: 0] += 1
-        arSafetyAfterVerifyCycle(accepted: accepted)
-        recordAdaptiveCycle(accepted: accepted)
         prefixCommitCount += 1
 
         guard let nextToken, let hiddenForNextMTP else {
@@ -2756,12 +2803,13 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
 
         nextMain = nextToken
-        if forceAutoregressiveFallback {
+        updateDepthAfterCommittedCycle(accepted: accepted)
+        if forceAutoregressiveFallback || arSafetyPaused {
             drafts.removeAll(keepingCapacity: true)
             draftProbabilities.removeAll(keepingCapacity: true)
             return
         }
-        let draftStart = Date.timeIntervalSinceReferenceDate
+        let draftStart = NativeMTPClock.now()
         let draftBatch = Self.makeDrafts(
             model: model,
             hidden: hiddenForNextMTP,
@@ -2775,7 +2823,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         draftProbabilities = draftBatch.probabilities
         mtpForwardCount += draftBatch.forwardCount
         materializeSyncTime += draftBatch.materializeSyncTime
-        mtpDraftTime += Date.timeIntervalSinceReferenceDate - draftStart
+        mtpDraftTime += NativeMTPClock.now() - draftStart
     }
 
     private struct VerifyDecision {
@@ -2829,11 +2877,11 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                         sampler: sampler,
                         speculativeSampler: speculativeSampler,
                         processor: &verifyProcessor)
-                    let syncStart = Date.timeIntervalSinceReferenceDate
+                    let syncStart = NativeMTPClock.now()
                     MLX.eval(sample.token)
                     tokenRows.append(sample.token)
                     tokenIDs.append(sample.token.item(Int.self))
-                    materializeSyncTime += Date.timeIntervalSinceReferenceDate - syncStart
+                    materializeSyncTime += NativeMTPClock.now() - syncStart
                 }
                 sampled = tokenRows
                 sampledIDs = tokenIDs
@@ -2875,9 +2923,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 logits: logits[0..., index, 0...],
                 speculativeSampler: speculativeSampler,
                 processor: &verifyProcessor)
-            let syncStart = Date.timeIntervalSinceReferenceDate
+            let syncStart = NativeMTPClock.now()
             MLX.eval(probabilities)
-            materializeSyncTime += Date.timeIntervalSinceReferenceDate - syncStart
+            materializeSyncTime += NativeMTPClock.now() - syncStart
             targetProbabilities.append(probabilities)
             if index < drafts.count {
                 verifyProcessor?.didSample(token: drafts[index])
@@ -2903,9 +2951,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             guard let correction = decision.correction else {
                 preconditionFailure("rejected speculative token must return a residual correction")
             }
-            let syncStart = Date.timeIntervalSinceReferenceDate
+            let syncStart = NativeMTPClock.now()
             MLX.eval(correction)
-            materializeSyncTime += Date.timeIntervalSinceReferenceDate - syncStart
+            materializeSyncTime += NativeMTPClock.now() - syncStart
             return VerifyDecision(
                 accepted: accepted,
                 nextToken: correction,
@@ -2916,9 +2964,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
 
         let bonus = speculativeSampler.sampleFromTarget(probabilities: targetProbabilities[drafts.count])
-        let syncStart = Date.timeIntervalSinceReferenceDate
+        let syncStart = NativeMTPClock.now()
         MLX.eval(bonus)
-        materializeSyncTime += Date.timeIntervalSinceReferenceDate - syncStart
+        materializeSyncTime += NativeMTPClock.now() - syncStart
         return VerifyDecision(
             accepted: accepted,
             nextToken: bonus,
@@ -3026,9 +3074,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             // on-graph and the NEXT cycle reads every draft id in one
             // batched readback. A per-level MLX.eval here stalled the whole
             // pipeline once per draft for a value nobody reads yet.
-            let syncStart = Date.timeIntervalSinceReferenceDate
+            let syncStart = NativeMTPClock.now()
             asyncEval(draft.token, out.hiddenStates)
-            materializeSyncTime += Date.timeIntervalSinceReferenceDate - syncStart
+            materializeSyncTime += NativeMTPClock.now() - syncStart
             tokens.append(draft.token)
             if !speculativeSampler.isGreedy {
                 probabilities.append(draft.probabilities)
@@ -3205,7 +3253,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
 
         let candidateLogits = logits[0..., 0 ..< count, 0...]
         let tokenBatch = argMax(candidateLogits, axis: -1).asType(.int32)
-        let syncStart = Date.timeIntervalSinceReferenceDate
+        let syncStart = NativeMTPClock.now()
         MLX.eval(tokenBatch)
         guard tokenBatch.size == count else {
             return nil
@@ -3214,7 +3262,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         guard tokenIds.count == count else {
             return nil
         }
-        let materializeSyncTime = Date.timeIntervalSinceReferenceDate - syncStart
+        let materializeSyncTime = NativeMTPClock.now() - syncStart
         let tokens = tokenIds.map { MLXArray([Int32($0)]) }
         return (
             tokens: tokens,

--- a/Package.swift
+++ b/Package.swift
@@ -849,6 +849,8 @@ let package = Package(
             sources: [
                 "ProposalHeadStampTests.swift",
                 "NativeMTPARSafetyTests.swift",
+                "NativeMTPDepthPolicyTests.swift",
+                "NativeMTPDepthExecutionTests.swift",
                 "RaptorTopLevelStampTests.swift",
                 "HybridRestoreBoundaryInvariantTests.swift",
                 "DualPathFamiliesTests.swift",

--- a/Tests/MLXLMCommonFocusedTests/NativeMTPDepthExecutionTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NativeMTPDepthExecutionTests.swift
@@ -1,0 +1,241 @@
+import Foundation
+import MLX
+import MLXNN
+import XCTest
+@testable import MLXLMCommon
+
+/// Exercises actual iterator verify dispatch. The zero-weight constant target
+/// makes every proposal correct; it is not a model-quality or speed benchmark.
+final class NativeMTPDepthExecutionTests: XCTestCase {
+    func testSampledRejectionPauseCanProbeAfterProposalQualityChanges() throws {
+        guard ProcessInfo.processInfo.environment["VMLX_NATIVE_MTP_AR_SAFETY"] != "0" else {
+            throw XCTSkip("Requires the real governor")
+        }
+        try FocusedMLXTestSupport.withLock {
+            let model = DepthDispatchTarget(sequence: true, backboneDelay: 0.003)
+            model.setWrongDraft(true)
+            var parameters = GenerateParameters(maxTokens: 240, temperature: 1)
+            parameters.randomSeed = 829
+            parameters.draftStrategy = .nativeMTP(depth: 1)
+            var iterator = try NativeMTPTokenIterator(
+                input: LMInput(tokens: MLXArray([1, 1, 1])), model: model,
+                parameters: parameters, depth: 1)
+            let start = ProcessInfo.processInfo.systemUptime
+            var tokens: [Int] = []
+            var verifiesAtChange = 0
+            while tokens.count < 240, let token = iterator.next() {
+                tokens.append(token)
+                if tokens.count == 96 {
+                    verifiesAtChange = iterator.verifyCalls
+                    model.setWrongDraft(false)
+                }
+            }
+            XCTAssertEqual(tokens, (0..<240).map { (2 + $0) % 32 })
+            XCTAssertGreaterThan(iterator.sequentialVerifierCount, 0)
+            XCTAssertEqual(iterator.stagedVerifierCommitCount, 0)
+            XCTAssertGreaterThan(iterator.rejectedCount, 0)
+            XCTAssertGreaterThan(iterator.autoregressiveFallbackTokenCount, 2)
+            XCTAssertGreaterThan(iterator.verifyCalls, verifiesAtChange)
+            print("SAMPLED-RECOVERY verifiesBefore=\(verifiesAtChange) after=\(iterator.verifyCalls) fixtureTokS=\(Double(tokens.count) / max(ProcessInfo.processInfo.systemUptime - start, 1e-9)) realModelSpeedProof=false")
+        }
+    }
+
+    func testLosingDepthsDescendAndChangedRegimeCanRecover() throws {
+        guard ProcessInfo.processInfo.environment["VMLX_NATIVE_MTP_AR_SAFETY"] != "0",
+              ProcessInfo.processInfo.environment["VMLX_MTP_VERIFY_PREFETCH"] == "0" else {
+            throw XCTSkip("Controlled host-cost row: governor on, verify prefetch off; prefetch parity is separate")
+        }
+        try FocusedMLXTestSupport.withLock {
+            let model = DepthDispatchTarget(sequence: true, backboneDelay: 0.004)
+            model.setVerifyDelays([2: 0.001, 3: 0.040, 4: 0.080])
+            var parameters = GenerateParameters(maxTokens: 480, temperature: 0)
+            parameters.draftStrategy = .nativeMTP(depth: 3)
+            var iterator = try NativeMTPTokenIterator(
+                input: LMInput(tokens: MLXArray([1, 1, 1])), model: model,
+                parameters: parameters, depth: 3)
+            let start = ProcessInfo.processInfo.systemUptime
+            var tokens: [Int] = []
+            var widthsAtChange = 0
+            while tokens.count < 480, let token = iterator.next() {
+                tokens.append(token)
+                if tokens.count == 240 {
+                    let widths = model.verifyWidths
+                    XCTAssertTrue(widths.contains(4))
+                    XCTAssertTrue(widths.contains(3), "D3 must descend through D2")
+                    XCTAssertTrue(widths.contains(2), "D1 should be discovered")
+                    widthsAtChange = widths.count
+                    model.setVerifyDelays([2: 0.001, 3: 0.001, 4: 0.001])
+                }
+            }
+            let recovered = Array(model.verifyWidths.dropFirst(widthsAtChange))
+            XCTAssertTrue(recovered.contains(3), "Changed regime must recover D2")
+            XCTAssertTrue(recovered.contains(4), "Changed regime must recover D3")
+            XCTAssertTrue(model.verifyWidths.allSatisfy { $0 <= 4 })
+            XCTAssertEqual(tokens, (0..<480).map { (2 + $0) % 32 })
+            print("MTP-LADDER widths=\(model.verifyWidths) recovered=\(recovered) fixtureTokS=\(Double(tokens.count) / max(ProcessInfo.processInfo.systemUptime - start, 1e-9)) realModelSpeedProof=false")
+        }
+    }
+
+    func testGovernorHandoffPreservesNonconstantAcceptedTokens() throws {
+        guard ProcessInfo.processInfo.environment["VMLX_NATIVE_MTP_AR_SAFETY"] != "0" else {
+            throw XCTSkip("Requires the real governor")
+        }
+        try FocusedMLXTestSupport.withLock {
+            let model = DepthDispatchTarget(sequence: true, verifyDelay: 0.020)
+            var parameters = GenerateParameters(maxTokens: 240, temperature: 0)
+            parameters.draftStrategy = .nativeMTP(depth: 3)
+            var iterator = try NativeMTPTokenIterator(
+                input: LMInput(tokens: MLXArray([1, 1, 1])), model: model,
+                parameters: parameters, depth: 3)
+            let start = ProcessInfo.processInfo.systemUptime
+            var tokens: [Int] = []
+            var previousAR = 0
+            while tokens.count < 240, let token = iterator.next() {
+                tokens.append(token)
+                if iterator.autoregressiveFallbackTokenCount > previousAR {
+                    previousAR = iterator.autoregressiveFallbackTokenCount
+                    let kv = try XCTUnwrap(iterator.cache.last as? KVCacheSimple)
+                    XCTAssertEqual(kv.offset, 3 + tokens.count - 1)
+                    let state = try XCTUnwrap(kv.readKV())
+                    XCTAssertEqual(state.keys.asArray(Int32.self), (0..<kv.offset).map(Int32.init))
+                    XCTAssertEqual(state.values.asArray(Int32.self),
+                                   [Int32(1), 1, 1] + tokens.dropLast().map(Int32.init))
+                }
+            }
+            XCTAssertEqual(tokens, (0..<240).map { (2 + $0) % 32 })
+            XCTAssertGreaterThan(iterator.stagedVerifierCommitCount, 0)
+            XCTAssertGreaterThan(iterator.arSafetyTrips, 0)
+            XCTAssertGreaterThan(iterator.autoregressiveFallbackTokenCount, 2)
+            print("GOVERNOR-QUEUE tokens=\(tokens.count) trips=\(iterator.arSafetyTrips) fixtureTokS=\(Double(tokens.count) / max(ProcessInfo.processInfo.systemUptime - start, 1e-9)) realModelSpeedProof=false")
+        }
+    }
+    func testFixedDepthsBoundExecutedVerifyWidths() throws {
+        try requireIsolatedDepthRun()
+        try FocusedMLXTestSupport.withLock {
+            for depth in 1...3 {
+                let widths = try run(depth: depth, policy: .fixed)
+                XCTAssertFalse(widths.isEmpty)
+                XCTAssertTrue(widths.allSatisfy { $0 <= depth + 1 }, "D\(depth): \(widths)")
+                XCTAssertTrue(widths.contains(depth + 1))
+            }
+        }
+    }
+
+    func testAdaptiveActuallyPromotesButRespectsCeiling() throws {
+        try requireIsolatedDepthRun()
+        try FocusedMLXTestSupport.withLock {
+            let widths = try run(depth: 1, policy: .adaptive(maximumDepth: 3))
+            XCTAssertTrue(widths.contains(2))
+            XCTAssertTrue(widths.contains { $0 > 2 }, "No actual promotion: \(widths)")
+            XCTAssertTrue(widths.allSatisfy { $0 <= 4 })
+        }
+    }
+
+    private func requireIsolatedDepthRun() throws {
+        guard ProcessInfo.processInfo.environment["VMLX_NATIVE_MTP_AR_SAFETY"] == "0" else {
+            throw XCTSkip("Run this dispatch-only fixture with VMLX_NATIVE_MTP_AR_SAFETY=0; real governor speed qualification is separate")
+        }
+    }
+
+    private func run(depth: Int, policy: NativeMTPDepthPolicy) throws -> [Int] {
+        let model = DepthDispatchTarget()
+        var parameters = GenerateParameters(maxTokens: 160, temperature: 0)
+        parameters.draftStrategy = .nativeMTP(depth: depth)
+        parameters.nativeMTPDepthPolicy = policy
+        var iterator = try NativeMTPTokenIterator(
+            input: LMInput(tokens: MLXArray([1, 1, 1])), model: model,
+            parameters: parameters, depth: depth)
+        var count = 0
+        let start = ProcessInfo.processInfo.systemUptime
+        while let token = iterator.next() {
+            XCTAssertEqual(token, 1)
+            count += 1
+            if count >= 160 { break }
+        }
+        XCTAssertEqual(count, 160)
+        XCTAssertGreaterThan(iterator.stagedVerifierCommitCount, 0)
+        print("DEPTH-DISPATCH requested=\(depth) policy=\(policy) widths=\(Set(model.verifyWidths).sorted()) stagedCommits=\(iterator.stagedVerifierCommitCount) fixtureTokens=\(count) fixtureTokS=\(Double(count) / max(ProcessInfo.processInfo.systemUptime - start, 1e-9)) realModelSpeedProof=false")
+        return model.verifyWidths
+    }
+}
+
+private final class DepthDispatchTarget: Module, LanguageModel, NativeMTPModel,
+    KVCacheDimensionProvider, DFlash2StagedVerifyRollbackModel, @unchecked Sendable
+{
+    var kvHeads: [Int] { sequence ? [1, 1] : [1] }
+    var nativeMTPAvailable: Bool { true }
+    private let timingLock = NSLock()
+    private var widths: [Int] = []
+    var verifyWidths: [Int] { timingLock.withLock { widths } }
+    private var delaysByWidth: [Int: TimeInterval] = [:]
+    private var wrongDraft = false
+    let sequence: Bool
+    let verifyDelay: TimeInterval
+    let backboneDelay: TimeInterval
+    init(sequence: Bool = false, verifyDelay: TimeInterval = 0, backboneDelay: TimeInterval = 0) {
+        self.sequence = sequence
+        self.verifyDelay = verifyDelay
+        self.backboneDelay = backboneDelay
+    }
+    func setVerifyDelays(_ values: [Int: TimeInterval]) {
+        timingLock.withLock { delaysByWidth = values }
+    }
+    func setWrongDraft(_ value: Bool) { timingLock.withLock { wrongDraft = value } }
+    func newCache(parameters: GenerateParameters?) -> [KVCache] {
+        sequence ? [MambaCache(), KVCacheSimple()] : [MambaCache()]
+    }
+    func makeNativeMTPCache() -> [KVCache] { [] }
+    func prepare(_ input: LMInput, cache: [KVCache], windowSize: Int?) throws -> PrepareResult {
+        .tokens(input.text)
+    }
+    func callAsFunction(_ inputs: MLXArray, cache: [KVCache]?) -> MLXArray {
+        appendKV(inputs, cache: cache)
+        return result(inputs).logits
+    }
+    func nativeBackboneForward(_ inputs: MLXArray, cache: [KVCache]?) -> NativeMTPForwardResult {
+        if backboneDelay > 0 { Thread.sleep(forTimeInterval: backboneDelay) }
+        appendKV(inputs, cache: cache)
+        return result(inputs)
+    }
+    func nativeBackboneMTPVerifyForward(_ inputs: MLXArray, cache: [KVCache]?) -> NativeMTPForwardResult {
+        let width = inputs.ndim >= 2 ? inputs.dim(1) : inputs.size
+        let delay = timingLock.withLock {
+            widths.append(width)
+            return delaysByWidth[width] ?? verifyDelay
+        }
+        if delay > 0 { Thread.sleep(forTimeInterval: delay) }
+        appendKV(inputs, cache: cache)
+        return result(inputs)
+    }
+    func nativeMTPForward(hiddenStates: MLXArray, nextTokenIds: MLXArray, cache: [KVCache]?) -> NativeMTPForwardResult {
+        if timingLock.withLock({ wrongDraft }) {
+            let length = nextTokenIds.size
+            return .init(logits: broadcast(MLXArray([Float(100)] + Array(repeating: Float(-100), count: 31)), to: [1, length, 32]),
+                         hiddenStates: MLXArray.zeros([1, length, 4]))
+        }
+        return result(nextTokenIds)
+    }
+    func commitVerifiedBlock(cache: [KVCache], acceptedInputs: Int) -> Bool { true }
+    func commitStagedVerifiedBlock(cache: [KVCache], acceptedInputs: Int, blockLength: Int) -> Bool { true }
+    private func appendKV(_ inputs: MLXArray, cache: [KVCache]?) {
+        guard sequence, let kv = cache?.last as? KVCacheSimple else { return }
+        let count = inputs.size
+        let positions = MLXArray((kv.offset..<(kv.offset + count)).map(Int32.init))
+        let arrays = kv.update(keys: positions.reshaped(1, 1, count, 1),
+                               values: inputs.reshaped(1, 1, count, 1))
+        MLX.eval(arrays.0, arrays.1)
+    }
+    private func result(_ inputs: MLXArray) -> NativeMTPForwardResult {
+        let length = inputs.ndim >= 2 ? inputs.dim(1) : inputs.size
+        if sequence {
+            let ids = inputs.reshaped(-1).asArray(Int32.self)
+            let logits = ids.flatMap { token in
+                (0..<32).map { $0 == (Int(token) + 1) % 32 ? Float(100) : Float(-100) }
+            }
+            return .init(logits: MLXArray(logits).reshaped(1, length, 32),
+                         hiddenStates: MLXArray.zeros([1, length, 4]))
+        }
+        return .init(logits: broadcast(MLXArray([Float(-100), 100, -100, -100]), to: [1, length, 4]),
+                     hiddenStates: MLXArray.zeros([1, length, 4]))
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/NativeMTPDepthPolicyTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NativeMTPDepthPolicyTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import MLXLMCommon
+
+final class NativeMTPDepthPolicyTests: XCTestCase {
+    func testFixedRequestsCannotPromoteAboveSelectedDepth() throws {
+        for depth in 1...3 {
+            let result = try NativeMTPDepthPolicy.fixed.resolve(requestedDepth: depth, runtimeCap: 5)
+            XCTAssertEqual(result.initialDepth, depth)
+            XCTAssertEqual(result.maximumDepth, depth)
+        }
+    }
+
+    func testAdaptiveExplorationIsExplicitAndBounded() throws {
+        let result = try NativeMTPDepthPolicy.adaptive(maximumDepth: 3)
+            .resolve(requestedDepth: 1, runtimeCap: 5)
+        XCTAssertEqual(result.initialDepth, 1)
+        XCTAssertEqual(result.maximumDepth, 3)
+        let capped = try NativeMTPDepthPolicy.adaptive(maximumDepth: 5)
+            .resolve(requestedDepth: 3, runtimeCap: 2)
+        XCTAssertEqual(capped.initialDepth, 2)
+        XCTAssertEqual(capped.maximumDepth, 2)
+    }
+
+    func testRuntimeCapCanOnlyLowerFixedDepth() throws {
+        let result = try NativeMTPDepthPolicy.fixed.resolve(requestedDepth: 3, runtimeCap: 2)
+        XCTAssertEqual(result.initialDepth, 2)
+        XCTAssertEqual(result.maximumDepth, 2)
+    }
+
+    func testInvalidPolicyInputsThrow() {
+        XCTAssertThrowsError(try NativeMTPDepthPolicy.fixed.resolve(requestedDepth: 0, runtimeCap: 5))
+        XCTAssertThrowsError(try NativeMTPDepthPolicy.fixed.resolve(requestedDepth: 3, runtimeCap: 0))
+        XCTAssertThrowsError(try NativeMTPDepthPolicy.adaptive(maximumDepth: -1)
+            .resolve(requestedDepth: 3, runtimeCap: 5))
+    }
+
+    func testParametersDefaultToFixedAndCopiesPreserveExplicitPolicy() {
+        var parameters = GenerateParameters()
+        XCTAssertEqual(parameters.nativeMTPDepthPolicy, .fixed)
+        parameters.nativeMTPDepthPolicy = .adaptive(maximumDepth: 3)
+        let copy = parameters
+        XCTAssertEqual(copy.nativeMTPDepthPolicy, .adaptive(maximumDepth: 3))
+    }
+}

--- a/Tests/MLXLMCommonFocusedTests/NativeMTPDepthPolicyTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NativeMTPDepthPolicyTests.swift
@@ -2,6 +2,20 @@ import XCTest
 @testable import MLXLMCommon
 
 final class NativeMTPDepthPolicyTests: XCTestCase {
+    func testManualRecommendationDoesNotClaimSamplerCoercion() throws {
+        let status = MTPBundleStatus(
+            bundleHasMTP: true, configuredLayers: 1, tensorCount: 57,
+            mode: .preservedEnabled, nativeMTPTuning: nil)
+        for depth in 1...3 {
+            let recommendation = try XCTUnwrap(NativeMTPAutoDecodePolicy.manualRecommendation(
+                depth: depth, configData: Data("{\"model_type\":\"qwen4_exp\"}".utf8),
+                jangConfig: nil, status: status))
+            XCTAssertEqual(recommendation.depth, depth)
+            XCTAssertTrue(recommendation.reason.contains("request sampling remains in effect"))
+            XCTAssertFalse(recommendation.reason.contains("greedy"))
+        }
+    }
+
     func testFixedRequestsCannotPromoteAboveSelectedDepth() throws {
         for depth in 1...3 {
             let result = try NativeMTPDepthPolicy.fixed.resolve(requestedDepth: depth, runtimeCap: 5)

--- a/Tests/MLXLMTests/NativeMTPManualDepthTests.swift
+++ b/Tests/MLXLMTests/NativeMTPManualDepthTests.swift
@@ -5,8 +5,7 @@ import Testing
 
 /// Manual-depth activation contract (the Speculative Depth 1/2/3 buttons):
 /// an explicit user depth activates a tensor-complete MTP head WITHOUT a
-/// measured `vmlx_mtp_tuning.json`, Auto stays tuning-gated, and any active
-/// launch pairs with enforced greedy sampling for that model+session.
+/// measured `vmlx_mtp_tuning.json`. Sampling is independent of depth selection.
 @Suite("Native MTP manual depth contract")
 struct NativeMTPManualDepthTests {
 


### PR DESCRIPTION
## Scope

Isolated follow-up to the merged AR/QSA/PLE work. Fixed requested depths become
ceilings; adaptive exploration is explicit. Safety descends one rung and probes
re-entry at D1, with measured-cost promotion and geometrically spaced recovery
instead of a lifetime depth lockout. Monotonic timing, full-step AR cost, full
six-cycle probe cost including re-prime, and periodic AR calibration support
current-context decisions. No quantization, model-format or sampler substitution.

Correctness prerequisite: policy decisions now occur after accepted output and
target-cache commit bookkeeping. Pausing previously cleared proposals while the
chunk verifier still needed them; this could skip accepted tokens and diverge
from cache contents. Paused paths no longer generate unused next-cycle drafts.
Sampled/sequential acceptance loss now uses reversible AR pause too.

## Local evidence — real iterator on tiny fixtures, not model speed

- Queue candidate MTPQueue__232439: exact240-token nonconstant chain, two pauses,
  KV offsets and every position/token value match at AR steps. One XCTest pass.
- Same test with only queue ordering reverted: MTPQueueBefore__232744 fails171
  assertions, skipped accepted triples and diverging KV offsets/values. Candidate
  source restored with exact hash verification.
- MTPLadder__233421:16 exercised tests,2 explicitly skipped dispatch-only tests.
  Controlled cost regime descends D3->D2->D1, then recovers to D3 after the regime
  changes. Token-chain invariance and existing AR arithmetic/policy tests hold.
- MTPDepthDispatch__233908: the two skipped cases separately exercised with the
  safety governor disabled for dispatch-only isolation. Fixed1/2/3 verify widths
  bounded2/3/4; adaptive1-to3 actually reaches widths2/3/4. Not live safety proof.
- MTPSampledRecovery__234021: two exercised tests, sampled rejection recovery
  (verify calls18 before quality change,24 after) plus token/KV invariant.
- MTPLadderBefore__234207 retains the queue fix but removes the new controller:
  misses D2 and D1 discovery/D2 recovery; sampled verify count stays12->12.
  Four assertions fail. Candidate restored with exact source hash verification.

All runs supervised,8GiB cap/40GiB raw-free floor/.25GiB swap-growth abort;
maximum recorded footprint2.76GiB including the initial compile-failed run,
swap .52GiB unchanged,normal pressure,cleanup0/0/0. Initial test compile error
(absent diagnostic property) is retained, not counted as product proof.

Exact committed-head rerun54b3b598dfdb40169d8e84956161ed8beac675fa:
MTPHead__234434 reports19 XCTest cases,17 exercised,2 explicitly skipped,
zero failures. Runner exit0, peak1.16GiB, swap unchanged .52GiB, cleanup0/0/0.
Latest exact head0c6ca3f9c91b050fd9b0155386056a5c6a6ac1da corrects a stale
manual-depth diagnostic claiming greedy enforcement; sampling remains independent.
MTPLadderFinal__005145 reports20 XCTest cases,18 exercised,2 skipped,0 failures,
exit0,peak.26GiB,swapflat.52GiB,cleanup0/0/0. The preceding default-prefetch run
exercised17 with3skips and0failures. No algorithm changes after54b3b598.
Matching Osaurus integration is draft #2714 at b7d4383c5, pinned to0c6ca3f9.

Real Release integration on appa472b01a9/runtime54b3b598: Flash Off chat and
current-time tool follow-up retained timestamps and correct372-second difference;
main requests used temperature1/topP.95/topK20/draftStrategy none. D3 and D2
subsequent answers retained the facts; D2 actual counters show2AR pauses and
1resume with depth ceiling2, no graph reload fromD3. Both eligible families
showed D3 controls before Send. Sampled verifier is sequential/exact-pq; D3
finalized UI26.7tok/s is NOT a demonstrated speedup. Two overall app runs hit
configured free-memory floors,swapunchanged,cleanup0/0/0; incomplete work is
excluded. The final-head evidence below supersedes the pending rebuild status.

Final integration: Osaurus b7d4383c53ab6126edfc899b6d7f59f3149f7fa6 pins exact runtime 0c6ca3f9. Signed Release -O binary c56d2298fb655d2733badf20f766474e74ce4a918140a7b07079dbd513980304 was exercised through the visible app and its API; all eight exact-head app checks completed successfully (34576452666/34576452667). Flash D1/Auto tool follow-ups retained correct timestamps and 51-second difference; 27B D3 used its distinct 31-tensor contract and retained a correct 43-second difference. Explicit D3 over a legacy cap 1 was observed on a resident-D2 graph without reload. Off unloaded/reloaded AR and reported MTP inactive. Current-head supervision exited0, peak61.00GiB, flat swap.52GiB, cleanup0/0/0.

This merges bounded policy/token-commit correctness, NOT a universal performance or model-quality qualification. Sampled verification remains sequential. Long 27B samples: D3-selected12.0981tok/s versus Off13.8144tok/s, different stochastic outputs/cache states; both had a factual arithmetic error despite correct century-year decisions. No speedup or causal quality attribution follows. Disk hits and pre-response cancellation are observed; comprehensive SSM/PLE/media, live mid-verifier cancellation, wider batching and matched AR/MTP speed-floor qualification remain PARTIAL. Controlled fixture delays are not hardware speed measurements. No release.
