### PR TITLE
Preserve Flash PLE recurrent state in disk cache restores

### DIFF
--- a/Libraries/MLXLMCommon/BatchEngine/CompilableMambaCache.swift
+++ b/Libraries/MLXLMCommon/BatchEngine/CompilableMambaCache.swift
@@ -120,7 +120,7 @@ public final class CompilableMambaCache: MambaCache, @unchecked Sendable {
     /// - Parameter mamba: Source cache, typically produced by a model's
     ///   prefill of Mamba / GDN layers.
     public convenience init(from mamba: MambaCache) {
-        self.init(slots: mamba.slotCount, leftPadding: nil)
+        self.init(slots: mamba.slotCount, persistentSlotCount: mamba.persistentSlotCount, leftPadding: nil)
 
         // Copy offset + leftPadding from source.
         self.offset = mamba.offset
@@ -136,6 +136,18 @@ public final class CompilableMambaCache: MambaCache, @unchecked Sendable {
     }
 
     // MARK: - Subscript override
+
+    public override init(slots: Int, persistentSlotCount: Int, leftPadding: [Int]? = nil) {
+        precondition((2 ... 6).contains(slots))
+        self.convStateArray = nil
+        self.hiddenStateArray = nil
+        self.companionStateArray2 = nil
+        self.companionStateArray3 = nil
+        self.companionStateArray4 = nil
+        self.companionStateArray5 = nil
+        self.stableSlotCount = slots
+        super.init(slots: slots, persistentSlotCount: persistentSlotCount, leftPadding: leftPadding)
+    }
 
     /// Route slot reads/writes to the direct `convStateArray` /
     /// `hiddenStateArray` properties. Existing model code that does
@@ -227,14 +239,10 @@ public final class CompilableMambaCache: MambaCache, @unchecked Sendable {
 
     /// Match the parent's state contract but route through our direct
     /// properties. Called by the cache coordinator on restore. The
-    /// setter validates exactly-2 entries because `MambaCache` always
-    /// has 2 state slots.
+    /// getter excludes the model-declared transient staging suffix.
     public override var state: [MLXArray] {
         get {
-            var out: [MLXArray] = []
-            if let conv = convStateArray { out.append(conv) }
-            if let hidden = hiddenStateArray { out.append(hidden) }
-            return out
+            (0..<persistentSlotCount).compactMap { self[$0] }
         }
         set {
             precondition(newValue.count <= stableSlotCount)
@@ -256,7 +264,7 @@ public final class CompilableMambaCache: MambaCache, @unchecked Sendable {
     // MARK: - Copy
 
     public override func copy() -> any KVCache {
-        let new = CompilableMambaCache(slots: stableSlotCount)
+        let new = CompilableMambaCache(slots: stableSlotCount, persistentSlotCount: persistentSlotCount)
         new.offset = self.offset
         new.leftPadding = self.leftPadding
         for index in 0 ..< stableSlotCount {

--- a/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
+++ b/Libraries/MLXLMCommon/Cache/CacheHelpers.swift
@@ -648,7 +648,7 @@ public func restoreSSMStates(
     // matching neither layout is refused outright rather than cross-wiring
     // layer N with layer N+1's state.
     func restoreArity(_ mamba: MambaCache, ordinaryArity: Int) -> Int {
-        mamba.slotCount > 2 ? mamba.slotCount - 2 : ordinaryArity
+        mamba.persistentSlotCount > 2 ? mamba.persistentSlotCount : ordinaryArity
     }
     var totalWithTwoSlotMamba = 0
     var totalWithOneSlotMamba = 0
@@ -833,6 +833,8 @@ private func restoreFromV2Arrays(
             continue
         }
         switch entry.data {
+        case .mamba, .cacheList:
+            guard canRestoreMambaRecords(entry.data, into: cache[entry.index]) else { return 0 }
         case .qkv(let comp):
             // Quantized-KV layers share the atomic contract: a record whose
             // group size / bit width no longer matches the runtime cache (or
@@ -958,7 +960,7 @@ private func restoreFromV2Arrays(
             // Mamba state arrays are cumulative — no sequence dim to
             // measure, so they don't contribute to `totalTokens`. The
             // attention side already provides that number.
-            restoreMambaLayer(comp, into: cache[i])
+            guard restoreMambaLayer(comp, into: cache[i]) else { return 0 }
 
         case .tq(let comp):
             // Restore the compressed prefix into the existing
@@ -1064,7 +1066,7 @@ private func restoreFromV2Arrays(
             // runtime CacheList's internal order — type matching does
             // the dispatch. This is the same convention SSM state
             // restoration in extractSSMStates uses.
-            for subData in subLayers {
+            for (subIndex, subData) in subLayers.enumerated() {
                 switch subData {
                 case .standard(let kv):
                     var keys = kv.keys
@@ -1082,7 +1084,9 @@ private func restoreFromV2Arrays(
                     restoreKVLayer(keys: keys, values: values, into: cache[i])
 
                 case .mamba(let comp):
-                    restoreMambaLayer(comp, into: cache[i])
+                    guard let list = cache[i] as? CacheList, subIndex < list.count,
+                          restoreMambaLayer(comp, into: list[subIndex])
+                    else { return 0 }
 
                 case .rotating(let comp):
                     restoreRotatingLayer(comp, into: cache[i])
@@ -1606,35 +1610,49 @@ private func restoreZayaCCATQLayer(
     return zaya.offset == comp.tq.offset && zaya.usesTurboQuantKV
 }
 
-/// Helper: restore Mamba SSM state into a `MambaCache` layer (or a
-/// `CacheList` containing one). Silently no-ops for other cache classes,
-/// which can happen if the serialized model layout has drifted from the
-/// current runtime.
+/// Validate Mamba state before restoration. CacheList children are validated
+/// at their serialized index. Any recurrent
+/// layout mismatch is rejected before the caller mutates an attention sibling.
+private func canRestoreMambaRecords(
+    _ data: TQDiskSerializer.LayerData, into layer: any KVCache
+) -> Bool {
+    switch data {
+    case .requiredMiss:
+        return false
+    case .mamba(let component):
+        guard let target = layer as? MambaCache else { return false }
+        if let count = component.persistentSlotCount {
+            guard count == target.persistentSlotCount else { return false }
+        } else {
+            guard target.persistentSlotCount <= 2 else { return false }
+        }
+        return component.occupiedStates.keys.allSatisfy {
+            $0 >= 0 && $0 < target.persistentSlotCount
+        }
+    case .cacheList(let components):
+        guard let list = layer as? CacheList, components.count == list.count else { return false }
+        return components.enumerated().allSatisfy {
+            canRestoreMambaRecords($0.element, into: list[$0.offset])
+        }
+    default:
+        return true
+    }
+}
+
+@discardableResult
 private func restoreMambaLayer(
     _ comp: TQDiskSerializer.MambaLayerComponents,
     into layer: any KVCache
-) {
-    func apply(_ mamba: MambaCache) {
-        if let state1 = comp.state1 {
-            mamba.state = [comp.state0, state1]
-        } else {
-            // Single-slot layout (LFM2/LFM2.5 short-conv): restore into
-            // slot 0 via the subscript so the 2-slot container geometry is
-            // preserved and slot 1 stays genuinely empty.
-            mamba[0] = comp.state0
-        }
-        mamba.offset = comp.offset
+) -> Bool {
+    guard canRestoreMambaRecords(.mamba(comp), into: layer),
+          let mamba = layer as? MambaCache
+    else { return false }
+    // Restore by index: compactMap would shift an occupied slot across a nil
+    // hole. Also clear scratch left over from a previous verify request.
+    for slot in 0..<mamba.slotCount {
+        mamba[slot] = comp.occupiedStates[slot]
     }
-    if let mamba = layer as? MambaCache {
-        apply(mamba)
-        return
-    }
-    if let cacheList = layer as? CacheList {
-        for i in 0..<cacheList.count {
-            if let mamba = cacheList[i] as? MambaCache {
-                apply(mamba)
-                return
-            }
-        }
-    }
+    mamba.clearVerifyStaging()
+    mamba.offset = comp.offset
+    return true
 }

--- a/Libraries/MLXLMCommon/Cache/DiskCache.swift
+++ b/Libraries/MLXLMCommon/Cache/DiskCache.swift
@@ -96,6 +96,33 @@ public final class DiskCache: @unchecked Sendable {
         let modificationDate: Date
     }
 
+    private struct ValidatedRecord {
+        let file: ValidatedFileFingerprint
+        let layout: [String]
+        let hasRecurrentGeometry: Bool
+    }
+
+    private static func hasRecurrentGeometry(_ names: Set<String>) -> Bool {
+        names.filter { $0.hasPrefix("mamba_") && $0.hasSuffix("_state0") }
+            .allSatisfy { name in
+                let prefix = String(name.dropLast("_state0".count))
+                return names.contains("__\(prefix)_slots__")
+                    && names.contains("__\(prefix)_occupied__")
+            }
+    }
+
+    /// Token identity alone cannot justify retaining an older representation.
+    /// Include tensor geometry and typed serializer metadata, without reading
+    /// the large state tensors back to the CPU or retaining mapped arrays.
+    private static func payloadLayout(_ arrays: [String: MLXArray]) -> [String] {
+        arrays.keys.sorted().map { key in
+            let array = arrays[key]!
+            let metadata = key.hasPrefix("__") && array.dtype == .int32
+                ? String(describing: array.asArray(Int32.self)) : ""
+            return "\(key)|\(array.dtype)|\(array.shape)|\(metadata)"
+        }
+    }
+
     // MARK: - Properties
 
     /// Root directory for cache files and the SQLite index.
@@ -153,7 +180,7 @@ public final class DiskCache: @unchecked Sendable {
     /// fingerprint lets `store` avoid realizing and rewriting the same large
     /// prompt boundary after a cache hit, while a fresh process still validates
     /// an inherited file before it can take the fast path.
-    private var validatedFiles: [String: ValidatedFileFingerprint] = [:]
+    private var validatedFiles: [String: ValidatedRecord] = [:]
 
     /// Trace-only identity of the most recent boundary written by this cache
     /// instance. Growing agent loops can store N tokens and immediately probe N
@@ -350,7 +377,9 @@ public final class DiskCache: @unchecked Sendable {
         // entry instead of preserving an assumption.
         if let validated = validatedFiles[hash],
            let current = _fileFingerprint(url: url),
-           current == validated,
+           current == validated.file,
+           validated.hasRecurrentGeometry,
+           Self.payloadLayout(arrays) == validated.layout,
            let indexed = _entryMetadataLocked(hash: hash),
            indexed.tokenCount == tokenCount,
            indexed.fileSize == current.size,
@@ -421,7 +450,9 @@ public final class DiskCache: @unchecked Sendable {
 
             _insertEntryLocked(hash: hash, tokenCount: tokenCount, fileSize: fileSize)
             if let fingerprint = _fileFingerprint(url: finalURL), fingerprint.size > 0 {
-                validatedFiles[hash] = fingerprint
+                validatedFiles[hash] = ValidatedRecord(
+                    file: fingerprint, layout: Self.payloadLayout(arrays),
+                    hasRecurrentGeometry: Self.hasRecurrentGeometry(Set(arrays.keys)))
             } else {
                 validatedFiles.removeValue(forKey: hash)
             }
@@ -516,7 +547,9 @@ public final class DiskCache: @unchecked Sendable {
                 throw DiskCacheIntegrityError.nonFinitePayload(nonFinite.joined(separator: ","))
             }
             if let fingerprint = _fileFingerprint(url: url), fingerprint.size > 0 {
-                validatedFiles[hash] = fingerprint
+                validatedFiles[hash] = ValidatedRecord(
+                    file: fingerprint, layout: Self.payloadLayout(arrays),
+                    hasRecurrentGeometry: Self.hasRecurrentGeometry(Set(arrays.keys)))
             }
             if touchRecency {
                 _touchEntryLocked(hash: hash)
@@ -574,7 +607,8 @@ public final class DiskCache: @unchecked Sendable {
 
         guard let validated = validatedFiles[hash],
               let current = _fileFingerprint(url: url),
-              current == validated,
+              current == validated.file,
+              validated.hasRecurrentGeometry,
               current.size > 0,
               let indexed = _entryMetadataLocked(hash: hash),
               indexed.tokenCount == tokens.count,
@@ -610,7 +644,15 @@ public final class DiskCache: @unchecked Sendable {
         else {
             return false
         }
-        return true
+        // A legacy recurrent payload is readable for ordinary two-slot caches,
+        // but cannot suppress producing the current declared representation.
+        // This also covers a cold process before its first fetch. Read only the
+        // safetensors header; do not map or realize model state to decide.
+        if let validated = validatedFiles[hash], validated.file == current {
+            return validated.hasRecurrentGeometry
+        }
+        guard let header = Self.tensorHeader(url: url) else { return false }
+        return Self.hasRecurrentGeometry(Set(header.tensors.keys))
     }
 
     /// Candidate prompt-boundary lengths currently present in the disk index.
@@ -822,6 +864,19 @@ public final class DiskCache: @unchecked Sendable {
     /// header, `data_offsets: [begin, end]` per tensor relative to the end
     /// of the header), or nil when the header itself cannot be read.
     static func declaredPayloadEnd(url: URL) -> Int? {
+        guard let header = tensorHeader(url: url) else { return nil }
+        var end = 0
+        for (key, value) in header.tensors where key != "__metadata__" {
+            guard let tensor = value as? [String: Any],
+                let offsets = tensor["data_offsets"] as? [Any], offsets.count == 2,
+                let last = (offsets[1] as? NSNumber)?.intValue
+            else { return nil }
+            end = max(end, last)
+        }
+        return 8 + header.length + end
+    }
+
+    private static func tensorHeader(url: URL) -> (length: Int, tensors: [String: Any])? {
         guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
         defer { try? handle.close() }
         guard let lengthData = try? handle.read(upToCount: 8), lengthData.count == 8 else { return nil }
@@ -830,15 +885,7 @@ public final class DiskCache: @unchecked Sendable {
         guard let headerData = try? handle.read(upToCount: headerLength), headerData.count == headerLength,
             let header = try? JSONSerialization.jsonObject(with: headerData) as? [String: Any]
         else { return nil }
-        var end = 0
-        for (key, value) in header where key != "__metadata__" {
-            guard let tensor = value as? [String: Any],
-                let offsets = tensor["data_offsets"] as? [Any], offsets.count == 2,
-                let last = (offsets[1] as? NSNumber)?.intValue
-            else { return nil }
-            end = max(end, last)
-        }
-        return 8 + headerLength + end
+        return (headerLength, header)
     }
 
     /// True when the file on disk holds every byte its header declares.

--- a/Libraries/MLXLMCommon/Cache/TQDiskSerializer.swift
+++ b/Libraries/MLXLMCommon/Cache/TQDiskSerializer.swift
@@ -465,18 +465,26 @@ public enum TQDiskSerializer {
         index i: Int,
         into result: inout [String: MLXArray]
     ) {
-        let state = mamba.state
-        guard state.count >= 1 else {
-            // Pre-prefill layer with no state at all — nothing to persist.
-            // Deserialization treats a tagged mamba layer without state as
-            // an atomic required miss.
-            return
+        serializeMambaState(mamba, prefix: "mamba_\(i)", into: &result)
+    }
+
+    /// An explicit occupancy map preserves nil holes and distinguishes a
+    /// missing tensor from an intentionally empty slot. Slot geometry comes
+    /// from the cache owner, never the model name or quantization preset.
+    private static func serializeMambaState(
+        _ mamba: MambaCache, prefix: String, into result: inout [String: MLXArray]
+    ) {
+        guard mamba[0] != nil else { return }
+        var occupied: [Int32] = []
+        for slot in 0..<mamba.persistentSlotCount {
+            if let state = mamba[slot] {
+                result["\(prefix)_state\(slot)"] = state
+                occupied.append(Int32(slot))
+            }
         }
-        result["mamba_\(i)_state0"] = state[0]
-        if state.count >= 2 {
-            result["mamba_\(i)_state1"] = state[1]
-        }
-        result["__mamba_\(i)_offset__"] = metaInt32(Int32(mamba.offset))
+        result["__\(prefix)_slots__"] = metaInt32(Int32(mamba.persistentSlotCount))
+        result["__\(prefix)_occupied__"] = MLXArray(occupied)
+        result["__\(prefix)_offset__"] = metaInt32(Int32(mamba.offset))
     }
 
     /// Serialize a single RotatingKVCache layer (sliding-window attention).
@@ -559,19 +567,9 @@ public enum TQDiskSerializer {
             let sub = list[j]
 
             if let mamba = sub as? MambaCache {
-                let state = mamba.state
-                if state.count >= 1 {
-                    result["mamba_\(i)_sub_\(j)_state0"] = state[0]
-                    if state.count >= 2 {
-                        result["mamba_\(i)_sub_\(j)_state1"] = state[1]
-                    }
-                    result["__mamba_\(i)_sub_\(j)_offset__"] =
-                        metaInt32(Int32(mamba.offset))
-                    result[subKindKey(layer: i, sub: j)] = kindArray(.mamba)
-                    anyPersisted = true
-                } else {
-                    result[subKindKey(layer: i, sub: j)] = kindArray(.skip)
-                }
+                serializeMambaState(mamba, prefix: "mamba_\(i)_sub_\(j)", into: &result)
+                result[subKindKey(layer: i, sub: j)] = kindArray(.mamba)
+                anyPersisted = true
                 continue
             }
 
@@ -893,6 +891,9 @@ public enum TQDiskSerializer {
         public let state0: MLXArray
         public let state1: MLXArray?
         public let offset: Int
+        /// Nil only for legacy one/two-slot entries.
+        public let persistentSlotCount: Int?
+        public let occupiedStates: [Int: MLXArray]
     }
 
     /// RotatingKVCache state for a single sliding-window attention layer.
@@ -1145,53 +1146,8 @@ public enum TQDiskSerializer {
                     out.append(IndexedLayerData(index: i, data: .requiredMiss))
                 }
             case .mamba:
-                if let s0 = arrays["mamba_\(i)_state0"] {
-                    // `state1` is optional: short-conv (LFM2/LFM2.5) layers
-                    // persist a single slot, full Mamba layers persist two.
-                    let offset: Int
-                    if let offArr = arrays["__mamba_\(i)_offset__"] {
-                        guard let off = readMetaInt32(offArr) else {
-                            // A recurrent state with an unreadable offset
-                            // cannot be trusted at any position — atomic miss,
-                            // same rule as an incomplete TQ payload.
-                            out.append(IndexedLayerData(index: i, data: .requiredMiss))
-                            continue
-                        }
-                        offset = Int(off)
-                    } else {
-                        // MISSING is damage, not "position zero".
-                        //
-                        // `serializeMambaLayer` writes `__mamba_i_offset__`
-                        // unconditionally whenever it writes `state0`, so a
-                        // payload carrying recurrent state without its offset
-                        // was truncated. Defaulting to 0 seated real state at
-                        // the wrong position and let the record report a hit —
-                        // the sibling branch two lines up already refuses an
-                        // UNREADABLE offset for exactly this reason, and a
-                        // missing one is no more trustworthy.
-                        out.append(IndexedLayerData(index: i, data: .requiredMiss))
-                        continue
-                    }
-                    out.append(
-                        IndexedLayerData(
-                            index: i,
-                            data: .mamba(
-                                MambaLayerComponents(
-                                    state0: s0,
-                                    state1: arrays["mamba_\(i)_state1"],
-                                    offset: offset
-                                )
-                            )
-                        )
-                    )
-                } else {
-                    // A tagged mamba layer without persisted state cannot
-                    // degrade to a KV-only hit: recurrent prefix state is
-                    // required, so the whole entry is an atomic miss (this
-                    // also retires pre-fix entries that skipped short-conv
-                    // state while stamping the mamba kind tag).
-                    out.append(IndexedLayerData(index: i, data: .requiredMiss))
-                }
+                let component = deserializeMambaState(prefix: "mamba_\(i)", from: arrays)
+                out.append(IndexedLayerData(index: i, data: component.map(LayerData.mamba) ?? .requiredMiss))
             case .qkv:
                 if let comp = deserializeQKVLayer(index: i, from: arrays) {
                     out.append(IndexedLayerData(index: i, data: .qkv(comp)))
@@ -1471,6 +1427,46 @@ public enum TQDiskSerializer {
         )
     }
 
+    private static func deserializeMambaState(
+        prefix: String, from arrays: [String: MLXArray]
+    ) -> MambaLayerComponents? {
+        guard let state0 = arrays["\(prefix)_state0"],
+              let offsetArray = arrays["__\(prefix)_offset__"],
+              let offset = readMetaInt32(offsetArray), offset >= 0
+        else { return nil }
+        let slotArray = arrays["__\(prefix)_slots__"]
+        let occupancyArray = arrays["__\(prefix)_occupied__"]
+        var states: [Int: MLXArray] = [0: state0]
+        let count: Int?
+        if slotArray != nil || occupancyArray != nil {
+            guard let slotArray, let occupancyArray,
+                  let slotCount = readMetaInt32(slotArray), slotCount > 0,
+                  occupancyArray.dtype == .int32, occupancyArray.ndim == 1,
+                  occupancyArray.size > 0, occupancyArray.size <= Int(slotCount)
+            else { return nil }
+            let occupied = occupancyArray.asArray(Int32.self).map(Int.init)
+            guard Set(occupied).count == occupied.count, occupied.contains(0),
+                  occupied.allSatisfy({ $0 >= 0 && $0 < Int(slotCount) })
+            else { return nil }
+            states = [:]
+            for slot in occupied {
+                guard let state = arrays["\(prefix)_state\(slot)"] else { return nil }
+                states[slot] = state
+            }
+            let payloadKeys = Set(arrays.keys.filter { $0.hasPrefix("\(prefix)_state") })
+            guard payloadKeys == Set(occupied.map { "\(prefix)_state\($0)" }) else { return nil }
+            count = Int(slotCount)
+        } else {
+            // Legacy records do not describe extended layouts. Restoration
+            // permits these only into ordinary one/two-slot cache geometry.
+            if let state1 = arrays["\(prefix)_state1"] { states[1] = state1 }
+            count = nil
+        }
+        return MambaLayerComponents(
+            state0: state0, state1: states[1], offset: Int(offset),
+            persistentSlotCount: count, occupiedStates: states)
+    }
+
     /// Deserialize a `CacheList` composite. Reads
     /// `__cache_list_{i}_count__` then iterates each sub-cache by its
     /// own `__cache_list_{i}_sub_{j}_kind__` tag, dispatching to the
@@ -1512,26 +1508,8 @@ public enum TQDiskSerializer {
                     subs.append(.skip)
                 }
             case .mamba:
-                if let s0 = arrays["mamba_\(i)_sub_\(j)_state0"] {
-                    let off: Int
-                    if let oa = arrays["__mamba_\(i)_sub_\(j)_offset__"] {
-                        guard let offValue = readMetaInt32(oa) else {
-                            subs.append(.skip)
-                            continue
-                        }
-                        off = Int(offValue)
-                    } else {
-                        off = 0
-                    }
-                    subs.append(
-                        .mamba(
-                            MambaLayerComponents(
-                                state0: s0,
-                                state1: arrays["mamba_\(i)_sub_\(j)_state1"],
-                                offset: off)))
-                } else {
-                    subs.append(.skip)
-                }
+                let component = deserializeMambaState(prefix: "mamba_\(i)_sub_\(j)", from: arrays)
+                subs.append(component.map(LayerData.mamba) ?? .requiredMiss)
             case .rotating:
                 if let k = arrays["rot_\(i)_sub_\(j)_keys"],
                    let v = arrays["rot_\(i)_sub_\(j)_values"],

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -1513,6 +1513,9 @@ public class ArraysCache: BaseKVCache {
 
 /// Simple cache for Mamba-style state space models
 public class MambaCache: ArraysCache {
+    /// Leading slots that belong to a resumable model state. Remaining slots
+    /// are request-local scratch and must never enter a disk snapshot.
+    public let persistentSlotCount: Int
     private struct PrefixCommitState {
         var arrays: [MLXArray]
         var offset: Int
@@ -1521,6 +1524,7 @@ public class MambaCache: ArraysCache {
     private var prefixCommitStates: [Int: PrefixCommitState] = [:]
 
     public init(leftPadding: [Int]? = nil) {
+        self.persistentSlotCount = 2
         super.init(size: 2, leftPadding: leftPadding)
     }
 
@@ -1529,7 +1533,20 @@ public class MambaCache: ArraysCache {
     /// layer's cache and stores previous-context token ids in slot 2 and the
     /// dilated-conv state in slot 3.
     public init(slots: Int, leftPadding: [Int]? = nil) {
+        precondition(slots > 0)
+        self.persistentSlotCount = slots
         super.init(size: slots, leftPadding: leftPadding)
+    }
+
+    public init(slots: Int, persistentSlotCount: Int, leftPadding: [Int]? = nil) {
+        precondition(persistentSlotCount > 0 && persistentSlotCount <= slots)
+        self.persistentSlotCount = persistentSlotCount
+        super.init(size: slots, leftPadding: leftPadding)
+    }
+
+    public override var state: [MLXArray] {
+        get { (0..<persistentSlotCount).compactMap { self[$0] } }
+        set { super.state = newValue }
     }
 
     public func recordPrefixCommitState(length: Int, arrays: [MLXArray], offset: Int) {
@@ -1645,7 +1662,7 @@ public class MambaCache: ArraysCache {
     }
 
     public override func copy() -> any KVCache {
-        let new = MambaCache(slots: slotCount)
+        let new = MambaCache(slots: slotCount, persistentSlotCount: persistentSlotCount)
         copySlots(into: new)
         new.offset = self.offset
         new.leftPadding = self.leftPadding

--- a/Libraries/MLXLMCommon/KVCache.swift
+++ b/Libraries/MLXLMCommon/KVCache.swift
@@ -1756,9 +1756,23 @@ public func savePromptCache(
     cache: [KVCache],
     metadata: [String: String] = [:]
 ) throws {
+    func needsMambaGeometry(_ mamba: MambaCache) -> Bool {
+        let occupied = (0..<mamba.persistentSlotCount).filter { mamba[$0] != nil }
+        return mamba.slotCount != 2 || mamba.persistentSlotCount != 2 || mamba.offset != 0
+            || occupied != Array(0..<occupied.count)
+    }
     let cacheData = cache.map { $0.state }
-    let cacheInfo = cache.map { $0.metaState }
-    // Use Python-compatible class names for cross-platform compatibility
+    let cacheInfo = cache.map { layer -> [String] in
+        if let mamba = layer as? MambaCache, needsMambaGeometry(mamba) {
+            let occupied = (0..<mamba.persistentSlotCount).filter { mamba[$0] != nil }
+            return ["1", String(mamba.slotCount), String(mamba.persistentSlotCount),
+                    String(mamba.offset), occupied.map(String.init).joined(separator: ",")]
+        }
+        return layer.metaState
+    }
+    // Ordinary layouts retain Python-compatible names. Extended recurrent
+    // records use a distinct class tag so older readers reject rather than
+    // silently seating a partial state into their default two-slot cache.
     let cacheClasses = cache.map { cache -> String in
         switch cache {
         case is ChunkedKVCache:
@@ -1769,8 +1783,8 @@ public func savePromptCache(
             return "RotatingKVCache"
         case is QuantizedKVCache:
             return "QuantizedKVCache"
-        case is MambaCache:
-            return "MambaCache"  // Must precede ArraysCache because of inheritance
+        case let mamba as MambaCache:
+            return needsMambaGeometry(mamba) ? "VmlxMambaCacheV1" : "MambaCache"
         case is ArraysCache:
             return "ArraysCache"
         case is CacheList:
@@ -1872,7 +1886,31 @@ public func loadPromptCache(
         case "ChunkedKVCache":
             cache = ChunkedKVCache()
         case "MambaCache":
+            guard cacheData[i].count <= 2 else {
+                throw KVCacheError(message: "Extended legacy Mamba cache lacks persistent-slot geometry")
+            }
             cache = MambaCache()
+        case "VmlxMambaCacheV1":
+            let info = cacheInfo[i]
+            guard info.count == 5, info[0] == "1",
+                  let slots = Int(info[1]), slots > 0, slots <= 4096,
+                  let persistent = Int(info[2]), persistent > 0, persistent <= slots,
+                  let offset = Int(info[3]), offset >= 0
+            else { throw KVCacheError(message: "Invalid persistent Mamba cache geometry") }
+            // Bound metadata-driven allocation before constructing the cache.
+            // This is a file-format resource limit, not model dispatch.
+            let rawIndices = info[4].split(separator: ",", omittingEmptySubsequences: false)
+            let occupied = info[4].isEmpty ? [] : rawIndices.compactMap { Int($0) }
+            guard (info[4].isEmpty || occupied.count == rawIndices.count),
+                  occupied.count == cacheData[i].count,
+                  Set(occupied).count == occupied.count, occupied == occupied.sorted(),
+                  occupied.allSatisfy({ $0 >= 0 && $0 < persistent })
+            else { throw KVCacheError(message: "Invalid persistent Mamba cache occupancy") }
+            let mamba = MambaCache(slots: slots, persistentSlotCount: persistent)
+            for (slot, state) in zip(occupied, cacheData[i]) { mamba[slot] = state }
+            mamba.offset = offset
+            caches.append(mamba)
+            continue
         case "ArraysCache":
             // Size doesn't matter here as it's only needed to initialize the `cache` container inside
             // The container will be set as a `state` with correct size before returning a cache

--- a/Libraries/MLXVLM/Models/Qwen4Exp.swift
+++ b/Libraries/MLXVLM/Models/Qwen4Exp.swift
@@ -1562,7 +1562,9 @@ public final class Qwen4Exp: Module, VLMModel, Qwen4ExpModelDirectoryConfigurabl
     public func newCache(parameters: GenerateParameters?) -> [KVCache] {
         textModel.layers.map { layer in
             if layer.isLinear {
-                return MambaCache(slots: layer.ple == nil ? 2 : 6) as KVCache
+                return MambaCache(
+                    slots: layer.ple == nil ? 2 : 6,
+                    persistentSlotCount: layer.ple == nil ? 2 : 4) as KVCache
             }
             return QSAKVCache() as KVCache
         }

--- a/Tests/MLXLMTests/CacheHelpersTests.swift
+++ b/Tests/MLXLMTests/CacheHelpersTests.swift
@@ -221,7 +221,7 @@ import Testing
 }
 
 @Test func restoreSSMStatesSupportsExtendedPLEMambaAlongsideOrdinaryMamba() {
-    let sourcePLE = MambaCache(slots: 6)
+    let sourcePLE = MambaCache(slots: 6, persistentSlotCount: 4)
     for index in 0 ..< 4 {
         sourcePLE[index] = MLXArray([Int32(index + 10)])
     }
@@ -232,7 +232,7 @@ import Testing
     let states = extractSSMStates(from: [sourcePLE, sourceOrdinary])
     #expect(states.count == 6)
 
-    let restoredPLE = MambaCache(slots: 6)
+    let restoredPLE = MambaCache(slots: 6, persistentSlotCount: 4)
     let restoredOrdinary = MambaCache()
     restoreSSMStates(states, into: [restoredPLE, restoredOrdinary], boundary: 17)
 

--- a/Tests/MLXLMTests/FlashPersistentDiskContinuationTests.swift
+++ b/Tests/MLXLMTests/FlashPersistentDiskContinuationTests.swift
@@ -1,0 +1,247 @@
+import Foundation
+import MLX
+import MLXNN
+import MLXRandom
+@testable import MLXLMCommon
+@testable import MLXVLM
+import Testing
+
+// Bounded generated fixture: no installed model or experimental sampled verifier.
+@Suite(.serialized)
+struct FlashPersistentDiskContinuationTests {
+    private func withFixture(routedBits: [Int] = [], mtpEnabled: Bool = false,
+                             inputProjectionBits: Int? = nil, _ body: (Qwen4Exp) throws -> Void) throws {
+        // Entire geometry is bounded before construction; no installed model is read.
+        let data = Data(
+            """
+            {
+              "model_type":"qwen4_exp","eos_token_id":1,
+              "text_config":{
+                "model_type":"qwen4_exp_text","dtype":"float32",
+                "hidden_size":64,"num_hidden_layers":2,"intermediate_size":64,
+                "num_attention_heads":4,"num_key_value_heads":1,"head_dim":16,
+                "linear_num_value_heads":4,"linear_num_key_heads":1,
+                "linear_key_head_dim":16,"linear_value_head_dim":16,
+                "linear_conv_kernel_dim":4,"vocab_size":128,
+                "num_experts":8,"num_experts_per_tok":2,
+                "moe_intermediate_size":16,"shared_expert_intermediate_size":16,
+                "layer_types":["linear_attention","full_attention"],
+                "hc_count":4,"hc_lowrank":8,"ple_layer_ids":[1],
+                "ple_embed_dim":64,"ple_conv_kernel_size":4,
+                "ngram_size":3,"heads_per_ngram":2,"ngram_vocab_size_base":101,
+                "make_ngram_vocab_size_divisible_by":128,"seed":1234,
+                "split_ngram_parts":4,"indexer_n_heads":2,"indexer_kv_heads":1,
+                "indexer_head_dim":8,"indexer_budget":32,"indexer_compress_ratio":4,
+                "mrope_section":[1,1,1],"mtp_num_hidden_layers":0
+              }
+            }
+            """.utf8)
+        var fixtureData = data
+        if mtpEnabled {
+            var root = try #require(JSONSerialization.jsonObject(with: fixtureData) as? [String: Any])
+            var text = try #require(root["text_config"] as? [String: Any])
+            text["mtp_num_hidden_layers"] = 1
+            root["text_config"] = text
+            fixtureData = try JSONSerialization.data(withJSONObject: root)
+        }
+        var routedSpecs: [String: Int] = [:]
+        if !routedBits.isEmpty {
+            try #require(routedBits.count == 3 && (routedBits == [0, 0, 0] || routedBits.allSatisfy { [2, 3, 4, 6].contains($0) }))
+            var root = try #require(JSONSerialization.jsonObject(with: fixtureData) as? [String: Any])
+            var text = try #require(root["text_config"] as? [String: Any])
+            text["dtype"] = "bfloat16"
+            text["moe_intermediate_size"] = 64
+            text["shared_expert_intermediate_size"] = 64
+            root["text_config"] = text
+            var quantization: [String: Any] = ["bits": 8, "group_size": 64]
+            for layer in 0..<2 {
+                for (projection, bits) in zip(["gate_proj", "up_proj", "down_proj"], routedBits) {
+                    if bits == 0 { continue } // BF16 dense control, same geometry.
+                    let path = "language_model.layers.\(layer).mlp.switch_mlp.\(projection)"
+                    routedSpecs[path] = bits
+                    quantization[path] = ["bits": bits, "group_size": 64]
+                }
+            }
+            if let bits = inputProjectionBits {
+                try #require([2, 3, 4, 6, 8].contains(bits))
+                for name in ["in_proj_qkv", "in_proj_z", "in_proj_a", "in_proj_b"] {
+                    let path = "language_model.layers.0.linear_attn.\(name)"
+                    routedSpecs[path] = bits
+                    quantization[path] = ["bits": bits, "group_size": 64]
+                }
+            }
+            if !routedSpecs.isEmpty { root["quantization"] = quantization }
+            fixtureData = try JSONSerialization.data(withJSONObject: root)
+        }
+        let config = try JSONDecoder().decode(Qwen4ExpConfiguration.self, from: fixtureData)
+        let text = config.base.textConfiguration
+        try #require(text.hiddenSize == 64 && text.hiddenLayers == 2)
+        try #require(text.vocabularySize == 128 && text.numExperts == 8)
+        MLXRandom.seed(0)
+        let model = Qwen4Exp(config)
+        let count = model.parameters().flattened().reduce(0) { $0 + $1.1.size }
+        try #require(count < 2_000_000, "refuse fixture drift before MLX evaluation")
+        if !routedBits.isEmpty {
+            // Match the retained live parameter-domain contract: ordinary
+            // parameters BF16, router weights FP32. This is still a tiny
+            // generated fixture, not a shipped-weight numerical reference.
+            model.update(parameters: ModuleParameters.unflattened(
+                model.parameters().flattened().map { path, value in
+                    (path, path.hasSuffix(".mlp.gate.weight") ? value : value.asType(.bfloat16))
+                }))
+        }
+        if !routedSpecs.isEmpty {
+            quantize(model: model, filter: { path, _ in
+                guard let bits = routedSpecs[path] else { return nil }
+                return (groupSize: 64, bits: bits, mode: QuantizationMode.affine)
+            })
+            let leaves = Dictionary(uniqueKeysWithValues: model.leafModules().flattened())
+            for (path, bits) in routedSpecs {
+                let projection = try #require(leaves[path] as? any Quantized)
+                try #require(projection.bits == bits && projection.groupSize == 64)
+            }
+            model.update(parameters: ModuleParameters.unflattened(
+                model.parameters().flattened().compactMap { path, value in
+                    guard path.hasSuffix(".scales") || path.hasSuffix(".biases") else { return nil }
+                    return (path, value.asType(.float16))
+                }))
+        }
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("flash-prefill-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        var arrays: [String: MLXArray] = [:]
+        var map: [String: String] = [:]
+        var specs: [String: [String: Int]] = [:]
+        for shard in 0 ..< 4 {
+            let base = "language_model.layers.0.ple.ngram_embedding.shards.\(shard)"
+            arrays[base + ".weight"] = MLXArray(
+                (0 ..< (128 * 2)).map { UInt32(truncatingIfNeeded: ($0 + shard) * 0x12345) }
+            ).reshaped(128, 2)
+            arrays[base + ".scales"] = MLXArray.full([128, 4], values: MLXArray(Float(0.01)))
+                .asType(.float16)
+            arrays[base + ".biases"] = MLXArray.full([128, 4], values: MLXArray(Float(-0.05)))
+                .asType(.float16)
+            specs[base + ".weight"] = ["bits": 4, "group_size": 4]
+            for suffix in [".weight", ".scales", ".biases"] {
+                map[base + suffix] = "model.safetensors"
+            }
+        }
+        try MLX.save(arrays: arrays, url: directory.appendingPathComponent("model.safetensors"))
+        try JSONSerialization.data(withJSONObject: ["weight_map": map])
+            .write(to: directory.appendingPathComponent("model.safetensors.index.json"))
+        try JSONSerialization.data(withJSONObject: ["jang_config": ["bit_map": specs]])
+            .write(to: directory.appendingPathComponent("config.json"))
+        try model.configure(modelDirectory: directory)
+        try body(model)
+    }
+
+    @Test("native Flash token cap never publishes pending tokens under an emitted-prefix key",
+          .enabled(if: ProcessInfo.processInfo.environment["MLX_ENABLE_TF32"] == "0",
+                   "Requires strict quantized-fixture oracle"), arguments: [2, 6])
+    func nativeFinalBoundaryDiskPublication(inputBits: Int) throws {
+        try MLXMetalTestLock.withLock {
+            try withFixture(routedBits: [2, 3, 4], mtpEnabled: true,
+                            inputProjectionBits: inputBits) { model in
+                for cap in [2, 3, 4, 9, 32] {
+                    let root = FileManager.default.temporaryDirectory
+                        .appendingPathComponent("flash-final-boundary-\(UUID().uuidString)")
+                    defer { try? FileManager.default.removeItem(at: root) }
+                    let coordinator = CacheCoordinator(config: CacheCoordinatorConfig(
+                        usePagedCache: false, enableDiskCache: true, diskCacheMaxGB: 1,
+                        diskCacheDir: root, modelKey: "flash-final-\(inputBits)-\(cap)"))
+                    // Let the production iterator derive topology from the
+                    // actual PLE/GDN/QSA caches, exactly as an ordinary load does.
+                    let promptIDs = [2, 3, 4]
+                    let prompt = MLXArray(promptIDs.map(Int32.init)).reshaped(1, 3)
+                    var parameters = GenerateParameters(maxTokens: cap, temperature: 1, topP: 0.95, topK: 20)
+                    parameters.randomSeed = 829
+                    parameters.draftStrategy = .nativeMTP(depth: 3)
+                    parameters.nativeMTPDepthPolicy = .fixed
+                    var iterator = try NativeMTPTokenIterator(
+                        input: LMInput(tokens: prompt), model: model, parameters: parameters,
+                        depth: 3, cacheCoordinator: coordinator)
+                    let started = Date()
+                    var emitted: [Int] = []
+                    while let token = iterator.next() { emitted.append(token) }
+                    #expect(emitted.count == cap)
+                    #expect(iterator.mtpForwardCount > 0, "native MTP must actually execute")
+                    iterator.storeCacheAfterGeneration(generatedTokenIds: emitted, includeGeneratedBoundary: true)
+                    let disk = try #require(coordinator.diskCache)
+                    // Exercise the production restore caller too; raw serializer
+                    // comparisons alone could omit a legitimate companion restore.
+                    let continuation = LMInput(tokens: MLXArray([Int32(2), 3, 4, 73]).reshaped(1, 4))
+                    var cachedIterator = try NativeMTPTokenIterator(
+                        input: continuation, model: model, parameters: parameters, depth: 3,
+                        cacheCoordinator: coordinator)
+                    var freshIterator = try NativeMTPTokenIterator(
+                        input: continuation, model: model, parameters: parameters, depth: 3)
+                    for (layer, pair) in zip(cachedIterator.cache, freshIterator.cache).enumerated() {
+                        #expect(pair.0.offset == pair.1.offset)
+                        #expect(pair.0.state.count == pair.1.state.count)
+                        for (slot, values) in zip(pair.0.state, pair.1.state).enumerated() {
+                            expectEqual(values.0, values.1,
+                                        "native restored inputBits\(inputBits) cap\(cap) layer\(layer) slot\(slot)")
+                        }
+                    }
+                    cachedIterator.storeCacheAfterGeneration(generatedTokenIds: [], includeGeneratedBoundary: false)
+                    freshIterator.storeCacheAfterGeneration(generatedTokenIds: [], includeGeneratedBoundary: false)
+                    // A missing post-answer snapshot is allowed for non-trimmable
+                    // recurrent state. A snapshot published under this key must
+                    // represent exactly the emitted prefix, never queued tokens.
+                    var restoredCount = 0
+                    for ids in [promptIDs, promptIDs + emitted] {
+                        guard let arrays = disk.fetch(
+                            tokens: ids,
+                            mediaSalt: computeCacheSalt(for: LMInput(tokens: prompt), parameters: parameters))
+                        else { continue }
+                        var restored = model.newCache(parameters: parameters)
+                        #expect(restoreFromDiskArrays(arrays, into: &restored) == ids.count)
+                        let reference = model.newCache(parameters: parameters)
+                        MLX.eval(model.nativeBackboneForward(prompt, cache: reference).logits)
+                        for id in ids.dropFirst(promptIDs.count) {
+                            MLX.eval(model.nativeBackboneForward(
+                                MLXArray([Int32(id)]).reshaped(1, 1), cache: reference).logits)
+                        }
+                        for (layer, pair) in zip(restored, reference).enumerated() {
+                            #expect(pair.0.offset == pair.1.offset)
+                            #expect(pair.0.state.count == pair.1.state.count)
+                            for (slot, values) in zip(pair.0.state, pair.1.state).enumerated() {
+                                expectEqual(values.0, values.1,
+                                            "disk inputBits\(inputBits) cap\(cap) boundary\(ids.count) layer\(layer) slot\(slot)")
+                            }
+                        }
+                        let followup = MLXArray([Int32(73)]).reshaped(1, 1)
+                        expectEqual(model(followup, cache: restored), model(followup, cache: reference),
+                                    "disk continuation inputBits\(inputBits) cap\(cap) boundary\(ids.count)")
+                        restoredCount += 1
+                    }
+                    #expect(restoredCount > 0, "positive disk publication control must execute")
+                    print("FLASH-FINAL-DISK inputBits=\(inputBits) cap=\(cap) restored=\(restoredCount) emitted=\(emitted.count) fixtureTokS=\(Double(emitted.count) / max(Date().timeIntervalSince(started), 1e-9)) realModelSpeedProof=false")
+                }
+            }
+        }
+    }
+
+    private func expectEqual(_ actual: MLXArray, _ expected: MLXArray, _ label: String) {
+        #expect(actual.shape == expected.shape, "\(label) shape")
+        guard actual.shape == expected.shape else { return }
+        let a = actual.asType(.float32)
+        let b = expected.asType(.float32)
+        let error = MLX.max(abs(a - b)).item(Float.self)
+        if !allClose(a, b, rtol: 1e-5, atol: 1e-5).item(Bool.self) {
+            let actualValues = a.reshaped(-1).asArray(Float.self)
+            let expectedValues = b.reshaped(-1).asArray(Float.self)
+            if let index = actualValues.indices.first(where: {
+                abs(actualValues[$0] - expectedValues[$0]) > 1e-5 + 1e-5 * abs(expectedValues[$0])
+            }) {
+                print("FLASH-PARITY-DIFF \(label) shape=\(a.shape) dtype=\(actual.dtype) index=\(index) actual=\(actualValues[index]) expected=\(expectedValues[index]) maxAbs=\(error)")
+            }
+        }
+        #expect(
+            allClose(a, b, rtol: 1e-5, atol: 1e-5).item(Bool.self),
+            "\(label) maxAbs=\(error)")
+    }
+
+}

--- a/Tests/MLXLMTests/MambaPersistentDiskTests.swift
+++ b/Tests/MLXLMTests/MambaPersistentDiskTests.swift
@@ -1,9 +1,62 @@
+import Foundation
 import MLX
 @testable import MLXLMCommon
 import Testing
 
 @Suite(.serialized)
 struct MambaPersistentDiskTests {
+    @Test
+    func malformedPromptGeometryThrowsWithoutAllocatingDeclaredCapacity() throws {
+        let lock = lockSerializedMLXTest()
+        defer { lock.unlock() }
+        let source = MambaCache(slots: 6, persistentSlotCount: 4)
+        for slot in 0..<4 { source[slot] = MLXArray([Int32(slot)]) }
+        source.offset = 8
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mamba-malformed-\(UUID().uuidString).safetensors")
+        defer { try? FileManager.default.removeItem(at: path) }
+        try savePromptCache(url: path, cache: [source])
+        let (arrays, originalMetadata) = try loadArraysAndMetadata(url: path)
+        for damage in 0..<5 {
+            var metadata = originalMetadata
+            switch damage {
+            case 0: metadata["0.0.1"] = "2147483647"
+            case 1: metadata["0.0.4"] = "0,1,2,2"
+            case 2: metadata["0.0.3"] = "-1"
+            case 3: metadata["0.0.4"] = "0,1,2,9"
+            default: metadata["2.0"] = "MambaCache"
+            }
+            try MLX.save(arrays: arrays, metadata: metadata, url: path)
+            #expect(throws: KVCacheError.self) { try loadPromptCache(url: path) }
+        }
+    }
+
+    @Test
+    func promptCacheFilePreservesDeclaredGeometryAndHoles() throws {
+        let lock = lockSerializedMLXTest()
+        defer { lock.unlock() }
+        let source = MambaCache(slots: 6, persistentSlotCount: 4)
+        source[0] = MLXArray([Int32(10)])
+        source[2] = MLXArray([Int32(12)])
+        source[3] = MLXArray([Int32(13)])
+        source[4] = MLXArray([Int32(999)])
+        source.offset = 8
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mamba-prompt-\(UUID().uuidString).safetensors")
+        defer { try? FileManager.default.removeItem(at: path) }
+        try savePromptCache(url: path, cache: [source], metadata: ["test": "preserve"])
+        let (restored, metadata) = try loadPromptCache(url: path)
+        let result = try #require(restored.first as? MambaCache)
+        #expect(metadata == ["test": "preserve"])
+        #expect(result.slotCount == 6 && result.persistentSlotCount == 4)
+        #expect(result.offset == 8)
+        if result.slotCount >= 6 {
+            #expect(result[1] == nil && result[4] == nil && result[5] == nil)
+            #expect(result[2]?.item(Int32.self) == 12)
+            #expect(result[3]?.item(Int32.self) == 13)
+        }
+    }
+
     private func attention() -> KVCacheSimple {
         let cache = KVCacheSimple()
         _ = cache.update(keys: MLXArray.ones([1, 1, 8, 4]), values: MLXArray.ones([1, 1, 8, 4]))

--- a/Tests/MLXLMTests/MambaPersistentDiskTests.swift
+++ b/Tests/MLXLMTests/MambaPersistentDiskTests.swift
@@ -1,0 +1,158 @@
+import MLX
+@testable import MLXLMCommon
+import Testing
+
+@Suite(.serialized)
+struct MambaPersistentDiskTests {
+    private func attention() -> KVCacheSimple {
+        let cache = KVCacheSimple()
+        _ = cache.update(keys: MLXArray.ones([1, 1, 8, 4]), values: MLXArray.ones([1, 1, 8, 4]))
+        return cache
+    }
+
+    @Test
+    func compiledPromotionPreservesHolesAndExcludesScratch() {
+        let lock = lockSerializedMLXTest()
+        defer { lock.unlock() }
+        let source = MambaCache(slots: 6, persistentSlotCount: 4)
+        source[0] = MLXArray([Int32(10)])
+        source[2] = MLXArray([Int32(12)])
+        source[3] = MLXArray([Int32(13)])
+        source[4] = MLXArray([Int32(999)])
+        source[5] = MLXArray([Int32(998)])
+        source.offset = 8
+        let promoted = CompilableMambaCache(from: source)
+        let copied = promoted.copy() as! CompilableMambaCache
+        #expect(copied.persistentSlotCount == 4)
+        #expect(copied.state.count == 3)
+        #expect(copied.innerState().count == 5)
+        let encoded = TQDiskSerializer.serialize(cache: [attention(), copied])
+        #expect(encoded["mamba_1_state1"] == nil)
+        #expect(encoded["mamba_1_state4"] == nil && encoded["mamba_1_state5"] == nil)
+        let target = CompilableMambaCache(slots: 6, persistentSlotCount: 4)
+        target[1] = MLXArray([Int32(7)])
+        target[4] = MLXArray([Int32(8)])
+        var restored: [any KVCache] = [KVCacheSimple(), target]
+        #expect(restoreFromDiskArrays(encoded, into: &restored) == 8)
+        #expect(target[1] == nil && target[4] == nil && target[5] == nil)
+        #expect(target[2]?.item(Int32.self) == 12)
+        #expect(target[3]?.item(Int32.self) == 13)
+    }
+
+    @Test
+    func damagedMetadataRefusesBeforeSiblingMutation() {
+        let lock = lockSerializedMLXTest()
+        defer { lock.unlock() }
+        let source = MambaCache(slots: 6, persistentSlotCount: 4)
+        for slot in 0..<4 { source[slot] = MLXArray([Int32(slot + 10)]) }
+        source.offset = 8
+        let original = TQDiskSerializer.serialize(cache: [attention(), source])
+        for damage in 0..<7 {
+            var encoded = original
+            switch damage {
+            case 0: encoded.removeValue(forKey: "mamba_1_state3")
+            case 1: encoded.removeValue(forKey: "__mamba_1_slots__")
+            case 2: encoded.removeValue(forKey: "__mamba_1_occupied__")
+            case 3: encoded["__mamba_1_occupied__"] = MLXArray([Int32(0), 1, 2, 2])
+            case 4: encoded["__mamba_1_occupied__"] = MLXArray([Int32(0), 1, 2, 7])
+            case 5: encoded["__mamba_1_slots__"] = MLXArray(Int32(5))
+            default: encoded.removeValue(forKey: "__mamba_1_offset__")
+            }
+            let sibling = KVCacheSimple()
+            let target = MambaCache(slots: 6, persistentSlotCount: 4)
+            var restored: [any KVCache] = [sibling, target]
+            #expect(restoreFromDiskArrays(encoded, into: &restored) == 0, "damage=\(damage)")
+            #expect(sibling.offset == 0 && target.state.isEmpty, "damage=\(damage)")
+        }
+    }
+
+    @Test
+    func nestedRecurrentChildrenRestoreByIndexAndRejectDamage() {
+        let lock = lockSerializedMLXTest()
+        defer { lock.unlock() }
+        let first = MambaCache()
+        first[0] = MLXArray([Int32(7)])
+        first.offset = 8
+        let second = MambaCache(slots: 6, persistentSlotCount: 4)
+        for slot in 0..<4 { second[slot] = MLXArray([Int32(slot + 20)]) }
+        second.offset = 8
+        let original = TQDiskSerializer.serialize(cache: [attention(), CacheList(first, second)])
+        for damaged in [false, true] {
+            var encoded = original
+            if damaged { encoded.removeValue(forKey: "mamba_1_sub_1_state3") }
+            let sibling = KVCacheSimple()
+            let a = MambaCache()
+            let b = MambaCache(slots: 6, persistentSlotCount: 4)
+            var restored: [any KVCache] = [sibling, CacheList(a, b)]
+            #expect(restoreFromDiskArrays(encoded, into: &restored) == (damaged ? 0 : 8))
+            if damaged {
+                #expect(sibling.offset == 0 && a.state.isEmpty && b.state.isEmpty)
+            } else {
+                #expect(a[0]?.item(Int32.self) == 7 && a[1] == nil)
+                #expect(b[0]?.item(Int32.self) == 20 && b[3]?.item(Int32.self) == 23)
+            }
+        }
+    }
+
+    @Test
+    func ordinaryLegacyOneAndTwoOccupiedSlotsRemainReadable() {
+        let lock = lockSerializedMLXTest()
+        defer { lock.unlock() }
+        for occupied in [1, 2] {
+            let source = MambaCache()
+            for slot in 0..<occupied { source[slot] = MLXArray([Int32(slot + 30)]) }
+            source.offset = 8
+            var encoded = TQDiskSerializer.serialize(cache: [attention(), source])
+            encoded.removeValue(forKey: "__mamba_1_slots__")
+            encoded.removeValue(forKey: "__mamba_1_occupied__")
+            let target = MambaCache()
+            var restored: [any KVCache] = [KVCacheSimple(), target]
+            #expect(restoreFromDiskArrays(encoded, into: &restored) == 8)
+            #expect(target.state.count == occupied)
+            #expect(target[0]?.item(Int32.self) == 30)
+        }
+    }
+
+    @Test
+    func extendedStateSurvivesWithoutCompanion() {
+        let lock = lockSerializedMLXTest()
+        defer { lock.unlock() }
+        let recurrent = MambaCache(slots: 6, persistentSlotCount: 4)
+        for slot in 0..<4 { recurrent[slot] = MLXArray([Int32(slot + 10)]) }
+        recurrent.offset = 8
+        let attention = KVCacheSimple()
+        _ = attention.update(
+            keys: MLXArray.ones([1, 1, 8, 4]), values: MLXArray.ones([1, 1, 8, 4]))
+        let encoded = TQDiskSerializer.serialize(cache: [attention, recurrent])
+        let target = MambaCache(slots: 6, persistentSlotCount: 4)
+        var restored: [any KVCache] = [KVCacheSimple(), target]
+        #expect(restoreFromDiskArrays(encoded, into: &restored) == 8)
+        for slot in 0..<4 {
+            #expect(target[slot]?.item(Int32.self) == Int32(slot + 10))
+        }
+        #expect(target.slotCount == 6)
+        #expect(target[4] == nil && target[5] == nil)
+    }
+
+    @Test
+    func legacyTwoSlotPayloadCannotSeatExtendedCache() {
+        let lock = lockSerializedMLXTest()
+        defer { lock.unlock() }
+        let old = MambaCache()
+        old[0] = MLXArray([Int32(10)])
+        old[1] = MLXArray([Int32(11)])
+        old.offset = 8
+        let attention = KVCacheSimple()
+        _ = attention.update(
+            keys: MLXArray.ones([1, 1, 8, 4]), values: MLXArray.ones([1, 1, 8, 4]))
+        var encoded = TQDiskSerializer.serialize(cache: [attention, old])
+        encoded.removeValue(forKey: "__mamba_1_slots__")
+        encoded.removeValue(forKey: "__mamba_1_occupied__")
+        let target = MambaCache(slots: 6, persistentSlotCount: 4)
+        let untouched = KVCacheSimple()
+        var restored: [any KVCache] = [untouched, target]
+        #expect(restoreFromDiskArrays(encoded, into: &restored) == 0)
+        #expect(untouched.offset == 0)
+        #expect(target.state.isEmpty)
+    }
+}

--- a/Tests/MLXLMTests/MambaPersistentDiskTests.swift
+++ b/Tests/MLXLMTests/MambaPersistentDiskTests.swift
@@ -6,6 +6,72 @@ import Testing
 @Suite(.serialized)
 struct MambaPersistentDiskTests {
     @Test
+    func sameKeyPayloadLayoutChangesAreNotDeduplicated() throws {
+        let lock = lockSerializedMLXTest()
+        defer { lock.unlock() }
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("disk-layout-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let disk = DiskCache(cacheDir: root, maxSizeGB: 0.1)
+        let tokens = [2, 3, 5]
+        for change in 0..<4 {
+            let arrays: [String: MLXArray] = [
+                "data": change < 2 ? MLXArray.ones([2, 2])
+                    : MLXArray.ones([2, 4]).asType(change == 2 ? .float32 : .float16),
+                "__test_geometry__": MLXArray([Int32(change == 0 ? 2 : 4)]),
+            ]
+            let skips = disk.snapshotStats().storeSkips
+            disk.store(tokens: tokens, arrays: arrays)
+            #expect(disk.snapshotStats().storeSkips == skips)
+            let restored = try #require(disk.fetch(tokens: tokens))
+            #expect(restored["data"]?.shape == arrays["data"]?.shape)
+            #expect(restored["data"]?.dtype == arrays["data"]?.dtype)
+            #expect(restored["__test_geometry__"]?.item(Int32.self) == (change == 0 ? 2 : 4))
+            disk.store(tokens: tokens, arrays: arrays)
+            #expect(disk.snapshotStats().storeSkips == skips + 1)
+        }
+    }
+
+    @Test
+    func legacyDiskRecordCanBeReplacedByCompletePersistentState() throws {
+        let lock = lockSerializedMLXTest()
+        defer { lock.unlock() }
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mamba-migration-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let disk = DiskCache(cacheDir: root, maxSizeGB: 0.1)
+        let source = MambaCache(slots: 6, persistentSlotCount: 4)
+        for slot in 0..<4 { source[slot] = MLXArray([Int32(slot + 10)]) }
+        source.offset = 8
+        let complete = TQDiskSerializer.serialize(cache: [attention(), source])
+        var legacy = complete
+        for key in ["__mamba_1_slots__", "__mamba_1_occupied__",
+                    "mamba_1_state2", "mamba_1_state3"] {
+            legacy.removeValue(forKey: key)
+        }
+        let tokens = Array(0..<8)
+        disk.store(tokens: tokens, arrays: legacy)
+        #expect(!disk.hasValidatedEntry(tokens: tokens))
+        #expect(!disk.hasDurableEntry(tokens: tokens))
+        let reopened = DiskCache(cacheDir: root, maxSizeGB: 0.1)
+        #expect(!reopened.hasDurableEntry(tokens: tokens))
+        let candidate = try #require(disk.fetch(tokens: tokens))
+        var rejected: [any KVCache] = [KVCacheSimple(), MambaCache(slots: 6, persistentSlotCount: 4)]
+        #expect(restoreFromDiskArrays(candidate, into: &rejected) == 0)
+        // A real full prefill republishes the same token key with complete state.
+        // A file-level validation must not suppress this format migration.
+        disk.store(tokens: tokens, arrays: complete)
+        #expect(disk.hasValidatedEntry(tokens: tokens))
+        #expect(reopened.hasDurableEntry(tokens: tokens))
+        let migrated = try #require(disk.fetch(tokens: tokens))
+        var restored: [any KVCache] = [KVCacheSimple(), MambaCache(slots: 6, persistentSlotCount: 4)]
+        #expect(restoreFromDiskArrays(migrated, into: &restored) == 8)
+        let skips = disk.snapshotStats().storeSkips
+        disk.store(tokens: tokens, arrays: complete)
+        #expect(disk.snapshotStats().storeSkips == skips + 1)
+    }
+
+    @Test
     func malformedPromptGeometryThrowsWithoutAllocatingDeclaredCapacity() throws {
         let lock = lockSerializedMLXTest()
         defer { lock.unlock() }

--- a/Tests/MLXLMTests/TQDiskSerializerTests.swift
+++ b/Tests/MLXLMTests/TQDiskSerializerTests.swift
@@ -348,9 +348,8 @@ func testRoundTripHybridWithSSMState() async throws {
     #expect(restored[2].state.count == 2)
 }
 
-/// Exact qwen4_exp warm-prefix sequence: the v2 payload seats the ordinary
-/// two-slot Mamba prefix first, then the separately stored SSM companion
-/// restores the PLE host's additional persistent slots. Neither step may
+/// Exact qwen4_exp warm-prefix sequence: the v2 payload seats every persistent
+/// slot, even when no separate SSM companion is available. Neither restore may
 /// collapse the model-declared six-slot container.
 @Test
 func testQwen4ExpExtendedPLEWarmRestoreSequence() async throws {
@@ -361,7 +360,7 @@ func testQwen4ExpExtendedPLEWarmRestoreSequence() async throws {
     let (keys, values) = smallKV(seqLen: 12)
     _ = attention.update(keys: keys, values: values)
 
-    let ple = MambaCache(slots: 6)
+    let ple = MambaCache(slots: 6, persistentSlotCount: 4)
     for index in 0 ..< 4 {
         ple[index] = MLXArray([Int32(index + 10)])
     }
@@ -377,15 +376,15 @@ func testQwen4ExpExtendedPLEWarmRestoreSequence() async throws {
     let companion = extractSSMStates(from: source)
     #expect(companion.count == 6)
 
-    let restoredPLE = MambaCache(slots: 6)
+    let restoredPLE = MambaCache(slots: 6, persistentSlotCount: 4)
     let restoredOrdinary = MambaCache()
     var restored: [any KVCache] = [KVCacheSimple(), restoredPLE, restoredOrdinary]
 
     let restoredTokens = restoreFromDiskArrays(diskPayload, into: &restored)
     #expect(restoredTokens == 12)
     #expect(restoredPLE.slotCount == 6)
-    #expect(restoredPLE.state.count == 2)
-    #expect(restoredPLE[2] == nil)
+    #expect(restoredPLE.state.count == 4)
+    #expect(restoredPLE[2]?.item(Int32.self) == 12)
 
     restoreSSMStates(companion, into: restored, boundary: restoredTokens)
     #expect(restoredPLE.slotCount == 6)


### PR DESCRIPTION
## Scope

Current head: 04b964a5d298d91b91cb52dc5fd5b0ae55c20031. Earlier candidate SHAs below identify their individual test stages, not the current PR head. Osaurus integration PR2719 pins this head at ec527251a5626163c598e465d086fe4ccb50155e; final Release build and visual proof remain pending.

Persist every runtime-declared recurrent state slot in the typed disk-cache record. Qwen3.8 Flash Next's PLE host declares four persistent slots in a six-slot cache; the last two slots are transient verification scratch. The previous serializer retained only slots0/1, losing token history and PLE convolution state while restoration still reported a hit.

The record now carries persistent-slot geometry and occupied indices. Decoding preserves nil holes and rejects missing or inconsistent metadata/tensors. Restoration checks recurrent layouts before mutating attention siblings, including indexed CacheList children. Legacy ordinary one/two-slot records remain readable; they cannot populate extended layouts. Compiled-cache promotion/copy retains the declaration. No quantization-preset or model-name dispatch is added to the serializer.

## Candidate and evidence — PARTIAL

Candidate: 2bfe43e5f15927d7fbf445a7e01616ad70802af3, based on main32c17d486ad18d1b0ee67e8036b9d3d3f4afd650. This PR excludes the pending QSA rollback retention and experimental sampled-MTP changes. No speed claim or default-MTP-policy change.

Failing-before focused test: MambaPersistentDiskBefore__053305, two tests/five assertion issues: restored slots2/3 were nil, and an incompatible record reported8tokens while mutating an attention sibling. Passing-after development gate: MambaPersistentDiskEdges__054329, eight selected tests passed, including compiled promotion, nil-hole preservation, scratch exclusion, metadata corruption, nested-cache indices and ordinary legacy one/two-slot controls. Peak1.07GiB, swap unchanged0.51GiB, cleanup0/0/0.

Preliminary native iterator fixture: FlashPersistentNativeRestore__054359 passed10 input-bit/token-cap combinations (2/6-bit inputs; caps2/3/4/9/32), where the earlier native disk-continuation fixture had89 assertion issues. This run included the separate uncommitted sampled-staging experiment and is NOT exact-commit proof for this PR. The fixture used strict TF32-off comparisons and generated tiny weights; it is not shipped-model speed or UI proof.

All named logs/.mem/.procs are under /Users/eric/vmlx-private-evidence/mtp-swift-2026-09-04/logs. Detailed source/test ledger: /Users/eric/vmlx-private-evidence/post-1653-qwen38-audit/MTP-SAMPLED-NEXT-2026-09-11.md.

## Isolated follow-up evidence

Current pushed candidate: d93d02e9b5673b01d45a27aac55d1ef66c70e93d. Generic prompt-cache files now preserve declared geometry, occupied indices and offset using a versioned class tag; older readers reject the extension instead of silently restoring two slots. Ordinary compatible two-slot records retain their old format. Malformed metadata is rejected before allocation. No Python interoperability claim for the new extension.

FlashPersistentIsolatedShared__054744 passed 21 tests on clean 2bfe43e5. MambaPromptGeometryBefore__055247 reproduced geometry and offset loss; MambaPromptGeometryAfter__055413 passed 10 selected tests. FlashPersistentFinalContract__055727 passed 24 tests in three suites on the exact source subsequently committed as d93d02e9, including native iterator continuation across all ten 2/6-bit input and token-cap combinations, mixed expert quantization, disk restore, copy, serialization, malformed metadata and SSM controls. Exit0; peak tracked footprint1.06GiB; swap unchanged0.51GiB; cleanup group/tracked/watchdog0/0/0. Generated tiny weights, TF32 off, prefetch off: this is runtime fixture proof, not shipped-model speed or visual app proof.

## Remaining gates

Upgrade follow-up: MambaMigrationBefore__060644 reproduced an incomplete legacy record surviving a same-key complete replacement (restored0instead8). The writer now compares tensor layout and typed serializer metadata before deduplication; validated/durable checks do not suppress upgrading legacy recurrent records lacking declared geometry. Legacy ordinary records remain readable. MambaMigrationAfter__060953 passed11 tests; final FlashDiskMigrationFinal__061128 passed40 tests/4 suites, including changed metadata/shape/dtype, unchanged-record deduplication, cold/warm legacy replacement eligibility, disk integrity and native continuation. Peak1.01GiB,swapflat0.51GiB,cleanup0/0/0. All fixtures only; app proof remains pending on the follow-up pin.

- Real Release Osaurus load, multi-turn/tool/cache restore proof, resource telemetry and app integration pin. No app consumes this commit yet.
- No claim that this fixes the separate16GiB back-to-back delegation refusal or guarantees an AR speed floor.

No release requested. Draft until remaining proof is recorded.
