### PR TITLE
Qwen4Exp: bound text prefill by the configured chunk size

### DIFF
--- a/Libraries/MLXVLM/Models/Qwen4Exp.swift
+++ b/Libraries/MLXVLM/Models/Qwen4Exp.swift
@@ -1575,7 +1575,26 @@ public final class Qwen4Exp: Module, VLMModel, Qwen4ExpModelDirectoryConfigurabl
 
         guard input.image != nil || input.video != nil else {
             setRopeDelta(0, for: cache)
-            return .logits(LMOutput(logits: callAsFunction(inputIds, cache: cache)))
+            // Native MTP calls prepare directly, unlike the batch AR lane's
+            // outer segmentation. Honor the same prefill budget here so a
+            // cold or required-tool request cannot materialize a whole long
+            // prompt's expert activations and vocabulary logits at once.
+            let tokens = inputIds.ndim == 1 ? inputIds.expandedDimensions(axis: 0) : inputIds
+            let step = windowSize ?? 512
+            let count = tokens.dim(1)
+            var offset = 0
+            if step > 0 {
+                while count - offset > step {
+                    try Task.checkCancellation()
+                    _ = callAsFunction(tokens[0..., offset..<(offset + step)], cache: cache)
+                    MLX.eval(cache)
+                    offset += step
+                    PrefillProgressReporter.reportCompletedUnits(offset)
+                    MLX.Memory.clearCache()
+                }
+            }
+            try Task.checkCancellation()
+            return .logits(LMOutput(logits: callAsFunction(tokens[0..., offset...], cache: cache)))
         }
 
         // Media arrived at a model that carries no vision tower. Refuse rather than embed the

--- a/Tests/MLXLMTests/FlashPersistentDiskContinuationTests.swift
+++ b/Tests/MLXLMTests/FlashPersistentDiskContinuationTests.swift
@@ -9,6 +9,23 @@ import Testing
 // Bounded generated fixture: no installed model or experimental sampled verifier.
 @Suite(.serialized)
 struct FlashPersistentDiskContinuationTests {
+    private final class ProgressRecorder: @unchecked Sendable {
+        private let lock = NSLock()
+        private var values: [Int] = []
+
+        func append(_ value: Int) {
+            lock.lock()
+            values.append(value)
+            lock.unlock()
+        }
+
+        func snapshot() -> [Int] {
+            lock.lock()
+            defer { lock.unlock() }
+            return values
+        }
+    }
+
     private func withFixture(routedBits: [Int] = [], mtpEnabled: Bool = false,
                              inputProjectionBits: Int? = nil, _ body: (Qwen4Exp) throws -> Void) throws {
         // Entire geometry is bounded before construction; no installed model is read.
@@ -222,6 +239,101 @@ struct FlashPersistentDiskContinuationTests {
                 }
             }
         }
+    }
+
+    @Test("Flash text prepare honors its chunk budget without changing continuation state",
+          .enabled(if: ProcessInfo.processInfo.environment["MLX_ENABLE_TF32"] == "0",
+                   "Requires strict fixture oracle"), arguments: [0, 2, 6])
+    func textPrefillChunkBudget(inputBits: Int) throws {
+        try MLXMetalTestLock.withLock {
+            try withFixture(routedBits: inputBits == 0 ? [] : [2, 3, 4],
+                            inputProjectionBits: inputBits == 0 ? nil : inputBits) { model in
+                let tokens = MLXArray((2..<15).map(Int32.init)).reshaped(1, 13)
+                let referenceCache = model.newCache(parameters: nil)
+                let referenceLogits = model(tokens, cache: referenceCache)
+                MLX.eval(referenceLogits, referenceCache)
+                for step in [1, 2, 4, 8, 13] {
+                    let cache = model.newCache(parameters: nil)
+                    guard case .logits(let output) = try model.prepare(
+                        LMInput(tokens: tokens), cache: cache, windowSize: step)
+                    else { Issue.record("text prepare must return final-chunk logits"); continue }
+                    MLX.eval(output.logits, cache)
+                    #expect(output.logits.dim(1) <= step,
+                            "prepare must not retain full-prompt logits beyond the supplied chunk budget")
+                    expectEqual(output.logits[0..., (-1)..., 0...],
+                                referenceLogits[0..., (-1)..., 0...], "chunk\(step) final logits")
+                    for (layer, pair) in zip(cache, referenceCache).enumerated() {
+                        #expect(pair.0.offset == pair.1.offset)
+                        #expect(pair.0.state.count == pair.1.state.count)
+                        for (slot, states) in zip(pair.0.state, pair.1.state).enumerated() {
+                            expectEqual(states.0, states.1, "chunk\(step) layer\(layer) state\(slot)")
+                        }
+                    }
+                    let next = MLXArray([Int32(73)]).reshaped(1, 1)
+                    let referenceCopy = referenceCache.map { $0.copy() }
+                    MLX.eval(referenceCopy)
+                    expectEqual(model(next, cache: cache), model(next, cache: referenceCopy),
+                                "chunk\(step) continuation")
+                }
+            }
+        }
+    }
+
+    @Test("Flash default prefill budget reports real progress past the QSA budget",
+          .enabled(if: ProcessInfo.processInfo.environment["MLX_ENABLE_TF32"] == "0",
+                   "Requires strict fixture oracle"))
+    func defaultPrefillBudgetAndProgress() throws {
+        try MLXMetalTestLock.withLock {
+            try withFixture { model in
+                let tokens = MLXArray((0..<513).map { Int32(2 + $0 % 100) }).reshaped(1, 513)
+                let referenceCache = model.newCache(parameters: nil)
+                let reference = model(tokens, cache: referenceCache)
+                MLX.eval(reference, referenceCache)
+                for step: Int? in [nil, 64, 0, -1] {
+                    let cache = model.newCache(parameters: nil)
+                    let recorder = ProgressRecorder()
+                    let prepared = try PrefillProgressReporter.withHandler({ recorder.append($0) }) {
+                        try model.prepare(LMInput(tokens: tokens), cache: cache, windowSize: step)
+                    }
+                    guard case .logits(let output) = prepared else {
+                        Issue.record("expected final logits"); continue
+                    }
+                    MLX.eval(output.logits, cache)
+                    let effectiveStep = step ?? 512
+                    #expect(output.logits.dim(1) == (effectiveStep > 0 ? 1 : 513))
+                    #expect(recorder.snapshot() == (effectiveStep > 0
+                        ? Array(stride(from: effectiveStep, to: 513, by: effectiveStep)) : []))
+                    expectEqual(output.logits[0..., (-1)..., 0...],
+                                reference[0..., (-1)..., 0...], "default/long QSA final logits")
+                    let referenceCopy = referenceCache.map { $0.copy() }
+                    MLX.eval(referenceCopy)
+                    let next = MLXArray([Int32(73)]).reshaped(1, 1)
+                    expectEqual(model(next, cache: cache), model(next, cache: referenceCopy),
+                                "default/long QSA continuation")
+                }
+            }
+        }
+    }
+
+    @Test("Flash text prefill cancellation does not advance the cache")
+    func cancelledPrefillDoesNotAdvanceCache() async throws {
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            try MLXMetalTestLock.withLock {
+                try withFixture { model in
+                    let cache = model.newCache(parameters: nil)
+                    do {
+                        _ = try model.prepare(
+                            LMInput(tokens: MLXArray([Int32(2), 3, 4]).reshaped(1, 3)),
+                            cache: cache, windowSize: 1)
+                        Issue.record("cancelled prepare unexpectedly completed")
+                    } catch is CancellationError {
+                        #expect(cache.allSatisfy { $0.offset == 0 })
+                    }
+                }
+            }
+        }
+        try await task.value
     }
 
     private func expectEqual(_ actual: MLXArray, _ expected: MLXArray, _ label: String) {


### PR DESCRIPTION
## Scope

Honor the supplied text prefill chunk size in Qwen4Exp.prepare, including native MTP's direct prepare call. Previously this path forwarded the entire prompt regardless of windowSize. Intermediate cache updates now materialize between chunks, real progress is reported, and cancellation is checked before each chunk. The final chunk supplies the first-token logits.

No sampler, template, quantization-preset dispatch, verifier, or media behavior changes. This stacks on #465's persistent recurrent disk-state changes; those are a separate PR.

## Evidence — PARTIAL

Failing-before: FlashPrefillBudgetBefore__071131, 1 test with 4 failures: a13-token input returned13-token logits for budgets1/2/4/8. After: FlashPrefillBudgetAfter__071220 passed the same dense fixture, final logits, recurrent/QSA state and continuation comparisons.

Final focused run FlashPrefillEdges__071500:14 tests/2 suites passed, covering dense and mixed2/3/4-bit routed experts with2/6-bit input projections; default512-token chunking over513tokens; nonpositive explicit chunk settings; actual progress values; cancellation; native disk continuation and Mamba persistent-state controls. Peak tracked footprint1.02GiB, swap unchanged0.51GiB, supervisor cleanup0/0/0. Tiny generated weights with strict TF32-off oracle: NOT shipped-model throughput or memory proof.

Logs, .mem and .procs: /Users/eric/vmlx-private-evidence/mtp-swift-2026-09-04/logs/. Detailed source/receipt ledger: /Users/eric/vmlx-private-evidence/post-1653-qwen38-audit/FLASH-TEXT-PREFILL-2026-09-11.md.

## Remaining gate

The motivating Osaurus Release run used ec527251a /engine04b964a5 and FlashNext JANG_2L at bundle defaults temperature1/topP.95/topK20. A4822-token D3 request exceeded the64GiB footprint cap and was stopped cleanly. This source defect is reproduced, but the change has not yet demonstrated lower peak footprint or completed restored continuation in the rebuilt app. Keep draft until exact-pin Release UI/API evidence is recorded. Runtime CI is waived; Osaurus exact-head CI remains required. No release.
