### PR TITLE
MTP: preserve productive depth across AR calibration

### DIFF
--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -468,6 +468,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private var arSafetyProbeStartedEmitted = 0
     private var arSafetyLastMeasuredToken = 0
     private var arSafetyCalibrationRemaining = 0
+    // Calibration refreshes the AR baseline; it is not evidence that the
+    // productive depth lost. Real loss recovery still begins at D1.
+    private var arSafetyCalibrationResumeDepth: Int?
     /// True while a kept re-entry is speculating: a trip in that state backs
     /// the resume interval off further instead of resetting it.
     private var arSafetyReentered = false
@@ -511,6 +514,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     /// measurement is dropped so the climb can be re-attempted (prompt
     /// character changes mid-generation — a table after prose).
     private var windowsSinceUpperProbe = 0
+
     private static let upperProbeCooldownWindows = 8
     /// A lower depth must beat the current one by this factor before the
     /// wall-clock rule demotes — hysteresis so measurement noise doesn't
@@ -2237,6 +2241,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
         arSafetyTokensSincePause = 0
         arSafetyCalibrationRemaining = loss ? 0 : 2
+        arSafetyCalibrationResumeDepth = loss ? nil : currentDepth
         arSafetyProbeCyclesRemaining = 0
         arSafetyProbeStartedAt = nil
         arSafetyRing.removeAll(keepingCapacity: true)
@@ -2281,11 +2286,14 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             guard arSafetyTokensSincePause >= arSafetyResumeInterval else { return }
         }
         arSafetyPaused = false
-        arSafetyStartSpeculating(hidden: hidden, nextToken: nextToken, probe: true)
+        let resumeDepth = arSafetyCalibrationResumeDepth ?? 1
+        arSafetyCalibrationResumeDepth = nil
+        arSafetyStartSpeculating(
+            hidden: hidden, nextToken: nextToken, probe: true, resumeDepth: resumeDepth)
     }
 
     private mutating func arSafetyStartSpeculating(
-        hidden: MLXArray, nextToken: MLXArray, probe: Bool
+        hidden: MLXArray, nextToken: MLXArray, probe: Bool, resumeDepth: Int = 1
     ) {
         // Same re-prime the depth controller uses on every depth change: a
         // fresh head cache, drafts from the current hidden. Drafts are only
@@ -2293,7 +2301,8 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         // cache can only cost acceptance, never correctness.
         mtpCache = model.makeNativeMTPCache()
         mtpCacheRefreshCount += 1
-        currentDepth = probe ? 1 : depth
+        currentDepth = probe
+            ? Swift.max(1, Swift.min(resumeDepth, adaptiveDepthCeiling)) : depth
         arSafetyRing.removeAll(keepingCapacity: true)
         arSafetyProbeCyclesRemaining = probe ? Self.arSafetyProbeWindow : 0
         arSafetyProbeStartedAt = probe ? NativeMTPClock.now() : nil

--- a/Tests/MLXLMCommonFocusedTests/NativeMTPDepthExecutionTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NativeMTPDepthExecutionTests.swift
@@ -7,6 +7,44 @@ import XCTest
 /// Exercises actual iterator verify dispatch. The zero-weight constant target
 /// makes every proposal correct; it is not a model-quality or speed benchmark.
 final class NativeMTPDepthExecutionTests: XCTestCase {
+    func testProductiveCalibrationResumesPriorDepth() throws {
+        guard ProcessInfo.processInfo.environment["VMLX_NATIVE_MTP_AR_SAFETY"] != "0",
+              ProcessInfo.processInfo.environment["VMLX_MTP_VERIFY_PREFETCH"] == "0" else {
+            throw XCTSkip("Requires governor on and prefetch off for controlled cost observation")
+        }
+        try FocusedMLXTestSupport.withLock {
+            for depth in 1...3 {
+                let model = DepthDispatchTarget(sequence: true, backboneDelay: 0.010)
+                var parameters = GenerateParameters(maxTokens: 340, temperature: 0)
+                parameters.draftStrategy = .nativeMTP(depth: depth)
+                var iterator = try NativeMTPTokenIterator(
+                    input: LMInput(tokens: MLXArray([1, 1, 1])), model: model,
+                    parameters: parameters, depth: depth)
+                var tokens: [Int] = []
+                var widthsBeforeCalibration: Int?
+                var resumedWidth: Int?
+                let started = ProcessInfo.processInfo.systemUptime
+                while tokens.count < 340, let token = iterator.next() {
+                    tokens.append(token)
+                    if iterator.autoregressiveFallbackTokenCount > 2,
+                       widthsBeforeCalibration == nil {
+                        widthsBeforeCalibration = model.verifyWidths.count
+                    }
+                    if let before = widthsBeforeCalibration,
+                       model.verifyWidths.count > before, resumedWidth == nil {
+                        resumedWidth = model.verifyWidths[before]
+                    }
+                }
+                XCTAssertEqual(tokens, (0..<340).map { (2 + $0) % 32 })
+                XCTAssertNotNil(widthsBeforeCalibration, "Must exercise real productive AR calibration")
+                XCTAssertEqual(iterator.autoregressiveFallbackTokenCount, 4,
+                    "Expected two seed and two calibration steps, not an unrelated loss recovery")
+                XCTAssertEqual(resumedWidth, depth + 1, "Calibration must retain the productive depth")
+                print("CALIBRATION-RESUME depth=\(depth) width=\(String(describing: resumedWidth)) fixtureTokS=\(Double(tokens.count) / max(ProcessInfo.processInfo.systemUptime - started, 1e-9)) realModelSpeedProof=false")
+            }
+        }
+    }
+
     func testSampledRejectionPauseCanProbeAfterProposalQualityChanges() throws {
         guard ProcessInfo.processInfo.environment["VMLX_NATIVE_MTP_AR_SAFETY"] != "0" else {
             throw XCTSkip("Requires the real governor")
@@ -46,8 +84,11 @@ final class NativeMTPDepthExecutionTests: XCTestCase {
             throw XCTSkip("Controlled host-cost row: governor on, verify prefetch off; prefetch parity is separate")
         }
         try FocusedMLXTestSupport.withLock {
-            let model = DepthDispatchTarget(sequence: true, backboneDelay: 0.004)
-            model.setVerifyDelays([2: 0.001, 3: 0.040, 4: 0.080])
+            // Deliberately separate cost regimes from sub-millisecond dispatch
+            // and timer jitter. D3/D2 initially lose to AR, D1 wins; afterward
+            // equal verify costs make each wider accepted block cheaper/token.
+            let model = DepthDispatchTarget(sequence: true, backboneDelay: 0.020)
+            model.setVerifyDelays([2: 0.012, 3: 0.160, 4: 0.320])
             var parameters = GenerateParameters(maxTokens: 480, temperature: 0)
             parameters.draftStrategy = .nativeMTP(depth: 3)
             var iterator = try NativeMTPTokenIterator(
@@ -64,7 +105,7 @@ final class NativeMTPDepthExecutionTests: XCTestCase {
                     XCTAssertTrue(widths.contains(3), "D3 must descend through D2")
                     XCTAssertTrue(widths.contains(2), "D1 should be discovered")
                     widthsAtChange = widths.count
-                    model.setVerifyDelays([2: 0.001, 3: 0.001, 4: 0.001])
+                    model.setVerifyDelays([2: 0.012, 3: 0.012, 4: 0.012])
                 }
             }
             let recovered = Array(model.verifyWidths.dropFirst(widthsAtChange))


### PR DESCRIPTION
## Scope

Preserve the productive native-MTP depth across the periodic two-step AR calibration. Calibration is not evidence of a loss; real loss recovery still starts at D1. The resumed depth remains capped by the resolved user selection and must pass the existing costed probe.

No sampling changes, model-family routing changes, or kernel changes.

## Regression evidence

- Production iterator fixture: D1/D2/D3 calibration resumes at verifier widths 2/3/4 with the exact expected token sequence.
- Isolated before-control: restoring only the old depth assignment produces the D2/D3 width failures.
- Governor-on suite: calibration, sampled recovery, committed-token preservation, and a clearly separated losing-to-winning cost regime executed without failures. The two governor-off dispatch controls were run separately.
- The cost-regime fixture uses explicit host delays; these are control-flow tests, not real-model speed results. Earlier 1 ms fixture timing produced suite-order-sensitive recovery and is not presented as performance qualification.

## Draft / remaining gates

The first fixture build used the app-pinned base ffe9153f plus the identical patch, commit d38130b7. This PR is a clean two-file cherry-pick onto main. Exact head 6923d6d60bafbddf4337968bb38b769818fd5803 was then built and executed: governor-on 4 executed/2 intentional skips/0 failures; governor-off 2 executed/4 intentional skips/0 failures. Binary SHA256: 536d7cba42c4791479f17eaf7234330d3411127da4cf7efc9630545b5e68d4d5.

Evidence logs: `SWIFTTEST_PR467_governor__094138.log` and `SWIFTTEST_PR467_dispatch__094422.log`, retained under `/Users/eric/vmlx-private-evidence/mtp-calibration-proof.UYyeIb` with supervision sidecars. The earlier 094226 dispatch preflight refused before execution and is not counted. These use a generated tiny target with explicit test settings, not a shipped model bundle.

- Measure actual MTP-Off versus internal-AR fallback, including synchronization, probe, and calibration overhead, on real workloads.
- Verify selected depth and transitions in the consuming Osaurus app, and preserve its existing bounded-prefill change when repinning.

This PR does not establish an absolute AR speed floor or complete the dynamic-MTP performance campaign. Keep draft pending those gates.
