### PR TITLE
MTP: measure initial admission and park on measured AR loss

### DIFF
--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -468,6 +468,9 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private var arSafetyProbeStartedEmitted = 0
     private var arSafetyLastMeasuredToken = 0
     private var arSafetyCalibrationRemaining = 0
+    // Calibration refreshes the AR baseline; it is not evidence that the
+    // productive depth lost. Real loss recovery still begins at D1.
+    private var arSafetyCalibrationResumeDepth: Int?
     /// True while a kept re-entry is speculating: a trip in that state backs
     /// the resume interval off further instead of resetting it.
     private var arSafetyReentered = false
@@ -511,6 +514,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     /// measurement is dropped so the climb can be re-attempted (prompt
     /// character changes mid-generation — a table after prose).
     private var windowsSinceUpperProbe = 0
+
     private static let upperProbeCooldownWindows = 8
     /// A lower depth must beat the current one by this factor before the
     /// wall-clock rule demotes — hysteresis so measurement noise doesn't
@@ -2237,6 +2241,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         }
         arSafetyTokensSincePause = 0
         arSafetyCalibrationRemaining = loss ? 0 : 2
+        arSafetyCalibrationResumeDepth = loss ? nil : currentDepth
         arSafetyProbeCyclesRemaining = 0
         arSafetyProbeStartedAt = nil
         arSafetyRing.removeAll(keepingCapacity: true)
@@ -2281,11 +2286,14 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             guard arSafetyTokensSincePause >= arSafetyResumeInterval else { return }
         }
         arSafetyPaused = false
-        arSafetyStartSpeculating(hidden: hidden, nextToken: nextToken, probe: true)
+        let resumeDepth = arSafetyCalibrationResumeDepth ?? 1
+        arSafetyCalibrationResumeDepth = nil
+        arSafetyStartSpeculating(
+            hidden: hidden, nextToken: nextToken, probe: true, resumeDepth: resumeDepth)
     }
 
     private mutating func arSafetyStartSpeculating(
-        hidden: MLXArray, nextToken: MLXArray, probe: Bool
+        hidden: MLXArray, nextToken: MLXArray, probe: Bool, resumeDepth: Int = 1
     ) {
         // Same re-prime the depth controller uses on every depth change: a
         // fresh head cache, drafts from the current hidden. Drafts are only
@@ -2293,7 +2301,8 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         // cache can only cost acceptance, never correctness.
         mtpCache = model.makeNativeMTPCache()
         mtpCacheRefreshCount += 1
-        currentDepth = probe ? 1 : depth
+        currentDepth = probe
+            ? Swift.max(1, Swift.min(resumeDepth, adaptiveDepthCeiling)) : depth
         arSafetyRing.removeAll(keepingCapacity: true)
         arSafetyProbeCyclesRemaining = probe ? Self.arSafetyProbeWindow : 0
         arSafetyProbeStartedAt = probe ? NativeMTPClock.now() : nil

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -2142,7 +2142,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             let arMs = (arSafetyLiveStepSec ?? arSafetySeedStepSec ?? 0) * 1000
             arSafetyProbeStartedAt = nil
             if arMs <= 0 || mtpMs * Self.arSafetyReentryHysteresis >= arMs {
-                arSafetyDemoteOrPause(reason: String(
+                arSafetyParkOnMeasuredLoss(reason: String(
                     format: "ar_safety_probe_lost(mtp=%.1fms/tok live_ar=%.1fms)",
                     mtpMs, arMs))
                 // Initial admission has not attempted recovery yet. Preserve
@@ -2190,7 +2190,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             tokenCount - arSafetyLastMeasuredToken < 512 {
             let arMs = live * 1000
             if mtpMs > arMs, median > arMs {
-                arSafetyDemoteOrPause(reason: String(
+                arSafetyParkOnMeasuredLoss(reason: String(
                     format: "ar_safety_fresh_loss(mtp=%.1fms/tok median=%.1fms live_ar=%.1fms depth=%d)",
                     mtpMs, median, arMs, currentDepth))
             }
@@ -2201,7 +2201,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             deltaVerifyMs: (newest.verifyTotal - oldest.verifyTotal) * 1000,
             margin: Self.arSafetyMargin),
             median > verdict.arBaselineMs * Self.arSafetyMargin {
-            arSafetyDemoteOrPause(reason: String(
+            arSafetyParkOnMeasuredLoss(reason: String(
                 format: "ar_safety_windowed(mtp=%.1fms/tok ar=%.1fms depth=%d)",
                 verdict.mtpMsPerToken, verdict.arBaselineMs, currentDepth))
         }
@@ -2214,28 +2214,16 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
         upperProbeNotBeforeCycle[currentDepth] = verifyCalls + delay
     }
 
-    private mutating func arSafetyDemoteOrPause(reason: String) {
-        guard currentDepth > 1 else {
-            arSafetyPause(reason: reason)
-            return
-        }
-        let previous = currentDepth
+    private mutating func arSafetyParkOnMeasuredLoss(reason: String) {
+        // Losing against measured AR is not evidence that the next lower
+        // speculative depth wins. Return to the measured baseline now; the
+        // existing timed re-entry starts at D1 and may climb within the ceiling.
+        // Keep acceptance-only/relative-depth decisions separate from this
+        // absolute AR-cost verdict.
         recordDepthLoss()
-        currentDepth -= 1
-        adaptiveDepthDownshiftCount += 1
         adaptiveWallClockDemotes += 1
-        arSafetyRing.removeAll(keepingCapacity: true)
-        adaptiveWindow.removeAll(keepingCapacity: true)
-        lastAdaptiveCycleTimestamp = nil
-        arSafetyFirstVerifySec = nil
-        arSafetyProbeCyclesRemaining = 0
-        arSafetyProbeStartedAt = nil
         windowsSinceUpperProbe = 0
-        mtpCache = model.makeNativeMTPCache()
-        mtpCacheRefreshCount += 1
-        headChainPairs = 0
-        FileHandle.standardError.write(Data(
-            "[NativeMTP] ar_safety depth=\(previous)->\(currentDepth) reason=\(reason)\n".utf8))
+        arSafetyPause(reason: reason)
     }
     private mutating func arSafetyPause(reason: String, loss: Bool = true) {
         arSafetyPaused = true

--- a/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
+++ b/Libraries/MLXLMCommon/SpecDec/NativeMTPTokenIterator.swift
@@ -466,6 +466,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     private var arSafetyProbeCyclesRemaining = 0
     private var arSafetyProbeStartedAt: TimeInterval?
     private var arSafetyProbeStartedEmitted = 0
+    private var arSafetyInitialProbe = false
     private var arSafetyLastMeasuredToken = 0
     private var arSafetyCalibrationRemaining = 0
     // Calibration refreshes the AR baseline; it is not evidence that the
@@ -2144,22 +2145,28 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
                 arSafetyDemoteOrPause(reason: String(
                     format: "ar_safety_probe_lost(mtp=%.1fms/tok live_ar=%.1fms)",
                     mtpMs, arMs))
-                if arSafetyPaused {
+                // Initial admission has not attempted recovery yet. Preserve
+                // the first retry interval; backoff belongs to failed re-entry.
+                if arSafetyPaused && !arSafetyInitialProbe {
                     let clearLoss = arMs > 0 && mtpMs >= arMs * Self.arSafetyClearLossFactor
                     arSafetyResumeInterval = Swift.min(
                         arSafetyResumeInterval * (clearLoss ? 4 : 2),
                         Self.arSafetyResumeIntervalMax)
                 }
             } else {
-                arSafetyResumes += 1
-                arSafetyReentered = true
+                if !arSafetyInitialProbe {
+                    arSafetyResumes += 1
+                    arSafetyReentered = true
+                }
                 arSafetySeedStepSec = arSafetyLiveStepSec ?? arSafetySeedStepSec
                 arSafetyFirstVerifySec = nil
                 adaptiveFallbackReason = nil
+                let event = arSafetyInitialProbe ? "admitted" : "resumed"
                 FileHandle.standardError.write(Data(String(
-                    format: "[NativeMTP] ar_safety resumed: mtp=%.1fms/tok live_ar=%.1fms depth=%d\n",
+                    format: "[NativeMTP] ar_safety \(event): mtp=%.1fms/tok live_ar=%.1fms depth=%d\n",
                     mtpMs, arMs, currentDepth).utf8))
             }
+            arSafetyInitialProbe = false
             return
         }
 
@@ -2269,7 +2276,12 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             if let first = arSafetySeedFirstSampleSec {
                 arSafetySeedStepSec = Swift.min(first, stepSec)
                 arSafetyLastMeasuredToken = tokenCount
-                arSafetyStartSpeculating(hidden: hidden, nextToken: nextToken, probe: false)
+                // Admission must measure the first trial, including draft re-prime,
+                // just like re-entry. Otherwise the initial depth bypasses the
+                // probe and waits for the longer warmup plus judgement window.
+                arSafetyStartSpeculating(
+                    hidden: hidden, nextToken: nextToken, probe: true, resumeDepth: depth,
+                    initialProbe: true)
             } else {
                 arSafetySeedFirstSampleSec = stepSec
             }
@@ -2293,7 +2305,8 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
     }
 
     private mutating func arSafetyStartSpeculating(
-        hidden: MLXArray, nextToken: MLXArray, probe: Bool, resumeDepth: Int = 1
+        hidden: MLXArray, nextToken: MLXArray, probe: Bool, resumeDepth: Int = 1,
+        initialProbe: Bool = false
     ) {
         // Same re-prime the depth controller uses on every depth change: a
         // fresh head cache, drafts from the current hidden. Drafts are only
@@ -2305,6 +2318,7 @@ struct NativeMTPTokenIterator: TokenIteratorProtocol {
             ? Swift.max(1, Swift.min(resumeDepth, adaptiveDepthCeiling)) : depth
         arSafetyRing.removeAll(keepingCapacity: true)
         arSafetyProbeCyclesRemaining = probe ? Self.arSafetyProbeWindow : 0
+        arSafetyInitialProbe = initialProbe
         arSafetyProbeStartedAt = probe ? NativeMTPClock.now() : nil
         arSafetyProbeStartedEmitted = arSafetyEmittedTotal
         arSafetyFirstVerifySec = nil

--- a/Tests/MLXLMCommonFocusedTests/NativeMTPDepthExecutionTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NativeMTPDepthExecutionTests.swift
@@ -7,6 +7,32 @@ import XCTest
 /// Exercises actual iterator verify dispatch. The zero-weight constant target
 /// makes every proposal correct; it is not a model-quality or speed benchmark.
 final class NativeMTPDepthExecutionTests: XCTestCase {
+    func testInitialDepthIsMeasuredAsAProbe() throws {
+        guard ProcessInfo.processInfo.environment["VMLX_NATIVE_MTP_AR_SAFETY"] != "0",
+              ProcessInfo.processInfo.environment["VMLX_MTP_VERIFY_PREFETCH"] == "0" else {
+            throw XCTSkip("Requires controlled governor costs without verify prefetch")
+        }
+        try FocusedMLXTestSupport.withLock {
+            let model = DepthDispatchTarget(sequence: true, backboneDelay: 0.010)
+            model.setVerifyDelays([2: 0.080, 3: 0.120, 4: 0.160])
+            var parameters = GenerateParameters(maxTokens: 100, temperature: 0)
+            parameters.draftStrategy = .nativeMTP(depth: 3)
+            var iterator = try NativeMTPTokenIterator(
+                input: LMInput(tokens: MLXArray([1, 1, 1])), model: model,
+                parameters: parameters, depth: 3)
+            let started = ProcessInfo.processInfo.systemUptime
+            var tokens: [Int] = []
+            while iterator.verifyCalls < 6, let token = iterator.next() {
+                tokens.append(token)
+            }
+            XCTAssertEqual(tokens, (0..<tokens.count).map { (2 + $0) % 32 })
+            XCTAssertEqual(iterator.verifyCalls, 6)
+            XCTAssertGreaterThan(iterator.adaptiveDepthDownshiftCount + iterator.arSafetyTrips, 0,
+                "The initial losing trial must be judged as a probe, not wait for warmup plus a window")
+            print("INITIAL-PROBE verifies=\(iterator.verifyCalls) fixtureTokS=\(Double(tokens.count) / max(ProcessInfo.processInfo.systemUptime - started, 1e-9)) realModelSpeedProof=false")
+        }
+    }
+
     func testProductiveCalibrationResumesPriorDepth() throws {
         guard ProcessInfo.processInfo.environment["VMLX_NATIVE_MTP_AR_SAFETY"] != "0",
               ProcessInfo.processInfo.environment["VMLX_MTP_VERIFY_PREFETCH"] == "0" else {
@@ -40,6 +66,8 @@ final class NativeMTPDepthExecutionTests: XCTestCase {
                 XCTAssertEqual(iterator.autoregressiveFallbackTokenCount, 4,
                     "Expected two seed and two calibration steps, not an unrelated loss recovery")
                 XCTAssertEqual(resumedWidth, depth + 1, "Calibration must retain the productive depth")
+                XCTAssertEqual(iterator.arSafetyResumes, 1,
+                    "Initial admission must not be counted as resuming a parked decoder")
                 print("CALIBRATION-RESUME depth=\(depth) width=\(String(describing: resumedWidth)) fixtureTokS=\(Double(tokens.count) / max(ProcessInfo.processInfo.systemUptime - started, 1e-9)) realModelSpeedProof=false")
             }
         }

--- a/Tests/MLXLMCommonFocusedTests/NativeMTPDepthExecutionTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NativeMTPDepthExecutionTests.swift
@@ -7,6 +7,41 @@ import XCTest
 /// Exercises actual iterator verify dispatch. The zero-weight constant target
 /// makes every proposal correct; it is not a model-quality or speed benchmark.
 final class NativeMTPDepthExecutionTests: XCTestCase {
+    func testMeasuredInitialLossParksDirectlyAtAR() throws {
+        guard ProcessInfo.processInfo.environment["VMLX_NATIVE_MTP_AR_SAFETY"] != "0",
+              ProcessInfo.processInfo.environment["VMLX_MTP_VERIFY_PREFETCH"] == "0" else {
+            throw XCTSkip("Requires controlled governor costs without verify prefetch")
+        }
+        try FocusedMLXTestSupport.withLock {
+            for depth in 1...3 {
+                let model = DepthDispatchTarget(sequence: true, backboneDelay: 0.010)
+                model.setVerifyDelays([2: 0.080, 3: 0.120, 4: 0.160])
+                var parameters = GenerateParameters(maxTokens: 100, temperature: 0)
+                parameters.draftStrategy = .nativeMTP(depth: depth)
+                var iterator = try NativeMTPTokenIterator(
+                    input: LMInput(tokens: MLXArray([1, 1, 1])), model: model,
+                    parameters: parameters, depth: depth)
+                let started = ProcessInfo.processInfo.systemUptime
+                var tokens: [Int] = []
+                while iterator.verifyCalls < 6, let token = iterator.next() {
+                    tokens.append(token)
+                }
+                XCTAssertEqual(iterator.arSafetyTrips, 1,
+                    "A measured loss must park at AR, not try another unqualified depth")
+                // Drain already verified tokens; the next computation must be AR.
+                for _ in 0...depth {
+                    if iterator.autoregressiveFallbackTokenCount > 2 { break }
+                    if let token = iterator.next() { tokens.append(token) }
+                }
+                XCTAssertEqual(iterator.verifyCalls, 6)
+                XCTAssertEqual(iterator.autoregressiveFallbackTokenCount, 3)
+                XCTAssertEqual(tokens, (0..<tokens.count).map { (2 + $0) % 32 })
+                XCTAssertTrue(model.verifyWidths.allSatisfy { $0 <= depth + 1 })
+                print("DIRECT-AR depth=\(depth) fixtureTokS=\(Double(tokens.count) / max(ProcessInfo.processInfo.systemUptime - started, 1e-9)) realModelSpeedProof=false")
+            }
+        }
+    }
+
     func testInitialDepthIsMeasuredAsAProbe() throws {
         guard ProcessInfo.processInfo.environment["VMLX_NATIVE_MTP_AR_SAFETY"] != "0",
               ProcessInfo.processInfo.environment["VMLX_MTP_VERIFY_PREFETCH"] == "0" else {
@@ -130,7 +165,8 @@ final class NativeMTPDepthExecutionTests: XCTestCase {
                 if tokens.count == 240 {
                     let widths = model.verifyWidths
                     XCTAssertTrue(widths.contains(4))
-                    XCTAssertTrue(widths.contains(3), "D3 must descend through D2")
+                    XCTAssertGreaterThan(iterator.arSafetyTrips, 0,
+                        "Losing D3 must park before probing a lower depth")
                     XCTAssertTrue(widths.contains(2), "D1 should be discovered")
                     widthsAtChange = widths.count
                     model.setVerifyDelays([2: 0.012, 3: 0.012, 4: 0.012])

--- a/Tests/MLXLMCommonFocusedTests/NativeMTPDepthExecutionTests.swift
+++ b/Tests/MLXLMCommonFocusedTests/NativeMTPDepthExecutionTests.swift
@@ -7,6 +7,44 @@ import XCTest
 /// Exercises actual iterator verify dispatch. The zero-weight constant target
 /// makes every proposal correct; it is not a model-quality or speed benchmark.
 final class NativeMTPDepthExecutionTests: XCTestCase {
+    func testProductiveCalibrationResumesPriorDepth() throws {
+        guard ProcessInfo.processInfo.environment["VMLX_NATIVE_MTP_AR_SAFETY"] != "0",
+              ProcessInfo.processInfo.environment["VMLX_MTP_VERIFY_PREFETCH"] == "0" else {
+            throw XCTSkip("Requires governor on and prefetch off for controlled cost observation")
+        }
+        try FocusedMLXTestSupport.withLock {
+            for depth in 1...3 {
+                let model = DepthDispatchTarget(sequence: true, backboneDelay: 0.010)
+                var parameters = GenerateParameters(maxTokens: 340, temperature: 0)
+                parameters.draftStrategy = .nativeMTP(depth: depth)
+                var iterator = try NativeMTPTokenIterator(
+                    input: LMInput(tokens: MLXArray([1, 1, 1])), model: model,
+                    parameters: parameters, depth: depth)
+                var tokens: [Int] = []
+                var widthsBeforeCalibration: Int?
+                var resumedWidth: Int?
+                let started = ProcessInfo.processInfo.systemUptime
+                while tokens.count < 340, let token = iterator.next() {
+                    tokens.append(token)
+                    if iterator.autoregressiveFallbackTokenCount > 2,
+                       widthsBeforeCalibration == nil {
+                        widthsBeforeCalibration = model.verifyWidths.count
+                    }
+                    if let before = widthsBeforeCalibration,
+                       model.verifyWidths.count > before, resumedWidth == nil {
+                        resumedWidth = model.verifyWidths[before]
+                    }
+                }
+                XCTAssertEqual(tokens, (0..<340).map { (2 + $0) % 32 })
+                XCTAssertNotNil(widthsBeforeCalibration, "Must exercise real productive AR calibration")
+                XCTAssertEqual(iterator.autoregressiveFallbackTokenCount, 4,
+                    "Expected two seed and two calibration steps, not an unrelated loss recovery")
+                XCTAssertEqual(resumedWidth, depth + 1, "Calibration must retain the productive depth")
+                print("CALIBRATION-RESUME depth=\(depth) width=\(String(describing: resumedWidth)) fixtureTokS=\(Double(tokens.count) / max(ProcessInfo.processInfo.systemUptime - started, 1e-9)) realModelSpeedProof=false")
+            }
+        }
+    }
+
     func testSampledRejectionPauseCanProbeAfterProposalQualityChanges() throws {
         guard ProcessInfo.processInfo.environment["VMLX_NATIVE_MTP_AR_SAFETY"] != "0" else {
             throw XCTSkip("Requires the real governor")
@@ -46,8 +84,11 @@ final class NativeMTPDepthExecutionTests: XCTestCase {
             throw XCTSkip("Controlled host-cost row: governor on, verify prefetch off; prefetch parity is separate")
         }
         try FocusedMLXTestSupport.withLock {
-            let model = DepthDispatchTarget(sequence: true, backboneDelay: 0.004)
-            model.setVerifyDelays([2: 0.001, 3: 0.040, 4: 0.080])
+            // Deliberately separate cost regimes from sub-millisecond dispatch
+            // and timer jitter. D3/D2 initially lose to AR, D1 wins; afterward
+            // equal verify costs make each wider accepted block cheaper/token.
+            let model = DepthDispatchTarget(sequence: true, backboneDelay: 0.020)
+            model.setVerifyDelays([2: 0.012, 3: 0.160, 4: 0.320])
             var parameters = GenerateParameters(maxTokens: 480, temperature: 0)
             parameters.draftStrategy = .nativeMTP(depth: 3)
             var iterator = try NativeMTPTokenIterator(
@@ -64,7 +105,7 @@ final class NativeMTPDepthExecutionTests: XCTestCase {
                     XCTAssertTrue(widths.contains(3), "D3 must descend through D2")
                     XCTAssertTrue(widths.contains(2), "D1 should be discovered")
                     widthsAtChange = widths.count
-                    model.setVerifyDelays([2: 0.001, 3: 0.001, 4: 0.001])
+                    model.setVerifyDelays([2: 0.012, 3: 0.012, 4: 0.012])
                 }
             }
             let recovered = Array(model.verifyWidths.dropFirst(widthsAtChange))


### PR DESCRIPTION
## Scope

Separate the governor correction from draft #468's unqualified sampled-verifier
and cache work. This supersedes #467's calibration-only proposal.

- Measure the initial selected depth through the existing timed admission probe.
- Park at measured AR after a speculative loss; re-entry probes start at D1 and
  may recover within the selected ceiling. Relative-depth/acceptance demotions
  remain separate from an absolute AR-loss verdict.
- Preserve a previously productive depth during periodic AR calibration, while
  still requiring the resumed trial to demonstrate benefit.
- Do not count initial admission as a resume or apply failed-reentry backoff to it.

No sampler, precision, model routing, projection, verifier or cache-format change.
This does not claim instantaneous or universal performance parity with Off.

## Evidence / remaining gate

Source head a5cf8a9ecff3ab5978285ee30799c881bd8a4c28. With only the runtime file
restored to main and identical candidate tests, all three new regression tests
fail (12 assertions): initial loss unjudged, no immediate parking, and D2/D3
calibration restarting at D1. Restoring the candidate reproduces its exact hash.

Bounded local run MTPAdmissionAfter0912__112011: 23 XCTest cases (2 explicit
dispatch-only skips), plus 3 Swift Testing cases; no failures. These are generated
fixtures, not model throughput. Peak tracked footprint1.26GB, flat swap.49GB,
normal pressure, cleanup0/0/0. Disabled-governor dispatch control recorded separately.

PARTIAL: exact-pinned Release app measurements, UI selected-depth execution,
short/long context and continuation proof are pending. Default sampled Flash
still uses sequential verification; experimental staged verification stays off.
